### PR TITLE
Chore: enable `prefer-arrow-callback` on ESLint codebase (fixes #6407)

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -90,9 +90,7 @@ function getTestFilePatterns() {
         testTemplatesPath = "tests/templates/",
         testBinPath = "tests/bin/";
 
-    return ls(testLibPath).filter(function(pathToCheck) {
-        return test("-d", testLibPath + pathToCheck);
-    }).reduce(function(initialValue, currentValues) {
+    return ls(testLibPath).filter(pathToCheck => test("-d", testLibPath + pathToCheck)).reduce((initialValue, currentValues) => {
         if (currentValues !== "rules") {
             initialValue.push(`"${testLibPath + currentValues}/**/*.js"`);
         }
@@ -135,7 +133,7 @@ function generateRulesIndex(basedir) {
 
     output += "    var rules = Object.create(null);\n";
 
-    find(`${basedir}rules/`).filter(fileType("js")).forEach(function(filename) {
+    find(`${basedir}rules/`).filter(fileType("js")).forEach(filename => {
         const basename = path.basename(filename, ".js");
 
         output += `    rules["${basename}"] = require("./rules/${basename}");\n`;
@@ -204,7 +202,7 @@ function generateRuleIndexPage(basedir) {
         categoryList = "conf/category-list.json",
         categoriesData = JSON.parse(cat(path.resolve(categoryList)));
 
-    find(path.join(basedir, "/lib/rules/")).filter(fileType("js")).forEach(function(filename) {
+    find(path.join(basedir, "/lib/rules/")).filter(fileType("js")).forEach(filename => {
         const rule = require(filename);
         const basename = path.basename(filename, ".js");
 
@@ -324,7 +322,7 @@ function getTagOfFirstOccurrence(filePath) {
     let tags = execSilent(`git tag --contains ${firstCommit}`);
 
     tags = splitCommandResultToLines(tags);
-    return tags.reduce(function(list, version) {
+    return tags.reduce((list, version) => {
         version = semver.valid(version.trim());
         if (version) {
             list.push(version);
@@ -363,12 +361,8 @@ function getFirstVersionOfDeletion(filePath) {
         tags = execSilent(`git tag --contains ${deletionCommit}`);
 
     return splitCommandResultToLines(tags)
-        .map(function(version) {
-            return semver.valid(version.trim());
-        })
-        .filter(function(version) {
-            return version;
-        })
+        .map(version => semver.valid(version.trim()))
+        .filter(version => version)
         .sort(semver.compare)[0];
 }
 
@@ -476,7 +470,7 @@ function getFormatterResults() {
         ].join("\n"),
         rawMessages = cli.executeOnText(codeString, "fullOfProblems.js", true);
 
-    return formatterFiles.reduce(function(data, filename) {
+    return formatterFiles.reduce((data, filename) => {
         const fileExt = path.extname(filename),
             name = path.basename(filename, fileExt);
 
@@ -594,9 +588,7 @@ target.gensite = function(prereleaseVersion) {
 
     // append version
     if (prereleaseVersion) {
-        docFiles = docFiles.map(function(docFile) {
-            return `/${prereleaseVersion}${docFile}`;
-        });
+        docFiles = docFiles.map(docFile => `/${prereleaseVersion}${docFile}`);
     }
 
     // 1. create temp and build directory
@@ -605,7 +597,7 @@ target.gensite = function(prereleaseVersion) {
     }
 
     // 2. remove old files from the site
-    docFiles.forEach(function(filePath) {
+    docFiles.forEach(filePath => {
         const fullPath = path.join(DOCS_DIR, filePath),
             htmlFullPath = fullPath.replace(".md", ".html");
 
@@ -632,7 +624,7 @@ target.gensite = function(prereleaseVersion) {
     }
 
     // 4. Loop through all files in temporary directory
-    find(TEMP_DIR).forEach(function(filename) {
+    find(TEMP_DIR).forEach(filename => {
         if (test("-f", filename) && path.extname(filename) === ".md") {
 
             const rulesUrl = "https://github.com/eslint/eslint/tree/master/lib/rules/",
@@ -763,7 +755,7 @@ target.checkRuleFiles = function() {
     const ruleFiles = find("lib/rules/").filter(fileType("js"));
     let errors = 0;
 
-    ruleFiles.forEach(function(filename) {
+    ruleFiles.forEach(filename => {
         const basename = path.basename(filename, ".js");
         const docFilename = `docs/rules/${basename}.md`;
 
@@ -838,35 +830,27 @@ target.checkLicenses = function() {
         const licenses = dependency.licenses;
 
         if (Array.isArray(licenses)) {
-            return licenses.some(function(license) {
-                return isPermissible({
-                    name: dependency.name,
-                    licenses: license
-                });
-            });
+            return licenses.some(license => isPermissible({
+                name: dependency.name,
+                licenses: license
+            }));
         }
 
-        return OPEN_SOURCE_LICENSES.some(function(license) {
-            return license.test(licenses);
-        });
+        return OPEN_SOURCE_LICENSES.some(license => license.test(licenses));
     }
 
     echo("Validating licenses");
 
     checker.init({
         start: __dirname
-    }, function(deps) {
-        const impermissible = Object.keys(deps).map(function(dependency) {
-            return {
-                name: dependency,
-                licenses: deps[dependency].licenses
-            };
-        }).filter(function(dependency) {
-            return !isPermissible(dependency);
-        });
+    }, deps => {
+        const impermissible = Object.keys(deps).map(dependency => ({
+            name: dependency,
+            licenses: deps[dependency].licenses
+        })).filter(dependency => !isPermissible(dependency));
 
         if (impermissible.length) {
-            impermissible.forEach(function(dependency) {
+            impermissible.forEach(dependency => {
                 console.error("%s license for %s is impermissible.",
                     dependency.licenses,
                     dependency.name
@@ -960,9 +944,7 @@ function createConfigForPerformanceTest() {
 
     content.push.apply(
         content,
-        ls("lib/rules").map(function(fileName) {
-            return `    ${path.basename(fileName, ".js")}: 1`;
-        })
+        ls("lib/rules").map(fileName => `    ${path.basename(fileName, ".js")}: 1`)
     );
 
     content.join("\n").to(PERF_ESLINTRC);
@@ -981,7 +963,7 @@ function createConfigForPerformanceTest() {
 function time(cmd, runs, runNumber, results, cb) {
     const start = process.hrtime();
 
-    exec(cmd, { silent: true }, function(code, stdout, stderr) {
+    exec(cmd, { silent: true }, (code, stdout, stderr) => {
         const diff = process.hrtime(start),
             actual = (diff[0] * 1e3 + diff[1] / 1e6); // ms
 
@@ -1026,14 +1008,12 @@ function runPerformanceTest(title, targets, multiplier, cb) {
     echo(title);
     echo("  CPU Speed is %d with multiplier %d", cpuSpeed, multiplier);
 
-    time(cmd, 5, 1, [], function(results) {
+    time(cmd, 5, 1, [], results => {
         if (!results || results.length === 0) {  // No results? Something is wrong.
             throw new Error("Performance test failed.");
         }
 
-        results.sort(function(a, b) {
-            return a - b;
-        });
+        results.sort((a, b) => a - b);
 
         const median = results[~~(results.length / 2)];
 
@@ -1068,9 +1048,7 @@ function loadPerformance() {
         results.push(loadPerfData.loadTime);
     }
 
-    results.sort(function(a, b) {
-        return a - b;
-    });
+    results.sort((a, b) => a - b);
     const median = results[~~(results.length / 2)];
 
     echo("");
@@ -1079,7 +1057,7 @@ function loadPerformance() {
 }
 
 target.perf = function() {
-    downloadMultifilesTestTarget(function() {
+    downloadMultifilesTestTarget(() => {
         createConfigForPerformanceTest();
 
         loadPerformance();
@@ -1088,7 +1066,7 @@ target.perf = function() {
             "Single File:",
             "tests/performance/jshint.js",
             PERF_MULTIPLIER,
-            function() {
+            () => {
 
                 // Count test target files.
                 const count = glob.sync(
@@ -1101,7 +1079,7 @@ target.perf = function() {
                     `Multi Files (${count} files):`,
                     PERF_MULTIFILES_TARGETS,
                     3 * PERF_MULTIPLIER,
-                    function() {}
+                    () => {}
                 );
             }
         );

--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -36,7 +36,7 @@ const concat = require("concat-stream"),
 // Execution
 //------------------------------------------------------------------------------
 
-process.on("uncaughtException", function(err) {
+process.on("uncaughtException", err => {
 
     // lazy load
     const lodash = require("lodash");
@@ -55,13 +55,13 @@ process.on("uncaughtException", function(err) {
 });
 
 if (useStdIn) {
-    process.stdin.pipe(concat({ encoding: "string" }, function(text) {
+    process.stdin.pipe(concat({ encoding: "string" }, text => {
         process.exitCode = cli.execute(process.argv, text);
     }));
 } else if (init) {
     const configInit = require("../lib/config/config-initializer");
 
-    configInit.initializeConfig(function(err) {
+    configInit.initializeConfig(err => {
         if (err) {
             process.exitCode = 1;
             console.error(err.message);

--- a/lib/ast-utils.js
+++ b/lib/ast-utils.js
@@ -176,9 +176,7 @@ function hasJSDocThisTag(node, sourceCode) {
     // because callbacks don't have its JSDoc comment.
     // e.g.
     //     sinon.test(/* @this sinon.Sandbox */function() { this.spy(); });
-    return sourceCode.getComments(node).leading.some(function(comment) {
-        return thisTagPattern.test(comment.value);
-    });
+    return sourceCode.getComments(node).leading.some(comment => thisTagPattern.test(comment.value));
 }
 
 /**

--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -90,7 +90,7 @@ const debug = require("debug")("eslint:cli-engine");
  * @private
  */
 function calculateStatsPerFile(messages) {
-    return messages.reduce(function(stat, message) {
+    return messages.reduce((stat, message) => {
         if (message.fatal || message.severity === 2) {
             stat.errorCount++;
         } else {
@@ -110,7 +110,7 @@ function calculateStatsPerFile(messages) {
  * @private
  */
 function calculateStatsPerRun(results) {
-    return results.reduce(function(stat, result) {
+    return results.reduce((stat, result) => {
         stat.errorCount += result.errorCount;
         stat.warningCount += result.warningCount;
         return stat;
@@ -241,7 +241,7 @@ function processText(text, configHelper, filename, fix, allowInlineConfig) {
         const parsedBlocks = processor.preprocess(text, filename);
         const unprocessedMessages = [];
 
-        parsedBlocks.forEach(function(block) {
+        parsedBlocks.forEach(block => {
             unprocessedMessages.push(eslint.verify(block, config, {
                 filename,
                 allowInlineConfig
@@ -466,15 +466,15 @@ function CLIEngine(options) {
     if (this.options.rulePaths) {
         const cwd = this.options.cwd;
 
-        this.options.rulePaths.forEach(function(rulesdir) {
+        this.options.rulePaths.forEach(rulesdir => {
             debug(`Loading rules from ${rulesdir}`);
             rules.load(rulesdir, cwd);
         });
     }
 
-    Object.keys(this.options.rules || {}).forEach(function(name) {
+    Object.keys(this.options.rules || {}).forEach(name => {
         validator.validateRuleOptions(name, this.options.rules[name], "CLI");
-    }.bind(this));
+    });
 }
 
 /**
@@ -526,7 +526,7 @@ CLIEngine.getFormatter = function(format) {
 CLIEngine.getErrorResults = function(results) {
     const filtered = [];
 
-    results.forEach(function(result) {
+    results.forEach(result => {
         const filteredMessages = result.messages.filter(isErrorMessage);
 
         if (filteredMessages.length > 0) {
@@ -549,9 +549,7 @@ CLIEngine.getErrorResults = function(results) {
  * @returns {void}
  */
 CLIEngine.outputFixes = function(report) {
-    report.results.filter(function(result) {
-        return result.hasOwnProperty("output");
-    }).forEach(function(result) {
+    report.results.filter(result => result.hasOwnProperty("output")).forEach(result => {
         fs.writeFileSync(result.filePath, result.output);
     });
 };
@@ -708,7 +706,7 @@ CLIEngine.prototype = {
         patterns = this.resolveFileGlobPatterns(patterns);
         const fileList = globUtil.listFilesToProcess(patterns, options);
 
-        fileList.forEach(function(fileInfo) {
+        fileList.forEach(fileInfo => {
             executeOnFile(fileInfo.filename, fileInfo.ignored);
         });
 

--- a/lib/code-path-analysis/debug-helpers.js
+++ b/lib/code-path-analysis/debug-helpers.js
@@ -108,7 +108,7 @@ module.exports = {
             }
 
             if (segment.internal.nodes.length > 0) {
-                text += segment.internal.nodes.map(function(node) {
+                text += segment.internal.nodes.map(node => {
                     switch (node.type) {
                         case "Identifier": return `${node.type} (${node.name})`;
                         case "Literal": return `${node.type} (${node.value})`;
@@ -116,7 +116,7 @@ module.exports = {
                     }
                 }).join("\\n");
             } else if (segment.internal.exitNodes.length > 0) {
-                text += segment.internal.exitNodes.map(function(node) {
+                text += segment.internal.exitNodes.map(node => {
                     switch (node.type) {
                         case "Identifier": return `${node.type}:exit (${node.name})`;
                         case "Literal": return `${node.type}:exit (${node.value})`;
@@ -176,7 +176,7 @@ module.exports = {
             stack.push([nextSegment, 0]);
         }
 
-        codePath.returnedSegments.forEach(function(finalSegment) {
+        codePath.returnedSegments.forEach(finalSegment => {
             if (lastId === finalSegment.id) {
                 text += "->final";
             } else {
@@ -185,7 +185,7 @@ module.exports = {
             lastId = null;
         });
 
-        codePath.thrownSegments.forEach(function(finalSegment) {
+        codePath.thrownSegments.forEach(finalSegment => {
             if (lastId === finalSegment.id) {
                 text += "->thrown";
             } else {

--- a/lib/config.js
+++ b/lib/config.js
@@ -197,7 +197,7 @@ function Config(options) {
 
     this.useEslintrc = (options.useEslintrc !== false);
 
-    this.env = (options.envs || []).reduce(function(envs, name) {
+    this.env = (options.envs || []).reduce((envs, name) => {
         envs[name] = true;
         return envs;
     }, {});
@@ -208,7 +208,7 @@ function Config(options) {
      * whether global is writable.
      * If user declares "foo", convert to "foo:false".
      */
-    this.globals = (options.globals || []).reduce(function(globals, def) {
+    this.globals = (options.globals || []).reduce((globals, def) => {
         const parts = def.split(":");
 
         globals[parts[0]] = (parts.length > 1 && parts[1] === "true");

--- a/lib/config/autoconfig.js
+++ b/lib/config/autoconfig.js
@@ -49,14 +49,12 @@ const MAX_CONFIG_COMBINATIONS = 17, // 16 combinations + 1 for severity only
  * @returns {Object}                  registryItems for each rule in provided rulesConfig
  */
 function makeRegistryItems(rulesConfig) {
-    return Object.keys(rulesConfig).reduce(function(accumulator, ruleId) {
-        accumulator[ruleId] = rulesConfig[ruleId].map(function(config) {
-            return {
-                config,
-                specificity: config.length || 1,
-                errorCount: void 0
-            };
-        });
+    return Object.keys(rulesConfig).reduce((accumulator, ruleId) => {
+        accumulator[ruleId] = rulesConfig[ruleId].map(config => ({
+            config,
+            specificity: config.length || 1,
+            errorCount: void 0
+        }));
         return accumulator;
     }, {});
 }
@@ -173,10 +171,8 @@ Registry.prototype = {
             newRegistry = new Registry();
 
         newRegistry.rules = Object.assign({}, this.rules);
-        ruleIds.forEach(function(ruleId) {
-            const errorFreeItems = newRegistry.rules[ruleId].filter(function(registryItem) {
-                return (registryItem.errorCount === 0);
-            });
+        ruleIds.forEach(ruleId => {
+            const errorFreeItems = newRegistry.rules[ruleId].filter(registryItem => (registryItem.errorCount === 0));
 
             if (errorFreeItems.length > 0) {
                 newRegistry.rules[ruleId] = errorFreeItems;
@@ -198,10 +194,8 @@ Registry.prototype = {
             newRegistry = new Registry();
 
         newRegistry.rules = Object.assign({}, this.rules);
-        ruleIds.forEach(function(ruleId) {
-            newRegistry.rules[ruleId] = newRegistry.rules[ruleId].filter(function(registryItem) {
-                return (typeof registryItem.errorCount !== "undefined");
-            });
+        ruleIds.forEach(ruleId => {
+            newRegistry.rules[ruleId] = newRegistry.rules[ruleId].filter(registryItem => (typeof registryItem.errorCount !== "undefined"));
         });
 
         return newRegistry;
@@ -218,15 +212,13 @@ Registry.prototype = {
         const ruleIds = Object.keys(this.rules),
             failingRegistry = new Registry();
 
-        ruleIds.forEach(function(ruleId) {
-            const failingConfigs = this.rules[ruleId].filter(function(registryItem) {
-                return (registryItem.errorCount > 0);
-            });
+        ruleIds.forEach(ruleId => {
+            const failingConfigs = this.rules[ruleId].filter(registryItem => (registryItem.errorCount > 0));
 
             if (failingConfigs && failingConfigs.length === this.rules[ruleId].length) {
                 failingRegistry.rules[ruleId] = failingConfigs;
             }
-        }.bind(this));
+        });
 
         return failingRegistry;
     },
@@ -241,11 +233,11 @@ Registry.prototype = {
         const ruleIds = Object.keys(this.rules),
             config = {rules: {}};
 
-        ruleIds.forEach(function(ruleId) {
+        ruleIds.forEach(ruleId => {
             if (this.rules[ruleId].length === 1) {
                 config.rules[ruleId] = this.rules[ruleId][0].config;
             }
-        }.bind(this));
+        });
 
         return config;
     },
@@ -261,11 +253,9 @@ Registry.prototype = {
             newRegistry = new Registry();
 
         newRegistry.rules = Object.assign({}, this.rules);
-        ruleIds.forEach(function(ruleId) {
-            newRegistry.rules[ruleId] = this.rules[ruleId].filter(function(registryItem) {
-                return (registryItem.specificity === specificity);
-            });
-        }.bind(this));
+        ruleIds.forEach(ruleId => {
+            newRegistry.rules[ruleId] = this.rules[ruleId].filter(registryItem => (registryItem.specificity === specificity));
+        });
 
         return newRegistry;
     },
@@ -294,16 +284,16 @@ Registry.prototype = {
         const filenames = Object.keys(sourceCodes);
         const totalFilesLinting = filenames.length * ruleSets.length;
 
-        filenames.forEach(function(filename) {
+        filenames.forEach(filename => {
             debug(`Linting file: ${filename}`);
 
             ruleSetIdx = 0;
 
-            ruleSets.forEach(function(ruleSet) {
+            ruleSets.forEach(ruleSet => {
                 const lintConfig = Object.assign({}, config, {rules: ruleSet});
                 const lintResults = eslint.verify(sourceCodes[filename], lintConfig);
 
-                lintResults.forEach(function(result) {
+                lintResults.forEach(result => {
 
                     // It is possible that the error is from a configuration comment
                     // in a linted file, in which case there may not be a config
@@ -342,11 +332,9 @@ function extendFromRecommended(config) {
 
     ConfigOps.normalizeToStrings(newConfig);
 
-    const recRules = Object.keys(recConfig.rules).filter(function(ruleId) {
-        return ConfigOps.isErrorSeverity(recConfig.rules[ruleId]);
-    });
+    const recRules = Object.keys(recConfig.rules).filter(ruleId => ConfigOps.isErrorSeverity(recConfig.rules[ruleId]));
 
-    recRules.forEach(function(ruleId) {
+    recRules.forEach(ruleId => {
         if (lodash.isEqual(recConfig.rules[ruleId], newConfig.rules[ruleId])) {
             delete newConfig.rules[ruleId];
         }

--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -359,7 +359,7 @@ function applyExtends(config, filePath, relativeTo) {
     }
 
     // Make the last element in an array take the highest precedence
-    config = configExtends.reduceRight(function(previousValue, parentPath) {
+    config = configExtends.reduceRight((previousValue, parentPath) => {
 
         if (parentPath === "eslint:recommended") {
 

--- a/lib/config/config-initializer.js
+++ b/lib/config/config-initializer.js
@@ -62,9 +62,7 @@ function installModules(config) {
 
     // Create a list of modules which should be installed based on config
     if (config.plugins) {
-        modules = modules.concat(config.plugins.map(function(name) {
-            return `eslint-plugin-${name}`;
-        }));
+        modules = modules.concat(config.plugins.map(name => `eslint-plugin-${name}`));
     }
     if (config.extends && config.extends.indexOf("eslint:") === -1) {
         modules.push(`eslint-config-${config.extends}`);
@@ -81,7 +79,7 @@ function installModules(config) {
     const installStatus = npmUtil.checkDevDeps(modules);
 
     // Install packages which aren't already installed
-    const modulesToInstall = Object.keys(installStatus).filter(function(module) {
+    const modulesToInstall = Object.keys(installStatus).filter(module => {
         const notInstalled = installStatus[module] === false;
 
         if (module === "eslint" && notInstalled) {
@@ -128,7 +126,7 @@ function configureRules(answers, config) {
     const patterns = answers.patterns.split(/[\s]+/);
 
     try {
-        sourceCodes = getSourceCodeOfFiles(patterns, { baseConfig: newConfig, useEslintrc: false }, function(total) {
+        sourceCodes = getSourceCodeOfFiles(patterns, { baseConfig: newConfig, useEslintrc: false }, total => {
             bar.tick((BAR_SOURCE_CODE_TOTAL / total));
         });
     } catch (e) {
@@ -147,20 +145,18 @@ function configureRules(answers, config) {
     registry.populateFromCoreRules();
 
     // Lint all files with each rule config in the registry
-    registry = registry.lintSourceCode(sourceCodes, newConfig, function(total) {
+    registry = registry.lintSourceCode(sourceCodes, newConfig, total => {
         bar.tick((BAR_TOTAL - BAR_SOURCE_CODE_TOTAL) / total); // Subtract out ticks used at beginning
     });
     debug(`\nRegistry: ${util.inspect(registry.rules, {depth: null})}`);
 
     // Create a list of recommended rules, because we don't want to disable them
-    const recRules = Object.keys(recConfig.rules).filter(function(ruleId) {
-        return ConfigOps.isErrorSeverity(recConfig.rules[ruleId]);
-    });
+    const recRules = Object.keys(recConfig.rules).filter(ruleId => ConfigOps.isErrorSeverity(recConfig.rules[ruleId]));
 
     // Find and disable rules which had no error-free configuration
     const failingRegistry = registry.getFailingRulesRegistry();
 
-    Object.keys(failingRegistry.rules).forEach(function(ruleId) {
+    Object.keys(failingRegistry.rules).forEach(ruleId => {
 
         // If the rule is recommended, set it to error, otherwise disable it
         disabledConfigs[ruleId] = (recRules.indexOf(ruleId) !== -1) ? 2 : 0;
@@ -194,9 +190,7 @@ function configureRules(answers, config) {
     // Log out some stats to let the user know what happened
     const finalRuleIds = Object.keys(newConfig.rules);
     const totalRules = finalRuleIds.length;
-    const enabledRules = finalRuleIds.filter(function(ruleId) {
-        return (newConfig.rules[ruleId] !== 0);
-    }).length;
+    const enabledRules = finalRuleIds.filter(ruleId => (newConfig.rules[ruleId] !== 0)).length;
     const resultMessage = [
         `\nEnabled ${enabledRules} out of ${totalRules}`,
         `rules based on ${fileQty}`,
@@ -227,7 +221,7 @@ function processAnswers(answers) {
     if (answers.commonjs) {
         config.env.commonjs = true;
     }
-    answers.env.forEach(function(env) {
+    answers.env.forEach(env => {
         config.env[env] = true;
     });
     if (answers.jsx) {
@@ -335,7 +329,7 @@ function promptUser(callback) {
                 return ((answers.source === "guide" && answers.packageJsonExists) || answers.source === "auto");
             }
         }
-    ], function(earlyAnswers) {
+    ], earlyAnswers => {
 
         // early exit if you are using a style guide
         if (earlyAnswers.source === "guide") {
@@ -384,9 +378,7 @@ function promptUser(callback) {
                 message: "Do you use CommonJS?",
                 default: false,
                 when(answers) {
-                    return answers.env.some(function(env) {
-                        return env === "browser";
-                    });
+                    return answers.env.some(env => env === "browser");
                 }
             },
             {
@@ -404,7 +396,7 @@ function promptUser(callback) {
                     return answers.jsx;
                 }
             }
-        ], function(secondAnswers) {
+        ], secondAnswers => {
 
             // early exit if you are using automatic style generation
             if (earlyAnswers.source === "auto") {
@@ -457,7 +449,7 @@ function promptUser(callback) {
                     default: "JavaScript",
                     choices: ["JavaScript", "YAML", "JSON"]
                 }
-            ], function(answers) {
+            ], answers => {
                 try {
                     const totalAnswers = Object.assign({}, earlyAnswers, secondAnswers, answers);
 

--- a/lib/config/config-ops.js
+++ b/lib/config/config-ops.js
@@ -18,7 +18,7 @@ const debug = require("debug")("eslint:config-ops");
 //------------------------------------------------------------------------------
 
 const RULE_SEVERITY_STRINGS = ["off", "warn", "error"],
-    RULE_SEVERITY = RULE_SEVERITY_STRINGS.reduce(function(map, value, index) {
+    RULE_SEVERITY = RULE_SEVERITY_STRINGS.reduce((map, value, index) => {
         map[value] = index;
         return map;
     }, {}),
@@ -57,9 +57,7 @@ module.exports = {
 
             envConfig.env = env;
 
-            Object.keys(env).filter(function(name) {
-                return env[name];
-            }).forEach(function(name) {
+            Object.keys(env).filter(name => env[name]).forEach(name => {
                 const environment = Environments.get(name);
 
                 if (environment) {
@@ -149,7 +147,7 @@ module.exports = {
             if (typeof src !== "object" && !Array.isArray(src)) {
                 src = [src];
             }
-            Object.keys(src).forEach(function(e, i) {
+            Object.keys(src).forEach((e, i) => {
                 e = src[i];
                 if (typeof dst[i] === "undefined") {
                     dst[i] = e;
@@ -171,11 +169,11 @@ module.exports = {
             });
         } else {
             if (target && typeof target === "object") {
-                Object.keys(target).forEach(function(key) {
+                Object.keys(target).forEach(key => {
                     dst[key] = target[key];
                 });
             }
-            Object.keys(src).forEach(function(key) {
+            Object.keys(src).forEach(key => {
                 if (Array.isArray(src[key]) || Array.isArray(target[key])) {
                     dst[key] = deepmerge(target[key], src[key], key === "plugins", isRule);
                 } else if (typeof src[key] !== "object" || !src[key] || key === "exported" || key === "astGlobals") {
@@ -199,7 +197,7 @@ module.exports = {
     normalize(config) {
 
         if (config.rules) {
-            Object.keys(config.rules).forEach(function(ruleId) {
+            Object.keys(config.rules).forEach(ruleId => {
                 const ruleConfig = config.rules[ruleId];
 
                 if (typeof ruleConfig === "string") {
@@ -221,7 +219,7 @@ module.exports = {
     normalizeToStrings(config) {
 
         if (config.rules) {
-            Object.keys(config.rules).forEach(function(ruleId) {
+            Object.keys(config.rules).forEach(ruleId => {
                 const ruleConfig = config.rules[ruleId];
 
                 if (typeof ruleConfig === "number") {

--- a/lib/config/config-rule.js
+++ b/lib/config/config-rule.js
@@ -23,7 +23,7 @@ const rules = require("../rules"),
  * @returns {Array[]}    An array of arrays.
  */
 function explodeArray(xs) {
-    return xs.reduce(function(accumulator, x) {
+    return xs.reduce((accumulator, x) => {
         accumulator.push([x]);
         return accumulator;
     }, []);
@@ -49,8 +49,8 @@ function combineArrays(arr1, arr2) {
     if (arr2.length === 0) {
         return explodeArray(arr1);
     }
-    arr1.forEach(function(x1) {
-        arr2.forEach(function(x2) {
+    arr1.forEach(x1 => {
+        arr2.forEach(x2 => {
             res.push([].concat(x1, x2));
         });
     });
@@ -78,16 +78,14 @@ function combineArrays(arr1, arr2) {
  * @returns {Array[]}          Array of arrays of objects grouped by property
  */
 function groupByProperty(objects) {
-    const groupedObj = objects.reduce(function(accumulator, obj) {
+    const groupedObj = objects.reduce((accumulator, obj) => {
         const prop = Object.keys(obj)[0];
 
         accumulator[prop] = accumulator[prop] ? accumulator[prop].concat(obj) : [obj];
         return accumulator;
     }, {});
 
-    return Object.keys(groupedObj).map(function(prop) {
-        return groupedObj[prop];
-    });
+    return Object.keys(groupedObj).map(prop => groupedObj[prop]);
 }
 
 
@@ -152,16 +150,16 @@ function combinePropertyObjects(objArr1, objArr2) {
     if (objArr2.length === 0) {
         return objArr1;
     }
-    objArr1.forEach(function(obj1) {
-        objArr2.forEach(function(obj2) {
+    objArr1.forEach(obj1 => {
+        objArr2.forEach(obj2 => {
             const combinedObj = {};
             const obj1Props = Object.keys(obj1);
             const obj2Props = Object.keys(obj2);
 
-            obj1Props.forEach(function(prop1) {
+            obj1Props.forEach(prop1 => {
                 combinedObj[prop1] = obj1[prop1];
             });
-            obj2Props.forEach(function(prop2) {
+            obj2Props.forEach(prop2 => {
                 combinedObj[prop2] = obj2[prop2];
             });
             res.push(combinedObj);
@@ -205,7 +203,7 @@ RuleConfigSet.prototype = {
     addErrorSeverity(severity) {
         severity = severity || 2;
 
-        this.ruleConfigs = this.ruleConfigs.map(function(config) {
+        this.ruleConfigs = this.ruleConfigs.map(config => {
             config.unshift(severity);
             return config;
         });
@@ -241,9 +239,7 @@ RuleConfigSet.prototype = {
             },
 
             combine() {
-                this.objectConfigs = groupByProperty(this.objectConfigs).reduce(function(accumulator, objArr) {
-                    return combinePropertyObjects(accumulator, objArr);
-                }, []);
+                this.objectConfigs = groupByProperty(this.objectConfigs).reduce((accumulator, objArr) => combinePropertyObjects(accumulator, objArr), []);
             }
         };
 
@@ -251,7 +247,7 @@ RuleConfigSet.prototype = {
          * The object schema could have multiple independent properties.
          * If any contain enums or booleans, they can be added and then combined
          */
-        Object.keys(obj.properties).forEach(function(prop) {
+        Object.keys(obj.properties).forEach(prop => {
             if (obj.properties[prop].enum) {
                 objectConfigSet.add(prop, obj.properties[prop].enum);
             }
@@ -276,7 +272,7 @@ function generateConfigsFromSchema(schema) {
     const configSet = new RuleConfigSet();
 
     if (Array.isArray(schema)) {
-        schema.forEach(function(opt) {
+        schema.forEach(opt => {
             if (opt.enum) {
                 configSet.addEnums(opt.enum);
             }
@@ -302,7 +298,7 @@ function generateConfigsFromSchema(schema) {
 function createCoreRuleConfigs() {
     const ruleList = loadRules();
 
-    return Object.keys(ruleList).reduce(function(accumulator, id) {
+    return Object.keys(ruleList).reduce((accumulator, id) => {
         const rule = rules.get(id);
         const schema = (typeof rule === "function") ? rule.schema : rule.meta.schema;
 

--- a/lib/config/config-validator.js
+++ b/lib/config/config-validator.js
@@ -105,7 +105,7 @@ function validateRuleOptions(id, options, source) {
         }
 
         if (validateRule && validateRule.errors) {
-            validateRule.errors.forEach(function(error) {
+            validateRule.errors.forEach(error => {
                 message.push(
                     "\tValue \"", error.value, "\" ", error.message, ".\n"
                 );
@@ -134,7 +134,7 @@ function validateEnvironment(environment, source) {
     }
 
     if (typeof environment === "object") {
-        Object.keys(environment).forEach(function(env) {
+        Object.keys(environment).forEach(env => {
             if (!Environments.get(env)) {
                 const message = [
                     source, ":\n",
@@ -158,7 +158,7 @@ function validateEnvironment(environment, source) {
 function validate(config, source) {
 
     if (typeof config.rules === "object") {
-        Object.keys(config.rules).forEach(function(id) {
+        Object.keys(config.rules).forEach(id => {
             validateRuleOptions(id, config.rules[id], source);
         });
     }

--- a/lib/config/environments.js
+++ b/lib/config/environments.js
@@ -22,7 +22,7 @@ let environments = new Map();
  * @private
  */
 function load() {
-    Object.keys(envs).forEach(function(envName) {
+    Object.keys(envs).forEach(envName => {
         environments.set(envName, envs[envName]);
     });
 }

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -57,7 +57,7 @@ function parseBooleanConfig(string, comment) {
     // Collapse whitespace around `:` and `,` to make parsing easier
     string = string.replace(/\s*([:,])\s*/g, "$1");
 
-    string.split(/\s|,+/).forEach(function(name) {
+    string.split(/\s|,+/).forEach(name => {
         if (!name) {
             return;
         }
@@ -138,7 +138,7 @@ function parseListConfig(string) {
     // Collapse whitespace around ,
     string = string.replace(/\s*,\s*/g, ",");
 
-    string.split(/,+/).forEach(function(name) {
+    string.split(/,+/).forEach(name => {
         name = name.trim();
         if (!name) {
             return;
@@ -165,7 +165,7 @@ function addDeclaredGlobals(program, globalScope, config) {
 
     Object.assign(declaredGlobals, builtin);
 
-    Object.keys(config.env).forEach(function(name) {
+    Object.keys(config.env).forEach(name => {
         if (config.env[name]) {
             const env = Environments.get(name),
                 environmentGlobals = env && env.globals;
@@ -180,7 +180,7 @@ function addDeclaredGlobals(program, globalScope, config) {
     Object.assign(declaredGlobals, config.globals);
     Object.assign(explicitGlobals, config.astGlobals);
 
-    Object.keys(declaredGlobals).forEach(function(name) {
+    Object.keys(declaredGlobals).forEach(name => {
         let variable = globalScope.set.get(name);
 
         if (!variable) {
@@ -192,7 +192,7 @@ function addDeclaredGlobals(program, globalScope, config) {
         variable.writeable = declaredGlobals[name];
     });
 
-    Object.keys(explicitGlobals).forEach(function(name) {
+    Object.keys(explicitGlobals).forEach(name => {
         let variable = globalScope.set.get(name);
 
         if (!variable) {
@@ -206,7 +206,7 @@ function addDeclaredGlobals(program, globalScope, config) {
     });
 
     // mark all exported variables as such
-    Object.keys(exportedGlobals).forEach(function(name) {
+    Object.keys(exportedGlobals).forEach(name => {
         const variable = globalScope.set.get(name);
 
         if (variable) {
@@ -219,7 +219,7 @@ function addDeclaredGlobals(program, globalScope, config) {
      * Since we augment the global scope using configuration, we need to update
      * references and remove the ones that were added by configuration.
      */
-    globalScope.through = globalScope.through.filter(function(reference) {
+    globalScope.through = globalScope.through.filter(reference => {
         const name = reference.identifier.name;
         const variable = globalScope.set.get(name);
 
@@ -250,7 +250,7 @@ function addDeclaredGlobals(program, globalScope, config) {
 function disableReporting(reportingConfig, start, rulesToDisable) {
 
     if (rulesToDisable.length) {
-        rulesToDisable.forEach(function(rule) {
+        rulesToDisable.forEach(rule => {
             reportingConfig.push({
                 start,
                 end: null,
@@ -278,7 +278,7 @@ function enableReporting(reportingConfig, start, rulesToEnable) {
     let i;
 
     if (rulesToEnable.length) {
-        rulesToEnable.forEach(function(rule) {
+        rulesToEnable.forEach(rule => {
             for (i = reportingConfig.length - 1; i >= 0; i--) {
                 if (!reportingConfig[i].end && reportingConfig[i].rule === rule) {
                     reportingConfig[i].end = start;
@@ -325,7 +325,7 @@ function modifyConfigsFromComments(filename, ast, config, reportingConfig, messa
     };
     const commentRules = {};
 
-    ast.comments.forEach(function(comment) {
+    ast.comments.forEach(comment => {
 
         let value = comment.value.trim();
         const match = /^(eslint(-\w+){0,3}|exported|globals?)(\s|$)/.exec(value);
@@ -359,7 +359,7 @@ function modifyConfigsFromComments(filename, ast, config, reportingConfig, messa
                     case "eslint": {
                         const items = parseJsonConfig(value, comment.loc, messages);
 
-                        Object.keys(items).forEach(function(name) {
+                        Object.keys(items).forEach(name => {
                             const ruleValue = items[name];
 
                             validator.validateRuleOptions(name, ruleValue, `${filename} line ${comment.loc.start.line}`);
@@ -383,7 +383,7 @@ function modifyConfigsFromComments(filename, ast, config, reportingConfig, messa
     });
 
     // apply environment configs
-    Object.keys(commentConfig.env).forEach(function(name) {
+    Object.keys(commentConfig.env).forEach(name => {
         const env = Environments.get(name);
 
         if (env) {
@@ -454,7 +454,7 @@ function prepareConfig(config) {
     let parserOptions = {};
 
     if (typeof config.rules === "object") {
-        Object.keys(config.rules).forEach(function(k) {
+        Object.keys(config.rules).forEach(k => {
             const rule = config.rules[k];
 
             if (rule === null) {
@@ -470,7 +470,7 @@ function prepareConfig(config) {
 
     // merge in environment parserOptions
     if (typeof config.env === "object") {
-        Object.keys(config.env).forEach(function(envName) {
+        Object.keys(config.env).forEach(envName => {
             const env = Environments.get(envName);
 
             if (config.env[envName] && env && env.parserOptions) {
@@ -797,7 +797,7 @@ module.exports = (function() {
             }
 
             parseResult = parse(
-                stripUnicodeBOM(text).replace(/^#!([^\r\n]+)/, function(match, captured) {
+                stripUnicodeBOM(text).replace(/^#!([^\r\n]+)/, (match, captured) => {
                     shebang = captured;
                     return `//${captured}`;
                 }),
@@ -834,9 +834,7 @@ module.exports = (function() {
             ConfigOps.normalize(config);
 
             // enable appropriate rules
-            Object.keys(config.rules).filter(function(key) {
-                return getRuleSeverity(config.rules[key]) > 0;
-            }).forEach(function(key) {
+            Object.keys(config.rules).filter(key => getRuleSeverity(config.rules[key]) > 0).forEach(key => {
                 let ruleCreator;
 
                 ruleCreator = rules.get(key);
@@ -867,7 +865,7 @@ module.exports = (function() {
                         ruleCreator(ruleContext);
 
                     // add all the node types as listeners
-                    Object.keys(rule).forEach(function(nodeType) {
+                    Object.keys(rule).forEach(nodeType => {
                         api.on(nodeType, timing.enabled
                             ? timing.time(key, rule[nodeType])
                             : rule[nodeType]
@@ -933,7 +931,7 @@ module.exports = (function() {
         }
 
         // sort by line and column
-        messages.sort(function(a, b) {
+        messages.sort((a, b) => {
             const lineDiff = a.line - b.line;
 
             if (lineDiff === 0) {
@@ -986,7 +984,7 @@ module.exports = (function() {
         }
 
         if (opts) {
-            message = message.replace(/\{\{\s*([^{}]+?)\s*\}\}/g, function(fullMatch, term) {
+            message = message.replace(/\{\{\s*([^{}]+?)\s*\}\}/g, (fullMatch, term) => {
                 if (term in opts) {
                     return opts[term];
                 }
@@ -1056,7 +1054,7 @@ module.exports = (function() {
     };
 
     // copy over methods
-    Object.keys(externalMethods).forEach(function(methodName) {
+    Object.keys(externalMethods).forEach(methodName => {
         const exMethodName = externalMethods[methodName];
 
         // All functions expected to have less arguments than 5.
@@ -1181,7 +1179,7 @@ module.exports = (function() {
      * @returns {void}
      */
     api.defineRules = function(rulesToDefine) {
-        Object.getOwnPropertyNames(rulesToDefine).forEach(function(ruleId) {
+        Object.getOwnPropertyNames(rulesToDefine).forEach(ruleId => {
             defineRule(ruleId, rulesToDefine[ruleId]);
         });
     };

--- a/lib/file-finder.js
+++ b/lib/file-finder.js
@@ -57,7 +57,7 @@ function FileFinder(files, cwd) {
 function normalizeDirectoryEntries(entries, directory, supportedConfigs) {
     const fileHash = {};
 
-    entries.forEach(function(entry) {
+    entries.forEach(entry => {
         if (supportedConfigs.indexOf(entry) >= 0) {
             const resolvedEntry = path.resolve(directory, entry);
 

--- a/lib/formatters/checkstyle.js
+++ b/lib/formatters/checkstyle.js
@@ -35,12 +35,12 @@ module.exports = function(results) {
     output += "<?xml version=\"1.0\" encoding=\"utf-8\"?>";
     output += "<checkstyle version=\"4.3\">";
 
-    results.forEach(function(result) {
+    results.forEach(result => {
         const messages = result.messages;
 
         output += `<file name="${xmlEscape(result.filePath)}">`;
 
-        messages.forEach(function(message) {
+        messages.forEach(message => {
             output += [
                 `<error line="${xmlEscape(message.line)}"`,
                 `column="${xmlEscape(message.column)}"`,

--- a/lib/formatters/compact.js
+++ b/lib/formatters/compact.js
@@ -32,13 +32,13 @@ module.exports = function(results) {
     let output = "",
         total = 0;
 
-    results.forEach(function(result) {
+    results.forEach(result => {
 
         const messages = result.messages;
 
         total += messages.length;
 
-        messages.forEach(function(message) {
+        messages.forEach(message => {
 
             output += `${result.filePath}: `;
             output += `line ${message.line || 0}`;

--- a/lib/formatters/html.js
+++ b/lib/formatters/html.js
@@ -70,7 +70,7 @@ function renderMessages(messages, parentIndex) {
      * @param {Object} message Message.
      * @returns {string} HTML (table row) describing a message.
      */
-    return lodash.map(messages, function(message) {
+    return lodash.map(messages, message => {
         const lineNumber = message.line || 0;
         const columnNumber = message.column || 0;
 
@@ -91,15 +91,13 @@ function renderMessages(messages, parentIndex) {
  * @returns {string} HTML string describing the results.
  */
 function renderResults(results) {
-    return lodash.map(results, function(result, index) {
-        return resultTemplate({
-            index,
-            color: renderColor(result.errorCount, result.warningCount),
-            filePath: result.filePath,
-            summary: renderSummary(result.errorCount, result.warningCount)
+    return lodash.map(results, (result, index) => resultTemplate({
+        index,
+        color: renderColor(result.errorCount, result.warningCount),
+        filePath: result.filePath,
+        summary: renderSummary(result.errorCount, result.warningCount)
 
-        }) + renderMessages(result.messages, index);
-    }).join("\n");
+    }) + renderMessages(result.messages, index)).join("\n");
 }
 
 //------------------------------------------------------------------------------
@@ -114,7 +112,7 @@ module.exports = function(results) {
     totalWarnings = 0;
 
     // Iterate over results to get totals
-    results.forEach(function(result) {
+    results.forEach(result => {
         totalErrors += result.errorCount;
         totalWarnings += result.warningCount;
     });

--- a/lib/formatters/jslint-xml.js
+++ b/lib/formatters/jslint-xml.js
@@ -17,12 +17,12 @@ module.exports = function(results) {
     output += "<?xml version=\"1.0\" encoding=\"utf-8\"?>";
     output += "<jslint>";
 
-    results.forEach(function(result) {
+    results.forEach(result => {
         const messages = result.messages;
 
         output += `<file name="${result.filePath}">`;
 
-        messages.forEach(function(message) {
+        messages.forEach(message => {
             output += [
                 `<issue line="${message.line}"`,
                 `char="${message.column}"`,

--- a/lib/formatters/junit.js
+++ b/lib/formatters/junit.js
@@ -35,7 +35,7 @@ module.exports = function(results) {
     output += "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n";
     output += "<testsuites>\n";
 
-    results.forEach(function(result) {
+    results.forEach(result => {
 
         const messages = result.messages;
 
@@ -43,7 +43,7 @@ module.exports = function(results) {
             output += `<testsuite package="org.eslint" time="0" tests="${messages.length}" errors="${messages.length}" name="${result.filePath}">\n`;
         }
 
-        messages.forEach(function(message) {
+        messages.forEach(message => {
             const type = message.fatal ? "error" : "failure";
 
             output += `<testcase time="0" name="org.eslint.${message.ruleId || "unknown"}">`;

--- a/lib/formatters/stylish.js
+++ b/lib/formatters/stylish.js
@@ -33,7 +33,7 @@ module.exports = function(results) {
         warnings = 0,
         summaryColor = "yellow";
 
-    results.forEach(function(result) {
+    results.forEach(result => {
         const messages = result.messages;
 
         if (messages.length === 0) {
@@ -44,7 +44,7 @@ module.exports = function(results) {
         output += `${chalk.underline(result.filePath)}\n`;
 
         output += `${table(
-            messages.map(function(message) {
+            messages.map(message => {
                 let messageType;
 
                 if (message.fatal || message.severity === 2) {
@@ -71,11 +71,7 @@ module.exports = function(results) {
                     return chalk.stripColor(str).length;
                 }
             }
-        ).split("\n").map(function(el) {
-            return el.replace(/(\d+)\s+(\d+)/, function(m, p1, p2) {
-                return chalk.dim(`${p1}:${p2}`);
-            });
-        }).join("\n")}\n\n`;
+        ).split("\n").map(el => el.replace(/(\d+)\s+(\d+)/, (m, p1, p2) => chalk.dim(`${p1}:${p2}`))).join("\n")}\n\n`;
     });
 
     if (total > 0) {

--- a/lib/formatters/table.js
+++ b/lib/formatters/table.js
@@ -36,7 +36,7 @@ function drawTable(messages) {
         chalk.bold("Rule ID")
     ]);
 
-    messages.forEach(function(message) {
+    messages.forEach(message => {
         let messageType;
 
         if (message.fatal || message.severity === 2) {
@@ -92,7 +92,7 @@ function drawTable(messages) {
 function drawReport(results) {
     let files;
 
-    files = results.map(function(result) {
+    files = results.map(result => {
         if (!result.messages.length) {
             return "";
         }
@@ -100,9 +100,7 @@ function drawReport(results) {
         return `\n${result.filePath}\n\n${drawTable(result.messages)}`;
     });
 
-    files = files.filter(function(content) {
-        return content.trim();
-    });
+    files = files.filter(content => content.trim());
 
     return files.join("");
 }
@@ -120,7 +118,7 @@ module.exports = function(report) {
     errorCount = 0;
     warningCount = 0;
 
-    report.forEach(function(fileReport) {
+    report.forEach(fileReport => {
         errorCount += fileReport.errorCount;
         warningCount += fileReport.warningCount;
     });

--- a/lib/formatters/tap.js
+++ b/lib/formatters/tap.js
@@ -44,7 +44,7 @@ function outputDiagnostics(diagnostic) {
 module.exports = function(results) {
     let output = `TAP version 13\n1..${results.length}\n`;
 
-    results.forEach(function(result, id) {
+    results.forEach((result, id) => {
         const messages = result.messages;
         let testResult = "ok";
         let diagnostics = {};
@@ -52,7 +52,7 @@ module.exports = function(results) {
         if (messages.length > 0) {
             testResult = "not ok";
 
-            messages.forEach(function(message) {
+            messages.forEach(message => {
                 const diagnostic = {
                     message: message.message,
                     severity: getMessageType(message),

--- a/lib/formatters/unix.js
+++ b/lib/formatters/unix.js
@@ -31,13 +31,13 @@ module.exports = function(results) {
     let output = "",
         total = 0;
 
-    results.forEach(function(result) {
+    results.forEach(result => {
 
         const messages = result.messages;
 
         total += messages.length;
 
-        messages.forEach(function(message) {
+        messages.forEach(message => {
 
             output += `${result.filePath}:`;
             output += `${message.line || 0}:`;

--- a/lib/formatters/visualstudio.js
+++ b/lib/formatters/visualstudio.js
@@ -33,13 +33,13 @@ module.exports = function(results) {
     let output = "",
         total = 0;
 
-    results.forEach(function(result) {
+    results.forEach(result => {
 
         const messages = result.messages;
 
         total += messages.length;
 
-        messages.forEach(function(message) {
+        messages.forEach(message => {
 
             output += result.filePath;
             output += `(${message.line || 0}`;

--- a/lib/load-rules.js
+++ b/lib/load-rules.js
@@ -31,7 +31,7 @@ module.exports = function(rulesDir, cwd) {
 
     const rules = Object.create(null);
 
-    fs.readdirSync(rulesDir).forEach(function(file) {
+    fs.readdirSync(rulesDir).forEach(file => {
         if (path.extname(file) !== ".js") {
             return;
         }

--- a/lib/rules.js
+++ b/lib/rules.js
@@ -40,7 +40,7 @@ function define(ruleId, ruleModule) {
 function load(rulesDir, cwd) {
     const newRules = loadRules(rulesDir, cwd);
 
-    Object.keys(newRules).forEach(function(ruleId) {
+    Object.keys(newRules).forEach(ruleId => {
         define(ruleId, newRules[ruleId]);
     });
 }
@@ -53,7 +53,7 @@ function load(rulesDir, cwd) {
  */
 function importPlugin(plugin, pluginName) {
     if (plugin.rules) {
-        Object.keys(plugin.rules).forEach(function(ruleId) {
+        Object.keys(plugin.rules).forEach(ruleId => {
             const qualifiedRuleId = `${pluginName}/${ruleId}`,
                 rule = plugin.rules[ruleId];
 

--- a/lib/rules/brace-style.js
+++ b/lib/rules/brace-style.js
@@ -105,7 +105,7 @@ module.exports = {
             const blockProperties = arguments;
 
             return function(node) {
-                Array.prototype.forEach.call(blockProperties, function(blockProp) {
+                Array.prototype.forEach.call(blockProperties, blockProp => {
                     const block = node[blockProp];
 
                     if (!isBlock(block)) {

--- a/lib/rules/comma-spacing.js
+++ b/lib/rules/comma-spacing.js
@@ -141,7 +141,7 @@ module.exports = {
         function addNullElementsToIgnoreList(node) {
             let previousToken = sourceCode.getFirstToken(node);
 
-            node.elements.forEach(function(element) {
+            node.elements.forEach(element => {
                 let token;
 
                 if (element === null) {
@@ -164,7 +164,7 @@ module.exports = {
 
         return {
             "Program:exit"() {
-                tokensAndComments.forEach(function(token, i) {
+                tokensAndComments.forEach((token, i) => {
 
                     if (!isComma(token)) {
                         return;

--- a/lib/rules/comma-style.js
+++ b/lib/rules/comma-style.js
@@ -173,7 +173,7 @@ module.exports = {
                 // seed as opening [
                 let previousItemToken = sourceCode.getFirstToken(node);
 
-                items.forEach(function(item) {
+                items.forEach(item => {
                     const commaToken = item ? sourceCode.getTokenBefore(item) : previousItemToken,
                         currentItemToken = item ? sourceCode.getFirstToken(item) : sourceCode.getTokenAfter(commaToken),
                         reportItem = item || currentItemToken,

--- a/lib/rules/consistent-this.js
+++ b/lib/rules/consistent-this.js
@@ -84,16 +84,14 @@ module.exports = {
                 return;
             }
 
-            if (variable.defs.some(function(def) {
-                return def.node.type === "VariableDeclarator" &&
-                def.node.init !== null;
-            })) {
+            if (variable.defs.some(def => def.node.type === "VariableDeclarator" &&
+                def.node.init !== null)) {
                 return;
             }
 
             // The alias has been declared and not assigned: check it was
             // assigned later in the same scope.
-            if (!variable.references.some(function(reference) {
+            if (!variable.references.some(reference => {
                 const write = reference.writeExpr;
 
                 return (
@@ -102,9 +100,7 @@ module.exports = {
                     write.parent.operator === "="
                 );
             })) {
-                variable.defs.map(function(def) {
-                    return def.node;
-                }).forEach(function(node) {
+                variable.defs.map(def => def.node).forEach(node => {
                     reportBadAssignment(node, alias);
                 });
             }
@@ -117,7 +113,7 @@ module.exports = {
         function ensureWasAssigned() {
             const scope = context.getScope();
 
-            aliases.forEach(function(alias) {
+            aliases.forEach(alias => {
                 checkWasAssigned(alias, scope);
             });
         }

--- a/lib/rules/constructor-super.js
+++ b/lib/rules/constructor-super.js
@@ -262,7 +262,7 @@ module.exports = {
 
                 funcInfo.codePath.traverseSegments(
                     {first: toSegment, last: fromSegment},
-                    function(segment) {
+                    segment => {
                         const info = segInfoMap[segment.id];
                         const prevSegments = segment.prevSegments;
 

--- a/lib/rules/curly.js
+++ b/lib/rules/curly.js
@@ -337,14 +337,14 @@ module.exports = {
                  * all have braces.
                  * If all nodes shouldn't have braces, make sure they don't.
                  */
-                const expected = preparedChecks.some(function(preparedCheck) {
+                const expected = preparedChecks.some(preparedCheck => {
                     if (preparedCheck.expected !== null) {
                         return preparedCheck.expected;
                     }
                     return preparedCheck.actual;
                 });
 
-                preparedChecks.forEach(function(preparedCheck) {
+                preparedChecks.forEach(preparedCheck => {
                     preparedCheck.expected = expected;
                 });
             }
@@ -359,7 +359,7 @@ module.exports = {
         return {
             IfStatement(node) {
                 if (node.parent.type !== "IfStatement") {
-                    prepareIfChecks(node).forEach(function(preparedCheck) {
+                    prepareIfChecks(node).forEach(preparedCheck => {
                         preparedCheck.check();
                     });
                 }

--- a/lib/rules/default-case.js
+++ b/lib/rules/default-case.js
@@ -67,9 +67,7 @@ module.exports = {
                     return;
                 }
 
-                const hasDefault = node.cases.some(function(v) {
-                    return v.test === null;
-                });
+                const hasDefault = node.cases.some(v => v.test === null);
 
                 if (!hasDefault) {
 

--- a/lib/rules/global-require.js
+++ b/lib/rules/global-require.js
@@ -23,10 +23,8 @@ const ACCEPTABLE_PARENTS = [
  * @returns {Reference|null} Returns the found reference or null if none were found.
  */
 function findReference(scope, node) {
-    const references = scope.references.filter(function(reference) {
-        return reference.identifier.range[0] === node.range[0] &&
-            reference.identifier.range[1] === node.range[1];
-    });
+    const references = scope.references.filter(reference => reference.identifier.range[0] === node.range[0] &&
+            reference.identifier.range[1] === node.range[1]);
 
     /* istanbul ignore else: correctly returns null */
     if (references.length === 1) {
@@ -65,9 +63,7 @@ module.exports = {
                 const currentScope = context.getScope();
 
                 if (node.callee.name === "require" && !isShadowed(currentScope, node.callee)) {
-                    const isGoodRequire = context.getAncestors().every(function(parent) {
-                        return ACCEPTABLE_PARENTS.indexOf(parent.type) > -1;
-                    });
+                    const isGoodRequire = context.getAncestors().every(parent => ACCEPTABLE_PARENTS.indexOf(parent.type) > -1);
 
                     if (!isGoodRequire) {
                         context.report(node, "Unexpected require().");

--- a/lib/rules/handle-callback-err.js
+++ b/lib/rules/handle-callback-err.js
@@ -59,9 +59,7 @@ module.exports = {
          * @returns {array} All parameters of the given scope.
          */
         function getParameters(scope) {
-            return scope.variables.filter(function(variable) {
-                return variable.defs[0] && variable.defs[0].type === "Parameter";
-            });
+            return scope.variables.filter(variable => variable.defs[0] && variable.defs[0].type === "Parameter");
         }
 
         /**

--- a/lib/rules/id-length.js
+++ b/lib/rules/id-length.js
@@ -50,7 +50,7 @@ module.exports = {
         const maxLength = typeof options.max !== "undefined" ? options.max : Infinity;
         const properties = options.properties !== "never";
         const exceptions = (options.exceptions ? options.exceptions : [])
-            .reduce(function(obj, item) {
+            .reduce((obj, item) => {
                 obj[item] = true;
 
                 return obj;

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -684,9 +684,7 @@ module.exports = {
             let elements = (node.type === "ArrayExpression") ? node.elements : node.properties;
 
             // filter out empty elements example would be [ , 2] so remove first element as espree considers it as null
-            elements = elements.filter(function(elem) {
-                return elem !== null;
-            });
+            elements = elements.filter(elem => elem !== null);
 
             let nodeIndent;
             let elementsIndent;
@@ -819,7 +817,7 @@ module.exports = {
          * @returns {ASTNode[]} Filtered elements
          */
         function filterOutSameLineVars(node) {
-            return node.declarations.reduce(function(finalCollection, elem) {
+            return node.declarations.reduce((finalCollection, elem) => {
                 const lastElem = finalCollection[finalCollection.length - 1];
 
                 if ((elem.loc.start.line !== node.loc.start.line && !lastElem) ||

--- a/lib/rules/key-spacing.js
+++ b/lib/rules/key-spacing.js
@@ -514,7 +514,7 @@ module.exports = {
                 return [node.properties];
             }
 
-            return node.properties.reduce(function(groups, property) {
+            return node.properties.reduce((groups, property) => {
                 const currentGroup = last(groups),
                     prev = last(currentGroup);
 
@@ -579,7 +579,7 @@ module.exports = {
          * @returns {void}
          */
         function verifyAlignment(node) {
-            createGroups(node).forEach(function(group) {
+            createGroups(node).forEach(group => {
                 verifyGroupAlignment(group.filter(isKeyValueProperty));
             });
         }

--- a/lib/rules/keyword-spacing.js
+++ b/lib/rules/keyword-spacing.js
@@ -81,7 +81,7 @@ module.exports = {
                     after: {type: "boolean"},
                     overrides: {
                         type: "object",
-                        properties: KEYS.reduce(function(retv, key) {
+                        properties: KEYS.reduce((retv, key) => {
                             retv[key] = {
                                 type: "object",
                                 properties: {

--- a/lib/rules/lines-around-comment.js
+++ b/lib/rules/lines-around-comment.js
@@ -21,16 +21,10 @@ const lodash = require("lodash"),
  * @returns {Array} An array of line numbers.
  */
 function getEmptyLineNums(lines) {
-    const emptyLines = lines.map(function(line, i) {
-        return {
-            code: line.trim(),
-            num: i + 1
-        };
-    }).filter(function(line) {
-        return !line.code;
-    }).map(function(line) {
-        return line.num;
-    });
+    const emptyLines = lines.map((line, i) => ({
+        code: line.trim(),
+        num: i + 1
+    })).filter(line => !line.code).map(line => line.num);
 
     return emptyLines;
 }
@@ -43,7 +37,7 @@ function getEmptyLineNums(lines) {
 function getCommentLineNums(comments) {
     const lines = [];
 
-    comments.forEach(function(token) {
+    comments.forEach(token => {
         const start = token.loc.start.line;
         const end = token.loc.end.line;
 

--- a/lib/rules/max-len.js
+++ b/lib/rules/max-len.js
@@ -103,7 +103,7 @@ module.exports = {
         function computeLineLength(line, tabWidth) {
             let extraCharacterCount = 0;
 
-            line.replace(/\t/g, function(match, offset) {
+            line.replace(/\t/g, (match, offset) => {
                 const totalOffset = offset + extraCharacterCount,
                     previousTabStopOffset = tabWidth ? totalOffset % tabWidth : 0,
                     spaceCount = tabWidth - previousTabStopOffset;
@@ -213,9 +213,7 @@ module.exports = {
          * @returns {ASTNode[]} An array of string nodes.
          */
         function getAllStrings() {
-            return sourceCode.ast.tokens.filter(function(token) {
-                return token.type === "String";
-            });
+            return sourceCode.ast.tokens.filter(token => token.type === "String");
         }
 
         /**
@@ -224,9 +222,7 @@ module.exports = {
          * @returns {ASTNode[]} An array of template literal nodes.
          */
         function getAllTemplateLiterals() {
-            return sourceCode.ast.tokens.filter(function(token) {
-                return token.type === "Template";
-            });
+            return sourceCode.ast.tokens.filter(token => token.type === "Template");
         }
 
 
@@ -236,9 +232,7 @@ module.exports = {
          * @returns {ASTNode[]} An array of RegExp literal nodes.
          */
         function getAllRegExpLiterals() {
-            return sourceCode.ast.tokens.filter(function(token) {
-                return token.type === "RegularExpression";
-            });
+            return sourceCode.ast.tokens.filter(token => token.type === "RegularExpression");
         }
 
 
@@ -283,7 +277,7 @@ module.exports = {
             const regExpLiterals = getAllRegExpLiterals(sourceCode);
             const regExpLiteralsByLine = regExpLiterals.reduce(groupByLineNumber, {});
 
-            lines.forEach(function(line, i) {
+            lines.forEach((line, i) => {
 
                 // i is zero-indexed, line numbers are one-indexed
                 const lineNumber = i + 1;

--- a/lib/rules/max-lines.js
+++ b/lib/rules/max-lines.js
@@ -114,26 +114,18 @@ module.exports = {
 
         return {
             "Program:exit"() {
-                let lines = sourceCode.lines.map(function(text, i) {
-                    return { lineNumber: i + 1, text };
-                });
+                let lines = sourceCode.lines.map((text, i) => ({ lineNumber: i + 1, text }));
 
                 if (skipBlankLines) {
-                    lines = lines.filter(function(l) {
-                        return l.text.trim() !== "";
-                    });
+                    lines = lines.filter(l => l.text.trim() !== "");
                 }
 
                 if (skipComments) {
                     const comments = sourceCode.getAllComments();
 
-                    const commentLines = lodash.flatten(comments.map(function(comment) {
-                        return getLinesWithoutCode(comment);
-                    }));
+                    const commentLines = lodash.flatten(comments.map(comment => getLinesWithoutCode(comment)));
 
-                    lines = lines.filter(function(l) {
-                        return !lodash.includes(commentLines, l.lineNumber);
-                    });
+                    lines = lines.filter(l => !lodash.includes(commentLines, l.lineNumber));
                 }
 
                 if (lines.length > max) {

--- a/lib/rules/max-statements.js
+++ b/lib/rules/max-statements.js
@@ -146,7 +146,7 @@ module.exports = {
                     return;
                 }
 
-                topLevelFunctions.forEach(function(element) {
+                topLevelFunctions.forEach(element => {
                     const count = element.count;
                     const node = element.node;
 

--- a/lib/rules/newline-after-var.js
+++ b/lib/rules/newline-after-var.js
@@ -37,7 +37,7 @@ module.exports = {
         const mode = context.options[0] === "never" ? "never" : "always";
 
         // Cache starting and ending line numbers of comments for faster lookup
-        const commentEndLine = sourceCode.getAllComments().reduce(function(result, token) {
+        const commentEndLine = sourceCode.getAllComments().reduce((result, token) => {
             result[token.loc.start.line] = token.loc.end.line;
             return result;
         }, {});

--- a/lib/rules/newline-before-return.js
+++ b/lib/rules/newline-before-return.js
@@ -36,9 +36,7 @@ module.exports = {
         function isPrecededByTokens(node, testTokens) {
             const tokenBefore = sourceCode.getTokenBefore(node);
 
-            return testTokens.some(function(token) {
-                return tokenBefore.value === token;
-            });
+            return testTokens.some(token => tokenBefore.value === token);
         }
 
         /**
@@ -82,7 +80,7 @@ module.exports = {
                 return numLinesComments;
             }
 
-            comments.forEach(function(comment) {
+            comments.forEach(comment => {
                 numLinesComments++;
 
                 if (comment.type === "Block") {

--- a/lib/rules/no-alert.js
+++ b/lib/rules/no-alert.js
@@ -41,10 +41,8 @@ function report(context, node, identifierName) {
  * @returns {Reference|null} Returns the found reference or null if none were found.
  */
 function findReference(scope, node) {
-    const references = scope.references.filter(function(reference) {
-        return reference.identifier.range[0] === node.range[0] &&
-            reference.identifier.range[1] === node.range[1];
-    });
+    const references = scope.references.filter(reference => reference.identifier.range[0] === node.range[0] &&
+            reference.identifier.range[1] === node.range[1]);
 
     if (references.length === 1) {
         return references[0];

--- a/lib/rules/no-class-assign.js
+++ b/lib/rules/no-class-assign.js
@@ -30,7 +30,7 @@ module.exports = {
          * @returns {void}
          */
         function checkVariable(variable) {
-            astUtils.getModifyingReferences(variable.references).forEach(function(reference) {
+            astUtils.getModifyingReferences(variable.references).forEach(reference => {
                 context.report(
                     reference.identifier,
                     "'{{name}}' is a class.",

--- a/lib/rules/no-const-assign.js
+++ b/lib/rules/no-const-assign.js
@@ -30,7 +30,7 @@ module.exports = {
          * @returns {void}
          */
         function checkVariable(variable) {
-            astUtils.getModifyingReferences(variable.references).forEach(function(reference) {
+            astUtils.getModifyingReferences(variable.references).forEach(reference => {
                 context.report(
                     reference.identifier,
                     "'{{name}}' is constant.",

--- a/lib/rules/no-control-regex.js
+++ b/lib/rules/no-control-regex.js
@@ -85,7 +85,7 @@ module.exports = {
                     stringControlChars = regexStr.slice(subStrIndex, -1)
                         .split(consecutiveSlashes)
                         .filter(Boolean)
-                        .map(function(x) {
+                        .map(x => {
                             const match = x.match(stringControlCharWithoutSlash) || [x];
 
                             return `\\${match[0]}`;
@@ -93,7 +93,7 @@ module.exports = {
                 }
             }
 
-            return controlChars.map(function(x) {
+            return controlChars.map(x => {
                 const hexCode = `0${x.charCodeAt(0).toString(16)}`.slice(-2);
 
                 return `\\x${hexCode}`;

--- a/lib/rules/no-duplicate-case.js
+++ b/lib/rules/no-duplicate-case.js
@@ -28,7 +28,7 @@ module.exports = {
             SwitchStatement(node) {
                 const mapping = {};
 
-                node.cases.forEach(function(switchCase) {
+                node.cases.forEach(switchCase => {
                     const key = sourceCode.getText(switchCase.test);
 
                     if (mapping[key]) {

--- a/lib/rules/no-ex-assign.js
+++ b/lib/rules/no-ex-assign.js
@@ -30,7 +30,7 @@ module.exports = {
          * @returns {void}
          */
         function checkVariable(variable) {
-            astUtils.getModifyingReferences(variable.references).forEach(function(reference) {
+            astUtils.getModifyingReferences(variable.references).forEach(reference => {
                 context.report(
                     reference.identifier,
                     "Do not assign to the exception parameter.");

--- a/lib/rules/no-extend-native.js
+++ b/lib/rules/no-extend-native.js
@@ -44,14 +44,10 @@ module.exports = {
 
         const config = context.options[0] || {};
         const exceptions = config.exceptions || [];
-        let modifiedBuiltins = Object.keys(globals.builtin).filter(function(builtin) {
-            return builtin[0].toUpperCase() === builtin[0];
-        });
+        let modifiedBuiltins = Object.keys(globals.builtin).filter(builtin => builtin[0].toUpperCase() === builtin[0]);
 
         if (exceptions.length) {
-            modifiedBuiltins = modifiedBuiltins.filter(function(builtIn) {
-                return exceptions.indexOf(builtIn) === -1;
-            });
+            modifiedBuiltins = modifiedBuiltins.filter(builtIn => exceptions.indexOf(builtIn) === -1);
         }
 
         return {
@@ -72,7 +68,7 @@ module.exports = {
                     return;
                 }
 
-                modifiedBuiltins.forEach(function(builtin) {
+                modifiedBuiltins.forEach(builtin => {
                     if (lhs.object.object.name === builtin) {
                         context.report({
                             node,

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -352,7 +352,7 @@ module.exports = {
                     report(node.arguments[0]);
                 }
             } else {
-                [].forEach.call(node.arguments, function(arg) {
+                [].forEach.call(node.arguments, arg => {
                     if (hasExcessParens(arg) && precedence(arg) >= precedence({type: "AssignmentExpression"})) {
                         report(arg);
                     }
@@ -381,7 +381,7 @@ module.exports = {
 
         return {
             ArrayExpression(node) {
-                [].forEach.call(node.elements, function(e) {
+                [].forEach.call(node.elements, e => {
                     if (e && hasExcessParens(e) && precedence(e) >= precedence({type: "AssignmentExpression"})) {
                         report(e);
                     }
@@ -531,7 +531,7 @@ module.exports = {
             NewExpression: dryCallNew,
 
             ObjectExpression(node) {
-                [].forEach.call(node.properties, function(e) {
+                [].forEach.call(node.properties, e => {
                     const v = e.value;
 
                     if (v && hasExcessParens(v) && precedence(v) >= precedence({type: "AssignmentExpression"})) {
@@ -557,7 +557,7 @@ module.exports = {
             },
 
             SequenceExpression(node) {
-                [].forEach.call(node.expressions, function(e) {
+                [].forEach.call(node.expressions, e => {
                     if (hasExcessParens(e) && precedence(e) >= precedence(node)) {
                         report(e);
                     }

--- a/lib/rules/no-func-assign.js
+++ b/lib/rules/no-func-assign.js
@@ -30,7 +30,7 @@ module.exports = {
          * @returns {void}
          */
         function checkReference(references) {
-            astUtils.getModifyingReferences(references).forEach(function(reference) {
+            astUtils.getModifyingReferences(references).forEach(reference => {
                 context.report(
                     reference.identifier,
                     "'{{name}}' is a function.",

--- a/lib/rules/no-implicit-globals.js
+++ b/lib/rules/no-implicit-globals.js
@@ -25,26 +25,26 @@ module.exports = {
             Program() {
                 const scope = context.getScope();
 
-                scope.variables.forEach(function(variable) {
+                scope.variables.forEach(variable => {
                     if (variable.writeable) {
                         return;
                     }
 
-                    variable.defs.forEach(function(def) {
+                    variable.defs.forEach(def => {
                         if (def.type === "FunctionName" || (def.type === "Variable" && def.parent.kind === "var")) {
                             context.report(def.node, "Implicit global variable, assign as global property instead.");
                         }
                     });
                 });
 
-                scope.implicit.variables.forEach(function(variable) {
+                scope.implicit.variables.forEach(variable => {
                     const scopeVariable = scope.set.get(variable.name);
 
                     if (scopeVariable && scopeVariable.writeable) {
                         return;
                     }
 
-                    variable.defs.forEach(function(def) {
+                    variable.defs.forEach(def => {
                         context.report(def.node, "Implicit global variable, assign as global property instead.");
                     });
                 });

--- a/lib/rules/no-irregular-whitespace.js
+++ b/lib/rules/no-irregular-whitespace.js
@@ -76,7 +76,7 @@ module.exports = {
             const locStart = node.loc.start;
             const locEnd = node.loc.end;
 
-            errors = errors.filter(function(error) {
+            errors = errors.filter(error => {
                 const errorLoc = error[1];
 
                 if (errorLoc.line >= locStart.line && errorLoc.line <= locEnd.line) {
@@ -142,7 +142,7 @@ module.exports = {
         function checkForIrregularWhitespace(node) {
             const sourceLines = sourceCode.lines;
 
-            sourceLines.forEach(function(sourceLine, lineIndex) {
+            sourceLines.forEach((sourceLine, lineIndex) => {
                 const lineNumber = lineIndex + 1;
                 let match;
 
@@ -233,7 +233,7 @@ module.exports = {
                 }
 
                 // If we have any errors remaining report on them
-                errors.forEach(function(error) {
+                errors.forEach(error => {
                     context.report.apply(context, error);
                 });
             };

--- a/lib/rules/no-mixed-operators.js
+++ b/lib/rules/no-mixed-operators.js
@@ -62,9 +62,7 @@ function normalizeOptions(options) {
  * @returns {boolean} `true` if such group existed.
  */
 function includesBothInAGroup(groups, left, right) {
-    return groups.some(function(group) {
-        return group.indexOf(left) !== -1 && group.indexOf(right) !== -1;
-    });
+    return groups.some(group => group.indexOf(left) !== -1 && group.indexOf(right) !== -1);
 }
 
 //------------------------------------------------------------------------------

--- a/lib/rules/no-mixed-requires.js
+++ b/lib/rules/no-mixed-requires.js
@@ -169,7 +169,7 @@ module.exports = {
         function isMixed(declarations) {
             const contains = {};
 
-            declarations.forEach(function(declaration) {
+            declarations.forEach(declaration => {
                 const type = getDeclarationType(declaration.init);
 
                 contains[type] = true;
@@ -190,7 +190,7 @@ module.exports = {
         function isGrouped(declarations) {
             const found = {};
 
-            declarations.forEach(function(declaration) {
+            declarations.forEach(declaration => {
                 if (getDeclarationType(declaration.init) === DECL_REQUIRE) {
                     found[inferModuleType(declaration.init)] = true;
                 }

--- a/lib/rules/no-mixed-spaces-and-tabs.js
+++ b/lib/rules/no-mixed-spaces-and-tabs.js
@@ -89,11 +89,11 @@ module.exports = {
                 const lines = sourceCode.lines,
                     comments = sourceCode.getAllComments();
 
-                comments.forEach(function(comment) {
+                comments.forEach(comment => {
                     ignoredLocs.push(comment.loc);
                 });
 
-                ignoredLocs.sort(function(first, second) {
+                ignoredLocs.sort((first, second) => {
                     if (beforeLoc(first, second.start.line, second.start.column)) {
                         return 1;
                     }
@@ -114,7 +114,7 @@ module.exports = {
                     regex = /^(?=[\t ]* \t)/;
                 }
 
-                lines.forEach(function(line, i) {
+                lines.forEach((line, i) => {
                     const match = regex.exec(line);
 
                     if (match) {

--- a/lib/rules/no-multi-spaces.js
+++ b/lib/rules/no-multi-spaces.js
@@ -47,7 +47,7 @@ module.exports = {
             lastCommentIndex = 0;
 
         if (options && options.exceptions) {
-            Object.keys(options.exceptions).forEach(function(key) {
+            Object.keys(options.exceptions).forEach(key => {
                 if (options.exceptions[key]) {
                     exceptions[key] = true;
                 } else {

--- a/lib/rules/no-new-symbol.js
+++ b/lib/rules/no-new-symbol.js
@@ -28,7 +28,7 @@ module.exports = {
                 const variable = globalScope.set.get("Symbol");
 
                 if (variable && variable.defs.length === 0) {
-                    variable.references.forEach(function(ref) {
+                    variable.references.forEach(ref => {
                         const node = ref.identifier;
 
                         if (node.parent && node.parent.type === "NewExpression") {

--- a/lib/rules/no-redeclare.js
+++ b/lib/rules/no-redeclare.js
@@ -40,14 +40,12 @@ module.exports = {
          * @private
          */
         function findVariablesInScope(scope) {
-            scope.variables.forEach(function(variable) {
+            scope.variables.forEach(variable => {
                 const hasBuiltin = options.builtinGlobals && "writeable" in variable;
                 const count = (hasBuiltin ? 1 : 0) + variable.identifiers.length;
 
                 if (count >= 2) {
-                    variable.identifiers.sort(function(a, b) {
-                        return a.range[1] - b.range[1];
-                    });
+                    variable.identifiers.sort((a, b) => a.range[1] - b.range[1]);
 
                     for (let i = (hasBuiltin ? 0 : 1), l = variable.identifiers.length; i < l; i++) {
                         context.report(

--- a/lib/rules/no-restricted-globals.js
+++ b/lib/rules/no-restricted-globals.js
@@ -60,14 +60,14 @@ module.exports = {
                 const scope = context.getScope();
 
                 // Report variables declared elsewhere (ex: variables defined as "global" by eslint)
-                scope.variables.forEach(function(variable) {
+                scope.variables.forEach(variable => {
                     if (!variable.defs.length && isRestricted(variable.name)) {
                         variable.references.forEach(reportReference);
                     }
                 });
 
                 // Report variables not declared at all
-                scope.through.forEach(function(reference) {
+                scope.through.forEach(reference => {
                     if (isRestricted(reference.identifier.name)) {
                         reportReference(reference);
                     }

--- a/lib/rules/no-restricted-syntax.js
+++ b/lib/rules/no-restricted-syntax.js
@@ -22,9 +22,7 @@ module.exports = {
             type: "array",
             items: [
                 {
-                    enum: Object.keys(nodeTypes).map(function(k) {
-                        return nodeTypes[k];
-                    })
+                    enum: Object.keys(nodeTypes).map(k => nodeTypes[k])
                 }
             ],
             uniqueItems: true,
@@ -43,7 +41,7 @@ module.exports = {
             context.report(node, "Using '{{type}}' is not allowed.", node);
         }
 
-        return context.options.reduce(function(result, nodeType) {
+        return context.options.reduce((result, nodeType) => {
             result[nodeType] = warn;
 
             return result;

--- a/lib/rules/no-this-before-super.js
+++ b/lib/rules/no-this-before-super.js
@@ -179,7 +179,7 @@ module.exports = {
                     return;
                 }
 
-                codePath.traverseSegments(function(segment, controller) {
+                codePath.traverseSegments((segment, controller) => {
                     const info = segInfoMap[segment.id];
 
                     for (let i = 0; i < info.invalidNodes.length; ++i) {
@@ -237,7 +237,7 @@ module.exports = {
                 // Update information inside of the loop.
                 funcInfo.codePath.traverseSegments(
                     {first: toSegment, last: fromSegment},
-                    function(segment, controller) {
+                    (segment, controller) => {
                         const info = segInfoMap[segment.id];
 
                         if (info.superCalled) {

--- a/lib/rules/no-undef.js
+++ b/lib/rules/no-undef.js
@@ -52,7 +52,7 @@ module.exports = {
             "Program:exit"(/* node */) {
                 const globalScope = context.getScope();
 
-                globalScope.through.forEach(function(ref) {
+                globalScope.through.forEach(ref => {
                     const identifier = ref.identifier;
 
                     if (!considerTypeOf && hasTypeOfOperator(identifier)) {

--- a/lib/rules/no-underscore-dangle.js
+++ b/lib/rules/no-underscore-dangle.js
@@ -57,9 +57,7 @@ module.exports = {
          * @private
          */
         function isAllowed(identifier) {
-            return ALLOWED_VARIABLES.some(function(ident) {
-                return ident === identifier;
-            });
+            return ALLOWED_VARIABLES.some(ident => ident === identifier);
         }
 
         /**

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -390,15 +390,11 @@ module.exports = {
          * @private
          */
         function isUsedVariable(variable) {
-            const functionNodes = variable.defs.filter(function(def) {
-                    return def.type === "FunctionName";
-                }).map(function(def) {
-                    return def.node;
-                }),
+            const functionNodes = variable.defs.filter(def => def.type === "FunctionName").map(def => def.node),
                 isFunctionDefinition = functionNodes.length > 0;
             let rhsNode = null;
 
-            return variable.references.some(function(ref) {
+            return variable.references.some(ref => {
                 if (isForInRef(ref)) {
                     return true;
                 }

--- a/lib/rules/no-use-before-define.js
+++ b/lib/rules/no-use-before-define.js
@@ -187,7 +187,7 @@ module.exports = {
          * @private
          */
         function findVariablesInScope(scope) {
-            scope.references.forEach(function(reference) {
+            scope.references.forEach(reference => {
                 const variable = reference.resolved;
 
                 // Skips when the reference is:

--- a/lib/rules/no-warning-comments.js
+++ b/lib/rules/no-warning-comments.js
@@ -95,7 +95,7 @@ module.exports = {
         function commentContainsWarningTerm(comment) {
             const matches = [];
 
-            warningRegExps.forEach(function(regex, index) {
+            warningRegExps.forEach((regex, index) => {
                 if (regex.test(comment)) {
                     matches.push(warningTerms[index]);
                 }
@@ -116,7 +116,7 @@ module.exports = {
 
             const matches = commentContainsWarningTerm(node.value);
 
-            matches.forEach(function(matchedTerm) {
+            matches.forEach(matchedTerm => {
                 context.report({
                     node,
                     message: "Unexpected '{{matchedTerm}}' comment.",

--- a/lib/rules/one-var-declaration-per-line.js
+++ b/lib/rules/one-var-declaration-per-line.js
@@ -59,7 +59,7 @@ module.exports = {
             const declarations = node.declarations;
             let prev;
 
-            declarations.forEach(function(current) {
+            declarations.forEach(current => {
                 if (prev && prev.loc.end.line === current.loc.start.line) {
                     if (always || prev.init || current.init) {
                         context.report({

--- a/lib/rules/prefer-const.js
+++ b/lib/rules/prefer-const.js
@@ -270,9 +270,7 @@ module.exports = {
                     message: "'{{name}}' is never reassigned. Use 'const' instead.",
                     data: node
                 },
-                varDeclParent = findUp(node, "VariableDeclaration", function(parentNode) {
-                    return lodash.endsWith(parentNode.type, "Statement");
-                }),
+                varDeclParent = findUp(node, "VariableDeclaration", parentNode => lodash.endsWith(parentNode.type, "Statement")),
                 isNormalVarDecl = (node.parent.parent.parent.type === "ForInStatement" ||
                         node.parent.parent.parent.type === "ForOfStatement" ||
                         node.parent.init),

--- a/lib/rules/quote-props.js
+++ b/lib/rules/quote-props.js
@@ -213,7 +213,7 @@ module.exports = {
             let keywordKeyName = null,
                 necessaryQuotes = false;
 
-            node.properties.forEach(function(property) {
+            node.properties.forEach(property => {
                 const key = property.key;
                 let tokens;
 

--- a/lib/rules/quotes.js
+++ b/lib/rules/quotes.js
@@ -51,7 +51,7 @@ QUOTE_SETTINGS.backtick.convert = function(str) {
     if (newQuote === oldQuote) {
         return str;
     }
-    return newQuote + str.slice(1, -1).replace(/\\(\${|\r\n?|\n|.)|["'`]|\${|(\r\n?|\n)/g, function(match, escaped, newline) {
+    return newQuote + str.slice(1, -1).replace(/\\(\${|\r\n?|\n|.)|["'`]|\${|(\r\n?|\n)/g, (match, escaped, newline) => {
         if (escaped === oldQuote || oldQuote === "`" && escaped === "${") {
             return escaped; // unescape
         }

--- a/lib/rules/radix.js
+++ b/lib/rules/radix.js
@@ -145,7 +145,7 @@ module.exports = {
                 // Check `parseInt()`
                 variable = astUtils.getVariableByName(scope, "parseInt");
                 if (!isShadowed(variable)) {
-                    variable.references.forEach(function(reference) {
+                    variable.references.forEach(reference => {
                         const node = reference.identifier;
 
                         if (astUtils.isCallee(node)) {
@@ -157,7 +157,7 @@ module.exports = {
                 // Check `Number.parseInt()`
                 variable = astUtils.getVariableByName(scope, "Number");
                 if (!isShadowed(variable)) {
-                    variable.references.forEach(function(reference) {
+                    variable.references.forEach(reference => {
                         const node = reference.identifier.parent;
 
                         if (isParseIntMethod(node) && astUtils.isCallee(node)) {

--- a/lib/rules/sort-vars.js
+++ b/lib/rules/sort-vars.js
@@ -37,7 +37,7 @@ module.exports = {
 
         return {
             VariableDeclaration(node) {
-                node.declarations.reduce(function(memo, decl) {
+                node.declarations.reduce((memo, decl) => {
                     if (decl.id.type === "ObjectPattern" || decl.id.type === "ArrayPattern") {
                         return memo;
                     }

--- a/lib/rules/space-in-parens.js
+++ b/lib/rules/space-in-parens.js
@@ -220,7 +220,7 @@ module.exports = {
                 exceptions = getExceptions();
                 const tokens = sourceCode.tokensAndComments;
 
-                tokens.forEach(function(token, i) {
+                tokens.forEach((token, i) => {
                     const prevToken = tokens[i - 1];
                     const nextToken = tokens[i + 1];
 

--- a/lib/rules/spaced-comment.js
+++ b/lib/rules/spaced-comment.js
@@ -240,7 +240,7 @@ module.exports = {
         const config = context.options[1] || {};
         const balanced = config.block && config.block.balanced;
 
-        const styleRules = ["block", "line"].reduce(function(rule, type) {
+        const styleRules = ["block", "line"].reduce((rule, type) => {
             const markers = parseMarkersOption(config[type] && config[type].markers || config.markers);
             const exceptions = config[type] && config[type].exceptions || config.exceptions || [];
             const endNeverPattern = "[ \t]+$";

--- a/lib/rules/symbol-description.js
+++ b/lib/rules/symbol-description.js
@@ -51,7 +51,7 @@ module.exports = {
                 const variable = astUtils.getVariableByName(scope, "Symbol");
 
                 if (variable && variable.defs.length === 0) {
-                    variable.references.forEach(function(reference) {
+                    variable.references.forEach(reference => {
                         const node = reference.identifier;
 
                         if (astUtils.isCallee(node)) {

--- a/lib/rules/valid-jsdoc.js
+++ b/lib/rules/valid-jsdoc.js
@@ -202,7 +202,7 @@ module.exports = {
 
             elements.forEach(validateType.bind(null, jsdocNode));
 
-            typesToCheck.forEach(function(typeToCheck) {
+            typesToCheck.forEach(typeToCheck => {
                 if (typeToCheck.expectedType &&
                     typeToCheck.expectedType !== typeToCheck.currentType) {
                     context.report({
@@ -254,7 +254,7 @@ module.exports = {
                     return;
                 }
 
-                jsdoc.tags.forEach(function(tag) {
+                jsdoc.tags.forEach(tag => {
 
                     switch (tag.title.toLowerCase()) {
 
@@ -352,7 +352,7 @@ module.exports = {
                 const jsdocParams = Object.keys(params);
 
                 if (node.params) {
-                    node.params.forEach(function(param, i) {
+                    node.params.forEach((param, i) => {
                         if (param.type === "AssignmentPattern") {
                             param = param.left;
                         }

--- a/lib/testers/event-generator-tester.js
+++ b/lib/testers/event-generator-tester.js
@@ -44,19 +44,19 @@ module.exports = {
      * @returns {void}
      */
     testEventGeneratorInterface(instance) {
-        this.describe("should implement EventGenerator interface", function() {
-            this.it("should have `emitter` property.", function() {
+        this.describe("should implement EventGenerator interface", () => {
+            this.it("should have `emitter` property.", () => {
                 assert.equal(typeof instance.emitter, "object");
                 assert.equal(typeof instance.emitter.emit, "function");
             });
 
-            this.it("should have `enterNode` property.", function() {
+            this.it("should have `enterNode` property.", () => {
                 assert.equal(typeof instance.enterNode, "function");
             });
 
-            this.it("should have `leaveNode` property.", function() {
+            this.it("should have `leaveNode` property.", () => {
                 assert.equal(typeof instance.leaveNode, "function");
             });
-        }.bind(this));
+        });
     }
 };

--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -307,9 +307,7 @@ RuleTester.prototype = {
                 if (validateSchema.errors) {
                     throw new Error([
                         `Schema for rule ${ruleName} is invalid:`
-                    ].concat(validateSchema.errors.map(function(error) {
-                        return `\t${error.field}: ${error.message}`;
-                    })).join("\n"));
+                    ].concat(validateSchema.errors.map(error => `\t${error.field}: ${error.message}`)).join("\n"));
                 }
             }
 
@@ -321,10 +319,10 @@ RuleTester.prototype = {
              * running the rule under test.
              */
             eslint.reset();
-            eslint.on("Program", function(node) {
+            eslint.on("Program", node => {
                 beforeAST = cloneDeeplyExcludesParent(node);
 
-                eslint.on("Program:exit", function(node) {
+                eslint.on("Program:exit", node => {
                     afterAST = cloneDeeplyExcludesParent(node);
                 });
             });
@@ -488,18 +486,18 @@ RuleTester.prototype = {
          * This creates a mocha test suite and pipes all supplied info through
          * one of the templates above.
          */
-        RuleTester.describe(ruleName, function() {
-            RuleTester.describe("valid", function() {
-                test.valid.forEach(function(valid) {
-                    RuleTester.it(valid.code || valid, function() {
+        RuleTester.describe(ruleName, () => {
+            RuleTester.describe("valid", () => {
+                test.valid.forEach(valid => {
+                    RuleTester.it(valid.code || valid, () => {
                         testValidTemplate(ruleName, valid);
                     });
                 });
             });
 
-            RuleTester.describe("invalid", function() {
-                test.invalid.forEach(function(invalid) {
-                    RuleTester.it(invalid.code, function() {
+            RuleTester.describe("invalid", () => {
+                test.invalid.forEach(invalid => {
+                    RuleTester.it(invalid.code, () => {
                         testInvalidTemplate(ruleName, invalid);
                     });
                 });

--- a/lib/timing.js
+++ b/lib/timing.js
@@ -84,7 +84,11 @@ function display(data) {
         }
     });
 
-    const table = rows.map(row => row.map((cell, index) => ALIGN[index](cell, widths[index])).join(" | "));
+    const table = rows.map(row =>
+        row
+            .map((cell, index) => ALIGN[index](cell, widths[index]))
+            .join(" | ")
+    );
 
     table.splice(1, 0, widths.map((w, index) => {
         if (index !== 0 && index !== widths.length - 1) {

--- a/lib/timing.js
+++ b/lib/timing.js
@@ -54,18 +54,16 @@ const ALIGN = [alignLeft, alignRight, alignRight];
 function display(data) {
     let total = 0;
     const rows = Object.keys(data)
-        .map(function(key) {
+        .map(key => {
             const time = data[key];
 
             total += time;
             return [key, time];
         })
-        .sort(function(a, b) {
-            return b[1] - a[1];
-        })
+        .sort((a, b) => b[1] - a[1])
         .slice(0, 10);
 
-    rows.forEach(function(row) {
+    rows.forEach(row => {
         row.push(`${(row[1] * 100 / total).toFixed(1)}%`);
         row[1] = row[1].toFixed(3);
     });
@@ -74,7 +72,7 @@ function display(data) {
 
     const widths = [];
 
-    rows.forEach(function(row) {
+    rows.forEach(row => {
         const len = row.length;
 
         for (let i = 0; i < len; i++) {
@@ -86,13 +84,9 @@ function display(data) {
         }
     });
 
-    const table = rows.map(function(row) {
-        return row.map(function(cell, index) {
-            return ALIGN[index](cell, widths[index]);
-        }).join(" | ");
-    });
+    const table = rows.map(row => row.map((cell, index) => ALIGN[index](cell, widths[index])).join(" | "));
 
-    table.splice(1, 0, widths.map(function(w, index) {
+    table.splice(1, 0, widths.map((w, index) => {
         if (index !== 0 && index !== widths.length - 1) {
             w++;
         }
@@ -130,7 +124,7 @@ module.exports = (function() {
     }
 
     if (enabled) {
-        process.on("exit", function() {
+        process.on("exit", () => {
             display(data);
         });
     }

--- a/lib/util/comment-event-generator.js
+++ b/lib/util/comment-event-generator.js
@@ -20,7 +20,7 @@
  */
 function emitComments(comments, emitter, locs, eventName) {
     if (comments.length > 0) {
-        comments.forEach(function(node) {
+        comments.forEach(node => {
             const index = locs.indexOf(node.loc);
 
             if (index >= 0) {

--- a/lib/util/glob-util.js
+++ b/lib/util/glob-util.js
@@ -43,9 +43,7 @@ function processPath(options) {
     const cwd = (options && options.cwd) || process.cwd();
     let extensions = (options && options.extensions) || [".js"];
 
-    extensions = extensions.map(function(ext) {
-        return ext.charAt(0) === "." ? ext.substr(1) : ext;
-    });
+    extensions = extensions.map(ext => ext.replace(/^\./, ""));
 
     let suffix = "/**";
 
@@ -150,7 +148,7 @@ function listFilesToProcess(globPatterns, options) {
     }
 
     debug("Creating list of files to process.");
-    globPatterns.forEach(function(pattern) {
+    globPatterns.forEach(pattern => {
         const file = path.resolve(cwd, pattern);
 
         if (shell.test("-f", file)) {
@@ -170,7 +168,7 @@ function listFilesToProcess(globPatterns, options) {
                 cwd,
             };
 
-            new GlobSync(pattern, globOptions, shouldIgnore).found.forEach(function(globMatch) {
+            new GlobSync(pattern, globOptions, shouldIgnore).found.forEach(globMatch => {
                 addFile(path.resolve(cwd, globMatch), false, ignoredPaths);
             });
         }

--- a/lib/util/npm-util.js
+++ b/lib/util/npm-util.js
@@ -89,7 +89,7 @@ function check(packages, opt) {
     if (opt.dependencies && typeof fileJson.dependencies === "object") {
         deps = deps.concat(Object.keys(fileJson.dependencies));
     }
-    return packages.reduce(function(status, pkg) {
+    return packages.reduce((status, pkg) => {
         status[pkg] = deps.indexOf(pkg) !== -1;
         return status;
     }, {});

--- a/lib/util/source-code-fixer.js
+++ b/lib/util/source-code-fixer.js
@@ -72,7 +72,7 @@ SourceCodeFixer.applyFixes = function(sourceCode, messages) {
     let lastFixPos = text.length + 1,
         prefix = (sourceCode.hasBOM ? BOM : "");
 
-    messages.forEach(function(problem) {
+    messages.forEach(problem => {
         if (problem.hasOwnProperty("fix")) {
             fixes.push(problem);
         } else {
@@ -84,14 +84,12 @@ SourceCodeFixer.applyFixes = function(sourceCode, messages) {
         debug("Found fixes to apply");
 
         // sort in reverse order of occurrence
-        fixes.sort(function(a, b) {
-            return b.fix.range[1] - a.fix.range[1] || b.fix.range[0] - a.fix.range[0];
-        });
+        fixes.sort((a, b) => b.fix.range[1] - a.fix.range[1] || b.fix.range[0] - a.fix.range[0]);
 
         // split into array of characters for easier manipulation
         const chars = text.split("");
 
-        fixes.forEach(function(problem) {
+        fixes.forEach(problem => {
             const fix = problem.fix;
             let start = fix.range[0];
             const end = fix.range[1];

--- a/lib/util/source-code-util.js
+++ b/lib/util/source-code-util.js
@@ -84,14 +84,14 @@ function getSourceCodeOfFiles(patterns, options, cb) {
     debug("constructed options:", opts);
     patterns = globUtil.resolveFileGlobPatterns(patterns, opts);
 
-    const filenames = globUtil.listFilesToProcess(patterns, opts).reduce(function(files, fileInfo) {
-        return !fileInfo.ignored ? files.concat(fileInfo.filename) : files;
-    }, []);
+    const filenames = globUtil.listFilesToProcess(patterns, opts)
+        .filter(fileInfo => !fileInfo.ignored)
+        .reduce((files, fileInfo) => files.concat(fileInfo.filename), []);
 
     if (filenames.length === 0) {
         debug(`Did not find any files matching pattern(s): ${patterns}`);
     }
-    filenames.forEach(function(filename) {
+    filenames.forEach(filename => {
         const sourceCode = getSourceCodeOfFile(filename, opts);
 
         if (sourceCode) {

--- a/lib/util/source-code.js
+++ b/lib/util/source-code.js
@@ -117,7 +117,9 @@ function SourceCode(text, ast) {
      */
     this.lines = SourceCode.splitLines(this.text);
 
-    this.tokensAndComments = ast.tokens.concat(ast.comments).sort((left, right) => left.range[0] - right.range[0]);
+    this.tokensAndComments = ast.tokens
+        .concat(ast.comments)
+        .sort((left, right) => left.range[0] - right.range[0]);
 
     // create token store methods
     const tokenStore = createTokenStore(ast.tokens);

--- a/lib/util/source-code.js
+++ b/lib/util/source-code.js
@@ -117,9 +117,7 @@ function SourceCode(text, ast) {
      */
     this.lines = SourceCode.splitLines(this.text);
 
-    this.tokensAndComments = ast.tokens.concat(ast.comments).sort(function(left, right) {
-        return left.range[0] - right.range[0];
-    });
+    this.tokensAndComments = ast.tokens.concat(ast.comments).sort((left, right) => left.range[0] - right.range[0]);
 
     // create token store methods
     const tokenStore = createTokenStore(ast.tokens);

--- a/lib/util/traverser.js
+++ b/lib/util/traverser.js
@@ -46,9 +46,7 @@ function Traverser() {
  * @private
  */
 Traverser.getKeys = function(node) {
-    return Object.keys(node).filter(function(key) {
-        return KEY_BLACKLIST.indexOf(key) === -1;
-    });
+    return Object.keys(node).filter(key => KEY_BLACKLIST.indexOf(key) === -1);
 };
 
 module.exports = Traverser;

--- a/lib/util/xml-escape.js
+++ b/lib/util/xml-escape.js
@@ -15,7 +15,7 @@
  * @private
  */
 module.exports = function(s) {
-    return (`${s}`).replace(/[<>&"'\x00-\x1F\x7F\u0080-\uFFFF]/g, function(c) { // eslint-disable-line no-control-regex
+    return (`${s}`).replace(/[<>&"'\x00-\x1F\x7F\u0080-\uFFFF]/g, c => { // eslint-disable-line no-control-regex
         switch (c) {
             case "<":
                 return "&lt;";

--- a/packages/eslint-config-eslint/default.yml
+++ b/packages/eslint-config-eslint/default.yml
@@ -93,6 +93,7 @@ rules:
     no-var: "error"
     object-shorthand: "error"
     one-var-declaration-per-line: "error"
+    prefer-arrow-callback: "error"
     prefer-const: "error"
     prefer-template: "error"
     quotes: ["error", "double"]

--- a/tests/lib/api.js
+++ b/tests/lib/api.js
@@ -8,21 +8,21 @@
 const assert = require("chai").assert,
     api = require("../../lib/api");
 
-describe("api", function() {
+describe("api", () => {
 
-    it("should have RuleTester exposed", function() {
+    it("should have RuleTester exposed", () => {
         assert.isFunction(api.RuleTester);
     });
 
-    it("should have CLIEngine exposed", function() {
+    it("should have CLIEngine exposed", () => {
         assert.isFunction(api.CLIEngine);
     });
 
-    it("should have linter exposed", function() {
+    it("should have linter exposed", () => {
         assert.isObject(api.linter);
     });
 
-    it("should have SourceCode exposed", function() {
+    it("should have SourceCode exposed", () => {
         assert.isFunction(api.SourceCode);
     });
 });

--- a/tests/lib/ast-utils.js
+++ b/tests/lib/ast-utils.js
@@ -20,21 +20,21 @@ const assert = require("chai").assert,
 // Tests
 //------------------------------------------------------------------------------
 
-describe("ast-utils", function() {
+describe("ast-utils", () => {
     const filename = "filename.js";
     let sandbox;
 
-    beforeEach(function() {
+    beforeEach(() => {
         sandbox = sinon.sandbox.create();
     });
 
-    afterEach(function() {
+    afterEach(() => {
         eslint.reset();
         sandbox.verifyAndRestore();
     });
 
-    describe("isTokenOnSameLine", function() {
-        it("should return false if its not on sameline", function() {
+    describe("isTokenOnSameLine", () => {
+        it("should return false if its not on sameline", () => {
 
             /**
              * Check the node for tokens
@@ -50,7 +50,7 @@ describe("ast-utils", function() {
             eslint.verify("if(a)\n{}", {}, filename, true);
         });
 
-        it("should return true if its on sameline", function() {
+        it("should return true if its on sameline", () => {
 
             /**
              * Check the node for tokens
@@ -67,8 +67,8 @@ describe("ast-utils", function() {
         });
     });
 
-    describe("isNullOrUndefined", function() {
-        it("should return true if its null", function() {
+    describe("isNullOrUndefined", () => {
+        it("should return true if its null", () => {
 
             /**
              * Check the node for tokens
@@ -84,7 +84,7 @@ describe("ast-utils", function() {
             eslint.verify("foo.apply(null, a, b);", {}, filename, true);
         });
 
-        it("should return true if its undefined", function() {
+        it("should return true if its undefined", () => {
 
             /**
              * Check the node for tokens
@@ -100,7 +100,7 @@ describe("ast-utils", function() {
             eslint.verify("foo.apply(undefined, a, b);", {}, filename, true);
         });
 
-        it("should return false if its a number", function() {
+        it("should return false if its a number", () => {
 
             /**
              * Check the node for tokens
@@ -116,7 +116,7 @@ describe("ast-utils", function() {
             eslint.verify("foo.apply(1, a, b);", {}, filename, true);
         });
 
-        it("should return false if its a string", function() {
+        it("should return false if its a string", () => {
 
             /**
              * Check the node for tokens
@@ -132,7 +132,7 @@ describe("ast-utils", function() {
             eslint.verify("foo.apply(`test`, a, b);", {}, filename, true);
         });
 
-        it("should return false if its a boolean", function() {
+        it("should return false if its a boolean", () => {
 
             /**
              * Check the node for tokens
@@ -148,7 +148,7 @@ describe("ast-utils", function() {
             eslint.verify("foo.apply(false, a, b);", {}, filename, true);
         });
 
-        it("should return false if its an object", function() {
+        it("should return false if its an object", () => {
 
             /**
              * Check the node for tokens
@@ -165,10 +165,10 @@ describe("ast-utils", function() {
         });
     });
 
-    describe("checkReference", function() {
+    describe("checkReference", () => {
 
         // catch
-        it("should return true if reference is assigned for catch", function() {
+        it("should return true if reference is assigned for catch", () => {
 
             /**
              * Check the node for tokens
@@ -187,7 +187,7 @@ describe("ast-utils", function() {
         });
 
         // const
-        it("should return true if reference is assigned for const", function() {
+        it("should return true if reference is assigned for const", () => {
 
             /**
              * Check the node for tokens
@@ -205,7 +205,7 @@ describe("ast-utils", function() {
             eslint.verify("const a = 1; a = 2;", {ecmaFeatures: {blockBindings: true}}, filename, true);
         });
 
-        it("should return false if reference is not assigned for const", function() {
+        it("should return false if reference is not assigned for const", () => {
 
             /**
              * Check the node for tokens
@@ -224,7 +224,7 @@ describe("ast-utils", function() {
         });
 
         // class
-        it("should return true if reference is assigned for class", function() {
+        it("should return true if reference is assigned for class", () => {
 
             /**
              * Check the node for tokens
@@ -243,7 +243,7 @@ describe("ast-utils", function() {
             eslint.verify("class A { }\n A = 1;", {ecmaFeatures: {classes: true}}, filename, true);
         });
 
-        it("should return false if reference is not assigned for class", function() {
+        it("should return false if reference is not assigned for class", () => {
 
             /**
              * Check the node for tokens
@@ -262,7 +262,7 @@ describe("ast-utils", function() {
         });
     });
 
-    describe("isDirectiveComment", function() {
+    describe("isDirectiveComment", () => {
 
         /**
          * Asserts the node is NOT a directive comment
@@ -282,7 +282,7 @@ describe("ast-utils", function() {
             assert.isTrue(astUtils.isDirectiveComment(node));
         }
 
-        it("should return false if it is not a directive line comment", function() {
+        it("should return false if it is not a directive line comment", () => {
             eslint.reset();
             eslint.on("LineComment", assertFalse);
             eslint.verify("// lalala I'm a normal comment", {}, filename, true);
@@ -291,7 +291,7 @@ describe("ast-utils", function() {
             eslint.verify("//eslint is awesome", {}, filename, true);
         });
 
-        it("should return false if it is not a directive block comment", function() {
+        it("should return false if it is not a directive block comment", () => {
             eslint.reset();
             eslint.on("BlockComment", assertFalse);
             eslint.verify("/* lalala I'm a normal comment */", {}, filename, true);
@@ -300,7 +300,7 @@ describe("ast-utils", function() {
             eslint.verify("/*eSlInT is awesome*/", {}, filename, true);
         });
 
-        it("should return true if it is a directive line comment", function() {
+        it("should return true if it is a directive line comment", () => {
             eslint.reset();
             eslint.on("LineComment", assertTrue);
             eslint.verify("// eslint-disable-line no-undef", {}, filename, true);
@@ -309,7 +309,7 @@ describe("ast-utils", function() {
             eslint.verify("//eslint-directive-without-padding", {}, filename, true);
         });
 
-        it("should return true if it is a directive block comment", function() {
+        it("should return true if it is a directive block comment", () => {
             eslint.reset();
             eslint.on("BlockComment", assertTrue);
             eslint.verify("/* eslint-disable no-undef", {}, filename, true);
@@ -320,7 +320,7 @@ describe("ast-utils", function() {
         });
     });
 
-    describe("isParenthesised", function() {
+    describe("isParenthesised", () => {
         const ESPREE_CONFIG = {
             ecmaVersion: 6,
             comment: true,
@@ -329,7 +329,7 @@ describe("ast-utils", function() {
             loc: true
         };
 
-        it("should return false for not parenthesised nodes", function() {
+        it("should return false for not parenthesised nodes", () => {
             const code = "condition ? 1 : 2";
             const ast = espree.parse(code, ESPREE_CONFIG);
             const sourceCode = new SourceCode(code, ast);
@@ -337,7 +337,7 @@ describe("ast-utils", function() {
             assert.isFalse(astUtils.isParenthesised(sourceCode, ast.body[0].expression));
         });
 
-        it("should return true for not parenthesised nodes", function() {
+        it("should return true for not parenthesised nodes", () => {
             const code = "(condition ? 1 : 2)";
             const ast = espree.parse(code, ESPREE_CONFIG);
             const sourceCode = new SourceCode(code, ast);
@@ -346,29 +346,29 @@ describe("ast-utils", function() {
         });
     });
 
-    describe("isFunction", function() {
-        it("should return true for FunctionDeclaration", function() {
+    describe("isFunction", () => {
+        it("should return true for FunctionDeclaration", () => {
             const ast = espree.parse("function a() {}");
             const node = ast.body[0];
 
             assert(astUtils.isFunction(node));
         });
 
-        it("should return true for FunctionExpression", function() {
+        it("should return true for FunctionExpression", () => {
             const ast = espree.parse("(function a() {})");
             const node = ast.body[0].expression;
 
             assert(astUtils.isFunction(node));
         });
 
-        it("should return true for AllowFunctionExpression", function() {
+        it("should return true for AllowFunctionExpression", () => {
             const ast = espree.parse("(() => {})", {ecmaVersion: 6});
             const node = ast.body[0].expression;
 
             assert(astUtils.isFunction(node));
         });
 
-        it("should return false for Program, VariableDeclaration, BlockStatement", function() {
+        it("should return false for Program, VariableDeclaration, BlockStatement", () => {
             const ast = espree.parse("var a; { }");
 
             assert(!astUtils.isFunction(ast));
@@ -377,43 +377,43 @@ describe("ast-utils", function() {
         });
     });
 
-    describe("isLoop", function() {
-        it("should return true for DoWhileStatement", function() {
+    describe("isLoop", () => {
+        it("should return true for DoWhileStatement", () => {
             const ast = espree.parse("do {} while (a)");
             const node = ast.body[0];
 
             assert(astUtils.isLoop(node));
         });
 
-        it("should return true for ForInStatement", function() {
+        it("should return true for ForInStatement", () => {
             const ast = espree.parse("for (var k in obj) {}");
             const node = ast.body[0];
 
             assert(astUtils.isLoop(node));
         });
 
-        it("should return true for ForOfStatement", function() {
+        it("should return true for ForOfStatement", () => {
             const ast = espree.parse("for (var x of list) {}", {ecmaVersion: 6});
             const node = ast.body[0];
 
             assert(astUtils.isLoop(node));
         });
 
-        it("should return true for ForStatement", function() {
+        it("should return true for ForStatement", () => {
             const ast = espree.parse("for (var i = 0; i < 10; ++i) {}");
             const node = ast.body[0];
 
             assert(astUtils.isLoop(node));
         });
 
-        it("should return true for WhileStatement", function() {
+        it("should return true for WhileStatement", () => {
             const ast = espree.parse("while (a) {}");
             const node = ast.body[0];
 
             assert(astUtils.isLoop(node));
         });
 
-        it("should return false for Program, VariableDeclaration, BlockStatement", function() {
+        it("should return false for Program, VariableDeclaration, BlockStatement", () => {
             const ast = espree.parse("var a; { }");
 
             assert(!astUtils.isLoop(ast));
@@ -422,141 +422,141 @@ describe("ast-utils", function() {
         });
     });
 
-    describe("getStaticPropertyName", function() {
-        it("should return 'b' for `a.b`", function() {
+    describe("getStaticPropertyName", () => {
+        it("should return 'b' for `a.b`", () => {
             const ast = espree.parse("a.b");
             const node = ast.body[0].expression;
 
             assert.strictEqual(astUtils.getStaticPropertyName(node), "b");
         });
 
-        it("should return 'b' for `a['b']`", function() {
+        it("should return 'b' for `a['b']`", () => {
             const ast = espree.parse("a['b']");
             const node = ast.body[0].expression;
 
             assert.strictEqual(astUtils.getStaticPropertyName(node), "b");
         });
 
-        it("should return 'b' for `a[`b`]`", function() {
+        it("should return 'b' for `a[`b`]`", () => {
             const ast = espree.parse("a[`b`]", {ecmaVersion: 6});
             const node = ast.body[0].expression;
 
             assert.strictEqual(astUtils.getStaticPropertyName(node), "b");
         });
 
-        it("should return '100' for `a[100]`", function() {
+        it("should return '100' for `a[100]`", () => {
             const ast = espree.parse("a[100]");
             const node = ast.body[0].expression;
 
             assert.strictEqual(astUtils.getStaticPropertyName(node), "100");
         });
 
-        it("should return null for `a[b]`", function() {
+        it("should return null for `a[b]`", () => {
             const ast = espree.parse("a[b]");
             const node = ast.body[0].expression;
 
             assert.strictEqual(astUtils.getStaticPropertyName(node), null);
         });
 
-        it("should return null for `a['a' + 'b']`", function() {
+        it("should return null for `a['a' + 'b']`", () => {
             const ast = espree.parse("a['a' + 'b']");
             const node = ast.body[0].expression;
 
             assert.strictEqual(astUtils.getStaticPropertyName(node), null);
         });
 
-        it("should return null for `a[tag`b`]`", function() {
+        it("should return null for `a[tag`b`]`", () => {
             const ast = espree.parse("a[tag`b`]", {ecmaVersion: 6});
             const node = ast.body[0].expression;
 
             assert.strictEqual(astUtils.getStaticPropertyName(node), null);
         });
 
-        it("should return null for `a[`${b}`]`", function() {
+        it("should return null for `a[`${b}`]`", () => {
             const ast = espree.parse("a[`${b}`]", {ecmaVersion: 6});
             const node = ast.body[0].expression;
 
             assert.strictEqual(astUtils.getStaticPropertyName(node), null);
         });
 
-        it("should return 'b' for `b: 1`", function() {
+        it("should return 'b' for `b: 1`", () => {
             const ast = espree.parse("({b: 1})");
             const node = ast.body[0].expression.properties[0];
 
             assert.strictEqual(astUtils.getStaticPropertyName(node), "b");
         });
 
-        it("should return 'b' for `b() {}`", function() {
+        it("should return 'b' for `b() {}`", () => {
             const ast = espree.parse("({b() {}})", {ecmaVersion: 6});
             const node = ast.body[0].expression.properties[0];
 
             assert.strictEqual(astUtils.getStaticPropertyName(node), "b");
         });
 
-        it("should return 'b' for `get b() {}`", function() {
+        it("should return 'b' for `get b() {}`", () => {
             const ast = espree.parse("({get b() {}})", {ecmaVersion: 6});
             const node = ast.body[0].expression.properties[0];
 
             assert.strictEqual(astUtils.getStaticPropertyName(node), "b");
         });
 
-        it("should return 'b' for `['b']: 1`", function() {
+        it("should return 'b' for `['b']: 1`", () => {
             const ast = espree.parse("({['b']: 1})", {ecmaVersion: 6});
             const node = ast.body[0].expression.properties[0];
 
             assert.strictEqual(astUtils.getStaticPropertyName(node), "b");
         });
 
-        it("should return 'b' for `['b']() {}`", function() {
+        it("should return 'b' for `['b']() {}`", () => {
             const ast = espree.parse("({['b']() {}})", {ecmaVersion: 6});
             const node = ast.body[0].expression.properties[0];
 
             assert.strictEqual(astUtils.getStaticPropertyName(node), "b");
         });
 
-        it("should return 'b' for `[`b`]: 1`", function() {
+        it("should return 'b' for `[`b`]: 1`", () => {
             const ast = espree.parse("({[`b`]: 1})", {ecmaVersion: 6});
             const node = ast.body[0].expression.properties[0];
 
             assert.strictEqual(astUtils.getStaticPropertyName(node), "b");
         });
 
-        it("should return '100' for` [100]: 1`", function() {
+        it("should return '100' for` [100]: 1`", () => {
             const ast = espree.parse("({[100]: 1})", {ecmaVersion: 6});
             const node = ast.body[0].expression.properties[0];
 
             assert.strictEqual(astUtils.getStaticPropertyName(node), "100");
         });
 
-        it("should return null for `[b]: 1`", function() {
+        it("should return null for `[b]: 1`", () => {
             const ast = espree.parse("({[b]: 1})", {ecmaVersion: 6});
             const node = ast.body[0].expression.properties[0];
 
             assert.strictEqual(astUtils.getStaticPropertyName(node), null);
         });
 
-        it("should return null for `['a' + 'b']: 1`", function() {
+        it("should return null for `['a' + 'b']: 1`", () => {
             const ast = espree.parse("({['a' + 'b']: 1})", {ecmaVersion: 6});
             const node = ast.body[0].expression.properties[0];
 
             assert.strictEqual(astUtils.getStaticPropertyName(node), null);
         });
 
-        it("should return null for `[tag`b`]: 1`", function() {
+        it("should return null for `[tag`b`]: 1`", () => {
             const ast = espree.parse("({[tag`b`]: 1})", {ecmaVersion: 6});
             const node = ast.body[0].expression.properties[0];
 
             assert.strictEqual(astUtils.getStaticPropertyName(node), null);
         });
 
-        it("should return null for `[`${b}`]: 1`", function() {
+        it("should return null for `[`${b}`]: 1`", () => {
             const ast = espree.parse("({[`${b}`]: 1})", {ecmaVersion: 6});
             const node = ast.body[0].expression.properties[0];
 
             assert.strictEqual(astUtils.getStaticPropertyName(node), null);
         });
 
-        it("should return null for non member expressions", function() {
+        it("should return null for non member expressions", () => {
             const ast = espree.parse("foo()");
 
             assert.strictEqual(astUtils.getStaticPropertyName(ast.body[0].expression), null);
@@ -567,50 +567,50 @@ describe("ast-utils", function() {
         });
     });
 
-    describe("getDirectivePrologue", function() {
-        it("should return empty array if node is not a Program, FunctionDeclaration, FunctionExpression, or ArrowFunctionExpression", function() {
+    describe("getDirectivePrologue", () => {
+        it("should return empty array if node is not a Program, FunctionDeclaration, FunctionExpression, or ArrowFunctionExpression", () => {
             const ast = espree.parse("if (a) { b(); }");
             const node = ast.body[0];
 
             assert.deepEqual(astUtils.getDirectivePrologue(node), []);
         });
 
-        it("should return empty array if node is a braceless ArrowFunctionExpression node", function() {
+        it("should return empty array if node is a braceless ArrowFunctionExpression node", () => {
             const ast = espree.parse("var foo = () => 'use strict';", { ecmaVersion: 6 });
             const node = ast.body[0].declarations[0].init;
 
             assert.deepEqual(astUtils.getDirectivePrologue(node), []);
         });
 
-        it("should return empty array if there are no directives in Program body", function() {
+        it("should return empty array if there are no directives in Program body", () => {
             const ast = espree.parse("var foo;");
             const node = ast;
 
             assert.deepEqual(astUtils.getDirectivePrologue(node), []);
         });
 
-        it("should return empty array if there are no directives in FunctionDeclaration body", function() {
+        it("should return empty array if there are no directives in FunctionDeclaration body", () => {
             const ast = espree.parse("function foo() { return bar; }");
             const node = ast.body[0];
 
             assert.deepEqual(astUtils.getDirectivePrologue(node), []);
         });
 
-        it("should return empty array if there are no directives in FunctionExpression body", function() {
+        it("should return empty array if there are no directives in FunctionExpression body", () => {
             const ast = espree.parse("var foo = function() { return bar; }");
             const node = ast.body[0].declarations[0].init;
 
             assert.deepEqual(astUtils.getDirectivePrologue(node), []);
         });
 
-        it("should return empty array if there are no directives in ArrowFunctionExpression body", function() {
+        it("should return empty array if there are no directives in ArrowFunctionExpression body", () => {
             const ast = espree.parse("var foo = () => { return bar; };", { ecmaVersion: 6 });
             const node = ast.body[0].declarations[0].init;
 
             assert.deepEqual(astUtils.getDirectivePrologue(node), []);
         });
 
-        it("should return directives in Program body", function() {
+        it("should return directives in Program body", () => {
             const ast = espree.parse("'use strict'; 'use asm'; var foo;");
             const result = astUtils.getDirectivePrologue(ast);
 
@@ -619,7 +619,7 @@ describe("ast-utils", function() {
             assert.equal(result[1].expression.value, "use asm");
         });
 
-        it("should return directives in FunctionDeclaration body", function() {
+        it("should return directives in FunctionDeclaration body", () => {
             const ast = espree.parse("function foo() { 'use strict'; 'use asm'; return bar; }");
             const result = astUtils.getDirectivePrologue(ast.body[0]);
 
@@ -628,7 +628,7 @@ describe("ast-utils", function() {
             assert.equal(result[1].expression.value, "use asm");
         });
 
-        it("should return directives in FunctionExpression body", function() {
+        it("should return directives in FunctionExpression body", () => {
             const ast = espree.parse("var foo = function() { 'use strict'; 'use asm'; return bar; }");
             const result = astUtils.getDirectivePrologue(ast.body[0].declarations[0].init);
 
@@ -637,7 +637,7 @@ describe("ast-utils", function() {
             assert.equal(result[1].expression.value, "use asm");
         });
 
-        it("should return directives in ArrowFunctionExpression body", function() {
+        it("should return directives in ArrowFunctionExpression body", () => {
             const ast = espree.parse("var foo = () => { 'use strict'; 'use asm'; return bar; };", { ecmaVersion: 6 });
             const result = astUtils.getDirectivePrologue(ast.body[0].declarations[0].init);
 
@@ -647,7 +647,7 @@ describe("ast-utils", function() {
         });
     });
 
-    describe("isDecimalInteger", function() {
+    describe("isDecimalInteger", () => {
         const expectedResults = {
             5: true,
             0: true,
@@ -661,7 +661,7 @@ describe("ast-utils", function() {
         };
 
         Object.keys(expectedResults).forEach(key => {
-            it(`should return ${expectedResults[key]} for ${key}`, function() {
+            it(`should return ${expectedResults[key]} for ${key}`, () => {
                 assert.strictEqual(astUtils.isDecimalInteger(espree.parse(key).body[0].expression), expectedResults[key]);
             });
         });

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -30,7 +30,7 @@ const proxyquire = require("proxyquire").noCallThru().noPreserveCache();
 // Tests
 //------------------------------------------------------------------------------
 
-describe("CLIEngine", function() {
+describe("CLIEngine", () => {
 
     const examplePluginName = "eslint-plugin-example",
         examplePluginNameWithNamespace = "@eslint/eslint-plugin-example",
@@ -64,7 +64,7 @@ describe("CLIEngine", function() {
     }
 
     // copy into clean area so as not to get "infected" by this project's .eslintrc files
-    before(function() {
+    before(() => {
         fixtureDir = path.join(os.tmpdir(), "/eslint/fixtures");
         mkdir("-p", fixtureDir);
         cp("-r", "./tests/fixtures/.", fixtureDir);
@@ -75,17 +75,17 @@ describe("CLIEngine", function() {
         Plugins.define(examplePreprocessorName, require("../fixtures/processors/custom-processor"));
     });
 
-    beforeEach(function() {
+    beforeEach(() => {
         CLIEngine = proxyquire("../../lib/cli-engine", requireStubs);
     });
 
-    after(function() {
+    after(() => {
         rm("-r", fixtureDir);
         Plugins.testReset();
     });
 
-    describe("new CLIEngine(options)", function() {
-        it("the default value of 'options.cwd' should be the current working directory.", function() {
+    describe("new CLIEngine(options)", () => {
+        it("the default value of 'options.cwd' should be the current working directory.", () => {
             process.chdir(__dirname);
             try {
                 const engine = new CLIEngine();
@@ -97,11 +97,11 @@ describe("CLIEngine", function() {
         });
     });
 
-    describe("executeOnText()", function() {
+    describe("executeOnText()", () => {
 
         let engine;
 
-        it("should report 5 message when using local cwd .eslintrc", function() {
+        it("should report 5 message when using local cwd .eslintrc", () => {
 
             engine = new CLIEngine();
 
@@ -118,7 +118,7 @@ describe("CLIEngine", function() {
             assert.equal(report.results[0].messages[4].ruleId, "eol-last");
         });
 
-        it("should report one message when using specific config file", function() {
+        it("should report one message when using specific config file", () => {
 
             engine = new CLIEngine({
                 configFile: "fixtures/configurations/quotes-error.json",
@@ -138,7 +138,7 @@ describe("CLIEngine", function() {
             assert.equal(report.results[0].warningCount, 0);
         });
 
-        it("should report the filename when passed in", function() {
+        it("should report the filename when passed in", () => {
 
             engine = new CLIEngine({
                 ignore: false,
@@ -150,7 +150,7 @@ describe("CLIEngine", function() {
             assert.equal(report.results[0].filePath, getFixturePath("test.js"));
         });
 
-        it("should return a warning when given a filename by --stdin-filename in excluded files list if warnIgnored is true", function() {
+        it("should return a warning when given a filename by --stdin-filename in excluded files list if warnIgnored is true", () => {
             engine = new CLIEngine({
                 ignorePath: getFixturePath(".eslintignore"),
                 cwd: getFixturePath("..")
@@ -169,7 +169,7 @@ describe("CLIEngine", function() {
             assert.equal(report.results[0].warningCount, 1);
         });
 
-        it("should not return a warning when given a filename by --stdin-filename in excluded files list if warnIgnored is false", function() {
+        it("should not return a warning when given a filename by --stdin-filename in excluded files list if warnIgnored is false", () => {
             engine = new CLIEngine({
                 ignorePath: getFixturePath(".eslintignore"),
                 cwd: getFixturePath("..")
@@ -182,7 +182,7 @@ describe("CLIEngine", function() {
             assert.equal(report.results.length, 0);
         });
 
-        it("should suppress excluded file warnings by default", function() {
+        it("should suppress excluded file warnings by default", () => {
             engine = new CLIEngine({
                 ignorePath: getFixturePath(".eslintignore"),
                 cwd: getFixturePath("..")
@@ -194,7 +194,7 @@ describe("CLIEngine", function() {
             assert.equal(report.results.length, 0);
         });
 
-        it("should return a message when given a filename by --stdin-filename in excluded files list and ignore is off", function() {
+        it("should return a message when given a filename by --stdin-filename in excluded files list and ignore is off", () => {
 
             engine = new CLIEngine({
                 ignorePath: "fixtures/.eslintignore",
@@ -215,7 +215,7 @@ describe("CLIEngine", function() {
             assert.isUndefined(report.results[0].messages[0].output);
         });
 
-        it("should return a message and fixed text when in fix mode", function() {
+        it("should return a message and fixed text when in fix mode", () => {
 
             engine = new CLIEngine({
                 useEslintrc: false,
@@ -244,7 +244,7 @@ describe("CLIEngine", function() {
             });
         });
 
-        it("should return a message and omit fixed text when in fix mode and fixes aren't done", function() {
+        it("should return a message and omit fixed text when in fix mode and fixes aren't done", () => {
 
             engine = new CLIEngine({
                 useEslintrc: false,
@@ -283,7 +283,7 @@ describe("CLIEngine", function() {
             });
         });
 
-        it("should not delete code if there is a syntax error after trying to autofix.", function() {
+        it("should not delete code if there is a syntax error after trying to autofix.", () => {
             engine = new CLIEngine({
                 useEslintrc: false,
                 fix: true,
@@ -321,7 +321,7 @@ describe("CLIEngine", function() {
             });
         });
 
-        it("should not crash even if there are any syntax error since the first time.", function() {
+        it("should not crash even if there are any syntax error since the first time.", () => {
             engine = new CLIEngine({
                 useEslintrc: false,
                 fix: true,
@@ -359,7 +359,7 @@ describe("CLIEngine", function() {
             });
         });
 
-        it("should return source code of file in `source` property when errors are present", function() {
+        it("should return source code of file in `source` property when errors are present", () => {
             engine = new CLIEngine({
                 useEslintrc: false,
                 rules: { semi: 2 }
@@ -370,7 +370,7 @@ describe("CLIEngine", function() {
             assert.equal(report.results[0].source, "var foo = 'bar'");
         });
 
-        it("should return source code of file in `source` property when warnings are present", function() {
+        it("should return source code of file in `source` property when warnings are present", () => {
             engine = new CLIEngine({
                 useEslintrc: false,
                 rules: { semi: 1 }
@@ -382,7 +382,7 @@ describe("CLIEngine", function() {
         });
 
 
-        it("should not return a `source` property when no errors or warnings are present", function() {
+        it("should not return a `source` property when no errors or warnings are present", () => {
             engine = new CLIEngine({
                 useEslintrc: false,
                 rules: { semi: 2 }
@@ -394,7 +394,7 @@ describe("CLIEngine", function() {
             assert.isUndefined(report.results[0].source);
         });
 
-        it("should not return a `source` property when fixes are applied", function() {
+        it("should not return a `source` property when fixes are applied", () => {
             engine = new CLIEngine({
                 useEslintrc: false,
                 fix: true,
@@ -410,7 +410,7 @@ describe("CLIEngine", function() {
             assert.equal(report.results[0].output, "var msg = 'hi' + foo;\n");
         });
 
-        it("should return a `source` property when a parsing error has occurred", function() {
+        it("should return a `source` property when a parsing error has occurred", () => {
             engine = new CLIEngine({
                 useEslintrc: false,
                 rules: { semi: 2 }
@@ -444,7 +444,7 @@ describe("CLIEngine", function() {
         });
 
         // https://github.com/eslint/eslint/issues/5547
-        it("should respect default ignore rules, even with --no-ignore", function() {
+        it("should respect default ignore rules, even with --no-ignore", () => {
 
             engine = new CLIEngine({
                 cwd: getFixturePath(),
@@ -461,11 +461,11 @@ describe("CLIEngine", function() {
 
     });
 
-    describe("executeOnFiles()", function() {
+    describe("executeOnFiles()", () => {
 
         let engine;
 
-        it("should use correct parser when custom parser is specified", function() {
+        it("should use correct parser when custom parser is specified", () => {
 
             engine = new CLIEngine({
                 cwd: originalDir,
@@ -482,7 +482,7 @@ describe("CLIEngine", function() {
         });
 
 
-        it("should report zero messages when given a config file and a valid file", function() {
+        it("should report zero messages when given a config file and a valid file", () => {
 
             engine = new CLIEngine({
                 cwd: originalDir,
@@ -496,7 +496,7 @@ describe("CLIEngine", function() {
             assert.equal(report.results[1].messages.length, 0);
         });
 
-        it("should handle multiple patterns with overlapping files", function() {
+        it("should handle multiple patterns with overlapping files", () => {
 
             engine = new CLIEngine({
                 cwd: originalDir,
@@ -510,7 +510,7 @@ describe("CLIEngine", function() {
             assert.equal(report.results[1].messages.length, 0);
         });
 
-        it("should report zero messages when given a config file and a valid file and espree as parser", function() {
+        it("should report zero messages when given a config file and a valid file and espree as parser", () => {
 
             engine = new CLIEngine({
                 parser: "espree",
@@ -524,7 +524,7 @@ describe("CLIEngine", function() {
             assert.equal(report.results[0].messages.length, 0);
         });
 
-        it("should report zero messages when given a config file and a valid file and esprima as parser", function() {
+        it("should report zero messages when given a config file and a valid file and esprima as parser", () => {
 
             engine = new CLIEngine({
                 parser: "esprima",
@@ -537,7 +537,7 @@ describe("CLIEngine", function() {
             assert.equal(report.results[0].messages.length, 0);
         });
 
-        it("should report one fatal message when given a config file and a valid file and invalid parser", function() {
+        it("should report one fatal message when given a config file and a valid file and invalid parser", () => {
 
             engine = new CLIEngine({
                 parser: "test11",
@@ -551,7 +551,7 @@ describe("CLIEngine", function() {
             assert.isTrue(report.results[0].messages[0].fatal);
         });
 
-        it("should report zero messages when given a directory with a .js2 file", function() {
+        it("should report zero messages when given a directory with a .js2 file", () => {
 
             engine = new CLIEngine({
                 cwd: path.join(fixtureDir, ".."),
@@ -564,7 +564,7 @@ describe("CLIEngine", function() {
             assert.equal(report.results[0].messages.length, 0);
         });
 
-        it("should report zero messages when given a directory with a .js and a .js2 file", function() {
+        it("should report zero messages when given a directory with a .js and a .js2 file", () => {
 
             engine = new CLIEngine({
                 extensions: [".js", ".js2"],
@@ -579,7 +579,7 @@ describe("CLIEngine", function() {
             assert.equal(report.results[1].messages.length, 0);
         });
 
-        it("should report zero messages when given a '**' pattern with a .js and a .js2 file", function() {
+        it("should report zero messages when given a '**' pattern with a .js and a .js2 file", () => {
 
             engine = new CLIEngine({
                 extensions: [".js", ".js2"],
@@ -594,7 +594,7 @@ describe("CLIEngine", function() {
             assert.equal(report.results[1].messages.length, 0);
         });
 
-        it("should report on all files passed explicitly, even if ignored by default", function() {
+        it("should report on all files passed explicitly, even if ignored by default", () => {
 
             engine = new CLIEngine({
                 cwd: getFixturePath("cli-engine")
@@ -609,7 +609,7 @@ describe("CLIEngine", function() {
             assert.equal(report.results[0].messages[0].message, expectedMsg);
         });
 
-        it("should report on globs with explicit inclusion of dotfiles, even though ignored by default", function() {
+        it("should report on globs with explicit inclusion of dotfiles, even though ignored by default", () => {
 
             engine = new CLIEngine({
                 cwd: getFixturePath("cli-engine"),
@@ -625,7 +625,7 @@ describe("CLIEngine", function() {
             assert.equal(report.results[0].warningCount, 0);
         });
 
-        it("should not check default ignored files without --no-ignore flag", function() {
+        it("should not check default ignored files without --no-ignore flag", () => {
 
             engine = new CLIEngine({
                 cwd: getFixturePath("cli-engine")
@@ -637,7 +637,7 @@ describe("CLIEngine", function() {
         });
 
         // https://github.com/eslint/eslint/issues/5547
-        it("should not check node_modules files even with --no-ignore flag", function() {
+        it("should not check node_modules files even with --no-ignore flag", () => {
 
             engine = new CLIEngine({
                 cwd: getFixturePath("cli-engine"),
@@ -649,7 +649,7 @@ describe("CLIEngine", function() {
             assert.equal(report.results.length, 0);
         });
 
-        it("should not check .hidden files if they are passed explicitly without --no-ignore flag", function() {
+        it("should not check .hidden files if they are passed explicitly without --no-ignore flag", () => {
 
             engine = new CLIEngine({
                 cwd: getFixturePath(".."),
@@ -668,7 +668,7 @@ describe("CLIEngine", function() {
             assert.equal(report.results[0].messages[0].message, expectedMsg);
         });
 
-        it("should check .hidden files if they are passed explicitly with --no-ignore flag", function() {
+        it("should check .hidden files if they are passed explicitly with --no-ignore flag", () => {
 
             engine = new CLIEngine({
                 cwd: getFixturePath(".."),
@@ -687,7 +687,7 @@ describe("CLIEngine", function() {
             assert.equal(report.results[0].messages[0].ruleId, "quotes");
         });
 
-        it("should check .hidden files if they are unignored with an --ignore-pattern", function() {
+        it("should check .hidden files if they are unignored with an --ignore-pattern", () => {
 
             engine = new CLIEngine({
                 cwd: getFixturePath("cli-engine"),
@@ -707,7 +707,7 @@ describe("CLIEngine", function() {
             assert.equal(report.results[0].messages[0].ruleId, "quotes");
         });
 
-        it("should report zero messages when given a pattern with a .js and a .js2 file", function() {
+        it("should report zero messages when given a pattern with a .js and a .js2 file", () => {
 
             engine = new CLIEngine({
                 extensions: [".js", ".js2"],
@@ -722,7 +722,7 @@ describe("CLIEngine", function() {
             assert.equal(report.results[1].messages.length, 0);
         });
 
-        it("should return one error message when given a config with rules with options and severity level set to error", function() {
+        it("should return one error message when given a config with rules with options and severity level set to error", () => {
 
             engine = new CLIEngine({
                 cwd: getFixturePath("configurations"),
@@ -740,7 +740,7 @@ describe("CLIEngine", function() {
             assert.equal(report.results[0].warningCount, 0);
         });
 
-        it("should return two messages when given a config file and a directory of files", function() {
+        it("should return two messages when given a config file and a directory of files", () => {
 
             engine = new CLIEngine({
                 cwd: path.join(fixtureDir, ".."),
@@ -763,7 +763,7 @@ describe("CLIEngine", function() {
             assert.equal(report.results[2].warningCount, 0);
         });
 
-        it("should process when file is given by not specifying extensions", function() {
+        it("should process when file is given by not specifying extensions", () => {
 
             engine = new CLIEngine({
                 ignore: false,
@@ -776,7 +776,7 @@ describe("CLIEngine", function() {
             assert.equal(report.results[0].messages.length, 0);
         });
 
-        it("should return zero messages when given a config with environment set to browser", function() {
+        it("should return zero messages when given a config with environment set to browser", () => {
 
             engine = new CLIEngine({
                 cwd: path.join(fixtureDir, ".."),
@@ -789,7 +789,7 @@ describe("CLIEngine", function() {
             assert.equal(report.results[0].messages.length, 0);
         });
 
-        it("should return zero messages when given an option to set environment to browser", function() {
+        it("should return zero messages when given an option to set environment to browser", () => {
 
             engine = new CLIEngine({
                 cwd: path.join(fixtureDir, ".."),
@@ -806,7 +806,7 @@ describe("CLIEngine", function() {
             assert.equal(report.results[0].messages.length, 0);
         });
 
-        it("should return zero messages when given a config with environment set to Node.js", function() {
+        it("should return zero messages when given a config with environment set to Node.js", () => {
 
             engine = new CLIEngine({
                 cwd: path.join(fixtureDir, ".."),
@@ -819,7 +819,7 @@ describe("CLIEngine", function() {
             assert.equal(report.results[0].messages.length, 0);
         });
 
-        it("should not return results from previous call when calling more than once", function() {
+        it("should not return results from previous call when calling more than once", () => {
 
             engine = new CLIEngine({
                 cwd: path.join(fixtureDir, ".."),
@@ -847,7 +847,7 @@ describe("CLIEngine", function() {
 
         });
 
-        it("should return zero messages when given a directory with eslint excluded files in the directory", function() {
+        it("should return zero messages when given a directory with eslint excluded files in the directory", () => {
 
             engine = new CLIEngine({
                 ignorePath: getFixturePath(".eslintignore")
@@ -858,7 +858,7 @@ describe("CLIEngine", function() {
             assert.equal(report.results.length, 0);
         });
 
-        it("should return zero messages when all given files are ignored", function() {
+        it("should return zero messages when all given files are ignored", () => {
             engine = new CLIEngine({
                 ignorePath: getFixturePath(".eslintignore")
             });
@@ -868,7 +868,7 @@ describe("CLIEngine", function() {
             assert.equal(report.results.length, 0);
         });
 
-        it("should return zero messages when all given files are ignored event with a `./` prefix", function() {
+        it("should return zero messages when all given files are ignored event with a `./` prefix", () => {
             engine = new CLIEngine({
                 ignorePath: getFixturePath(".eslintignore")
             });
@@ -879,7 +879,7 @@ describe("CLIEngine", function() {
         });
 
         // https://github.com/eslint/eslint/issues/3788
-        it("should ignore one-level down node_modules when ignore file has 'node_modules/' in it", function() {
+        it("should ignore one-level down node_modules when ignore file has 'node_modules/' in it", () => {
             engine = new CLIEngine({
                 ignorePath: getFixturePath("cli-engine", "nested_node_modules", ".eslintignore"),
                 useEslintrc: false,
@@ -897,7 +897,7 @@ describe("CLIEngine", function() {
         });
 
         // https://github.com/eslint/eslint/issues/3812
-        it("should ignore all files when tests/fixtures/ is in ignore file", function() {
+        it("should ignore all files when tests/fixtures/ is in ignore file", () => {
             engine = new CLIEngine({
                 ignorePath: getFixturePath("cli-engine/.eslintignore2"),
                 useEslintrc: false,
@@ -911,7 +911,7 @@ describe("CLIEngine", function() {
             assert.equal(report.results.length, 0);
         });
 
-        it("should return zero messages when all given files are ignored via ignore-pattern", function() {
+        it("should return zero messages when all given files are ignored via ignore-pattern", () => {
             engine = new CLIEngine({
                 ignorePattern: "tests/fixtures/single-quoted.js"
             });
@@ -921,7 +921,7 @@ describe("CLIEngine", function() {
             assert.equal(report.results.length, 0);
         });
 
-        it("should return a warning when an explicitly given file is ignored", function() {
+        it("should return a warning when an explicitly given file is ignored", () => {
             engine = new CLIEngine({
                 ignorePath: getFixturePath(".eslintignore"),
                 cwd: getFixturePath()
@@ -941,7 +941,7 @@ describe("CLIEngine", function() {
             assert.equal(report.results[0].warningCount, 1);
         });
 
-        it("should return two messages when given a file in excluded files list while ignore is off", function() {
+        it("should return two messages when given a file in excluded files list while ignore is off", () => {
 
             engine = new CLIEngine({
                 ignorePath: getFixturePath(".eslintignore"),
@@ -963,7 +963,7 @@ describe("CLIEngine", function() {
             assert.equal(report.results[0].messages[1].severity, 2);
         });
 
-        it("should return zero messages when executing a file with a shebang", function() {
+        it("should return zero messages when executing a file with a shebang", () => {
 
             engine = new CLIEngine({
                 ignore: false
@@ -975,7 +975,7 @@ describe("CLIEngine", function() {
             assert.equal(report.results[0].messages.length, 0);
         });
 
-        it("should give a warning when loading a custom rule that doesn't exist", function() {
+        it("should give a warning when loading a custom rule that doesn't exist", () => {
 
             engine = new CLIEngine({
                 ignore: false,
@@ -993,7 +993,7 @@ describe("CLIEngine", function() {
 
         });
 
-        it("should throw an error when loading a bad custom rule", function() {
+        it("should throw an error when loading a bad custom rule", () => {
 
             engine = new CLIEngine({
                 ignore: false,
@@ -1002,12 +1002,12 @@ describe("CLIEngine", function() {
             });
 
 
-            assert.throws(function() {
+            assert.throws(() => {
                 engine.executeOnFiles([getFixturePath("rules", "test", "test-custom-rule.js")]);
             }, /Error while loading rule 'custom-rule'/);
         });
 
-        it("should return one message when a custom rule matches a file", function() {
+        it("should return one message when a custom rule matches a file", () => {
 
             engine = new CLIEngine({
                 ignore: false,
@@ -1027,7 +1027,7 @@ describe("CLIEngine", function() {
             assert.equal(report.results[0].messages[0].severity, 1);
         });
 
-        it("should load custom rule from the provided cwd", function() {
+        it("should load custom rule from the provided cwd", () => {
             const cwd = path.resolve(getFixturePath("rules"));
 
             engine = new CLIEngine({
@@ -1048,7 +1048,7 @@ describe("CLIEngine", function() {
             assert.equal(report.results[0].messages[0].severity, 1);
         });
 
-        it("should return messages when multiple custom rules match a file", function() {
+        it("should return messages when multiple custom rules match a file", () => {
 
             engine = new CLIEngine({
                 ignore: false,
@@ -1072,7 +1072,7 @@ describe("CLIEngine", function() {
             assert.equal(report.results[0].messages[1].severity, 2);
         });
 
-        it("should return zero messages when executing without useEslintrc flag", function() {
+        it("should return zero messages when executing without useEslintrc flag", () => {
 
             engine = new CLIEngine({
                 ignore: false,
@@ -1088,7 +1088,7 @@ describe("CLIEngine", function() {
             assert.equal(report.results[0].messages.length, 0);
         });
 
-        it("should return zero messages when executing without useEslintrc flag in Node.js environment", function() {
+        it("should return zero messages when executing without useEslintrc flag in Node.js environment", () => {
 
             engine = new CLIEngine({
                 ignore: false,
@@ -1105,7 +1105,7 @@ describe("CLIEngine", function() {
             assert.equal(report.results[0].messages.length, 0);
         });
 
-        it("should return zero messages when executing with base-config flag set to false", function() {
+        it("should return zero messages when executing with base-config flag set to false", () => {
 
             engine = new CLIEngine({
                 ignore: false,
@@ -1122,7 +1122,7 @@ describe("CLIEngine", function() {
             assert.equal(report.results[0].messages.length, 0);
         });
 
-        it("should return zero messages and ignore .eslintrc files when executing with no-eslintrc flag", function() {
+        it("should return zero messages and ignore .eslintrc files when executing with no-eslintrc flag", () => {
 
             engine = new CLIEngine({
                 ignore: false,
@@ -1139,7 +1139,7 @@ describe("CLIEngine", function() {
             assert.equal(report.results[0].messages.length, 0);
         });
 
-        it("should return zero messages and ignore package.json files when executing with no-eslintrc flag", function() {
+        it("should return zero messages and ignore package.json files when executing with no-eslintrc flag", () => {
 
             engine = new CLIEngine({
                 ignore: false,
@@ -1156,7 +1156,7 @@ describe("CLIEngine", function() {
             assert.equal(report.results[0].messages.length, 0);
         });
 
-        it("should not fail if an ignored file cannot be resolved", function() {
+        it("should not fail if an ignored file cannot be resolved", () => {
 
             const fakeFS = leche.fake(fs),
                 LocalCLIEngine = proxyquire("../../lib/cli-engine", {
@@ -1171,15 +1171,15 @@ describe("CLIEngine", function() {
                 ignorePattern: "tests"
             });
 
-            assert.doesNotThrow(function() {
+            assert.doesNotThrow(() => {
                 engine.executeOnFiles(["tests/fixtures/file-not-found.js"]);
             });
 
         });
 
-        describe("Fix Mode", function() {
+        describe("Fix Mode", () => {
 
-            it("should return fixed text on multiple files when in fix mode", function() {
+            it("should return fixed text on multiple files when in fix mode", () => {
 
                 /**
                  * Converts CRLF to LF in output.
@@ -1268,10 +1268,10 @@ describe("CLIEngine", function() {
 
         // These tests have to do with https://github.com/eslint/eslint/issues/963
 
-        describe("configuration hierarchy", function() {
+        describe("configuration hierarchy", () => {
 
             // Default configuration - blank
-            it("should return zero messages when executing with no .eslintrc", function() {
+            it("should return zero messages when executing with no .eslintrc", () => {
 
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, ".."),
@@ -1285,7 +1285,7 @@ describe("CLIEngine", function() {
             });
 
             // No default configuration rules - conf/environments.js (/*eslint-env node*/)
-            it("should return zero messages when executing with no .eslintrc in the Node.js environment", function() {
+            it("should return zero messages when executing with no .eslintrc in the Node.js environment", () => {
 
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, ".."),
@@ -1300,7 +1300,7 @@ describe("CLIEngine", function() {
             });
 
             // Project configuration - first level .eslintrc
-            it("should return zero messages when executing with .eslintrc in the Node.js environment", function() {
+            it("should return zero messages when executing with .eslintrc in the Node.js environment", () => {
 
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, "..")
@@ -1313,7 +1313,7 @@ describe("CLIEngine", function() {
             });
 
             // Project configuration - first level .eslintrc
-            it("should return zero messages when executing with .eslintrc in the Node.js environment", function() {
+            it("should return zero messages when executing with .eslintrc in the Node.js environment", () => {
 
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, "..")
@@ -1326,7 +1326,7 @@ describe("CLIEngine", function() {
             });
 
             // Project configuration - first level .eslintrc
-            it("should return one message when executing with .eslintrc", function() {
+            it("should return one message when executing with .eslintrc", () => {
 
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, "..")
@@ -1341,7 +1341,7 @@ describe("CLIEngine", function() {
             });
 
             // Project configuration - second level .eslintrc
-            it("should return one message when executing with local .eslintrc that overrides parent .eslintrc", function() {
+            it("should return one message when executing with local .eslintrc that overrides parent .eslintrc", () => {
 
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, "..")
@@ -1356,7 +1356,7 @@ describe("CLIEngine", function() {
             });
 
             // Project configuration - third level .eslintrc
-            it("should return one message when executing with local .eslintrc that overrides parent and grandparent .eslintrc", function() {
+            it("should return one message when executing with local .eslintrc that overrides parent and grandparent .eslintrc", () => {
 
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, "..")
@@ -1371,7 +1371,7 @@ describe("CLIEngine", function() {
             });
 
             // Project configuration - first level package.json
-            it("should return one message when executing with package.json", function() {
+            it("should return one message when executing with package.json", () => {
 
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, "..")
@@ -1386,7 +1386,7 @@ describe("CLIEngine", function() {
             });
 
              // Project configuration - second level package.json
-            it("should return zero messages when executing with local package.json that overrides parent package.json", function() {
+            it("should return zero messages when executing with local package.json that overrides parent package.json", () => {
 
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, "..")
@@ -1399,7 +1399,7 @@ describe("CLIEngine", function() {
             });
 
             // Project configuration - third level package.json
-            it("should return one message when executing with local package.json that overrides parent and grandparent package.json", function() {
+            it("should return one message when executing with local package.json that overrides parent and grandparent package.json", () => {
 
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, "..")
@@ -1414,7 +1414,7 @@ describe("CLIEngine", function() {
             });
 
             // Project configuration - .eslintrc overrides package.json in same directory
-            it("should return one message when executing with .eslintrc that overrides a package.json in the same directory", function() {
+            it("should return one message when executing with .eslintrc that overrides a package.json in the same directory", () => {
 
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, "..")
@@ -1429,7 +1429,7 @@ describe("CLIEngine", function() {
             });
 
             // Command line configuration - --config with first level .eslintrc
-            it("should return two messages when executing with config file that adds to local .eslintrc", function() {
+            it("should return two messages when executing with config file that adds to local .eslintrc", () => {
 
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, ".."),
@@ -1447,7 +1447,7 @@ describe("CLIEngine", function() {
             });
 
             // Command line configuration - --config with first level .eslintrc
-            it("should return no messages when executing with config file that overrides local .eslintrc", function() {
+            it("should return no messages when executing with config file that overrides local .eslintrc", () => {
 
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, ".."),
@@ -1461,7 +1461,7 @@ describe("CLIEngine", function() {
             });
 
             // Command line configuration - --config with second level .eslintrc
-            it("should return two messages when executing with config file that adds to local and parent .eslintrc", function() {
+            it("should return two messages when executing with config file that adds to local and parent .eslintrc", () => {
 
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, ".."),
@@ -1479,7 +1479,7 @@ describe("CLIEngine", function() {
             });
 
             // Command line configuration - --config with second level .eslintrc
-            it("should return one message when executing with config file that overrides local and parent .eslintrc", function() {
+            it("should return one message when executing with config file that overrides local and parent .eslintrc", () => {
 
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, ".."),
@@ -1495,7 +1495,7 @@ describe("CLIEngine", function() {
             });
 
             // Command line configuration - --config with first level .eslintrc
-            it("should return no messages when executing with config file that overrides local .eslintrc", function() {
+            it("should return no messages when executing with config file that overrides local .eslintrc", () => {
 
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, ".."),
@@ -1509,7 +1509,7 @@ describe("CLIEngine", function() {
             });
 
             // Command line configuration - --rule with --config and first level .eslintrc
-            it("should return one message when executing with command line rule and config file that overrides local .eslintrc", function() {
+            it("should return one message when executing with command line rule and config file that overrides local .eslintrc", () => {
 
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, ".."),
@@ -1528,7 +1528,7 @@ describe("CLIEngine", function() {
             });
 
             // Command line configuration - --rule with --config and first level .eslintrc
-            it("should return one message when executing with command line rule and config file that overrides local .eslintrc", function() {
+            it("should return one message when executing with command line rule and config file that overrides local .eslintrc", () => {
 
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, ".."),
@@ -1548,8 +1548,8 @@ describe("CLIEngine", function() {
 
         });
 
-        describe("plugins", function() {
-            it("should return two messages when executing with config file that specifies a plugin", function() {
+        describe("plugins", () => {
+            it("should return two messages when executing with config file that specifies a plugin", () => {
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, ".."),
                     configFile: getFixturePath("configurations", "plugins-with-prefix.json"),
@@ -1563,7 +1563,7 @@ describe("CLIEngine", function() {
                 assert.equal(report.results[0].messages[0].ruleId, "example/example-rule");
             });
 
-            it("should return two messages when executing with config file that specifies a plugin with namespace", function() {
+            it("should return two messages when executing with config file that specifies a plugin with namespace", () => {
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, ".."),
                     configFile: getFixturePath("configurations", "plugins-with-prefix-and-namespace.json"),
@@ -1577,7 +1577,7 @@ describe("CLIEngine", function() {
                 assert.equal(report.results[0].messages[0].ruleId, "example/example-rule");
             });
 
-            it("should return two messages when executing with config file that specifies a plugin without prefix", function() {
+            it("should return two messages when executing with config file that specifies a plugin without prefix", () => {
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, ".."),
                     configFile: getFixturePath("configurations", "plugins-without-prefix.json"),
@@ -1591,7 +1591,7 @@ describe("CLIEngine", function() {
                 assert.equal(report.results[0].messages[0].ruleId, "example/example-rule");
             });
 
-            it("should return two messages when executing with config file that specifies a plugin without prefix and with namespace", function() {
+            it("should return two messages when executing with config file that specifies a plugin without prefix and with namespace", () => {
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, ".."),
                     configFile: getFixturePath("configurations", "plugins-without-prefix-with-namespace.json"),
@@ -1605,7 +1605,7 @@ describe("CLIEngine", function() {
                 assert.equal(report.results[0].messages[0].ruleId, "example/example-rule");
             });
 
-            it("should return two messages when executing with cli option that specifies a plugin", function() {
+            it("should return two messages when executing with cli option that specifies a plugin", () => {
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, ".."),
                     useEslintrc: false,
@@ -1620,7 +1620,7 @@ describe("CLIEngine", function() {
                 assert.equal(report.results[0].messages[0].ruleId, "example/example-rule");
             });
 
-            it("should return two messages when executing with cli option that specifies preloaded plugin", function() {
+            it("should return two messages when executing with cli option that specifies preloaded plugin", () => {
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, ".."),
                     useEslintrc: false,
@@ -1638,7 +1638,7 @@ describe("CLIEngine", function() {
             });
         });
 
-        describe("cache", function() {
+        describe("cache", () => {
             let sandbox;
 
             /**
@@ -1668,17 +1668,17 @@ describe("CLIEngine", function() {
                 doDelete(path.resolve(".cache/custom-cache"));
             }
 
-            beforeEach(function() {
+            beforeEach(() => {
                 deleteCache();
                 sandbox = sinon.sandbox.create();
             });
 
-            afterEach(function() {
+            afterEach(() => {
                 sandbox.restore();
                 deleteCache();
             });
 
-            describe("when the cacheFile is a directory or looks like a directory", function() {
+            describe("when the cacheFile is a directory or looks like a directory", () => {
 
                 /**
                 * helper method to delete the cache files created during testing
@@ -1695,15 +1695,15 @@ describe("CLIEngine", function() {
                          */
                     }
                 }
-                beforeEach(function() {
+                beforeEach(() => {
                     deleteCacheDir();
                 });
 
-                afterEach(function() {
+                afterEach(() => {
                     deleteCacheDir();
                 });
 
-                it("should create the cache file inside the provided directory", function() {
+                it("should create the cache file inside the provided directory", () => {
                     assert.isFalse(shell.test("-d", path.resolve("./tmp/.cacheFileDir/.cache_hashOfCurrentWorkingDirectory")), "the cache for eslint does not exist");
 
                     engine = new CLIEngine({
@@ -1730,7 +1730,7 @@ describe("CLIEngine", function() {
                 });
             });
 
-            it("should create the cache file inside the provided directory using the cacheLocation option", function() {
+            it("should create the cache file inside the provided directory using the cacheLocation option", () => {
                 assert.isFalse(shell.test("-d", path.resolve("./tmp/.cacheFileDir/.cache_hashOfCurrentWorkingDirectory")), "the cache for eslint does not exist");
 
                 engine = new CLIEngine({
@@ -1756,7 +1756,7 @@ describe("CLIEngine", function() {
                 sandbox.restore();
             });
 
-            it("should create the cache file inside cwd when no cacheLocation provided", function() {
+            it("should create the cache file inside cwd when no cacheLocation provided", () => {
                 const cwd = path.resolve(getFixturePath("cli-engine"));
 
                 engine = new CLIEngine({
@@ -1777,7 +1777,7 @@ describe("CLIEngine", function() {
                 assert.isTrue(shell.test("-f", path.resolve(cwd, ".eslintcache")), "the cache for eslint was created at provided cwd");
             });
 
-            it("should invalidate the cache if the configuration changed between executions", function() {
+            it("should invalidate the cache if the configuration changed between executions", () => {
                 assert.isFalse(shell.test("-f", path.resolve(".eslintcache")), "the cache for eslint does not exist");
 
                 engine = new CLIEngine({
@@ -1831,7 +1831,7 @@ describe("CLIEngine", function() {
                 assert.isTrue(shell.test("-f", path.resolve(".eslintcache")), "the cache for eslint was created");
             });
 
-            it("should remember the files from a previous run and do not operate on them if not changed", function() {
+            it("should remember the files from a previous run and do not operate on them if not changed", () => {
 
                 assert.isFalse(shell.test("-f", path.resolve(".eslintcache")), "the cache for eslint does not exist");
 
@@ -1886,7 +1886,7 @@ describe("CLIEngine", function() {
                 assert.isFalse(spy.called, "the file was not loaded because it used the cache");
             });
 
-            it("should remember the files from a previous run and do not operate on then if not changed", function() {
+            it("should remember the files from a previous run and do not operate on then if not changed", () => {
 
                 const cacheFile = getFixturePath(".eslintcache");
                 const cliEngineOptions = {
@@ -1923,7 +1923,7 @@ describe("CLIEngine", function() {
                 assert.isFalse(shell.test("-f", cacheFile), "the cache for eslint was deleted since last run did not used the cache");
             });
 
-            it("should not store in the cache a file that failed the test", function() {
+            it("should not store in the cache a file that failed the test", () => {
 
                 const cacheFile = getFixturePath(".eslintcache");
 
@@ -1961,7 +1961,7 @@ describe("CLIEngine", function() {
                 assert.deepEqual(result, cachedResult, "result is the same with or without cache");
             });
 
-            it("should not contain in the cache a file that was deleted", function() {
+            it("should not contain in the cache a file that was deleted", () => {
 
                 const cacheFile = getFixturePath(".eslintcache");
 
@@ -2003,7 +2003,7 @@ describe("CLIEngine", function() {
                 assert.isTrue(typeof cache[toBeDeletedFile] === "undefined", "the entry for the file to be deleted is not in the cache");
             });
 
-            it("should contain files that were not visited in the cache provided they still exist", function() {
+            it("should contain files that were not visited in the cache provided they still exist", () => {
 
                 const cacheFile = getFixturePath(".eslintcache");
 
@@ -2043,7 +2043,7 @@ describe("CLIEngine", function() {
                 assert.isTrue(typeof cache[testFile2] === "object", "the entry for the test-file2 is in the cache");
             });
 
-            it("should not delete cache when executing on text", function() {
+            it("should not delete cache when executing on text", () => {
                 const cacheFile = getFixturePath(".eslintcache");
 
                 engine = new CLIEngine({
@@ -2064,7 +2064,7 @@ describe("CLIEngine", function() {
                 assert.isTrue(shell.test("-f", cacheFile), "the cache for eslint still exists");
             });
 
-            it("should not delete cache when executing on text with a provided filename", function() {
+            it("should not delete cache when executing on text with a provided filename", () => {
                 const cacheFile = getFixturePath(".eslintcache");
 
                 engine = new CLIEngine({
@@ -2085,7 +2085,7 @@ describe("CLIEngine", function() {
                 assert.isTrue(shell.test("-f", cacheFile), "the cache for eslint still exists");
             });
 
-            it("should not delete cache when executing on files with --cache flag", function() {
+            it("should not delete cache when executing on files with --cache flag", () => {
                 const cacheFile = getFixturePath(".eslintcache");
 
                 engine = new CLIEngine({
@@ -2109,7 +2109,7 @@ describe("CLIEngine", function() {
                 assert.isTrue(shell.test("-f", cacheFile), "the cache for eslint still exists");
             });
 
-            it("should delete cache when executing on files without --cache flag", function() {
+            it("should delete cache when executing on files without --cache flag", () => {
                 const cacheFile = getFixturePath(".eslintcache");
 
                 engine = new CLIEngine({
@@ -2132,8 +2132,8 @@ describe("CLIEngine", function() {
                 assert.isFalse(shell.test("-f", cacheFile), "the cache for eslint has been deleted");
             });
 
-            describe("cacheFile", function() {
-                it("should use the specified cache file", function() {
+            describe("cacheFile", () => {
+                it("should use the specified cache file", () => {
                     const customCacheFile = path.resolve(".cache/custom-cache");
 
                     assert.isFalse(shell.test("-f", customCacheFile), "the cache for eslint does not exist");
@@ -2174,8 +2174,8 @@ describe("CLIEngine", function() {
             });
         });
 
-        describe("processors", function() {
-            it("should return two messages when executing with config file that specifies a processor", function() {
+        describe("processors", () => {
+            it("should return two messages when executing with config file that specifies a processor", () => {
                 engine = new CLIEngine({
                     configFile: getFixturePath("configurations", "processors.json"),
                     useEslintrc: false,
@@ -2188,7 +2188,7 @@ describe("CLIEngine", function() {
                 assert.equal(report.results.length, 1);
                 assert.equal(report.results[0].messages.length, 2);
             });
-            it("should return two messages when executing with config file that specifies preloaded processor", function() {
+            it("should return two messages when executing with config file that specifies preloaded processor", () => {
                 engine = new CLIEngine({
                     useEslintrc: false,
                     plugins: ["test-processor"],
@@ -2218,7 +2218,7 @@ describe("CLIEngine", function() {
                 assert.equal(report.results.length, 1);
                 assert.equal(report.results[0].messages.length, 2);
             });
-            it("should run processors when calling executeOnFiles with config file that specifies a processor", function() {
+            it("should run processors when calling executeOnFiles with config file that specifies a processor", () => {
                 engine = new CLIEngine({
                     configFile: getFixturePath("configurations", "processors.json"),
                     useEslintrc: false,
@@ -2231,7 +2231,7 @@ describe("CLIEngine", function() {
                 assert.equal(report.results[0].messages[0].message, "'b' is defined but never used.");
                 assert.equal(report.results[0].messages[0].ruleId, "post-processed");
             });
-            it("should run processors when calling executeOnFiles with config file that specifies preloaded processor", function() {
+            it("should run processors when calling executeOnFiles with config file that specifies preloaded processor", () => {
                 engine = new CLIEngine({
                     useEslintrc: false,
                     plugins: ["test-processor"],
@@ -2262,7 +2262,7 @@ describe("CLIEngine", function() {
                 assert.equal(report.results[0].messages[0].message, "'b' is defined but never used.");
                 assert.equal(report.results[0].messages[0].ruleId, "post-processed");
             });
-            it("should run processors when calling executeOnText with config file that specifies a processor", function() {
+            it("should run processors when calling executeOnText with config file that specifies a processor", () => {
                 engine = new CLIEngine({
                     configFile: getFixturePath("configurations", "processors.json"),
                     useEslintrc: false,
@@ -2275,7 +2275,7 @@ describe("CLIEngine", function() {
                 assert.equal(report.results[0].messages[0].message, "'b' is defined but never used.");
                 assert.equal(report.results[0].messages[0].ruleId, "post-processed");
             });
-            it("should run processors when calling executeOnText with config file that specifies preloaded processor", function() {
+            it("should run processors when calling executeOnText with config file that specifies preloaded processor", () => {
                 engine = new CLIEngine({
                     useEslintrc: false,
                     plugins: ["test-processor"],
@@ -2309,9 +2309,9 @@ describe("CLIEngine", function() {
         });
     });
 
-    describe("getConfigForFile", function() {
+    describe("getConfigForFile", () => {
 
-        it("should return the info from Config#getConfig when called", function() {
+        it("should return the info from Config#getConfig when called", () => {
 
             const engine = new CLIEngine({
                 configFile: getFixturePath("configurations", "quotes-error.json")
@@ -2329,7 +2329,7 @@ describe("CLIEngine", function() {
         });
 
 
-        it("should return the config when run from within a subdir", function() {
+        it("should return the config when run from within a subdir", () => {
 
             const engine = new CLIEngine({
                 cwd: getFixturePath("config-hierarchy", "root-true", "parent", "root", "subdir")
@@ -2349,19 +2349,19 @@ describe("CLIEngine", function() {
 
     });
 
-    describe("isPathIgnored", function() {
+    describe("isPathIgnored", () => {
         let sandbox;
 
-        beforeEach(function() {
+        beforeEach(() => {
             sandbox = sinon.sandbox.create();
             sandbox.stub(console, "info").returns(void 0);
         });
 
-        afterEach(function() {
+        afterEach(() => {
             sandbox.restore();
         });
 
-        it("should check if the given path is ignored", function() {
+        it("should check if the given path is ignored", () => {
             const engine = new CLIEngine({
                 ignorePath: getFixturePath(".eslintignore2"),
                 cwd: getFixturePath()
@@ -2371,7 +2371,7 @@ describe("CLIEngine", function() {
             assert.isFalse(engine.isPathIgnored("passing.js"));
         });
 
-        it("should return false if ignoring is disabled", function() {
+        it("should return false if ignoring is disabled", () => {
             const engine = new CLIEngine({
                 ignore: false,
                 ignorePath: getFixturePath(".eslintignore2"),
@@ -2382,7 +2382,7 @@ describe("CLIEngine", function() {
         });
 
         // https://github.com/eslint/eslint/issues/5547
-        it("should return true for default ignores even if ignoring is disabled", function() {
+        it("should return true for default ignores even if ignoring is disabled", () => {
             const engine = new CLIEngine({
                 ignore: false,
                 cwd: getFixturePath("cli-engine")
@@ -2393,30 +2393,30 @@ describe("CLIEngine", function() {
 
     });
 
-    describe("getFormatter()", function() {
+    describe("getFormatter()", () => {
 
-        it("should return a function when a bundled formatter is requested", function() {
+        it("should return a function when a bundled formatter is requested", () => {
             const engine = new CLIEngine(),
                 formatter = engine.getFormatter("compact");
 
             assert.isFunction(formatter);
         });
 
-        it("should return a function when no argument is passed", function() {
+        it("should return a function when no argument is passed", () => {
             const engine = new CLIEngine(),
                 formatter = engine.getFormatter();
 
             assert.isFunction(formatter);
         });
 
-        it("should return a function when a custom formatter is requested", function() {
+        it("should return a function when a custom formatter is requested", () => {
             const engine = new CLIEngine(),
                 formatter = engine.getFormatter(getFixturePath("formatters", "simple.js"));
 
             assert.isFunction(formatter);
         });
 
-        it("should return a function when a custom formatter is requested, also if the path has backslashes", function() {
+        it("should return a function when a custom formatter is requested, also if the path has backslashes", () => {
             const engine = new CLIEngine({
                     cwd: path.join(fixtureDir, "..")
                 }),
@@ -2425,46 +2425,46 @@ describe("CLIEngine", function() {
             assert.isFunction(formatter);
         });
 
-        it("should return null when a customer formatter doesn't exist", function() {
+        it("should return null when a customer formatter doesn't exist", () => {
             const engine = new CLIEngine(),
                 formatterPath = getFixturePath("formatters", "doesntexist.js");
 
-            assert.throws(function() {
+            assert.throws(() => {
                 engine.getFormatter(formatterPath);
             }, `There was a problem loading formatter: ${formatterPath}\nError: Cannot find module '${formatterPath}'`);
         });
 
-        it("should return null when a built-in formatter doesn't exist", function() {
+        it("should return null when a built-in formatter doesn't exist", () => {
             const engine = new CLIEngine();
 
-            assert.throws(function() {
+            assert.throws(() => {
                 engine.getFormatter("special");
             }, "There was a problem loading formatter: ./formatters/special\nError: Cannot find module './formatters/special'");
         });
 
-        it("should throw if the required formatter exists but has an error", function() {
+        it("should throw if the required formatter exists but has an error", () => {
             const engine = new CLIEngine(),
                 formatterPath = getFixturePath("formatters", "broken.js");
 
-            assert.throws(function() {
+            assert.throws(() => {
                 engine.getFormatter(formatterPath);
             }, `There was a problem loading formatter: ${formatterPath}\nError: Cannot find module 'this-module-does-not-exist'`);
         });
 
-        it("should return null when a non-string formatter name is passed", function() {
+        it("should return null when a non-string formatter name is passed", () => {
             const engine = new CLIEngine(),
                 formatter = engine.getFormatter(5);
 
             assert.isNull(formatter);
         });
 
-        it("should return a function when called as a static function on CLIEngine", function() {
+        it("should return a function when called as a static function on CLIEngine", () => {
             const formatter = CLIEngine.getFormatter();
 
             assert.isFunction(formatter);
         });
 
-        it("should return a function when called as a static function on CLIEngine and a custom formatter is requested", function() {
+        it("should return a function when called as a static function on CLIEngine and a custom formatter is requested", () => {
             const formatter = CLIEngine.getFormatter(getFixturePath("formatters", "simple.js"));
 
             assert.isFunction(formatter);
@@ -2472,8 +2472,8 @@ describe("CLIEngine", function() {
 
     });
 
-    describe("getErrorResults()", function() {
-        it("should report 5 error messages when looking for errors only", function() {
+    describe("getErrorResults()", () => {
+        it("should report 5 error messages when looking for errors only", () => {
 
             process.chdir(originalDir);
             const engine = new CLIEngine();
@@ -2495,7 +2495,7 @@ describe("CLIEngine", function() {
             assert.equal(errorResults[0].messages[4].severity, 2);
         });
 
-        it("should report a warningCount of 0 when looking for errors only", function() {
+        it("should report a warningCount of 0 when looking for errors only", () => {
 
             process.chdir(originalDir);
             const engine = new CLIEngine();
@@ -2506,7 +2506,7 @@ describe("CLIEngine", function() {
             assert.equal(errorResults[0].warningCount, 0);
         });
 
-        it("should return 0 error or warning messages even when the file has warnings", function() {
+        it("should return 0 error or warning messages even when the file has warnings", () => {
             const engine = new CLIEngine({
                 ignorePath: path.join(fixtureDir, ".eslintignore"),
                 cwd: path.join(fixtureDir, "..")
@@ -2523,7 +2523,7 @@ describe("CLIEngine", function() {
             assert.equal(report.results[0].warningCount, 1);
         });
 
-        it("should return source code of file in the `source` property", function() {
+        it("should return source code of file in the `source` property", () => {
             process.chdir(originalDir);
             const engine = new CLIEngine({
                 useEslintrc: false,
@@ -2538,7 +2538,7 @@ describe("CLIEngine", function() {
             assert.equal(errorResults[0].source, "var foo = 'bar';");
         });
 
-        it("should contain `output` property after fixes", function() {
+        it("should contain `output` property after fixes", () => {
             process.chdir(originalDir);
             const engine = new CLIEngine({
                 useEslintrc: false,
@@ -2557,15 +2557,15 @@ describe("CLIEngine", function() {
         });
     });
 
-    describe("outputFixes()", function() {
+    describe("outputFixes()", () => {
 
         const sandbox = sinon.sandbox.create();
 
-        afterEach(function() {
+        afterEach(() => {
             sandbox.verifyAndRestore();
         });
 
-        it("should call fs.writeFileSync() for each result with output", function() {
+        it("should call fs.writeFileSync() for each result with output", () => {
             const fakeFS = leche.fake(fs),
                 localCLIEngine = proxyquire("../../lib/cli-engine", {
                     fs: fakeFS
@@ -2594,7 +2594,7 @@ describe("CLIEngine", function() {
 
         });
 
-        it("should call fs.writeFileSync() for each result with output and not at all for a result without output", function() {
+        it("should call fs.writeFileSync() for each result with output and not at all for a result without output", () => {
             const fakeFS = leche.fake(fs),
                 localCLIEngine = proxyquire("../../lib/cli-engine", {
                     fs: fakeFS
@@ -2628,15 +2628,15 @@ describe("CLIEngine", function() {
 
     });
 
-    describe("resolveFileGlobPatterns", function() {
+    describe("resolveFileGlobPatterns", () => {
 
         leche.withData([
             [".", "**/*.js"],
             ["./", "**/*.js"],
             ["../", "../**/*.js"]
-        ], function(input, expected) {
+        ], (input, expected) => {
 
-            it(`should correctly resolve ${input} to ${expected}`, function() {
+            it(`should correctly resolve ${input} to ${expected}`, () => {
                 const engine = new CLIEngine();
 
                 const result = engine.resolveFileGlobPatterns([input]);
@@ -2648,9 +2648,9 @@ describe("CLIEngine", function() {
 
     });
 
-    describe("when evaluating code with comments to change config when allowInlineConfig is disabled", function() {
+    describe("when evaluating code with comments to change config when allowInlineConfig is disabled", () => {
 
-        it("should report a violation for disabling rules", function() {
+        it("should report a violation for disabling rules", () => {
             const code = [
                 "alert('test'); // eslint-disable-line no-alert"
             ].join("\n");
@@ -2676,7 +2676,7 @@ describe("CLIEngine", function() {
             assert.equal(messages[0].ruleId, "no-alert");
         });
 
-        it("should not report a violation by default", function() {
+        it("should not report a violation by default", () => {
             const code = [
                 "alert('test'); // eslint-disable-line no-alert"
             ].join("\n");

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -27,7 +27,7 @@ const proxyquire = require("proxyquire").noCallThru().noPreserveCache();
 // Tests
 //------------------------------------------------------------------------------
 
-describe("cli", function() {
+describe("cli", () => {
 
     let fixtureDir;
     const log = {
@@ -78,37 +78,37 @@ describe("cli", function() {
     }
 
     // copy into clean area so as not to get "infected" by this project's .eslintrc files
-    before(function() {
+    before(() => {
         fixtureDir = `${os.tmpdir()}/eslint/fixtures`;
         sh.mkdir("-p", fixtureDir);
         sh.cp("-r", "./tests/fixtures/.", fixtureDir);
     });
 
-    afterEach(function() {
+    afterEach(() => {
         log.info.reset();
         log.error.reset();
     });
 
-    after(function() {
+    after(() => {
         sh.rm("-r", fixtureDir);
     });
 
-    describe("execute()", function() {
-        it("should return error when text with incorrect quotes is passed as argument", function() {
+    describe("execute()", () => {
+        it("should return error when text with incorrect quotes is passed as argument", () => {
             const configFile = getFixturePath("configurations", "quotes-error.json");
             const result = cli.execute(`-c ${configFile}`, "var foo = 'bar';");
 
             assert.equal(result, 1);
         });
 
-        it("should return no error when --ext .js2 is specified", function() {
+        it("should return no error when --ext .js2 is specified", () => {
             const filePath = getFixturePath("files");
             const result = cli.execute(`--ext .js2 ${filePath}`);
 
             assert.equal(result, 0);
         });
 
-        it("should exit with console error when passed unsupported arguments", function() {
+        it("should exit with console error when passed unsupported arguments", () => {
             const filePath = getFixturePath("files");
             const result = cli.execute(`--blah --another ${filePath}`);
 
@@ -117,26 +117,26 @@ describe("cli", function() {
 
     });
 
-    describe("when given a config file", function() {
-        it("should load the specified config file", function() {
+    describe("when given a config file", () => {
+        it("should load the specified config file", () => {
             const configPath = getFixturePath(".eslintrc");
             const filePath = getFixturePath("passing.js");
 
-            assert.doesNotThrow(function() {
+            assert.doesNotThrow(() => {
                 cli.execute(`--config ${configPath} ${filePath}`);
             });
         });
     });
 
-    describe("when there is a local config file", function() {
+    describe("when there is a local config file", () => {
         const code = "lib/cli.js";
 
-        it("should load the local config file", function() {
+        it("should load the local config file", () => {
 
             // Mock CWD
             process.eslintCwd = getFixturePath("configurations", "single-quotes");
 
-            assert.doesNotThrow(function() {
+            assert.doesNotThrow(() => {
                 cli.execute(code);
             });
 
@@ -146,8 +146,8 @@ describe("cli", function() {
         });
     });
 
-    describe("when given a config with rules with options and severity level set to error", function() {
-        it("should exit with an error status (1)", function() {
+    describe("when given a config with rules with options and severity level set to error", () => {
+        it("should exit with an error status (1)", () => {
             const configPath = getFixturePath("configurations", "quotes-error.json");
             const filePath = getFixturePath("single-quoted.js");
             const code = `--no-ignore --config ${configPath} ${filePath}`;
@@ -158,15 +158,15 @@ describe("cli", function() {
         });
     });
 
-    describe("when given a config file and a directory of files", function() {
-        it("should load and execute without error", function() {
+    describe("when given a config file and a directory of files", () => {
+        it("should load and execute without error", () => {
             const configPath = getFixturePath("configurations", "semi-error.json");
             const filePath = getFixturePath("formatters");
             const code = `--config ${configPath} ${filePath}`;
 
             let exitStatus;
 
-            assert.doesNotThrow(function() {
+            assert.doesNotThrow(() => {
                 exitStatus = cli.execute(code);
             });
 
@@ -174,8 +174,8 @@ describe("cli", function() {
         });
     });
 
-    describe("when given a config with environment set to browser", function() {
-        it("should execute without any errors", function() {
+    describe("when given a config with environment set to browser", () => {
+        it("should execute without any errors", () => {
             const configPath = getFixturePath("configurations", "env-browser.json");
             const filePath = getFixturePath("globals-browser.js");
             const code = `--config ${configPath} ${filePath}`;
@@ -186,8 +186,8 @@ describe("cli", function() {
         });
     });
 
-    describe("when given a config with environment set to Node.js", function() {
-        it("should execute without any errors", function() {
+    describe("when given a config with environment set to Node.js", () => {
+        it("should execute without any errors", () => {
             const configPath = getFixturePath("configurations", "env-node.json");
             const filePath = getFixturePath("globals-node.js");
             const code = `--config ${configPath} ${filePath}`;
@@ -198,8 +198,8 @@ describe("cli", function() {
         });
     });
 
-    describe("when given a config with environment set to Nashorn", function() {
-        it("should execute without any errors", function() {
+    describe("when given a config with environment set to Nashorn", () => {
+        it("should execute without any errors", () => {
             const configPath = getFixturePath("configurations", "env-nashorn.json");
             const filePath = getFixturePath("globals-nashorn.js");
             const code = `--config ${configPath} ${filePath}`;
@@ -210,8 +210,8 @@ describe("cli", function() {
         });
     });
 
-    describe("when given a config with environment set to WebExtensions", function() {
-        it("should execute without any errors", function() {
+    describe("when given a config with environment set to WebExtensions", () => {
+        it("should execute without any errors", () => {
             const configPath = getFixturePath("configurations", "env-webextensions.json");
             const filePath = getFixturePath("globals-webextensions.js");
             const code = `--config ${configPath} ${filePath}`;
@@ -222,8 +222,8 @@ describe("cli", function() {
         });
     });
 
-    describe("when given a valid built-in formatter name", function() {
-        it("should execute without any errors", function() {
+    describe("when given a valid built-in formatter name", () => {
+        it("should execute without any errors", () => {
             const filePath = getFixturePath("passing.js");
             const exit = cli.execute(`-f checkstyle ${filePath}`);
 
@@ -231,8 +231,8 @@ describe("cli", function() {
         });
     });
 
-    describe("when given an invalid built-in formatter name", function() {
-        it("should execute with error", function() {
+    describe("when given an invalid built-in formatter name", () => {
+        it("should execute with error", () => {
             const filePath = getFixturePath("passing.js");
             const exit = cli.execute(`-f fakeformatter ${filePath}`);
 
@@ -240,8 +240,8 @@ describe("cli", function() {
         });
     });
 
-    describe("when given a valid formatter path", function() {
-        it("should execute without any errors", function() {
+    describe("when given a valid formatter path", () => {
+        it("should execute without any errors", () => {
             const formatterPath = getFixturePath("formatters", "simple.js");
             const filePath = getFixturePath("passing.js");
             const exit = cli.execute(`-f ${formatterPath} ${filePath}`);
@@ -250,8 +250,8 @@ describe("cli", function() {
         });
     });
 
-    describe("when given an invalid formatter path", function() {
-        it("should execute with error", function() {
+    describe("when given an invalid formatter path", () => {
+        it("should execute with error", () => {
             const formatterPath = getFixturePath("formatters", "file-does-not-exist.js");
             const filePath = getFixturePath("passing.js");
             const exit = cli.execute(`-f ${formatterPath} ${filePath}`);
@@ -260,8 +260,8 @@ describe("cli", function() {
         });
     });
 
-    describe("when executing a file with a lint error", function() {
-        it("should exit with error", function() {
+    describe("when executing a file with a lint error", () => {
+        it("should exit with error", () => {
             const filePath = getFixturePath("undef.js");
             const code = `--no-ignore --config --rule no-undef:2 ${filePath}`;
 
@@ -271,8 +271,8 @@ describe("cli", function() {
         });
     });
 
-    describe("when executing a file with a syntax error", function() {
-        it("should exit with error", function() {
+    describe("when executing a file with a syntax error", () => {
+        it("should exit with error", () => {
             const filePath = getFixturePath("syntax-error.js");
             const exit = cli.execute(`--no-ignore ${filePath}`);
 
@@ -280,8 +280,8 @@ describe("cli", function() {
         });
     });
 
-    describe("when calling execute more than once", function() {
-        it("should not print the results from previous execution", function() {
+    describe("when calling execute more than once", () => {
+        it("should not print the results from previous execution", () => {
             const filePath = getFixturePath("missing-semicolon.js");
             const passingPath = getFixturePath("passing.js");
 
@@ -297,24 +297,24 @@ describe("cli", function() {
         });
     });
 
-    describe("when executing with version flag", function() {
-        it("should print out current version", function() {
+    describe("when executing with version flag", () => {
+        it("should print out current version", () => {
             cli.execute("-v");
 
             assert.equal(log.info.callCount, 1);
         });
     });
 
-    describe("when executing with help flag", function() {
-        it("should print out help", function() {
+    describe("when executing with help flag", () => {
+        it("should print out help", () => {
             cli.execute("-h");
 
             assert.equal(log.info.callCount, 1);
         });
     });
 
-    describe("when given a directory with eslint excluded files in the directory", function() {
-        it("should not process any files", function() {
+    describe("when given a directory with eslint excluded files in the directory", () => {
+        it("should not process any files", () => {
             const ignorePath = getFixturePath(".eslintignore");
             const filePath = getFixturePath(".");
             const exit = cli.execute(`--ignore-path ${ignorePath} ${filePath}`);
@@ -324,9 +324,9 @@ describe("cli", function() {
         });
     });
 
-    describe("when given a file in excluded files list", function() {
+    describe("when given a file in excluded files list", () => {
 
-        it("should not process the file", function() {
+        it("should not process the file", () => {
             const ignorePath = getFixturePath(".eslintignore");
             const filePath = getFixturePath("passing.js");
             const exit = cli.execute(`--ignore-path ${ignorePath} ${filePath}`);
@@ -336,7 +336,7 @@ describe("cli", function() {
             assert.equal(exit, 0);
         });
 
-        it("should process the file when forced", function() {
+        it("should process the file when forced", () => {
             const ignorePath = getFixturePath(".eslintignore");
             const filePath = getFixturePath("passing.js");
             const exit = cli.execute(`--ignore-path ${ignorePath} --no-ignore ${filePath}`);
@@ -347,8 +347,8 @@ describe("cli", function() {
         });
     });
 
-    describe("when given a pattern to ignore", function() {
-        it("should not process any files", function() {
+    describe("when given a pattern to ignore", () => {
+        it("should not process any files", () => {
             const ignoredFile = getFixturePath("cli/syntax-error.js");
             const filePath = getFixturePath("cli/passing.js");
             const exit = cli.execute(`--ignore-pattern cli/ ${ignoredFile} ${filePath}`);
@@ -359,13 +359,11 @@ describe("cli", function() {
         });
     });
 
-    describe("when given patterns to ignore", function() {
-        it("should not process any matching files", function() {
+    describe("when given patterns to ignore", () => {
+        it("should not process any matching files", () => {
             const ignorePaths = ["a", "b"];
 
-            const cmd = ignorePaths.map(function(ignorePath) {
-                return `--ignore-pattern ${ignorePath}`;
-            }).concat(".").join(" ");
+            const cmd = ignorePaths.map(ignorePath => `--ignore-pattern ${ignorePath}`).concat(".").join(" ");
 
             const opts = {
                 ignorePattern: ignorePaths
@@ -375,9 +373,9 @@ describe("cli", function() {
         });
     });
 
-    describe("when executing a file with a shebang", function() {
+    describe("when executing a file with a shebang", () => {
 
-        it("should execute without error", function() {
+        it("should execute without error", () => {
             const filePath = getFixturePath("shebang.js");
             const exit = cli.execute(`--no-ignore ${filePath}`);
 
@@ -385,22 +383,22 @@ describe("cli", function() {
         });
     });
 
-    describe("when loading a custom rule", function() {
+    describe("when loading a custom rule", () => {
 
-        it("should return an error when rule isn't found", function() {
+        it("should return an error when rule isn't found", () => {
             const rulesPath = getFixturePath("rules", "wrong");
             const configPath = getFixturePath("rules", "eslint.json");
             const filePath = getFixturePath("rules", "test", "test-custom-rule.js");
             const code = `--rulesdir ${rulesPath} --config ${configPath} --no-ignore ${filePath}`;
 
-            assert.throws(function() {
+            assert.throws(() => {
                 const exit = cli.execute(code);
 
                 assert.equal(exit, 1);
             }, /Error while loading rule 'custom-rule': Cannot read property/);
         });
 
-        it("should return a warning when rule is matched", function() {
+        it("should return a warning when rule is matched", () => {
             const rulesPath = getFixturePath("rules");
             const configPath = getFixturePath("rules", "eslint.json");
             const filePath = getFixturePath("rules", "test", "test-custom-rule.js");
@@ -412,7 +410,7 @@ describe("cli", function() {
             assert.isTrue(log.info.neverCalledWith(""));
         });
 
-        it("should return warnings from multiple rules in different directories", function() {
+        it("should return warnings from multiple rules in different directories", () => {
             const rulesPath = getFixturePath("rules", "dir1");
             const rulesPath2 = getFixturePath("rules", "dir2");
             const configPath = getFixturePath("rules", "multi-rulesdirs.json");
@@ -433,8 +431,8 @@ describe("cli", function() {
 
     });
 
-    describe("when executing with no-eslintrc flag", function() {
-        it("should ignore a local config file", function() {
+    describe("when executing with no-eslintrc flag", () => {
+        it("should ignore a local config file", () => {
             const filePath = getFixturePath("eslintrc", "quotes.js");
             const exit = cli.execute(`--no-eslintrc --no-ignore ${filePath}`);
 
@@ -443,8 +441,8 @@ describe("cli", function() {
         });
     });
 
-    describe("when executing without no-eslintrc flag", function() {
-        it("should load a local config file", function() {
+    describe("when executing without no-eslintrc flag", () => {
+        it("should load a local config file", () => {
             const filePath = getFixturePath("eslintrc", "quotes.js");
             const exit = cli.execute(`--no-ignore ${filePath}`);
 
@@ -453,8 +451,8 @@ describe("cli", function() {
         });
     });
 
-    describe("when executing without env flag", function() {
-        it("should not define environment-specific globals", function() {
+    describe("when executing without env flag", () => {
+        it("should not define environment-specific globals", () => {
             const files = [
                 getFixturePath("globals-browser.js"),
                 getFixturePath("globals-node.js")
@@ -466,8 +464,8 @@ describe("cli", function() {
         });
     });
 
-    describe("when executing with global flag", function() {
-        it("should default defined variables to read-only", function() {
+    describe("when executing with global flag", () => {
+        it("should default defined variables to read-only", () => {
             const filePath = getFixturePath("undef.js");
             const exit = cli.execute(`--global baz,bat --no-ignore --rule no-global-assign:2 ${filePath}`);
 
@@ -475,7 +473,7 @@ describe("cli", function() {
             assert.equal(exit, 1);
         });
 
-        it("should allow defining writable global variables", function() {
+        it("should allow defining writable global variables", () => {
             const filePath = getFixturePath("undef.js");
             const exit = cli.execute(`--global baz:false,bat:true --no-ignore ${filePath}`);
 
@@ -483,7 +481,7 @@ describe("cli", function() {
             assert.equal(exit, 0);
         });
 
-        it("should allow defining variables with multiple flags", function() {
+        it("should allow defining variables with multiple flags", () => {
             const filePath = getFixturePath("undef.js");
             const exit = cli.execute(`--global baz --global bat:true --no-ignore ${filePath}`);
 
@@ -492,8 +490,8 @@ describe("cli", function() {
         });
     });
 
-    describe("when supplied with rule flag and severity level set to error", function() {
-        it("should exit with an error status (2)", function() {
+    describe("when supplied with rule flag and severity level set to error", () => {
+        it("should exit with an error status (2)", () => {
             const filePath = getFixturePath("single-quoted.js");
             const code = `--no-ignore --rule 'quotes: [2, double]' ${filePath}`;
             const exitStatus = cli.execute(code);
@@ -502,9 +500,9 @@ describe("cli", function() {
         });
     });
 
-    describe("when the quiet option is enabled", function() {
+    describe("when the quiet option is enabled", () => {
 
-        it("should only print error", function() {
+        it("should only print error", () => {
             const filePath = getFixturePath("single-quoted.js");
             const cliArgs = `--no-ignore --quiet  -f compact --rule 'quotes: [2, double]' --rule 'no-unused-vars: 1' ${filePath}`;
 
@@ -518,7 +516,7 @@ describe("cli", function() {
             assert.notInclude(formattedOutput, "Warning");
         });
 
-        it("should print nothing if there are no errors", function() {
+        it("should print nothing if there are no errors", () => {
             const filePath = getFixturePath("single-quoted.js");
             const cliArgs = `--quiet  -f compact --rule 'quotes: [1, double]' --rule 'no-unused-vars: 1' ${filePath}`;
 
@@ -528,13 +526,13 @@ describe("cli", function() {
         });
     });
 
-    describe("when supplied with report output file path", function() {
+    describe("when supplied with report output file path", () => {
 
-        afterEach(function() {
+        afterEach(() => {
             sh.rm("-rf", "tests/output");
         });
 
-        it("should write the file and create dirs if they don't exist", function() {
+        it("should write the file and create dirs if they don't exist", () => {
             const filePath = getFixturePath("single-quoted.js");
             const code = `--no-ignore --rule 'quotes: [1, double]' --o tests/output/eslint-output.txt ${filePath}`;
 
@@ -544,7 +542,7 @@ describe("cli", function() {
             assert.isTrue(log.info.notCalled);
         });
 
-        it("should return an error if the path is a directory", function() {
+        it("should return an error if the path is a directory", () => {
             const filePath = getFixturePath("single-quoted.js");
             const code = `--no-ignore --rule 'quotes: [1, double]' --o tests/output ${filePath}`;
 
@@ -557,7 +555,7 @@ describe("cli", function() {
             assert.isTrue(log.error.calledOnce);
         });
 
-        it("should return an error if the path could not be written to", function() {
+        it("should return an error if the path could not be written to", () => {
             const filePath = getFixturePath("single-quoted.js");
             const code = `--no-ignore --rule 'quotes: [1, double]' --o tests/output/eslint-output.txt ${filePath}`;
 
@@ -571,9 +569,9 @@ describe("cli", function() {
         });
     });
 
-    describe("when supplied with a plugin", function() {
+    describe("when supplied with a plugin", () => {
 
-        it("should pass plugins to CLIEngine", function() {
+        it("should pass plugins to CLIEngine", () => {
             const examplePluginName = "eslint-plugin-example";
 
             verifyCLIEngineOpts(`--no-ignore --plugin ${examplePluginName} foo.js`, {
@@ -583,15 +581,15 @@ describe("cli", function() {
 
     });
 
-    describe("when given an parser name", function() {
-        it("should exit with error if parser is invalid", function() {
+    describe("when given an parser name", () => {
+        it("should exit with error if parser is invalid", () => {
             const filePath = getFixturePath("passing.js");
             const exit = cli.execute(`--no-ignore --parser test111 ${filePath}`);
 
             assert.equal(exit, 1);
         });
 
-        it("should exit with no error if parser is valid", function() {
+        it("should exit with no error if parser is valid", () => {
             const filePath = getFixturePath("passing.js");
             const exit = cli.execute(`--no-ignore --parser espree ${filePath}`);
 
@@ -599,36 +597,36 @@ describe("cli", function() {
         });
     });
 
-    describe("when given parser options", function() {
-        it("should exit with error if parser options are invalid", function() {
+    describe("when given parser options", () => {
+        it("should exit with error if parser options are invalid", () => {
             const filePath = getFixturePath("passing.js");
             const exit = cli.execute(`--no-ignore --parser-options test111 ${filePath}`);
 
             assert.equal(exit, 1);
         });
 
-        it("should exit with no error if parser is valid", function() {
+        it("should exit with no error if parser is valid", () => {
             const filePath = getFixturePath("passing.js");
             const exit = cli.execute(`--no-ignore --parser-options=ecmaVersion:6 ${filePath}`);
 
             assert.equal(exit, 0);
         });
 
-        it("should exit with an error on ecmaVersion 7 feature in ecmaVersion 6", function() {
+        it("should exit with an error on ecmaVersion 7 feature in ecmaVersion 6", () => {
             const filePath = getFixturePath("passing-es7.js");
             const exit = cli.execute(`--no-ignore --parser-options=ecmaVersion:6 ${filePath}`);
 
             assert.equal(exit, 1);
         });
 
-        it("should exit with no error on ecmaVersion 7 feature in ecmaVersion 7", function() {
+        it("should exit with no error on ecmaVersion 7 feature in ecmaVersion 7", () => {
             const filePath = getFixturePath("passing-es7.js");
             const exit = cli.execute(`--no-ignore --parser-options=ecmaVersion:7 ${filePath}`);
 
             assert.equal(exit, 0);
         });
 
-        it("should exit with no error on ecmaVersion 7 feature with config ecmaVersion 6 and command line ecmaVersion 7", function() {
+        it("should exit with no error on ecmaVersion 7 feature with config ecmaVersion 6 and command line ecmaVersion 7", () => {
             const configPath = getFixturePath("configurations", "es6.json");
             const filePath = getFixturePath("passing-es7.js");
             const exit = cli.execute(`--no-ignore --config ${configPath} --parser-options=ecmaVersion:7 ${filePath}`);
@@ -637,15 +635,15 @@ describe("cli", function() {
         });
     });
 
-    describe("when given the max-warnings flag", function() {
-        it("should not change exit code if warning count under threshold", function() {
+    describe("when given the max-warnings flag", () => {
+        it("should not change exit code if warning count under threshold", () => {
             const filePath = getFixturePath("max-warnings");
             const exitCode = cli.execute(`--no-ignore --max-warnings 10 ${filePath}`);
 
             assert.equal(exitCode, 0);
         });
 
-        it("should exit with exit code 1 if warning count exceeds threshold", function() {
+        it("should exit with exit code 1 if warning count exceeds threshold", () => {
             const filePath = getFixturePath("max-warnings");
             const exitCode = cli.execute(`--no-ignore --max-warnings 5 ${filePath}`);
 
@@ -654,14 +652,14 @@ describe("cli", function() {
             assert.include(log.error.getCall(0).args[0], "ESLint found too many warnings");
         });
 
-        it("should not change exit code if warning count equals threshold", function() {
+        it("should not change exit code if warning count equals threshold", () => {
             const filePath = getFixturePath("max-warnings");
             const exitCode = cli.execute(`--no-ignore --max-warnings 6 ${filePath}`);
 
             assert.equal(exitCode, 0);
         });
 
-        it("should not change exit code if flag is not specified and there are warnings", function() {
+        it("should not change exit code if flag is not specified and there are warnings", () => {
             const filePath = getFixturePath("max-warnings");
             const exitCode = cli.execute(filePath);
 
@@ -669,16 +667,16 @@ describe("cli", function() {
         });
     });
 
-    describe("when passed --no-inline-config", function() {
+    describe("when passed --no-inline-config", () => {
 
         const sandbox = sinon.sandbox.create();
         let localCLI;
 
-        afterEach(function() {
+        afterEach(() => {
             sandbox.verifyAndRestore();
         });
 
-        it("should pass allowInlineConfig:true to CLIEngine when --no-inline-config is used", function() {
+        it("should pass allowInlineConfig:true to CLIEngine when --no-inline-config is used", () => {
 
             // create a fake CLIEngine to test with
             const fakeCLIEngine = sandbox.mock().withExactArgs(sinon.match({ allowInlineConfig: false }));
@@ -698,9 +696,7 @@ describe("cli", function() {
                     ]
                 }]
             });
-            sandbox.stub(fakeCLIEngine.prototype, "getFormatter").returns(function() {
-                return "done";
-            });
+            sandbox.stub(fakeCLIEngine.prototype, "getFormatter").returns(() => "done");
             fakeCLIEngine.outputFixes = sandbox.stub();
 
             localCLI = proxyquire("../../lib/cli", {
@@ -711,7 +707,7 @@ describe("cli", function() {
             localCLI.execute("--no-inline-config .");
         });
 
-        it("should not error and allowInlineConfig should be true by default", function() {
+        it("should not error and allowInlineConfig should be true by default", () => {
 
             // create a fake CLIEngine to test with
             const fakeCLIEngine = sandbox.mock().withExactArgs(sinon.match({ allowInlineConfig: true }));
@@ -722,9 +718,7 @@ describe("cli", function() {
                 warningCount: 0,
                 results: []
             });
-            sandbox.stub(fakeCLIEngine.prototype, "getFormatter").returns(function() {
-                return "done";
-            });
+            sandbox.stub(fakeCLIEngine.prototype, "getFormatter").returns(() => "done");
             fakeCLIEngine.outputFixes = sandbox.stub();
 
             localCLI = proxyquire("../../lib/cli", {
@@ -740,16 +734,16 @@ describe("cli", function() {
 
     });
 
-    describe("when passed --fix", function() {
+    describe("when passed --fix", () => {
 
         const sandbox = sinon.sandbox.create();
         let localCLI;
 
-        afterEach(function() {
+        afterEach(() => {
             sandbox.verifyAndRestore();
         });
 
-        it("should pass fix:true to CLIEngine when executing on files", function() {
+        it("should pass fix:true to CLIEngine when executing on files", () => {
 
             // create a fake CLIEngine to test with
             const fakeCLIEngine = sandbox.mock().withExactArgs(sinon.match({ fix: true }));
@@ -760,9 +754,7 @@ describe("cli", function() {
                 warningCount: 0,
                 results: []
             });
-            sandbox.stub(fakeCLIEngine.prototype, "getFormatter").returns(function() {
-                return "done";
-            });
+            sandbox.stub(fakeCLIEngine.prototype, "getFormatter").returns(() => "done");
             fakeCLIEngine.outputFixes = sandbox.stub();
 
             localCLI = proxyquire("../../lib/cli", {
@@ -776,7 +768,7 @@ describe("cli", function() {
 
         });
 
-        it("should rewrite files when in fix mode", function() {
+        it("should rewrite files when in fix mode", () => {
 
             const report = {
                 errorCount: 1,
@@ -798,9 +790,7 @@ describe("cli", function() {
 
             fakeCLIEngine.prototype = leche.fake(CLIEngine.prototype);
             sandbox.stub(fakeCLIEngine.prototype, "executeOnFiles").returns(report);
-            sandbox.stub(fakeCLIEngine.prototype, "getFormatter").returns(function() {
-                return "done";
-            });
+            sandbox.stub(fakeCLIEngine.prototype, "getFormatter").returns(() => "done");
             fakeCLIEngine.outputFixes = sandbox.mock().withExactArgs(report);
 
             localCLI = proxyquire("../../lib/cli", {
@@ -814,7 +804,7 @@ describe("cli", function() {
 
         });
 
-        it("should rewrite files when in fix mode and quiet mode", function() {
+        it("should rewrite files when in fix mode and quiet mode", () => {
 
             const report = {
                 errorCount: 0,
@@ -836,9 +826,7 @@ describe("cli", function() {
 
             fakeCLIEngine.prototype = leche.fake(CLIEngine.prototype);
             sandbox.stub(fakeCLIEngine.prototype, "executeOnFiles").returns(report);
-            sandbox.stub(fakeCLIEngine.prototype, "getFormatter").returns(function() {
-                return "done";
-            });
+            sandbox.stub(fakeCLIEngine.prototype, "getFormatter").returns(() => "done");
             fakeCLIEngine.getErrorResults = sandbox.stub().returns([]);
             fakeCLIEngine.outputFixes = sandbox.mock().withExactArgs(report);
 
@@ -853,7 +841,7 @@ describe("cli", function() {
 
         });
 
-        it("should not call CLIEngine and return 1 when executing on text", function() {
+        it("should not call CLIEngine and return 1 when executing on text", () => {
 
             // create a fake CLIEngine to test with
             const fakeCLIEngine = sandbox.mock().never();
@@ -870,8 +858,8 @@ describe("cli", function() {
 
     });
 
-    describe("when passing --print-config", function() {
-        it("should print out the configuration", function() {
+    describe("when passing --print-config", () => {
+        it("should print out the configuration", () => {
             const filePath = getFixturePath("files");
 
             const exitCode = cli.execute(`--print-config ${filePath}`);
@@ -880,7 +868,7 @@ describe("cli", function() {
             assert.equal(exitCode, 0);
         });
 
-        it("should error if any positional file arguments are passed", function() {
+        it("should error if any positional file arguments are passed", () => {
             const filePath1 = getFixturePath("files", "bar.js");
             const filePath2 = getFixturePath("files", "foo.js");
 
@@ -891,7 +879,7 @@ describe("cli", function() {
             assert.equal(exitCode, 1);
         });
 
-        it("should error out when executing on text", function() {
+        it("should error out when executing on text", () => {
             const exitCode = cli.execute("--print-config", "foo = bar;");
 
             assert.isTrue(log.info.notCalled);

--- a/tests/lib/code-path-analysis/code-path-analyzer.js
+++ b/tests/lib/code-path-analysis/code-path-analyzer.js
@@ -52,9 +52,9 @@ function getExpectedDotArrows(source) {
 // Tests
 //------------------------------------------------------------------------------
 
-describe("CodePathAnalyzer", function() {
+describe("CodePathAnalyzer", () => {
 
-    afterEach(function() {
+    afterEach(() => {
         eslint.reset();
     });
 
@@ -62,36 +62,34 @@ describe("CodePathAnalyzer", function() {
         new CodePathAnalyzer(new NodeEventGenerator(new EventEmitter()))
     );
 
-    describe("interface of code paths", function() {
+    describe("interface of code paths", () => {
         let actual = [];
 
-        beforeEach(function() {
+        beforeEach(() => {
             actual = [];
-            eslint.defineRule("test", function() {
-                return {
-                    onCodePathStart(codePath) {
-                        actual.push(codePath);
-                    }
-                };
-            });
+            eslint.defineRule("test", () => ({
+                onCodePathStart(codePath) {
+                    actual.push(codePath);
+                }
+            }));
             eslint.verify(
                 "function foo(a) { if (a) return 0; else throw new Error(); }",
                 {rules: {test: 2}}
             );
         });
 
-        it("should have `id` as unique string", function() {
+        it("should have `id` as unique string", () => {
             assert(typeof actual[0].id === "string");
             assert(typeof actual[1].id === "string");
             assert(actual[0].id !== actual[1].id);
         });
 
-        it("should have `upper` as CodePath", function() {
+        it("should have `upper` as CodePath", () => {
             assert(actual[0].upper === null);
             assert(actual[1].upper === actual[0]);
         });
 
-        it("should have `childCodePaths` as CodePath[]", function() {
+        it("should have `childCodePaths` as CodePath[]", () => {
             assert(Array.isArray(actual[0].childCodePaths));
             assert(Array.isArray(actual[1].childCodePaths));
             assert(actual[0].childCodePaths.length === 1);
@@ -99,14 +97,14 @@ describe("CodePathAnalyzer", function() {
             assert(actual[0].childCodePaths[0] === actual[1]);
         });
 
-        it("should have `initialSegment` as CodePathSegment", function() {
+        it("should have `initialSegment` as CodePathSegment", () => {
             assert(actual[0].initialSegment instanceof CodePathSegment);
             assert(actual[1].initialSegment instanceof CodePathSegment);
             assert(actual[0].initialSegment.prevSegments.length === 0);
             assert(actual[1].initialSegment.prevSegments.length === 0);
         });
 
-        it("should have `finalSegments` as CodePathSegment[]", function() {
+        it("should have `finalSegments` as CodePathSegment[]", () => {
             assert(Array.isArray(actual[0].finalSegments));
             assert(Array.isArray(actual[1].finalSegments));
             assert(actual[0].finalSegments.length === 1);
@@ -121,7 +119,7 @@ describe("CodePathAnalyzer", function() {
             assert(actual[1].finalSegments[1] === actual[1].thrownSegments[0]);
         });
 
-        it("should have `returnedSegments` as CodePathSegment[]", function() {
+        it("should have `returnedSegments` as CodePathSegment[]", () => {
             assert(Array.isArray(actual[0].returnedSegments));
             assert(Array.isArray(actual[1].returnedSegments));
             assert(actual[0].returnedSegments.length === 1);
@@ -130,7 +128,7 @@ describe("CodePathAnalyzer", function() {
             assert(actual[1].returnedSegments[0] instanceof CodePathSegment);
         });
 
-        it("should have `thrownSegments` as CodePathSegment[]", function() {
+        it("should have `thrownSegments` as CodePathSegment[]", () => {
             assert(Array.isArray(actual[0].thrownSegments));
             assert(Array.isArray(actual[1].thrownSegments));
             assert(actual[0].thrownSegments.length === 0);
@@ -138,14 +136,14 @@ describe("CodePathAnalyzer", function() {
             assert(actual[1].thrownSegments[0] instanceof CodePathSegment);
         });
 
-        it("should have `currentSegments` as CodePathSegment[]", function() {
+        it("should have `currentSegments` as CodePathSegment[]", () => {
             assert(Array.isArray(actual[0].currentSegments));
             assert(Array.isArray(actual[1].currentSegments));
             assert(actual[0].currentSegments.length === 0);
             assert(actual[1].currentSegments.length === 0);
 
             // there is the current segment in progress.
-            eslint.defineRule("test", function() {
+            eslint.defineRule("test", () => {
                 let codePath = null;
 
                 return {
@@ -169,25 +167,23 @@ describe("CodePathAnalyzer", function() {
         });
     });
 
-    describe("interface of code path segments", function() {
+    describe("interface of code path segments", () => {
         let actual = [];
 
-        beforeEach(function() {
+        beforeEach(() => {
             actual = [];
-            eslint.defineRule("test", function() {
-                return {
-                    onCodePathSegmentStart(segment) {
-                        actual.push(segment);
-                    }
-                };
-            });
+            eslint.defineRule("test", () => ({
+                onCodePathSegmentStart(segment) {
+                    actual.push(segment);
+                }
+            }));
             eslint.verify(
                 "function foo(a) { if (a) return 0; else throw new Error(); }",
                 {rules: {test: 2}}
             );
         });
 
-        it("should have `id` as unique string", function() {
+        it("should have `id` as unique string", () => {
             assert(typeof actual[0].id === "string");
             assert(typeof actual[1].id === "string");
             assert(typeof actual[2].id === "string");
@@ -200,7 +196,7 @@ describe("CodePathAnalyzer", function() {
             assert(actual[2].id !== actual[3].id);
         });
 
-        it("should have `nextSegments` as CodePathSegment[]", function() {
+        it("should have `nextSegments` as CodePathSegment[]", () => {
             assert(Array.isArray(actual[0].nextSegments));
             assert(Array.isArray(actual[1].nextSegments));
             assert(Array.isArray(actual[2].nextSegments));
@@ -213,7 +209,7 @@ describe("CodePathAnalyzer", function() {
             assert(actual[1].nextSegments[1] === actual[3]);
         });
 
-        it("should have `allNextSegments` as CodePathSegment[]", function() {
+        it("should have `allNextSegments` as CodePathSegment[]", () => {
             assert(Array.isArray(actual[0].allNextSegments));
             assert(Array.isArray(actual[1].allNextSegments));
             assert(Array.isArray(actual[2].allNextSegments));
@@ -226,7 +222,7 @@ describe("CodePathAnalyzer", function() {
             assert(actual[3].allNextSegments[0].reachable === false);
         });
 
-        it("should have `prevSegments` as CodePathSegment[]", function() {
+        it("should have `prevSegments` as CodePathSegment[]", () => {
             assert(Array.isArray(actual[0].prevSegments));
             assert(Array.isArray(actual[1].prevSegments));
             assert(Array.isArray(actual[2].prevSegments));
@@ -239,7 +235,7 @@ describe("CodePathAnalyzer", function() {
             assert(actual[3].prevSegments[0] === actual[1]);
         });
 
-        it("should have `allPrevSegments` as CodePathSegment[]", function() {
+        it("should have `allPrevSegments` as CodePathSegment[]", () => {
             assert(Array.isArray(actual[0].allPrevSegments));
             assert(Array.isArray(actual[1].allPrevSegments));
             assert(Array.isArray(actual[2].allPrevSegments));
@@ -250,7 +246,7 @@ describe("CodePathAnalyzer", function() {
             assert(actual[3].allPrevSegments.length === 1);
         });
 
-        it("should have `reachable` as boolean", function() {
+        it("should have `reachable` as boolean", () => {
             assert(actual[0].reachable === true);
             assert(actual[1].reachable === true);
             assert(actual[2].reachable === true);
@@ -258,42 +254,40 @@ describe("CodePathAnalyzer", function() {
         });
     });
 
-    describe("onCodePathStart", function() {
-        it("should be fired at the head of programs/functions", function() {
+    describe("onCodePathStart", () => {
+        it("should be fired at the head of programs/functions", () => {
             let count = 0;
             let lastCodePathNodeType = null;
 
-            eslint.defineRule("test", function() {
-                return {
-                    onCodePathStart(cp, node) {
-                        count += 1;
-                        lastCodePathNodeType = node.type;
+            eslint.defineRule("test", () => ({
+                onCodePathStart(cp, node) {
+                    count += 1;
+                    lastCodePathNodeType = node.type;
 
-                        assert(cp instanceof CodePath);
-                        if (count === 1) {
-                            assert(node.type === "Program");
-                        } else if (count === 2) {
-                            assert(node.type === "FunctionDeclaration");
-                        } else if (count === 3) {
-                            assert(node.type === "FunctionExpression");
-                        } else if (count === 4) {
-                            assert(node.type === "ArrowFunctionExpression");
-                        }
-                    },
-                    Program() {
-                        assert(lastCodePathNodeType === "Program");
-                    },
-                    FunctionDeclaration() {
-                        assert(lastCodePathNodeType === "FunctionDeclaration");
-                    },
-                    FunctionExpression() {
-                        assert(lastCodePathNodeType === "FunctionExpression");
-                    },
-                    ArrowFunctionExpression() {
-                        assert(lastCodePathNodeType === "ArrowFunctionExpression");
+                    assert(cp instanceof CodePath);
+                    if (count === 1) {
+                        assert(node.type === "Program");
+                    } else if (count === 2) {
+                        assert(node.type === "FunctionDeclaration");
+                    } else if (count === 3) {
+                        assert(node.type === "FunctionExpression");
+                    } else if (count === 4) {
+                        assert(node.type === "ArrowFunctionExpression");
                     }
-                };
-            });
+                },
+                Program() {
+                    assert(lastCodePathNodeType === "Program");
+                },
+                FunctionDeclaration() {
+                    assert(lastCodePathNodeType === "FunctionDeclaration");
+                },
+                FunctionExpression() {
+                    assert(lastCodePathNodeType === "FunctionExpression");
+                },
+                ArrowFunctionExpression() {
+                    assert(lastCodePathNodeType === "ArrowFunctionExpression");
+                }
+            }));
             eslint.verify(
                 "foo(); function foo() {} var foo = function() {}; var foo = () => {};",
                 {rules: {test: 2}, env: {es6: true}}
@@ -303,42 +297,40 @@ describe("CodePathAnalyzer", function() {
         });
     });
 
-    describe("onCodePathEnd", function() {
-        it("should be fired at the end of programs/functions", function() {
+    describe("onCodePathEnd", () => {
+        it("should be fired at the end of programs/functions", () => {
             let count = 0;
             let lastNodeType = null;
 
-            eslint.defineRule("test", function() {
-                return {
-                    onCodePathEnd(cp, node) {
-                        count += 1;
+            eslint.defineRule("test", () => ({
+                onCodePathEnd(cp, node) {
+                    count += 1;
 
-                        assert(cp instanceof CodePath);
-                        if (count === 4) {
-                            assert(node.type === "Program");
-                        } else if (count === 1) {
-                            assert(node.type === "FunctionDeclaration");
-                        } else if (count === 2) {
-                            assert(node.type === "FunctionExpression");
-                        } else if (count === 3) {
-                            assert(node.type === "ArrowFunctionExpression");
-                        }
-                        assert(node.type === lastNodeType);
-                    },
-                    "Program:exit"() {
-                        lastNodeType = "Program";
-                    },
-                    "FunctionDeclaration:exit"() {
-                        lastNodeType = "FunctionDeclaration";
-                    },
-                    "FunctionExpression:exit"() {
-                        lastNodeType = "FunctionExpression";
-                    },
-                    "ArrowFunctionExpression:exit"() {
-                        lastNodeType = "ArrowFunctionExpression";
+                    assert(cp instanceof CodePath);
+                    if (count === 4) {
+                        assert(node.type === "Program");
+                    } else if (count === 1) {
+                        assert(node.type === "FunctionDeclaration");
+                    } else if (count === 2) {
+                        assert(node.type === "FunctionExpression");
+                    } else if (count === 3) {
+                        assert(node.type === "ArrowFunctionExpression");
                     }
-                };
-            });
+                    assert(node.type === lastNodeType);
+                },
+                "Program:exit"() {
+                    lastNodeType = "Program";
+                },
+                "FunctionDeclaration:exit"() {
+                    lastNodeType = "FunctionDeclaration";
+                },
+                "FunctionExpression:exit"() {
+                    lastNodeType = "FunctionExpression";
+                },
+                "ArrowFunctionExpression:exit"() {
+                    lastNodeType = "ArrowFunctionExpression";
+                }
+            }));
             eslint.verify(
                 "foo(); function foo() {} var foo = function() {}; var foo = () => {};",
                 {rules: {test: 2}, env: {es6: true}}
@@ -348,42 +340,40 @@ describe("CodePathAnalyzer", function() {
         });
     });
 
-    describe("onCodePathSegmentStart", function() {
-        it("should be fired at the head of programs/functions for the initial segment", function() {
+    describe("onCodePathSegmentStart", () => {
+        it("should be fired at the head of programs/functions for the initial segment", () => {
             let count = 0;
             let lastCodePathNodeType = null;
 
-            eslint.defineRule("test", function() {
-                return {
-                    onCodePathSegmentStart(segment, node) {
-                        count += 1;
-                        lastCodePathNodeType = node.type;
+            eslint.defineRule("test", () => ({
+                onCodePathSegmentStart(segment, node) {
+                    count += 1;
+                    lastCodePathNodeType = node.type;
 
-                        assert(segment instanceof CodePathSegment);
-                        if (count === 1) {
-                            assert(node.type === "Program");
-                        } else if (count === 2) {
-                            assert(node.type === "FunctionDeclaration");
-                        } else if (count === 3) {
-                            assert(node.type === "FunctionExpression");
-                        } else if (count === 4) {
-                            assert(node.type === "ArrowFunctionExpression");
-                        }
-                    },
-                    Program() {
-                        assert(lastCodePathNodeType === "Program");
-                    },
-                    FunctionDeclaration() {
-                        assert(lastCodePathNodeType === "FunctionDeclaration");
-                    },
-                    FunctionExpression() {
-                        assert(lastCodePathNodeType === "FunctionExpression");
-                    },
-                    ArrowFunctionExpression() {
-                        assert(lastCodePathNodeType === "ArrowFunctionExpression");
+                    assert(segment instanceof CodePathSegment);
+                    if (count === 1) {
+                        assert(node.type === "Program");
+                    } else if (count === 2) {
+                        assert(node.type === "FunctionDeclaration");
+                    } else if (count === 3) {
+                        assert(node.type === "FunctionExpression");
+                    } else if (count === 4) {
+                        assert(node.type === "ArrowFunctionExpression");
                     }
-                };
-            });
+                },
+                Program() {
+                    assert(lastCodePathNodeType === "Program");
+                },
+                FunctionDeclaration() {
+                    assert(lastCodePathNodeType === "FunctionDeclaration");
+                },
+                FunctionExpression() {
+                    assert(lastCodePathNodeType === "FunctionExpression");
+                },
+                ArrowFunctionExpression() {
+                    assert(lastCodePathNodeType === "ArrowFunctionExpression");
+                }
+            }));
             eslint.verify(
                 "foo(); function foo() {} var foo = function() {}; var foo = () => {};",
                 {rules: {test: 2}, env: {es6: true}}
@@ -393,42 +383,40 @@ describe("CodePathAnalyzer", function() {
         });
     });
 
-    describe("onCodePathSegmentEnd", function() {
-        it("should be fired at the end of programs/functions for the final segment", function() {
+    describe("onCodePathSegmentEnd", () => {
+        it("should be fired at the end of programs/functions for the final segment", () => {
             let count = 0;
             let lastNodeType = null;
 
-            eslint.defineRule("test", function() {
-                return {
-                    onCodePathSegmentEnd(cp, node) {
-                        count += 1;
+            eslint.defineRule("test", () => ({
+                onCodePathSegmentEnd(cp, node) {
+                    count += 1;
 
-                        assert(cp instanceof CodePathSegment);
-                        if (count === 4) {
-                            assert(node.type === "Program");
-                        } else if (count === 1) {
-                            assert(node.type === "FunctionDeclaration");
-                        } else if (count === 2) {
-                            assert(node.type === "FunctionExpression");
-                        } else if (count === 3) {
-                            assert(node.type === "ArrowFunctionExpression");
-                        }
-                        assert(node.type === lastNodeType);
-                    },
-                    "Program:exit"() {
-                        lastNodeType = "Program";
-                    },
-                    "FunctionDeclaration:exit"() {
-                        lastNodeType = "FunctionDeclaration";
-                    },
-                    "FunctionExpression:exit"() {
-                        lastNodeType = "FunctionExpression";
-                    },
-                    "ArrowFunctionExpression:exit"() {
-                        lastNodeType = "ArrowFunctionExpression";
+                    assert(cp instanceof CodePathSegment);
+                    if (count === 4) {
+                        assert(node.type === "Program");
+                    } else if (count === 1) {
+                        assert(node.type === "FunctionDeclaration");
+                    } else if (count === 2) {
+                        assert(node.type === "FunctionExpression");
+                    } else if (count === 3) {
+                        assert(node.type === "ArrowFunctionExpression");
                     }
-                };
-            });
+                    assert(node.type === lastNodeType);
+                },
+                "Program:exit"() {
+                    lastNodeType = "Program";
+                },
+                "FunctionDeclaration:exit"() {
+                    lastNodeType = "FunctionDeclaration";
+                },
+                "FunctionExpression:exit"() {
+                    lastNodeType = "FunctionExpression";
+                },
+                "ArrowFunctionExpression:exit"() {
+                    lastNodeType = "ArrowFunctionExpression";
+                }
+            }));
             eslint.verify(
                 "foo(); function foo() {} var foo = function() {}; var foo = () => {};",
                 {rules: {test: 2}, env: {es6: true}}
@@ -438,20 +426,18 @@ describe("CodePathAnalyzer", function() {
         });
     });
 
-    describe("onCodePathSegmentLoop", function() {
-        it("should be fired in `while` loops", function() {
+    describe("onCodePathSegmentLoop", () => {
+        it("should be fired in `while` loops", () => {
             let count = 0;
 
-            eslint.defineRule("test", function() {
-                return {
-                    onCodePathSegmentLoop(fromSegment, toSegment, node) {
-                        count += 1;
-                        assert(fromSegment instanceof CodePathSegment);
-                        assert(toSegment instanceof CodePathSegment);
-                        assert(node.type === "WhileStatement");
-                    }
-                };
-            });
+            eslint.defineRule("test", () => ({
+                onCodePathSegmentLoop(fromSegment, toSegment, node) {
+                    count += 1;
+                    assert(fromSegment instanceof CodePathSegment);
+                    assert(toSegment instanceof CodePathSegment);
+                    assert(node.type === "WhileStatement");
+                }
+            }));
             eslint.verify(
                 "while (a) { foo(); }",
                 {rules: {test: 2}}
@@ -460,19 +446,17 @@ describe("CodePathAnalyzer", function() {
             assert(count === 1);
         });
 
-        it("should be fired in `do-while` loops", function() {
+        it("should be fired in `do-while` loops", () => {
             let count = 0;
 
-            eslint.defineRule("test", function() {
-                return {
-                    onCodePathSegmentLoop(fromSegment, toSegment, node) {
-                        count += 1;
-                        assert(fromSegment instanceof CodePathSegment);
-                        assert(toSegment instanceof CodePathSegment);
-                        assert(node.type === "DoWhileStatement");
-                    }
-                };
-            });
+            eslint.defineRule("test", () => ({
+                onCodePathSegmentLoop(fromSegment, toSegment, node) {
+                    count += 1;
+                    assert(fromSegment instanceof CodePathSegment);
+                    assert(toSegment instanceof CodePathSegment);
+                    assert(node.type === "DoWhileStatement");
+                }
+            }));
             eslint.verify(
                 "do { foo(); } while (a);",
                 {rules: {test: 2}}
@@ -481,26 +465,24 @@ describe("CodePathAnalyzer", function() {
             assert(count === 1);
         });
 
-        it("should be fired in `for` loops", function() {
+        it("should be fired in `for` loops", () => {
             let count = 0;
 
-            eslint.defineRule("test", function() {
-                return {
-                    onCodePathSegmentLoop(fromSegment, toSegment, node) {
-                        count += 1;
-                        assert(fromSegment instanceof CodePathSegment);
-                        assert(toSegment instanceof CodePathSegment);
+            eslint.defineRule("test", () => ({
+                onCodePathSegmentLoop(fromSegment, toSegment, node) {
+                    count += 1;
+                    assert(fromSegment instanceof CodePathSegment);
+                    assert(toSegment instanceof CodePathSegment);
 
-                        if (count === 1) {
+                    if (count === 1) {
 
                             // connect path: "update" -> "test"
-                            assert(node.parent.type === "ForStatement");
-                        } else if (count === 2) {
-                            assert(node.type === "ForStatement");
-                        }
+                        assert(node.parent.type === "ForStatement");
+                    } else if (count === 2) {
+                        assert(node.type === "ForStatement");
                     }
-                };
-            });
+                }
+            }));
             eslint.verify(
                 "for (var i = 0; i < 10; ++i) { foo(); }",
                 {rules: {test: 2}}
@@ -509,26 +491,24 @@ describe("CodePathAnalyzer", function() {
             assert(count === 2);
         });
 
-        it("should be fired in `for-in` loops", function() {
+        it("should be fired in `for-in` loops", () => {
             let count = 0;
 
-            eslint.defineRule("test", function() {
-                return {
-                    onCodePathSegmentLoop(fromSegment, toSegment, node) {
-                        count += 1;
-                        assert(fromSegment instanceof CodePathSegment);
-                        assert(toSegment instanceof CodePathSegment);
+            eslint.defineRule("test", () => ({
+                onCodePathSegmentLoop(fromSegment, toSegment, node) {
+                    count += 1;
+                    assert(fromSegment instanceof CodePathSegment);
+                    assert(toSegment instanceof CodePathSegment);
 
-                        if (count === 1) {
+                    if (count === 1) {
 
                             // connect path: "right" -> "left"
-                            assert(node.parent.type === "ForInStatement");
-                        } else if (count === 2) {
-                            assert(node.type === "ForInStatement");
-                        }
+                        assert(node.parent.type === "ForInStatement");
+                    } else if (count === 2) {
+                        assert(node.type === "ForInStatement");
                     }
-                };
-            });
+                }
+            }));
             eslint.verify(
                 "for (var k in obj) { foo(); }",
                 {rules: {test: 2}}
@@ -537,26 +517,24 @@ describe("CodePathAnalyzer", function() {
             assert(count === 2);
         });
 
-        it("should be fired in `for-of` loops", function() {
+        it("should be fired in `for-of` loops", () => {
             let count = 0;
 
-            eslint.defineRule("test", function() {
-                return {
-                    onCodePathSegmentLoop(fromSegment, toSegment, node) {
-                        count += 1;
-                        assert(fromSegment instanceof CodePathSegment);
-                        assert(toSegment instanceof CodePathSegment);
+            eslint.defineRule("test", () => ({
+                onCodePathSegmentLoop(fromSegment, toSegment, node) {
+                    count += 1;
+                    assert(fromSegment instanceof CodePathSegment);
+                    assert(toSegment instanceof CodePathSegment);
 
-                        if (count === 1) {
+                    if (count === 1) {
 
                             // connect path: "right" -> "left"
-                            assert(node.parent.type === "ForOfStatement");
-                        } else if (count === 2) {
-                            assert(node.type === "ForOfStatement");
-                        }
+                        assert(node.parent.type === "ForOfStatement");
+                    } else if (count === 2) {
+                        assert(node.type === "ForOfStatement");
                     }
-                };
-            });
+                }
+            }));
             eslint.verify(
                 "for (var x of xs) { foo(); }",
                 {rules: {test: 2}, env: {es6: true}}
@@ -566,25 +544,23 @@ describe("CodePathAnalyzer", function() {
         });
     });
 
-    describe("completed code paths are correct", function() {
+    describe("completed code paths are correct", () => {
         const testDataDir = path.join(__dirname, "../../fixtures/code-path-analysis/");
         const testDataFiles = fs.readdirSync(testDataDir);
 
-        testDataFiles.forEach(function(file) {
-            it(file, function() {
+        testDataFiles.forEach(file => {
+            it(file, () => {
                 const source = fs.readFileSync(path.join(testDataDir, file), {encoding: "utf8"});
                 const expected = getExpectedDotArrows(source);
                 const actual = [];
 
                 assert(expected.length > 0, "/*expected */ comments not found.");
 
-                eslint.defineRule("test", function() {
-                    return {
-                        onCodePathEnd(codePath) {
-                            actual.push(debug.makeDotArrows(codePath));
-                        }
-                    };
-                });
+                eslint.defineRule("test", () => ({
+                    onCodePathEnd(codePath) {
+                        actual.push(debug.makeDotArrows(codePath));
+                    }
+                }));
                 const messages = eslint.verify(source, {rules: {test: 2}, env: {es6: true}});
 
                 assert.equal(messages.length, 0);

--- a/tests/lib/code-path-analysis/code-path.js
+++ b/tests/lib/code-path-analysis/code-path.js
@@ -26,13 +26,11 @@ function parseCodePaths(code) {
     const retv = [];
 
     eslint.reset();
-    eslint.defineRule("test", function() {
-        return {
-            onCodePathStart(codePath) {
-                retv.push(codePath);
-            }
-        };
-    });
+    eslint.defineRule("test", () => ({
+        onCodePathStart(codePath) {
+            retv.push(codePath);
+        }
+    }));
     eslint.verify(code, {rules: {test: 2}});
 
     return retv;
@@ -51,7 +49,7 @@ function parseCodePaths(code) {
 function getOrderOfTraversing(codePath, options, callback) {
     const retv = [];
 
-    codePath.traverseSegments(options, function(segment, controller) {
+    codePath.traverseSegments(options, (segment, controller) => {
         retv.push(segment.id);
         if (callback) {
             callback(segment, controller); // eslint-disable-line callback-return
@@ -65,10 +63,10 @@ function getOrderOfTraversing(codePath, options, callback) {
 // Tests
 //------------------------------------------------------------------------------
 
-describe("CodePathAnalyzer", function() {
-    describe(".traverseSegments()", function() {
-        describe("should traverse segments from the first to the end:", function() {
-            it("simple", function() {
+describe("CodePathAnalyzer", () => {
+    describe(".traverseSegments()", () => {
+        describe("should traverse segments from the first to the end:", () => {
+            it("simple", () => {
                 const codePath = parseCodePaths("foo(); bar(); baz();")[0];
                 const order = getOrderOfTraversing(codePath);
 
@@ -85,7 +83,7 @@ describe("CodePathAnalyzer", function() {
                 */
             });
 
-            it("if", function() {
+            it("if", () => {
                 const codePath = parseCodePaths("if (a) foo(); else bar(); baz();")[0];
                 const order = getOrderOfTraversing(codePath);
 
@@ -106,7 +104,7 @@ describe("CodePathAnalyzer", function() {
                 */
             });
 
-            it("switch", function() {
+            it("switch", () => {
                 const codePath = parseCodePaths("switch (a) { case 0: foo(); break; case 1: bar(); } baz();")[0];
                 const order = getOrderOfTraversing(codePath);
 
@@ -131,7 +129,7 @@ describe("CodePathAnalyzer", function() {
                 */
             });
 
-            it("while", function() {
+            it("while", () => {
                 const codePath = parseCodePaths("while (a) foo(); bar();")[0];
                 const order = getOrderOfTraversing(codePath);
 
@@ -151,7 +149,7 @@ describe("CodePathAnalyzer", function() {
                 */
             });
 
-            it("for", function() {
+            it("for", () => {
                 const codePath = parseCodePaths("for (var i = 0; i < 10; ++i) foo(i); bar();")[0];
                 const order = getOrderOfTraversing(codePath);
 
@@ -172,7 +170,7 @@ describe("CodePathAnalyzer", function() {
                 */
             });
 
-            it("for-in", function() {
+            it("for-in", () => {
                 const codePath = parseCodePaths("for (var key in obj) foo(key); bar();")[0];
                 const order = getOrderOfTraversing(codePath);
 
@@ -195,7 +193,7 @@ describe("CodePathAnalyzer", function() {
                 */
             });
 
-            it("try-catch", function() {
+            it("try-catch", () => {
                 const codePath = parseCodePaths("try { foo(); } catch (e) { bar(); } baz();")[0];
                 const order = getOrderOfTraversing(codePath);
 
@@ -218,7 +216,7 @@ describe("CodePathAnalyzer", function() {
             });
         });
 
-        it("should traverse segments from `options.first` to `options.last`.", function() {
+        it("should traverse segments from `options.first` to `options.last`.", () => {
             const codePath = parseCodePaths("if (a) { if (b) { foo(); } bar(); } else { out1(); } out2();")[0];
             const order = getOrderOfTraversing(codePath, {
                 first: codePath.initialSegment.nextSegments[0],
@@ -246,9 +244,9 @@ describe("CodePathAnalyzer", function() {
             */
         });
 
-        it("should stop immediately when 'controller.break()' was called.", function() {
+        it("should stop immediately when 'controller.break()' was called.", () => {
             const codePath = parseCodePaths("if (a) { if (b) { foo(); } bar(); } else { out1(); } out2();")[0];
-            const order = getOrderOfTraversing(codePath, null, function(segment, controller) {
+            const order = getOrderOfTraversing(codePath, null, (segment, controller) => {
                 if (segment.id === "s1_2") {
                     controller.break();
                 }
@@ -275,9 +273,9 @@ describe("CodePathAnalyzer", function() {
             */
         });
 
-        it("should skip the current branch when 'controller.skip()' was called.", function() {
+        it("should skip the current branch when 'controller.skip()' was called.", () => {
             const codePath = parseCodePaths("if (a) { if (b) { foo(); } bar(); } else { out1(); } out2();")[0];
-            const order = getOrderOfTraversing(codePath, null, function(segment, controller) {
+            const order = getOrderOfTraversing(codePath, null, (segment, controller) => {
                 if (segment.id === "s1_2") {
                     controller.skip();
                 }

--- a/tests/lib/config.js
+++ b/tests/lib/config.js
@@ -85,7 +85,7 @@ function assertConfigsEqual(actual, expected) {
 // Tests
 //------------------------------------------------------------------------------
 
-describe("Config", function() {
+describe("Config", () => {
 
     let fixtureDir,
         sandbox;
@@ -115,28 +115,28 @@ describe("Config", function() {
     }
 
     // copy into clean area so as not to get "infected" by this project's .eslintrc files
-    before(function() {
+    before(() => {
         fixtureDir = `${os.tmpdir()}/eslint/fixtures`;
         mkdir("-p", fixtureDir);
         cp("-r", "./tests/fixtures/config-hierarchy", fixtureDir);
     });
 
-    beforeEach(function() {
+    beforeEach(() => {
         sandbox = sinon.sandbox.create();
     });
 
-    afterEach(function() {
+    afterEach(() => {
         sandbox.verifyAndRestore();
     });
 
-    after(function() {
+    after(() => {
         rm("-r", fixtureDir);
     });
 
-    describe("new Config()", function() {
+    describe("new Config()", () => {
 
         // https://github.com/eslint/eslint/issues/2380
-        it("should not modify baseConfig when format is specified", function() {
+        it("should not modify baseConfig when format is specified", () => {
             const customBaseConfig = { foo: "bar" },
                 configHelper = new Config({ baseConfig: customBaseConfig, format: "foo" });
 
@@ -146,7 +146,7 @@ describe("Config", function() {
         });
     });
 
-    describe("findLocalConfigFiles()", function() {
+    describe("findLocalConfigFiles()", () => {
 
         /**
          * Returns the path inside of the fixture directory.
@@ -163,7 +163,7 @@ describe("Config", function() {
             return path.join.apply(path, args);
         }
 
-        before(function() {
+        before(() => {
             mockFs({
                 eslint: {
                     fixtures: {
@@ -173,11 +173,11 @@ describe("Config", function() {
             });
         });
 
-        after(function() {
+        after(() => {
             mockFs.restore();
         });
 
-        it("should return the path when an .eslintrc file is found", function() {
+        it("should return the path when an .eslintrc file is found", () => {
             const configHelper = new Config(),
                 expected = getFakeFixturePath("broken", ".eslintrc"),
                 actual = configHelper.findLocalConfigFiles(getFakeFixturePath("broken"))[0];
@@ -185,7 +185,7 @@ describe("Config", function() {
             assert.equal(actual, expected);
         });
 
-        it("should return an empty array when an .eslintrc file is not found", function() {
+        it("should return an empty array when an .eslintrc file is not found", () => {
             const configHelper = new Config(),
                 actual = configHelper.findLocalConfigFiles(getFakeFixturePath());
 
@@ -193,7 +193,7 @@ describe("Config", function() {
             assert.lengthOf(actual, 0);
         });
 
-        it("should return package.json only when no other config files are found", function() {
+        it("should return package.json only when no other config files are found", () => {
             const configHelper = new Config(),
                 expected0 = getFakeFixturePath("packagejson", "subdir", "package.json"),
                 expected1 = getFakeFixturePath("packagejson", ".eslintrc"),
@@ -205,7 +205,7 @@ describe("Config", function() {
             assert.equal(actual[1], expected1);
         });
 
-        it("should return the only one config file even if there are multiple found", function() {
+        it("should return the only one config file even if there are multiple found", () => {
             const configHelper = new Config(),
                 expected = getFakeFixturePath("broken", ".eslintrc"),
 
@@ -216,7 +216,7 @@ describe("Config", function() {
             assert.equal(actual, expected);
         });
 
-        it("should return all possible files when multiple are found", function() {
+        it("should return all possible files when multiple are found", () => {
             const configHelper = new Config(),
                 expected = [
                     getFakeFixturePath("fileexts/subdir/subsubdir/", ".eslintrc.json"),
@@ -229,7 +229,7 @@ describe("Config", function() {
             assert.deepEqual(actual, expected);
         });
 
-        it("should return an empty array when a package.json file is not found", function() {
+        it("should return an empty array when a package.json file is not found", () => {
             const configHelper = new Config(),
                 actual = configHelper.findLocalConfigFiles(getFakeFixturePath());
 
@@ -238,16 +238,16 @@ describe("Config", function() {
         });
     });
 
-    describe("getConfig()", function() {
+    describe("getConfig()", () => {
 
-        it("should return the project config when called in current working directory", function() {
+        it("should return the project config when called in current working directory", () => {
             const configHelper = new Config({cwd: process.cwd()}),
                 actual = configHelper.getConfig();
 
             assert.equal(actual.rules.strict[1], "global");
         });
 
-        it("should not retain configs from previous directories when called multiple times", function() {
+        it("should not retain configs from previous directories when called multiple times", () => {
 
             const firstpath = path.resolve(__dirname, "..", "fixtures", "configurations", "single-quotes", "subdir", ".eslintrc");
             const secondpath = path.resolve(__dirname, "..", "fixtures", "configurations", "single-quotes", ".eslintrc");
@@ -262,7 +262,7 @@ describe("Config", function() {
             assert.equal(config.rules["no-new"], 1);
         });
 
-        it("should throw an error when an invalid path is given", function() {
+        it("should throw an error when an invalid path is given", () => {
             const configPath = path.resolve(__dirname, "..", "fixtures", "configurations", "foobaz", ".eslintrc");
             const homePath = "does-not-exist";
 
@@ -272,36 +272,36 @@ describe("Config", function() {
 
             sandbox.stub(fs, "readdirSync").throws(new Error());
 
-            assert.throws(function() {
+            assert.throws(() => {
                 configHelper.getConfig(configPath);
             }, "No ESLint configuration found.");
         });
 
-        it("should throw error when a configuration file doesn't exist", function() {
+        it("should throw error when a configuration file doesn't exist", () => {
             const configPath = path.resolve(__dirname, "..", "fixtures", "configurations", ".eslintrc");
             const configHelper = new Config({cwd: process.cwd()});
 
             sandbox.stub(fs, "readFileSync").throws(new Error());
 
-            assert.throws(function() {
+            assert.throws(() => {
                 configHelper.getConfig(configPath);
             }, "Cannot read config file");
 
         });
 
-        it("should throw error when a configuration file is not require-able", function() {
+        it("should throw error when a configuration file is not require-able", () => {
             const configPath = ".eslintrc";
             const configHelper = new Config({cwd: process.cwd()});
 
             sandbox.stub(fs, "readFileSync").throws(new Error());
 
-            assert.throws(function() {
+            assert.throws(() => {
                 configHelper.getConfig(configPath);
             }, "Cannot read config file");
 
         });
 
-        it("should cache config when the same directory is passed twice", function() {
+        it("should cache config when the same directory is passed twice", () => {
             const configPath = path.resolve(__dirname, "..", "fixtures", "configurations", "single-quotes", ".eslintrc");
             const configHelper = new Config({cwd: process.cwd()});
 
@@ -317,7 +317,7 @@ describe("Config", function() {
         });
 
         // make sure JS-style comments don't throw an error
-        it("should load the config file when there are JS-style comments in the text", function() {
+        it("should load the config file when there are JS-style comments in the text", () => {
             const configPath = path.resolve(__dirname, "..", "fixtures", "configurations", "comments.json"),
                 configHelper = new Config({configFile: configPath}),
                 semi = configHelper.useSpecificConfig.rules.semi,
@@ -328,7 +328,7 @@ describe("Config", function() {
         });
 
         // make sure YAML files work correctly
-        it("should load the config file when a YAML file is used", function() {
+        it("should load the config file when a YAML file is used", () => {
             const configPath = path.resolve(__dirname, "..", "fixtures", "configurations", "env-browser.yaml"),
                 configHelper = new Config({configFile: configPath}),
                 noAlert = configHelper.useSpecificConfig.rules["no-alert"],
@@ -338,7 +338,7 @@ describe("Config", function() {
             assert.equal(noUndef, 2);
         });
 
-        it("should contain the correct value for parser when a custom parser is specified", function() {
+        it("should contain the correct value for parser when a custom parser is specified", () => {
             const configPath = path.resolve(__dirname, "../fixtures/configurations/parser/.eslintrc.json"),
                 configHelper = new Config({ cwd: process.cwd() }),
                 config = configHelper.getConfig(configPath);
@@ -349,7 +349,7 @@ describe("Config", function() {
         // Configuration hierarchy ---------------------------------------------
 
         // https://github.com/eslint/eslint/issues/3915
-        it("should correctly merge environment settings", function() {
+        it("should correctly merge environment settings", () => {
             const configHelper = new Config({ useEslintrc: true, cwd: process.cwd() }),
                 file = getFixturePath("envs", "sub", "foo.js"),
                 expected = {
@@ -369,7 +369,7 @@ describe("Config", function() {
         });
 
         // Default configuration - blank
-        it("should return a blank config when using no .eslintrc", function() {
+        it("should return a blank config when using no .eslintrc", () => {
 
             const configHelper = new Config({ useEslintrc: false }),
                 file = getFixturePath("broken", "console-wrong-quotes.js"),
@@ -383,7 +383,7 @@ describe("Config", function() {
             assertConfigsEqual(actual, expected);
         });
 
-        it("should return a blank config when baseConfig is set to false and no .eslintrc", function() {
+        it("should return a blank config when baseConfig is set to false and no .eslintrc", () => {
             const configHelper = new Config({ baseConfig: false, useEslintrc: false }),
                 file = getFixturePath("broken", "console-wrong-quotes.js"),
                 expected = {
@@ -397,7 +397,7 @@ describe("Config", function() {
         });
 
         // No default configuration
-        it("should return an empty config when not using .eslintrc", function() {
+        it("should return an empty config when not using .eslintrc", () => {
 
             const configHelper = new Config({ useEslintrc: false }),
                 file = getFixturePath("broken", "console-wrong-quotes.js"),
@@ -406,7 +406,7 @@ describe("Config", function() {
             assertConfigsEqual(actual, {});
         });
 
-        it("should return a modified config when baseConfig is set to an object and no .eslintrc", function() {
+        it("should return a modified config when baseConfig is set to an object and no .eslintrc", () => {
 
 
             const configHelper = new Config({
@@ -434,7 +434,7 @@ describe("Config", function() {
             assertConfigsEqual(actual, expected);
         });
 
-        it("should return a modified config without plugin rules enabled when baseConfig is set to an object with plugin and no .eslintrc", function() {
+        it("should return a modified config without plugin rules enabled when baseConfig is set to an object with plugin and no .eslintrc", () => {
             const customRule = require("../fixtures/rules/custom-rule");
             const examplePluginName = "eslint-plugin-example";
             const requireStubs = {};
@@ -474,7 +474,7 @@ describe("Config", function() {
         });
 
         // Project configuration - second level .eslintrc
-        it("should merge configs when local .eslintrc overrides parent .eslintrc", function() {
+        it("should merge configs when local .eslintrc overrides parent .eslintrc", () => {
 
             const configHelper = new Config({cwd: process.cwd()}),
                 file = getFixturePath("broken", "subbroken", "console-wrong-quotes.js"),
@@ -495,7 +495,7 @@ describe("Config", function() {
         });
 
         // Project configuration - third level .eslintrc
-        it("should merge configs when local .eslintrc overrides parent and grandparent .eslintrc", function() {
+        it("should merge configs when local .eslintrc overrides parent and grandparent .eslintrc", () => {
 
             const configHelper = new Config({cwd: process.cwd()}),
                 file = getFixturePath("broken", "subbroken", "subsubbroken", "console-wrong-quotes.js"),
@@ -516,7 +516,7 @@ describe("Config", function() {
         });
 
         // Project configuration - root set in second level .eslintrc
-        it("should not return configurations in parents of config with root:true", function() {
+        it("should not return configurations in parents of config with root:true", () => {
             const configHelper = new Config({cwd: process.cwd()}),
                 file = getFixturePath("root-true", "parent", "root", "wrong-semi.js"),
                 expected = {
@@ -530,7 +530,7 @@ describe("Config", function() {
         });
 
         // Project configuration - root set in second level .eslintrc
-        it("should return project config when called with a relative path from a subdir", function() {
+        it("should return project config when called with a relative path from a subdir", () => {
             const configHelper = new Config({cwd: getFixturePath("root-true", "parent", "root", "subdir")}),
                 dir = ".",
                 expected = {
@@ -544,7 +544,7 @@ describe("Config", function() {
         });
 
         // Command line configuration - --config with first level .eslintrc
-        it("should merge command line config when config file adds to local .eslintrc", function() {
+        it("should merge command line config when config file adds to local .eslintrc", () => {
 
             const configHelper = new Config({
                     configFile: getFixturePath("broken", "add-conf.yaml"),
@@ -568,7 +568,7 @@ describe("Config", function() {
         });
 
         // Command line configuration - --config with first level .eslintrc
-        it("should merge command line config when config file overrides local .eslintrc", function() {
+        it("should merge command line config when config file overrides local .eslintrc", () => {
 
             const configHelper = new Config({
                     configFile: getFixturePath("broken", "override-conf.yaml"),
@@ -591,7 +591,7 @@ describe("Config", function() {
         });
 
         // Command line configuration - --config with second level .eslintrc
-        it("should merge command line config when config file adds to local and parent .eslintrc", function() {
+        it("should merge command line config when config file adds to local and parent .eslintrc", () => {
 
             const configHelper = new Config({
                     configFile: getFixturePath("broken", "add-conf.yaml"),
@@ -616,7 +616,7 @@ describe("Config", function() {
         });
 
         // Command line configuration - --config with second level .eslintrc
-        it("should merge command line config when config file overrides local and parent .eslintrc", function() {
+        it("should merge command line config when config file overrides local and parent .eslintrc", () => {
 
             const configHelper = new Config({
                     configFile: getFixturePath("broken", "override-conf.yaml"),
@@ -640,7 +640,7 @@ describe("Config", function() {
         });
 
         // Command line configuration - --rule with --config and first level .eslintrc
-        it("should merge command line config and rule when rule and config file overrides local .eslintrc", function() {
+        it("should merge command line config and rule when rule and config file overrides local .eslintrc", () => {
 
             const configHelper = new Config({
                     configFile: getFixturePath("broken", "override-conf.yaml"),
@@ -666,7 +666,7 @@ describe("Config", function() {
         });
 
         // Command line configuration - --plugin
-        it("should merge command line plugin with local .eslintrc", function() {
+        it("should merge command line plugin with local .eslintrc", () => {
 
             // stub out Config to use stub config file
             const StubbedConfig = createStubbedConfigWithPlugins({
@@ -691,7 +691,7 @@ describe("Config", function() {
         });
 
 
-        it("should merge multiple different config file formats", function() {
+        it("should merge multiple different config file formats", () => {
 
             const configHelper = new Config({cwd: process.cwd()}),
                 file = getFixturePath("fileexts/subdir/subsubdir/foo.js"),
@@ -711,7 +711,7 @@ describe("Config", function() {
 
 
 
-        it("should load user config globals", function() {
+        it("should load user config globals", () => {
             const configPath = path.resolve(__dirname, "..", "fixtures", "globals", "conf.yaml"),
                 configHelper = new Config({ configFile: configPath, useEslintrc: false });
 
@@ -726,7 +726,7 @@ describe("Config", function() {
             assertConfigsEqual(actual, expected);
         });
 
-        it("should not load disabled environments", function() {
+        it("should not load disabled environments", () => {
             const configPath = path.resolve(__dirname, "..", "fixtures", "environments", "disable.yaml");
 
             const configHelper = new Config({ configFile: configPath, useEslintrc: false });
@@ -736,15 +736,15 @@ describe("Config", function() {
             assert.isUndefined(config.globals.window);
         });
 
-        it("should error on fake environments", function() {
+        it("should error on fake environments", () => {
             const configPath = path.resolve(__dirname, "..", "fixtures", "environments", "fake.yaml");
 
-            assert.throw(function() {
+            assert.throw(() => {
                 new Config({ configFile: configPath, useEslintrc: false, cwd: process.cwd() }); // eslint-disable-line no-new
             });
         });
 
-        it("should gracefully handle empty files", function() {
+        it("should gracefully handle empty files", () => {
             const configPath = path.resolve(__dirname, "..", "fixtures", "configurations", "env-node.json"),
                 configHelper = new Config({configFile: configPath, cwd: process.cwd()});
 
@@ -752,10 +752,10 @@ describe("Config", function() {
         });
 
         // Meaningful stack-traces
-        it("should include references to where an `extends` configuration was loaded from", function() {
+        it("should include references to where an `extends` configuration was loaded from", () => {
             const configPath = path.resolve(__dirname, "..", "fixtures", "config-extends", "error.json");
 
-            assert.throws(function() {
+            assert.throws(() => {
                 const configHelper = new Config({ useEslintrc: false, configFile: configPath });
 
                 configHelper.getConfig(configPath);
@@ -763,7 +763,7 @@ describe("Config", function() {
         });
 
         // Keep order with the last array element taking highest precedence
-        it("should make the last element in an array take the highest precedence", function() {
+        it("should make the last element in an array take the highest precedence", () => {
             const configPath = path.resolve(__dirname, "..", "fixtures", "config-extends", "array", ".eslintrc"),
                 configHelper = new Config({ useEslintrc: false, configFile: configPath }),
                 expected = {
@@ -775,8 +775,8 @@ describe("Config", function() {
             assertConfigsEqual(actual, expected);
         });
 
-        describe("with env in a child configuration file", function() {
-            it("should overwrite parserOptions of the parent with env of the child", function() {
+        describe("with env in a child configuration file", () => {
+            it("should overwrite parserOptions of the parent with env of the child", () => {
                 const config = new Config({ cwd: process.cwd() });
                 const targetPath = getFixturePath("overwrite-ecmaFeatures", "child", "foo.js");
                 const expected = {
@@ -790,7 +790,7 @@ describe("Config", function() {
             });
         });
 
-        describe("personal config file within home directory", function() {
+        describe("personal config file within home directory", () => {
 
             /**
              * Returns the path inside of the fixture directory.
@@ -822,11 +822,11 @@ describe("Config", function() {
                 });
             }
 
-            afterEach(function() {
+            afterEach(() => {
                 mockFs.restore();
             });
 
-            it("should load the personal config if no local config was found", function() {
+            it("should load the personal config if no local config was found", () => {
                 const projectPath = getFakeFixturePath("personal-config", "project-without-config"),
                     homePath = getFakeFixturePath("personal-config", "home-folder"),
                     filePath = getFakeFixturePath("personal-config", "project-without-config", "foo.js");
@@ -851,7 +851,7 @@ describe("Config", function() {
                 assert.deepEqual(actual, expected);
             });
 
-            it("should ignore the personal config if a local config was found", function() {
+            it("should ignore the personal config if a local config was found", () => {
                 const projectPath = getFakeFixturePath("personal-config", "home-folder", "project"),
                     homePath = getFakeFixturePath("personal-config", "home-folder"),
                     filePath = getFakeFixturePath("personal-config", "home-folder", "project", "foo.js");
@@ -876,7 +876,7 @@ describe("Config", function() {
                 assert.deepEqual(actual, expected);
             });
 
-            it("should ignore the personal config if config is passed through cli", function() {
+            it("should ignore the personal config if config is passed through cli", () => {
                 const configPath = getFakeFixturePath("quotes-error.json");
                 const projectPath = getFakeFixturePath("personal-config", "project-without-config"),
                     homePath = getFakeFixturePath("personal-config", "home-folder"),
@@ -902,7 +902,7 @@ describe("Config", function() {
                 assert.deepEqual(actual, expected);
             });
 
-            it("should still load the project config if the current working directory is the same as the home folder", function() {
+            it("should still load the project config if the current working directory is the same as the home folder", () => {
                 const projectPath = getFakeFixturePath("personal-config", "project-with-config"),
                     filePath = getFakeFixturePath("personal-config", "project-with-config", "subfolder", "foo.js");
 
@@ -928,7 +928,7 @@ describe("Config", function() {
             });
         });
 
-        describe("when no local or personal config is found", function() {
+        describe("when no local or personal config is found", () => {
 
             /**
              * Returns the path inside of the fixture directory.
@@ -960,11 +960,11 @@ describe("Config", function() {
                 });
             }
 
-            afterEach(function() {
+            afterEach(() => {
                 mockFs.restore();
             });
 
-            it("should throw an error if no local config and no personal config was found", function() {
+            it("should throw an error if no local config and no personal config was found", () => {
                 const projectPath = getFakeFixturePath("personal-config", "project-without-config"),
                     homePath = getFakeFixturePath("personal-config", "folder-does-not-exist"),
                     filePath = getFakeFixturePath("personal-config", "project-without-config", "foo.js");
@@ -976,12 +976,12 @@ describe("Config", function() {
 
                 const config = new StubbedConfig({ cwd: process.cwd() });
 
-                assert.throws(function() {
+                assert.throws(() => {
                     config.getConfig(filePath);
                 }, "No ESLint configuration found");
             });
 
-            it("should throw an error if no local config was found and ~/package.json contains no eslintConfig section", function() {
+            it("should throw an error if no local config was found and ~/package.json contains no eslintConfig section", () => {
                 const projectPath = getFakeFixturePath("personal-config", "project-without-config"),
                     homePath = getFakeFixturePath("personal-config", "home-folder-with-packagejson"),
                     filePath = getFakeFixturePath("personal-config", "project-without-config", "foo.js");
@@ -993,12 +993,12 @@ describe("Config", function() {
 
                 const configHelper = new StubbedConfig({ cwd: process.cwd() });
 
-                assert.throws(function() {
+                assert.throws(() => {
                     configHelper.getConfig(filePath);
                 }, "No ESLint configuration found");
             });
 
-            it("should not throw an error if no local config and no personal config was found but useEslintrc is false", function() {
+            it("should not throw an error if no local config and no personal config was found but useEslintrc is false", () => {
                 const projectPath = getFakeFixturePath("personal-config", "project-without-config"),
                     homePath = getFakeFixturePath("personal-config", "folder-does-not-exist"),
                     filePath = getFakeFixturePath("personal-config", "project-without-config", "foo.js");
@@ -1013,12 +1013,12 @@ describe("Config", function() {
                     useEslintrc: false
                 });
 
-                assert.doesNotThrow(function() {
+                assert.doesNotThrow(() => {
                     config.getConfig(filePath);
                 }, "No ESLint configuration found");
             });
 
-            it("should not throw an error if no local config and no personal config was found but rules are specified", function() {
+            it("should not throw an error if no local config and no personal config was found but rules are specified", () => {
                 const projectPath = getFakeFixturePath("personal-config", "project-without-config"),
                     homePath = getFakeFixturePath("personal-config", "folder-does-not-exist"),
                     filePath = getFakeFixturePath("personal-config", "project-without-config", "foo.js");
@@ -1033,12 +1033,12 @@ describe("Config", function() {
                     rules: { quotes: [2, "single"] }
                 });
 
-                assert.doesNotThrow(function() {
+                assert.doesNotThrow(() => {
                     config.getConfig(filePath);
                 }, "No ESLint configuration found");
             });
 
-            it("should not throw an error if no local config and no personal config was found but baseConfig is specified", function() {
+            it("should not throw an error if no local config and no personal config was found but baseConfig is specified", () => {
                 const projectPath = getFakeFixturePath("personal-config", "project-without-config"),
                     homePath = getFakeFixturePath("personal-config", "folder-does-not-exist"),
                     filePath = getFakeFixturePath("personal-config", "project-without-config", "foo.js");
@@ -1053,15 +1053,15 @@ describe("Config", function() {
                     baseConfig: {}
                 });
 
-                assert.doesNotThrow(function() {
+                assert.doesNotThrow(() => {
                     config.getConfig(filePath);
                 }, "No ESLint configuration found");
             });
         });
     });
 
-    describe("Plugin Environments", function() {
-        it("should load environments from plugin", function() {
+    describe("Plugin Environments", () => {
+        it("should load environments from plugin", () => {
 
             const StubbedConfig = createStubbedConfigWithPlugins({
                 "eslint-plugin-test": {

--- a/tests/lib/config/autoconfig.js
+++ b/tests/lib/config/autoconfig.js
@@ -55,11 +55,11 @@ const errorRulesConfig = {
     ]
 };
 
-describe("autoconfig", function() {
+describe("autoconfig", () => {
 
-    describe("Registry", function() {
+    describe("Registry", () => {
 
-        it("should set up a registry for rules in a provided rulesConfig", function() {
+        it("should set up a registry for rules in a provided rulesConfig", () => {
             const expectedRules = Object.keys(rulesConfig);
             const registry = new autoconfig.Registry(rulesConfig);
 
@@ -73,14 +73,14 @@ describe("autoconfig", function() {
             assert.lengthOf(registry.rules.quotes, 7);
         });
 
-        it("should not have any rules if constructed without a config argument", function() {
+        it("should not have any rules if constructed without a config argument", () => {
             const registry = new autoconfig.Registry();
 
             assert.isObject(registry.rules);
             assert.lengthOf(Object.keys(registry.rules), 0);
         });
 
-        it("should create registryItems for each rule with the proper keys", function() {
+        it("should create registryItems for each rule with the proper keys", () => {
             const registry = new autoconfig.Registry(rulesConfig);
 
             assert.isObject(registry.rules.semi[0]);
@@ -91,7 +91,7 @@ describe("autoconfig", function() {
             assert.property(registry.rules.semi[0], "errorCount");
         });
 
-        it("should populate the config property correctly", function() {
+        it("should populate the config property correctly", () => {
             const registry = new autoconfig.Registry(rulesConfig);
 
             assert.equal(registry.rules.quotes[0].config, SEVERITY);
@@ -103,7 +103,7 @@ describe("autoconfig", function() {
             assert.deepEqual(registry.rules.quotes[6].config, [SEVERITY, "backtick", "avoid-escape"]);
         });
 
-        it("should assign the correct specificity", function() {
+        it("should assign the correct specificity", () => {
             const registry = new autoconfig.Registry(rulesConfig);
 
             assert.equal(registry.rules.quotes[0].specificity, 1);
@@ -111,7 +111,7 @@ describe("autoconfig", function() {
             assert.equal(registry.rules.quotes[6].specificity, 3);
         });
 
-        it("should initially leave the errorCount as undefined", function() {
+        it("should initially leave the errorCount as undefined", () => {
             const registry = new autoconfig.Registry(rulesConfig);
 
             assert.isUndefined(registry.rules.quotes[0].errorCount);
@@ -119,9 +119,9 @@ describe("autoconfig", function() {
             assert.isUndefined(registry.rules.quotes[6].errorCount);
         });
 
-        describe("populateFromCoreRules()", function() {
+        describe("populateFromCoreRules()", () => {
 
-            it("should add core rules to registry", function() {
+            it("should add core rules to registry", () => {
                 const registry = new autoconfig.Registry();
 
                 registry.populateFromCoreRules();
@@ -131,50 +131,48 @@ describe("autoconfig", function() {
                 assert.include(Object.keys(registry.rules), "eqeqeq");
             });
 
-            it("should not add duplicate rules", function() {
+            it("should not add duplicate rules", () => {
                 const registry = new autoconfig.Registry(rulesConfig);
 
                 registry.populateFromCoreRules();
-                const semiCount = Object.keys(registry.rules).filter(function(ruleId) {
-                    return ruleId === "semi";
-                }).length;
+                const semiCount = Object.keys(registry.rules).filter(ruleId => ruleId === "semi").length;
 
                 assert.equal(semiCount, 1);
             });
         });
 
-        describe("buildRuleSets()", function() {
+        describe("buildRuleSets()", () => {
             let ruleSets;
 
-            beforeEach(function() {
+            beforeEach(() => {
                 const registry = new autoconfig.Registry(rulesConfig);
 
                 ruleSets = registry.buildRuleSets();
             });
 
-            it("should create an array of rule configuration sets", function() {
+            it("should create an array of rule configuration sets", () => {
                 assert.isArray(ruleSets);
             });
 
-            it("should include configs for each rule (at least for the first set)", function() {
+            it("should include configs for each rule (at least for the first set)", () => {
                 assert.sameMembers(Object.keys(ruleSets[0]), ["semi", "semi-spacing", "quotes"]);
             });
 
-            it("should create the first set from default rule configs (severity only)", function() {
+            it("should create the first set from default rule configs (severity only)", () => {
                 assert.deepEqual(ruleSets[0], { semi: SEVERITY, "semi-spacing": SEVERITY, quotes: SEVERITY });
             });
 
-            it("should create as many ruleSets as the highest number of configs in a rule", function() {
+            it("should create as many ruleSets as the highest number of configs in a rule", () => {
 
                 // `quotes` has 7 possible configurations
                 assert.lengthOf(ruleSets, 7);
             });
         });
 
-        describe("lintSourceCode()", function() {
+        describe("lintSourceCode()", () => {
             let registry;
 
-            beforeEach(function() {
+            beforeEach(() => {
                 const config = {ignore: false};
                 const sourceCode = sourceCodeUtil.getSourceCodeOfFiles(SOURCE_CODE_FIXTURE_FILENAME, config);
 
@@ -182,26 +180,26 @@ describe("autoconfig", function() {
                 registry = registry.lintSourceCode(sourceCode, defaultOptions);
             });
 
-            it("should populate the errorCount of all registryItems", function() {
+            it("should populate the errorCount of all registryItems", () => {
                 const expectedRules = ["semi", "semi-spacing", "quotes"];
 
                 assert.sameMembers(Object.keys(registry.rules), expectedRules);
-                expectedRules.forEach(function(ruleId) {
+                expectedRules.forEach(ruleId => {
                     assert(registry.rules[ruleId].length > 0);
-                    registry.rules[ruleId].forEach(function(conf) {
+                    registry.rules[ruleId].forEach(conf => {
                         assert.isNumber(conf.errorCount);
                     });
                 });
             });
 
-            it("should correctly set the error count of configurations", function() {
+            it("should correctly set the error count of configurations", () => {
                 assert.equal(registry.rules.semi[0].config, SEVERITY);
                 assert.equal(registry.rules.semi[0].errorCount, 0);
                 assert.deepEqual(registry.rules.semi[2].config, [SEVERITY, "never"]);
                 assert.equal(registry.rules.semi[2].errorCount, 3);
             });
 
-            it("should respect inline eslint config comments (and not crash when they make linting errors)", function() {
+            it("should respect inline eslint config comments (and not crash when they make linting errors)", () => {
                 const config = {ignore: false};
                 const sourceCode = sourceCodeUtil.getSourceCodeOfFiles(CONFIG_COMMENTS_FILENAME, config);
                 const expectedRegistry = [
@@ -217,10 +215,10 @@ describe("autoconfig", function() {
             });
         });
 
-        describe("stripFailingConfigs()", function() {
+        describe("stripFailingConfigs()", () => {
             let registry;
 
-            beforeEach(function() {
+            beforeEach(() => {
                 const config = {ignore: false};
                 const sourceCode = sourceCodeUtil.getSourceCodeOfFiles(SOURCE_CODE_FIXTURE_FILENAME, config);
 
@@ -229,26 +227,26 @@ describe("autoconfig", function() {
                 registry = registry.stripFailingConfigs();
             });
 
-            it("should remove all registryItems with a non-zero errorCount", function() {
+            it("should remove all registryItems with a non-zero errorCount", () => {
                 assert.lengthOf(registry.rules.semi, 2);
                 assert.lengthOf(registry.rules["semi-spacing"], 3);
                 assert.lengthOf(registry.rules.quotes, 1);
-                registry.rules.semi.forEach(function(registryItem) {
+                registry.rules.semi.forEach(registryItem => {
                     assert.equal(registryItem.errorCount, 0);
                 });
-                registry.rules["semi-spacing"].forEach(function(registryItem) {
+                registry.rules["semi-spacing"].forEach(registryItem => {
                     assert.equal(registryItem.errorCount, 0);
                 });
-                registry.rules.quotes.forEach(function(registryItem) {
+                registry.rules.quotes.forEach(registryItem => {
                     assert.equal(registryItem.errorCount, 0);
                 });
             });
         });
 
-        describe("getFailingRulesRegistry()", function() {
+        describe("getFailingRulesRegistry()", () => {
             let failingRegistry;
 
-            beforeEach(function() {
+            beforeEach(() => {
                 const config = {ignore: false};
                 const sourceCode = sourceCodeUtil.getSourceCodeOfFiles(SOURCE_CODE_FIXTURE_FILENAME, config);
                 let registry = new autoconfig.Registry(errorRulesConfig);
@@ -257,7 +255,7 @@ describe("autoconfig", function() {
                 failingRegistry = registry.getFailingRulesRegistry();
             });
 
-            it("should return a registry with no registryItems with an errorCount of zero", function() {
+            it("should return a registry with no registryItems with an errorCount of zero", () => {
                 const failingRules = Object.keys(failingRegistry.rules);
 
                 assert.deepEqual(failingRules, ["no-unused-vars"]);
@@ -266,10 +264,10 @@ describe("autoconfig", function() {
             });
         });
 
-        describe("createConfig()", function() {
+        describe("createConfig()", () => {
             let createdConfig;
 
-            beforeEach(function() {
+            beforeEach(() => {
                 const config = {ignore: false};
                 const sourceCode = sourceCodeUtil.getSourceCodeOfFiles(SOURCE_CODE_FIXTURE_FILENAME, config);
                 let registry = new autoconfig.Registry(rulesConfig);
@@ -279,21 +277,21 @@ describe("autoconfig", function() {
                 createdConfig = registry.createConfig();
             });
 
-            it("should create a config with a rules property", function() {
+            it("should create a config with a rules property", () => {
                 assert.property(createdConfig, "rules");
             });
 
-            it("should add rules which have only one registryItem to the config", function() {
+            it("should add rules which have only one registryItem to the config", () => {
                 const configuredRules = Object.keys(createdConfig.rules);
 
                 assert.deepEqual(configuredRules, ["quotes"]);
             });
 
-            it("should set the configuration of the rule to the registryItem's `config` value", function() {
+            it("should set the configuration of the rule to the registryItem's `config` value", () => {
                 assert.deepEqual(createdConfig.rules.quotes, [ 2, "double", "avoid-escape" ]);
             });
 
-            it("should not care how many errors the config has", function() {
+            it("should not care how many errors the config has", () => {
                 const config = {ignore: false};
                 const sourceCode = sourceCodeUtil.getSourceCodeOfFiles(SOURCE_CODE_FIXTURE_FILENAME, config);
                 let registry = new autoconfig.Registry(errorRulesConfig);
@@ -308,14 +306,14 @@ describe("autoconfig", function() {
             });
         });
 
-        describe("filterBySpecificity()", function() {
+        describe("filterBySpecificity()", () => {
             let registry;
 
-            beforeEach(function() {
+            beforeEach(() => {
                 registry = new autoconfig.Registry(rulesConfig);
             });
 
-            it("should return a registry where all configs have a desired specificity", function() {
+            it("should return a registry where all configs have a desired specificity", () => {
                 const filteredRegistry1 = registry.filterBySpecificity(1);
                 const filteredRegistry2 = registry.filterBySpecificity(2);
                 const filteredRegistry3 = registry.filterBySpecificity(3);

--- a/tests/lib/config/config-file.js
+++ b/tests/lib/config/config-file.js
@@ -140,17 +140,17 @@ function createStubModuleResolver(mapping) {
 // Tests
 //------------------------------------------------------------------------------
 
-describe("ConfigFile", function() {
+describe("ConfigFile", () => {
 
-    describe("CONFIG_FILES", function() {
-        it("should be present when imported", function() {
+    describe("CONFIG_FILES", () => {
+        it("should be present when imported", () => {
             assert.isTrue(Array.isArray(ConfigFile.CONFIG_FILES));
         });
     });
 
-    describe("applyExtends()", function() {
+    describe("applyExtends()", () => {
 
-        it("should apply extension 'foo' when specified from root directory config", function() {
+        it("should apply extension 'foo' when specified from root directory config", () => {
 
             const resolvedPath = path.resolve(PROJECT_PATH, "./node_modules/eslint-config-foo/index.js");
 
@@ -184,7 +184,7 @@ describe("ConfigFile", function() {
 
         });
 
-        it("should apply all rules when extends config includes 'eslint:all'", function() {
+        it("should apply all rules when extends config includes 'eslint:all'", () => {
 
             const configDeps = {
                 "../util/module-resolver": createStubModuleResolver({})
@@ -199,7 +199,7 @@ describe("ConfigFile", function() {
 
         });
 
-        it("should throw an error when extends config is not found", function() {
+        it("should throw an error when extends config is not found", () => {
 
             const configDeps = {
                 "../util/module-resolver": createStubModuleResolver({})
@@ -207,7 +207,7 @@ describe("ConfigFile", function() {
 
             const StubbedConfigFile = proxyquire("../../../lib/config/config-file", configDeps);
 
-            assert.throws(function() {
+            assert.throws(() => {
                 StubbedConfigFile.applyExtends({
                     extends: "foo",
                     rules: { eqeqeq: 2 }
@@ -216,7 +216,7 @@ describe("ConfigFile", function() {
 
         });
 
-        it("should apply extensions recursively when specified from package", function() {
+        it("should apply extensions recursively when specified from package", () => {
 
             const resolvedPaths = [
                 path.resolve(PROJECT_PATH, "./node_modules/eslint-config-foo/index.js"),
@@ -265,7 +265,7 @@ describe("ConfigFile", function() {
 
         });
 
-        it("should apply extensions when specified from a JavaScript file", function() {
+        it("should apply extensions when specified from a JavaScript file", () => {
 
             const config = ConfigFile.applyExtends({
                 extends: ".eslintrc.js",
@@ -285,7 +285,7 @@ describe("ConfigFile", function() {
 
         });
 
-        it("should apply extensions when specified from a YAML file", function() {
+        it("should apply extensions when specified from a YAML file", () => {
 
             const config = ConfigFile.applyExtends({
                 extends: ".eslintrc.yaml",
@@ -304,7 +304,7 @@ describe("ConfigFile", function() {
 
         });
 
-        it("should apply extensions when specified from a JSON file", function() {
+        it("should apply extensions when specified from a JSON file", () => {
 
             const config = ConfigFile.applyExtends({
                 extends: ".eslintrc.json",
@@ -324,7 +324,7 @@ describe("ConfigFile", function() {
 
         });
 
-        it("should apply extensions when specified from a package.json file in a sibling directory", function() {
+        it("should apply extensions when specified from a package.json file in a sibling directory", () => {
 
             const config = ConfigFile.applyExtends({
                 extends: "../package-json/package.json",
@@ -345,19 +345,19 @@ describe("ConfigFile", function() {
 
     });
 
-    describe("load()", function() {
+    describe("load()", () => {
 
-        it("should throw error if file doesnt exist", function() {
-            assert.throws(function() {
+        it("should throw error if file doesnt exist", () => {
+            assert.throws(() => {
                 ConfigFile.load(getFixturePath("legacy/nofile.js"));
             });
 
-            assert.throws(function() {
+            assert.throws(() => {
                 ConfigFile.load(getFixturePath("legacy/package.json"));
             });
         });
 
-        it("should load information from a legacy file", function() {
+        it("should load information from a legacy file", () => {
             const config = ConfigFile.load(getFixturePath("legacy/.eslintrc"));
 
             assert.deepEqual(config, {
@@ -370,7 +370,7 @@ describe("ConfigFile", function() {
             });
         });
 
-        it("should load information from a JavaScript file", function() {
+        it("should load information from a JavaScript file", () => {
             const config = ConfigFile.load(getFixturePath("js/.eslintrc.js"));
 
             assert.deepEqual(config, {
@@ -383,13 +383,13 @@ describe("ConfigFile", function() {
             });
         });
 
-        it("should throw error when loading invalid JavaScript file", function() {
-            assert.throws(function() {
+        it("should throw error when loading invalid JavaScript file", () => {
+            assert.throws(() => {
                 ConfigFile.load(getFixturePath("js/.eslintrc.broken.js"));
             }, /Cannot read config file/);
         });
 
-        it("should interpret parser module name when present in a JavaScript file", function() {
+        it("should interpret parser module name when present in a JavaScript file", () => {
             const config = ConfigFile.load(getFixturePath("js/.eslintrc.parser.js"));
 
             assert.deepEqual(config, {
@@ -403,7 +403,7 @@ describe("ConfigFile", function() {
             });
         });
 
-        it("should interpret parser path when present in a JavaScript file", function() {
+        it("should interpret parser path when present in a JavaScript file", () => {
             const config = ConfigFile.load(getFixturePath("js/.eslintrc.parser2.js"));
 
             assert.deepEqual(config, {
@@ -417,7 +417,7 @@ describe("ConfigFile", function() {
             });
         });
 
-        it("should not interpret parser module name or path when parser is set to default parser in a JavaScript file", function() {
+        it("should not interpret parser module name or path when parser is set to default parser in a JavaScript file", () => {
             const config = ConfigFile.load(getFixturePath("js/.eslintrc.parser3.js"));
 
             assert.deepEqual(config, {
@@ -431,7 +431,7 @@ describe("ConfigFile", function() {
             });
         });
 
-        it("should load information from a JSON file", function() {
+        it("should load information from a JSON file", () => {
             const config = ConfigFile.load(getFixturePath("json/.eslintrc.json"));
 
             assert.deepEqual(config, {
@@ -444,7 +444,7 @@ describe("ConfigFile", function() {
             });
         });
 
-        it("should load fresh information from a JSON file", function() {
+        it("should load fresh information from a JSON file", () => {
             const initialConfig = {
                     parserOptions: {},
                     env: {},
@@ -471,7 +471,7 @@ describe("ConfigFile", function() {
             assert.deepEqual(config, updatedConfig);
         });
 
-        it("should load information from a package.json file", function() {
+        it("should load information from a package.json file", () => {
             const config = ConfigFile.load(getFixturePath("package-json/package.json"));
 
             assert.deepEqual(config, {
@@ -482,13 +482,13 @@ describe("ConfigFile", function() {
             });
         });
 
-        it("should throw error when loading invalid package.json file", function() {
-            assert.throws(function() {
+        it("should throw error when loading invalid package.json file", () => {
+            assert.throws(() => {
                 ConfigFile.load(getFixturePath("broken-package-json/package.json"));
             }, /Cannot read config file/);
         });
 
-        it("should load information from a package.json file and apply environments", function() {
+        it("should load information from a package.json file and apply environments", () => {
             const config = ConfigFile.load(getFixturePath("package-json/package.json"), true);
 
             assert.deepEqual(config, {
@@ -499,7 +499,7 @@ describe("ConfigFile", function() {
             });
         });
 
-        it("should load fresh information from a package.json file", function() {
+        it("should load fresh information from a package.json file", () => {
             const initialConfig = {
                     eslintConfig: {
                         parserOptions: {},
@@ -530,7 +530,7 @@ describe("ConfigFile", function() {
             assert.deepEqual(config, updatedConfig.eslintConfig);
         });
 
-        it("should load fresh information from a .eslintrc.js file", function() {
+        it("should load fresh information from a .eslintrc.js file", () => {
             const initialConfig = {
                     parserOptions: {},
                     env: {},
@@ -557,7 +557,7 @@ describe("ConfigFile", function() {
             assert.deepEqual(config, updatedConfig);
         });
 
-        it("should load information from a YAML file", function() {
+        it("should load information from a YAML file", () => {
             const config = ConfigFile.load(getFixturePath("yaml/.eslintrc.yaml"));
 
             assert.deepEqual(config, {
@@ -568,7 +568,7 @@ describe("ConfigFile", function() {
             });
         });
 
-        it("should load information from a YAML file", function() {
+        it("should load information from a YAML file", () => {
             const config = ConfigFile.load(getFixturePath("yaml/.eslintrc.empty.yaml"));
 
             assert.deepEqual(config, {
@@ -579,7 +579,7 @@ describe("ConfigFile", function() {
             });
         });
 
-        it("should load information from a YAML file and apply environments", function() {
+        it("should load information from a YAML file and apply environments", () => {
             const config = ConfigFile.load(getFixturePath("yaml/.eslintrc.yaml"), true);
 
             assert.deepEqual(config, {
@@ -590,7 +590,7 @@ describe("ConfigFile", function() {
             });
         });
 
-        it("should load information from a YML file", function() {
+        it("should load information from a YML file", () => {
             const config = ConfigFile.load(getFixturePath("yml/.eslintrc.yml"));
 
             assert.deepEqual(config, {
@@ -601,7 +601,7 @@ describe("ConfigFile", function() {
             });
         });
 
-        it("should load information from a YML file and apply environments", function() {
+        it("should load information from a YML file and apply environments", () => {
             const config = ConfigFile.load(getFixturePath("yml/.eslintrc.yml"), true);
 
             assert.deepEqual(config, {
@@ -612,7 +612,7 @@ describe("ConfigFile", function() {
             });
         });
 
-        it("should load information from a YML file and apply extensions", function() {
+        it("should load information from a YML file and apply extensions", () => {
             const config = ConfigFile.load(getFixturePath("extends/.eslintrc.yml"), true);
 
             assert.deepEqual(config, {
@@ -624,7 +624,7 @@ describe("ConfigFile", function() {
             });
         });
 
-        it("should load information from `extends` chain.", function() {
+        it("should load information from `extends` chain.", () => {
             const config = ConfigFile.load(getFixturePath("extends-chain/.eslintrc.json"));
 
             assert.deepEqual(config, {
@@ -640,7 +640,7 @@ describe("ConfigFile", function() {
             });
         });
 
-        it("should load information from `extends` chain with relative path.", function() {
+        it("should load information from `extends` chain with relative path.", () => {
             const config = ConfigFile.load(getFixturePath("extends-chain-2/.eslintrc.json"));
 
             assert.deepEqual(config, {
@@ -655,7 +655,7 @@ describe("ConfigFile", function() {
             });
         });
 
-        it("should load information from `extends` chain in .eslintrc with relative path.", function() {
+        it("should load information from `extends` chain in .eslintrc with relative path.", () => {
             const config = ConfigFile.load(getFixturePath("extends-chain-2/relative.eslintrc.json"));
 
             assert.deepEqual(config, {
@@ -670,7 +670,7 @@ describe("ConfigFile", function() {
             });
         });
 
-        it("should load information from `parser` in .eslintrc with relative path.", function() {
+        it("should load information from `parser` in .eslintrc with relative path.", () => {
             const config = ConfigFile.load(getFixturePath("extends-chain-2/parser.eslintrc.json"));
             const parserPath = getFixturePath("extends-chain-2/parser.js");
 
@@ -683,10 +683,10 @@ describe("ConfigFile", function() {
             });
         });
 
-        describe("even if it's in another directory,", function() {
+        describe("even if it's in another directory,", () => {
             let fixturePath = "";
 
-            before(function() {
+            before(() => {
                 const tempDir = temp.mkdirSync("eslint-test-chain");
                 const chain2 = getFixturePath("extends-chain-2");
 
@@ -694,11 +694,11 @@ describe("ConfigFile", function() {
                 shell.cp("-r", chain2, fixturePath);
             });
 
-            after(function() {
+            after(() => {
                 temp.cleanupSync();
             });
 
-            it("should load information from `extends` chain in .eslintrc with relative path.", function() {
+            it("should load information from `extends` chain in .eslintrc with relative path.", () => {
                 const config = ConfigFile.load(path.join(fixturePath, "relative.eslintrc.json"));
 
                 assert.deepEqual(config, {
@@ -713,7 +713,7 @@ describe("ConfigFile", function() {
                 });
             });
 
-            it("should load information from `parser` in .eslintrc with relative path.", function() {
+            it("should load information from `parser` in .eslintrc with relative path.", () => {
                 const config = ConfigFile.load(path.join(fixturePath, "parser.eslintrc.json"));
                 const parserPath = path.join(fixturePath, "parser.js");
 
@@ -727,9 +727,9 @@ describe("ConfigFile", function() {
             });
         });
 
-        describe("Plugins", function() {
+        describe("Plugins", () => {
 
-            it("should load information from a YML file and load plugins", function() {
+            it("should load information from a YML file and load plugins", () => {
 
                 const StubbedPlugins = proxyquire("../../../lib/config/plugins", {
                     "eslint-plugin-test": {
@@ -757,8 +757,8 @@ describe("ConfigFile", function() {
             });
         });
 
-        describe("even if config files have Unicode BOM,", function() {
-            it("should read the JSON config file correctly.", function() {
+        describe("even if config files have Unicode BOM,", () => {
+            it("should read the JSON config file correctly.", () => {
                 const config = ConfigFile.load(getFixturePath("bom/.eslintrc.json"));
 
                 assert.deepEqual(config, {
@@ -771,7 +771,7 @@ describe("ConfigFile", function() {
                 });
             });
 
-            it("should read the YAML config file correctly.", function() {
+            it("should read the YAML config file correctly.", () => {
                 const config = ConfigFile.load(getFixturePath("bom/.eslintrc.yaml"));
 
                 assert.deepEqual(config, {
@@ -784,7 +784,7 @@ describe("ConfigFile", function() {
                 });
             });
 
-            it("should read the config in package.json correctly.", function() {
+            it("should read the config in package.json correctly.", () => {
                 const config = ConfigFile.load(getFixturePath("bom/package.json"));
 
                 assert.deepEqual(config, {
@@ -799,9 +799,9 @@ describe("ConfigFile", function() {
         });
     });
 
-    describe("resolve()", function() {
+    describe("resolve()", () => {
 
-        describe("Relative to CWD", function() {
+        describe("Relative to CWD", () => {
 
             leche.withData([
                 [ ".eslintrc", path.resolve(".eslintrc") ],
@@ -811,8 +811,8 @@ describe("ConfigFile", function() {
                 [ "@foo/eslint-config", getProjectModulePath("@foo/eslint-config") ],
                 [ "@foo/bar", getProjectModulePath("@foo/eslint-config-bar") ],
                 [ "plugin:foo/bar", getProjectModulePath("eslint-plugin-foo") ]
-            ], function(input, expected) {
-                it(`should return ${expected} when passed ${input}`, function() {
+            ], (input, expected) => {
+                it(`should return ${expected} when passed ${input}`, () => {
 
                     const configDeps = {
                         "eslint-config-foo": getProjectModulePath("eslint-config-foo"),
@@ -833,7 +833,7 @@ describe("ConfigFile", function() {
             });
         });
 
-        describe("Relative to config file", function() {
+        describe("Relative to config file", () => {
 
             const relativePath = path.resolve("./foo/bar");
 
@@ -845,8 +845,8 @@ describe("ConfigFile", function() {
                 [ "@foo/eslint-config", getRelativeModulePath("@foo/eslint-config", relativePath), relativePath],
                 [ "@foo/bar", getRelativeModulePath("@foo/eslint-config-bar", relativePath), relativePath],
                 [ "plugin:@foo/bar/baz", getRelativeModulePath("@foo/eslint-plugin-bar", relativePath), relativePath]
-            ], function(input, expected, relativeTo) {
-                it(`should return ${expected} when passed ${input}`, function() {
+            ], (input, expected, relativeTo) => {
+                it(`should return ${expected} when passed ${input}`, () => {
 
                     const configDeps = {
                         "eslint-config-foo": getRelativeModulePath("eslint-config-foo", relativePath),
@@ -872,8 +872,8 @@ describe("ConfigFile", function() {
                 [ "eslint-config-foo/bar", path.resolve("./node_modules", "eslint-config-foo", "bar.json"), relativePath],
                 [ "eslint-config-foo/bar", path.resolve("./node_modules", "eslint-config-foo/bar", "index.js"), relativePath],
                 [ "eslint-config-foo/bar", path.resolve("./node_modules", "eslint-config-foo", "bar.js"), relativePath]
-            ], function(input, expected, relativeTo) {
-                it(`should return ${expected} when passed ${input}`, function() {
+            ], (input, expected, relativeTo) => {
+                it(`should return ${expected} when passed ${input}`, () => {
 
                     const configDeps = {
                         "eslint-config-foo/bar": expected
@@ -893,32 +893,32 @@ describe("ConfigFile", function() {
 
     });
 
-    describe("getBaseDir()", function() {
+    describe("getBaseDir()", () => {
 
         // can only run this test if there's a home directory
         if (userHome) {
 
-            it("should return project path when config file is in home directory", function() {
+            it("should return project path when config file is in home directory", () => {
                 const result = ConfigFile.getBaseDir(userHome);
 
                 assert.equal(result, PROJECT_PATH);
             });
         }
 
-        it("should return project path when config file is in an ancestor directory of the project path", function() {
+        it("should return project path when config file is in an ancestor directory of the project path", () => {
             const result = ConfigFile.getBaseDir(path.resolve(PROJECT_PATH, "../../"));
 
             assert.equal(result, PROJECT_PATH);
         });
 
-        it("should return config file path when config file is in a descendant directory of the project path", function() {
+        it("should return config file path when config file is in a descendant directory of the project path", () => {
             const configFilePath = path.resolve(PROJECT_PATH, "./foo/bar/"),
                 result = ConfigFile.getBaseDir(path.resolve(PROJECT_PATH, "./foo/bar/"));
 
             assert.equal(result, configFilePath);
         });
 
-        it("should return project path when config file is not an ancestor or descendant of the project path", function() {
+        it("should return project path when config file is not an ancestor or descendant of the project path", () => {
             const result = ConfigFile.getBaseDir(path.resolve("/tmp/foo"));
 
             assert.equal(result, PROJECT_PATH);
@@ -926,32 +926,32 @@ describe("ConfigFile", function() {
 
     });
 
-    describe("getLookupPath()", function() {
+    describe("getLookupPath()", () => {
 
         // can only run this test if there's a home directory
         if (userHome) {
 
-            it("should return project path when config file is in home directory", function() {
+            it("should return project path when config file is in home directory", () => {
                 const result = ConfigFile.getLookupPath(userHome);
 
                 assert.equal(result, PROJECT_DEPS_PATH);
             });
         }
 
-        it("should return project path when config file is in an ancestor directory of the project path", function() {
+        it("should return project path when config file is in an ancestor directory of the project path", () => {
             const result = ConfigFile.getLookupPath(path.resolve(PROJECT_DEPS_PATH, "../../"));
 
             assert.equal(result, PROJECT_DEPS_PATH);
         });
 
-        it("should return config file path when config file is in a descendant directory of the project path", function() {
+        it("should return config file path when config file is in a descendant directory of the project path", () => {
             const configFilePath = path.resolve(PROJECT_DEPS_PATH, "./foo/bar/node_modules"),
                 result = ConfigFile.getLookupPath(path.resolve(PROJECT_DEPS_PATH, "./foo/bar/"));
 
             assert.equal(result, configFilePath);
         });
 
-        it("should return project path when config file is not an ancestor or descendant of the project path", function() {
+        it("should return project path when config file is not an ancestor or descendant of the project path", () => {
             const result = ConfigFile.getLookupPath(path.resolve("/tmp/foo"));
 
             assert.equal(result, PROJECT_DEPS_PATH);
@@ -959,7 +959,7 @@ describe("ConfigFile", function() {
 
     });
 
-    describe("getFilenameFromDirectory()", function() {
+    describe("getFilenameFromDirectory()", () => {
 
         leche.withData([
             [ getFixturePath("legacy"), ".eslintrc" ],
@@ -967,8 +967,8 @@ describe("ConfigFile", function() {
             [ getFixturePath("yml"), ".eslintrc.yml" ],
             [ getFixturePath("json"), ".eslintrc.json" ],
             [ getFixturePath("js"), ".eslintrc.js" ]
-        ], function(input, expected) {
-            it(`should return ${expected} when passed ${input}`, function() {
+        ], (input, expected) => {
+            it(`should return ${expected} when passed ${input}`, () => {
                 const result = ConfigFile.getFilenameForDirectory(input);
 
                 assert.equal(result, path.resolve(input, expected));
@@ -977,7 +977,7 @@ describe("ConfigFile", function() {
 
     });
 
-    describe("normalizePackageName()", function() {
+    describe("normalizePackageName()", () => {
 
         leche.withData([
             [ "foo", "eslint-config-foo" ],
@@ -987,8 +987,8 @@ describe("ConfigFile", function() {
             [ "@z\\foo\\bar.js", "@z/eslint-config-foo/bar.js" ],
             [ "@z/eslint-config", "@z/eslint-config" ],
             [ "@z/eslint-config-foo", "@z/eslint-config-foo" ]
-        ], function(input, expected) {
-            it(`should return ${expected} when passed ${input}`, function() {
+        ], (input, expected) => {
+            it(`should return ${expected} when passed ${input}`, () => {
                 const result = ConfigFile.normalizePackageName(input, "eslint-config");
 
                 assert.equal(result, expected);
@@ -997,12 +997,12 @@ describe("ConfigFile", function() {
 
     });
 
-    describe("write()", function() {
+    describe("write()", () => {
 
         let sandbox,
             config;
 
-        beforeEach(function() {
+        beforeEach(() => {
             sandbox = sinon.sandbox.create();
             config = {
                 env: {
@@ -1016,7 +1016,7 @@ describe("ConfigFile", function() {
             };
         });
 
-        afterEach(function() {
+        afterEach(() => {
             sandbox.verifyAndRestore();
         });
 
@@ -1025,16 +1025,14 @@ describe("ConfigFile", function() {
             ["JSON", "bar.json", JSON.parse],
             ["YAML", "foo.yaml", yaml.safeLoad],
             ["YML", "foo.yml", yaml.safeLoad]
-        ], function(fileType, filename, validate) {
+        ], (fileType, filename, validate) => {
 
-            it(`should write a file through fs when a ${fileType} path is passed`, function() {
+            it(`should write a file through fs when a ${fileType} path is passed`, () => {
                 const fakeFS = leche.fake(fs);
 
                 sandbox.mock(fakeFS).expects("writeFileSync").withExactArgs(
                     filename,
-                    sinon.match(function(value) {
-                        return !!validate(value);
-                    }),
+                    sinon.match(value => !!validate(value)),
                     "utf8"
                 );
 
@@ -1047,8 +1045,8 @@ describe("ConfigFile", function() {
 
         });
 
-        it("should throw error if file extension is not valid", function() {
-            assert.throws(function() {
+        it("should throw error if file extension is not valid", () => {
+            assert.throws(() => {
                 ConfigFile.write({}, getFixturePath("yaml/.eslintrc.class"));
             }, /write to unknown file type/);
         });

--- a/tests/lib/config/config-initializer.js
+++ b/tests/lib/config/config-initializer.js
@@ -27,7 +27,7 @@ const proxyquire = require("proxyquire").noPreserveCache();
 
 let answers = {};
 
-describe("configInitializer", function() {
+describe("configInitializer", () => {
 
     let fixtureDir,
         npmCheckStub,
@@ -62,40 +62,38 @@ describe("configInitializer", function() {
     }
 
     // copy into clean area so as not to get "infected" by this project's .eslintrc files
-    before(function() {
+    before(() => {
         fixtureDir = `${os.tmpdir()}/eslint/fixtures/config-initializer`;
         sh.mkdir("-p", fixtureDir);
         sh.cp("-r", "./tests/fixtures/config-initializer/.", fixtureDir);
         fixtureDir = fs.realpathSync(fixtureDir);
     });
 
-    beforeEach(function() {
+    beforeEach(() => {
         npmInstallStub = sinon.stub(npmUtil, "installSyncSaveDev");
-        npmCheckStub = sinon.stub(npmUtil, "checkDevDeps", function(packages) {
-            return packages.reduce(function(status, pkg) {
-                status[pkg] = false;
-                return status;
-            }, {});
-        });
+        npmCheckStub = sinon.stub(npmUtil, "checkDevDeps", packages => packages.reduce((status, pkg) => {
+            status[pkg] = false;
+            return status;
+        }, {}));
         init = proxyquire("../../../lib/config/config-initializer", requireStubs);
     });
 
-    afterEach(function() {
+    afterEach(() => {
         log.info.reset();
         log.error.reset();
         npmInstallStub.restore();
         npmCheckStub.restore();
     });
 
-    after(function() {
+    after(() => {
         sh.rm("-r", fixtureDir);
     });
 
-    describe("processAnswers()", function() {
+    describe("processAnswers()", () => {
 
-        describe("prompt", function() {
+        describe("prompt", () => {
 
-            beforeEach(function() {
+            beforeEach(() => {
                 answers = {
                     source: "prompt",
                     extendDefault: true,
@@ -113,7 +111,7 @@ describe("configInitializer", function() {
                 };
             });
 
-            it("should create default config", function() {
+            it("should create default config", () => {
                 const config = init.processAnswers(answers);
 
                 assert.deepEqual(config.rules.indent, ["error", 2]);
@@ -126,21 +124,21 @@ describe("configInitializer", function() {
                 assert.equal(config.extends, "eslint:recommended");
             });
 
-            it("should disable semi", function() {
+            it("should disable semi", () => {
                 answers.semi = false;
                 const config = init.processAnswers(answers);
 
                 assert.deepEqual(config.rules.semi, ["error", "never"]);
             });
 
-            it("should enable jsx flag", function() {
+            it("should enable jsx flag", () => {
                 answers.jsx = true;
                 const config = init.processAnswers(answers);
 
                 assert.equal(config.parserOptions.ecmaFeatures.jsx, true);
             });
 
-            it("should enable react plugin", function() {
+            it("should enable react plugin", () => {
                 answers.jsx = true;
                 answers.react = true;
                 const config = init.processAnswers(answers);
@@ -150,26 +148,26 @@ describe("configInitializer", function() {
                 assert.deepEqual(config.plugins, ["react"]);
             });
 
-            it("should not enable es6", function() {
+            it("should not enable es6", () => {
                 answers.es6 = false;
                 const config = init.processAnswers(answers);
 
                 assert.isUndefined(config.env.es6);
             });
 
-            it("should extend eslint:recommended", function() {
+            it("should extend eslint:recommended", () => {
                 const config = init.processAnswers(answers);
 
                 assert.equal(config.extends, "eslint:recommended");
             });
 
-            it("should not use commonjs by default", function() {
+            it("should not use commonjs by default", () => {
                 const config = init.processAnswers(answers);
 
                 assert.isUndefined(config.env.commonjs);
             });
 
-            it("should use commonjs when set", function() {
+            it("should use commonjs when set", () => {
                 answers.commonjs = true;
                 const config = init.processAnswers(answers);
 
@@ -177,49 +175,49 @@ describe("configInitializer", function() {
             });
         });
 
-        describe("guide", function() {
-            it("should support the google style guide", function() {
+        describe("guide", () => {
+            it("should support the google style guide", () => {
                 const config = init.getConfigForStyleGuide("google");
 
                 assert.deepEqual(config, {extends: "google", installedESLint: true});
             });
 
-            it("should support the airbnb style guide", function() {
+            it("should support the airbnb style guide", () => {
                 const config = init.getConfigForStyleGuide("airbnb");
 
                 assert.deepEqual(config, {extends: "airbnb", installedESLint: true, plugins: ["react", "jsx-a11y", "import"]});
             });
 
-            it("should support the standard style guide", function() {
+            it("should support the standard style guide", () => {
                 const config = init.getConfigForStyleGuide("standard");
 
                 assert.deepEqual(config, {extends: "standard", installedESLint: true, plugins: ["standard", "promise"]});
             });
 
-            it("should throw when encountering an unsupported style guide", function() {
-                assert.throws(function() {
+            it("should throw when encountering an unsupported style guide", () => {
+                assert.throws(() => {
                     init.getConfigForStyleGuide("non-standard");
                 }, "You referenced an unsupported guide.");
             });
 
-            it("should install required sharable config", function() {
+            it("should install required sharable config", () => {
                 init.getConfigForStyleGuide("google");
                 assert(npmInstallStub.calledOnce);
                 assert.deepEqual(npmInstallStub.firstCall.args[0][1], "eslint-config-google");
             });
 
-            it("should install ESLint if not installed locally", function() {
+            it("should install ESLint if not installed locally", () => {
                 init.getConfigForStyleGuide("google");
                 assert(npmInstallStub.calledOnce);
                 assert.deepEqual(npmInstallStub.firstCall.args[0][0], "eslint");
             });
         });
 
-        describe("auto", function() {
+        describe("auto", () => {
             const completeSpy = sinon.spy();
             let config;
 
-            before(function() {
+            before(() => {
                 const patterns = [
                     getFixturePath("lib"),
                     getFixturePath("tests")
@@ -255,39 +253,39 @@ describe("configInitializer", function() {
                 }
             });
 
-            it("should create a config", function() {
+            it("should create a config", () => {
                 assert.isTrue(completeSpy.notCalled);
                 assert.ok(config);
             });
 
-            it("should create the config based on examined files", function() {
+            it("should create the config based on examined files", () => {
                 assert.deepEqual(config.rules.quotes, ["error", "double"]);
                 assert.equal(config.rules.semi, "off");
             });
 
-            it("should extend and not disable recommended rules", function() {
+            it("should extend and not disable recommended rules", () => {
                 assert.equal(config.extends, "eslint:recommended");
                 assert.notProperty(config.rules, "no-console");
             });
 
-            it("should throw on fatal parsing error", function() {
+            it("should throw on fatal parsing error", () => {
                 const filename = getFixturePath("parse-error");
 
                 sinon.stub(autoconfig, "extendFromRecommended");
                 answers.patterns = filename;
                 process.chdir(fixtureDir);
-                assert.throws(function() {
+                assert.throws(() => {
                     config = init.processAnswers(answers);
                 }, "Parsing error: Unexpected token ;");
                 process.chdir(originalDir);
                 autoconfig.extendFromRecommended.restore();
             });
 
-            it("should throw if no files are matched from patterns", function() {
+            it("should throw if no files are matched from patterns", () => {
                 sinon.stub(autoconfig, "extendFromRecommended");
                 answers.patterns = "not-a-real-filename";
                 process.chdir(fixtureDir);
-                assert.throws(function() {
+                assert.throws(() => {
                     config = init.processAnswers(answers);
                 }, "Automatic Configuration failed.  No files were able to be parsed.");
                 process.chdir(originalDir);

--- a/tests/lib/config/config-ops.js
+++ b/tests/lib/config/config-ops.js
@@ -19,10 +19,10 @@ const proxyquire = require("proxyquire").noCallThru().noPreserveCache();
 // Tests
 //------------------------------------------------------------------------------
 
-describe("ConfigOps", function() {
+describe("ConfigOps", () => {
 
-    describe("applyEnvironments()", function() {
-        it("should apply environment settings to config without destroying original settings", function() {
+    describe("applyEnvironments()", () => {
+        it("should apply environment settings to config without destroying original settings", () => {
             const config = {
                 env: {
                     node: true
@@ -44,7 +44,7 @@ describe("ConfigOps", function() {
             });
         });
 
-        it("should not apply environment settings to config without environments", function() {
+        it("should not apply environment settings to config without environments", () => {
             const config = {
                 rules: {
                     foo: 2
@@ -56,7 +56,7 @@ describe("ConfigOps", function() {
             assert.equal(result, config);
         });
 
-        it("should apply multiple environment settings to config without destroying original settings", function() {
+        it("should apply multiple environment settings to config without destroying original settings", () => {
             const config = {
                 env: {
                     node: true,
@@ -81,9 +81,9 @@ describe("ConfigOps", function() {
         });
     });
 
-    describe("createEnvironmentConfig()", function() {
+    describe("createEnvironmentConfig()", () => {
 
-        it("should return empty config if called without any config", function() {
+        it("should return empty config if called without any config", () => {
             const config = ConfigOps.createEnvironmentConfig(null);
 
             assert.deepEqual(config, {
@@ -94,7 +94,7 @@ describe("ConfigOps", function() {
             });
         });
 
-        it("should return correct config for env with no globals", function() {
+        it("should return correct config for env with no globals", () => {
             const StubbedConfigOps = proxyquire("../../../lib/config/config-ops", {
                 "./environments": {
                     get() {
@@ -121,7 +121,7 @@ describe("ConfigOps", function() {
             });
         });
 
-        it("should create the correct config for Node.js environment", function() {
+        it("should create the correct config for Node.js environment", () => {
             const config = ConfigOps.createEnvironmentConfig({ node: true });
 
             assert.deepEqual(config, {
@@ -136,7 +136,7 @@ describe("ConfigOps", function() {
             });
         });
 
-        it("should create the correct config for ES6 environment", function() {
+        it("should create the correct config for ES6 environment", () => {
             const config = ConfigOps.createEnvironmentConfig({ es6: true });
 
             assert.deepEqual(config, {
@@ -151,7 +151,7 @@ describe("ConfigOps", function() {
             });
         });
 
-        it("should create empty config when no environments are specified", function() {
+        it("should create empty config when no environments are specified", () => {
             const config = ConfigOps.createEnvironmentConfig({});
 
             assert.deepEqual(config, {
@@ -162,7 +162,7 @@ describe("ConfigOps", function() {
             });
         });
 
-        it("should create empty config when an unknown environment is specified", function() {
+        it("should create empty config when an unknown environment is specified", () => {
             const config = ConfigOps.createEnvironmentConfig({ foo: true });
 
             assert.deepEqual(config, {
@@ -177,9 +177,9 @@ describe("ConfigOps", function() {
 
     });
 
-    describe("merge()", function() {
+    describe("merge()", () => {
 
-        it("should combine two objects when passed two objects with different top-level properties", function() {
+        it("should combine two objects when passed two objects with different top-level properties", () => {
             const config = [
                 { env: { browser: true } },
                 { globals: { foo: "bar"} }
@@ -191,7 +191,7 @@ describe("ConfigOps", function() {
             assert.isTrue(result.env.browser);
         });
 
-        it("should combine without blowing up on null values", function() {
+        it("should combine without blowing up on null values", () => {
             const config = [
                 { env: { browser: true } },
                 { env: { node: null } }
@@ -203,7 +203,7 @@ describe("ConfigOps", function() {
             assert.isTrue(result.env.browser);
         });
 
-        it("should combine two objects with parser when passed two objects with different top-level properties", function() {
+        it("should combine two objects with parser when passed two objects with different top-level properties", () => {
             const config = [
                 { env: { browser: true }, parser: "espree" },
                 { globals: { foo: "bar"} }
@@ -214,7 +214,7 @@ describe("ConfigOps", function() {
             assert.equal(result.parser, "espree");
         });
 
-        it("should combine configs and override rules when passed configs with the same rules", function() {
+        it("should combine configs and override rules when passed configs with the same rules", () => {
             const config = [
                 { rules: { "no-mixed-requires": [0, false] } },
                 { rules: { "no-mixed-requires": [1, true] } }
@@ -227,7 +227,7 @@ describe("ConfigOps", function() {
             assert.equal(result.rules["no-mixed-requires"][1], true);
         });
 
-        it("should combine configs when passed configs with parserOptions", function() {
+        it("should combine configs when passed configs with parserOptions", () => {
             const config = [
                 { parserOptions: { ecmaFeatures: { blockBindings: true } } },
                 { parserOptions: { ecmaFeatures: { forOf: true } } }
@@ -249,7 +249,7 @@ describe("ConfigOps", function() {
             assert.deepEqual(config[1], { parserOptions: { ecmaFeatures: { forOf: true }}});
         });
 
-        it("should override configs when passed configs with the same ecmaFeatures", function() {
+        it("should override configs when passed configs with the same ecmaFeatures", () => {
             const config = [
                 { parserOptions: { ecmaFeatures: { forOf: false } } },
                 { parserOptions: { ecmaFeatures: { forOf: true } } }
@@ -266,7 +266,7 @@ describe("ConfigOps", function() {
             });
         });
 
-        it("should combine configs and override rules when merging two configs with arrays and int", function() {
+        it("should combine configs and override rules when merging two configs with arrays and int", () => {
 
             const config = [
                 { rules: { "no-mixed-requires": [0, false] } },
@@ -282,7 +282,7 @@ describe("ConfigOps", function() {
             assert.deepEqual(config[1], { rules: { "no-mixed-requires": 1 }});
         });
 
-        it("should combine configs and override rules options completely", function() {
+        it("should combine configs and override rules options completely", () => {
 
             const config = [
                 { rules: { "no-mixed-requires": [1, { event: ["evt", "e"] }] } },
@@ -297,7 +297,7 @@ describe("ConfigOps", function() {
             assert.deepEqual(config[1], { rules: { "no-mixed-requires": [1, {err: ["error", "e"]}] }});
         });
 
-        it("should combine configs and override rules options without array or object", function() {
+        it("should combine configs and override rules options without array or object", () => {
 
             const config = [
                 { rules: { "no-mixed-requires": ["warn", "nconf", "underscore"] } },
@@ -313,7 +313,7 @@ describe("ConfigOps", function() {
             assert.deepEqual(config[1], { rules: { "no-mixed-requires": [2, "requirejs"] }});
         });
 
-        it("should combine configs and override rules options without array or object but special case", function() {
+        it("should combine configs and override rules options without array or object but special case", () => {
 
             const config = [
                 { rules: { "no-mixed-requires": [1, "nconf", "underscore"] } },
@@ -329,7 +329,7 @@ describe("ConfigOps", function() {
             assert.deepEqual(config[1], { rules: { "no-mixed-requires": "error" }});
         });
 
-        it("should combine configs correctly", function() {
+        it("should combine configs correctly", () => {
 
             const config = [
                 {
@@ -427,7 +427,7 @@ describe("ConfigOps", function() {
             });
         });
 
-        it("should copy deeply if there is not the destination's property", function() {
+        it("should copy deeply if there is not the destination's property", () => {
             const a = {};
             const b = {foo: {bar: 1}};
 
@@ -442,14 +442,14 @@ describe("ConfigOps", function() {
             assert(result.foo.bar === 2);
         });
 
-        describe("plugins", function() {
+        describe("plugins", () => {
             let baseConfig;
 
-            beforeEach(function() {
+            beforeEach(() => {
                 baseConfig = { plugins: ["foo", "bar"] };
             });
 
-            it("should combine the plugin entries when each config has different plugins", function() {
+            it("should combine the plugin entries when each config has different plugins", () => {
                 const customConfig = { plugins: ["baz"] },
                     expectedResult = { plugins: ["foo", "bar", "baz"] },
                     result = ConfigOps.merge(baseConfig, customConfig);
@@ -459,7 +459,7 @@ describe("ConfigOps", function() {
                 assert.deepEqual(customConfig, { plugins: ["baz"] });
             });
 
-            it("should avoid duplicate plugin entries when each config has the same plugin", function() {
+            it("should avoid duplicate plugin entries when each config has the same plugin", () => {
                 const customConfig = { plugins: ["bar"] },
                     expectedResult = { plugins: ["foo", "bar"] },
                     result = ConfigOps.merge(baseConfig, customConfig);
@@ -467,7 +467,7 @@ describe("ConfigOps", function() {
                 assert.deepEqual(result, expectedResult);
             });
 
-            it("should create a valid config when one argument is an empty object", function() {
+            it("should create a valid config when one argument is an empty object", () => {
                 const customConfig = { plugins: ["foo"] },
                     result = ConfigOps.merge({}, customConfig);
 
@@ -479,8 +479,8 @@ describe("ConfigOps", function() {
 
     });
 
-    describe("normalize()", function() {
-        it("should convert error rule setting to 2 when rule has just a severity", function() {
+    describe("normalize()", () => {
+        it("should convert error rule setting to 2 when rule has just a severity", () => {
             const config = {
                 rules: {
                     foo: "errOr",
@@ -498,7 +498,7 @@ describe("ConfigOps", function() {
             });
         });
 
-        it("should convert error rule setting to 2 when rule has array with severity", function() {
+        it("should convert error rule setting to 2 when rule has array with severity", () => {
             const config = {
                 rules: {
                     foo: ["Error", "something"],
@@ -516,7 +516,7 @@ describe("ConfigOps", function() {
             });
         });
 
-        it("should convert warn rule setting to 1 when rule has just a severity", function() {
+        it("should convert warn rule setting to 1 when rule has just a severity", () => {
             const config = {
                 rules: {
                     foo: "waRn",
@@ -534,7 +534,7 @@ describe("ConfigOps", function() {
             });
         });
 
-        it("should convert warn rule setting to 1 when rule has array with severity", function() {
+        it("should convert warn rule setting to 1 when rule has array with severity", () => {
             const config = {
                 rules: {
                     foo: ["Warn", "something"],
@@ -552,7 +552,7 @@ describe("ConfigOps", function() {
             });
         });
 
-        it("should convert off rule setting to 0 when rule has just a severity", function() {
+        it("should convert off rule setting to 0 when rule has just a severity", () => {
             const config = {
                 rules: {
                     foo: "ofF",
@@ -570,7 +570,7 @@ describe("ConfigOps", function() {
             });
         });
 
-        it("should convert off rule setting to 0 when rule has array with severity", function() {
+        it("should convert off rule setting to 0 when rule has array with severity", () => {
             const config = {
                 rules: {
                     foo: ["Off", "something"],
@@ -588,7 +588,7 @@ describe("ConfigOps", function() {
             });
         });
 
-        it("should convert invalid rule setting to 0 when rule has just a severity", function() {
+        it("should convert invalid rule setting to 0 when rule has just a severity", () => {
             const config = {
                 rules: {
                     foo: "invalid",
@@ -606,7 +606,7 @@ describe("ConfigOps", function() {
             });
         });
 
-        it("should convert invalid rule setting to 0 when rule has array with severity", function() {
+        it("should convert invalid rule setting to 0 when rule has array with severity", () => {
             const config = {
                 rules: {
                     foo: ["invalid", "something"],
@@ -625,8 +625,8 @@ describe("ConfigOps", function() {
         });
     });
 
-    describe("normalizeToStrings()", function() {
-        it("should convert 2 rule setting to error when rule has just a severity", function() {
+    describe("normalizeToStrings()", () => {
+        it("should convert 2 rule setting to error when rule has just a severity", () => {
             const config = {
                 rules: {
                     foo: 2,
@@ -644,7 +644,7 @@ describe("ConfigOps", function() {
             });
         });
 
-        it("should convert 2 rule setting to error when rule has array with severity", function() {
+        it("should convert 2 rule setting to error when rule has array with severity", () => {
             const config = {
                 rules: {
                     foo: [2, "something"],
@@ -662,7 +662,7 @@ describe("ConfigOps", function() {
             });
         });
 
-        it("should convert 1 rule setting to warn when rule has just a severity", function() {
+        it("should convert 1 rule setting to warn when rule has just a severity", () => {
             const config = {
                 rules: {
                     foo: 1,
@@ -680,7 +680,7 @@ describe("ConfigOps", function() {
             });
         });
 
-        it("should convert 1 rule setting to warn when rule has array with severity", function() {
+        it("should convert 1 rule setting to warn when rule has array with severity", () => {
             const config = {
                 rules: {
                     foo: [1, "something"],
@@ -698,7 +698,7 @@ describe("ConfigOps", function() {
             });
         });
 
-        it("should convert 0 rule setting to off when rule has just a severity", function() {
+        it("should convert 0 rule setting to off when rule has just a severity", () => {
             const config = {
                 rules: {
                     foo: 0,
@@ -716,7 +716,7 @@ describe("ConfigOps", function() {
             });
         });
 
-        it("should convert 0 rule setting to off when rule has array with severity", function() {
+        it("should convert 0 rule setting to off when rule has array with severity", () => {
             const config = {
                 rules: {
                     foo: [0, "something"],
@@ -734,7 +734,7 @@ describe("ConfigOps", function() {
             });
         });
 
-        it("should convert 256 rule setting to off when rule has just a severity", function() {
+        it("should convert 256 rule setting to off when rule has just a severity", () => {
             const config = {
                 rules: {
                     foo: 256,
@@ -752,7 +752,7 @@ describe("ConfigOps", function() {
             });
         });
 
-        it("should convert 256 rule setting to off when rule has array with severity", function() {
+        it("should convert 256 rule setting to off when rule has array with severity", () => {
             const config = {
                 rules: {
                     foo: [256, "something"],
@@ -771,7 +771,7 @@ describe("ConfigOps", function() {
         });
     });
 
-    describe("isError()", function() {
+    describe("isError()", () => {
 
         leche.withData([
             ["error", true],
@@ -783,9 +783,9 @@ describe("ConfigOps", function() {
             [["error", "foo"], true],
             [["eRror", "bar"], true],
             [[2, "baz"], true]
-        ], function(input, expected) {
+        ], (input, expected) => {
 
-            it(`should return ${expected}when passed ${input}`, function() {
+            it(`should return ${expected}when passed ${input}`, () => {
                 const result = ConfigOps.isErrorSeverity(input);
 
                 assert.equal(result, expected);

--- a/tests/lib/config/config-rule.js
+++ b/tests/lib/config/config-rule.js
@@ -20,81 +20,81 @@ const assert = require("chai").assert,
 
 const SEVERITY = 2;
 
-describe("ConfigRule", function() {
+describe("ConfigRule", () => {
 
-    describe("generateConfigsFromSchema()", function() {
+    describe("generateConfigsFromSchema()", () => {
         let actualConfigs;
 
-        it("should create a config with only severity for an empty schema", function() {
+        it("should create a config with only severity for an empty schema", () => {
             actualConfigs = ConfigRule.generateConfigsFromSchema([]);
             assert.deepEqual(actualConfigs, [SEVERITY]);
         });
 
-        it("should create a config with only severity with no arguments", function() {
+        it("should create a config with only severity with no arguments", () => {
             actualConfigs = ConfigRule.generateConfigsFromSchema();
             assert.deepEqual(actualConfigs, [SEVERITY]);
         });
 
-        describe("for a single enum schema", function() {
+        describe("for a single enum schema", () => {
 
-            before(function() {
+            before(() => {
                 actualConfigs = ConfigRule.generateConfigsFromSchema(schema.enum);
             });
 
-            it("should create an array of configs", function() {
+            it("should create an array of configs", () => {
                 assert.isArray(actualConfigs);
                 assert.equal(actualConfigs.length, 3);
             });
 
-            it("should include the error severity (2) without options as the first config", function() {
+            it("should include the error severity (2) without options as the first config", () => {
                 assert.equal(actualConfigs[0], SEVERITY);
             });
 
-            it("should set all configs to error severity (2)", function() {
-                actualConfigs.forEach(function(actualConfig) {
+            it("should set all configs to error severity (2)", () => {
+                actualConfigs.forEach(actualConfig => {
                     if (Array.isArray(actualConfig)) {
                         assert.equal(actualConfig[0], SEVERITY);
                     }
                 });
             });
 
-            it("should return configs with each enumerated value in the schema", function() {
+            it("should return configs with each enumerated value in the schema", () => {
                 assert.sameDeepMembers(actualConfigs, [SEVERITY, [SEVERITY, "always"], [SEVERITY, "never"]]);
             });
         });
 
-        describe("for a object schema with a single enum property", function() {
+        describe("for a object schema with a single enum property", () => {
 
-            before(function() {
+            before(() => {
                 actualConfigs = ConfigRule.generateConfigsFromSchema(schema.objectWithEnum);
             });
 
-            it("should return configs with option objects", function() {
+            it("should return configs with option objects", () => {
 
                 // Skip first config (severity only)
-                actualConfigs.slice(1).forEach(function(actualConfig) {
+                actualConfigs.slice(1).forEach(actualConfig => {
                     const actualConfigOption = actualConfig[1]; // severity is first element, option is second
 
                     assert.isObject(actualConfigOption);
                 });
             });
 
-            it("should use the object property name from the schema", function() {
+            it("should use the object property name from the schema", () => {
                 const propName = "enumProperty";
 
                 assert.equal(actualConfigs.length, 3);
-                actualConfigs.slice(1).forEach(function(actualConfig) {
+                actualConfigs.slice(1).forEach(actualConfig => {
                     const actualConfigOption = actualConfig[1];
 
                     assert.property(actualConfigOption, propName);
                 });
             });
 
-            it("should have each enum as option object values", function() {
+            it("should have each enum as option object values", () => {
                 const propName = "enumProperty",
                     actualValues = [];
 
-                actualConfigs.slice(1).forEach(function(actualConfig) {
+                actualConfigs.slice(1).forEach(actualConfig => {
                     const configOption = actualConfig[1];
 
                     actualValues.push(configOption[propName]);
@@ -103,17 +103,17 @@ describe("ConfigRule", function() {
             });
         });
 
-        describe("for a object schema with a multiple enum properties", function() {
+        describe("for a object schema with a multiple enum properties", () => {
 
-            before(function() {
+            before(() => {
                 actualConfigs = ConfigRule.generateConfigsFromSchema(schema.objectWithMultipleEnums);
             });
 
-            it("should create configs for all properties in each config", function() {
+            it("should create configs for all properties in each config", () => {
                 const expectedProperties = ["firstEnum", "anotherEnum"];
 
                 assert.equal(actualConfigs.length, 7);
-                actualConfigs.slice(1).forEach(function(actualConfig) {
+                actualConfigs.slice(1).forEach(actualConfig => {
                     const configOption = actualConfig[1];
                     const actualProperties = Object.keys(configOption);
 
@@ -121,7 +121,7 @@ describe("ConfigRule", function() {
                 });
             });
 
-            it("should create configs for every possible combination", function() {
+            it("should create configs for every possible combination", () => {
                 const expectedConfigs = [
                     { firstEnum: "always", anotherEnum: "var" },
                     { firstEnum: "always", anotherEnum: "let" },
@@ -130,46 +130,44 @@ describe("ConfigRule", function() {
                     { firstEnum: "never", anotherEnum: "let" },
                     { firstEnum: "never", anotherEnum: "const" }
                 ];
-                const actualConfigOptions = actualConfigs.slice(1).map(function(actualConfig) {
-                    return actualConfig[1];
-                });
+                const actualConfigOptions = actualConfigs.slice(1).map(actualConfig => actualConfig[1]);
 
                 assert.sameDeepMembers(actualConfigOptions, expectedConfigs);
             });
 
         });
 
-        describe("for a object schema with a single boolean property", function() {
+        describe("for a object schema with a single boolean property", () => {
 
-            before(function() {
+            before(() => {
                 actualConfigs = ConfigRule.generateConfigsFromSchema(schema.objectWithBool);
             });
 
-            it("should return configs with option objects", function() {
+            it("should return configs with option objects", () => {
                 assert.equal(actualConfigs.length, 3);
-                actualConfigs.slice(1).forEach(function(actualConfig) {
+                actualConfigs.slice(1).forEach(actualConfig => {
                     const actualConfigOption = actualConfig[1];
 
                     assert.isObject(actualConfigOption);
                 });
             });
 
-            it("should use the object property name from the schema", function() {
+            it("should use the object property name from the schema", () => {
                 const propName = "boolProperty";
 
                 assert.equal(actualConfigs.length, 3);
-                actualConfigs.slice(1).forEach(function(actualConfig) {
+                actualConfigs.slice(1).forEach(actualConfig => {
                     const actualConfigOption = actualConfig[1];
 
                     assert.property(actualConfigOption, propName);
                 });
             });
 
-            it("should include both true and false configs", function() {
+            it("should include both true and false configs", () => {
                 const propName = "boolProperty",
                     actualValues = [];
 
-                actualConfigs.slice(1).forEach(function(actualConfig) {
+                actualConfigs.slice(1).forEach(actualConfig => {
                     const configOption = actualConfig[1];
 
                     actualValues.push(configOption[propName]);
@@ -178,17 +176,17 @@ describe("ConfigRule", function() {
             });
         });
 
-        describe("for a object schema with a multiple bool properties", function() {
+        describe("for a object schema with a multiple bool properties", () => {
 
-            before(function() {
+            before(() => {
                 actualConfigs = ConfigRule.generateConfigsFromSchema(schema.objectWithMultipleBools);
             });
 
-            it("should create configs for all properties in each config", function() {
+            it("should create configs for all properties in each config", () => {
                 const expectedProperties = ["firstBool", "anotherBool"];
 
                 assert.equal(actualConfigs.length, 5);
-                actualConfigs.slice(1).forEach(function(config) {
+                actualConfigs.slice(1).forEach(config => {
                     const configOption = config[1];
                     const actualProperties = Object.keys(configOption);
 
@@ -196,28 +194,26 @@ describe("ConfigRule", function() {
                 });
             });
 
-            it("should create configs for every possible combination", function() {
+            it("should create configs for every possible combination", () => {
                 const expectedConfigOptions = [
                     { firstBool: true, anotherBool: true },
                     { firstBool: true, anotherBool: false },
                     { firstBool: false, anotherBool: true },
                     { firstBool: false, anotherBool: false }
                 ];
-                const actualConfigOptions = actualConfigs.slice(1).map(function(config) {
-                    return config[1];
-                });
+                const actualConfigOptions = actualConfigs.slice(1).map(config => config[1]);
 
                 assert.sameDeepMembers(actualConfigOptions, expectedConfigOptions);
             });
         });
 
-        describe("for a schema with an enum and an object", function() {
+        describe("for a schema with an enum and an object", () => {
 
-            before(function() {
+            before(() => {
                 actualConfigs = ConfigRule.generateConfigsFromSchema(schema.mixedEnumObject);
             });
 
-            it("should create configs with only the enum values", function() {
+            it("should create configs with only the enum values", () => {
                 assert.equal(actualConfigs[1].length, 2);
                 assert.equal(actualConfigs[2].length, 2);
                 const actualOptions = [actualConfigs[1][1], actualConfigs[2][1]];
@@ -225,55 +221,55 @@ describe("ConfigRule", function() {
                 assert.sameMembers(actualOptions, ["always", "never"]);
             });
 
-            it("should create configs with a string and an object", function() {
+            it("should create configs with a string and an object", () => {
                 assert.equal(actualConfigs.length, 7);
-                actualConfigs.slice(3).forEach(function(config) {
+                actualConfigs.slice(3).forEach(config => {
                     assert.isString(config[1]);
                     assert.isObject(config[2]);
                 });
             });
         });
 
-        describe("for a schema with an enum and an object with no usable properties", function() {
-            before(function() {
+        describe("for a schema with an enum and an object with no usable properties", () => {
+            before(() => {
                 actualConfigs = ConfigRule.generateConfigsFromSchema(schema.mixedEnumObjectWithNothing);
             });
 
-            it("should create config only for the enum", function() {
+            it("should create config only for the enum", () => {
                 const expectedConfigs = [2, [2, "always"], [2, "never"]];
 
                 assert.sameDeepMembers(actualConfigs, expectedConfigs);
             });
         });
 
-        describe("for a schema with oneOf", function() {
+        describe("for a schema with oneOf", () => {
 
-            before(function() {
+            before(() => {
                 actualConfigs = ConfigRule.generateConfigsFromSchema(schema.oneOf);
             });
 
-            it("should create a set of configs", function() {
+            it("should create a set of configs", () => {
                 assert.isArray(actualConfigs);
             });
         });
 
-        describe("for a schema with nested objects", function() {
+        describe("for a schema with nested objects", () => {
 
-            before(function() {
+            before(() => {
                 actualConfigs = ConfigRule.generateConfigsFromSchema(schema.nestedObjects);
             });
 
-            it("should create a set of configs", function() {
+            it("should create a set of configs", () => {
                 assert.isArray(actualConfigs);
             });
         });
     });
 
-    describe("createCoreRuleConfigs()", function() {
+    describe("createCoreRuleConfigs()", () => {
 
         const rulesConfig = ConfigRule.createCoreRuleConfigs();
 
-        it("should create a rulesConfig containing all core rules", function() {
+        it("should create a rulesConfig containing all core rules", () => {
             const coreRules = loadRules(),
                 expectedRules = Object.keys(coreRules),
                 actualRules = Object.keys(rulesConfig);
@@ -281,12 +277,12 @@ describe("ConfigRule", function() {
             assert.sameMembers(actualRules, expectedRules);
         });
 
-        it("should create arrays of configs for rules", function() {
+        it("should create arrays of configs for rules", () => {
             assert.isArray(rulesConfig.quotes);
             assert.include(rulesConfig.quotes, 2);
         });
 
-        it("should create configs for rules with meta", function() {
+        it("should create configs for rules with meta", () => {
             assert(rulesConfig["accessor-pairs"].length > 1);
         });
     });

--- a/tests/lib/config/config-validator.js
+++ b/tests/lib/config/config-validator.js
@@ -71,75 +71,75 @@ function mockNoOptionsRule(context) {
 
 mockNoOptionsRule.schema = [];
 
-describe("Validator", function() {
+describe("Validator", () => {
 
-    beforeEach(function() {
+    beforeEach(() => {
         eslint.defineRule("mock-rule", mockRule);
     });
 
-    describe("validate", function() {
+    describe("validate", () => {
 
-        it("should do nothing with an empty config", function() {
+        it("should do nothing with an empty config", () => {
             const fn = validator.validate.bind(null, {}, "tests");
 
             assert.doesNotThrow(fn);
         });
 
-        it("should do nothing with an empty rules object", function() {
+        it("should do nothing with an empty rules object", () => {
             const fn = validator.validate.bind(null, { rules: {} }, "tests");
 
             assert.doesNotThrow(fn);
         });
 
-        it("should do nothing with a valid config", function() {
+        it("should do nothing with a valid config", () => {
             const fn = validator.validate.bind(null, { rules: { "mock-rule": [2, "second"] } }, "tests");
 
             assert.doesNotThrow(fn);
         });
 
-        it("should do nothing with a valid config when severity is off", function() {
+        it("should do nothing with a valid config when severity is off", () => {
             const fn = validator.validate.bind(null, { rules: { "mock-rule": ["off", "second"] } }, "tests");
 
             assert.doesNotThrow(fn);
         });
 
-        it("should do nothing with a valid config when severity is warn", function() {
+        it("should do nothing with a valid config when severity is warn", () => {
             const fn = validator.validate.bind(null, { rules: { "mock-rule": ["warn", "second"] } }, "tests");
 
             assert.doesNotThrow(fn);
         });
 
-        it("should do nothing with a valid config when severity is error", function() {
+        it("should do nothing with a valid config when severity is error", () => {
             const fn = validator.validate.bind(null, { rules: { "mock-rule": ["error", "second"] } }, "tests");
 
             assert.doesNotThrow(fn);
         });
 
-        it("should do nothing with a valid config when severity is Off", function() {
+        it("should do nothing with a valid config when severity is Off", () => {
             const fn = validator.validate.bind(null, { rules: { "mock-rule": ["Off", "second"] } }, "tests");
 
             assert.doesNotThrow(fn);
         });
 
-        it("should do nothing with a valid config when severity is Warn", function() {
+        it("should do nothing with a valid config when severity is Warn", () => {
             const fn = validator.validate.bind(null, { rules: { "mock-rule": ["Warn", "second"] } }, "tests");
 
             assert.doesNotThrow(fn);
         });
 
-        it("should do nothing with a valid config when severity is Error", function() {
+        it("should do nothing with a valid config when severity is Error", () => {
             const fn = validator.validate.bind(null, { rules: { "mock-rule": ["Error", "second"] } }, "tests");
 
             assert.doesNotThrow(fn);
         });
 
-        it("should catch invalid rule options", function() {
+        it("should catch invalid rule options", () => {
             const fn = validator.validate.bind(null, { rules: { "mock-rule": [3, "third"] } }, "tests");
 
             assert.throws(fn, "tests:\n\tConfiguration for rule \"mock-rule\" is invalid:\n\tSeverity should be one of the following: 0 = off, 1 = warn, 2 = error (you passed '3').\n\tValue \"third\" must be an enum value.\n");
         });
 
-        it("should allow for rules with no options", function() {
+        it("should allow for rules with no options", () => {
             eslint.defineRule("mock-no-options-rule", mockNoOptionsRule);
 
             const fn = validator.validate.bind(null, { rules: { "mock-no-options-rule": 2 } }, "tests");
@@ -147,7 +147,7 @@ describe("Validator", function() {
             assert.doesNotThrow(fn);
         });
 
-        it("should not allow options for rules with no options", function() {
+        it("should not allow options for rules with no options", () => {
             eslint.defineRule("mock-no-options-rule", mockNoOptionsRule);
 
             const fn = validator.validate.bind(null, { rules: { "mock-no-options-rule": [2, "extra"] } }, "tests");
@@ -155,31 +155,31 @@ describe("Validator", function() {
             assert.throws(fn, "tests:\n\tConfiguration for rule \"mock-no-options-rule\" is invalid:\n\tValue \"extra\" has more items than allowed.\n");
         });
 
-        it("should throw with an array environment", function() {
+        it("should throw with an array environment", () => {
             const fn = validator.validate.bind(null, { env: [] });
 
             assert.throws(fn, "Environment must not be an array");
         });
 
-        it("should throw with a primitive environment", function() {
+        it("should throw with a primitive environment", () => {
             const fn = validator.validate.bind(null, { env: 1 });
 
             assert.throws(fn, "Environment must be an object");
         });
 
-        it("should catch invalid environments", function() {
+        it("should catch invalid environments", () => {
             const fn = validator.validate.bind(null, { env: {browser: true, invalid: true } });
 
             assert.throws(fn, "Environment key \"invalid\" is unknown\n");
         });
 
-        it("should catch disabled invalid environments", function() {
+        it("should catch disabled invalid environments", () => {
             const fn = validator.validate.bind(null, { env: {browser: true, invalid: false } });
 
             assert.throws(fn, "Environment key \"invalid\" is unknown\n");
         });
 
-        it("should do nothing with an undefined environment", function() {
+        it("should do nothing with an undefined environment", () => {
             const fn = validator.validate.bind(null, {});
 
             assert.doesNotThrow(fn);
@@ -187,13 +187,13 @@ describe("Validator", function() {
 
     });
 
-    describe("getRuleOptionsSchema", function() {
+    describe("getRuleOptionsSchema", () => {
 
-        it("should return null for a missing rule", function() {
+        it("should return null for a missing rule", () => {
             assert.equal(validator.getRuleOptionsSchema("non-existent-rule"), null);
         });
 
-        it("should not modify object schema", function() {
+        it("should not modify object schema", () => {
             eslint.defineRule("mock-object-rule", mockObjectRule);
             assert.deepEqual(validator.getRuleOptionsSchema("mock-object-rule"), {
                 enum: ["first", "second"]
@@ -202,45 +202,45 @@ describe("Validator", function() {
 
     });
 
-    describe("validateRuleOptions", function() {
+    describe("validateRuleOptions", () => {
 
-        it("should throw for incorrect warning level number", function() {
+        it("should throw for incorrect warning level number", () => {
             const fn = validator.validateRuleOptions.bind(null, "mock-rule", 3, "tests");
 
             assert.throws(fn, "tests:\n\tConfiguration for rule \"mock-rule\" is invalid:\n\tSeverity should be one of the following: 0 = off, 1 = warn, 2 = error (you passed '3').\n");
         });
 
-        it("should throw for incorrect warning level string", function() {
+        it("should throw for incorrect warning level string", () => {
             const fn = validator.validateRuleOptions.bind(null, "mock-rule", "booya", "tests");
 
             assert.throws(fn, "tests:\n\tConfiguration for rule \"mock-rule\" is invalid:\n\tSeverity should be one of the following: 0 = off, 1 = warn, 2 = error (you passed '\"booya\"').\n");
         });
 
-        it("should throw for invalid-type warning level", function() {
+        it("should throw for invalid-type warning level", () => {
             const fn = validator.validateRuleOptions.bind(null, "mock-rule", [["error"]], "tests");
 
             assert.throws(fn, "tests:\n\tConfiguration for rule \"mock-rule\" is invalid:\n\tSeverity should be one of the following: 0 = off, 1 = warn, 2 = error (you passed '[ \"error\" ]').\n");
         });
 
-        it("should only check warning level for nonexistent rules", function() {
+        it("should only check warning level for nonexistent rules", () => {
             const fn = validator.validateRuleOptions.bind(null, "non-existent-rule", [3, "foobar"], "tests");
 
             assert.throws(fn, "tests:\n\tConfiguration for rule \"non-existent-rule\" is invalid:\n\tSeverity should be one of the following: 0 = off, 1 = warn, 2 = error (you passed '3').\n");
         });
 
-        it("should only check warning level for plugin rules", function() {
+        it("should only check warning level for plugin rules", () => {
             const fn = validator.validateRuleOptions.bind(null, "plugin/rule", 3, "tests");
 
             assert.throws(fn, "tests:\n\tConfiguration for rule \"plugin/rule\" is invalid:\n\tSeverity should be one of the following: 0 = off, 1 = warn, 2 = error (you passed '3').\n");
         });
 
-        it("should throw for incorrect configuration values", function() {
+        it("should throw for incorrect configuration values", () => {
             const fn = validator.validateRuleOptions.bind(null, "mock-rule", [2, "frist"], "tests");
 
             assert.throws(fn, "tests:\n\tConfiguration for rule \"mock-rule\" is invalid:\n\tValue \"frist\" must be an enum value.\n");
         });
 
-        it("should throw for too many configuration values", function() {
+        it("should throw for too many configuration values", () => {
             const fn = validator.validateRuleOptions.bind(null, "mock-rule", [2, "first", "second"], "tests");
 
             assert.throws(fn, "tests:\n\tConfiguration for rule \"mock-rule\" is invalid:\n\tValue \"first,second\" has more items than allowed.\n");

--- a/tests/lib/config/environments.js
+++ b/tests/lib/config/environments.js
@@ -16,32 +16,32 @@ const assert = require("chai").assert,
 // Tests
 //------------------------------------------------------------------------------
 
-describe("Environments", function() {
+describe("Environments", () => {
 
-    describe("load()", function() {
+    describe("load()", () => {
 
-        it("should have all default environments loaded", function() {
-            Object.keys(envs).forEach(function(envName) {
+        it("should have all default environments loaded", () => {
+            Object.keys(envs).forEach(envName => {
                 assert.deepEqual(Environments.get(envName), envs[envName]);
             });
         });
 
-        it("should have all default environments loaded after being cleared", function() {
+        it("should have all default environments loaded after being cleared", () => {
             Environments.testReset();
 
-            Object.keys(envs).forEach(function(envName) {
+            Object.keys(envs).forEach(envName => {
                 assert.deepEqual(Environments.get(envName), envs[envName]);
             });
         });
     });
 
-    describe("define()", function() {
+    describe("define()", () => {
 
-        afterEach(function() {
+        afterEach(() => {
             Environments.testReset();
         });
 
-        it("should add an environment with the given name", function() {
+        it("should add an environment with the given name", () => {
             const env = { globals: { foo: true }};
 
             Environments.define("foo", env);
@@ -52,13 +52,13 @@ describe("Environments", function() {
         });
     });
 
-    describe("importPlugin()", function() {
+    describe("importPlugin()", () => {
 
-        afterEach(function() {
+        afterEach(() => {
             Environments.testReset();
         });
 
-        it("should import all environments from a plugin object", function() {
+        it("should import all environments from a plugin object", () => {
             const plugin = {
                 environments: {
                     foo: {

--- a/tests/lib/config/plugins.js
+++ b/tests/lib/config/plugins.js
@@ -17,16 +17,16 @@ const proxyquire = require("proxyquire").noCallThru().noPreserveCache();
 // Tests
 //------------------------------------------------------------------------------
 
-describe("Plugins", function() {
+describe("Plugins", () => {
 
-    describe("get", function() {
+    describe("get", () => {
 
-        it("should return null when plugin doesn't exist", function() {
+        it("should return null when plugin doesn't exist", () => {
             assert.isNull(Plugins.get("foo"));
         });
     });
 
-    describe("load()", function() {
+    describe("load()", () => {
 
         let StubbedPlugins,
             Rules,
@@ -34,7 +34,7 @@ describe("Plugins", function() {
             plugin,
             scopedPlugin;
 
-        beforeEach(function() {
+        beforeEach(() => {
             plugin = {};
             scopedPlugin = {};
             Environments = require("../../../lib/config/environments");
@@ -47,17 +47,17 @@ describe("Plugins", function() {
             });
         });
 
-        it("should load a plugin when referenced by short name", function() {
+        it("should load a plugin when referenced by short name", () => {
             StubbedPlugins.load("example");
             assert.equal(StubbedPlugins.get("example"), plugin);
         });
 
-        it("should load a plugin when referenced by long name", function() {
+        it("should load a plugin when referenced by long name", () => {
             StubbedPlugins.load("eslint-plugin-example");
             assert.equal(StubbedPlugins.get("example"), plugin);
         });
 
-        it("should register environments when plugin has environments", function() {
+        it("should register environments when plugin has environments", () => {
             plugin.environments = {
                 foo: {
                     globals: { foo: true }
@@ -73,7 +73,7 @@ describe("Plugins", function() {
             assert.deepEqual(Environments.get("example/bar"), plugin.environments.bar);
         });
 
-        it("should register rules when plugin has rules", function() {
+        it("should register rules when plugin has rules", () => {
             plugin.rules = {
                 baz: {},
                 qux: {}
@@ -85,23 +85,23 @@ describe("Plugins", function() {
             assert.deepEqual(Rules.get("example/qux"), plugin.rules.qux);
         });
 
-        it("should throw an error when a plugin has whitespace", function() {
-            assert.throws(function() {
+        it("should throw an error when a plugin has whitespace", () => {
+            assert.throws(() => {
                 StubbedPlugins.load("whitespace ");
             }, /Whitespace found in plugin name 'whitespace '/);
-            assert.throws(function() {
+            assert.throws(() => {
                 StubbedPlugins.load("whitespace\t");
             }, /Whitespace found in plugin name/);
-            assert.throws(function() {
+            assert.throws(() => {
                 StubbedPlugins.load("whitespace\n");
             }, /Whitespace found in plugin name/);
-            assert.throws(function() {
+            assert.throws(() => {
                 StubbedPlugins.load("whitespace\r");
             }, /Whitespace found in plugin name/);
         });
 
-        it("should throw an error when a plugin doesn't exist", function() {
-            assert.throws(function() {
+        it("should throw an error when a plugin doesn't exist", () => {
+            assert.throws(() => {
                 StubbedPlugins.load("nonexistentplugin");
             }, /Failed to load plugin/);
         });
@@ -165,7 +165,7 @@ describe("Plugins", function() {
         });
     });
 
-    describe("loadAll()", function() {
+    describe("loadAll()", () => {
 
         let StubbedPlugins,
             Rules,
@@ -173,7 +173,7 @@ describe("Plugins", function() {
             plugin1,
             plugin2;
 
-        beforeEach(function() {
+        beforeEach(() => {
             plugin1 = {};
             plugin2 = {};
             Environments = require("../../../lib/config/environments");
@@ -186,13 +186,13 @@ describe("Plugins", function() {
             });
         });
 
-        it("should load plugins when passed multiple plugins", function() {
+        it("should load plugins when passed multiple plugins", () => {
             StubbedPlugins.loadAll(["example1", "example2"]);
             assert.equal(StubbedPlugins.get("example1"), plugin1);
             assert.equal(StubbedPlugins.get("example2"), plugin2);
         });
 
-        it("should load environments from plugins when passed multiple plugins", function() {
+        it("should load environments from plugins when passed multiple plugins", () => {
             plugin1.environments = {
                 foo: {}
             };
@@ -206,7 +206,7 @@ describe("Plugins", function() {
             assert.equal(Environments.get("example2/bar"), plugin2.environments.bar);
         });
 
-        it("should load rules from plugins when passed multiple plugins", function() {
+        it("should load rules from plugins when passed multiple plugins", () => {
             plugin1.rules = {
                 foo: {}
             };
@@ -222,30 +222,30 @@ describe("Plugins", function() {
 
     });
 
-    describe("removePrefix()", function() {
-        it("should remove common prefix when passed a plugin name  with a prefix", function() {
+    describe("removePrefix()", () => {
+        it("should remove common prefix when passed a plugin name  with a prefix", () => {
             const pluginName = Plugins.removePrefix("eslint-plugin-test");
 
             assert.equal(pluginName, "test");
         });
 
-        it("should not modify plugin name when passed a plugin name without a prefix", function() {
+        it("should not modify plugin name when passed a plugin name without a prefix", () => {
             const pluginName = Plugins.removePrefix("test");
 
             assert.equal(pluginName, "test");
         });
     });
 
-    describe("getNamespace()", function() {
-        it("should remove namepace when passed with namepace", function() {
+    describe("getNamespace()", () => {
+        it("should remove namepace when passed with namepace", () => {
             const namespace = Plugins.getNamespace("@namepace/eslint-plugin-test");
 
             assert.equal(namespace, "@namepace/");
         });
     });
 
-    describe("removeNamespace()", function() {
-        it("should remove namepace when passed with namepace", function() {
+    describe("removeNamespace()", () => {
+        it("should remove namepace when passed with namepace", () => {
             const namespace = Plugins.removeNamespace("@namepace/eslint-plugin-test");
 
             assert.equal(namespace, "eslint-plugin-test");

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -57,7 +57,7 @@ const TEST_CODE = "var answer = 6 * 7;",
 function getVariable(scope, name) {
     let variable = null;
 
-    scope.variables.some(function(v) {
+    scope.variables.some(v => {
         if (v.name === name) {
             variable = v;
             return true;
@@ -71,39 +71,39 @@ function getVariable(scope, name) {
 // Tests
 //------------------------------------------------------------------------------
 
-describe("eslint", function() {
+describe("eslint", () => {
     const filename = "filename.js";
     let sandbox;
 
-    beforeEach(function() {
+    beforeEach(() => {
         sandbox = sinon.sandbox.create();
     });
 
-    afterEach(function() {
+    afterEach(() => {
         eslint.reset();
         sandbox.verifyAndRestore();
     });
 
-    describe("when using events", function() {
+    describe("when using events", () => {
         const code = TEST_CODE;
 
-        it("an error should be thrown when an error occurs inside of an event handler", function() {
+        it("an error should be thrown when an error occurs inside of an event handler", () => {
             const config = { rules: {} };
 
             eslint.reset();
-            eslint.on("Program", function() {
+            eslint.on("Program", () => {
                 throw new Error("Intentional error.");
             });
 
-            assert.throws(function() {
+            assert.throws(() => {
                 eslint.verify(code, config, filename, true);
             }, Error);
         });
     });
 
-    describe("getSourceLines()", function() {
+    describe("getSourceLines()", () => {
 
-        it("should get proper lines when using \\n as a line break", function() {
+        it("should get proper lines when using \\n as a line break", () => {
             const code = "a;\nb;";
 
             eslint.verify(code, {}, filename, true);
@@ -114,7 +114,7 @@ describe("eslint", function() {
             assert.equal(lines[1], "b;");
         });
 
-        it("should get proper lines when using \\r\\n as a line break", function() {
+        it("should get proper lines when using \\r\\n as a line break", () => {
             const code = "a;\r\nb;";
 
             eslint.verify(code, {}, filename, true);
@@ -125,7 +125,7 @@ describe("eslint", function() {
             assert.equal(lines[1], "b;");
         });
 
-        it("should get proper lines when using \\r as a line break", function() {
+        it("should get proper lines when using \\r as a line break", () => {
             const code = "a;\rb;";
 
             eslint.verify(code, {}, filename, true);
@@ -136,7 +136,7 @@ describe("eslint", function() {
             assert.equal(lines[1], "b;");
         });
 
-        it("should get proper lines when using \\u2028 as a line break", function() {
+        it("should get proper lines when using \\u2028 as a line break", () => {
             const code = "a;\u2028b;";
 
             eslint.verify(code, {}, filename, true);
@@ -147,7 +147,7 @@ describe("eslint", function() {
             assert.equal(lines[1], "b;");
         });
 
-        it("should get proper lines when using \\u2029 as a line break", function() {
+        it("should get proper lines when using \\u2029 as a line break", () => {
             const code = "a;\u2029b;";
 
             eslint.verify(code, {}, filename, true);
@@ -161,10 +161,10 @@ describe("eslint", function() {
 
     });
 
-    describe("getSourceCode()", function() {
+    describe("getSourceCode()", () => {
         const code = TEST_CODE;
 
-        it("should retrieve SourceCode object after reset", function() {
+        it("should retrieve SourceCode object after reset", () => {
             eslint.reset();
             eslint.verify(code, {}, filename, true);
 
@@ -175,7 +175,7 @@ describe("eslint", function() {
             assert.isObject(sourceCode.ast);
         });
 
-        it("should retrieve SourceCode object without reset", function() {
+        it("should retrieve SourceCode object without reset", () => {
             eslint.reset();
             eslint.verify(code, {}, filename);
 
@@ -188,10 +188,10 @@ describe("eslint", function() {
 
     });
 
-    describe("getSource()", function() {
+    describe("getSource()", () => {
         const code = TEST_CODE;
 
-        it("should retrieve all text when used without parameters", function() {
+        it("should retrieve all text when used without parameters", () => {
 
             /**
              * Callback handler
@@ -213,7 +213,7 @@ describe("eslint", function() {
             assert(spy.calledOnce);
         });
 
-        it("should retrieve all text for root node", function() {
+        it("should retrieve all text for root node", () => {
 
             /**
              * Callback handler
@@ -236,7 +236,7 @@ describe("eslint", function() {
             assert(spy.calledOnce);
         });
 
-        it("should clamp to valid range when retrieving characters before start of source", function() {
+        it("should clamp to valid range when retrieving characters before start of source", () => {
 
             /**
              * Callback handler
@@ -259,11 +259,11 @@ describe("eslint", function() {
             assert(spy.calledOnce);
         });
 
-        it("should retrieve all text for binary expression", function() {
+        it("should retrieve all text for binary expression", () => {
             const config = { rules: {} };
 
             eslint.reset();
-            eslint.on("BinaryExpression", function(node) {
+            eslint.on("BinaryExpression", node => {
                 const source = eslint.getSource(node);
 
                 assert.equal(source, "6 * 7");
@@ -272,11 +272,11 @@ describe("eslint", function() {
             eslint.verify(code, config, filename, true);
         });
 
-        it("should retrieve all text plus two characters before for binary expression", function() {
+        it("should retrieve all text plus two characters before for binary expression", () => {
             const config = { rules: {} };
 
             eslint.reset();
-            eslint.on("BinaryExpression", function(node) {
+            eslint.on("BinaryExpression", node => {
                 const source = eslint.getSource(node, 2);
 
                 assert.equal(source, "= 6 * 7");
@@ -285,11 +285,11 @@ describe("eslint", function() {
             eslint.verify(code, config, filename, true);
         });
 
-        it("should retrieve all text plus one character after for binary expression", function() {
+        it("should retrieve all text plus one character after for binary expression", () => {
             const config = { rules: {} };
 
             eslint.reset();
-            eslint.on("BinaryExpression", function(node) {
+            eslint.on("BinaryExpression", node => {
                 const source = eslint.getSource(node, 0, 1);
 
                 assert.equal(source, "6 * 7;");
@@ -298,11 +298,11 @@ describe("eslint", function() {
             eslint.verify(code, config, filename, true);
         });
 
-        it("should retrieve all text plus two characters before and one character after for binary expression", function() {
+        it("should retrieve all text plus two characters before and one character after for binary expression", () => {
             const config = { rules: {} };
 
             eslint.reset();
-            eslint.on("BinaryExpression", function(node) {
+            eslint.on("BinaryExpression", node => {
                 const source = eslint.getSource(node, 2, 1);
 
                 assert.equal(source, "= 6 * 7;");
@@ -313,15 +313,15 @@ describe("eslint", function() {
 
     });
 
-    describe("when calling getAncestors", function() {
+    describe("when calling getAncestors", () => {
         const code = TEST_CODE;
 
-        it("should retrieve all ancestors when used", function() {
+        it("should retrieve all ancestors when used", () => {
 
             const config = { rules: {} };
 
             eslint.reset();
-            eslint.on("BinaryExpression", function() {
+            eslint.on("BinaryExpression", () => {
                 const ancestors = eslint.getAncestors();
 
                 assert.equal(ancestors.length, 3);
@@ -330,11 +330,11 @@ describe("eslint", function() {
             eslint.verify(code, config, filename, true);
         });
 
-        it("should retrieve empty ancestors for root node", function() {
+        it("should retrieve empty ancestors for root node", () => {
             const config = { rules: {} };
 
             eslint.reset();
-            eslint.on("Program", function() {
+            eslint.on("Program", () => {
                 const ancestors = eslint.getAncestors();
 
                 assert.equal(ancestors.length, 0);
@@ -344,14 +344,14 @@ describe("eslint", function() {
         });
     });
 
-    describe("when calling getNodeByRangeIndex", function() {
+    describe("when calling getNodeByRangeIndex", () => {
         const code = TEST_CODE;
 
-        it("should retrieve a node starting at the given index", function() {
+        it("should retrieve a node starting at the given index", () => {
             const config = { rules: {} };
 
             eslint.reset();
-            eslint.on("Program", function() {
+            eslint.on("Program", () => {
                 const node = eslint.getNodeByRangeIndex(4);
 
                 assert.equal(node.type, "Identifier");
@@ -360,11 +360,11 @@ describe("eslint", function() {
             eslint.verify(code, config, filename, true);
         });
 
-        it("should retrieve a node containing the given index", function() {
+        it("should retrieve a node containing the given index", () => {
             const config = { rules: {} };
 
             eslint.reset();
-            eslint.on("Program", function() {
+            eslint.on("Program", () => {
                 const node = eslint.getNodeByRangeIndex(6);
 
                 assert.equal(node.type, "Identifier");
@@ -373,11 +373,11 @@ describe("eslint", function() {
             eslint.verify(code, config, filename, true);
         });
 
-        it("should retrieve a node that is exactly the given index", function() {
+        it("should retrieve a node that is exactly the given index", () => {
             const config = { rules: {} };
 
             eslint.reset();
-            eslint.on("Program", function() {
+            eslint.on("Program", () => {
                 const node = eslint.getNodeByRangeIndex(13);
 
                 assert.equal(node.type, "Literal");
@@ -387,11 +387,11 @@ describe("eslint", function() {
             eslint.verify(code, config, filename, true);
         });
 
-        it("should retrieve a node ending with the given index", function() {
+        it("should retrieve a node ending with the given index", () => {
             const config = { rules: {} };
 
             eslint.reset();
-            eslint.on("Program", function() {
+            eslint.on("Program", () => {
                 const node = eslint.getNodeByRangeIndex(9);
 
                 assert.equal(node.type, "Identifier");
@@ -400,11 +400,11 @@ describe("eslint", function() {
             eslint.verify(code, config, filename, true);
         });
 
-        it("should retrieve the deepest node containing the given index", function() {
+        it("should retrieve the deepest node containing the given index", () => {
             const config = { rules: {} };
 
             eslint.reset();
-            eslint.on("Program", function() {
+            eslint.on("Program", () => {
                 let node = eslint.getNodeByRangeIndex(14);
 
                 assert.equal(node.type, "BinaryExpression");
@@ -415,11 +415,11 @@ describe("eslint", function() {
             eslint.verify(code, config, filename, true);
         });
 
-        it("should return null if the index is outside the range of any node", function() {
+        it("should return null if the index is outside the range of any node", () => {
             const config = { rules: {} };
 
             eslint.reset();
-            eslint.on("Program", function() {
+            eslint.on("Program", () => {
                 let node = eslint.getNodeByRangeIndex(-1);
 
                 assert.isNull(node);
@@ -430,11 +430,11 @@ describe("eslint", function() {
             eslint.verify(code, config, filename, true);
         });
 
-        it("should attach the node's parent", function() {
+        it("should attach the node's parent", () => {
             const config = { rules: {} };
 
             eslint.reset();
-            eslint.on("Program", function() {
+            eslint.on("Program", () => {
                 const node = eslint.getNodeByRangeIndex(14);
 
                 assert.property(node, "parent");
@@ -444,11 +444,11 @@ describe("eslint", function() {
             eslint.verify(code, config, filename, true);
         });
 
-        it("should not modify the node when attaching the parent", function() {
+        it("should not modify the node when attaching the parent", () => {
             const config = { rules: {} };
 
             eslint.reset();
-            eslint.on("Program", function() {
+            eslint.on("Program", () => {
                 let node = eslint.getNodeByRangeIndex(10);
 
                 assert.equal(node.type, "VariableDeclarator");
@@ -466,14 +466,14 @@ describe("eslint", function() {
 
 
 
-    describe("when calling getScope", function() {
+    describe("when calling getScope", () => {
         const code = "function foo() { q: for(;;) { break q; } } function bar () { var q = t; } var baz = (() => { return 1; });";
 
-        it("should retrieve the global scope correctly from a Program", function() {
+        it("should retrieve the global scope correctly from a Program", () => {
             const config = { rules: {} };
 
             eslint.reset();
-            eslint.on("Program", function() {
+            eslint.on("Program", () => {
                 const scope = eslint.getScope();
 
                 assert.equal(scope.type, "global");
@@ -482,11 +482,11 @@ describe("eslint", function() {
             eslint.verify(code, config, filename, true);
         });
 
-        it("should retrieve the function scope correctly from a FunctionDeclaration", function() {
+        it("should retrieve the function scope correctly from a FunctionDeclaration", () => {
             const config = { rules: {} };
 
             eslint.reset();
-            eslint.on("FunctionDeclaration", function() {
+            eslint.on("FunctionDeclaration", () => {
                 const scope = eslint.getScope();
 
                 assert.equal(scope.type, "function");
@@ -495,11 +495,11 @@ describe("eslint", function() {
             eslint.verify(code, config, filename, true);
         });
 
-        it("should retrieve the function scope correctly from a LabeledStatement", function() {
+        it("should retrieve the function scope correctly from a LabeledStatement", () => {
             const config = { rules: {} };
 
             eslint.reset();
-            eslint.on("LabeledStatement", function() {
+            eslint.on("LabeledStatement", () => {
                 const scope = eslint.getScope();
 
                 assert.equal(scope.type, "function");
@@ -509,11 +509,11 @@ describe("eslint", function() {
             eslint.verify(code, config, filename, true);
         });
 
-        it("should retrieve the function scope correctly from within an ArrowFunctionExpression", function() {
+        it("should retrieve the function scope correctly from within an ArrowFunctionExpression", () => {
             const config = { rules: {}, ecmaFeatures: { arrowFunctions: true } };
 
             eslint.reset();
-            eslint.on("ReturnStatement", function() {
+            eslint.on("ReturnStatement", () => {
                 const scope = eslint.getScope();
 
                 assert.equal(scope.type, "function");
@@ -523,11 +523,11 @@ describe("eslint", function() {
             eslint.verify(code, config, filename, true);
         });
 
-        it("should retrieve the function scope correctly from within an SwitchStatement", function() {
+        it("should retrieve the function scope correctly from within an SwitchStatement", () => {
             const config = { rules: {}, parserOptions: { ecmaVersion: 6 } };
 
             eslint.reset();
-            eslint.on("SwitchStatement", function() {
+            eslint.on("SwitchStatement", () => {
                 const scope = eslint.getScope();
 
                 assert.equal(scope.type, "switch");
@@ -537,11 +537,11 @@ describe("eslint", function() {
             eslint.verify("switch(foo){ case 'a': var b = 'foo'; }", config, filename, true);
         });
 
-        it("should retrieve the function scope correctly from within a BlockStatement", function() {
+        it("should retrieve the function scope correctly from within a BlockStatement", () => {
             const config = { rules: {}, parserOptions: { ecmaVersion: 6 } };
 
             eslint.reset();
-            eslint.on("BlockStatement", function() {
+            eslint.on("BlockStatement", () => {
                 const scope = eslint.getScope();
 
                 assert.equal(scope.type, "block");
@@ -551,11 +551,11 @@ describe("eslint", function() {
             eslint.verify("var x; {let y = 1}", config, filename, true);
         });
 
-        it("should retrieve the function scope correctly from within a nested block statement", function() {
+        it("should retrieve the function scope correctly from within a nested block statement", () => {
             const config = { rules: {}, parserOptions: { ecmaVersion: 6 } };
 
             eslint.reset();
-            eslint.on("BlockStatement", function() {
+            eslint.on("BlockStatement", () => {
                 const scope = eslint.getScope();
 
                 assert.equal(scope.type, "block");
@@ -565,11 +565,11 @@ describe("eslint", function() {
             eslint.verify("if (true) { let x = 1 }", config, filename, true);
         });
 
-        it("should retrieve the function scope correctly from within a FunctionDeclaration", function() {
+        it("should retrieve the function scope correctly from within a FunctionDeclaration", () => {
             const config = { rules: {}, parserOptions: { ecmaVersion: 6 } };
 
             eslint.reset();
-            eslint.on("FunctionDeclaration", function() {
+            eslint.on("FunctionDeclaration", () => {
                 const scope = eslint.getScope();
 
                 assert.equal(scope.type, "function");
@@ -579,11 +579,11 @@ describe("eslint", function() {
             eslint.verify("function foo() {}", config, filename, true);
         });
 
-        it("should retrieve the function scope correctly from within a FunctionExpression", function() {
+        it("should retrieve the function scope correctly from within a FunctionExpression", () => {
             const config = { rules: {}, parserOptions: { ecmaVersion: 6 } };
 
             eslint.reset();
-            eslint.on("FunctionExpression", function() {
+            eslint.on("FunctionExpression", () => {
                 const scope = eslint.getScope();
 
                 assert.equal(scope.type, "function");
@@ -593,11 +593,11 @@ describe("eslint", function() {
             eslint.verify("(function foo() {})();", config, filename, true);
         });
 
-        it("should retrieve the catch scope correctly from within a CatchClause", function() {
+        it("should retrieve the catch scope correctly from within a CatchClause", () => {
             const config = { rules: {}, parserOptions: { ecmaVersion: 6 } };
 
             eslint.reset();
-            eslint.on("CatchClause", function() {
+            eslint.on("CatchClause", () => {
                 const scope = eslint.getScope();
 
                 assert.equal(scope.type, "catch");
@@ -607,11 +607,11 @@ describe("eslint", function() {
             eslint.verify("try {} catch (err) {}", config, filename, true);
         });
 
-        it("should retrieve module scope correctly from an ES6 module", function() {
+        it("should retrieve module scope correctly from an ES6 module", () => {
             const config = { rules: {}, parserOptions: { sourceType: "module" } };
 
             eslint.reset();
-            eslint.on("AssignmentExpression", function() {
+            eslint.on("AssignmentExpression", () => {
                 const scope = eslint.getScope();
 
                 assert.equal(scope.type, "module");
@@ -620,11 +620,11 @@ describe("eslint", function() {
             eslint.verify("var foo = {}; foo.bar = 1;", config, filename, true);
         });
 
-        it("should retrieve function scope correctly when globalReturn is true", function() {
+        it("should retrieve function scope correctly when globalReturn is true", () => {
             const config = { rules: {}, parserOptions: { ecmaFeatures: { globalReturn: true } } };
 
             eslint.reset();
-            eslint.on("AssignmentExpression", function() {
+            eslint.on("AssignmentExpression", () => {
                 const scope = eslint.getScope();
 
                 assert.equal(scope.type, "function");
@@ -634,12 +634,12 @@ describe("eslint", function() {
         });
     });
 
-    describe("marking variables as used", function() {
-        it("should mark variables in current scope as used", function() {
+    describe("marking variables as used", () => {
+        it("should mark variables in current scope as used", () => {
             const code = "var a = 1, b = 2;";
 
             eslint.reset();
-            eslint.on("Program:exit", function() {
+            eslint.on("Program:exit", () => {
                 eslint.markVariableAsUsed("a");
 
                 const scope = eslint.getScope();
@@ -650,11 +650,11 @@ describe("eslint", function() {
 
             eslint.verify(code, {}, filename, true);
         });
-        it("should mark variables in function args as used", function() {
+        it("should mark variables in function args as used", () => {
             const code = "function abc(a, b) { return 1; }";
 
             eslint.reset();
-            eslint.on("ReturnStatement", function() {
+            eslint.on("ReturnStatement", () => {
                 eslint.markVariableAsUsed("a");
 
                 const scope = eslint.getScope();
@@ -665,14 +665,14 @@ describe("eslint", function() {
 
             eslint.verify(code, {}, filename, true);
         });
-        it("should mark variables in higher scopes as used", function() {
+        it("should mark variables in higher scopes as used", () => {
             const code = "var a, b; function abc() { return 1; }";
 
             eslint.reset();
-            eslint.on("ReturnStatement", function() {
+            eslint.on("ReturnStatement", () => {
                 eslint.markVariableAsUsed("a");
             });
-            eslint.on("Program:exit", function() {
+            eslint.on("Program:exit", () => {
                 const scope = eslint.getScope();
 
                 assert.isTrue(getVariable(scope, "a").eslintUsed);
@@ -682,11 +682,11 @@ describe("eslint", function() {
             eslint.verify(code, {}, filename, true);
         });
 
-        it("should mark variables in Node.js environment as used", function() {
+        it("should mark variables in Node.js environment as used", () => {
             const code = "var a = 1, b = 2;";
 
             eslint.reset();
-            eslint.on("Program:exit", function() {
+            eslint.on("Program:exit", () => {
                 const globalScope = eslint.getScope(),
                     childScope = globalScope.childScopes[0];
 
@@ -699,11 +699,11 @@ describe("eslint", function() {
             eslint.verify(code, { env: { node: true }}, filename, true);
         });
 
-        it("should mark variables in modules as used", function() {
+        it("should mark variables in modules as used", () => {
             const code = "var a = 1, b = 2;";
 
             eslint.reset();
-            eslint.on("Program:exit", function() {
+            eslint.on("Program:exit", () => {
                 const globalScope = eslint.getScope(),
                     childScope = globalScope.childScopes[0];
 
@@ -717,17 +717,17 @@ describe("eslint", function() {
         });
     });
 
-    describe("report()", function() {
+    describe("report()", () => {
 
         let config;
 
-        beforeEach(function() {
+        beforeEach(() => {
             eslint.reset();
             config = { rules: {} };
         });
 
-        it("should correctly parse a message when being passed all options", function() {
-            eslint.on("Program", function(node) {
+        it("should correctly parse a message when being passed all options", () => {
+            eslint.on("Program", node => {
                 eslint.report("test-rule", 2, node, node.loc.end, "hello {{dynamic}}", {dynamic: node.type});
             });
 
@@ -744,8 +744,8 @@ describe("eslint", function() {
             });
         });
 
-        it("should use the report the provided location when given", function() {
-            eslint.on("Program", function(node) {
+        it("should use the report the provided location when given", () => {
+            eslint.on("Program", node => {
                 eslint.report("test-rule", 2, node, {line: 42, column: 13}, "hello world");
             });
 
@@ -762,73 +762,73 @@ describe("eslint", function() {
             });
         });
 
-        it("should not throw an error if node is provided and location is not", function() {
-            eslint.on("Program", function(node) {
+        it("should not throw an error if node is provided and location is not", () => {
+            eslint.on("Program", node => {
                 eslint.report("test-rule", 2, node, "hello world");
             });
 
-            assert.doesNotThrow(function() {
+            assert.doesNotThrow(() => {
                 eslint.verify("0", config, "", true);
             });
         });
 
-        it("should not throw an error if location is provided and node is not", function() {
-            eslint.on("Program", function() {
+        it("should not throw an error if location is provided and node is not", () => {
+            eslint.on("Program", () => {
                 eslint.report("test-rule", 2, null, { line: 1, column: 1}, "hello world");
             });
 
-            assert.doesNotThrow(function() {
+            assert.doesNotThrow(() => {
                 eslint.verify("0", config, "", true);
             });
         });
 
-        it("should throw an error if neither node nor location is provided", function() {
-            eslint.on("Program", function() {
+        it("should throw an error if neither node nor location is provided", () => {
+            eslint.on("Program", () => {
                 eslint.report("test-rule", 2, null, "hello world");
             });
 
-            assert.throws(function() {
+            assert.throws(() => {
                 eslint.verify("0", config, "", true);
             }, /Node must be provided when reporting error if location is not provided$/);
         });
 
-        it("should throw an error if node is not an object", function() {
-            eslint.on("Program", function() {
+        it("should throw an error if node is not an object", () => {
+            eslint.on("Program", () => {
                 eslint.report("test-rule", 2, "not a node", "hello world");
             });
 
-            assert.throws(function() {
+            assert.throws(() => {
                 eslint.verify("0", config, "", true);
             }, /Node must be an object$/);
         });
 
-        it("should throw an error if fix is passed but meta has no `fixable` property", function() {
+        it("should throw an error if fix is passed but meta has no `fixable` property", () => {
             const meta = {
                 docs: {},
                 schema: []
             };
 
-            eslint.on("Program", function(node) {
+            eslint.on("Program", node => {
                 eslint.report("test-rule", 2, node, "hello world", [], { range: [1, 1], text: "" }, meta);
             });
 
-            assert.throws(function() {
+            assert.throws(() => {
                 eslint.verify("0", config, "", true);
             }, /Fixable rules should export a `meta\.fixable` property.$/);
         });
 
-        it("should not throw an error if fix is passed and no metadata is passed", function() {
-            eslint.on("Program", function(node) {
+        it("should not throw an error if fix is passed and no metadata is passed", () => {
+            eslint.on("Program", node => {
                 eslint.report("test-rule", 2, node, "hello world", [], { range: [1, 1], text: "" });
             });
 
-            assert.doesNotThrow(function() {
+            assert.doesNotThrow(() => {
                 eslint.verify("0", config, "", true);
             });
         });
 
-        it("should correctly parse a message with object keys as numbers", function() {
-            eslint.on("Program", function(node) {
+        it("should correctly parse a message with object keys as numbers", () => {
+            eslint.on("Program", node => {
                 eslint.report("test-rule", 2, node, "my message {{name}}{{0}}", {0: "!", name: "testing"});
             });
 
@@ -845,8 +845,8 @@ describe("eslint", function() {
             });
         });
 
-        it("should correctly parse a message with array", function() {
-            eslint.on("Program", function(node) {
+        it("should correctly parse a message with array", () => {
+            eslint.on("Program", node => {
                 eslint.report("test-rule", 2, node, "my message {{1}}{{0}}", ["!", "testing"]);
             });
 
@@ -863,8 +863,8 @@ describe("eslint", function() {
             });
         });
 
-        it("should include a fix passed as the last argument when location is not passed", function() {
-            eslint.on("Program", function(node) {
+        it("should include a fix passed as the last argument when location is not passed", () => {
+            eslint.on("Program", node => {
                 eslint.report("test-rule", 2, node, "my message {{1}}{{0}}", ["!", "testing"], { range: [1, 1], text: "" });
             });
 
@@ -882,17 +882,15 @@ describe("eslint", function() {
             });
         });
 
-        it("should allow template parameter with inner whitespace", function() {
+        it("should allow template parameter with inner whitespace", () => {
             eslint.reset();
-            eslint.defineRule("test-rule", function(context) {
-                return {
-                    Literal(node) {
-                        context.report(node, "message {{parameter name}}", {
-                            "parameter name": "yay!"
-                        });
-                    }
-                };
-            });
+            eslint.defineRule("test-rule", context => ({
+                Literal(node) {
+                    context.report(node, "message {{parameter name}}", {
+                        "parameter name": "yay!"
+                    });
+                }
+            }));
 
             config.rules["test-rule"] = 1;
 
@@ -901,15 +899,13 @@ describe("eslint", function() {
             assert.equal(messages[0].message, "message yay!");
         });
 
-        it("should not crash if no template parameters are passed", function() {
+        it("should not crash if no template parameters are passed", () => {
             eslint.reset();
-            eslint.defineRule("test-rule", function(context) {
-                return {
-                    Literal(node) {
-                        context.report(node, "message {{code}}");
-                    }
-                };
-            });
+            eslint.defineRule("test-rule", context => ({
+                Literal(node) {
+                    context.report(node, "message {{code}}");
+                }
+            }));
 
             config.rules["test-rule"] = 1;
 
@@ -918,17 +914,15 @@ describe("eslint", function() {
             assert.equal(messages[0].message, "message {{code}}");
         });
 
-        it("should allow template parameter with non-identifier characters", function() {
+        it("should allow template parameter with non-identifier characters", () => {
             eslint.reset();
-            eslint.defineRule("test-rule", function(context) {
-                return {
-                    Literal(node) {
-                        context.report(node, "message {{parameter-name}}", {
-                            "parameter-name": "yay!"
-                        });
-                    }
-                };
-            });
+            eslint.defineRule("test-rule", context => ({
+                Literal(node) {
+                    context.report(node, "message {{parameter-name}}", {
+                        "parameter-name": "yay!"
+                    });
+                }
+            }));
 
             config.rules["test-rule"] = 1;
 
@@ -937,17 +931,15 @@ describe("eslint", function() {
             assert.equal(messages[0].message, "message yay!");
         });
 
-        it("should allow template parameter wrapped in braces", function() {
+        it("should allow template parameter wrapped in braces", () => {
             eslint.reset();
-            eslint.defineRule("test-rule", function(context) {
-                return {
-                    Literal(node) {
-                        context.report(node, "message {{{param}}}", {
-                            param: "yay!"
-                        });
-                    }
-                };
-            });
+            eslint.defineRule("test-rule", context => ({
+                Literal(node) {
+                    context.report(node, "message {{{param}}}", {
+                        param: "yay!"
+                    });
+                }
+            }));
 
             config.rules["test-rule"] = 1;
 
@@ -956,15 +948,13 @@ describe("eslint", function() {
             assert.equal(messages[0].message, "message {yay!}");
         });
 
-        it("should ignore template parameter with no specified value", function() {
+        it("should ignore template parameter with no specified value", () => {
             eslint.reset();
-            eslint.defineRule("test-rule", function(context) {
-                return {
-                    Literal(node) {
-                        context.report(node, "message {{parameter}}", {});
-                    }
-                };
-            });
+            eslint.defineRule("test-rule", context => ({
+                Literal(node) {
+                    context.report(node, "message {{parameter}}", {});
+                }
+            }));
 
             config.rules["test-rule"] = 1;
 
@@ -973,15 +963,13 @@ describe("eslint", function() {
             assert.equal(messages[0].message, "message {{parameter}}");
         });
 
-        it("should ignore template parameter with no specified value with warn severity", function() {
+        it("should ignore template parameter with no specified value with warn severity", () => {
             eslint.reset();
-            eslint.defineRule("test-rule", function(context) {
-                return {
-                    Literal(node) {
-                        context.report(node, "message {{parameter}}", {});
-                    }
-                };
-            });
+            eslint.defineRule("test-rule", context => ({
+                Literal(node) {
+                    context.report(node, "message {{parameter}}", {});
+                }
+            }));
 
             config.rules["test-rule"] = "warn";
 
@@ -991,17 +979,15 @@ describe("eslint", function() {
             assert.equal(messages[0].message, "message {{parameter}}");
         });
 
-        it("should handle leading whitespace in template parameter", function() {
+        it("should handle leading whitespace in template parameter", () => {
             eslint.reset();
-            eslint.defineRule("test-rule", function(context) {
-                return {
-                    Literal(node) {
-                        context.report(node, "message {{ parameter}}", {
-                            parameter: "yay!"
-                        });
-                    }
-                };
-            });
+            eslint.defineRule("test-rule", context => ({
+                Literal(node) {
+                    context.report(node, "message {{ parameter}}", {
+                        parameter: "yay!"
+                    });
+                }
+            }));
 
             config.rules["test-rule"] = 1;
 
@@ -1010,17 +996,15 @@ describe("eslint", function() {
             assert.equal(messages[0].message, "message yay!");
         });
 
-        it("should handle trailing whitespace in template parameter", function() {
+        it("should handle trailing whitespace in template parameter", () => {
             eslint.reset();
-            eslint.defineRule("test-rule", function(context) {
-                return {
-                    Literal(node) {
-                        context.report(node, "message {{parameter }}", {
-                            parameter: "yay!"
-                        });
-                    }
-                };
-            });
+            eslint.defineRule("test-rule", context => ({
+                Literal(node) {
+                    context.report(node, "message {{parameter }}", {
+                        parameter: "yay!"
+                    });
+                }
+            }));
 
             config.rules["test-rule"] = 1;
 
@@ -1029,17 +1013,15 @@ describe("eslint", function() {
             assert.equal(messages[0].message, "message yay!");
         });
 
-        it("should still allow inner whitespace as well as leading/trailing", function() {
+        it("should still allow inner whitespace as well as leading/trailing", () => {
             eslint.reset();
-            eslint.defineRule("test-rule", function(context) {
-                return {
-                    Literal(node) {
-                        context.report(node, "message {{ parameter name }}", {
-                            "parameter name": "yay!"
-                        });
-                    }
-                };
-            });
+            eslint.defineRule("test-rule", context => ({
+                Literal(node) {
+                    context.report(node, "message {{ parameter name }}", {
+                        "parameter name": "yay!"
+                    });
+                }
+            }));
 
             config.rules["test-rule"] = 1;
 
@@ -1048,17 +1030,15 @@ describe("eslint", function() {
             assert.equal(messages[0].message, "message yay!");
         });
 
-        it("should still allow non-identifier characters as well as leading/trailing whitespace", function() {
+        it("should still allow non-identifier characters as well as leading/trailing whitespace", () => {
             eslint.reset();
-            eslint.defineRule("test-rule", function(context) {
-                return {
-                    Literal(node) {
-                        context.report(node, "message {{ parameter-name }}", {
-                            "parameter-name": "yay!"
-                        });
-                    }
-                };
-            });
+            eslint.defineRule("test-rule", context => ({
+                Literal(node) {
+                    context.report(node, "message {{ parameter-name }}", {
+                        "parameter-name": "yay!"
+                    });
+                }
+            }));
 
             config.rules["test-rule"] = 1;
 
@@ -1067,8 +1047,8 @@ describe("eslint", function() {
             assert.equal(messages[0].message, "message yay!");
         });
 
-        it("should include a fix passed as the last argument when location is passed", function() {
-            eslint.on("Program", function(node) {
+        it("should include a fix passed as the last argument when location is passed", () => {
+            eslint.on("Program", node => {
                 eslint.report("test-rule", 2, node, { line: 42, column: 23 }, "my message {{1}}{{0}}", ["!", "testing"], { range: [1, 1], text: "" });
             });
 
@@ -1086,8 +1066,8 @@ describe("eslint", function() {
             });
         });
 
-        it("should not have 'endLine' and 'endColumn' when there is not 'loc' property.", function() {
-            eslint.on("Program", function(node) {
+        it("should not have 'endLine' and 'endColumn' when there is not 'loc' property.", () => {
+            eslint.on("Program", node => {
                 eslint.report(
                     "test-rule",
                     2,
@@ -1102,8 +1082,8 @@ describe("eslint", function() {
             assert.strictEqual(messages[0].endColumn, void 0);
         });
 
-        it("should have 'endLine' and 'endColumn' when 'loc' property has 'end' property.", function() {
-            eslint.on("Program", function(node) {
+        it("should have 'endLine' and 'endColumn' when 'loc' property has 'end' property.", () => {
+            eslint.on("Program", node => {
                 eslint.report(
                     "test-rule",
                     2,
@@ -1119,8 +1099,8 @@ describe("eslint", function() {
             assert.strictEqual(messages[0].endColumn, 2);
         });
 
-        it("should not have 'endLine' and 'endColumn' when 'loc' property doe not have 'end' property.", function() {
-            eslint.on("Program", function(node) {
+        it("should not have 'endLine' and 'endColumn' when 'loc' property doe not have 'end' property.", () => {
+            eslint.on("Program", node => {
                 eslint.report(
                     "test-rule",
                     2,
@@ -1138,10 +1118,10 @@ describe("eslint", function() {
 
     });
 
-    describe("when evaluating code", function() {
+    describe("when evaluating code", () => {
         const code = TEST_CODE;
 
-        it("events for each node type should fire", function() {
+        it("events for each node type should fire", () => {
             const config = { rules: {} };
 
             // spies for various AST node types
@@ -1169,18 +1149,16 @@ describe("eslint", function() {
         });
     });
 
-    describe("when config has shared settings for rules", function() {
+    describe("when config has shared settings for rules", () => {
         const code = "test-rule";
 
-        it("should pass settings to all rules", function() {
+        it("should pass settings to all rules", () => {
             eslint.reset();
-            eslint.defineRule(code, function(context) {
-                return {
-                    Literal(node) {
-                        context.report(node, context.settings.info);
-                    }
-                };
-            });
+            eslint.defineRule(code, context => ({
+                Literal(node) {
+                    context.report(node, context.settings.info);
+                }
+            }));
 
             const config = { rules: {}, settings: { info: "Hello" } };
 
@@ -1192,17 +1170,15 @@ describe("eslint", function() {
             assert.equal(messages[0].message, "Hello");
         });
 
-        it("should not have any settings if they were not passed in", function() {
+        it("should not have any settings if they were not passed in", () => {
             eslint.reset();
-            eslint.defineRule(code, function(context) {
-                return {
-                    Literal(node) {
-                        if (Object.getOwnPropertyNames(context.settings).length !== 0) {
-                            context.report(node, "Settings should be empty");
-                        }
+            eslint.defineRule(code, context => ({
+                Literal(node) {
+                    if (Object.getOwnPropertyNames(context.settings).length !== 0) {
+                        context.report(node, "Settings should be empty");
                     }
-                };
-            });
+                }
+            }));
 
             const config = { rules: {} };
 
@@ -1214,9 +1190,9 @@ describe("eslint", function() {
         });
     });
 
-    describe("when config has parseOptions", function() {
+    describe("when config has parseOptions", () => {
 
-        it("should pass ecmaFeatures to all rules when provided on config", function() {
+        it("should pass ecmaFeatures to all rules when provided on config", () => {
 
             const parserOptions = {
                 ecmaFeatures: {
@@ -1235,7 +1211,7 @@ describe("eslint", function() {
             eslint.verify("0", config, filename);
         });
 
-        it("should pass parserOptions to all rules when default parserOptions is used", function() {
+        it("should pass parserOptions to all rules when default parserOptions is used", () => {
 
             const parserOptions = {};
 
@@ -1251,11 +1227,11 @@ describe("eslint", function() {
 
     });
 
-    describe("when config has parser", function() {
+    describe("when config has parser", () => {
 
         // custom parser unsupported in browser, only test in Node
         if (typeof window === "undefined") {
-            it("should pass parser as parserPath to all rules when provided on config", function() {
+            it("should pass parser as parserPath to all rules when provided on config", () => {
 
                 const alternateParser = "esprima-fb";
 
@@ -1269,7 +1245,7 @@ describe("eslint", function() {
                 eslint.verify("0", config, filename);
             });
 
-            it("should use parseForESLint() in custom parser when custom parser is specified", function() {
+            it("should use parseForESLint() in custom parser when custom parser is specified", () => {
 
                 const alternateParser = path.resolve(__dirname, "../fixtures/parsers/enhanced-parser.js");
 
@@ -1281,21 +1257,19 @@ describe("eslint", function() {
                 assert.equal(messages.length, 0);
             });
 
-            it("should expose parser services when using parseForESLint() and services are specified", function() {
+            it("should expose parser services when using parseForESLint() and services are specified", () => {
 
                 const alternateParser = path.resolve(__dirname, "../fixtures/parsers/enhanced-parser.js");
 
                 eslint.reset();
-                eslint.defineRule("test-service-rule", function(context) {
-                    return {
-                        Literal(node) {
-                            context.report({
-                                node,
-                                message: context.parserServices.test.getMessage()
-                            });
-                        }
-                    };
-                });
+                eslint.defineRule("test-service-rule", context => ({
+                    Literal(node) {
+                        context.report({
+                            node,
+                            message: context.parserServices.test.getMessage()
+                        });
+                    }
+                }));
 
                 const config = { rules: { "test-service-rule": 2 }, parser: alternateParser };
                 const messages = eslint.verify("0", config, filename);
@@ -1305,7 +1279,7 @@ describe("eslint", function() {
             });
         }
 
-        it("should pass parser as parserPath to all rules when default parser is used", function() {
+        it("should pass parser as parserPath to all rules when default parser is used", () => {
 
             const DEFAULT_PARSER = eslint.defaults().parser;
 
@@ -1322,10 +1296,10 @@ describe("eslint", function() {
     });
 
 
-    describe("when passing in configuration values for rules", function() {
+    describe("when passing in configuration values for rules", () => {
         const code = "var answer = 6 * 7";
 
-        it("should be configurable by only setting the integer value", function() {
+        it("should be configurable by only setting the integer value", () => {
             const rule = "semi",
                 config = { rules: {} };
 
@@ -1338,7 +1312,7 @@ describe("eslint", function() {
             assert.equal(messages[0].ruleId, rule);
         });
 
-        it("should be configurable by only setting the string value", function() {
+        it("should be configurable by only setting the string value", () => {
             const rule = "semi",
                 config = { rules: {} };
 
@@ -1352,7 +1326,7 @@ describe("eslint", function() {
             assert.equal(messages[0].ruleId, rule);
         });
 
-        it("should be configurable by passing in values as an array", function() {
+        it("should be configurable by passing in values as an array", () => {
             const rule = "semi",
                 config = { rules: {} };
 
@@ -1365,7 +1339,7 @@ describe("eslint", function() {
             assert.equal(messages[0].ruleId, rule);
         });
 
-        it("should be configurable by passing in string value as an array", function() {
+        it("should be configurable by passing in string value as an array", () => {
             const rule = "semi",
                 config = { rules: {} };
 
@@ -1379,7 +1353,7 @@ describe("eslint", function() {
             assert.equal(messages[0].ruleId, rule);
         });
 
-        it("should not be configurable by setting other value", function() {
+        it("should not be configurable by setting other value", () => {
             const rule = "semi",
                 config = { rules: {} };
 
@@ -1391,7 +1365,7 @@ describe("eslint", function() {
             assert.equal(messages.length, 0);
         });
 
-        it("should process empty config", function() {
+        it("should process empty config", () => {
             const config = {};
 
             eslint.reset();
@@ -1401,10 +1375,10 @@ describe("eslint", function() {
         });
     });
 
-    describe("after calling reset()", function() {
+    describe("after calling reset()", () => {
         const code = TEST_CODE;
 
-        it("previously registered event handlers should not be called", function() {
+        it("previously registered event handlers should not be called", () => {
 
             const config = { rules: {} };
 
@@ -1433,7 +1407,7 @@ describe("eslint", function() {
             sinon.assert.notCalled(spyBinaryExpression);
         });
 
-        it("text should not be available", function() {
+        it("text should not be available", () => {
             const config = { rules: {} };
 
             eslint.reset();
@@ -1445,7 +1419,7 @@ describe("eslint", function() {
             assert.isNull(eslint.getSource());
         });
 
-        it("source for nodes should not be available", function() {
+        it("source for nodes should not be available", () => {
             const config = { rules: {} };
 
             eslint.reset();
@@ -1458,14 +1432,14 @@ describe("eslint", function() {
         });
     });
 
-    describe("when evaluating code containing /*global */ and /*globals */ blocks", function() {
+    describe("when evaluating code containing /*global */ and /*globals */ blocks", () => {
         const code = "/*global a b:true c:false*/ function foo() {} /*globals d:true*/";
 
-        it("variables should be available in global scope", function() {
+        it("variables should be available in global scope", () => {
             const config = { rules: {} };
 
             eslint.reset();
-            eslint.on("Program", function() {
+            eslint.on("Program", () => {
                 const scope = eslint.getScope();
                 const a = getVariable(scope, "a"),
                     b = getVariable(scope, "b"),
@@ -1486,14 +1460,14 @@ describe("eslint", function() {
         });
     });
 
-    describe("when evaluating code containing a /*global */ block with sloppy whitespace", function() {
+    describe("when evaluating code containing a /*global */ block with sloppy whitespace", () => {
         const code = "/* global  a b  : true   c:  false*/";
 
-        it("variables should be available in global scope", function() {
+        it("variables should be available in global scope", () => {
             const config = { rules: {} };
 
             eslint.reset();
-            eslint.on("Program", function() {
+            eslint.on("Program", () => {
                 const scope = eslint.getScope(),
                     a = getVariable(scope, "a"),
                     b = getVariable(scope, "b"),
@@ -1511,13 +1485,13 @@ describe("eslint", function() {
         });
     });
 
-    describe("when evaluating code containing /*eslint-env */ block", function() {
-        it("variables should be available in global scope", function() {
+    describe("when evaluating code containing /*eslint-env */ block", () => {
+        it("variables should be available in global scope", () => {
             const code = "/*eslint-env node*/ function f() {} /*eslint-env browser, foo*/";
             const config = { rules: {} };
 
             eslint.reset();
-            eslint.on("Program", function() {
+            eslint.on("Program", () => {
                 const scope = eslint.getScope(),
                     exports = getVariable(scope, "exports"),
                     window = getVariable(scope, "window");
@@ -1529,14 +1503,14 @@ describe("eslint", function() {
         });
     });
 
-    describe("when evaluating code containing /*eslint-env */ block with sloppy whitespace", function() {
+    describe("when evaluating code containing /*eslint-env */ block with sloppy whitespace", () => {
         const code = "/* eslint-env ,, node  , no-browser ,,  */";
 
-        it("variables should be available in global scope", function() {
+        it("variables should be available in global scope", () => {
             const config = { rules: {} };
 
             eslint.reset();
-            eslint.on("Program", function() {
+            eslint.on("Program", () => {
                 const scope = eslint.getScope(),
                     exports = getVariable(scope, "exports"),
                     window = getVariable(scope, "window");
@@ -1548,9 +1522,9 @@ describe("eslint", function() {
         });
     });
 
-    describe("when evaluating code containing /*exported */ block", function() {
+    describe("when evaluating code containing /*exported */ block", () => {
 
-        it("we should behave nicely when no matching variable is found", function() {
+        it("we should behave nicely when no matching variable is found", () => {
             const code = "/* exported horse */";
             const config = { rules: {} };
 
@@ -1558,12 +1532,12 @@ describe("eslint", function() {
             eslint.verify(code, config, filename, true);
         });
 
-        it("variables should be exported", function() {
+        it("variables should be exported", () => {
             const code = "/* exported horse */\n\nvar horse = 'circus'";
             const config = { rules: {} };
 
             eslint.reset();
-            eslint.on("Program", function() {
+            eslint.on("Program", () => {
                 const scope = eslint.getScope(),
                     horse = getVariable(scope, "horse");
 
@@ -1572,12 +1546,12 @@ describe("eslint", function() {
             eslint.verify(code, config, filename, true);
         });
 
-        it("undefined variables should not be exported", function() {
+        it("undefined variables should not be exported", () => {
             const code = "/* exported horse */\n\nhorse = 'circus'";
             const config = { rules: {} };
 
             eslint.reset();
-            eslint.on("Program", function() {
+            eslint.on("Program", () => {
                 const scope = eslint.getScope(),
                     horse = getVariable(scope, "horse");
 
@@ -1586,12 +1560,12 @@ describe("eslint", function() {
             eslint.verify(code, config, filename, true);
         });
 
-        it("variables should be exported in strict mode", function() {
+        it("variables should be exported in strict mode", () => {
             const code = "/* exported horse */\n'use strict';\nvar horse = 'circus'";
             const config = { rules: {} };
 
             eslint.reset();
-            eslint.on("Program", function() {
+            eslint.on("Program", () => {
                 const scope = eslint.getScope(),
                     horse = getVariable(scope, "horse");
 
@@ -1600,12 +1574,12 @@ describe("eslint", function() {
             eslint.verify(code, config, filename, true);
         });
 
-        it("variables should not be exported in the es6 module environment", function() {
+        it("variables should not be exported in the es6 module environment", () => {
             const code = "/* exported horse */\nvar horse = 'circus'";
             const config = { rules: {}, parserOptions: { sourceType: "module" }};
 
             eslint.reset();
-            eslint.on("Program", function() {
+            eslint.on("Program", () => {
                 const scope = eslint.getScope(),
                     horse = getVariable(scope, "horse");
 
@@ -1614,12 +1588,12 @@ describe("eslint", function() {
             eslint.verify(code, config, filename, true);
         });
 
-        it("variables should not be exported when in the node environment", function() {
+        it("variables should not be exported when in the node environment", () => {
             const code = "/* exported horse */\nvar horse = 'circus'";
             const config = { rules: {}, env: { node: true } };
 
             eslint.reset();
-            eslint.on("Program", function() {
+            eslint.on("Program", () => {
                 const scope = eslint.getScope(),
                     horse = getVariable(scope, "horse");
 
@@ -1629,15 +1603,15 @@ describe("eslint", function() {
         });
     });
 
-    describe("when evaluating code containing a line comment", function() {
+    describe("when evaluating code containing a line comment", () => {
         const code = "//global a \n function f() {}";
 
-        it("should not introduce a global variable", function() {
+        it("should not introduce a global variable", () => {
 
             const config = { rules: {} };
 
             eslint.reset();
-            eslint.on("Program", function() {
+            eslint.on("Program", () => {
                 const scope = eslint.getScope();
 
                 assert.equal(getVariable(scope, "a"), null);
@@ -1646,14 +1620,14 @@ describe("eslint", function() {
         });
     });
 
-    describe("when evaluating code containing normal block comments", function() {
+    describe("when evaluating code containing normal block comments", () => {
         const code = "/**/  /*a*/  /*b:true*/  /*foo c:false*/";
 
-        it("should not introduce a global variable", function() {
+        it("should not introduce a global variable", () => {
             const config = { rules: {} };
 
             eslint.reset();
-            eslint.on("Program", function() {
+            eslint.on("Program", () => {
                 const scope = eslint.getScope();
 
                 assert.equal(getVariable(scope, "a"), null);
@@ -1665,14 +1639,14 @@ describe("eslint", function() {
         });
     });
 
-    describe("when evaluating any code", function() {
+    describe("when evaluating any code", () => {
         const code = "";
 
-        it("builtin global variables should be available in the global scope", function() {
+        it("builtin global variables should be available in the global scope", () => {
             const config = { rules: {} };
 
             eslint.reset();
-            eslint.on("Program", function() {
+            eslint.on("Program", () => {
                 const scope = eslint.getScope();
 
                 assert.notEqual(getVariable(scope, "Object"), null);
@@ -1682,11 +1656,11 @@ describe("eslint", function() {
             eslint.verify(code, config, filename, true);
         });
 
-        it("ES6 global variables should not be available by default", function() {
+        it("ES6 global variables should not be available by default", () => {
             const config = { rules: {} };
 
             eslint.reset();
-            eslint.on("Program", function() {
+            eslint.on("Program", () => {
                 const scope = eslint.getScope();
 
                 assert.equal(getVariable(scope, "Promise"), null);
@@ -1696,11 +1670,11 @@ describe("eslint", function() {
             eslint.verify(code, config, filename, true);
         });
 
-        it("ES6 global variables should be available in the es6 environment", function() {
+        it("ES6 global variables should be available in the es6 environment", () => {
             const config = { rules: {} };
 
             eslint.reset();
-            eslint.on("Program", function() {
+            eslint.on("Program", () => {
                 const scope = eslint.getScope();
 
                 assert.notEqual(getVariable(scope, "Promise"), null);
@@ -1711,29 +1685,27 @@ describe("eslint", function() {
         });
     });
 
-    describe("when evaluating empty code", function() {
+    describe("when evaluating empty code", () => {
         const code = "",
             config = { rules: {} };
 
-        it("getSource() should return an empty string", function() {
+        it("getSource() should return an empty string", () => {
             eslint.reset();
             eslint.verify(code, config, filename, true);
             assert.equal(eslint.getSource(), "");
         });
     });
 
-    describe("at any time", function() {
+    describe("at any time", () => {
         const code = "new-rule";
 
-        it("can add a rule dynamically", function() {
+        it("can add a rule dynamically", () => {
             eslint.reset();
-            eslint.defineRule(code, function(context) {
-                return {
-                    Literal(node) {
-                        context.report(node, "message");
-                    }
-                };
-            });
+            eslint.defineRule(code, context => ({
+                Literal(node) {
+                    context.report(node, "message");
+                }
+            }));
 
             const config = { rules: {} };
 
@@ -1747,15 +1719,15 @@ describe("eslint", function() {
         });
     });
 
-    describe("at any time", function() {
+    describe("at any time", () => {
         const code = ["new-rule-0", "new-rule-1"];
 
-        it("can add multiple rules dynamically", function() {
+        it("can add multiple rules dynamically", () => {
             eslint.reset();
             const config = { rules: {} };
             const newRules = {};
 
-            code.forEach(function(item) {
+            code.forEach(item => {
                 config.rules[item] = 1;
                 newRules[item] = function(context) {
                     return {
@@ -1770,29 +1742,25 @@ describe("eslint", function() {
             const messages = eslint.verify("0", config, filename);
 
             assert.equal(messages.length, code.length);
-            code.forEach(function(item) {
-                assert.ok(messages.some(function(message) {
-                    return message.ruleId === item;
-                }));
+            code.forEach(item => {
+                assert.ok(messages.some(message => message.ruleId === item));
             });
-            messages.forEach(function(message) {
+            messages.forEach(message => {
                 assert.equal(message.nodeType, "Literal");
             });
         });
     });
 
-    describe("at any time", function() {
+    describe("at any time", () => {
         const code = "filename-rule";
 
-        it("has access to the filename", function() {
+        it("has access to the filename", () => {
             eslint.reset();
-            eslint.defineRule(code, function(context) {
-                return {
-                    Literal(node) {
-                        context.report(node, context.getFilename());
-                    }
-                };
-            });
+            eslint.defineRule(code, context => ({
+                Literal(node) {
+                    context.report(node, context.getFilename());
+                }
+            }));
 
             const config = { rules: {} };
 
@@ -1803,15 +1771,13 @@ describe("eslint", function() {
             assert.equal(messages[0].message, filename);
         });
 
-        it("defaults filename to '<input>'", function() {
+        it("defaults filename to '<input>'", () => {
             eslint.reset();
-            eslint.defineRule(code, function(context) {
-                return {
-                    Literal(node) {
-                        context.report(node, context.getFilename());
-                    }
-                };
-            });
+            eslint.defineRule(code, context => ({
+                Literal(node) {
+                    context.report(node, context.getFilename());
+                }
+            }));
 
             const config = { rules: {} };
 
@@ -1823,9 +1789,9 @@ describe("eslint", function() {
         });
     });
 
-    describe("when evaluating code with comments to enable rules", function() {
+    describe("when evaluating code with comments to enable rules", () => {
 
-        it("should report a violation", function() {
+        it("should report a violation", () => {
             const code = "/*eslint no-alert:1*/ alert('test');";
             const config = { rules: {} };
 
@@ -1837,7 +1803,7 @@ describe("eslint", function() {
             assert.include(messages[0].nodeType, "CallExpression");
         });
 
-        it("rules should not change initial config", function() {
+        it("rules should not change initial config", () => {
             const config = { rules: {strict: 2} };
             const codeA = "/*eslint strict: 0*/ function bar() { return 2; }";
             const codeB = "function foo() { return 1; }";
@@ -1851,7 +1817,7 @@ describe("eslint", function() {
             assert.equal(messages.length, 1);
         });
 
-        it("rules should not change initial config", function() {
+        it("rules should not change initial config", () => {
             const config = { rules: {quotes: [2, "double"]} };
             const codeA = "/*eslint quotes: 0*/ function bar() { return '2'; }";
             const codeB = "function foo() { return '1'; }";
@@ -1865,7 +1831,7 @@ describe("eslint", function() {
             assert.equal(messages.length, 1);
         });
 
-        it("rules should not change initial config", function() {
+        it("rules should not change initial config", () => {
             const config = { rules: {quotes: [2, "double"]} };
             const codeA = "/*eslint quotes: [0, \"single\"]*/ function bar() { return '2'; }";
             const codeB = "function foo() { return '1'; }";
@@ -1879,7 +1845,7 @@ describe("eslint", function() {
             assert.equal(messages.length, 1);
         });
 
-        it("rules should not change initial config", function() {
+        it("rules should not change initial config", () => {
             const config = { rules: {"no-unused-vars": [2, {vars: "all"}]} };
             const codeA = "/*eslint no-unused-vars: [0, {\"vars\": \"local\"}]*/ var a = 44;";
             const codeB = "var b = 55;";
@@ -1894,10 +1860,10 @@ describe("eslint", function() {
         });
     });
 
-    describe("when evaluating code with invalid comments to enable rules", function() {
+    describe("when evaluating code with invalid comments to enable rules", () => {
         const code = "/*eslint no-alert:true*/ alert('test');";
 
-        it("should report a violation", function() {
+        it("should report a violation", () => {
             const config = { rules: {} };
 
             const fn = eslint.verify.bind(eslint, code, config, filename);
@@ -1906,10 +1872,10 @@ describe("eslint", function() {
         });
     });
 
-    describe("when evaluating code with comments to disable rules", function() {
+    describe("when evaluating code with comments to disable rules", () => {
         const code = "/*eslint no-alert:0*/ alert('test');";
 
-        it("should not report a violation", function() {
+        it("should not report a violation", () => {
             const config = { rules: { "no-alert": 1 } };
 
             const messages = eslint.verify(code, config, filename);
@@ -1918,10 +1884,10 @@ describe("eslint", function() {
         });
     });
 
-    describe("when evaluating code with comments to enable multiple rules", function() {
+    describe("when evaluating code with comments to enable multiple rules", () => {
         const code = "/*eslint no-alert:1 no-console:1*/ alert('test'); console.log('test');";
 
-        it("should report a violation", function() {
+        it("should report a violation", () => {
             const config = { rules: {} };
 
             const messages = eslint.verify(code, config, filename);
@@ -1934,10 +1900,10 @@ describe("eslint", function() {
         });
     });
 
-    describe("when evaluating code with comments to enable and disable multiple rules", function() {
+    describe("when evaluating code with comments to enable and disable multiple rules", () => {
         const code = "/*eslint no-alert:1 no-console:0*/ alert('test'); console.log('test');";
 
-        it("should report a violation", function() {
+        it("should report a violation", () => {
             const config = { rules: { "no-console": 1, "no-alert": 0 } };
 
             const messages = eslint.verify(code, config, filename);
@@ -1949,19 +1915,17 @@ describe("eslint", function() {
         });
     });
 
-    describe("when evaluating code with comments to disable and enable configurable rule as part of plugin", function() {
+    describe("when evaluating code with comments to disable and enable configurable rule as part of plugin", () => {
 
-        eslint.defineRule("test-plugin/test-rule", function(context) {
-            return {
-                Literal(node) {
-                    if (node.value === "trigger violation") {
-                        context.report(node, "Reporting violation.");
-                    }
+        eslint.defineRule("test-plugin/test-rule", context => ({
+            Literal(node) {
+                if (node.value === "trigger violation") {
+                    context.report(node, "Reporting violation.");
                 }
-            };
-        });
+            }
+        }));
 
-        it("should not report a violation when inline comment enables plugin rule and there's no violation", function() {
+        it("should not report a violation when inline comment enables plugin rule and there's no violation", () => {
             const config = { rules: {} };
             const code = "/*eslint test-plugin/test-rule: 2*/ var a = \"no violation\";";
 
@@ -1971,7 +1935,7 @@ describe("eslint", function() {
             assert.equal(messages.length, 0);
         });
 
-        it("should not report a violation when inline comment disables plugin rule", function() {
+        it("should not report a violation when inline comment disables plugin rule", () => {
             const code = "/*eslint test-plugin/test-rule:0*/ var a = \"trigger violation\"";
             const config = { rules: { "test-plugin/test-rule": 1 } };
 
@@ -1980,7 +1944,7 @@ describe("eslint", function() {
             assert.equal(messages.length, 0);
         });
 
-        it("rules should not change initial config", function() {
+        it("rules should not change initial config", () => {
             const config = { rules: {"test-plugin/test-rule": 2} };
             const codeA = "/*eslint test-plugin/test-rule: 0*/ var a = \"trigger violation\";";
             const codeB = "var a = \"trigger violation\";";
@@ -1995,8 +1959,8 @@ describe("eslint", function() {
         });
     });
 
-    describe("when evaluating code with comments to enable and disable all reporting", function() {
-        it("should report a violation", function() {
+    describe("when evaluating code with comments to enable and disable all reporting", () => {
+        it("should report a violation", () => {
 
             const code = [
                 "/*eslint-disable */",
@@ -2015,7 +1979,7 @@ describe("eslint", function() {
             assert.equal(messages[0].line, 4);
         });
 
-        it("should not report a violation", function() {
+        it("should not report a violation", () => {
             const code = [
                 "/*eslint-disable */",
                 "alert('test');",
@@ -2028,7 +1992,7 @@ describe("eslint", function() {
             assert.equal(messages.length, 0);
         });
 
-        it("should not report a violation", function() {
+        it("should not report a violation", () => {
             const code = [
                 "                    alert('test1');/*eslint-disable */\n",
                 "alert('test');",
@@ -2044,7 +2008,7 @@ describe("eslint", function() {
             assert.equal(messages[1].column, 19);
         });
 
-        it("should not report a violation", function() {
+        it("should not report a violation", () => {
 
             const code = [
                 "/*eslint-disable */",
@@ -2064,7 +2028,7 @@ describe("eslint", function() {
         });
 
 
-        it("should not report a violation", function() {
+        it("should not report a violation", () => {
             const code = [
                 "/*eslint-disable */",
                 "(function(){ var b = 44;})()",
@@ -2078,7 +2042,7 @@ describe("eslint", function() {
             assert.equal(messages.length, 0);
         });
 
-        it("should not report a violation", function() {
+        it("should not report a violation", () => {
             const code = [
                 "(function(){ /*eslint-disable */ var b = 44;})()",
                 "/*eslint-enable */;any();"
@@ -2092,10 +2056,10 @@ describe("eslint", function() {
         });
     });
 
-    describe("when evaluating code with comments to ignore reporting on of specific rules on a specific line", function() {
+    describe("when evaluating code with comments to ignore reporting on of specific rules on a specific line", () => {
 
-        describe("eslint-disable-line", function() {
-            it("should report a violation", function() {
+        describe("eslint-disable-line", () => {
+            it("should report a violation", () => {
                 const code = [
                     "alert('test'); // eslint-disable-line no-alert",
                     "console.log('test');" // here
@@ -2114,7 +2078,7 @@ describe("eslint", function() {
                 assert.equal(messages[0].ruleId, "no-console");
             });
 
-            it("should report a violation", function() {
+            it("should report a violation", () => {
                 const code = [
                     "alert('test'); // eslint-disable-line no-alert",
                     "console.log('test'); // eslint-disable-line no-console",
@@ -2134,7 +2098,7 @@ describe("eslint", function() {
                 assert.equal(messages[0].ruleId, "no-alert");
             });
 
-            it("should report a violation", function() {
+            it("should report a violation", () => {
                 const code = [
                     "alert('test'); // eslint-disable-line no-alert",
                     "alert('test'); /*eslint-disable-line no-alert*/" // here
@@ -2152,7 +2116,7 @@ describe("eslint", function() {
                 assert.equal(messages[0].ruleId, "no-alert");
             });
 
-            it("should not report a violation", function() {
+            it("should not report a violation", () => {
                 const code = [
                     "alert('test'); // eslint-disable-line no-alert",
                     "console('test'); // eslint-disable-line no-console"
@@ -2169,7 +2133,7 @@ describe("eslint", function() {
                 assert.equal(messages.length, 0);
             });
 
-            it("should not report a violation", function() {
+            it("should not report a violation", () => {
                 const code = [
                     "alert('test') // eslint-disable-line no-alert, quotes, semi",
                     "console('test'); // eslint-disable-line"
@@ -2189,8 +2153,8 @@ describe("eslint", function() {
             });
         });
 
-        describe("eslint-disable-next-line", function() {
-            it("should ignore violation of specified rule on next line", function() {
+        describe("eslint-disable-next-line", () => {
+            it("should ignore violation of specified rule on next line", () => {
                 const code = [
                     "// eslint-disable-next-line no-alert",
                     "alert('test');",
@@ -2208,7 +2172,7 @@ describe("eslint", function() {
                 assert.equal(messages[0].ruleId, "no-console");
             });
 
-            it("should ignore violations only of specified rule", function() {
+            it("should ignore violations only of specified rule", () => {
                 const code = [
                     "// eslint-disable-next-line no-console",
                     "alert('test');",
@@ -2227,7 +2191,7 @@ describe("eslint", function() {
                 assert.equal(messages[1].ruleId, "no-console");
             });
 
-            it("should ignore violations of multiple rules when specified", function() {
+            it("should ignore violations of multiple rules when specified", () => {
                 const code = [
                     "// eslint-disable-next-line no-alert, quotes",
                     "alert(\"test\");",
@@ -2246,7 +2210,7 @@ describe("eslint", function() {
                 assert.equal(messages[0].ruleId, "no-console");
             });
 
-            it("should ignore violations of specified rule on next line only", function() {
+            it("should ignore violations of specified rule on next line only", () => {
                 const code = [
                     "alert('test');",
                     "// eslint-disable-next-line no-alert",
@@ -2266,7 +2230,7 @@ describe("eslint", function() {
                 assert.equal(messages[1].ruleId, "no-console");
             });
 
-            it("should ignore all rule violations on next line if none specified", function() {
+            it("should ignore all rule violations on next line if none specified", () => {
                 const code = [
                     "// eslint-disable-next-line",
                     "alert(\"test\");",
@@ -2286,7 +2250,7 @@ describe("eslint", function() {
                 assert.equal(messages[0].ruleId, "no-console");
             });
 
-            it("should not report if comment is in block quotes", function() {
+            it("should not report if comment is in block quotes", () => {
                 const code = [
                     "alert('test');",
                     "/* eslint-disable-next-line no-alert */",
@@ -2309,9 +2273,9 @@ describe("eslint", function() {
         });
     });
 
-    describe("when evaluating code with comments to enable and disable reporting of specific rules", function() {
+    describe("when evaluating code with comments to enable and disable reporting of specific rules", () => {
 
-        it("should report a violation", function() {
+        it("should report a violation", () => {
             const code = [
                 "/*eslint-disable no-alert */",
                 "alert('test');",
@@ -2326,7 +2290,7 @@ describe("eslint", function() {
             assert.equal(messages[0].ruleId, "no-console");
         });
 
-        it("should report a violation", function() {
+        it("should report a violation", () => {
             const code = [
                 "/*eslint-disable no-alert, no-console */",
                 "alert('test');",
@@ -2348,7 +2312,7 @@ describe("eslint", function() {
             assert.equal(messages[1].line, 6);
         });
 
-        it("should report a violation", function() {
+        it("should report a violation", () => {
             const code = [
                 "/*eslint-disable no-alert */",
                 "alert('test');",
@@ -2367,7 +2331,7 @@ describe("eslint", function() {
         });
 
 
-        it("should report a violation", function() {
+        it("should report a violation", () => {
             const code = [
                 "/*eslint-disable no-alert, no-console */",
                 "alert('test');",
@@ -2388,7 +2352,7 @@ describe("eslint", function() {
         });
 
 
-        it("should report a violation", function() {
+        it("should report a violation", () => {
             const code = [
                 "/*eslint-disable no-alert */",
 
@@ -2424,7 +2388,7 @@ describe("eslint", function() {
 
         });
 
-        it("should report a violation", function() {
+        it("should report a violation", () => {
             const code = [
                 "/*eslint-disable no-alert, no-console */",
                 "alert('test');",
@@ -2458,7 +2422,7 @@ describe("eslint", function() {
 
         });
 
-        it("should report a violation when severity is warn", function() {
+        it("should report a violation when severity is warn", () => {
             const code = [
                 "/*eslint-disable no-alert, no-console */",
                 "alert('test');",
@@ -2493,10 +2457,10 @@ describe("eslint", function() {
         });
     });
 
-    describe("when evaluating code with comments to enable and disable multiple comma separated rules", function() {
+    describe("when evaluating code with comments to enable and disable multiple comma separated rules", () => {
         const code = "/*eslint no-alert:1, no-console:0*/ alert('test'); console.log('test');";
 
-        it("should report a violation", function() {
+        it("should report a violation", () => {
             const config = { rules: { "no-console": 1, "no-alert": 0 } };
 
             const messages = eslint.verify(code, config, filename);
@@ -2508,10 +2472,10 @@ describe("eslint", function() {
         });
     });
 
-    describe("when evaluating code with comments to enable configurable rule", function() {
+    describe("when evaluating code with comments to enable configurable rule", () => {
         const code = "/*eslint quotes:[2, \"double\"]*/ alert('test');";
 
-        it("should report a violation", function() {
+        it("should report a violation", () => {
             const config = { rules: { quotes: [2, "single"] } };
 
             const messages = eslint.verify(code, config, filename);
@@ -2523,10 +2487,10 @@ describe("eslint", function() {
         });
     });
 
-    describe("when evaluating code with comments to enable configurable rule using string severity", function() {
+    describe("when evaluating code with comments to enable configurable rule using string severity", () => {
         const code = "/*eslint quotes:[\"error\", \"double\"]*/ alert('test');";
 
-        it("should report a violation", function() {
+        it("should report a violation", () => {
             const config = { rules: { quotes: [2, "single"] } };
 
             const messages = eslint.verify(code, config, filename);
@@ -2538,8 +2502,8 @@ describe("eslint", function() {
         });
     });
 
-    describe("when evaluating code with incorrectly formatted comments to disable rule", function() {
-        it("should report a violation", function() {
+    describe("when evaluating code with incorrectly formatted comments to disable rule", () => {
+        it("should report a violation", () => {
             const code = "/*eslint no-alert:'1'*/ alert('test');";
 
             const config = { rules: { "no-alert": 1} };
@@ -2564,7 +2528,7 @@ describe("eslint", function() {
             assert.include(messages[1].nodeType, "CallExpression");
         });
 
-        it("should report a violation", function() {
+        it("should report a violation", () => {
             const code = "/*eslint no-alert:abc*/ alert('test');";
 
             const config = { rules: { "no-alert": 1} };
@@ -2589,7 +2553,7 @@ describe("eslint", function() {
             assert.include(messages[1].nodeType, "CallExpression");
         });
 
-        it("should report a violation", function() {
+        it("should report a violation", () => {
             const code = "/*eslint no-alert:0 2*/ alert('test');";
 
             const config = { rules: { "no-alert": 1} };
@@ -2615,10 +2579,10 @@ describe("eslint", function() {
         });
     });
 
-    describe("when evaluating code with comments which have colon in its value", function() {
+    describe("when evaluating code with comments which have colon in its value", () => {
         const code = "/* eslint max-len: [2, 100, 2, {ignoreUrls: true, ignorePattern: \"data:image\\/|\\s*require\\s*\\(|^\\s*loader\\.lazy|-\\*-\"}] */\nalert('test');";
 
-        it("should not parse errors, should report a violation", function() {
+        it("should not parse errors, should report a violation", () => {
             const messages = eslint.verify(code, {}, filename);
 
             assert.equal(messages.length, 1);
@@ -2628,10 +2592,10 @@ describe("eslint", function() {
         });
     });
 
-    describe("when evaluating a file with a shebang", function() {
+    describe("when evaluating a file with a shebang", () => {
         const code = "#!bin/program\n\nvar foo;;";
 
-        it("should preserve line numbers", function() {
+        it("should preserve line numbers", () => {
             const config = { rules: { "no-extra-semi": 1 } };
             const messages = eslint.verify(code, config);
 
@@ -2641,12 +2605,12 @@ describe("eslint", function() {
             assert.equal(messages[0].line, 3);
         });
 
-        it("should not have a comment with the shebang in it", function() {
+        it("should not have a comment with the shebang in it", () => {
             const config = { rules: { "no-extra-semi": 1 } };
 
             eslint.reset();
 
-            eslint.on("Program", function(node) {
+            eslint.on("Program", node => {
                 assert.equal(node.comments.length, 0);
 
                 let comments = eslint.getComments(node);
@@ -2661,7 +2625,7 @@ describe("eslint", function() {
             eslint.verify(code, config, "foo.js", true);
         });
 
-        it("should not fire a LineComment event for a comment with the shebang in it", function() {
+        it("should not fire a LineComment event for a comment with the shebang in it", () => {
             const config = { rules: { "no-extra-semi": 1 } };
 
             eslint.reset();
@@ -2671,10 +2635,10 @@ describe("eslint", function() {
         });
     });
 
-    describe("when evaluating broken code", function() {
+    describe("when evaluating broken code", () => {
         const code = BROKEN_TEST_CODE;
 
-        it("should report a violation with a useful parse error prefix", function() {
+        it("should report a violation with a useful parse error prefix", () => {
             const messages = eslint.verify(code);
 
             assert.equal(messages.length, 1);
@@ -2687,7 +2651,7 @@ describe("eslint", function() {
             assert.match(messages[0].message, /^Parsing error:/);
         });
 
-        it("should report source code where the issue is present", function() {
+        it("should report source code where the issue is present", () => {
             const inValidCode = [
                 "var x = 20;",
                 "if (x ==4 {",
@@ -2704,7 +2668,7 @@ describe("eslint", function() {
         });
     });
 
-    describe("when using an invalid (undefined) rule", function() {
+    describe("when using an invalid (undefined) rule", () => {
         const code = TEST_CODE;
         const results = eslint.verify(code, { rules: {foobar: 2 } });
         const result = results[0];
@@ -2713,7 +2677,7 @@ describe("eslint", function() {
         const objectOptionResults = eslint.verify(code, { rules: {foobar: [1, {bar: false}]} });
         const resultsMultiple = eslint.verify(code, { rules: {foobar: 2, barfoo: 1} });
 
-        it("should add a stub rule", function() {
+        it("should add a stub rule", () => {
             assert.isNotNull(result);
             assert.isArray(results);
             assert.isObject(result);
@@ -2721,58 +2685,58 @@ describe("eslint", function() {
             assert.equal(result.ruleId, "foobar");
         });
 
-        it("should report that the rule does not exist", function() {
+        it("should report that the rule does not exist", () => {
             assert.property(result, "message");
             assert.equal(result.message, "Definition for rule 'foobar' was not found");
         });
 
-        it("should report at the correct severity", function() {
+        it("should report at the correct severity", () => {
             assert.property(result, "severity");
             assert.equal(result.severity, 2);
             assert.equal(warningResult.severity, 1);
         });
 
-        it("should accept any valid rule configuration", function() {
+        it("should accept any valid rule configuration", () => {
             assert.isObject(arrayOptionResults[0]);
             assert.isObject(objectOptionResults[0]);
         });
 
-        it("should report multiple missing rules", function() {
+        it("should report multiple missing rules", () => {
             assert.isArray(resultsMultiple);
             assert.equal(resultsMultiple[1].ruleId, "barfoo");
         });
     });
 
-    describe("when using a rule which has been replaced", function() {
+    describe("when using a rule which has been replaced", () => {
         const code = TEST_CODE;
         const results = eslint.verify(code, { rules: {"no-comma-dangle": 2 } });
 
-        it("should report the new rule", function() {
+        it("should report the new rule", () => {
             assert.equal(results[0].ruleId, "no-comma-dangle");
             assert.equal(results[0].message, "Rule 'no-comma-dangle' was removed and replaced by: comma-dangle");
         });
     });
 
-    describe("when using invalid rule config", function() {
+    describe("when using invalid rule config", () => {
         const code = TEST_CODE;
 
-        it("should throw an error", function() {
-            assert.throws(function() {
+        it("should throw an error", () => {
+            assert.throws(() => {
                 eslint.verify(code, { rules: {foobar: null } });
             }, /Invalid config for rule 'foobar'\./);
         });
     });
 
-    describe("when calling defaults", function() {
-        it("should return back config object", function() {
+    describe("when calling defaults", () => {
+        it("should return back config object", () => {
             const config = eslint.defaults();
 
             assert.isNotNull(config.rules);
         });
     });
 
-    describe("when evaluating code without comments to environment", function() {
-        it("should report a violation when using typed array", function() {
+    describe("when evaluating code without comments to environment", () => {
+        it("should report a violation when using typed array", () => {
             const code = "var array = new Uint8Array();";
 
             const config = { rules: { "no-undef": 1} };
@@ -2782,7 +2746,7 @@ describe("eslint", function() {
             assert.equal(messages.length, 1);
         });
 
-        it("should report a violation when using Promise", function() {
+        it("should report a violation when using Promise", () => {
             const code = "new Promise();";
 
             const config = { rules: { "no-undef": 1} };
@@ -2793,8 +2757,8 @@ describe("eslint", function() {
         });
     });
 
-    describe("when evaluating code with comments to environment", function() {
-        it("should not support legacy config", function() {
+    describe("when evaluating code with comments to environment", () => {
+        it("should not support legacy config", () => {
             const code = "/*jshint mocha:true */ describe();";
 
             const config = { rules: { "no-undef": 1} };
@@ -2807,7 +2771,7 @@ describe("eslint", function() {
             assert.equal(messages[0].line, 1);
         });
 
-        it("should not report a violation", function() {
+        it("should not report a violation", () => {
             const code = "/*eslint-env es6 */ new Promise();";
 
             const config = { rules: { "no-undef": 1 } };
@@ -2817,7 +2781,7 @@ describe("eslint", function() {
             assert.equal(messages.length, 0);
         });
 
-        it("should not report a violation", function() {
+        it("should not report a violation", () => {
             const code = "/*eslint-env mocha,node */ require();describe();";
 
             const config = { rules: { "no-undef": 1} };
@@ -2827,7 +2791,7 @@ describe("eslint", function() {
             assert.equal(messages.length, 0);
         });
 
-        it("should not report a violation", function() {
+        it("should not report a violation", () => {
             const code = "/*eslint-env mocha */ suite();test();";
 
             const config = { rules: { "no-undef": 1} };
@@ -2837,7 +2801,7 @@ describe("eslint", function() {
             assert.equal(messages.length, 0);
         });
 
-        it("should not report a violation", function() {
+        it("should not report a violation", () => {
             const code = "/*eslint-env amd */ define();require();";
 
             const config = { rules: { "no-undef": 1} };
@@ -2847,7 +2811,7 @@ describe("eslint", function() {
             assert.equal(messages.length, 0);
         });
 
-        it("should not report a violation", function() {
+        it("should not report a violation", () => {
             const code = "/*eslint-env jasmine */ expect();spyOn();";
 
             const config = { rules: { "no-undef": 1} };
@@ -2857,7 +2821,7 @@ describe("eslint", function() {
             assert.equal(messages.length, 0);
         });
 
-        it("should not report a violation", function() {
+        it("should not report a violation", () => {
             const code = "/*globals require: true */ /*eslint-env node */ require = 1;";
 
             const config = { rules: {"no-undef": 1} };
@@ -2867,7 +2831,7 @@ describe("eslint", function() {
             assert.equal(messages.length, 0);
         });
 
-        it("should not report a violation", function() {
+        it("should not report a violation", () => {
             const code = "/*eslint-env node */ process.exit();";
 
             const config = { rules: {} };
@@ -2877,7 +2841,7 @@ describe("eslint", function() {
             assert.equal(messages.length, 0);
         });
 
-        it("should not report a violation", function() {
+        it("should not report a violation", () => {
             const code = "/*eslint no-process-exit: 0 */ /*eslint-env node */ process.exit();";
 
             const config = { rules: {"no-undef": 1} };
@@ -2888,9 +2852,9 @@ describe("eslint", function() {
         });
     });
 
-    describe("when evaluating code with comments to change config when allowInlineConfig is enabled", function() {
+    describe("when evaluating code with comments to change config when allowInlineConfig is enabled", () => {
 
-        it("should report a violation for disabling rules", function() {
+        it("should report a violation for disabling rules", () => {
             const code = [
                 "alert('test'); // eslint-disable-line no-alert"
             ].join("\n");
@@ -2910,7 +2874,7 @@ describe("eslint", function() {
         });
 
         it("should report a violation for global variable declarations",
-        function() {
+        () => {
             const code = [
                 "/* global foo */"
             ].join("\n");
@@ -2943,7 +2907,7 @@ describe("eslint", function() {
             assert(ok);
         });
 
-        it("should report a violation for eslint-disable", function() {
+        it("should report a violation for eslint-disable", () => {
             const code = [
                 "/* eslint-disable */",
                 "alert('test');"
@@ -2963,7 +2927,7 @@ describe("eslint", function() {
             assert.equal(messages[0].ruleId, "no-alert");
         });
 
-        it("should not report a violation for rule changes", function() {
+        it("should not report a violation for rule changes", () => {
             const code = [
                 "/*eslint no-alert:2*/",
                 "alert('test');"
@@ -2982,7 +2946,7 @@ describe("eslint", function() {
             assert.equal(messages.length, 0);
         });
 
-        it("should report a violation for disable-line", function() {
+        it("should report a violation for disable-line", () => {
             const code = [
                 "alert('test'); // eslint-disable-line"
             ].join("\n");
@@ -3001,7 +2965,7 @@ describe("eslint", function() {
             assert.equal(messages[0].ruleId, "no-alert");
         });
 
-        it("should report a violation for env changes", function() {
+        it("should report a violation for env changes", () => {
             const code = [
                 "/*eslint-env browser*/"
             ].join("\n");
@@ -3035,9 +2999,9 @@ describe("eslint", function() {
         });
     });
 
-    describe("when evaluating code with comments to change config when allowInlineConfig is disabled", function() {
+    describe("when evaluating code with comments to change config when allowInlineConfig is disabled", () => {
 
-        it("should not report a violation", function() {
+        it("should not report a violation", () => {
             const code = [
                 "alert('test'); // eslint-disable-line no-alert"
             ].join("\n");
@@ -3056,9 +3020,9 @@ describe("eslint", function() {
         });
     });
 
-    describe("when evaluating code with code comments", function() {
+    describe("when evaluating code with code comments", () => {
 
-        it("should emit enter only once for each comment", function() {
+        it("should emit enter only once for each comment", () => {
 
             const code = "a; /*zz*/ b;";
 
@@ -3072,7 +3036,7 @@ describe("eslint", function() {
             assert.equal(spy.calledOnce, true);
         });
 
-        it("should emit exit only once for each comment", function() {
+        it("should emit exit only once for each comment", () => {
 
             const code = "a; //zz\n b;";
 
@@ -3088,15 +3052,15 @@ describe("eslint", function() {
 
     });
 
-    describe("when evaluating code with hashbang", function() {
-        it("should comment hashbang without breaking offset", function() {
+    describe("when evaluating code with hashbang", () => {
+        it("should comment hashbang without breaking offset", () => {
 
             const code = "#!/usr/bin/env node\n'123';";
 
             const config = { rules: {} };
 
             eslint.reset();
-            eslint.on("ExpressionStatement", function(node) {
+            eslint.on("ExpressionStatement", node => {
                 assert.equal(eslint.getSource(node), "'123';");
             });
 
@@ -3105,9 +3069,9 @@ describe("eslint", function() {
 
     });
 
-    describe("verify()", function() {
-        describe("filenames", function() {
-            it("should allow filename to be passed on options object", function() {
+    describe("verify()", () => {
+        describe("filenames", () => {
+            it("should allow filename to be passed on options object", () => {
 
                 eslint.verify("foo;", {}, { filename: "foo.js"});
                 const result = eslint.getFilename();
@@ -3115,7 +3079,7 @@ describe("eslint", function() {
                 assert.equal(result, "foo.js");
             });
 
-            it("should allow filename to be passed as third argument", function() {
+            it("should allow filename to be passed as third argument", () => {
 
                 eslint.verify("foo;", {}, "foo.js");
                 const result = eslint.getFilename();
@@ -3123,7 +3087,7 @@ describe("eslint", function() {
                 assert.equal(result, "foo.js");
             });
 
-            it("should default filename to <input> when options object doesn't have filename", function() {
+            it("should default filename to <input> when options object doesn't have filename", () => {
 
                 eslint.verify("foo;", {}, {});
                 const result = eslint.getFilename();
@@ -3131,7 +3095,7 @@ describe("eslint", function() {
                 assert.equal(result, "<input>");
             });
 
-            it("should default filename to <input> when only two arguments are passed", function() {
+            it("should default filename to <input> when only two arguments are passed", () => {
 
                 eslint.verify("foo;", {});
                 const result = eslint.getFilename();
@@ -3140,8 +3104,8 @@ describe("eslint", function() {
             });
         });
 
-        describe("saveState", function() {
-            it("should save the state when saveState is passed as an option", function() {
+        describe("saveState", () => {
+            it("should save the state when saveState is passed as an option", () => {
 
                 const spy = sinon.spy(eslint, "reset");
 
@@ -3150,7 +3114,7 @@ describe("eslint", function() {
             });
         });
 
-        it("should report warnings in order by line and column when called", function() {
+        it("should report warnings in order by line and column when called", () => {
 
             const code = "foo()\n    alert('test')";
             const config = { rules: { "no-mixed-spaces-and-tabs": 1, "eol-last": 1, semi: [1, "always"] } };
@@ -3166,9 +3130,9 @@ describe("eslint", function() {
             assert.equal(messages[2].column, 18);
         });
 
-        describe("ecmaVersion", function() {
-            describe("it should properly parse let declaration when", function() {
-                it("the ECMAScript version number is 6", function() {
+        describe("ecmaVersion", () => {
+            describe("it should properly parse let declaration when", () => {
+                it("the ECMAScript version number is 6", () => {
                     const messages = eslint.verify("let x = 5;", {
                         parserOptions: {
                             ecmaVersion: 6
@@ -3178,7 +3142,7 @@ describe("eslint", function() {
                     assert.equal(messages.length, 0);
                 });
 
-                it("the ECMAScript version number is 2015", function() {
+                it("the ECMAScript version number is 2015", () => {
                     const messages = eslint.verify("let x = 5;", {
                         parserOptions: {
                             ecmaVersion: 2015
@@ -3189,7 +3153,7 @@ describe("eslint", function() {
                 });
             });
 
-            it("should fail to parse exponentiation operator when the ECMAScript version number is 2015", function() {
+            it("should fail to parse exponentiation operator when the ECMAScript version number is 2015", () => {
                 const messages = eslint.verify("x ** y;", {
                     parserOptions: {
                         ecmaVersion: 2015
@@ -3199,8 +3163,8 @@ describe("eslint", function() {
                 assert.equal(messages.length, 1);
             });
 
-            describe("should properly parse exponentiation operator when", function() {
-                it("the ECMAScript version number is 7", function() {
+            describe("should properly parse exponentiation operator when", () => {
+                it("the ECMAScript version number is 7", () => {
                     const messages = eslint.verify("x ** y;", {
                         parserOptions: {
                             ecmaVersion: 7
@@ -3210,7 +3174,7 @@ describe("eslint", function() {
                     assert.equal(messages.length, 0);
                 });
 
-                it("the ECMAScript version number is 2016", function() {
+                it("the ECMAScript version number is 2016", () => {
                     const messages = eslint.verify("x ** y;", {
                         parserOptions: {
                             ecmaVersion: 2016
@@ -3222,7 +3186,7 @@ describe("eslint", function() {
             });
         });
 
-        it("should properly parse object spread when passed ecmaFeatures", function() {
+        it("should properly parse object spread when passed ecmaFeatures", () => {
 
             const messages = eslint.verify("var x = { ...y };", {
                 parserOptions: {
@@ -3236,7 +3200,7 @@ describe("eslint", function() {
             assert.equal(messages.length, 0);
         });
 
-        it("should properly parse global return when passed ecmaFeatures", function() {
+        it("should properly parse global return when passed ecmaFeatures", () => {
 
             const messages = eslint.verify("return;", {
                 parserOptions: {
@@ -3249,7 +3213,7 @@ describe("eslint", function() {
             assert.equal(messages.length, 0);
         });
 
-        it("should properly parse global return when in Node.js environment", function() {
+        it("should properly parse global return when in Node.js environment", () => {
 
             const messages = eslint.verify("return;", {
                 env: {
@@ -3260,7 +3224,7 @@ describe("eslint", function() {
             assert.equal(messages.length, 0);
         });
 
-        it("should not parse global return when in Node.js environment with globalReturn explicitly off", function() {
+        it("should not parse global return when in Node.js environment with globalReturn explicitly off", () => {
 
             const messages = eslint.verify("return;", {
                 env: {
@@ -3277,7 +3241,7 @@ describe("eslint", function() {
             assert.equal(messages[0].message, "Parsing error: 'return' outside of function");
         });
 
-        it("should not parse global return when Node.js environment is false", function() {
+        it("should not parse global return when Node.js environment is false", () => {
 
             const messages = eslint.verify("return;", {}, filename);
 
@@ -3285,14 +3249,14 @@ describe("eslint", function() {
             assert.equal(messages[0].message, "Parsing error: 'return' outside of function");
         });
 
-        it("should properly parse sloppy-mode code when impliedStrict is false", function() {
+        it("should properly parse sloppy-mode code when impliedStrict is false", () => {
 
             const messages = eslint.verify("var private;", {}, filename);
 
             assert.equal(messages.length, 0);
         });
 
-        it("should not parse sloppy-mode code when impliedStrict is true", function() {
+        it("should not parse sloppy-mode code when impliedStrict is true", () => {
 
             const messages = eslint.verify("var private;", {
                 parserOptions: {
@@ -3306,7 +3270,7 @@ describe("eslint", function() {
             assert.equal(messages[0].message, "Parsing error: The keyword 'private' is reserved");
         });
 
-        it("should properly parse valid code when impliedStrict is true", function() {
+        it("should properly parse valid code when impliedStrict is true", () => {
 
             const messages = eslint.verify("var foo;", {
                 parserOptions: {
@@ -3319,7 +3283,7 @@ describe("eslint", function() {
             assert.equal(messages.length, 0);
         });
 
-        it("should properly parse JSX when passed ecmaFeatures", function() {
+        it("should properly parse JSX when passed ecmaFeatures", () => {
 
             const messages = eslint.verify("var x = <div/>;", {
                 parserOptions: {
@@ -3332,7 +3296,7 @@ describe("eslint", function() {
             assert.equal(messages.length, 0);
         });
 
-        it("should report an error when JSX code is encountered and JSX is not enabled", function() {
+        it("should report an error when JSX code is encountered and JSX is not enabled", () => {
             const code = "var myDivElement = <div className=\"foo\" />;";
             const messages = eslint.verify(code, {}, "filename");
 
@@ -3342,21 +3306,21 @@ describe("eslint", function() {
             assert.equal(messages[0].message, "Parsing error: Unexpected token <");
         });
 
-        it("should not report an error when JSX code is encountered and JSX is enabled", function() {
+        it("should not report an error when JSX code is encountered and JSX is enabled", () => {
             const code = "var myDivElement = <div className=\"foo\" />;";
             const messages = eslint.verify(code, { parserOptions: { ecmaFeatures: { jsx: true }}}, "filename");
 
             assert.equal(messages.length, 0);
         });
 
-        it("should not report an error when JSX code contains a spread operator and JSX is enabled", function() {
+        it("should not report an error when JSX code contains a spread operator and JSX is enabled", () => {
             const code = "var myDivElement = <div {...this.props} />;";
             const messages = eslint.verify(code, { parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true }}}, "filename");
 
             assert.equal(messages.length, 0);
         });
 
-        it("should be able to use es6 features if there is a comment which has \"eslint-env es6\"", function() {
+        it("should be able to use es6 features if there is a comment which has \"eslint-env es6\"", () => {
             const code = [
                 "/* eslint-env es6 */",
                 "var arrow = () => 0;",
@@ -3385,13 +3349,13 @@ describe("eslint", function() {
             assert.equal(messages.length, 0);
         });
 
-        it("should be able to return in global if there is a comment which has \"eslint-env node\"", function() {
+        it("should be able to return in global if there is a comment which has \"eslint-env node\"", () => {
             const messages = eslint.verify("/* eslint-env node */ return;", null, "eslint-env node");
 
             assert.equal(messages.length, 0);
         });
 
-        it("should attach a \"/*global\" comment node to declared variables", function() {
+        it("should attach a \"/*global\" comment node to declared variables", () => {
             const code = "/* global foo */\n/* global bar, baz */";
             let ok = false;
 
@@ -3428,12 +3392,12 @@ describe("eslint", function() {
             assert(ok);
         });
 
-        it("should not crash when we reuse the SourceCode object", function() {
+        it("should not crash when we reuse the SourceCode object", () => {
             eslint.verify("function render() { return <div className='test'>{hello}</div> }", { parserOptions: { ecmaVersion: 6, ecmaFeatures: {jsx: true} }});
             eslint.verify(eslint.getSourceCode(), { parserOptions: { ecmaVersion: 6, ecmaFeatures: {jsx: true} }});
         });
 
-        it("should allow 'await' as a property name in modules", function() {
+        it("should allow 'await' as a property name in modules", () => {
             const result = eslint.verify(
                 "obj.await",
                 {parserOptions: {ecmaVersion: 6, sourceType: "module"}}
@@ -3443,7 +3407,7 @@ describe("eslint", function() {
         });
     });
 
-    describe("Variables and references", function() {
+    describe("Variables and references", () => {
         const code = [
             "a;",
             "function foo() { b; }",
@@ -3458,7 +3422,7 @@ describe("eslint", function() {
         ].join("\n");
         let scope = null;
 
-        beforeEach(function() {
+        beforeEach(() => {
             let ok = false;
 
             eslint.defineRules({test(context) {
@@ -3473,11 +3437,11 @@ describe("eslint", function() {
             assert(ok);
         });
 
-        afterEach(function() {
+        afterEach(() => {
             scope = null;
         });
 
-        it("Scope#through should contain references of undefined variables", function() {
+        it("Scope#through should contain references of undefined variables", () => {
             assert.equal(scope.through.length, 2);
             assert.equal(scope.through[0].identifier.name, "a");
             assert.equal(scope.through[0].identifier.loc.start.line, 1);
@@ -3487,28 +3451,16 @@ describe("eslint", function() {
             assert.equal(scope.through[1].resolved, null);
         });
 
-        it("Scope#variables should contain global variables", function() {
-            assert(scope.variables.some(function(v) {
-                return v.name === "Object";
-            }));
-            assert(scope.variables.some(function(v) {
-                return v.name === "foo";
-            }));
-            assert(scope.variables.some(function(v) {
-                return v.name === "c";
-            }));
-            assert(scope.variables.some(function(v) {
-                return v.name === "d";
-            }));
-            assert(scope.variables.some(function(v) {
-                return v.name === "e";
-            }));
-            assert(scope.variables.some(function(v) {
-                return v.name === "f";
-            }));
+        it("Scope#variables should contain global variables", () => {
+            assert(scope.variables.some(v => v.name === "Object"));
+            assert(scope.variables.some(v => v.name === "foo"));
+            assert(scope.variables.some(v => v.name === "c"));
+            assert(scope.variables.some(v => v.name === "d"));
+            assert(scope.variables.some(v => v.name === "e"));
+            assert(scope.variables.some(v => v.name === "f"));
         });
 
-        it("Scope#set should contain global variables", function() {
+        it("Scope#set should contain global variables", () => {
             assert(scope.set.get("Object"));
             assert(scope.set.get("foo"));
             assert(scope.set.get("c"));
@@ -3517,7 +3469,7 @@ describe("eslint", function() {
             assert(scope.set.get("f"));
         });
 
-        it("Variables#references should contain their references", function() {
+        it("Variables#references should contain their references", () => {
             assert.equal(scope.set.get("Object").references.length, 1);
             assert.equal(scope.set.get("Object").references[0].identifier.name, "Object");
             assert.equal(scope.set.get("Object").references[0].identifier.loc.start.line, 3);
@@ -3544,7 +3496,7 @@ describe("eslint", function() {
             assert.equal(scope.set.get("f").references[0].resolved, scope.set.get("f"));
         });
 
-        it("Reference#resolved should be their variable", function() {
+        it("Reference#resolved should be their variable", () => {
             assert.equal(scope.set.get("Object").references[0].resolved, scope.set.get("Object"));
             assert.equal(scope.set.get("foo").references[0].resolved, scope.set.get("foo"));
             assert.equal(scope.set.get("c").references[0].resolved, scope.set.get("c"));
@@ -3554,7 +3506,7 @@ describe("eslint", function() {
         });
     });
 
-    describe("getDeclaredVariables(node)", function() {
+    describe("getDeclaredVariables(node)", () => {
 
         /**
          * Assert `eslint.getDeclaredVariables(node)` is empty.
@@ -3649,7 +3601,7 @@ describe("eslint", function() {
             assert.equal(0, expectedNamesList.length);
         }
 
-        it("VariableDeclaration", function() {
+        it("VariableDeclaration", () => {
             const code = "\n var {a, x: [b], y: {c = 0}} = foo;\n let {d, x: [e], y: {f = 0}} = foo;\n const {g, x: [h], y: {i = 0}} = foo, {j, k = function(z) { let l; }} = bar;\n ";
             const namesList = [
                 ["a", "b", "c"],
@@ -3661,7 +3613,7 @@ describe("eslint", function() {
             verify(code, "VariableDeclaration", namesList);
         });
 
-        it("VariableDeclaration (on for-in/of loop)", function() {
+        it("VariableDeclaration (on for-in/of loop)", () => {
 
             // TDZ scope is created here, so tests to exclude those.
             const code = "\n for (var {a, x: [b], y: {c = 0}} in foo) {\n let g;\n }\n for (let {d, x: [e], y: {f = 0}} of foo) {\n let h;\n }\n ";
@@ -3675,7 +3627,7 @@ describe("eslint", function() {
             verify(code, "VariableDeclaration", namesList);
         });
 
-        it("VariableDeclarator", function() {
+        it("VariableDeclarator", () => {
 
             // TDZ scope is created here, so tests to exclude those.
             const code = "\n var {a, x: [b], y: {c = 0}} = foo;\n let {d, x: [e], y: {f = 0}} = foo;\n const {g, x: [h], y: {i = 0}} = foo, {j, k = function(z) { let l; }} = bar;\n ";
@@ -3690,7 +3642,7 @@ describe("eslint", function() {
             verify(code, "VariableDeclarator", namesList);
         });
 
-        it("FunctionDeclaration", function() {
+        it("FunctionDeclaration", () => {
             const code = "\n function foo({a, x: [b], y: {c = 0}}, [d, e]) {\n let z;\n }\n function bar({f, x: [g], y: {h = 0}}, [i, j = function(q) { let w; }]) {\n let z;\n }\n ";
             const namesList = [
                 ["foo", "a", "b", "c", "d", "e"],
@@ -3700,7 +3652,7 @@ describe("eslint", function() {
             verify(code, "FunctionDeclaration", namesList);
         });
 
-        it("FunctionExpression", function() {
+        it("FunctionExpression", () => {
             const code = "\n (function foo({a, x: [b], y: {c = 0}}, [d, e]) {\n let z;\n });\n (function bar({f, x: [g], y: {h = 0}}, [i, j = function(q) { let w; }]) {\n let z;\n });\n ";
             const namesList = [
                 ["foo", "a", "b", "c", "d", "e"],
@@ -3711,7 +3663,7 @@ describe("eslint", function() {
             verify(code, "FunctionExpression", namesList);
         });
 
-        it("ArrowFunctionExpression", function() {
+        it("ArrowFunctionExpression", () => {
             const code = "\n (({a, x: [b], y: {c = 0}}, [d, e]) => {\n let z;\n });\n (({f, x: [g], y: {h = 0}}, [i, j]) => {\n let z;\n });\n ";
             const namesList = [
                 ["a", "b", "c", "d", "e"],
@@ -3721,7 +3673,7 @@ describe("eslint", function() {
             verify(code, "ArrowFunctionExpression", namesList);
         });
 
-        it("ClassDeclaration", function() {
+        it("ClassDeclaration", () => {
             const code = "\n class A { foo(x) { let y; } }\n class B { foo(x) { let y; } }\n ";
             const namesList = [
                 ["A", "A"], // outer scope's and inner scope's.
@@ -3731,7 +3683,7 @@ describe("eslint", function() {
             verify(code, "ClassDeclaration", namesList);
         });
 
-        it("ClassExpression", function() {
+        it("ClassExpression", () => {
             const code = "\n (class A { foo(x) { let y; } });\n (class B { foo(x) { let y; } });\n ";
             const namesList = [
                 ["A"],
@@ -3741,7 +3693,7 @@ describe("eslint", function() {
             verify(code, "ClassExpression", namesList);
         });
 
-        it("CatchClause", function() {
+        it("CatchClause", () => {
             const code = "\n try {} catch ({a, b}) {\n let x;\n try {} catch ({c, d}) {\n let y;\n }\n }\n ";
             const namesList = [
                 ["a", "b"],
@@ -3751,7 +3703,7 @@ describe("eslint", function() {
             verify(code, "CatchClause", namesList);
         });
 
-        it("ImportDeclaration", function() {
+        it("ImportDeclaration", () => {
             const code = "\n import \"aaa\";\n import * as a from \"bbb\";\n import b, {c, x as d} from \"ccc\";\n ";
             const namesList = [
                 [],
@@ -3762,7 +3714,7 @@ describe("eslint", function() {
             verify(code, "ImportDeclaration", namesList);
         });
 
-        it("ImportSpecifier", function() {
+        it("ImportSpecifier", () => {
             const code = "\n import \"aaa\";\n import * as a from \"bbb\";\n import b, {c, x as d} from \"ccc\";\n ";
             const namesList = [
                 ["c"],
@@ -3772,7 +3724,7 @@ describe("eslint", function() {
             verify(code, "ImportSpecifier", namesList);
         });
 
-        it("ImportDefaultSpecifier", function() {
+        it("ImportDefaultSpecifier", () => {
             const code = "\n import \"aaa\";\n import * as a from \"bbb\";\n import b, {c, x as d} from \"ccc\";\n ";
             const namesList = [
                 ["b"]
@@ -3781,7 +3733,7 @@ describe("eslint", function() {
             verify(code, "ImportDefaultSpecifier", namesList);
         });
 
-        it("ImportNamespaceSpecifier", function() {
+        it("ImportNamespaceSpecifier", () => {
             const code = "\n import \"aaa\";\n import * as a from \"bbb\";\n import b, {c, x as d} from \"ccc\";\n ";
             const namesList = [
                 ["a"]
@@ -3791,56 +3743,54 @@ describe("eslint", function() {
         });
     });
 
-    describe("Edge cases", function() {
+    describe("Edge cases", () => {
 
-        it("should properly parse import statements when sourceType is module", function() {
+        it("should properly parse import statements when sourceType is module", () => {
             const code = "import foo from 'foo';";
             const messages = eslint.verify(code, { parserOptions: { sourceType: "module" } });
 
             assert.equal(messages.length, 0);
         });
 
-        it("should properly parse import all statements when sourceType is module", function() {
+        it("should properly parse import all statements when sourceType is module", () => {
             const code = "import * as foo from 'foo';";
             const messages = eslint.verify(code, { parserOptions: { sourceType: "module" } });
 
             assert.equal(messages.length, 0);
         });
 
-        it("should properly parse default export statements when sourceType is module", function() {
+        it("should properly parse default export statements when sourceType is module", () => {
             const code = "export default function initialize() {}";
             const messages = eslint.verify(code, { parserOptions: { sourceType: "module" } });
 
             assert.equal(messages.length, 0);
         });
 
-        it("should not crash when invalid parentheses syntax is encountered", function() {
+        it("should not crash when invalid parentheses syntax is encountered", () => {
             eslint.verify("left = (aSize.width/2) - ()");
         });
 
-        it("should not crash when let is used inside of switch case", function() {
+        it("should not crash when let is used inside of switch case", () => {
             eslint.verify("switch(foo) { case 1: let bar=2; }", { parserOptions: { ecmaVersion: 6 }});
         });
 
-        it("should not crash when parsing destructured assignment", function() {
+        it("should not crash when parsing destructured assignment", () => {
             eslint.verify("var { a='a' } = {};", { parserOptions: { ecmaVersion: 6 }});
         });
 
-        it("should report syntax error when a keyword exists in object property shorthand", function() {
+        it("should report syntax error when a keyword exists in object property shorthand", () => {
             const messages = eslint.verify("let a = {this}", { parserOptions: { ecmaVersion: 6 }});
 
             assert.equal(messages.length, 1);
             assert.equal(messages[0].fatal, true);
         });
 
-        it("should not rewrite env setting in core (https://github.com/eslint/eslint/issues/4814)", function() {
+        it("should not rewrite env setting in core (https://github.com/eslint/eslint/issues/4814)", () => {
 
             // This test focuses on the instance of https://github.com/eslint/eslint/blob/v2.0.0-alpha-2/conf/environments.js#L26-L28
 
             // This `verify()` takes the instance and runs https://github.com/eslint/eslint/blob/v2.0.0-alpha-2/lib/eslint.js#L416
-            eslint.defineRule("test", function() {
-                return {};
-            });
+            eslint.defineRule("test", () => ({}));
             eslint.verify("var a = 0;", {
                 env: {node: true},
                 parserOptions: {sourceType: "module"},
@@ -3850,7 +3800,7 @@ describe("eslint", function() {
             // This `verify()` takes the instance and tests that the instance was not modified.
             let ok = false;
 
-            eslint.defineRule("test", function(context) {
+            eslint.defineRule("test", context => {
                 assert(
                     context.parserOptions.ecmaFeatures.globalReturn,
                     "`ecmaFeatures.globalReturn` of the node environment should not be modified."
@@ -3870,12 +3820,12 @@ describe("eslint", function() {
     // only test in Node.js, not browser
     if (typeof window === "undefined") {
 
-        describe("Custom parser", function() {
+        describe("Custom parser", () => {
 
             const parserFixtures = path.join(__dirname, "../fixtures/parsers"),
                 errorPrefix = "Parsing error: ";
 
-            it("should have file path passed to it", function() {
+            it("should have file path passed to it", () => {
                 const code = "/* this is code */";
                 const parser = path.join(parserFixtures, "stub-parser.js");
                 const parseSpy = sinon.spy(require(parser), "parse");
@@ -3885,14 +3835,14 @@ describe("eslint", function() {
                 sinon.assert.calledWithMatch(parseSpy, "", { filePath: filename });
             });
 
-            it("should not report an error when JSX code contains a spread operator and JSX is enabled", function() {
+            it("should not report an error when JSX code contains a spread operator and JSX is enabled", () => {
                 const code = "var myDivElement = <div {...this.props} />;";
                 const messages = eslint.verify(code, { parser: "esprima-fb" }, "filename");
 
                 assert.equal(messages.length, 0);
             });
 
-            it("should return an error when the custom parser can't be found", function() {
+            it("should return an error when the custom parser can't be found", () => {
                 const code = "var myDivElement = <div {...this.props} />;";
                 const messages = eslint.verify(code, { parser: "esprima-fbxyz" }, "filename");
 
@@ -3901,7 +3851,7 @@ describe("eslint", function() {
                 assert.equal(messages[0].message, "Cannot find module 'esprima-fbxyz'");
             });
 
-            it("should strip leading line: prefix from parser error", function() {
+            it("should strip leading line: prefix from parser error", () => {
                 const parser = path.join(parserFixtures, "line-error.js");
                 const messages = eslint.verify(";", { parser }, "filename");
 
@@ -3911,7 +3861,7 @@ describe("eslint", function() {
                 assert.equal(messages[0].message, errorPrefix + require(parser).expectedError);
             });
 
-            it("should not modify a parser error message without a leading line: prefix", function() {
+            it("should not modify a parser error message without a leading line: prefix", () => {
                 const parser = path.join(parserFixtures, "no-line-error.js");
                 const messages = eslint.verify(";", { parser }, "filename");
 

--- a/tests/lib/file-finder.js
+++ b/tests/lib/file-finder.js
@@ -17,7 +17,7 @@ const assert = require("chai").assert,
 // Tests
 //------------------------------------------------------------------------------
 
-describe("FileFinder", function() {
+describe("FileFinder", () => {
     const fixtureDir = path.resolve(__dirname, "..", "fixtures"),
         fileFinderDir = path.join(fixtureDir, "file-finder"),
         subdir = path.join(fileFinderDir, "subdir"),
@@ -26,14 +26,14 @@ describe("FileFinder", function() {
         absentFileName = "4ktrgrtUTYjkopoohFe54676hnjyumlimn6r787",
         uniqueFileName = "xvgRHtyH56756764535jkJ6jthty65tyhteHTEY";
 
-    describe("findAllInDirectoryAndParents()", function() {
+    describe("findAllInDirectoryAndParents()", () => {
         let actual,
             expected,
             finder;
 
-        describe("a file present in the cwd", function() {
+        describe("a file present in the cwd", () => {
 
-            it("should be found, and returned as the first element of an array", function() {
+            it("should be found, and returned as the first element of an array", () => {
                 finder = new FileFinder(uniqueFileName, process.cwd());
                 actual = finder.findAllInDirectoryAndParents(fileFinderDir);
                 expected = path.join(fileFinderDir, uniqueFileName);
@@ -43,9 +43,9 @@ describe("FileFinder", function() {
             });
         });
 
-        describe("a file present in a parent directory", function() {
+        describe("a file present in a parent directory", () => {
 
-            it("should be found, and returned as the first element of an array", function() {
+            it("should be found, and returned as the first element of an array", () => {
                 finder = new FileFinder(uniqueFileName, process.cwd());
                 actual = finder.findAllInDirectoryAndParents(subsubsubdir);
                 expected = path.join(fileFinderDir, "subdir", uniqueFileName);
@@ -55,9 +55,9 @@ describe("FileFinder", function() {
             });
         });
 
-        describe("a relative file present in a parent directory", function() {
+        describe("a relative file present in a parent directory", () => {
 
-            it("should be found, and returned as the first element of an array", function() {
+            it("should be found, and returned as the first element of an array", () => {
                 finder = new FileFinder(uniqueFileName, subsubdir);
                 actual = finder.findAllInDirectoryAndParents("./subsubsubdir");
                 expected = path.join(fileFinderDir, "subdir", uniqueFileName);
@@ -67,9 +67,9 @@ describe("FileFinder", function() {
             });
         });
 
-        describe("searching for multiple files", function() {
+        describe("searching for multiple files", () => {
 
-            it("should return only the first specified file", function() {
+            it("should return only the first specified file", () => {
                 const firstExpected = path.join(fileFinderDir, "subdir", "empty"),
                     secondExpected = path.join(fileFinderDir, "empty");
 
@@ -81,7 +81,7 @@ describe("FileFinder", function() {
                 assert.equal(actual[1], secondExpected);
             });
 
-            it("should return the second file when the first is missing", function() {
+            it("should return the second file when the first is missing", () => {
                 const firstExpected = path.join(fileFinderDir, "subdir", uniqueFileName),
                     secondExpected = path.join(fileFinderDir, uniqueFileName);
 
@@ -93,7 +93,7 @@ describe("FileFinder", function() {
                 assert.equal(actual[1], secondExpected);
             });
 
-            it("should return multiple files when the first is missing and more than one filename is requested", function() {
+            it("should return multiple files when the first is missing and more than one filename is requested", () => {
                 const firstExpected = path.join(fileFinderDir, "subdir", uniqueFileName),
                     secondExpected = path.join(fileFinderDir, uniqueFileName);
 
@@ -107,15 +107,15 @@ describe("FileFinder", function() {
 
         });
 
-        describe("two files present with the same name in parent directories", function() {
+        describe("two files present with the same name in parent directories", () => {
             const firstExpected = path.join(fileFinderDir, "subdir", uniqueFileName),
                 secondExpected = path.join(fileFinderDir, uniqueFileName);
 
-            before(function() {
+            before(() => {
                 finder = new FileFinder(uniqueFileName, process.cwd());
             });
 
-            it("should both be found, and returned in an array", function() {
+            it("should both be found, and returned in an array", () => {
                 actual = finder.findAllInDirectoryAndParents(subsubsubdir);
 
                 assert.isArray(actual);
@@ -123,7 +123,7 @@ describe("FileFinder", function() {
                 assert.equal(actual[1], secondExpected);
             });
 
-            it("should be in the cache after they have been found", function() {
+            it("should be in the cache after they have been found", () => {
 
                 assert.equal(finder.cache[subsubsubdir][0], firstExpected);
                 assert.equal(finder.cache[subsubsubdir][1], secondExpected);
@@ -136,9 +136,9 @@ describe("FileFinder", function() {
             });
         });
 
-        describe("an absent file", function() {
+        describe("an absent file", () => {
 
-            it("should not be found, and an empty array returned", function() {
+            it("should not be found, and an empty array returned", () => {
                 finder = new FileFinder(absentFileName, process.cwd());
                 actual = finder.findAllInDirectoryAndParents();
 
@@ -156,8 +156,8 @@ describe("FileFinder", function() {
          * be better. The original code assumed there will never be a package.json
          * outside of the eslint workspace, but that cannot be guaranteed.
          */
-        describe("Not consider directory with expected file names", function() {
-            it("should only find one package.json from the root", function() {
+        describe("Not consider directory with expected file names", () => {
+            it("should only find one package.json from the root", () => {
                 expected = path.join(process.cwd(), "package.json");
                 finder = new FileFinder("package.json", process.cwd());
                 actual = finder.findAllInDirectoryAndParents(fileFinderDir);
@@ -168,9 +168,7 @@ describe("FileFinder", function() {
                  * In order to eliminate side effects of files located outside of
                  * workspace this should be done for all test cases here.
                  */
-                actual = actual.filter(function(file) {
-                    return (file || "").indexOf(process.cwd()) === 0;
-                });
+                actual = actual.filter(file => (file || "").indexOf(process.cwd()) === 0);
 
                 assert.equal(actual, expected);
             });

--- a/tests/lib/formatters/checkstyle.js
+++ b/tests/lib/formatters/checkstyle.js
@@ -16,8 +16,8 @@ const assert = require("chai").assert,
 // Tests
 //------------------------------------------------------------------------------
 
-describe("formatter:checkstyle", function() {
-    describe("when passed a single message", function() {
+describe("formatter:checkstyle", () => {
+    describe("when passed a single message", () => {
         const code = [{
             filePath: "foo.js",
             messages: [{
@@ -29,13 +29,13 @@ describe("formatter:checkstyle", function() {
             }]
         }];
 
-        it("should return a string in the format filename: line x, col y, Error - z for errors", function() {
+        it("should return a string in the format filename: line x, col y, Error - z for errors", () => {
             const result = formatter(code);
 
             assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"foo.js\"><error line=\"5\" column=\"10\" severity=\"error\" message=\"Unexpected foo. (foo)\" source=\"eslint.rules.foo\" /></file></checkstyle>");
         });
 
-        it("should return a string in the format filename: line x, col y, Warning - z for warnings", function() {
+        it("should return a string in the format filename: line x, col y, Warning - z for warnings", () => {
             code[0].messages[0].severity = 1;
             const result = formatter(code);
 
@@ -43,7 +43,7 @@ describe("formatter:checkstyle", function() {
         });
     });
 
-    describe("when passed a message with XML control characters", function() {
+    describe("when passed a message with XML control characters", () => {
         const code = [{
             filePath: "<>&\"'.js",
             messages: [{
@@ -55,14 +55,14 @@ describe("formatter:checkstyle", function() {
             }]
         }];
 
-        it("should return a string in the format filename: line x, col y, Error - z", function() {
+        it("should return a string in the format filename: line x, col y, Error - z", () => {
             const result = formatter(code);
 
             assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"&lt;&gt;&amp;&quot;&apos;.js\"><error line=\"&lt;\" column=\"&gt;\" severity=\"error\" message=\"Unexpected &lt;&gt;&amp;&quot;&apos;&#8;&#9;&#10;&#12;&#13;&#29275;&#36924;. (foo)\" source=\"eslint.rules.foo\" /></file></checkstyle>");
         });
     });
 
-    describe("when passed a fatal error message", function() {
+    describe("when passed a fatal error message", () => {
         const code = [{
             filePath: "foo.js",
             messages: [{
@@ -74,14 +74,14 @@ describe("formatter:checkstyle", function() {
             }]
         }];
 
-        it("should return a string in the format filename: line x, col y, Error - z", function() {
+        it("should return a string in the format filename: line x, col y, Error - z", () => {
             const result = formatter(code);
 
             assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"foo.js\"><error line=\"5\" column=\"10\" severity=\"error\" message=\"Unexpected foo. (foo)\" source=\"eslint.rules.foo\" /></file></checkstyle>");
         });
     });
 
-    describe("when passed multiple messages", function() {
+    describe("when passed multiple messages", () => {
         const code = [{
             filePath: "foo.js",
             messages: [{
@@ -99,14 +99,14 @@ describe("formatter:checkstyle", function() {
             }]
         }];
 
-        it("should return a string with multiple entries", function() {
+        it("should return a string with multiple entries", () => {
             const result = formatter(code);
 
             assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"foo.js\"><error line=\"5\" column=\"10\" severity=\"error\" message=\"Unexpected foo. (foo)\" source=\"eslint.rules.foo\" /><error line=\"6\" column=\"11\" severity=\"warning\" message=\"Unexpected bar. (bar)\" source=\"eslint.rules.bar\" /></file></checkstyle>");
         });
     });
 
-    describe("when passed multiple files with 1 message each", function() {
+    describe("when passed multiple files with 1 message each", () => {
         const code = [{
             filePath: "foo.js",
             messages: [{
@@ -127,14 +127,14 @@ describe("formatter:checkstyle", function() {
             }]
         }];
 
-        it("should return a string with multiple entries", function() {
+        it("should return a string with multiple entries", () => {
             const result = formatter(code);
 
             assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"foo.js\"><error line=\"5\" column=\"10\" severity=\"error\" message=\"Unexpected foo. (foo)\" source=\"eslint.rules.foo\" /></file><file name=\"bar.js\"><error line=\"6\" column=\"11\" severity=\"warning\" message=\"Unexpected bar. (bar)\" source=\"eslint.rules.bar\" /></file></checkstyle>");
         });
     });
 
-    describe("when passing single message without rule id", function() {
+    describe("when passing single message without rule id", () => {
         const code = [{
             filePath: "foo.js",
             messages: [{
@@ -145,7 +145,7 @@ describe("formatter:checkstyle", function() {
             }]
         }];
 
-        it("should return a string in the format filename: line x, col y, Error - z for errors", function() {
+        it("should return a string in the format filename: line x, col y, Error - z for errors", () => {
             const result = formatter(code);
 
             assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"foo.js\"><error line=\"5\" column=\"10\" severity=\"error\" message=\"Unexpected foo.\" source=\"\" /></file></checkstyle>");

--- a/tests/lib/formatters/codeframe.js
+++ b/tests/lib/formatters/codeframe.js
@@ -40,31 +40,31 @@ const formatter = proxyquire("../../../lib/formatters/codeframe", { chalk: chalk
 // Tests
 //------------------------------------------------------------------------------
 
-describe("formatter:codeframe", function() {
+describe("formatter:codeframe", () => {
     let sandbox;
 
-    beforeEach(function() {
+    beforeEach(() => {
         sandbox = sinon.sandbox.create();
     });
 
-    afterEach(function() {
+    afterEach(() => {
         sandbox.verifyAndRestore();
     });
 
-    describe("when passed no messages", function() {
+    describe("when passed no messages", () => {
         const code = [{
             filePath: "foo.js",
             messages: []
         }];
 
-        it("should return nothing", function() {
+        it("should return nothing", () => {
             const result = formatter(code);
 
             assert.equal(result, "");
         });
     });
 
-    describe("when passed a single message", function() {
+    describe("when passed a single message", () => {
         const code = [{
             filePath: path.join(process.cwd(), "lib", "foo.js"),
             source: "var foo = 1;\n var bar = 2;\n",
@@ -77,7 +77,7 @@ describe("formatter:codeframe", function() {
             }]
         }];
 
-        it("should return a string in the correct format for errors", function() {
+        it("should return a string in the correct format for errors", () => {
             const result = formatter(code);
 
             assert.equal(chalk.stripColor(result), [
@@ -91,7 +91,7 @@ describe("formatter:codeframe", function() {
             ].join("\n"));
         });
 
-        it("should return a string in the correct format for warnings", function() {
+        it("should return a string in the correct format for warnings", () => {
             code[0].messages[0].severity = 1;
 
             const result = formatter(code);
@@ -107,7 +107,7 @@ describe("formatter:codeframe", function() {
             ].join("\n"));
         });
 
-        it("should return bold red summary when there are errors", function() {
+        it("should return bold red summary when there are errors", () => {
             sandbox.spy(chalkStub.yellow, "bold");
             sandbox.spy(chalkStub.red, "bold");
             code[0].messages[0].severity = 2;
@@ -118,7 +118,7 @@ describe("formatter:codeframe", function() {
             assert.equal(chalkStub.red.bold.callCount, 1);
         });
 
-        it("should return bold yellow summary when there are only warnings", function() {
+        it("should return bold yellow summary when there are only warnings", () => {
             sandbox.spy(chalkStub.yellow, "bold");
             sandbox.spy(chalkStub.red, "bold");
             code[0].messages[0].severity = 1;
@@ -130,7 +130,7 @@ describe("formatter:codeframe", function() {
         });
     });
 
-    describe("when passed multiple messages", function() {
+    describe("when passed multiple messages", () => {
         const code = [{
             filePath: "foo.js",
             source: "const foo = 1\n",
@@ -149,7 +149,7 @@ describe("formatter:codeframe", function() {
             }],
         }];
 
-        it("should return a string with multiple entries", function() {
+        it("should return a string with multiple entries", () => {
             const result = formatter(code);
 
             assert.equal(chalk.stripColor(result), [
@@ -167,7 +167,7 @@ describe("formatter:codeframe", function() {
             ].join("\n"));
         });
 
-        it("should return bold red summary when at least 1 of the messages is an error", function() {
+        it("should return bold red summary when at least 1 of the messages is an error", () => {
             sandbox.spy(chalkStub.yellow, "bold");
             sandbox.spy(chalkStub.red, "bold");
             code[0].messages[0].severity = 1;
@@ -179,7 +179,7 @@ describe("formatter:codeframe", function() {
         });
     });
 
-    describe("when passed one file with 1 message and fixes applied", function() {
+    describe("when passed one file with 1 message and fixes applied", () => {
         const code = [{
             filePath: "foo.js",
             messages: [{
@@ -193,7 +193,7 @@ describe("formatter:codeframe", function() {
             output: "function foo() {\n\n    // a comment\n    const foo = 1;\n}\n\n"
         }];
 
-        it("should return a string with code preview pointing to the correct location after fixes", function() {
+        it("should return a string with code preview pointing to the correct location after fixes", () => {
             const result = formatter(code);
 
             assert.equal(chalk.stripColor(result), [
@@ -211,7 +211,7 @@ describe("formatter:codeframe", function() {
         });
     });
 
-    describe("when passed multiple files with 1 message each", function() {
+    describe("when passed multiple files with 1 message each", () => {
         const code = [{
             filePath: "foo.js",
             source: "const foo = 1\n",
@@ -234,7 +234,7 @@ describe("formatter:codeframe", function() {
             }]
         }];
 
-        it("should return a string with multiple entries", function() {
+        it("should return a string with multiple entries", () => {
             const result = formatter(code);
 
             assert.equal(chalk.stripColor(result), [
@@ -253,7 +253,7 @@ describe("formatter:codeframe", function() {
         });
     });
 
-    describe("when passed a fatal error message", function() {
+    describe("when passed a fatal error message", () => {
         const code = [{
             filePath: "foo.js",
             source: "e{}\n",
@@ -268,7 +268,7 @@ describe("formatter:codeframe", function() {
             }]
         }];
 
-        it("should return a string in the correct format", function() {
+        it("should return a string in the correct format", () => {
             const result = formatter(code);
 
             assert.equal(chalk.stripColor(result), [
@@ -282,7 +282,7 @@ describe("formatter:codeframe", function() {
         });
     });
 
-    describe("when passed one file not found message", function() {
+    describe("when passed one file not found message", () => {
         const code = [{
             filePath: "foo.js",
             messages: [{
@@ -291,14 +291,14 @@ describe("formatter:codeframe", function() {
             }]
         }];
 
-        it("should return a string without code preview (codeframe)", function() {
+        it("should return a string without code preview (codeframe)", () => {
             const result = formatter(code);
 
             assert.equal(chalk.stripColor(result), "error: Couldn't find foo.js at foo.js\n\n\n1 error found.");
         });
     });
 
-    describe("when passed a single message with no line or column", function() {
+    describe("when passed a single message with no line or column", () => {
         const code = [{
             filePath: "foo.js",
             messages: [{
@@ -309,13 +309,13 @@ describe("formatter:codeframe", function() {
             }]
         }];
 
-        it("should return a string without code preview (codeframe)", function() {
+        it("should return a string without code preview (codeframe)", () => {
             const result = formatter(code);
 
             assert.equal(chalk.stripColor(result), "error: Unexpected foo (foo) at foo.js\n\n\n1 error found.");
         });
 
-        it("should output filepath but without 'line:column' appended", function() {
+        it("should output filepath but without 'line:column' appended", () => {
             const result = formatter(code);
 
             assert.equal(chalk.stripColor(result), "error: Unexpected foo (foo) at foo.js\n\n\n1 error found.");

--- a/tests/lib/formatters/compact.js
+++ b/tests/lib/formatters/compact.js
@@ -16,21 +16,21 @@ const assert = require("chai").assert,
 // Tests
 //------------------------------------------------------------------------------
 
-describe("formatter:compact", function() {
-    describe("when passed no messages", function() {
+describe("formatter:compact", () => {
+    describe("when passed no messages", () => {
         const code = [{
             filePath: "foo.js",
             messages: []
         }];
 
-        it("should return nothing", function() {
+        it("should return nothing", () => {
             const result = formatter(code);
 
             assert.equal(result, "");
         });
     });
 
-    describe("when passed a single message", function() {
+    describe("when passed a single message", () => {
         const code = [{
             filePath: "foo.js",
             messages: [{
@@ -42,13 +42,13 @@ describe("formatter:compact", function() {
             }]
         }];
 
-        it("should return a string in the format filename: line x, col y, Error - z for errors", function() {
+        it("should return a string in the format filename: line x, col y, Error - z for errors", () => {
             const result = formatter(code);
 
             assert.equal(result, "foo.js: line 5, col 10, Error - Unexpected foo. (foo)\n\n1 problem");
         });
 
-        it("should return a string in the format filename: line x, col y, Warning - z for warnings", function() {
+        it("should return a string in the format filename: line x, col y, Warning - z for warnings", () => {
             code[0].messages[0].severity = 1;
             const result = formatter(code);
 
@@ -56,7 +56,7 @@ describe("formatter:compact", function() {
         });
     });
 
-    describe("when passed a fatal error message", function() {
+    describe("when passed a fatal error message", () => {
         const code = [{
             filePath: "foo.js",
             messages: [{
@@ -68,14 +68,14 @@ describe("formatter:compact", function() {
             }]
         }];
 
-        it("should return a string in the format filename: line x, col y, Error - z", function() {
+        it("should return a string in the format filename: line x, col y, Error - z", () => {
             const result = formatter(code);
 
             assert.equal(result, "foo.js: line 5, col 10, Error - Unexpected foo. (foo)\n\n1 problem");
         });
     });
 
-    describe("when passed multiple messages", function() {
+    describe("when passed multiple messages", () => {
         const code = [{
             filePath: "foo.js",
             messages: [{
@@ -93,14 +93,14 @@ describe("formatter:compact", function() {
             }]
         }];
 
-        it("should return a string with multiple entries", function() {
+        it("should return a string with multiple entries", () => {
             const result = formatter(code);
 
             assert.equal(result, "foo.js: line 5, col 10, Error - Unexpected foo. (foo)\nfoo.js: line 6, col 11, Warning - Unexpected bar. (bar)\n\n2 problems");
         });
     });
 
-    describe("when passed multiple files with 1 message each", function() {
+    describe("when passed multiple files with 1 message each", () => {
         const code = [{
             filePath: "foo.js",
             messages: [{
@@ -121,14 +121,14 @@ describe("formatter:compact", function() {
             }]
         }];
 
-        it("should return a string with multiple entries", function() {
+        it("should return a string with multiple entries", () => {
             const result = formatter(code);
 
             assert.equal(result, "foo.js: line 5, col 10, Error - Unexpected foo. (foo)\nbar.js: line 6, col 11, Warning - Unexpected bar. (bar)\n\n2 problems");
         });
     });
 
-    describe("when passed one file not found message", function() {
+    describe("when passed one file not found message", () => {
         const code = [{
             filePath: "foo.js",
             messages: [{
@@ -137,7 +137,7 @@ describe("formatter:compact", function() {
             }]
         }];
 
-        it("should return a string without line and column", function() {
+        it("should return a string without line and column", () => {
             const result = formatter(code);
 
             assert.equal(result, "foo.js: line 0, col 0, Error - Couldn't find foo.js.\n\n1 problem");

--- a/tests/lib/formatters/html.js
+++ b/tests/lib/formatters/html.js
@@ -63,8 +63,8 @@ function checkContentRow($, row, args) {
 // Tests
 //------------------------------------------------------------------------------
 
-describe("formatter:html", function() {
-    describe("when passed a single error message", function() {
+describe("formatter:html", () => {
+    describe("when passed a single error message", () => {
 
         const code = [{
             filePath: "foo.js",
@@ -80,7 +80,7 @@ describe("formatter:html", function() {
             }]
         }];
 
-        it("should return a string in HTML format with 1 issue in 1 file and styled accordingly", function() {
+        it("should return a string in HTML format with 1 issue in 1 file and styled accordingly", () => {
             const result = formatter(code);
             const $ = cheerio.load(result);
 
@@ -95,7 +95,7 @@ describe("formatter:html", function() {
         });
     });
 
-    describe("when passed a single warning message", function() {
+    describe("when passed a single warning message", () => {
 
         const code = [{
             filePath: "foo.js",
@@ -111,7 +111,7 @@ describe("formatter:html", function() {
             }]
         }];
 
-        it("should return a string in HTML format with 1 issue in 1 file and styled accordingly", function() {
+        it("should return a string in HTML format with 1 issue in 1 file and styled accordingly", () => {
             const result = formatter(code);
             const $ = cheerio.load(result);
 
@@ -126,7 +126,7 @@ describe("formatter:html", function() {
         });
     });
 
-    describe("when passed a single error message", function() {
+    describe("when passed a single error message", () => {
 
         const code = [{
             filePath: "foo.js",
@@ -142,7 +142,7 @@ describe("formatter:html", function() {
             }]
         }];
 
-        it("should return a string in HTML format with 1 issue in 1 file and styled accordingly", function() {
+        it("should return a string in HTML format with 1 issue in 1 file and styled accordingly", () => {
             const result = formatter(code);
             const $ = cheerio.load(result);
 
@@ -157,7 +157,7 @@ describe("formatter:html", function() {
         });
     });
 
-    describe("when passed no error/warning messages", function() {
+    describe("when passed no error/warning messages", () => {
 
         const code = [{
             filePath: "foo.js",
@@ -166,7 +166,7 @@ describe("formatter:html", function() {
             messages: []
         }];
 
-        it("should return a string in HTML format with 0 issues in 1 file and styled accordingly", function() {
+        it("should return a string in HTML format with 0 issues in 1 file and styled accordingly", () => {
             const result = formatter(code);
             const $ = cheerio.load(result);
 
@@ -179,7 +179,7 @@ describe("formatter:html", function() {
         });
     });
 
-    describe("when passed multiple messages", function() {
+    describe("when passed multiple messages", () => {
         const code = [{
             filePath: "foo.js",
             errorCount: 1,
@@ -201,7 +201,7 @@ describe("formatter:html", function() {
             }]
         }];
 
-        it("should return a string in HTML format with 2 issues in 1 file and styled accordingly", function() {
+        it("should return a string in HTML format with 2 issues in 1 file and styled accordingly", () => {
             const result = formatter(code);
             const $ = cheerio.load(result);
 
@@ -217,7 +217,7 @@ describe("formatter:html", function() {
         });
     });
 
-    describe("when passed multiple files with 1 error & warning message respectively", function() {
+    describe("when passed multiple files with 1 error & warning message respectively", () => {
         const code = [{
             filePath: "foo.js",
             errorCount: 1,
@@ -244,7 +244,7 @@ describe("formatter:html", function() {
             }]
         }];
 
-        it("should return a string in HTML format with 2 issues in 2 files and styled accordingly", function() {
+        it("should return a string in HTML format with 2 issues in 2 files and styled accordingly", () => {
             const result = formatter(code);
             const $ = cheerio.load(result);
 
@@ -261,7 +261,7 @@ describe("formatter:html", function() {
         });
     });
 
-    describe("when passed multiple files with 1 warning message each", function() {
+    describe("when passed multiple files with 1 warning message each", () => {
         const code = [{
             filePath: "foo.js",
             errorCount: 0,
@@ -288,7 +288,7 @@ describe("formatter:html", function() {
             }]
         }];
 
-        it("should return a string in HTML format with 2 issues in 2 files and styled accordingly", function() {
+        it("should return a string in HTML format with 2 issues in 2 files and styled accordingly", () => {
             const result = formatter(code);
             const $ = cheerio.load(result);
 
@@ -305,7 +305,7 @@ describe("formatter:html", function() {
         });
     });
 
-    describe("when passing a single message with illegal characters", function() {
+    describe("when passing a single message with illegal characters", () => {
 
         const code = [{
             filePath: "foo.js",
@@ -321,7 +321,7 @@ describe("formatter:html", function() {
             }]
         }];
 
-        it("should return a string in HTML format with 1 issue in 1 file", function() {
+        it("should return a string in HTML format with 1 issue in 1 file", () => {
             const result = formatter(code);
             const $ = cheerio.load(result);
 
@@ -351,7 +351,7 @@ describe("formatter:html", function() {
     // });
     // */
 
-    describe("when passing a single message with no rule id or message", function() {
+    describe("when passing a single message with no rule id or message", () => {
         const code = [{
             filePath: "foo.js",
             errorCount: 1,
@@ -363,7 +363,7 @@ describe("formatter:html", function() {
             }]
         }];
 
-        it("should return a string in HTML format with 1 issue in 1 file", function() {
+        it("should return a string in HTML format with 1 issue in 1 file", () => {
             const result = formatter(code);
             const $ = cheerio.load(result);
 
@@ -371,7 +371,7 @@ describe("formatter:html", function() {
         });
     });
 
-    describe("when passed a single message with no line or column", function() {
+    describe("when passed a single message with no line or column", () => {
 
         const code = [{
             filePath: "foo.js",
@@ -385,7 +385,7 @@ describe("formatter:html", function() {
             }]
         }];
 
-        it("should return a string in HTML format with 1 issue in 1 file and styled accordingly", function() {
+        it("should return a string in HTML format with 1 issue in 1 file and styled accordingly", () => {
             const result = formatter(code);
             const $ = cheerio.load(result);
 

--- a/tests/lib/formatters/jslint-xml.js
+++ b/tests/lib/formatters/jslint-xml.js
@@ -16,8 +16,8 @@ const assert = require("chai").assert,
 // Tests
 //------------------------------------------------------------------------------
 
-describe("formatter:jslint-xml", function() {
-    describe("when passed a single message", function() {
+describe("formatter:jslint-xml", () => {
+    describe("when passed a single message", () => {
 
         const code = [{
             filePath: "foo.js",
@@ -31,14 +31,14 @@ describe("formatter:jslint-xml", function() {
             }]
         }];
 
-        it("should return a string in JSLint XML format with 1 issue in 1 file", function() {
+        it("should return a string in JSLint XML format with 1 issue in 1 file", () => {
             const result = formatter(code);
 
             assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><jslint><file name=\"foo.js\"><issue line=\"5\" char=\"10\" evidence=\"foo\" reason=\"Unexpected foo. (foo)\" /></file></jslint>");
         });
     });
 
-    describe("when passed a fatal error message", function() {
+    describe("when passed a fatal error message", () => {
 
         const code = [{
             filePath: "foo.js",
@@ -52,14 +52,14 @@ describe("formatter:jslint-xml", function() {
             }]
         }];
 
-        it("should return a string in JSLint XML format with 1 issue in 1 file", function() {
+        it("should return a string in JSLint XML format with 1 issue in 1 file", () => {
             const result = formatter(code);
 
             assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><jslint><file name=\"foo.js\"><issue line=\"5\" char=\"10\" evidence=\"foo\" reason=\"Unexpected foo. (foo)\" /></file></jslint>");
         });
     });
 
-    describe("when passed multiple messages", function() {
+    describe("when passed multiple messages", () => {
         const code = [{
             filePath: "foo.js",
             messages: [{
@@ -79,14 +79,14 @@ describe("formatter:jslint-xml", function() {
             }]
         }];
 
-        it("should return a string in JSLint XML format with 2 issues in 1 file", function() {
+        it("should return a string in JSLint XML format with 2 issues in 1 file", () => {
             const result = formatter(code);
 
             assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><jslint><file name=\"foo.js\"><issue line=\"5\" char=\"10\" evidence=\"foo\" reason=\"Unexpected foo. (foo)\" /><issue line=\"6\" char=\"11\" evidence=\"bar\" reason=\"Unexpected bar. (bar)\" /></file></jslint>");
         });
     });
 
-    describe("when passed multiple files with 1 message each", function() {
+    describe("when passed multiple files with 1 message each", () => {
         const code = [{
             filePath: "foo.js",
             messages: [{
@@ -109,14 +109,14 @@ describe("formatter:jslint-xml", function() {
             }]
         }];
 
-        it("should return a string in JSLint XML format with 2 issues in 2 files", function() {
+        it("should return a string in JSLint XML format with 2 issues in 2 files", () => {
             const result = formatter(code);
 
             assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><jslint><file name=\"foo.js\"><issue line=\"5\" char=\"10\" evidence=\"foo\" reason=\"Unexpected foo. (foo)\" /></file><file name=\"bar.js\"><issue line=\"6\" char=\"11\" evidence=\"bar\" reason=\"Unexpected bar. (bar)\" /></file></jslint>");
         });
     });
 
-    describe("when passing a single message with illegal characters", function() {
+    describe("when passing a single message with illegal characters", () => {
 
         const code = [{
             filePath: "foo.js",
@@ -130,14 +130,14 @@ describe("formatter:jslint-xml", function() {
             }]
         }];
 
-        it("should return a string in JSLint XML format with 1 issue in 1 file", function() {
+        it("should return a string in JSLint XML format with 1 issue in 1 file", () => {
             const result = formatter(code);
 
             assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><jslint><file name=\"foo.js\"><issue line=\"5\" char=\"10\" evidence=\"foo\" reason=\"Unexpected &lt;&amp;&quot;&apos;&gt;&#8;&#9;&#10;&#12;&#13;&#29275;&#36924; foo. (foo)\" /></file></jslint>");
         });
     });
 
-    describe("when passing a single message with no source", function() {
+    describe("when passing a single message with no source", () => {
 
         const code = [{
             filePath: "foo.js",
@@ -150,14 +150,14 @@ describe("formatter:jslint-xml", function() {
             }]
         }];
 
-        it("should return a string in JSLint XML format with 1 issue in 1 file", function() {
+        it("should return a string in JSLint XML format with 1 issue in 1 file", () => {
             const result = formatter(code);
 
             assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><jslint><file name=\"foo.js\"><issue line=\"5\" char=\"10\" evidence=\"\" reason=\"Unexpected foo. (foo)\" /></file></jslint>");
         });
     });
 
-    describe("when passing a single message without rule id", function() {
+    describe("when passing a single message without rule id", () => {
         const code = [{
             filePath: "foo.js",
             messages: [{
@@ -167,7 +167,7 @@ describe("formatter:jslint-xml", function() {
             }]
         }];
 
-        it("should return a string in JSLint XML format with 1 issue in 1 file", function() {
+        it("should return a string in JSLint XML format with 1 issue in 1 file", () => {
             const result = formatter(code);
 
             assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><jslint><file name=\"foo.js\"><issue line=\"5\" char=\"10\" evidence=\"\" reason=\"\" /></file></jslint>");

--- a/tests/lib/formatters/json.js
+++ b/tests/lib/formatters/json.js
@@ -16,7 +16,7 @@ const assert = require("chai").assert,
 // Tests
 //------------------------------------------------------------------------------
 
-describe("formatter:json", function() {
+describe("formatter:json", () => {
     const code = [{
         filePath: "foo.js",
         messages: [{
@@ -39,7 +39,7 @@ describe("formatter:json", function() {
         }]
     }];
 
-    it("should return passed results as a JSON string without any modification", function() {
+    it("should return passed results as a JSON string without any modification", () => {
         const result = JSON.parse(formatter(code));
 
         assert.deepEqual(result, code);

--- a/tests/lib/formatters/junit.js
+++ b/tests/lib/formatters/junit.js
@@ -18,18 +18,18 @@ const assert = require("chai").assert,
 // Tests
 //------------------------------------------------------------------------------
 
-describe("formatter:junit", function() {
-    describe("when there are no problems", function() {
+describe("formatter:junit", () => {
+    describe("when there are no problems", () => {
         const code = [];
 
-        it("should not complain about anything", function() {
+        it("should not complain about anything", () => {
             const result = formatter(code);
 
             assert.equal(result.replace(/\n/g, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites></testsuites>");
         });
     });
 
-    describe("when passed a single message", function() {
+    describe("when passed a single message", () => {
         const code = [{
             filePath: "foo.js",
             messages: [{
@@ -41,13 +41,13 @@ describe("formatter:junit", function() {
             }]
         }];
 
-        it("should return a single <testcase> with a message and the line and col number in the body (error)", function() {
+        it("should return a single <testcase> with a message and the line and col number in the body (error)", () => {
             const result = formatter(code);
 
             assert.equal(result.replace(/\n/g, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><failure message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Error - Unexpected foo. (foo)]]></failure></testcase></testsuite></testsuites>");
         });
 
-        it("should return a single <testcase> with a message and the line and col number in the body (warning)", function() {
+        it("should return a single <testcase> with a message and the line and col number in the body (warning)", () => {
             code[0].messages[0].severity = 1;
             const result = formatter(code);
 
@@ -55,7 +55,7 @@ describe("formatter:junit", function() {
         });
     });
 
-    describe("when passed a fatal error message", function() {
+    describe("when passed a fatal error message", () => {
         const code = [{
             filePath: "foo.js",
             messages: [{
@@ -67,14 +67,14 @@ describe("formatter:junit", function() {
             }]
         }];
 
-        it("should return a single <testcase> and an <error>", function() {
+        it("should return a single <testcase> and an <error>", () => {
             const result = formatter(code);
 
             assert.equal(result.replace(/\n/g, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><error message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Error - Unexpected foo. (foo)]]></error></testcase></testsuite></testsuites>");
         });
     });
 
-    describe("when passed a fatal error message with no line or column", function() {
+    describe("when passed a fatal error message with no line or column", () => {
         const code = [{
             filePath: "foo.js",
             messages: [{
@@ -83,14 +83,14 @@ describe("formatter:junit", function() {
             }]
         }];
 
-        it("should return a single <testcase> and an <error>", function() {
+        it("should return a single <testcase> and an <error>", () => {
             const result = formatter(code);
 
             assert.equal(result.replace(/\n/g, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.unknown\"><error message=\"Unexpected foo.\"><![CDATA[line 0, col 0, Error - Unexpected foo.]]></error></testcase></testsuite></testsuites>");
         });
     });
 
-    describe("when passed a fatal error message with no line, column, or message text", function() {
+    describe("when passed a fatal error message with no line, column, or message text", () => {
         const code = [{
             filePath: "foo.js",
             messages: [{
@@ -98,14 +98,14 @@ describe("formatter:junit", function() {
             }]
         }];
 
-        it("should return a single <testcase> and an <error>", function() {
+        it("should return a single <testcase> and an <error>", () => {
             const result = formatter(code);
 
             assert.equal(result.replace(/\n/g, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.unknown\"><error message=\"\"><![CDATA[line 0, col 0, Error - ]]></error></testcase></testsuite></testsuites>");
         });
     });
 
-    describe("when passed multiple messages", function() {
+    describe("when passed multiple messages", () => {
         const code = [{
             filePath: "foo.js",
             messages: [{
@@ -123,14 +123,14 @@ describe("formatter:junit", function() {
             }]
         }];
 
-        it("should return a multiple <testcase>'s", function() {
+        it("should return a multiple <testcase>'s", () => {
             const result = formatter(code);
 
             assert.equal(result.replace(/\n/g, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"2\" errors=\"2\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><failure message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Error - Unexpected foo. (foo)]]></failure></testcase><testcase time=\"0\" name=\"org.eslint.bar\"><failure message=\"Unexpected bar.\"><![CDATA[line 6, col 11, Warning - Unexpected bar. (bar)]]></failure></testcase></testsuite></testsuites>");
         });
     });
 
-    describe("when passed special characters", function() {
+    describe("when passed special characters", () => {
         const code = [{
             filePath: "foo.js",
             messages: [{
@@ -142,14 +142,14 @@ describe("formatter:junit", function() {
             }]
         }];
 
-        it("should make them go away", function() {
+        it("should make them go away", () => {
             const result = formatter(code);
 
             assert.equal(result.replace(/\n/g, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><failure message=\"Unexpected &lt;foo&gt;&lt;/foo&gt;&#8;&#9;&#10;&#12;&#13;&#29275;&#36924;.\"><![CDATA[line 5, col 10, Warning - Unexpected &lt;foo&gt;&lt;/foo&gt;&#8;&#9;&#10;&#12;&#13;&#29275;&#36924;. (foo)]]></failure></testcase></testsuite></testsuites>");
         });
     });
 
-    describe("when passed multiple files with 1 message each", function() {
+    describe("when passed multiple files with 1 message each", () => {
         const code = [{
             filePath: "foo.js",
             messages: [{
@@ -170,14 +170,14 @@ describe("formatter:junit", function() {
             }]
         }];
 
-        it("should return 2 <testsuite>'s", function() {
+        it("should return 2 <testsuite>'s", () => {
             const result = formatter(code);
 
             assert.equal(result.replace(/\n/g, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><failure message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Warning - Unexpected foo. (foo)]]></failure></testcase></testsuite><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"bar.js\"><testcase time=\"0\" name=\"org.eslint.bar\"><failure message=\"Unexpected bar.\"><![CDATA[line 6, col 11, Error - Unexpected bar. (bar)]]></failure></testcase></testsuite></testsuites>");
         });
     });
 
-    describe("when passed multiple files with total 1 failure", function() {
+    describe("when passed multiple files with total 1 failure", () => {
         const code = [{
             filePath: "foo.js",
             messages: [{
@@ -192,7 +192,7 @@ describe("formatter:junit", function() {
             messages: []
         }];
 
-        it("should return 1 <testsuite>", function() {
+        it("should return 1 <testsuite>", () => {
             const result = formatter(code);
 
             assert.equal(result.replace(/\n/g, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><failure message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Warning - Unexpected foo. (foo)]]></failure></testcase></testsuite></testsuites>");

--- a/tests/lib/formatters/stylish.js
+++ b/tests/lib/formatters/stylish.js
@@ -40,29 +40,29 @@ const formatter = proxyquire("../../../lib/formatters/stylish", { chalk: chalkSt
 // Tests
 //------------------------------------------------------------------------------
 
-describe("formatter:stylish", function() {
+describe("formatter:stylish", () => {
     let sandbox;
     const colorsEnabled = chalk.enabled;
 
-    beforeEach(function() {
+    beforeEach(() => {
         chalk.enabled = false;
         sandbox = sinon.sandbox.create();
         sandbox.spy(chalkStub.yellow, "bold");
         sandbox.spy(chalkStub.red, "bold");
     });
 
-    afterEach(function() {
+    afterEach(() => {
         sandbox.verifyAndRestore();
         chalk.enabled = colorsEnabled;
     });
 
-    describe("when passed no messages", function() {
+    describe("when passed no messages", () => {
         const code = [{
             filePath: "foo.js",
             messages: []
         }];
 
-        it("should not return message", function() {
+        it("should not return message", () => {
             const result = formatter(code);
 
             assert.equal(result, "");
@@ -71,7 +71,7 @@ describe("formatter:stylish", function() {
         });
     });
 
-    describe("when passed a single message", function() {
+    describe("when passed a single message", () => {
         const code = [{
             filePath: "foo.js",
             messages: [{
@@ -83,7 +83,7 @@ describe("formatter:stylish", function() {
             }]
         }];
 
-        it("should return a string in the correct format for errors", function() {
+        it("should return a string in the correct format for errors", () => {
             const result = formatter(code);
 
             assert.equal(result, "\nfoo.js\n  5:10  error  Unexpected foo  foo\n\n\u2716 1 problem (1 error, 0 warnings)\n");
@@ -91,7 +91,7 @@ describe("formatter:stylish", function() {
             assert.equal(chalkStub.red.bold.callCount, 1);
         });
 
-        it("should return a string in the correct format for warnings", function() {
+        it("should return a string in the correct format for warnings", () => {
             code[0].messages[0].severity = 1;
             const result = formatter(code);
 
@@ -101,7 +101,7 @@ describe("formatter:stylish", function() {
         });
     });
 
-    describe("when passed a fatal error message", function() {
+    describe("when passed a fatal error message", () => {
         const code = [{
             filePath: "foo.js",
             messages: [{
@@ -113,7 +113,7 @@ describe("formatter:stylish", function() {
             }]
         }];
 
-        it("should return a string in the correct format", function() {
+        it("should return a string in the correct format", () => {
             const result = formatter(code);
 
             assert.equal(result, "\nfoo.js\n  5:10  error  Unexpected foo  foo\n\n\u2716 1 problem (1 error, 0 warnings)\n");
@@ -122,7 +122,7 @@ describe("formatter:stylish", function() {
         });
     });
 
-    describe("when passed multiple messages", function() {
+    describe("when passed multiple messages", () => {
         const code = [{
             filePath: "foo.js",
             messages: [{
@@ -140,7 +140,7 @@ describe("formatter:stylish", function() {
             }]
         }];
 
-        it("should return a string with multiple entries", function() {
+        it("should return a string with multiple entries", () => {
             const result = formatter(code);
 
             assert.equal(result, "\nfoo.js\n  5:10  error    Unexpected foo  foo\n  6:11  warning  Unexpected bar  bar\n\n\u2716 2 problems (1 error, 1 warning)\n");
@@ -149,7 +149,7 @@ describe("formatter:stylish", function() {
         });
     });
 
-    describe("when passed multiple files with 1 message each", function() {
+    describe("when passed multiple files with 1 message each", () => {
         const code = [{
             filePath: "foo.js",
             messages: [{
@@ -170,7 +170,7 @@ describe("formatter:stylish", function() {
             }]
         }];
 
-        it("should return a string with multiple entries", function() {
+        it("should return a string with multiple entries", () => {
             const result = formatter(code);
 
             assert.equal(result, "\nfoo.js\n  5:10  error  Unexpected foo  foo\n\nbar.js\n  6:11  warning  Unexpected bar  bar\n\n\u2716 2 problems (1 error, 1 warning)\n");
@@ -179,7 +179,7 @@ describe("formatter:stylish", function() {
         });
     });
 
-    describe("when passed one file not found message", function() {
+    describe("when passed one file not found message", () => {
         const code = [{
             filePath: "foo.js",
             messages: [{
@@ -188,7 +188,7 @@ describe("formatter:stylish", function() {
             }]
         }];
 
-        it("should return a string without line and column", function() {
+        it("should return a string without line and column", () => {
             const result = formatter(code);
 
             assert.equal(result, "\nfoo.js\n  0:0  error  Couldn't find foo.js\n\n\u2716 1 problem (1 error, 0 warnings)\n");

--- a/tests/lib/formatters/table.js
+++ b/tests/lib/formatters/table.js
@@ -15,8 +15,8 @@ const assert = require("chai").assert,
 // Tests
 //------------------------------------------------------------------------------
 
-describe("formatter:table", function() {
-    describe("when passed no messages", function() {
+describe("formatter:table", () => {
+    describe("when passed no messages", () => {
         const code = [
             {
                 filePath: "foo.js",
@@ -26,7 +26,7 @@ describe("formatter:table", function() {
             }
         ];
 
-        it("should return a table of error and warning count with no messages", function() {
+        it("should return a table of error and warning count with no messages", () => {
             const expectedOutput = [
                 "",
                 "╔════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗",
@@ -43,8 +43,8 @@ describe("formatter:table", function() {
         });
     });
 
-    describe("when passed a single message", function() {
-        it("should return a string in the correct format for errors", function() {
+    describe("when passed a single message", () => {
+        it("should return a string in the correct format for errors", () => {
             const code = [
                 {
                     filePath: "foo.js",
@@ -83,7 +83,7 @@ describe("formatter:table", function() {
             assert.equal(result, expectedOutput);
         });
 
-        it("should return a string in the correct format for warnings", function() {
+        it("should return a string in the correct format for warnings", () => {
             const code = [
                 {
                     filePath: "foo.js",
@@ -123,8 +123,8 @@ describe("formatter:table", function() {
         });
     });
 
-    describe("when passed a fatal error message", function() {
-        it("should return a string in the correct format", function() {
+    describe("when passed a fatal error message", () => {
+        it("should return a string in the correct format", () => {
             const code = [
                 {
                     filePath: "foo.js",
@@ -164,8 +164,8 @@ describe("formatter:table", function() {
         });
     });
 
-    describe("when passed multiple messages", function() {
-        it("should return a string with multiple entries", function() {
+    describe("when passed multiple messages", () => {
+        it("should return a string with multiple entries", () => {
             const code = [
                 {
                     filePath: "foo.js",
@@ -213,8 +213,8 @@ describe("formatter:table", function() {
         });
     });
 
-    describe("when passed multiple files with 1 message each", function() {
-        it("should return a string with multiple entries", function() {
+    describe("when passed multiple files with 1 message each", () => {
+        it("should return a string with multiple entries", () => {
             const code = [
                 {
                     filePath: "foo.js",
@@ -273,8 +273,8 @@ describe("formatter:table", function() {
         });
     });
 
-    describe("when passed one file not found message", function() {
-        it("should return a string without line and column (0, 0)", function() {
+    describe("when passed one file not found message", () => {
+        it("should return a string without line and column (0, 0)", () => {
             const code = [
                 {
                     filePath: "foo.js",

--- a/tests/lib/formatters/tap.js
+++ b/tests/lib/formatters/tap.js
@@ -16,21 +16,21 @@ const assert = require("chai").assert,
 // Tests
 //------------------------------------------------------------------------------
 
-describe("formatter:tap", function() {
-    describe("when passed no messages", function() {
+describe("formatter:tap", () => {
+    describe("when passed no messages", () => {
         const code = [{
             filePath: "foo.js",
             messages: []
         }];
 
-        it("should return nothing", function() {
+        it("should return nothing", () => {
             const result = formatter(code);
 
             assert.equal(result, "TAP version 13\n1..1\nok 1 - foo.js\n");
         });
     });
 
-    describe("when passed a single message", function() {
+    describe("when passed a single message", () => {
         const code = [{
             filePath: "foo.js",
             messages: [{
@@ -42,13 +42,13 @@ describe("formatter:tap", function() {
             }]
         }];
 
-        it("should return a string with YAML severity, line and column", function() {
+        it("should return a string with YAML severity, line and column", () => {
             const result = formatter(code);
 
             assert.equal(result, "TAP version 13\n1..1\nnot ok 1 - foo.js\n  ---\n  message: Unexpected foo.\n  severity: error\n  data:\n    line: 5\n    column: 10\n    ruleId: foo\n  ...\n");
         });
 
-        it("should return a string with line: x, column: y, severity: warning for warnings", function() {
+        it("should return a string with line: x, column: y, severity: warning for warnings", () => {
             code[0].messages[0].severity = 1;
             const result = formatter(code);
 
@@ -60,7 +60,7 @@ describe("formatter:tap", function() {
         });
     });
 
-    describe("when passed a fatal error message", function() {
+    describe("when passed a fatal error message", () => {
         const code = [{
             filePath: "foo.js",
             messages: [{
@@ -72,7 +72,7 @@ describe("formatter:tap", function() {
             }]
         }];
 
-        it("should return a an error string", function() {
+        it("should return a an error string", () => {
             const result = formatter(code);
 
             assert.include(result, "not ok");
@@ -80,7 +80,7 @@ describe("formatter:tap", function() {
         });
     });
 
-    describe("when passed multiple messages", function() {
+    describe("when passed multiple messages", () => {
         const code = [{
             filePath: "foo.js",
             messages: [{
@@ -104,7 +104,7 @@ describe("formatter:tap", function() {
             }]
         }];
 
-        it("should return a string with multiple entries", function() {
+        it("should return a string with multiple entries", () => {
             const result = formatter(code);
 
             assert.include(result, "not ok");
@@ -121,7 +121,7 @@ describe("formatter:tap", function() {
         });
     });
 
-    describe("when passed multiple files with 1 message each", function() {
+    describe("when passed multiple files with 1 message each", () => {
         const code = [{
             filePath: "foo.js",
             messages: [{
@@ -142,7 +142,7 @@ describe("formatter:tap", function() {
             }]
         }];
 
-        it("should return a string with multiple entries", function() {
+        it("should return a string with multiple entries", () => {
             const result = formatter(code);
 
             assert.include(result, "not ok 1");
@@ -150,7 +150,7 @@ describe("formatter:tap", function() {
         });
     });
 
-    describe("when passed one file not found message", function() {
+    describe("when passed one file not found message", () => {
         const code = [{
             filePath: "foo.js",
             messages: [{
@@ -159,7 +159,7 @@ describe("formatter:tap", function() {
             }]
         }];
 
-        it("should return a string without line and column", function() {
+        it("should return a string without line and column", () => {
             const result = formatter(code);
 
             assert.include(result, "line: 0");

--- a/tests/lib/formatters/unix.js
+++ b/tests/lib/formatters/unix.js
@@ -16,21 +16,21 @@ const assert = require("chai").assert,
 // Tests
 //------------------------------------------------------------------------------
 
-describe("formatter:compact", function() {
-    describe("when passed no messages", function() {
+describe("formatter:compact", () => {
+    describe("when passed no messages", () => {
         const code = [{
             filePath: "foo.js",
             messages: []
         }];
 
-        it("should return nothing", function() {
+        it("should return nothing", () => {
             const result = formatter(code);
 
             assert.equal(result, "");
         });
     });
 
-    describe("when passed a single message", function() {
+    describe("when passed a single message", () => {
         const code = [{
             filePath: "foo.js",
             messages: [{
@@ -42,13 +42,13 @@ describe("formatter:compact", function() {
             }]
         }];
 
-        it("should return a string in the format filename:line:column: error [Error/rule_id]", function() {
+        it("should return a string in the format filename:line:column: error [Error/rule_id]", () => {
             const result = formatter(code);
 
             assert.equal(result, "foo.js:5:10: Unexpected foo. [Error/foo]\n\n1 problem");
         });
 
-        it("should return a string in the format filename:line:column: warning [Warning/rule_id]", function() {
+        it("should return a string in the format filename:line:column: warning [Warning/rule_id]", () => {
             code[0].messages[0].severity = 1;
             const result = formatter(code);
 
@@ -56,7 +56,7 @@ describe("formatter:compact", function() {
         });
     });
 
-    describe("when passed a fatal error message", function() {
+    describe("when passed a fatal error message", () => {
         const code = [{
             filePath: "foo.js",
             messages: [{
@@ -68,14 +68,14 @@ describe("formatter:compact", function() {
             }]
         }];
 
-        it("should return a string in the format filename:line:column: error [Error/rule_id]", function() {
+        it("should return a string in the format filename:line:column: error [Error/rule_id]", () => {
             const result = formatter(code);
 
             assert.equal(result, "foo.js:5:10: Unexpected foo. [Error/foo]\n\n1 problem");
         });
     });
 
-    describe("when passed multiple messages", function() {
+    describe("when passed multiple messages", () => {
         const code = [{
             filePath: "foo.js",
             messages: [{
@@ -93,14 +93,14 @@ describe("formatter:compact", function() {
             }]
         }];
 
-        it("should return a string with multiple entries", function() {
+        it("should return a string with multiple entries", () => {
             const result = formatter(code);
 
             assert.equal(result, "foo.js:5:10: Unexpected foo. [Error/foo]\nfoo.js:6:11: Unexpected bar. [Warning/bar]\n\n2 problems");
         });
     });
 
-    describe("when passed multiple files with 1 message each", function() {
+    describe("when passed multiple files with 1 message each", () => {
         const code = [{
             filePath: "foo.js",
             messages: [{
@@ -121,14 +121,14 @@ describe("formatter:compact", function() {
             }]
         }];
 
-        it("should return a string with multiple entries", function() {
+        it("should return a string with multiple entries", () => {
             const result = formatter(code);
 
             assert.equal(result, "foo.js:5:10: Unexpected foo. [Error/foo]\nbar.js:6:11: Unexpected bar. [Warning/bar]\n\n2 problems");
         });
     });
 
-    describe("when passed one file not found message", function() {
+    describe("when passed one file not found message", () => {
         const code = [{
             filePath: "foo.js",
             messages: [{
@@ -137,7 +137,7 @@ describe("formatter:compact", function() {
             }]
         }];
 
-        it("should return a string without line and column", function() {
+        it("should return a string without line and column", () => {
             const result = formatter(code);
 
             assert.equal(result, "foo.js:0:0: Couldn't find foo.js. [Error]\n\n1 problem");

--- a/tests/lib/formatters/visualstudio.js
+++ b/tests/lib/formatters/visualstudio.js
@@ -16,21 +16,21 @@ const assert = require("chai").assert,
 // Tests
 //------------------------------------------------------------------------------
 
-describe("formatter:visualstudio", function() {
-    describe("when passed no messages", function() {
+describe("formatter:visualstudio", () => {
+    describe("when passed no messages", () => {
         const code = [{
             filePath: "foo.js",
             messages: []
         }];
 
-        it("should return nothing", function() {
+        it("should return nothing", () => {
             const result = formatter(code);
 
             assert.equal(result, "no problems");
         });
     });
 
-    describe("when passed a single message", function() {
+    describe("when passed a single message", () => {
         const code = [{
             filePath: "foo.js",
             messages: [{
@@ -42,13 +42,13 @@ describe("formatter:visualstudio", function() {
             }]
         }];
 
-        it("should return a string in the format filename(x,y): error z for errors", function() {
+        it("should return a string in the format filename(x,y): error z for errors", () => {
             const result = formatter(code);
 
             assert.equal(result, "foo.js(5,10): error foo : Unexpected foo.\n\n1 problem");
         });
 
-        it("should return a string in the format filename(x,y): warning z for warnings", function() {
+        it("should return a string in the format filename(x,y): warning z for warnings", () => {
             code[0].messages[0].severity = 1;
             const result = formatter(code);
 
@@ -56,7 +56,7 @@ describe("formatter:visualstudio", function() {
         });
     });
 
-    describe("when passed a fatal error message", function() {
+    describe("when passed a fatal error message", () => {
         const code = [{
             filePath: "foo.js",
             messages: [{
@@ -68,14 +68,14 @@ describe("formatter:visualstudio", function() {
             }]
         }];
 
-        it("should return a string in the format filename(x,y): error  z", function() {
+        it("should return a string in the format filename(x,y): error  z", () => {
             const result = formatter(code);
 
             assert.equal(result, "foo.js(5,10): error foo : Unexpected foo.\n\n1 problem");
         });
     });
 
-    describe("when passed multiple messages", function() {
+    describe("when passed multiple messages", () => {
         const code = [{
             filePath: "foo.js",
             messages: [{
@@ -93,14 +93,14 @@ describe("formatter:visualstudio", function() {
             }]
         }];
 
-        it("should return a string with multiple entries", function() {
+        it("should return a string with multiple entries", () => {
             const result = formatter(code);
 
             assert.equal(result, "foo.js(5,10): error foo : Unexpected foo.\nfoo.js(6,11): warning bar : Unexpected bar.\n\n2 problems");
         });
     });
 
-    describe("when passed multiple files with 1 message each", function() {
+    describe("when passed multiple files with 1 message each", () => {
         const code = [{
             filePath: "foo.js",
             messages: [{
@@ -121,14 +121,14 @@ describe("formatter:visualstudio", function() {
             }]
         }];
 
-        it("should return a string with multiple entries", function() {
+        it("should return a string with multiple entries", () => {
             const result = formatter(code);
 
             assert.equal(result, "foo.js(5,10): error foo : Unexpected foo.\nbar.js(6,11): warning bar : Unexpected bar.\n\n2 problems");
         });
     });
 
-    describe("when passed one file not found message", function() {
+    describe("when passed one file not found message", () => {
         const code = [{
             filePath: "foo.js",
             messages: [{
@@ -137,7 +137,7 @@ describe("formatter:visualstudio", function() {
             }]
         }];
 
-        it("should return a string without line and column", function() {
+        it("should return a string without line and column", () => {
             const result = formatter(code);
 
             assert.equal(result, "foo.js(0): error : Couldn't find foo.js.\n\n1 problem");

--- a/tests/lib/ignored-paths.js
+++ b/tests/lib/ignored-paths.js
@@ -158,7 +158,11 @@ describe("IgnoredPaths", () => {
                 ignorePattern
             });
 
-            assert.ok(ignorePattern.every(pattern => getIgnoreRules(ignoredPaths).filter(rule => (rule.pattern === pattern)).length > 0));
+            assert.ok(
+                ignorePattern.every(pattern =>
+                    getIgnoreRules(ignoredPaths).some(rule => rule.pattern === pattern)
+                )
+            );
         });
     });
 

--- a/tests/lib/ignored-paths.js
+++ b/tests/lib/ignored-paths.js
@@ -36,13 +36,11 @@ function getIgnoreRules(ignoredPaths) {
     const ignoreRulesProperty = "_rules";
     let ignoreRules = [];
 
-    Object.keys(ignoredPaths.ig).forEach(function(key) {
+    Object.keys(ignoredPaths.ig).forEach(key => {
         const rules = ignoredPaths.ig[key][ignoreRulesProperty];
 
-        rules.forEach(function(rule) {
-            const ruleOrigins = ignoreRules.map(function(ruleObj) {
-                return ruleObj.origin;
-            });
+        rules.forEach(rule => {
+            const ruleOrigins = ignoreRules.map(ruleObj => ruleObj.origin);
 
             /*
              * Don't include duplicate ignore rules.
@@ -75,9 +73,7 @@ function getIgnoreFiles(ignoredPaths) {
 function getIgnorePatterns(ignoredPaths) {
     const ignoreRules = getIgnoreRules(ignoredPaths);
 
-    return ignoreRules.map(function(rule) {
-        return rule.origin;
-    });
+    return ignoreRules.map(rule => rule.origin);
 }
 
 /**
@@ -110,22 +106,22 @@ function getFixturePath() {
 // Tests
 //------------------------------------------------------------------------------
 
-describe("IgnoredPaths", function() {
+describe("IgnoredPaths", () => {
 
     // copy into clean area so as not to get "infected" by this project's .eslintrc files
-    before(function() {
+    before(() => {
         fixtureDir = path.join(os.tmpdir(), "/eslint/fixtures/ignored-paths/");
         mkdir("-p", fixtureDir);
         cp("-r", "./tests/fixtures/ignored-paths/.", fixtureDir);
     });
 
-    after(function() {
+    after(() => {
         rm("-r", fixtureDir);
     });
 
-    describe("initialization", function() {
+    describe("initialization", () => {
 
-        it("should load .eslintignore from cwd when explicitly passed", function() {
+        it("should load .eslintignore from cwd when explicitly passed", () => {
             const expectedIgnoreFile = getFixturePath(".eslintignore");
             const ignoredPaths = new IgnoredPaths({ ignore: true, cwd: getFixturePath() });
             const ignorePatterns = getIgnorePatterns(ignoredPaths);
@@ -135,44 +131,40 @@ describe("IgnoredPaths", function() {
             assert.include(ignorePatterns, "sampleignorepattern");
         });
 
-        it("should set baseDir to cwd when no ignore file was loaded", function() {
+        it("should set baseDir to cwd when no ignore file was loaded", () => {
             const ignoredPaths = new IgnoredPaths({ cwd: getFixturePath("no-ignore-file") });
 
             assert.equal(ignoredPaths.baseDir, getFixturePath("no-ignore-file"));
         });
 
-        it("should not travel to parent directories to find .eslintignore when it's missing and cwd is provided", function() {
+        it("should not travel to parent directories to find .eslintignore when it's missing and cwd is provided", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: true, cwd: getFixturePath("configurations") });
 
             assert.lengthOf(getIgnoreRules(ignoredPaths), 4);
             assert.lengthOf(getIgnoreFiles(ignoredPaths), 0);
         });
 
-        it("should load empty array with ignorePath set to false", function() {
+        it("should load empty array with ignorePath set to false", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: true, ignorePath: false, cwd: getFixturePath("no-ignore-file") });
 
             assert.isArray(getIgnoreRules(ignoredPaths));
             assert.lengthOf(getIgnoreRules(ignoredPaths), countDefaultPatterns(ignoredPaths));
         });
 
-        it("should accept an array for options.ignorePattern", function() {
+        it("should accept an array for options.ignorePattern", () => {
             const ignorePattern = ["a", "b"];
 
             const ignoredPaths = new IgnoredPaths({
                 ignorePattern
             });
 
-            assert.ok(ignorePattern.every(function(pattern) {
-                return getIgnoreRules(ignoredPaths).filter(function(rule) {
-                    return (rule.pattern === pattern);
-                }).length > 0;
-            }));
+            assert.ok(ignorePattern.every(pattern => getIgnoreRules(ignoredPaths).filter(rule => (rule.pattern === pattern)).length > 0));
         });
     });
 
-    describe("initialization with ignorePattern", function() {
+    describe("initialization with ignorePattern", () => {
 
-        it("should ignore a normal pattern", function() {
+        it("should ignore a normal pattern", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: true, ignorePattern: "ignore-me.txt", cwd: getFixturePath("ignore-pattern") });
 
             assert.isTrue(ignoredPaths.contains(getFixturePath("ignore-pattern", "ignore-me.txt")));
@@ -180,15 +172,15 @@ describe("IgnoredPaths", function() {
 
     });
 
-    describe("initialization with ignorePath", function() {
+    describe("initialization with ignorePath", () => {
 
         let ignoreFilePath;
 
-        before(function() {
+        before(() => {
             ignoreFilePath = getFixturePath(".eslintignore");
         });
 
-        it("should set baseDir to directory containing ignorePath if provided", function() {
+        it("should set baseDir to directory containing ignorePath if provided", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: true, ignorePath: ignoreFilePath, cwd: getFixturePath() });
 
             assert.equal(ignoredPaths.baseDir, path.dirname(ignoreFilePath));
@@ -196,27 +188,27 @@ describe("IgnoredPaths", function() {
 
     });
 
-    describe("initialization with ignorePath file not named .eslintignore", function() {
+    describe("initialization with ignorePath file not named .eslintignore", () => {
 
         let ignoreFilePath;
 
-        before(function() {
+        before(() => {
             ignoreFilePath = getFixturePath("custom-name", "ignore-file");
         });
 
-        it("should work when cwd is a parent directory", function() {
+        it("should work when cwd is a parent directory", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: true, ignorePath: ignoreFilePath, cwd: getFixturePath() });
 
             assert.notEqual(getIgnoreRules(ignoredPaths).length, countDefaultPatterns(ignoredPaths));
         });
 
-        it("should work when the file is in the cwd", function() {
+        it("should work when the file is in the cwd", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: true, ignorePath: ignoreFilePath, cwd: getFixturePath("custom-name") });
 
             assert.notEqual(getIgnoreRules(ignoredPaths).length, countDefaultPatterns(ignoredPaths));
         });
 
-        it("should work when cwd is a subdirectory", function() {
+        it("should work when cwd is a subdirectory", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: true, ignorePath: ignoreFilePath, cwd: getFixturePath("custom-name", "subdirectory") });
 
             assert.notEqual(getIgnoreRules(ignoredPaths).length, countDefaultPatterns(ignoredPaths));
@@ -224,9 +216,9 @@ describe("IgnoredPaths", function() {
 
     });
 
-    describe("initialization without ignorePath", function() {
+    describe("initialization without ignorePath", () => {
 
-        it("should not load an ignore file if none is in cwd", function() {
+        it("should not load an ignore file if none is in cwd", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: true, cwd: getFixturePath("no-ignore-file") });
 
             assert.lengthOf(getIgnoreFiles(ignoredPaths), 0);
@@ -235,16 +227,16 @@ describe("IgnoredPaths", function() {
 
     });
 
-    describe("initialization with invalid file", function() {
+    describe("initialization with invalid file", () => {
 
         let invalidFilepath;
 
-        before(function() {
+        before(() => {
             invalidFilepath = getFixturePath("not-a-directory", ".foobaz");
         });
 
-        it("should throw error", function() {
-            assert.throws(function() {
+        it("should throw error", () => {
+            assert.throws(() => {
                 const ignoredPaths = new IgnoredPaths({ ignore: true, ignorePath: invalidFilepath, cwd: getFixturePath() });
 
                 assert.ok(ignoredPaths);
@@ -253,29 +245,29 @@ describe("IgnoredPaths", function() {
 
     });
 
-    describe("contains", function() {
+    describe("contains", () => {
 
-        it("should throw if initialized with invalid options", function() {
+        it("should throw if initialized with invalid options", () => {
             const ignoredPaths = new IgnoredPaths(null);
 
             assert.throw(ignoredPaths.contains, Error);
         });
 
-        it("should not throw if given a relative filename", function() {
+        it("should not throw if given a relative filename", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: true, ignorePattern: "undef.js", cwd: getFixturePath() });
 
-            assert.doesNotThrow(function() {
+            assert.doesNotThrow(() => {
                 ignoredPaths.contains("undef.js");
             });
         });
 
-        it("should return true for files which match an ignorePattern even if they do not exist on the filesystem", function() {
+        it("should return true for files which match an ignorePattern even if they do not exist on the filesystem", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: true, ignorePattern: "not-a-file", cwd: getFixturePath() });
 
             assert.isTrue(ignoredPaths.contains(getFixturePath("not-a-file")));
         });
 
-        it("should return false for files outside of the cwd (with no ignore file provided)", function() {
+        it("should return false for files outside of the cwd (with no ignore file provided)", () => {
 
             // Default ignore patterns should not inadvertantly ignore files in parent directories
             const ignoredPaths = new IgnoredPaths({ ignore: true, cwd: getFixturePath("no-ignore-file") });
@@ -283,43 +275,43 @@ describe("IgnoredPaths", function() {
             assert.isFalse(ignoredPaths.contains(getFixturePath("undef.js")));
         });
 
-        it("should return false for files outside of ignorePath's directory", function() {
+        it("should return false for files outside of ignorePath's directory", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: true, ignorePath: getFixturePath("custom-name", "ignore-file"), cwd: getFixturePath() });
 
             assert.isFalse(ignoredPaths.contains(getFixturePath("undef.js")));
         });
 
-        it("should return true for file matching an ignore pattern exactly", function() {
+        it("should return true for file matching an ignore pattern exactly", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: true, ignorePattern: "undef.js", cwd: getFixturePath() });
 
             assert.isTrue(ignoredPaths.contains(getFixturePath("undef.js")));
         });
 
-        it("should return false for file matching an invalid ignore pattern with leading './'", function() {
+        it("should return false for file matching an invalid ignore pattern with leading './'", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: true, ignorePattern: "./undef.js", cwd: getFixturePath() });
 
             assert.isFalse(ignoredPaths.contains(getFixturePath("undef.js")));
         });
 
-        it("should return false for file in subfolder of cwd matching an ignore pattern with leading '/'", function() {
+        it("should return false for file in subfolder of cwd matching an ignore pattern with leading '/'", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: true, ignorePattern: "/undef.js", cwd: getFixturePath() });
 
             assert.isFalse(ignoredPaths.contains(getFixturePath("subdir", "undef.js")));
         });
 
-        it("should return true for file matching a child of an ignore pattern", function() {
+        it("should return true for file matching a child of an ignore pattern", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: true, ignorePattern: "ignore-pattern", cwd: getFixturePath() });
 
             assert.isTrue(ignoredPaths.contains(getFixturePath("ignore-pattern", "ignore-me.txt")));
         });
 
-        it("should return true for file matching a grandchild of an ignore pattern", function() {
+        it("should return true for file matching a grandchild of an ignore pattern", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: true, ignorePattern: "ignore-pattern", cwd: getFixturePath() });
 
             assert.isTrue(ignoredPaths.contains(getFixturePath("ignore-pattern", "subdir", "ignore-me.txt")));
         });
 
-        it("should return true for file matching a child of an ignore pattern with windows line termination", function() {
+        it("should return true for file matching a child of an ignore pattern with windows line termination", () => {
             sinon.stub(fs, "readFileSync")
                 .withArgs(".eslintignore")
                 .returns("subdir\r\n");
@@ -334,13 +326,13 @@ describe("IgnoredPaths", function() {
             fs.statSync.restore();
         });
 
-        it("should return false for file not matching any ignore pattern", function() {
+        it("should return false for file not matching any ignore pattern", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: true, ignorePattern: "failing.js", cwd: getFixturePath() });
 
             assert.isFalse(ignoredPaths.contains(getFixturePath("unignored.js")));
         });
 
-        it("should return false for ignored file when unignored with ignore pattern", function() {
+        it("should return false for ignored file when unignored with ignore pattern", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: true, ignorePath: getFixturePath(".eslintignore"), ignorePattern: "!sampleignorepattern", cwd: getFixturePath() });
 
             assert.isFalse(ignoredPaths.contains(getFixturePath("sampleignorepattern")));
@@ -348,15 +340,15 @@ describe("IgnoredPaths", function() {
         });
     });
 
-    describe("initialization with ignorePath containing commented lines", function() {
+    describe("initialization with ignorePath containing commented lines", () => {
 
         let ignoreFilePath;
 
-        before(function() {
+        before(() => {
             ignoreFilePath = getFixturePath(".eslintignoreWithComments");
         });
 
-        it("should not include comments in ignore rules", function() {
+        it("should not include comments in ignore rules", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: true, ignorePath: ignoreFilePath, cwd: getFixturePath() });
             const ignorePatterns = getIgnorePatterns(ignoredPaths);
 
@@ -366,20 +358,20 @@ describe("IgnoredPaths", function() {
 
     });
 
-    describe("initialization with ignorePath containing negations", function() {
+    describe("initialization with ignorePath containing negations", () => {
         let ignoreFilePath;
 
-        before(function() {
+        before(() => {
             ignoreFilePath = getFixturePath(".eslintignoreWithNegation");
         });
 
-        it("should ignore a non-negated pattern", function() {
+        it("should ignore a non-negated pattern", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: true, ignorePath: ignoreFilePath, cwd: getFixturePath() });
 
             assert.isTrue(ignoredPaths.contains(getFixturePath("negation", "ignore.js")));
         });
 
-        it("should not ignore a negated pattern", function() {
+        it("should not ignore a negated pattern", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: true, ignorePath: ignoreFilePath, cwd: getFixturePath() });
 
             assert.isFalse(ignoredPaths.contains(getFixturePath("negation", "unignore.js")));
@@ -387,95 +379,95 @@ describe("IgnoredPaths", function() {
 
     });
 
-    describe("default ignores", function() {
+    describe("default ignores", () => {
 
-        it("should contain /bower_components/*", function() {
+        it("should contain /bower_components/*", () => {
             const ignoredPaths = new IgnoredPaths();
 
             assert.include(ignoredPaths.defaultPatterns, "/bower_components/*");
         });
 
-        it("should contain /node_modules/*", function() {
+        it("should contain /node_modules/*", () => {
             const ignoredPaths = new IgnoredPaths();
 
             assert.include(ignoredPaths.defaultPatterns, "/node_modules/*");
         });
 
-        it("should always apply defaultPatterns if ignore option is true", function() {
+        it("should always apply defaultPatterns if ignore option is true", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: true, cwd: getFixturePath() });
 
             assert.isTrue(ignoredPaths.contains(getFixturePath("bower_components/package/file.js")));
             assert.isTrue(ignoredPaths.contains(getFixturePath("node_modules/package/file.js")));
         });
 
-        it("should still apply defaultPatterns if ignore option is is false", function() {
+        it("should still apply defaultPatterns if ignore option is is false", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: false, cwd: getFixturePath() });
 
             assert.isTrue(ignoredPaths.contains(getFixturePath("bower_components/package/file.js")));
             assert.isTrue(ignoredPaths.contains(getFixturePath("node_modules/package/file.js")));
         });
 
-        it("should not ignore files in defaultPatterns within a subdirectory", function() {
+        it("should not ignore files in defaultPatterns within a subdirectory", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: true, cwd: getFixturePath() });
 
             assert.isFalse(ignoredPaths.contains(getFixturePath("subdir/bower_components/package/file.js")));
             assert.isFalse(ignoredPaths.contains(getFixturePath("subdir/node_modules/package/file.js")));
         });
 
-        it("should allow subfolders of defaultPatterns to be unignored by ignorePattern", function() {
+        it("should allow subfolders of defaultPatterns to be unignored by ignorePattern", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: true, cwd: getFixturePath(), ignorePattern: "!/node_modules/package" });
 
             assert.isFalse(ignoredPaths.contains(getFixturePath("node_modules", "package", "file.js")));
         });
 
-        it("should allow subfolders of defaultPatterns to be unignored by ignorePath", function() {
+        it("should allow subfolders of defaultPatterns to be unignored by ignorePath", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: true, cwd: getFixturePath(), ignorePath: getFixturePath(".eslintignoreWithUnignoredDefaults") });
 
             assert.isFalse(ignoredPaths.contains(getFixturePath("node_modules", "package", "file.js")));
         });
 
-        it("should ignore dotfiles", function() {
+        it("should ignore dotfiles", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: true, cwd: getFixturePath() });
 
             assert.isTrue(ignoredPaths.contains(getFixturePath(".foo")));
             assert.isTrue(ignoredPaths.contains(getFixturePath("foo/.bar")));
         });
 
-        it("should ignore directories beginning with a dot", function() {
+        it("should ignore directories beginning with a dot", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: true, cwd: getFixturePath() });
 
             assert.isTrue(ignoredPaths.contains(getFixturePath(".foo/bar")));
             assert.isTrue(ignoredPaths.contains(getFixturePath("foo/.bar/baz")));
         });
 
-        it("should still ignore dotfiles when ignore option disabled", function() {
+        it("should still ignore dotfiles when ignore option disabled", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: false, cwd: getFixturePath() });
 
             assert.isTrue(ignoredPaths.contains(getFixturePath(".foo")));
             assert.isTrue(ignoredPaths.contains(getFixturePath("foo/.bar")));
         });
 
-        it("should still ignore directories beginning with a dot when ignore option disabled", function() {
+        it("should still ignore directories beginning with a dot when ignore option disabled", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: false, cwd: getFixturePath() });
 
             assert.isTrue(ignoredPaths.contains(getFixturePath(".foo/bar")));
             assert.isTrue(ignoredPaths.contains(getFixturePath("foo/.bar/baz")));
         });
 
-        it("should not ignore absolute paths containing '..'", function() {
+        it("should not ignore absolute paths containing '..'", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: true, cwd: getFixturePath() });
 
             assert.isFalse(ignoredPaths.contains(`${getFixturePath("foo")}/../unignored.js`));
         });
 
-        it("should ignore /node_modules/ at top level relative to .eslintignore when loaded", function() {
+        it("should ignore /node_modules/ at top level relative to .eslintignore when loaded", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: true, ignorePath: getFixturePath(".eslintignore"), cwd: getFixturePath() });
 
             assert.isTrue(ignoredPaths.contains(getFixturePath("node_modules", "existing.js")));
             assert.isFalse(ignoredPaths.contains(getFixturePath("foo", "node_modules", "existing.js")));
         });
 
-        it("should ignore /node_modules/ at top level relative to cwd without an .eslintignore", function() {
+        it("should ignore /node_modules/ at top level relative to cwd without an .eslintignore", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: true, cwd: getFixturePath("no-ignore-file") });
 
             assert.isTrue(ignoredPaths.contains(getFixturePath("no-ignore-file", "node_modules", "existing.js")));
@@ -484,9 +476,9 @@ describe("IgnoredPaths", function() {
 
     });
 
-    describe("two globstar '**' ignore pattern", function() {
+    describe("two globstar '**' ignore pattern", () => {
 
-        it("should ignore files in nested directories", function() {
+        it("should ignore files in nested directories", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: true, ignorePattern: "**/*.js", cwd: getFixturePath() });
 
             assert.isTrue(ignoredPaths instanceof IgnoredPaths);
@@ -499,28 +491,28 @@ describe("IgnoredPaths", function() {
         });
     });
 
-    describe("dotfiles option", function() {
+    describe("dotfiles option", () => {
 
-        it("should add at least one pattern when false", function() {
+        it("should add at least one pattern when false", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: true, dotfiles: false, cwd: getFixturePath("no-ignore-file") });
 
             assert(getIgnoreRules(ignoredPaths).length > ignoredPaths.defaultPatterns.length);
         });
 
-        it("should add no patterns when true", function() {
+        it("should add no patterns when true", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: true, dotfiles: true, cwd: getFixturePath("no-ignore-file") });
 
             assert.lengthOf(getIgnoreRules(ignoredPaths), ignoredPaths.defaultPatterns.length);
         });
 
-        it("should not ignore dotfiles when true", function() {
+        it("should not ignore dotfiles when true", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: true, dotfiles: true, cwd: getFixturePath() });
 
             assert.isFalse(ignoredPaths.contains(getFixturePath(".foo")));
             assert.isFalse(ignoredPaths.contains(getFixturePath("foo/.bar")));
         });
 
-        it("should not ignore directories beginning with a dot when true", function() {
+        it("should not ignore directories beginning with a dot when true", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: true, dotfiles: true, cwd: getFixturePath() });
 
             assert.isFalse(ignoredPaths.contains(getFixturePath(".foo/bar")));
@@ -529,7 +521,7 @@ describe("IgnoredPaths", function() {
 
     });
 
-    describe("getIgnoredFoldersGlobChecker", function() {
+    describe("getIgnoredFoldersGlobChecker", () => {
 
         /**
          * Creates a function to resolve the given relative path according to the `cwd`
@@ -542,7 +534,7 @@ describe("IgnoredPaths", function() {
             };
         }
 
-        it("should ignore default folders when there is no eslintignore file", function() {
+        it("should ignore default folders when there is no eslintignore file", () => {
             const cwd = getFixturePath("no-ignore-file");
             const ignoredPaths = new IgnoredPaths({ ignore: true, cwd });
 
@@ -556,7 +548,7 @@ describe("IgnoredPaths", function() {
             assert.isFalse(shouldIgnore(resolve(".hidden")));
         });
 
-        it("should ignore default folders there is an ignore file without unignored defaults", function() {
+        it("should ignore default folders there is an ignore file without unignored defaults", () => {
             const cwd = getFixturePath();
             const ignoredPaths = new IgnoredPaths({ ignore: true, ignorePath: getFixturePath(".eslintignore"), cwd });
 
@@ -570,7 +562,7 @@ describe("IgnoredPaths", function() {
             assert.isFalse(shouldIgnore(resolve(".hidden")));
         });
 
-        it("should not ignore things which are re-included in ignore file", function() {
+        it("should not ignore things which are re-included in ignore file", () => {
             const cwd = getFixturePath();
             const ignoredPaths = new IgnoredPaths({ ignore: true, ignorePath: getFixturePath(".eslintignoreWithUnignoredDefaults"), cwd });
 
@@ -586,7 +578,7 @@ describe("IgnoredPaths", function() {
             assert.isFalse(shouldIgnore(resolve("bower_components/package")));
         });
 
-        it("should ignore files which we try to re-include in ignore file when ignore option is disabled", function() {
+        it("should ignore files which we try to re-include in ignore file when ignore option is disabled", () => {
             const cwd = getFixturePath();
             const ignoredPaths = new IgnoredPaths({ ignore: false, ignorePath: getFixturePath(".eslintignoreWithUnignoredDefaults"), cwd });
 
@@ -602,7 +594,7 @@ describe("IgnoredPaths", function() {
             assert.isTrue(shouldIgnore(resolve("bower_components/package")));
         });
 
-        it("should not ignore dirs which are re-included by ignorePattern", function() {
+        it("should not ignore dirs which are re-included by ignorePattern", () => {
             const cwd = getFixturePath("no-ignore-file");
             const ignoredPaths = new IgnoredPaths({ ignore: true, cwd, ignorePattern: "!/node_modules/package" });
 

--- a/tests/lib/options.js
+++ b/tests/lib/options.js
@@ -20,25 +20,25 @@ const assert = require("chai").assert,
  * This is testing the interface of the options object.
  */
 
-describe("options", function() {
-    describe("--help", function() {
-        it("should return true for .help when passed", function() {
+describe("options", () => {
+    describe("--help", () => {
+        it("should return true for .help when passed", () => {
             const currentOptions = options.parse("--help");
 
             assert.isTrue(currentOptions.help);
         });
     });
 
-    describe("-h", function() {
-        it("should return true for .help when passed", function() {
+    describe("-h", () => {
+        it("should return true for .help when passed", () => {
             const currentOptions = options.parse("-h");
 
             assert.isTrue(currentOptions.help);
         });
     });
 
-    describe("--config", function() {
-        it("should return a string for .config when passed a string", function() {
+    describe("--config", () => {
+        it("should return a string for .config when passed a string", () => {
             const currentOptions = options.parse("--config file");
 
             assert.isString(currentOptions.config);
@@ -46,8 +46,8 @@ describe("options", function() {
         });
     });
 
-    describe("-c", function() {
-        it("should return a string for .config when passed a string", function() {
+    describe("-c", () => {
+        it("should return a string for .config when passed a string", () => {
             const currentOptions = options.parse("-c file");
 
             assert.isString(currentOptions.config);
@@ -55,15 +55,15 @@ describe("options", function() {
         });
     });
 
-    describe("--ext", function() {
-        it("should return an array with one item when passed .jsx", function() {
+    describe("--ext", () => {
+        it("should return an array with one item when passed .jsx", () => {
             const currentOptions = options.parse("--ext .jsx");
 
             assert.isArray(currentOptions.ext);
             assert.equal(currentOptions.ext[0], ".jsx");
         });
 
-        it("should return an array with two items when passed .js and .jsx", function() {
+        it("should return an array with two items when passed .js and .jsx", () => {
             const currentOptions = options.parse("--ext .jsx --ext .js");
 
             assert.isArray(currentOptions.ext);
@@ -71,7 +71,7 @@ describe("options", function() {
             assert.equal(currentOptions.ext[1], ".js");
         });
 
-        it("should return an array with two items when passed .jsx,.js", function() {
+        it("should return an array with two items when passed .jsx,.js", () => {
             const currentOptions = options.parse("--ext .jsx,.js");
 
             assert.isArray(currentOptions.ext);
@@ -79,7 +79,7 @@ describe("options", function() {
             assert.equal(currentOptions.ext[1], ".js");
         });
 
-        it("should return an array one item when not passed", function() {
+        it("should return an array one item when not passed", () => {
             const currentOptions = options.parse("");
 
             assert.isArray(currentOptions.ext);
@@ -87,8 +87,8 @@ describe("options", function() {
         });
     });
 
-    describe("--rulesdir", function() {
-        it("should return a string for .rulesdir when passed a string", function() {
+    describe("--rulesdir", () => {
+        it("should return a string for .rulesdir when passed a string", () => {
             const currentOptions = options.parse("--rulesdir /morerules");
 
             assert.isArray(currentOptions.rulesdir);
@@ -96,15 +96,15 @@ describe("options", function() {
         });
     });
 
-    describe("--format", function() {
-        it("should return a string for .format when passed a string", function() {
+    describe("--format", () => {
+        it("should return a string for .format when passed a string", () => {
             const currentOptions = options.parse("--format compact");
 
             assert.isString(currentOptions.format);
             assert.equal(currentOptions.format, "compact");
         });
 
-        it("should return stylish for .format when not passed", function() {
+        it("should return stylish for .format when not passed", () => {
             const currentOptions = options.parse("");
 
             assert.isString(currentOptions.format);
@@ -112,8 +112,8 @@ describe("options", function() {
         });
     });
 
-    describe("-f", function() {
-        it("should return a string for .format when passed a string", function() {
+    describe("-f", () => {
+        it("should return a string for .format when passed a string", () => {
             const currentOptions = options.parse("-f compact");
 
             assert.isString(currentOptions.format);
@@ -121,48 +121,48 @@ describe("options", function() {
         });
     });
 
-    describe("--version", function() {
-        it("should return true for .version when passed", function() {
+    describe("--version", () => {
+        it("should return true for .version when passed", () => {
             const currentOptions = options.parse("--version");
 
             assert.isTrue(currentOptions.version);
         });
     });
 
-    describe("-v", function() {
-        it("should return true for .version when passed", function() {
+    describe("-v", () => {
+        it("should return true for .version when passed", () => {
             const currentOptions = options.parse("-v");
 
             assert.isTrue(currentOptions.version);
         });
     });
 
-    describe("when asking for help", function() {
-        it("should return string of help text when called", function() {
+    describe("when asking for help", () => {
+        it("should return string of help text when called", () => {
             const helpText = options.generateHelp();
 
             assert.isString(helpText);
         });
     });
 
-    describe("--no-ignore", function() {
-        it("should return false for .ignore when passed", function() {
+    describe("--no-ignore", () => {
+        it("should return false for .ignore when passed", () => {
             const currentOptions = options.parse("--no-ignore");
 
             assert.isFalse(currentOptions.ignore);
         });
     });
 
-    describe("--ignore-path", function() {
-        it("should return a string for .ignorePath when passed", function() {
+    describe("--ignore-path", () => {
+        it("should return a string for .ignorePath when passed", () => {
             const currentOptions = options.parse("--ignore-path .gitignore");
 
             assert.equal(currentOptions.ignorePath, ".gitignore");
         });
     });
 
-    describe("--ignore-pattern", function() {
-        it("should return a string array for .ignorePattern when passed", function() {
+    describe("--ignore-pattern", () => {
+        it("should return a string array for .ignorePattern when passed", () => {
             const currentOptions = options.parse("--ignore-pattern *.js");
 
             assert.ok(currentOptions.ignorePattern);
@@ -170,7 +170,7 @@ describe("options", function() {
             assert.equal(currentOptions.ignorePattern[0], "*.js");
         });
 
-        it("should return a string array for multiple values", function() {
+        it("should return a string array for multiple values", () => {
             const currentOptions = options.parse("--ignore-pattern *.js --ignore-pattern *.ts");
 
             assert.ok(currentOptions.ignorePattern);
@@ -179,7 +179,7 @@ describe("options", function() {
             assert.equal(currentOptions.ignorePattern[1], "*.ts");
         });
 
-        it("should return a string array of properly parsed values, when those values include commas", function() {
+        it("should return a string array of properly parsed values, when those values include commas", () => {
             const currentOptions = options.parse("--ignore-pattern *.js --ignore-pattern foo-{bar,baz}.js");
 
             assert.ok(currentOptions.ignorePattern);
@@ -189,38 +189,38 @@ describe("options", function() {
         });
     });
 
-    describe("--color", function() {
-        it("should return true for .color when passed --color", function() {
+    describe("--color", () => {
+        it("should return true for .color when passed --color", () => {
             const currentOptions = options.parse("--color");
 
             assert.isTrue(currentOptions.color);
         });
 
-        it("should return false for .color when passed --no-color", function() {
+        it("should return false for .color when passed --no-color", () => {
             const currentOptions = options.parse("--no-color");
 
             assert.isFalse(currentOptions.color);
         });
     });
 
-    describe("--stdin", function() {
-        it("should return true for .stdin when passed", function() {
+    describe("--stdin", () => {
+        it("should return true for .stdin when passed", () => {
             const currentOptions = options.parse("--stdin");
 
             assert.isTrue(currentOptions.stdin);
         });
     });
 
-    describe("--stdin-filename", function() {
-        it("should return a string for .stdinFilename when passed", function() {
+    describe("--stdin-filename", () => {
+        it("should return a string for .stdinFilename when passed", () => {
             const currentOptions = options.parse("--stdin-filename test.js");
 
             assert.equal(currentOptions.stdinFilename, "test.js");
         });
     });
 
-    describe("--global", function() {
-        it("should return an array for a single occurrence", function() {
+    describe("--global", () => {
+        it("should return an array for a single occurrence", () => {
             const currentOptions = options.parse("--global foo");
 
             assert.isArray(currentOptions.global);
@@ -228,7 +228,7 @@ describe("options", function() {
             assert.equal(currentOptions.global[0], "foo");
         });
 
-        it("should split variable names using commas", function() {
+        it("should split variable names using commas", () => {
             const currentOptions = options.parse("--global foo,bar");
 
             assert.isArray(currentOptions.global);
@@ -237,7 +237,7 @@ describe("options", function() {
             assert.equal(currentOptions.global[1], "bar");
         });
 
-        it("should not split on colons", function() {
+        it("should not split on colons", () => {
             const currentOptions = options.parse("--global foo:false,bar:true");
 
             assert.isArray(currentOptions.global);
@@ -246,7 +246,7 @@ describe("options", function() {
             assert.equal(currentOptions.global[1], "bar:true");
         });
 
-        it("should concatenate successive occurrences", function() {
+        it("should concatenate successive occurrences", () => {
             const currentOptions = options.parse("--global foo:true --global bar:false");
 
             assert.isArray(currentOptions.global);
@@ -256,8 +256,8 @@ describe("options", function() {
         });
     });
 
-    describe("--plugin", function() {
-        it("should return an array when passed a single occurrence", function() {
+    describe("--plugin", () => {
+        it("should return an array when passed a single occurrence", () => {
             const currentOptions = options.parse("--plugin single");
 
             assert.isArray(currentOptions.plugin);
@@ -265,7 +265,7 @@ describe("options", function() {
             assert.equal(currentOptions.plugin[0], "single");
         });
 
-        it("should return an array when passed a comma-delimiated string", function() {
+        it("should return an array when passed a comma-delimiated string", () => {
             const currentOptions = options.parse("--plugin foo,bar");
 
             assert.isArray(currentOptions.plugin);
@@ -274,7 +274,7 @@ describe("options", function() {
             assert.equal(currentOptions.plugin[1], "bar");
         });
 
-        it("should return an array when passed multiple times", function() {
+        it("should return an array when passed multiple times", () => {
             const currentOptions = options.parse("--plugin foo --plugin bar");
 
             assert.isArray(currentOptions.plugin);
@@ -284,82 +284,82 @@ describe("options", function() {
         });
     });
 
-    describe("--quiet", function() {
-        it("should return true for .quiet when passed", function() {
+    describe("--quiet", () => {
+        it("should return true for .quiet when passed", () => {
             const currentOptions = options.parse("--quiet");
 
             assert.isTrue(currentOptions.quiet);
         });
     });
 
-    describe("--max-warnings", function() {
-        it("should return correct value for .maxWarnings when passed", function() {
+    describe("--max-warnings", () => {
+        it("should return correct value for .maxWarnings when passed", () => {
             const currentOptions = options.parse("--max-warnings 10");
 
             assert.equal(currentOptions.maxWarnings, 10);
         });
 
-        it("should return -1 for .maxWarnings when not passed", function() {
+        it("should return -1 for .maxWarnings when not passed", () => {
             const currentOptions = options.parse("");
 
             assert.equal(currentOptions.maxWarnings, -1);
         });
 
-        it("should throw an error when supplied with a non-integer", function() {
-            assert.throws(function() {
+        it("should throw an error when supplied with a non-integer", () => {
+            assert.throws(() => {
                 options.parse("--max-warnings 10.2");
             }, /Invalid value for option 'max-warnings' - expected type Int/);
         });
     });
 
-    describe("--init", function() {
-        it("should return true for --init when passed", function() {
+    describe("--init", () => {
+        it("should return true for --init when passed", () => {
             const currentOptions = options.parse("--init");
 
             assert.isTrue(currentOptions.init);
         });
     });
 
-    describe("--fix", function() {
-        it("should return true for --fix when passed", function() {
+    describe("--fix", () => {
+        it("should return true for --fix when passed", () => {
             const currentOptions = options.parse("--fix");
 
             assert.isTrue(currentOptions.fix);
         });
     });
 
-    describe("--debug", function() {
-        it("should return true for --debug when passed", function() {
+    describe("--debug", () => {
+        it("should return true for --debug when passed", () => {
             const currentOptions = options.parse("--debug");
 
             assert.isTrue(currentOptions.debug);
         });
     });
 
-    describe("--inline-config", function() {
-        it("should return false when passed --no-inline-config", function() {
+    describe("--inline-config", () => {
+        it("should return false when passed --no-inline-config", () => {
             const currentOptions = options.parse("--no-inline-config");
 
             assert.isFalse(currentOptions.inlineConfig);
         });
 
-        it("should return true for --inline-config when empty", function() {
+        it("should return true for --inline-config when empty", () => {
             const currentOptions = options.parse("");
 
             assert.isTrue(currentOptions.inlineConfig);
         });
     });
 
-    describe("--parser", function() {
-        it("should return a string for --parser when passed", function() {
+    describe("--parser", () => {
+        it("should return a string for --parser when passed", () => {
             const currentOptions = options.parse("--parser test");
 
             assert.equal(currentOptions.parser, "test");
         });
     });
 
-    describe("--print-config", function() {
-        it("should return file path when passed --print-config", function() {
+    describe("--print-config", () => {
+        it("should return file path when passed --print-config", () => {
             const currentOptions = options.parse("--print-config file.js");
 
             assert.strictEqual(currentOptions.printConfig, "file.js");

--- a/tests/lib/rule-context.js
+++ b/tests/lib/rule-context.js
@@ -19,19 +19,19 @@ const sinon = require("sinon"),
 // Tests
 //------------------------------------------------------------------------------
 
-describe("RuleContext", function() {
+describe("RuleContext", () => {
     const sandbox = sinon.sandbox.create();
 
-    describe("report()", function() {
+    describe("report()", () => {
         let ruleContext, eslint;
 
-        beforeEach(function() {
+        beforeEach(() => {
             eslint = leche.fake(realESLint);
             ruleContext = new RuleContext("fake-rule", eslint, 2, {}, {}, {}, "espree");
         });
 
-        describe("old-style call with location", function() {
-            it("should call eslint.report() with rule ID and severity prepended", function() {
+        describe("old-style call with location", () => {
+            it("should call eslint.report() with rule ID and severity prepended", () => {
                 const node = {},
                     location = {},
                     message = "Message",
@@ -49,8 +49,8 @@ describe("RuleContext", function() {
             });
         });
 
-        describe("old-style call without location", function() {
-            it("should call eslint.report() with rule ID and severity prepended", function() {
+        describe("old-style call without location", () => {
+            it("should call eslint.report() with rule ID and severity prepended", () => {
                 const node = {},
                     message = "Message",
                     messageOpts = {};
@@ -67,8 +67,8 @@ describe("RuleContext", function() {
             });
         });
 
-        describe("new-style call with all options", function() {
-            it("should call eslint.report() with rule ID and severity prepended and all new-style options", function() {
+        describe("new-style call with all options", () => {
+            it("should call eslint.report() with rule ID and severity prepended and all new-style options", () => {
                 const node = {},
                     location = {},
                     message = "Message",
@@ -96,9 +96,9 @@ describe("RuleContext", function() {
         });
     });
 
-    describe("parserServices", function() {
+    describe("parserServices", () => {
 
-        it("should pass through parserServices properties to context", function() {
+        it("should pass through parserServices properties to context", () => {
             const services = {
                 test: {}
             };
@@ -107,7 +107,7 @@ describe("RuleContext", function() {
             assert.equal(ruleContext.parserServices.test, services.test);
         });
 
-        it("should copy parserServices properties to a new object", function() {
+        it("should copy parserServices properties to a new object", () => {
             const services = {
                 test: {}
             };
@@ -116,7 +116,7 @@ describe("RuleContext", function() {
             assert.notEqual(ruleContext.parserServices, services);
         });
 
-        it("should make context.parserServices a frozen object", function() {
+        it("should make context.parserServices a frozen object", () => {
             const services = {
                 test: {}
             };

--- a/tests/lib/rules.js
+++ b/tests/lib/rules.js
@@ -16,38 +16,38 @@ const assert = require("chai").assert,
 // Tests
 //------------------------------------------------------------------------------
 
-describe("rules", function() {
+describe("rules", () => {
 
-    beforeEach(function() {
+    beforeEach(() => {
         rules.testClear();
     });
 
-    afterEach(function() {
+    afterEach(() => {
         rules.load();
     });
 
-    describe("when given an invalid rules directory", function() {
+    describe("when given an invalid rules directory", () => {
         const code = "invaliddir";
 
-        it("should log an error and exit", function() {
-            assert.throws(function() {
+        it("should log an error and exit", () => {
+            assert.throws(() => {
                 rules.load(code);
             });
         });
     });
 
-    describe("when given a valid rules directory", function() {
+    describe("when given a valid rules directory", () => {
         const code = "tests/fixtures/rules";
 
-        it("should load rules and not log an error or exit", function() {
+        it("should load rules and not log an error or exit", () => {
             assert.equal(typeof rules.get("fixture-rule"), "undefined");
             rules.load(code, process.cwd());
             assert.equal(typeof rules.get("fixture-rule"), "object");
         });
     });
 
-    describe("when a rule has been defined", function() {
-        it("should be able to retrieve the rule", function() {
+    describe("when a rule has been defined", () => {
+        it("should be able to retrieve the rule", () => {
             const ruleId = "michaelficarra";
 
             rules.define(ruleId, {});
@@ -55,7 +55,7 @@ describe("rules", function() {
         });
     });
 
-    describe("when importing plugin rules", function() {
+    describe("when importing plugin rules", () => {
         const customPlugin = {
                 rules: {
                     "custom-rule"() { }
@@ -63,7 +63,7 @@ describe("rules", function() {
             },
             pluginName = "custom-plugin";
 
-        it("should define all plugin rules with a qualified rule id", function() {
+        it("should define all plugin rules with a qualified rule id", () => {
             rules.importPlugin(customPlugin, pluginName);
 
             assert.isDefined(rules.get("custom-plugin/custom-rule"));

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -38,7 +38,7 @@ function expectedErrors(indentType, errors) {
         errors = [errors];
     }
 
-    return errors.map(function(err) {
+    return errors.map(err => {
         let message;
 
         if (typeof err[1] === "string" && typeof err[2] === "string") {

--- a/tests/lib/rules/no-empty-function.js
+++ b/tests/lib/rules/no-empty-function.js
@@ -65,10 +65,8 @@ function toValidInvalid(patterns, item) {
         parserOptions: {ecmaVersion: 6}
     });
     ALLOW_OPTIONS
-        .filter(function(allow) {
-            return allow !== item.allow;
-        })
-        .forEach(function(allow) {
+        .filter(allow => allow !== item.allow)
+        .forEach(allow => {
 
             // non related "allow" option has no effect.
             patterns.invalid.push({

--- a/tests/lib/rules/no-invalid-this.js
+++ b/tests/lib/rules/no-invalid-this.js
@@ -68,21 +68,19 @@ function MODULES(pattern) {
 function extractPatterns(patterns, type) {
 
     // Clone and apply the pattern environment.
-    const patternsList = patterns.map(function(pattern) {
-        return pattern[type].map(function(applyCondition) {
-            const thisPattern = lodash.cloneDeep(pattern);
+    const patternsList = patterns.map(pattern => pattern[type].map(applyCondition => {
+        const thisPattern = lodash.cloneDeep(pattern);
 
-            applyCondition(thisPattern);
+        applyCondition(thisPattern);
 
-            if (type === "valid") {
-                thisPattern.errors = [];
-            } else {
-                thisPattern.code += " /* should error */";
-            }
+        if (type === "valid") {
+            thisPattern.errors = [];
+        } else {
+            thisPattern.code += " /* should error */";
+        }
 
-            return thisPattern;
-        });
-    });
+        return thisPattern;
+    }));
 
     // Flatten.
     return Array.prototype.concat.apply([], patternsList);

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -18,7 +18,7 @@ const rule = require("../../../lib/rules/no-unused-vars"),
 
 const ruleTester = new RuleTester();
 
-ruleTester.defineRule("use-every-a", function(context) {
+ruleTester.defineRule("use-every-a", context => {
 
     /**
      * Mark a variable as used

--- a/tests/lib/testers/rule-tester.js
+++ b/tests/lib/testers/rule-tester.js
@@ -42,18 +42,18 @@ RuleTester.it = function(text, method) {
 // Tests
 //------------------------------------------------------------------------------
 
-describe("RuleTester", function() {
+describe("RuleTester", () => {
 
     let ruleTester;
 
-    beforeEach(function() {
+    beforeEach(() => {
         RuleTester.resetDefaultConfig();
         ruleTester = new RuleTester();
     });
 
-    it("should not throw an error when everything passes", function() {
+    it("should not throw an error when everything passes", () => {
 
-        assert.doesNotThrow(function() {
+        assert.doesNotThrow(() => {
             ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [
                     "Eval(foo)"
@@ -65,9 +65,9 @@ describe("RuleTester", function() {
         });
     });
 
-    it("should throw an error when valid code is invalid", function() {
+    it("should throw an error when valid code is invalid", () => {
 
-        assert.throws(function() {
+        assert.throws(() => {
             ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [
                     "eval(foo)"
@@ -79,9 +79,9 @@ describe("RuleTester", function() {
         }, /Should have no errors but had 1/);
     });
 
-    it("should throw an error when valid code is invalid", function() {
+    it("should throw an error when valid code is invalid", () => {
 
-        assert.throws(function() {
+        assert.throws(() => {
             ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [
                     { code: "eval(foo)" }
@@ -93,9 +93,9 @@ describe("RuleTester", function() {
         }, /Should have no errors but had 1/);
     });
 
-    it("should throw an error if invalid code is valid", function() {
+    it("should throw an error if invalid code is valid", () => {
 
-        assert.throws(function() {
+        assert.throws(() => {
             ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [
                     "Eval(foo)"
@@ -107,8 +107,8 @@ describe("RuleTester", function() {
         }, /Should have 1 error but had 0/);
     });
 
-    it("should throw an error when the error message is wrong", function() {
-        assert.throws(function() {
+    it("should throw an error when the error message is wrong", () => {
+        assert.throws(() => {
             ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
 
                 // Only the invalid test matters here
@@ -122,8 +122,8 @@ describe("RuleTester", function() {
         }, /Bad var\..*==.*Bad error message/);
     });
 
-    it("should throw an error when the error is neither an object nor a string", function() {
-        assert.throws(function() {
+    it("should throw an error when the error is neither an object nor a string", () => {
+        assert.throws(() => {
             ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
 
                 // Only the invalid test matters here
@@ -137,8 +137,8 @@ describe("RuleTester", function() {
         }, /Error should be a string or object/);
     });
 
-    it("should throw an error when the error is a string and it does not match error message", function() {
-        assert.throws(function() {
+    it("should throw an error when the error is a string and it does not match error message", () => {
+        assert.throws(() => {
             ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
 
                 // Only the invalid test matters here
@@ -152,8 +152,8 @@ describe("RuleTester", function() {
         }, /Bad var\..*==.*Bad error message/);
     });
 
-    it("should not throw an error when the error is a string and it matches error message", function() {
-        assert.doesNotThrow(function() {
+    it("should not throw an error when the error is a string and it matches error message", () => {
+        assert.doesNotThrow(() => {
             ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
 
                 // Only the invalid test matters here
@@ -167,9 +167,9 @@ describe("RuleTester", function() {
         });
     });
 
-    it("should throw an error when the expected output doesn't match", function() {
+    it("should throw an error when the expected output doesn't match", () => {
 
-        assert.throws(function() {
+        assert.throws(() => {
             ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [
                     "bar = baz;"
@@ -181,9 +181,9 @@ describe("RuleTester", function() {
         }, /Output is incorrect/);
     });
 
-    it("should throw an error if invalid code specifies wrong type", function() {
+    it("should throw an error if invalid code specifies wrong type", () => {
 
-        assert.throws(function() {
+        assert.throws(() => {
             ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [
                     "Eval(foo)"
@@ -195,9 +195,9 @@ describe("RuleTester", function() {
         }, /Error type should be CallExpression2/);
     });
 
-    it("should throw an error if invalid code specifies wrong line", function() {
+    it("should throw an error if invalid code specifies wrong line", () => {
 
-        assert.throws(function() {
+        assert.throws(() => {
             ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [
                     "Eval(foo)"
@@ -209,8 +209,8 @@ describe("RuleTester", function() {
         }, /Error line should be 5/);
     });
 
-    it("should not skip line assertion if line is a falsy value", function() {
-        assert.throws(function() {
+    it("should not skip line assertion if line is a falsy value", () => {
+        assert.throws(() => {
             ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [
                     "Eval(foo)"
@@ -222,11 +222,11 @@ describe("RuleTester", function() {
         }, /Error line should be 0/);
     });
 
-    it("should throw an error if invalid code specifies wrong column", function() {
+    it("should throw an error if invalid code specifies wrong column", () => {
         const wrongColumn = 10,
             expectedErrorMessage = "Error column should be 1";
 
-        assert.throws(function() {
+        assert.throws(() => {
             ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [ "Eval(foo)" ],
                 invalid: [ {
@@ -240,9 +240,9 @@ describe("RuleTester", function() {
         }, expectedErrorMessage);
     });
 
-    it("should not skip column assertion if column is a falsy value", function() {
+    it("should not skip column assertion if column is a falsy value", () => {
 
-        assert.throws(function() {
+        assert.throws(() => {
             ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [ "Eval(foo)" ],
                 invalid: [ {
@@ -253,8 +253,8 @@ describe("RuleTester", function() {
         }, /Error column should be 0/);
     });
 
-    it("should throw an error if invalid code specifies wrong endLine", function() {
-        assert.throws(function() {
+    it("should throw an error if invalid code specifies wrong endLine", () => {
+        assert.throws(() => {
             ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [
                     "bar = baz;"
@@ -266,8 +266,8 @@ describe("RuleTester", function() {
         }, "Error endLine should be 10");
     });
 
-    it("should throw an error if invalid code specifies wrong endColumn", function() {
-        assert.throws(function() {
+    it("should throw an error if invalid code specifies wrong endColumn", () => {
+        assert.throws(() => {
             ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [
                     "bar = baz;"
@@ -279,9 +279,9 @@ describe("RuleTester", function() {
         }, "Error endColumn should be 10");
     });
 
-    it("should throw an error if invalid code has the wrong number of errors", function() {
+    it("should throw an error if invalid code has the wrong number of errors", () => {
 
-        assert.throws(function() {
+        assert.throws(() => {
             ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [
                     "Eval(foo)"
@@ -296,8 +296,8 @@ describe("RuleTester", function() {
         }, /Should have 2 errors but had 1/);
     });
 
-    it("should throw an error if invalid code does not have errors", function() {
-        assert.throws(function() {
+    it("should throw an error if invalid code does not have errors", () => {
+        assert.throws(() => {
             ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [
                     "Eval(foo)"
@@ -309,9 +309,9 @@ describe("RuleTester", function() {
         }, /Did not specify errors for an invalid test of no-eval/);
     });
 
-    it("should throw an error if invalid code has the wrong explicit number of errors", function() {
+    it("should throw an error if invalid code has the wrong explicit number of errors", () => {
 
-        assert.throws(function() {
+        assert.throws(() => {
             ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [
                     "Eval(foo)"
@@ -324,9 +324,9 @@ describe("RuleTester", function() {
     });
 
     // https://github.com/eslint/eslint/issues/4779
-    it("should throw an error if there's a parsing error and output doesn't match", function() {
+    it("should throw an error if there's a parsing error and output doesn't match", () => {
 
-        assert.throws(function() {
+        assert.throws(() => {
             ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [],
                 invalid: [
@@ -336,8 +336,8 @@ describe("RuleTester", function() {
         }, /fatal parsing error/i);
     });
 
-    it("should not throw an error if invalid code has at least an expected empty error object", function() {
-        assert.doesNotThrow(function() {
+    it("should not throw an error if invalid code has at least an expected empty error object", () => {
+        assert.doesNotThrow(() => {
             ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [ "Eval(foo)" ],
                 invalid: [ {
@@ -348,8 +348,8 @@ describe("RuleTester", function() {
         });
     });
 
-    it("should pass-through the globals config of valid tests to the to rule", function() {
-        assert.doesNotThrow(function() {
+    it("should pass-through the globals config of valid tests to the to rule", () => {
+        assert.doesNotThrow(() => {
             ruleTester.run("no-test-global", require("../../fixtures/testers/rule-tester/no-test-global"), {
                 valid: [
                     "var test = 'foo'",
@@ -367,8 +367,8 @@ describe("RuleTester", function() {
         });
     });
 
-    it("should pass-through the globals config of invalid tests to the to rule", function() {
-        assert.doesNotThrow(function() {
+    it("should pass-through the globals config of invalid tests to the to rule", () => {
+        assert.doesNotThrow(() => {
             ruleTester.run("no-test-global", require("../../fixtures/testers/rule-tester/no-test-global"), {
                 valid: [ "var test = 'foo'" ],
                 invalid: [
@@ -391,8 +391,8 @@ describe("RuleTester", function() {
         });
     });
 
-    it("should pass-through the settings config to rules", function() {
-        assert.doesNotThrow(function() {
+    it("should pass-through the settings config to rules", () => {
+        assert.doesNotThrow(() => {
             ruleTester.run("no-test-settings", require("../../fixtures/testers/rule-tester/no-test-settings"), {
                 valid: [
                     {
@@ -408,7 +408,7 @@ describe("RuleTester", function() {
         });
     });
 
-    it("should pass-through the filename to the rule", function() {
+    it("should pass-through the filename to the rule", () => {
         (function() {
             ruleTester.run("", require("../../fixtures/testers/rule-tester/no-test-filename"), {
                 valid: [
@@ -429,8 +429,8 @@ describe("RuleTester", function() {
         }());
     });
 
-    it("should pass-through the options to the rule", function() {
-        assert.doesNotThrow(function() {
+    it("should pass-through the options to the rule", () => {
+        assert.doesNotThrow(() => {
             ruleTester.run("no-invalid-args", require("../../fixtures/testers/rule-tester/no-invalid-args"), {
                 valid: [
                     {
@@ -449,9 +449,9 @@ describe("RuleTester", function() {
         });
     });
 
-    it("should pass-through the parser to the rule", function() {
+    it("should pass-through the parser to the rule", () => {
 
-        assert.doesNotThrow(function() {
+        assert.doesNotThrow(() => {
             const spy = sinon.spy(eslint, "verify");
 
             ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
@@ -472,9 +472,9 @@ describe("RuleTester", function() {
         });
     });
 
-    it("should prevent invalid options schemas", function() {
+    it("should prevent invalid options schemas", () => {
 
-        assert.throws(function() {
+        assert.throws(() => {
             ruleTester.run("no-invalid-schema", require("../../fixtures/testers/rule-tester/no-invalid-schema"), {
                 valid: [
                     "var answer = 6 * 7;",
@@ -488,9 +488,9 @@ describe("RuleTester", function() {
 
     });
 
-    it("should prevent schema violations in options", function() {
+    it("should prevent schema violations in options", () => {
 
-        assert.throws(function() {
+        assert.throws(() => {
             ruleTester.run("no-schema-violation", require("../../fixtures/testers/rule-tester/no-schema-violation"), {
                 valid: [
                     "var answer = 6 * 7;",
@@ -504,12 +504,12 @@ describe("RuleTester", function() {
 
     });
 
-    it("should pass-through the tester config to the rule", function() {
+    it("should pass-through the tester config to the rule", () => {
         ruleTester = new RuleTester({
             global: { test: true }
         });
 
-        assert.doesNotThrow(function() {
+        assert.doesNotThrow(() => {
             ruleTester.run("no-test-global", require("../../fixtures/testers/rule-tester/no-test-global"), {
                 valid: [
                     "var test = 'foo'",
@@ -520,7 +520,7 @@ describe("RuleTester", function() {
         });
     });
 
-    it("should correctly set the global configuration", function() {
+    it("should correctly set the global configuration", () => {
         const config = { global: { test: true } };
 
         RuleTester.setDefaultConfig(config);
@@ -530,7 +530,7 @@ describe("RuleTester", function() {
         );
     });
 
-    it("should correctly reset the global configuration", function() {
+    it("should correctly reset the global configuration", () => {
         const config = { global: { test: true } };
 
         RuleTester.setDefaultConfig(config);
@@ -542,7 +542,7 @@ describe("RuleTester", function() {
         );
     });
 
-    it("should enforce the global configuration to be an object", function() {
+    it("should enforce the global configuration to be an object", () => {
 
         /**
          * Set the default config for the rules tester
@@ -563,13 +563,13 @@ describe("RuleTester", function() {
         assert.throw(setConfig(true));
     });
 
-    it("should pass-through the global config to the tester then to the to rule", function() {
+    it("should pass-through the global config to the tester then to the to rule", () => {
         const config = { global: { test: true } };
 
         RuleTester.setDefaultConfig(config);
         ruleTester = new RuleTester();
 
-        assert.doesNotThrow(function() {
+        assert.doesNotThrow(() => {
             ruleTester.run("no-test-global", require("../../fixtures/testers/rule-tester/no-test-global"), {
                 valid: [
                     "var test = 'foo'",
@@ -580,8 +580,8 @@ describe("RuleTester", function() {
         });
     });
 
-    it("should throw an error if AST was modified", function() {
-        assert.throws(function() {
+    it("should throw an error if AST was modified", () => {
+        assert.throws(() => {
             ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast"), {
                 valid: [
                     "var foo = 0;"
@@ -589,7 +589,7 @@ describe("RuleTester", function() {
                 invalid: []
             });
         }, "Rule should not modify AST.");
-        assert.throws(function() {
+        assert.throws(() => {
             ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast"), {
                 valid: [],
                 invalid: [
@@ -599,8 +599,8 @@ describe("RuleTester", function() {
         }, "Rule should not modify AST.");
     });
 
-    it("should throw an error if AST was modified (at Program)", function() {
-        assert.throws(function() {
+    it("should throw an error if AST was modified (at Program)", () => {
+        assert.throws(() => {
             ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-first"), {
                 valid: [
                     "var foo = 0;"
@@ -608,7 +608,7 @@ describe("RuleTester", function() {
                 invalid: []
             });
         }, "Rule should not modify AST.");
-        assert.throws(function() {
+        assert.throws(() => {
             ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-first"), {
                 valid: [],
                 invalid: [
@@ -618,8 +618,8 @@ describe("RuleTester", function() {
         }, "Rule should not modify AST.");
     });
 
-    it("should throw an error if AST was modified (at Program:exit)", function() {
-        assert.throws(function() {
+    it("should throw an error if AST was modified (at Program:exit)", () => {
+        assert.throws(() => {
             ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"), {
                 valid: [
                     "var foo = 0;"
@@ -627,7 +627,7 @@ describe("RuleTester", function() {
                 invalid: []
             });
         }, "Rule should not modify AST.");
-        assert.throws(function() {
+        assert.throws(() => {
             ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"), {
                 valid: [],
                 invalid: [

--- a/tests/lib/token-store.js
+++ b/tests/lib/token-store.js
@@ -49,40 +49,40 @@ function check(tokens, expected) {
 // Tests
 //------------------------------------------------------------------------------
 
-describe("TokenStore", function() {
+describe("TokenStore", () => {
     const store = new TokenStore(TOKENS);
 
-    describe("when calling getTokens", function() {
+    describe("when calling getTokens", () => {
 
-        it("should retrieve all tokens for root node", function() {
+        it("should retrieve all tokens for root node", () => {
             check(
                 store.getTokens(Program),
                 ["var", "answer", "=", "a", "*", "b", "call", "(", ")", ";"]
             );
         });
 
-        it("should retrieve all tokens for binary expression", function() {
+        it("should retrieve all tokens for binary expression", () => {
             check(
                 store.getTokens(BinaryExpression),
                 ["a", "*", "b"]
             );
         });
 
-        it("should retrieve all tokens plus one before for binary expression", function() {
+        it("should retrieve all tokens plus one before for binary expression", () => {
             check(
                 store.getTokens(BinaryExpression, 1),
                 ["=", "a", "*", "b"]
             );
         });
 
-        it("should retrieve all tokens plus one after for binary expression", function() {
+        it("should retrieve all tokens plus one after for binary expression", () => {
             check(
                 store.getTokens(BinaryExpression, 0, 1),
                 ["a", "*", "b", "call"]
             );
         });
 
-        it("should retrieve all tokens plus two before and one after for binary expression", function() {
+        it("should retrieve all tokens plus two before and one after for binary expression", () => {
             check(
                 store.getTokens(BinaryExpression, 2, 1),
                 ["answer", "=", "a", "*", "b", "call"]
@@ -91,30 +91,30 @@ describe("TokenStore", function() {
 
     });
 
-    describe("when calling getTokensBefore", function() {
+    describe("when calling getTokensBefore", () => {
 
-        it("should retrieve zero tokens before a node", function() {
+        it("should retrieve zero tokens before a node", () => {
             check(
                 store.getTokensBefore(BinaryExpression, 0),
                 []
             );
         });
 
-        it("should retrieve one token before a node", function() {
+        it("should retrieve one token before a node", () => {
             check(
                 store.getTokensBefore(BinaryExpression, 1),
                 ["="]
             );
         });
 
-        it("should retrieve more than one token before a node", function() {
+        it("should retrieve more than one token before a node", () => {
             check(
                 store.getTokensBefore(BinaryExpression, 2),
                 ["answer", "="]
             );
         });
 
-        it("should retrieve all tokens before a node", function() {
+        it("should retrieve all tokens before a node", () => {
             check(
                 store.getTokensBefore(BinaryExpression, 9e9),
                 ["var", "answer", "="]
@@ -123,16 +123,16 @@ describe("TokenStore", function() {
 
     });
 
-    describe("when calling getTokenBefore", function() {
+    describe("when calling getTokenBefore", () => {
 
-        it("should retrieve one token before a node", function() {
+        it("should retrieve one token before a node", () => {
             assert.equal(
                 store.getTokenBefore(BinaryExpression).value,
                 "="
             );
         });
 
-        it("should skip a given number of tokens", function() {
+        it("should skip a given number of tokens", () => {
             assert.equal(
                 store.getTokenBefore(BinaryExpression, 1).value,
                 "answer"
@@ -145,30 +145,30 @@ describe("TokenStore", function() {
 
     });
 
-    describe("when calling getTokensAfter", function() {
+    describe("when calling getTokensAfter", () => {
 
-        it("should retrieve zero tokens after a node", function() {
+        it("should retrieve zero tokens after a node", () => {
             check(
                 store.getTokensAfter(VariableDeclarator.id, 0),
                 []
             );
         });
 
-        it("should retrieve one token after a node", function() {
+        it("should retrieve one token after a node", () => {
             check(
                 store.getTokensAfter(VariableDeclarator.id, 1),
                 ["="]
             );
         });
 
-        it("should retrieve more than one token after a node", function() {
+        it("should retrieve more than one token after a node", () => {
             check(
                 store.getTokensAfter(VariableDeclarator.id, 2),
                 ["=", "a"]
             );
         });
 
-        it("should retrieve all tokens after a node", function() {
+        it("should retrieve all tokens after a node", () => {
             check(
                 store.getTokensAfter(VariableDeclarator.id, 9e9),
                 ["=", "a", "*", "b", "call", "(", ")", ";"]
@@ -177,16 +177,16 @@ describe("TokenStore", function() {
 
     });
 
-    describe("when calling getTokenAfter", function() {
+    describe("when calling getTokenAfter", () => {
 
-        it("should retrieve one token after a node", function() {
+        it("should retrieve one token after a node", () => {
             assert.equal(
                 store.getTokenAfter(VariableDeclarator.id).value,
                 "="
             );
         });
 
-        it("should skip a given number of tokens", function() {
+        it("should skip a given number of tokens", () => {
             assert.equal(
                 store.getTokenAfter(VariableDeclarator.id, 1).value,
                 "a"
@@ -199,30 +199,30 @@ describe("TokenStore", function() {
 
     });
 
-    describe("when calling getFirstTokens", function() {
+    describe("when calling getFirstTokens", () => {
 
-        it("should retrieve zero tokens from a node's token stream", function() {
+        it("should retrieve zero tokens from a node's token stream", () => {
             check(
                 store.getFirstTokens(BinaryExpression, 0),
                 []
             );
         });
 
-        it("should retrieve one token from a node's token stream", function() {
+        it("should retrieve one token from a node's token stream", () => {
             check(
                 store.getFirstTokens(BinaryExpression, 1),
                 ["a"]
             );
         });
 
-        it("should retrieve more than one token from a node's token stream", function() {
+        it("should retrieve more than one token from a node's token stream", () => {
             check(
                 store.getFirstTokens(BinaryExpression, 2),
                 ["a", "*"]
             );
         });
 
-        it("should retrieve all tokens from a node's token stream", function() {
+        it("should retrieve all tokens from a node's token stream", () => {
             check(
                 store.getFirstTokens(BinaryExpression, 9e9),
                 ["a", "*", "b"]
@@ -231,16 +231,16 @@ describe("TokenStore", function() {
 
     });
 
-    describe("when calling getFirstToken", function() {
+    describe("when calling getFirstToken", () => {
 
-        it("should retrieve the first token of a node's token stream", function() {
+        it("should retrieve the first token of a node's token stream", () => {
             assert.equal(
                 store.getFirstToken(BinaryExpression).value,
                 "a"
             );
         });
 
-        it("should skip a given number of tokens", function() {
+        it("should skip a given number of tokens", () => {
             assert.equal(
                 store.getFirstToken(BinaryExpression, 1).value,
                 "*"
@@ -253,30 +253,30 @@ describe("TokenStore", function() {
 
     });
 
-    describe("when calling getLastTokens", function() {
+    describe("when calling getLastTokens", () => {
 
-        it("should retrieve zero tokens from the end of a node's token stream", function() {
+        it("should retrieve zero tokens from the end of a node's token stream", () => {
             check(
                 store.getLastTokens(BinaryExpression, 0),
                 []
             );
         });
 
-        it("should retrieve one token from the end of a node's token stream", function() {
+        it("should retrieve one token from the end of a node's token stream", () => {
             check(
                 store.getLastTokens(BinaryExpression, 1),
                 ["b"]
             );
         });
 
-        it("should retrieve more than one token from the end of a node's token stream", function() {
+        it("should retrieve more than one token from the end of a node's token stream", () => {
             check(
                 store.getLastTokens(BinaryExpression, 2),
                 ["*", "b"]
             );
         });
 
-        it("should retrieve all tokens from the end of a node's token stream", function() {
+        it("should retrieve all tokens from the end of a node's token stream", () => {
             check(
                 store.getLastTokens(BinaryExpression, 9e9),
                 ["a", "*", "b"]
@@ -285,9 +285,9 @@ describe("TokenStore", function() {
 
     });
 
-    describe("when calling getLastToken", function() {
+    describe("when calling getLastToken", () => {
 
-        it("should retrieve the last token of a node's token stream", function() {
+        it("should retrieve the last token of a node's token stream", () => {
             assert.equal(
                 store.getLastToken(BinaryExpression).value,
                 "b"
@@ -298,7 +298,7 @@ describe("TokenStore", function() {
             );
         });
 
-        it("should skip a given number of tokens", function() {
+        it("should skip a given number of tokens", () => {
             assert.equal(
                 store.getLastToken(BinaryExpression, 1).value,
                 "*"
@@ -311,30 +311,30 @@ describe("TokenStore", function() {
 
     });
 
-    describe("when calling getTokensBetween", function() {
+    describe("when calling getTokensBetween", () => {
 
-        it("should retrieve zero tokens between adjacent nodes", function() {
+        it("should retrieve zero tokens between adjacent nodes", () => {
             check(
                 store.getTokensBetween(BinaryExpression, CallExpression),
                 []
             );
         });
 
-        it("should retrieve one token between nodes", function() {
+        it("should retrieve one token between nodes", () => {
             check(
                 store.getTokensBetween(BinaryExpression.left, BinaryExpression.right),
                 ["*"]
             );
         });
 
-        it("should retrieve multiple tokens between non-adjacent nodes", function() {
+        it("should retrieve multiple tokens between non-adjacent nodes", () => {
             check(
                 store.getTokensBetween(VariableDeclarator.id, BinaryExpression.right),
                 ["=", "a", "*"]
             );
         });
 
-        it("should retrieve surrounding tokens when asked for padding", function() {
+        it("should retrieve surrounding tokens when asked for padding", () => {
             check(
                 store.getTokensBetween(VariableDeclarator.id, BinaryExpression.left, 2),
                 ["var", "answer", "=", "a", "*"]
@@ -343,16 +343,16 @@ describe("TokenStore", function() {
 
     });
 
-    describe("when calling getTokenByRangeStart", function() {
+    describe("when calling getTokenByRangeStart", () => {
 
-        it("should return identifier token", function() {
+        it("should return identifier token", () => {
             const result = store.getTokenByRangeStart(4);
 
             assert.equal(result.type, "Identifier");
             assert.equal(result.value, "answer");
         });
 
-        it("should return null when token doesn't exist", function() {
+        it("should return null when token doesn't exist", () => {
             const result = store.getTokenByRangeStart(5);
 
             assert.isNull(result);

--- a/tests/lib/util/comment-event-generator.js
+++ b/tests/lib/util/comment-event-generator.js
@@ -22,12 +22,12 @@ const assert = require("assert"),
 // Tests
 //------------------------------------------------------------------------------
 
-describe("NodeEventGenerator", function() {
+describe("NodeEventGenerator", () => {
     EventGeneratorTester.testEventGeneratorInterface(
         new CommentEventGenerator(new NodeEventGenerator(new EventEmitter()))
     );
 
-    it("should generate comment events without duplicate.", function() {
+    it("should generate comment events without duplicate.", () => {
         const emitter = new EventEmitter();
         let generator = new NodeEventGenerator(emitter);
         const code = "//foo\nvar zzz /*aaa*/ = 777;\n//bar";

--- a/tests/lib/util/glob-util.js
+++ b/tests/lib/util/glob-util.js
@@ -37,21 +37,21 @@ function getFixturePath() {
 // Tests
 //------------------------------------------------------------------------------
 
-describe("globUtil", function() {
+describe("globUtil", () => {
 
-    before(function() {
+    before(() => {
         fixtureDir = `${os.tmpdir()}/eslint/tests/fixtures/`;
         sh.mkdir("-p", fixtureDir);
         sh.cp("-r", "./tests/fixtures/*", fixtureDir);
     });
 
-    after(function() {
+    after(() => {
         sh.rm("-r", fixtureDir);
     });
 
-    describe("resolveFileGlobPatterns()", function() {
+    describe("resolveFileGlobPatterns()", () => {
 
-        it("should convert a directory name with no provided extensions into a glob pattern", function() {
+        it("should convert a directory name with no provided extensions into a glob pattern", () => {
             const patterns = ["one-js-file"];
             const opts = {
                 cwd: getFixturePath("glob-util")
@@ -61,7 +61,7 @@ describe("globUtil", function() {
             assert.deepEqual(result, ["one-js-file/**/*.js"]);
         });
 
-        it("should convert an absolute directory name with no provided extensions into a posix glob pattern", function() {
+        it("should convert an absolute directory name with no provided extensions into a posix glob pattern", () => {
             const patterns = [getFixturePath("glob-util", "one-js-file")];
             const opts = {
                 cwd: getFixturePath("glob-util")
@@ -72,7 +72,7 @@ describe("globUtil", function() {
             assert.deepEqual(result, expected);
         });
 
-        it("should convert a directory name with a single provided extension into a glob pattern", function() {
+        it("should convert a directory name with a single provided extension into a glob pattern", () => {
             const patterns = ["one-js-file"];
             const opts = {
                 cwd: getFixturePath("glob-util"),
@@ -83,7 +83,7 @@ describe("globUtil", function() {
             assert.deepEqual(result, ["one-js-file/**/*.jsx"]);
         });
 
-        it("should convert a directory name with multiple provided extensions into a glob pattern", function() {
+        it("should convert a directory name with multiple provided extensions into a glob pattern", () => {
             const patterns = ["one-js-file"];
             const opts = {
                 cwd: getFixturePath("glob-util"),
@@ -94,7 +94,7 @@ describe("globUtil", function() {
             assert.deepEqual(result, ["one-js-file/**/*.{jsx,js}"]);
         });
 
-        it("should convert multiple directory names into glob patterns", function() {
+        it("should convert multiple directory names into glob patterns", () => {
             const patterns = ["one-js-file", "two-js-files"];
             const opts = {
                 cwd: getFixturePath("glob-util")
@@ -104,7 +104,7 @@ describe("globUtil", function() {
             assert.deepEqual(result, ["one-js-file/**/*.js", "two-js-files/**/*.js"]);
         });
 
-        it("should remove leading './' from glob patterns", function() {
+        it("should remove leading './' from glob patterns", () => {
             const patterns = ["./one-js-file"];
             const opts = {
                 cwd: getFixturePath("glob-util")
@@ -114,7 +114,7 @@ describe("globUtil", function() {
             assert.deepEqual(result, ["one-js-file/**/*.js"]);
         });
 
-        it("should convert a directory name with a trailing '/' into a glob pattern", function() {
+        it("should convert a directory name with a trailing '/' into a glob pattern", () => {
             const patterns = ["one-js-file/"];
             const opts = {
                 cwd: getFixturePath("glob-util")
@@ -124,7 +124,7 @@ describe("globUtil", function() {
             assert.deepEqual(result, ["one-js-file/**/*.js"]);
         });
 
-        it("should return filenames as they are", function() {
+        it("should return filenames as they are", () => {
             const patterns = ["some-file.js"];
             const opts = {
                 cwd: getFixturePath("glob-util")
@@ -134,7 +134,7 @@ describe("globUtil", function() {
             assert.deepEqual(result, ["some-file.js"]);
         });
 
-        it("should convert backslashes into forward slashes", function() {
+        it("should convert backslashes into forward slashes", () => {
             const patterns = ["one-js-file\\example.js"];
             const opts = {
                 cwd: getFixturePath()
@@ -146,9 +146,9 @@ describe("globUtil", function() {
 
     });
 
-    describe("listFilesToProcess()", function() {
+    describe("listFilesToProcess()", () => {
 
-        it("should return an array with a resolved (absolute) filename", function() {
+        it("should return an array with a resolved (absolute) filename", () => {
             const patterns = [getFixturePath("glob-util", "one-js-file", "**/*.js")];
             const result = globUtil.listFilesToProcess(patterns, {
                 cwd: getFixturePath()
@@ -160,7 +160,7 @@ describe("globUtil", function() {
             assert.deepEqual(result, [{filename: file1, ignored: false}]);
         });
 
-        it("should return all files matching a glob pattern", function() {
+        it("should return all files matching a glob pattern", () => {
             const patterns = [getFixturePath("glob-util", "two-js-files", "**/*.js")];
             const result = globUtil.listFilesToProcess(patterns, {
                 cwd: getFixturePath()
@@ -176,7 +176,7 @@ describe("globUtil", function() {
             ]);
         });
 
-        it("should return all files matching multiple glob patterns", function() {
+        it("should return all files matching multiple glob patterns", () => {
             const patterns = [
                 getFixturePath("glob-util", "two-js-files", "**/*.js"),
                 getFixturePath("glob-util", "one-js-file", "**/*.js")
@@ -197,7 +197,7 @@ describe("globUtil", function() {
             ]);
         });
 
-        it("should not return hidden files for standard glob patterns", function() {
+        it("should not return hidden files for standard glob patterns", () => {
             const patterns = [getFixturePath("glob-util", "hidden", "**/*.js")];
             const result = globUtil.listFilesToProcess(patterns, {
                 cwd: getFixturePath()
@@ -206,7 +206,7 @@ describe("globUtil", function() {
             assert.equal(result.length, 0);
         });
 
-        it("should return hidden files if included in glob pattern", function() {
+        it("should return hidden files if included in glob pattern", () => {
             const patterns = [getFixturePath("glob-util", "hidden", "**/.*.js")];
             const result = globUtil.listFilesToProcess(patterns, {
                 cwd: getFixturePath()
@@ -220,7 +220,7 @@ describe("globUtil", function() {
             ]);
         });
 
-        it("should silently ignore default ignored files if not passed explicitly", function() {
+        it("should silently ignore default ignored files if not passed explicitly", () => {
             const directory = getFixturePath("glob-util", "hidden");
             const patterns = [directory];
             const result = globUtil.listFilesToProcess(patterns, {
@@ -230,7 +230,7 @@ describe("globUtil", function() {
             assert.equal(result.length, 0);
         });
 
-        it("should ignore and warn for default ignored files when passed explicitly", function() {
+        it("should ignore and warn for default ignored files when passed explicitly", () => {
             const filename = getFixturePath("glob-util", "hidden", ".foo.js");
             const patterns = [filename];
             const result = globUtil.listFilesToProcess(patterns, {
@@ -241,7 +241,7 @@ describe("globUtil", function() {
             assert.deepEqual(result[0], { filename, ignored: true });
         });
 
-        it("should silently ignore default ignored files if not passed explicitly even if ignore is false", function() {
+        it("should silently ignore default ignored files if not passed explicitly even if ignore is false", () => {
             const directory = getFixturePath("glob-util", "hidden");
             const patterns = [directory];
             const result = globUtil.listFilesToProcess(patterns, {
@@ -252,7 +252,7 @@ describe("globUtil", function() {
             assert.equal(result.length, 0);
         });
 
-        it("should not ignore default ignored files when passed explicitly if ignore is false", function() {
+        it("should not ignore default ignored files when passed explicitly if ignore is false", () => {
             const filename = getFixturePath("glob-util", "hidden", ".foo.js");
             const patterns = [filename];
             const result = globUtil.listFilesToProcess(patterns, {
@@ -264,14 +264,14 @@ describe("globUtil", function() {
             assert.deepEqual(result[0], { filename, ignored: false });
         });
 
-        it("should not return a file which does not exist", function() {
+        it("should not return a file which does not exist", () => {
             const patterns = ["tests/fixtures/glob-util/hidden/bar.js"];
             const result = globUtil.listFilesToProcess(patterns);
 
             assert.equal(result.length, 0);
         });
 
-        it("should not return an ignored file", function() {
+        it("should not return an ignored file", () => {
 
             // Relying here on the .eslintignore from the repo root
             const patterns = ["tests/fixtures/glob-util/ignored/**/*.js"];
@@ -280,7 +280,7 @@ describe("globUtil", function() {
             assert.equal(result.length, 0);
         });
 
-        it("should return an ignored file, if ignore option is turned off", function() {
+        it("should return an ignored file, if ignore option is turned off", () => {
             const options = { ignore: false };
             const patterns = [getFixturePath("glob-util", "ignored", "**/*.js")];
             const result = globUtil.listFilesToProcess(patterns, options);
@@ -288,7 +288,7 @@ describe("globUtil", function() {
             assert.equal(result.length, 1);
         });
 
-        it("should not return a file from a glob if it matches a pattern in an ignore file", function() {
+        it("should not return a file from a glob if it matches a pattern in an ignore file", () => {
             const options = { ignore: true, ignorePath: getFixturePath("glob-util", "ignored", ".eslintignore") };
             const patterns = [getFixturePath("glob-util", "ignored", "**/*.js")];
             const result = globUtil.listFilesToProcess(patterns, options);
@@ -296,7 +296,7 @@ describe("globUtil", function() {
             assert.equal(result.length, 0);
         });
 
-        it("should not return a file from a glob if matching a specified ignore pattern", function() {
+        it("should not return a file from a glob if matching a specified ignore pattern", () => {
             const options = { ignore: true, ignorePattern: "foo.js", cwd: getFixturePath() };
             const patterns = [getFixturePath("glob-util", "ignored", "**/*.js")];
             const result = globUtil.listFilesToProcess(patterns, options);
@@ -304,7 +304,7 @@ describe("globUtil", function() {
             assert.equal(result.length, 0);
         });
 
-        it("should return a file only once if listed in more than 1 pattern", function() {
+        it("should return a file only once if listed in more than 1 pattern", () => {
             const patterns = [
                 getFixturePath("glob-util", "one-js-file", "**/*.js"),
                 getFixturePath("glob-util", "one-js-file", "baz.js")
@@ -321,7 +321,7 @@ describe("globUtil", function() {
             ]);
         });
 
-        it("should set 'ignored: true' for files that are explicitly specified but ignored", function() {
+        it("should set 'ignored: true' for files that are explicitly specified but ignored", () => {
             const options = { ignore: true, ignorePattern: "foo.js", cwd: getFixturePath() };
             const filename = getFixturePath("glob-util", "ignored", "foo.js");
             const patterns = [filename];
@@ -333,19 +333,17 @@ describe("globUtil", function() {
             ]);
         });
 
-        it("should not return files from default ignored folders", function() {
+        it("should not return files from default ignored folders", () => {
             const options = { cwd: getFixturePath("glob-util") };
             const glob = getFixturePath("glob-util", "**/*.js");
             const patterns = [glob];
             const result = globUtil.listFilesToProcess(patterns, options);
-            const resultFilenames = result.map(function(resultObj) {
-                return resultObj.filename;
-            });
+            const resultFilenames = result.map(resultObj => resultObj.filename);
 
             assert.notInclude(resultFilenames, getFixturePath("glob-util", "node_modules", "dependency.js"));
         });
 
-        it("should return unignored files from default ignored folders", function() {
+        it("should return unignored files from default ignored folders", () => {
             const options = { ignorePattern: "!/node_modules/dependency.js", cwd: getFixturePath("glob-util") };
             const glob = getFixturePath("glob-util", "**/*.js");
             const patterns = [glob];

--- a/tests/lib/util/module-resolver.js
+++ b/tests/lib/util/module-resolver.js
@@ -23,9 +23,9 @@ const FIXTURES_PATH = path.resolve(__dirname, "../../fixtures/module-resolver");
 // Tests
 //------------------------------------------------------------------------------
 
-describe("ModuleResolver", function() {
+describe("ModuleResolver", () => {
 
-    describe("resolve()", function() {
+    describe("resolve()", () => {
 
         leche.withData([
 
@@ -35,8 +35,8 @@ describe("ModuleResolver", function() {
             // resolve with a different location
             [ "foo", path.resolve(FIXTURES_PATH, "node_modules"), path.resolve(FIXTURES_PATH, "node_modules/foo.js")]
 
-        ], function(name, lookupPath, expected) {
-            it("should find the correct location of a file", function() {
+        ], (name, lookupPath, expected) => {
+            it("should find the correct location of a file", () => {
                 const resolver = new ModuleResolver(),
                     result = resolver.resolve(name, lookupPath);
 

--- a/tests/lib/util/node-event-generator.js
+++ b/tests/lib/util/node-event-generator.js
@@ -18,20 +18,20 @@ const assert = require("assert"),
 // Tests
 //------------------------------------------------------------------------------
 
-describe("NodeEventGenerator", function() {
+describe("NodeEventGenerator", () => {
     EventGeneratorTester.testEventGeneratorInterface(
         new NodeEventGenerator(new EventEmitter())
     );
 
     let emitter, generator;
 
-    beforeEach(function() {
+    beforeEach(() => {
         emitter = new EventEmitter();
         emitter.emit = sinon.spy(emitter.emit);
         generator = new NodeEventGenerator(emitter);
     });
 
-    it("should generate events for entering AST node.", function() {
+    it("should generate events for entering AST node.", () => {
         const dummyNode = {type: "Foo", value: 1};
 
         generator.enterNode(dummyNode);
@@ -40,7 +40,7 @@ describe("NodeEventGenerator", function() {
         assert(emitter.emit.calledWith("Foo", dummyNode));
     });
 
-    it("should generate events for exitting AST node.", function() {
+    it("should generate events for exitting AST node.", () => {
         const dummyNode = {type: "Foo", value: 1};
 
         generator.leaveNode(dummyNode);

--- a/tests/lib/util/npm-util.js
+++ b/tests/lib/util/npm-util.js
@@ -61,8 +61,8 @@ describe("npmUtil", () => {
         });
 
         it("should handle missing devDependencies key", () => {
-            sandbox.stub(shell, "test", () => true);
-            sandbox.stub(fs, "readFileSync", () => JSON.stringify({
+            sandbox.stub(shell, "test").returns(true);
+            sandbox.stub(fs, "readFileSync").returns(JSON.stringify({
                 private: true,
                 dependencies: {}
             }));
@@ -75,8 +75,8 @@ describe("npmUtil", () => {
         it("should throw with message when parsing invalid package.json", () => {
             const logInfo = sandbox.stub(log, "info");
 
-            sandbox.stub(shell, "test", () => true);
-            sandbox.stub(fs, "readFileSync", () => "{ \"not: \"valid json\" }");
+            sandbox.stub(shell, "test").returns(true);
+            sandbox.stub(fs, "readFileSync").returns("{ \"not: \"valid json\" }");
 
             const fn = npmUtil.checkDevDeps.bind(null, ["some-package"]);
 
@@ -121,8 +121,8 @@ describe("npmUtil", () => {
         });
 
         it("should handle missing dependencies key", () => {
-            sandbox.stub(shell, "test", () => true);
-            sandbox.stub(fs, "readFileSync", () => JSON.stringify({
+            sandbox.stub(shell, "test").returns(true);
+            sandbox.stub(fs, "readFileSync").returns(JSON.stringify({
                 private: true,
                 devDependencies: {}
             }));
@@ -138,8 +138,8 @@ describe("npmUtil", () => {
         it("should throw with message when parsing invalid package.json", () => {
             const logInfo = sandbox.stub(log, "info");
 
-            sandbox.stub(shell, "test", () => true);
-            sandbox.stub(fs, "readFileSync", () => "{ \"not: \"valid json\" }");
+            sandbox.stub(shell, "test").returns(true);
+            sandbox.stub(fs, "readFileSync").returns("{ \"not: \"valid json\" }");
 
             const fn = npmUtil.checkDevDeps.bind(null, ["some-package"]);
 

--- a/tests/lib/util/npm-util.js
+++ b/tests/lib/util/npm-util.js
@@ -20,71 +20,63 @@ const assert = require("chai").assert,
 // Tests
 //------------------------------------------------------------------------------
 
-describe("npmUtil", function() {
+describe("npmUtil", () => {
 
     let sandbox;
 
-    beforeEach(function() {
+    beforeEach(() => {
         sandbox = sinon.sandbox.create();
     });
 
-    afterEach(function() {
+    afterEach(() => {
         sandbox.verifyAndRestore();
     });
 
-    describe("checkDevDeps()", function() {
+    describe("checkDevDeps()", () => {
         let installStatus;
 
-        before(function() {
+        before(() => {
             installStatus = npmUtil.checkDevDeps(["debug", "mocha", "notarealpackage", "jshint"]);
         });
 
-        it("should not find a direct dependency of the project", function() {
+        it("should not find a direct dependency of the project", () => {
             assert.isFalse(installStatus.debug);
         });
 
-        it("should find a dev dependency of the project", function() {
+        it("should find a dev dependency of the project", () => {
             assert.isTrue(installStatus.mocha);
         });
 
-        it("should not find non-dependencies", function() {
+        it("should not find non-dependencies", () => {
             assert.isFalse(installStatus.notarealpackage);
         });
 
-        it("should not find nested dependencies", function() {
+        it("should not find nested dependencies", () => {
             assert.isFalse(installStatus.jshint);
         });
 
-        it("should return false for a single, non-existent package", function() {
+        it("should return false for a single, non-existent package", () => {
             installStatus = npmUtil.checkDevDeps(["notarealpackage"]);
             assert.isFalse(installStatus.notarealpackage);
         });
 
-        it("should handle missing devDependencies key", function() {
-            sandbox.stub(shell, "test", function() {
-                return true;
-            });
-            sandbox.stub(fs, "readFileSync", function() {
-                return JSON.stringify({
-                    private: true,
-                    dependencies: {}
-                });
-            });
+        it("should handle missing devDependencies key", () => {
+            sandbox.stub(shell, "test", () => true);
+            sandbox.stub(fs, "readFileSync", () => JSON.stringify({
+                private: true,
+                dependencies: {}
+            }));
 
             const fn = npmUtil.checkDevDeps.bind(null, ["some-package"]);
 
             assert.doesNotThrow(fn);
         });
 
-        it("should throw with message when parsing invalid package.json", function() {
+        it("should throw with message when parsing invalid package.json", () => {
             const logInfo = sandbox.stub(log, "info");
 
-            sandbox.stub(shell, "test", function() {
-                return true;
-            });
-            sandbox.stub(fs, "readFileSync", function() {
-                return "{ \"not: \"valid json\" }";
-            });
+            sandbox.stub(shell, "test", () => true);
+            sandbox.stub(fs, "readFileSync", () => "{ \"not: \"valid json\" }");
 
             const fn = npmUtil.checkDevDeps.bind(null, ["some-package"]);
 
@@ -94,50 +86,46 @@ describe("npmUtil", function() {
         });
     });
 
-    describe("checkDeps()", function() {
+    describe("checkDeps()", () => {
         let installStatus;
 
-        before(function() {
+        before(() => {
             installStatus = npmUtil.checkDeps(["debug", "mocha", "notarealpackage", "jshint"]);
         });
 
-        it("should find a direct dependency of the project", function() {
+        it("should find a direct dependency of the project", () => {
             assert.isTrue(installStatus.debug);
         });
 
-        it("should not find a dev dependency of the project", function() {
+        it("should not find a dev dependency of the project", () => {
             assert.isFalse(installStatus.mocha);
         });
 
-        it("should not find non-dependencies", function() {
+        it("should not find non-dependencies", () => {
             assert.isFalse(installStatus.notarealpackage);
         });
 
-        it("should not find nested dependencies", function() {
+        it("should not find nested dependencies", () => {
             assert.isFalse(installStatus.jshint);
         });
 
-        it("should return false for a single, non-existent package", function() {
+        it("should return false for a single, non-existent package", () => {
             installStatus = npmUtil.checkDeps(["notarealpackage"]);
             assert.isFalse(installStatus.notarealpackage);
         });
 
-        it("should throw if no package.json can be found", function() {
-            assert.throws(function() {
+        it("should throw if no package.json can be found", () => {
+            assert.throws(() => {
                 installStatus = npmUtil.checkDeps(["notarealpackage"], "/fakepath");
             }, "Could not find a package.json file");
         });
 
-        it("should handle missing dependencies key", function() {
-            sandbox.stub(shell, "test", function() {
-                return true;
-            });
-            sandbox.stub(fs, "readFileSync", function() {
-                return JSON.stringify({
-                    private: true,
-                    devDependencies: {}
-                });
-            });
+        it("should handle missing dependencies key", () => {
+            sandbox.stub(shell, "test", () => true);
+            sandbox.stub(fs, "readFileSync", () => JSON.stringify({
+                private: true,
+                devDependencies: {}
+            }));
 
             const fn = npmUtil.checkDeps.bind(null, ["some-package"]);
 
@@ -147,15 +135,11 @@ describe("npmUtil", function() {
             fs.readFileSync.restore();
         });
 
-        it("should throw with message when parsing invalid package.json", function() {
+        it("should throw with message when parsing invalid package.json", () => {
             const logInfo = sandbox.stub(log, "info");
 
-            sandbox.stub(shell, "test", function() {
-                return true;
-            });
-            sandbox.stub(fs, "readFileSync", function() {
-                return "{ \"not: \"valid json\" }";
-            });
+            sandbox.stub(shell, "test", () => true);
+            sandbox.stub(fs, "readFileSync", () => "{ \"not: \"valid json\" }");
 
             const fn = npmUtil.checkDevDeps.bind(null, ["some-package"]);
 
@@ -169,12 +153,12 @@ describe("npmUtil", function() {
         });
     });
 
-    describe("checkPackageJson()", function() {
-        after(function() {
+    describe("checkPackageJson()", () => {
+        after(() => {
             mockFs.restore();
         });
 
-        it("should return true if package.json exists", function() {
+        it("should return true if package.json exists", () => {
             mockFs({
                 "package.json": "{ \"file\": \"contents\" }"
             });
@@ -182,14 +166,14 @@ describe("npmUtil", function() {
             assert.equal(npmUtil.checkPackageJson(), true);
         });
 
-        it("should return false if package.json does not exist", function() {
+        it("should return false if package.json does not exist", () => {
             mockFs({});
             assert.equal(npmUtil.checkPackageJson(), false);
         });
     });
 
-    describe("installSyncSaveDev()", function() {
-        it("should invoke npm to install a single desired package", function() {
+    describe("installSyncSaveDev()", () => {
+        it("should invoke npm to install a single desired package", () => {
             const stub = sandbox.stub(shell, "exec");
 
             npmUtil.installSyncSaveDev("desired-package");
@@ -198,7 +182,7 @@ describe("npmUtil", function() {
             stub.restore();
         });
 
-        it("should accept an array of packages to install", function() {
+        it("should accept an array of packages to install", () => {
             const stub = sandbox.stub(shell, "exec");
 
             npmUtil.installSyncSaveDev(["first-package", "second-package"]);

--- a/tests/lib/util/path-util.js
+++ b/tests/lib/util/path-util.js
@@ -17,32 +17,32 @@ const path = require("path"),
 // Tests
 //------------------------------------------------------------------------------
 
-describe("pathUtil", function() {
+describe("pathUtil", () => {
 
-    describe("convertPathToPosix()", function() {
+    describe("convertPathToPosix()", () => {
 
-        it("should remove a leading './'", function() {
+        it("should remove a leading './'", () => {
             const input = "./relative/file/path.js";
             const result = pathUtil.convertPathToPosix(input);
 
             assert.equal(result, "relative/file/path.js");
         });
 
-        it("should remove interior '../'", function() {
+        it("should remove interior '../'", () => {
             const input = "./relative/file/../path.js";
             const result = pathUtil.convertPathToPosix(input);
 
             assert.equal(result, "relative/path.js");
         });
 
-        it("should not remove a leading '../'", function() {
+        it("should not remove a leading '../'", () => {
             const input = "../parent/file/path.js";
             const result = pathUtil.convertPathToPosix(input);
 
             assert.equal(result, "../parent/file/path.js");
         });
 
-        it("should convert windows path seperators into posix style path seperators", function() {
+        it("should convert windows path seperators into posix style path seperators", () => {
             const input = "windows\\style\\path.js";
             const result = pathUtil.convertPathToPosix(input);
 
@@ -51,9 +51,9 @@ describe("pathUtil", function() {
 
     });
 
-    describe("getRelativePath()", function() {
+    describe("getRelativePath()", () => {
 
-        it("should return a path relative to the provided base path", function() {
+        it("should return a path relative to the provided base path", () => {
             const filePath = "/absolute/file/path.js";
             const basePath = "/absolute/";
             const result = pathUtil.getRelativePath(filePath, basePath);
@@ -61,22 +61,20 @@ describe("pathUtil", function() {
             assert.equal(result, path.normalize("file/path.js"));
         });
 
-        it("should throw if the base path is not absolute", function() {
+        it("should throw if the base path is not absolute", () => {
             const filePath = "/absolute/file/path.js";
             const basePath = "somewhere/";
 
-            assert.throws(function() {
+            assert.throws(() => {
                 pathUtil.getRelativePath(filePath, basePath);
             });
         });
 
-        it("should treat relative file path arguments as being relative to process.cwd", function() {
+        it("should treat relative file path arguments as being relative to process.cwd", () => {
             const filePath = "file/path.js";
             const basePath = "/absolute/file";
 
-            sinon.stub(process, "cwd", function() {
-                return "/absolute/";
-            });
+            sinon.stub(process, "cwd", () => "/absolute/");
             const result = pathUtil.getRelativePath(filePath, basePath);
 
             assert.equal(result, "path.js");
@@ -84,7 +82,7 @@ describe("pathUtil", function() {
             process.cwd.restore();
         });
 
-        it("should strip a leading '/' if no baseDir is provided", function() {
+        it("should strip a leading '/' if no baseDir is provided", () => {
             const filePath = "/absolute/file/path.js";
             const result = pathUtil.getRelativePath(filePath);
 

--- a/tests/lib/util/rule-fixer.js
+++ b/tests/lib/util/rule-fixer.js
@@ -15,17 +15,17 @@ const assert = require("chai").assert,
 // Tests
 //------------------------------------------------------------------------------
 
-describe("RuleFixer", function() {
+describe("RuleFixer", () => {
 
     let fixer;
 
-    beforeEach(function() {
+    beforeEach(() => {
         fixer = new RuleFixer();
     });
 
-    describe("insertTextBefore", function() {
+    describe("insertTextBefore", () => {
 
-        it("should return an object with the correct information when called", function() {
+        it("should return an object with the correct information when called", () => {
 
             const result = fixer.insertTextBefore({ range: [0, 1] }, "Hi");
 
@@ -38,9 +38,9 @@ describe("RuleFixer", function() {
 
     });
 
-    describe("insertTextBeforeRange", function() {
+    describe("insertTextBeforeRange", () => {
 
-        it("should return an object with the correct information when called", function() {
+        it("should return an object with the correct information when called", () => {
 
             const result = fixer.insertTextBeforeRange([0, 1], "Hi");
 
@@ -53,9 +53,9 @@ describe("RuleFixer", function() {
 
     });
 
-    describe("insertTextAfter", function() {
+    describe("insertTextAfter", () => {
 
-        it("should return an object with the correct information when called", function() {
+        it("should return an object with the correct information when called", () => {
 
             const result = fixer.insertTextAfter({ range: [0, 1] }, "Hi");
 
@@ -68,9 +68,9 @@ describe("RuleFixer", function() {
 
     });
 
-    describe("insertTextAfterRange", function() {
+    describe("insertTextAfterRange", () => {
 
-        it("should return an object with the correct information when called", function() {
+        it("should return an object with the correct information when called", () => {
 
             const result = fixer.insertTextAfterRange([0, 1], "Hi");
 
@@ -83,9 +83,9 @@ describe("RuleFixer", function() {
 
     });
 
-    describe("removeAfter", function() {
+    describe("removeAfter", () => {
 
-        it("should return an object with the correct information when called", function() {
+        it("should return an object with the correct information when called", () => {
 
             const result = fixer.remove({ range: [0, 1] });
 
@@ -98,9 +98,9 @@ describe("RuleFixer", function() {
 
     });
 
-    describe("removeAfterRange", function() {
+    describe("removeAfterRange", () => {
 
-        it("should return an object with the correct information when called", function() {
+        it("should return an object with the correct information when called", () => {
 
             const result = fixer.removeRange([0, 1]);
 
@@ -114,9 +114,9 @@ describe("RuleFixer", function() {
     });
 
 
-    describe("replaceText", function() {
+    describe("replaceText", () => {
 
-        it("should return an object with the correct information when called", function() {
+        it("should return an object with the correct information when called", () => {
 
             const result = fixer.replaceText({ range: [0, 1] }, "Hi");
 
@@ -129,9 +129,9 @@ describe("RuleFixer", function() {
 
     });
 
-    describe("replaceTextRange", function() {
+    describe("replaceTextRange", () => {
 
-        it("should return an object with the correct information when called", function() {
+        it("should return an object with the correct information when called", () => {
 
             const result = fixer.replaceTextRange([0, 1], "Hi");
 

--- a/tests/lib/util/source-code-fixer.js
+++ b/tests/lib/util/source-code-fixer.js
@@ -128,57 +128,57 @@ const INSERT_AT_END = {
 // Tests
 //------------------------------------------------------------------------------
 
-describe("SourceCodeFixer", function() {
+describe("SourceCodeFixer", () => {
 
-    describe("constructor", function() {
+    describe("constructor", () => {
 
-        it("Should not be able to add anything to this", function() {
+        it("Should not be able to add anything to this", () => {
             const result = new SourceCodeFixer();
 
-            assert.throws(function() {
+            assert.throws(() => {
                 result.test = 1;
             });
         });
     });
 
-    describe("applyFixes() with no BOM", function() {
+    describe("applyFixes() with no BOM", () => {
 
         let sourceCode;
 
-        beforeEach(function() {
+        beforeEach(() => {
             sourceCode = new SourceCode(TEST_CODE, TEST_AST);
         });
 
-        it("Should have empty output if sourceCode is not provided", function() {
+        it("Should have empty output if sourceCode is not provided", () => {
             const result = SourceCodeFixer.applyFixes(null, [ INSERT_AT_END ]);
 
             assert.equal(result.output.length, 0);
         });
 
-        describe("Text Insertion", function() {
+        describe("Text Insertion", () => {
 
-            it("should insert text at the end of the code", function() {
+            it("should insert text at the end of the code", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ INSERT_AT_END ]);
 
                 assert.equal(result.output, TEST_CODE + INSERT_AT_END.fix.text);
                 assert.equal(result.messages.length, 0);
             });
 
-            it("should insert text at the beginning of the code", function() {
+            it("should insert text at the beginning of the code", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ INSERT_AT_START ]);
 
                 assert.equal(result.output, INSERT_AT_START.fix.text + TEST_CODE);
                 assert.equal(result.messages.length, 0);
             });
 
-            it("should insert text in the middle of the code", function() {
+            it("should insert text in the middle of the code", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ INSERT_IN_MIDDLE ]);
 
                 assert.equal(result.output, TEST_CODE.replace("6 *", `${INSERT_IN_MIDDLE.fix.text}6 *`));
                 assert.equal(result.messages.length, 0);
             });
 
-            it("should insert text at the beginning, middle, and end of the code", function() {
+            it("should insert text at the beginning, middle, and end of the code", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ INSERT_IN_MIDDLE, INSERT_AT_START, INSERT_AT_END ]);
 
                 assert.equal(result.output, INSERT_AT_START.fix.text + TEST_CODE.replace("6 *", `${INSERT_IN_MIDDLE.fix.text}6 *`) + INSERT_AT_END.fix.text);
@@ -188,9 +188,9 @@ describe("SourceCodeFixer", function() {
         });
 
 
-        describe("Text Replacement", function() {
+        describe("Text Replacement", () => {
 
-            it("should replace text at the end of the code", function() {
+            it("should replace text at the end of the code", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ REPLACE_VAR ]);
 
                 assert.equal(result.messages.length, 0);
@@ -198,7 +198,7 @@ describe("SourceCodeFixer", function() {
                 assert.isTrue(result.fixed);
             });
 
-            it("should replace text at the beginning of the code", function() {
+            it("should replace text at the beginning of the code", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ REPLACE_ID ]);
 
                 assert.equal(result.messages.length, 0);
@@ -206,7 +206,7 @@ describe("SourceCodeFixer", function() {
                 assert.isTrue(result.fixed);
             });
 
-            it("should replace text in the middle of the code", function() {
+            it("should replace text in the middle of the code", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ REPLACE_NUM ]);
 
                 assert.equal(result.messages.length, 0);
@@ -214,7 +214,7 @@ describe("SourceCodeFixer", function() {
                 assert.isTrue(result.fixed);
             });
 
-            it("should replace text at the beginning and end of the code", function() {
+            it("should replace text at the beginning and end of the code", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ REPLACE_ID, REPLACE_VAR, REPLACE_NUM ]);
 
                 assert.equal(result.messages.length, 0);
@@ -224,9 +224,9 @@ describe("SourceCodeFixer", function() {
 
         });
 
-        describe("Text Removal", function() {
+        describe("Text Removal", () => {
 
-            it("should remove text at the start of the code", function() {
+            it("should remove text at the start of the code", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ REMOVE_START ]);
 
                 assert.equal(result.messages.length, 0);
@@ -234,7 +234,7 @@ describe("SourceCodeFixer", function() {
                 assert.isTrue(result.fixed);
             });
 
-            it("should remove text in the middle of the code", function() {
+            it("should remove text in the middle of the code", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ REMOVE_MIDDLE ]);
 
                 assert.equal(result.messages.length, 0);
@@ -242,7 +242,7 @@ describe("SourceCodeFixer", function() {
                 assert.isTrue(result.fixed);
             });
 
-            it("should remove text towards the end of the code", function() {
+            it("should remove text towards the end of the code", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ REMOVE_END ]);
 
                 assert.equal(result.messages.length, 0);
@@ -250,7 +250,7 @@ describe("SourceCodeFixer", function() {
                 assert.isTrue(result.fixed);
             });
 
-            it("should remove text at the beginning, middle, and end of the code", function() {
+            it("should remove text at the beginning, middle, and end of the code", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ REMOVE_END, REMOVE_START, REMOVE_MIDDLE ]);
 
                 assert.equal(result.messages.length, 0);
@@ -259,9 +259,9 @@ describe("SourceCodeFixer", function() {
             });
         });
 
-        describe("Combination", function() {
+        describe("Combination", () => {
 
-            it("should replace text at the beginning, remove text in the middle, and insert text at the end", function() {
+            it("should replace text at the beginning, remove text in the middle, and insert text at the end", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ INSERT_AT_END, REMOVE_END, REPLACE_VAR ]);
 
                 assert.equal(result.output, "let answer = 6;// end");
@@ -269,7 +269,7 @@ describe("SourceCodeFixer", function() {
                 assert.equal(result.messages.length, 0);
             });
 
-            it("should only apply one fix when ranges overlap", function() {
+            it("should only apply one fix when ranges overlap", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ REMOVE_MIDDLE, REPLACE_ID ]);
 
                 assert.equal(result.output, TEST_CODE.replace("answer", "a"));
@@ -278,7 +278,7 @@ describe("SourceCodeFixer", function() {
                 assert.isTrue(result.fixed);
             });
 
-            it("should apply one fix when the end of one range is the same as the start of a previous range overlap", function() {
+            it("should apply one fix when the end of one range is the same as the start of a previous range overlap", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ REMOVE_START, REPLACE_ID ]);
 
                 assert.equal(result.output, TEST_CODE.replace("answer", "foo"));
@@ -287,7 +287,7 @@ describe("SourceCodeFixer", function() {
                 assert.isTrue(result.fixed);
             });
 
-            it("should only apply one fix when ranges overlap and one message has no fix", function() {
+            it("should only apply one fix when ranges overlap and one message has no fix", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ REMOVE_MIDDLE, REPLACE_ID, NO_FIX ]);
 
                 assert.equal(result.output, TEST_CODE.replace("answer", "a"));
@@ -297,7 +297,7 @@ describe("SourceCodeFixer", function() {
                 assert.isTrue(result.fixed);
             });
 
-            it("should apply the same fix when ranges overlap regardless of order", function() {
+            it("should apply the same fix when ranges overlap regardless of order", () => {
                 const result1 = SourceCodeFixer.applyFixes(sourceCode, [ REMOVE_MIDDLE, REPLACE_ID]);
                 const result2 = SourceCodeFixer.applyFixes(sourceCode, [ REPLACE_ID, REMOVE_MIDDLE]);
 
@@ -305,9 +305,9 @@ describe("SourceCodeFixer", function() {
             });
         });
 
-        describe("No Fixes", function() {
+        describe("No Fixes", () => {
 
-            it("should only apply one fix when ranges overlap and one message has no fix", function() {
+            it("should only apply one fix when ranges overlap and one message has no fix", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ NO_FIX ]);
 
                 assert.equal(result.output, TEST_CODE);
@@ -316,7 +316,7 @@ describe("SourceCodeFixer", function() {
                 assert.isFalse(result.fixed);
             });
 
-            it("should sort the no fix messages correctly", function() {
+            it("should sort the no fix messages correctly", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ REPLACE_ID, NO_FIX2, NO_FIX1 ]);
 
                 assert.equal(result.output, TEST_CODE.replace("answer", "foo"));
@@ -328,9 +328,9 @@ describe("SourceCodeFixer", function() {
 
         });
 
-        describe("BOM manipulations", function() {
+        describe("BOM manipulations", () => {
 
-            it("should insert BOM with an insertion of '\uFEFF' at 0", function() {
+            it("should insert BOM with an insertion of '\uFEFF' at 0", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ INSERT_BOM ]);
 
                 assert.equal(result.output, `\uFEFF${TEST_CODE}`);
@@ -338,7 +338,7 @@ describe("SourceCodeFixer", function() {
                 assert.equal(result.messages.length, 0);
             });
 
-            it("should insert BOM with an insertion of '\uFEFFfoobar' at 0", function() {
+            it("should insert BOM with an insertion of '\uFEFFfoobar' at 0", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ INSERT_BOM_WITH_TEXT ]);
 
                 assert.equal(result.output, `\uFEFF// start\n${TEST_CODE}`);
@@ -346,7 +346,7 @@ describe("SourceCodeFixer", function() {
                 assert.equal(result.messages.length, 0);
             });
 
-            it("should remove BOM with a negative range", function() {
+            it("should remove BOM with a negative range", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ REMOVE_BOM ]);
 
                 assert.equal(result.output, TEST_CODE);
@@ -354,7 +354,7 @@ describe("SourceCodeFixer", function() {
                 assert.equal(result.messages.length, 0);
             });
 
-            it("should replace BOM with a negative range and 'foobar'", function() {
+            it("should replace BOM with a negative range and 'foobar'", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ REPLACE_BOM_WITH_TEXT ]);
 
                 assert.equal(result.output, `// start\n${TEST_CODE}`);
@@ -368,38 +368,38 @@ describe("SourceCodeFixer", function() {
 
     // This section is almost same as "with no BOM".
     // Just `result.output` has BOM.
-    describe("applyFixes() with BOM", function() {
+    describe("applyFixes() with BOM", () => {
 
         let sourceCode;
 
-        beforeEach(function() {
+        beforeEach(() => {
             sourceCode = new SourceCode(`\uFEFF${TEST_CODE}`, TEST_AST);
         });
 
-        describe("Text Insertion", function() {
+        describe("Text Insertion", () => {
 
-            it("should insert text at the end of the code", function() {
+            it("should insert text at the end of the code", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ INSERT_AT_END ]);
 
                 assert.equal(result.output, `\uFEFF${TEST_CODE}${INSERT_AT_END.fix.text}`);
                 assert.equal(result.messages.length, 0);
             });
 
-            it("should insert text at the beginning of the code", function() {
+            it("should insert text at the beginning of the code", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ INSERT_AT_START ]);
 
                 assert.equal(result.output, `\uFEFF${INSERT_AT_START.fix.text}${TEST_CODE}`);
                 assert.equal(result.messages.length, 0);
             });
 
-            it("should insert text in the middle of the code", function() {
+            it("should insert text in the middle of the code", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ INSERT_IN_MIDDLE ]);
 
                 assert.equal(result.output, `\uFEFF${TEST_CODE.replace("6 *", `${INSERT_IN_MIDDLE.fix.text}6 *`)}`);
                 assert.equal(result.messages.length, 0);
             });
 
-            it("should insert text at the beginning, middle, and end of the code", function() {
+            it("should insert text at the beginning, middle, and end of the code", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ INSERT_IN_MIDDLE, INSERT_AT_START, INSERT_AT_END ]);
                 const insertInMiddle = TEST_CODE.replace("6 *", `${INSERT_IN_MIDDLE.fix.text}6 *`);
 
@@ -409,9 +409,9 @@ describe("SourceCodeFixer", function() {
 
         });
 
-        describe("Text Replacement", function() {
+        describe("Text Replacement", () => {
 
-            it("should replace text at the end of the code", function() {
+            it("should replace text at the end of the code", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ REPLACE_VAR ]);
 
                 assert.equal(result.messages.length, 0);
@@ -419,7 +419,7 @@ describe("SourceCodeFixer", function() {
                 assert.isTrue(result.fixed);
             });
 
-            it("should replace text at the beginning of the code", function() {
+            it("should replace text at the beginning of the code", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ REPLACE_ID ]);
 
                 assert.equal(result.messages.length, 0);
@@ -427,7 +427,7 @@ describe("SourceCodeFixer", function() {
                 assert.isTrue(result.fixed);
             });
 
-            it("should replace text in the middle of the code", function() {
+            it("should replace text in the middle of the code", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ REPLACE_NUM ]);
 
                 assert.equal(result.messages.length, 0);
@@ -435,7 +435,7 @@ describe("SourceCodeFixer", function() {
                 assert.isTrue(result.fixed);
             });
 
-            it("should replace text at the beginning and end of the code", function() {
+            it("should replace text at the beginning and end of the code", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ REPLACE_ID, REPLACE_VAR, REPLACE_NUM ]);
 
                 assert.equal(result.messages.length, 0);
@@ -445,9 +445,9 @@ describe("SourceCodeFixer", function() {
 
         });
 
-        describe("Text Removal", function() {
+        describe("Text Removal", () => {
 
-            it("should remove text at the start of the code", function() {
+            it("should remove text at the start of the code", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ REMOVE_START ]);
 
                 assert.equal(result.messages.length, 0);
@@ -455,7 +455,7 @@ describe("SourceCodeFixer", function() {
                 assert.isTrue(result.fixed);
             });
 
-            it("should remove text in the middle of the code", function() {
+            it("should remove text in the middle of the code", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ REMOVE_MIDDLE ]);
 
                 assert.equal(result.messages.length, 0);
@@ -463,7 +463,7 @@ describe("SourceCodeFixer", function() {
                 assert.isTrue(result.fixed);
             });
 
-            it("should remove text towards the end of the code", function() {
+            it("should remove text towards the end of the code", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ REMOVE_END ]);
 
                 assert.equal(result.messages.length, 0);
@@ -471,7 +471,7 @@ describe("SourceCodeFixer", function() {
                 assert.isTrue(result.fixed);
             });
 
-            it("should remove text at the beginning, middle, and end of the code", function() {
+            it("should remove text at the beginning, middle, and end of the code", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ REMOVE_END, REMOVE_START, REMOVE_MIDDLE ]);
 
                 assert.equal(result.messages.length, 0);
@@ -480,9 +480,9 @@ describe("SourceCodeFixer", function() {
             });
         });
 
-        describe("Combination", function() {
+        describe("Combination", () => {
 
-            it("should replace text at the beginning, remove text in the middle, and insert text at the end", function() {
+            it("should replace text at the beginning, remove text in the middle, and insert text at the end", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ INSERT_AT_END, REMOVE_END, REPLACE_VAR ]);
 
                 assert.equal(result.output, "\uFEFFlet answer = 6;// end");
@@ -490,7 +490,7 @@ describe("SourceCodeFixer", function() {
                 assert.equal(result.messages.length, 0);
             });
 
-            it("should only apply one fix when ranges overlap", function() {
+            it("should only apply one fix when ranges overlap", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ REMOVE_MIDDLE, REPLACE_ID ]);
 
                 assert.equal(result.output, `\uFEFF${TEST_CODE.replace("answer", "a")}`);
@@ -499,7 +499,7 @@ describe("SourceCodeFixer", function() {
                 assert.isTrue(result.fixed);
             });
 
-            it("should apply one fix when the end of one range is the same as the start of a previous range overlap", function() {
+            it("should apply one fix when the end of one range is the same as the start of a previous range overlap", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ REMOVE_START, REPLACE_ID ]);
 
                 assert.equal(result.output, `\uFEFF${TEST_CODE.replace("answer", "foo")}`);
@@ -508,7 +508,7 @@ describe("SourceCodeFixer", function() {
                 assert.isTrue(result.fixed);
             });
 
-            it("should only apply one fix when ranges overlap and one message has no fix", function() {
+            it("should only apply one fix when ranges overlap and one message has no fix", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ REMOVE_MIDDLE, REPLACE_ID, NO_FIX ]);
 
                 assert.equal(result.output, `\uFEFF${TEST_CODE.replace("answer", "a")}`);
@@ -518,7 +518,7 @@ describe("SourceCodeFixer", function() {
                 assert.isTrue(result.fixed);
             });
 
-            it("should apply the same fix when ranges overlap regardless of order", function() {
+            it("should apply the same fix when ranges overlap regardless of order", () => {
                 const result1 = SourceCodeFixer.applyFixes(sourceCode, [ REMOVE_MIDDLE, REPLACE_ID]);
                 const result2 = SourceCodeFixer.applyFixes(sourceCode, [ REPLACE_ID, REMOVE_MIDDLE]);
 
@@ -527,9 +527,9 @@ describe("SourceCodeFixer", function() {
 
         });
 
-        describe("No Fixes", function() {
+        describe("No Fixes", () => {
 
-            it("should only apply one fix when ranges overlap and one message has no fix", function() {
+            it("should only apply one fix when ranges overlap and one message has no fix", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ NO_FIX ]);
 
                 assert.equal(result.output, `\uFEFF${TEST_CODE}`);
@@ -540,9 +540,9 @@ describe("SourceCodeFixer", function() {
 
         });
 
-        describe("BOM manipulations", function() {
+        describe("BOM manipulations", () => {
 
-            it("should insert BOM with an insertion of '\uFEFF' at 0", function() {
+            it("should insert BOM with an insertion of '\uFEFF' at 0", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ INSERT_BOM ]);
 
                 assert.equal(result.output, `\uFEFF${TEST_CODE}`);
@@ -550,7 +550,7 @@ describe("SourceCodeFixer", function() {
                 assert.equal(result.messages.length, 0);
             });
 
-            it("should insert BOM with an insertion of '\uFEFFfoobar' at 0", function() {
+            it("should insert BOM with an insertion of '\uFEFFfoobar' at 0", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ INSERT_BOM_WITH_TEXT ]);
 
                 assert.equal(result.output, `\uFEFF// start\n${TEST_CODE}`);
@@ -558,7 +558,7 @@ describe("SourceCodeFixer", function() {
                 assert.equal(result.messages.length, 0);
             });
 
-            it("should remove BOM with a negative range", function() {
+            it("should remove BOM with a negative range", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ REMOVE_BOM ]);
 
                 assert.equal(result.output, TEST_CODE);
@@ -566,7 +566,7 @@ describe("SourceCodeFixer", function() {
                 assert.equal(result.messages.length, 0);
             });
 
-            it("should replace BOM with a negative range and 'foobar'", function() {
+            it("should replace BOM with a negative range and 'foobar'", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ REPLACE_BOM_WITH_TEXT ]);
 
                 assert.equal(result.output, `// start\n${TEST_CODE}`);

--- a/tests/lib/util/source-code-util.js
+++ b/tests/lib/util/source-code-util.js
@@ -25,7 +25,7 @@ const originalDir = process.cwd();
 // Tests
 //------------------------------------------------------------------------------
 
-describe("SourceCodeUtil", function() {
+describe("SourceCodeUtil", () => {
 
     let fixtureDir,
         getSourceCodeOfFiles;
@@ -58,36 +58,36 @@ describe("SourceCodeUtil", function() {
     };
 
     // copy into clean area so as not to get "infected" by this project's .eslintrc files
-    before(function() {
+    before(() => {
         fixtureDir = `${os.tmpdir()}/eslint/fixtures/source-code-util`;
         sh.mkdir("-p", fixtureDir);
         sh.cp("-r", "./tests/fixtures/source-code-util/.", fixtureDir);
         fixtureDir = fs.realpathSync(fixtureDir);
     });
 
-    beforeEach(function() {
+    beforeEach(() => {
         getSourceCodeOfFiles = proxyquire("../../../lib/util/source-code-util", requireStubs).getSourceCodeOfFiles;
     });
 
-    afterEach(function() {
+    afterEach(() => {
         log.info.reset();
         log.error.reset();
     });
 
-    after(function() {
+    after(() => {
         sh.rm("-r", fixtureDir);
     });
 
-    describe("getSourceCodeOfFiles()", function() {
+    describe("getSourceCodeOfFiles()", () => {
 
-        it("should handle single string filename arguments", function() {
+        it("should handle single string filename arguments", () => {
             const filename = getFixturePath("foo.js");
             const sourceCode = getSourceCodeOfFiles(filename, {cwd: fixtureDir});
 
             assert.isObject(sourceCode);
         });
 
-        it("should accept an array of string filenames", function() {
+        it("should accept an array of string filenames", () => {
             const fooFilename = getFixturePath("foo.js");
             const barFilename = getFixturePath("bar.js");
             const sourceCode = getSourceCodeOfFiles([fooFilename, barFilename], {cwd: fixtureDir});
@@ -95,7 +95,7 @@ describe("SourceCodeUtil", function() {
             assert.isObject(sourceCode);
         });
 
-        it("should accept a glob argument", function() {
+        it("should accept a glob argument", () => {
             const glob = getFixturePath("*.js");
             const filename = getFixturePath("foo.js");
             const sourceCode = getSourceCodeOfFiles(glob, {cwd: fixtureDir});
@@ -104,7 +104,7 @@ describe("SourceCodeUtil", function() {
             assert.property(sourceCode, filename);
         });
 
-        it("should accept a relative filename", function() {
+        it("should accept a relative filename", () => {
             const filename = "foo.js";
             const sourceCode = getSourceCodeOfFiles(filename, {cwd: fixtureDir});
 
@@ -112,7 +112,7 @@ describe("SourceCodeUtil", function() {
             assert.property(sourceCode, getFixturePath(filename));
         });
 
-        it("should accept a relative path to a file in a parent directory", function() {
+        it("should accept a relative path to a file in a parent directory", () => {
             const filename = "../foo.js";
             const sourceCode = getSourceCodeOfFiles(filename, {cwd: getFixturePath("nested")});
 
@@ -120,7 +120,7 @@ describe("SourceCodeUtil", function() {
             assert.property(sourceCode, getFixturePath("foo.js"));
         });
 
-        it("should accept a callback", function() {
+        it("should accept a callback", () => {
             const filename = getFixturePath("foo.js");
             const spy = sinon.spy();
 
@@ -130,7 +130,7 @@ describe("SourceCodeUtil", function() {
             assert(spy.calledOnce);
         });
 
-        it("should call the callback with total number of files being processed", function() {
+        it("should call the callback with total number of files being processed", () => {
             const filename = getFixturePath("foo.js");
             const spy = sinon.spy();
 
@@ -140,7 +140,7 @@ describe("SourceCodeUtil", function() {
             assert.equal(spy.firstCall.args[0], 1);
         });
 
-        it("should use default options if none are provided", function() {
+        it("should use default options if none are provided", () => {
             const filename = getFixturePath("foo.js");
             const spy = sinon.spy(globUtil, "resolveFileGlobPatterns");
 
@@ -149,7 +149,7 @@ describe("SourceCodeUtil", function() {
             assert.deepEqual(spy.firstCall.args[1].extensions, [ ".js" ]);
         });
 
-        it("should create an object with located filenames as keys", function() {
+        it("should create an object with located filenames as keys", () => {
             const fooFilename = getFixturePath("foo.js");
             const barFilename = getFixturePath("bar.js");
             const sourceCode = getSourceCodeOfFiles([fooFilename, barFilename], {cwd: fixtureDir});
@@ -158,23 +158,23 @@ describe("SourceCodeUtil", function() {
             assert.property(sourceCode, barFilename);
         });
 
-        it("should should not include non-existent filesnames in results", function() {
+        it("should should not include non-existent filesnames in results", () => {
             const filename = getFixturePath("missing.js");
             const sourceCode = getSourceCodeOfFiles(filename, {cwd: fixtureDir});
 
             assert.notProperty(sourceCode, filename);
         });
 
-        it("should throw for files with parsing errors", function() {
+        it("should throw for files with parsing errors", () => {
             const filename = getFixturePath("parse-error", "parse-error.js");
 
-            assert.throw(function() {
+            assert.throw(() => {
                 getSourceCodeOfFiles(filename, {cwd: fixtureDir});
             }, /Parsing error: Unexpected token ;/);
 
         });
 
-        it("should obtain the sourceCode of a file", function() {
+        it("should obtain the sourceCode of a file", () => {
             const filename = getFixturePath("foo.js");
             const sourceCode = getSourceCodeOfFiles(filename, {cwd: fixtureDir});
 
@@ -182,7 +182,7 @@ describe("SourceCodeUtil", function() {
             assert.instanceOf(sourceCode[filename], SourceCode);
         });
 
-        it("should obtain the sourceCode of JSX files", function() {
+        it("should obtain the sourceCode of JSX files", () => {
             const filename = getFixturePath("jsx", "foo.jsx");
             const options = {
                 cwd: fixtureDir,
@@ -198,7 +198,7 @@ describe("SourceCodeUtil", function() {
             assert.instanceOf(sourceCode[filename], SourceCode);
         });
 
-        it("should honor .eslintignore files by default", function() {
+        it("should honor .eslintignore files by default", () => {
             const glob = getFixturePath("*.js");
             const unignoredFilename = getFixturePath("foo.js");
             const ignoredFilename = getFixturePath("ignored.js");
@@ -208,7 +208,7 @@ describe("SourceCodeUtil", function() {
             assert.notProperty(sourceCode, ignoredFilename);
         });
 
-        it("should obtain the sourceCode of all files in a specified folder", function() {
+        it("should obtain the sourceCode of all files in a specified folder", () => {
             const folder = getFixturePath("nested");
             const fooFile = getFixturePath("nested/foo.js");
             const barFile = getFixturePath("nested/bar.js");
@@ -219,7 +219,7 @@ describe("SourceCodeUtil", function() {
             assert.instanceOf(sourceCode[barFile], SourceCode);
         });
 
-        it("should accept cli options", function() {
+        it("should accept cli options", () => {
             const pattern = getFixturePath("ext");
             const abcFile = getFixturePath("ext/foo.abc");
             const cliOptions = {extensions: [".abc"], cwd: fixtureDir};
@@ -229,7 +229,7 @@ describe("SourceCodeUtil", function() {
             assert.instanceOf(sourceCode[abcFile], SourceCode);
         });
 
-        it("should execute the callback function, if provided", function() {
+        it("should execute the callback function, if provided", () => {
             const callback = sinon.spy();
             const filename = getFixturePath("foo.js");
 
@@ -237,7 +237,7 @@ describe("SourceCodeUtil", function() {
             assert(callback.calledOnce);
         });
 
-        it("should execute callback function once per file", function() {
+        it("should execute callback function once per file", () => {
             const callback = sinon.spy();
             const fooFilename = getFixturePath("foo.js");
             const barFilename = getFixturePath("bar.js");
@@ -246,7 +246,7 @@ describe("SourceCodeUtil", function() {
             assert.equal(callback.callCount, 2);
         });
 
-        it("should call callback function with total number of files with sourceCode", function() {
+        it("should call callback function with total number of files with sourceCode", () => {
             const callback = sinon.spy();
             const firstFn = getFixturePath("foo.js");
             const secondFn = getFixturePath("bar.js");

--- a/tests/lib/util/source-code.js
+++ b/tests/lib/util/source-code.js
@@ -36,11 +36,11 @@ const AST = espree.parse("let foo = bar;", DEFAULT_CONFIG),
 // Tests
 //------------------------------------------------------------------------------
 
-describe("SourceCode", function() {
+describe("SourceCode", () => {
 
-    describe("new SourceCode()", function() {
+    describe("new SourceCode()", () => {
 
-        it("should create a new instance when called with valid data", function() {
+        it("should create a new instance when called with valid data", () => {
             const ast = { comments: [], tokens: [], loc: {}, range: [] };
             const sourceCode = new SourceCode("foo;", ast);
 
@@ -49,7 +49,7 @@ describe("SourceCode", function() {
             assert.equal(sourceCode.ast, ast);
         });
 
-        it("should split text into lines when called with valid data", function() {
+        it("should split text into lines when called with valid data", () => {
             const ast = { comments: [], tokens: [], loc: {}, range: [] };
             const sourceCode = new SourceCode("foo;\nbar;", ast);
 
@@ -61,38 +61,38 @@ describe("SourceCode", function() {
 
         /* eslint-disable no-new */
 
-        it("should throw an error when called with an AST that's missing tokens", function() {
+        it("should throw an error when called with an AST that's missing tokens", () => {
 
-            assert.throws(function() {
+            assert.throws(() => {
                 new SourceCode("foo;", { comments: [], loc: {}, range: [] });
             }, /missing the tokens array/);
 
         });
 
-        it("should throw an error when called with an AST that's missing comments", function() {
+        it("should throw an error when called with an AST that's missing comments", () => {
 
-            assert.throws(function() {
+            assert.throws(() => {
                 new SourceCode("foo;", { tokens: [], loc: {}, range: [] });
             }, /missing the comments array/);
 
         });
 
-        it("should throw an error when called with an AST that's missing comments", function() {
+        it("should throw an error when called with an AST that's missing comments", () => {
 
-            assert.throws(function() {
+            assert.throws(() => {
                 new SourceCode("foo;", { comments: [], tokens: [], range: [] });
             }, /missing location information/);
 
         });
 
-        it("should throw an error when called with an AST that's missing comments", function() {
+        it("should throw an error when called with an AST that's missing comments", () => {
 
-            assert.throws(function() {
+            assert.throws(() => {
                 new SourceCode("foo;", { comments: [], tokens: [], loc: {} });
             }, /missing range information/);
         });
 
-        it("should store all tokens and comments sorted by range", function() {
+        it("should store all tokens and comments sorted by range", () => {
             const comments = [
                 { range: [0, 2] },
                 { range: [10, 12] }
@@ -110,43 +110,43 @@ describe("SourceCode", function() {
             assert.deepEqual(actual, expected);
         });
 
-        describe("if a text has BOM,", function() {
+        describe("if a text has BOM,", () => {
             let sourceCode;
 
-            beforeEach(function() {
+            beforeEach(() => {
                 const ast = { comments: [], tokens: [], loc: {}, range: [] };
 
                 sourceCode = new SourceCode("\uFEFFconsole.log('hello');", ast);
             });
 
-            it("should has true at `hasBOM` property.", function() {
+            it("should has true at `hasBOM` property.", () => {
                 assert.equal(sourceCode.hasBOM, true);
             });
 
-            it("should not has BOM in `text` property.", function() {
+            it("should not has BOM in `text` property.", () => {
                 assert.equal(sourceCode.text, "console.log('hello');");
             });
         });
 
-        describe("if a text doesn't have BOM,", function() {
+        describe("if a text doesn't have BOM,", () => {
             let sourceCode;
 
-            beforeEach(function() {
+            beforeEach(() => {
                 const ast = { comments: [], tokens: [], loc: {}, range: [] };
 
                 sourceCode = new SourceCode("console.log('hello');", ast);
             });
 
-            it("should has false at `hasBOM` property.", function() {
+            it("should has false at `hasBOM` property.", () => {
                 assert.equal(sourceCode.hasBOM, false);
             });
 
-            it("should not has BOM in `text` property.", function() {
+            it("should not has BOM in `text` property.", () => {
                 assert.equal(sourceCode.text, "console.log('hello');");
             });
         });
 
-        describe("when it read a UTF-8 file (has BOM), SourceCode", function() {
+        describe("when it read a UTF-8 file (has BOM), SourceCode", () => {
             const UTF8_FILE = path.resolve(__dirname, "../../fixtures/utf8-bom.js");
             const text = fs.readFileSync(
                     UTF8_FILE,
@@ -154,13 +154,13 @@ describe("SourceCode", function() {
                 ).replace(/\r\n/g, "\n"); // <-- For autocrlf of "git for Windows"
             let sourceCode;
 
-            beforeEach(function() {
+            beforeEach(() => {
                 const ast = { comments: [], tokens: [], loc: {}, range: [] };
 
                 sourceCode = new SourceCode(text, ast);
             });
 
-            it("to be clear, check the file has UTF-8 BOM.", function() {
+            it("to be clear, check the file has UTF-8 BOM.", () => {
                 const buffer = fs.readFileSync(UTF8_FILE);
 
                 assert.equal(buffer[0], 0xEF);
@@ -168,11 +168,11 @@ describe("SourceCode", function() {
                 assert.equal(buffer[2], 0xBF);
             });
 
-            it("should has true at `hasBOM` property.", function() {
+            it("should has true at `hasBOM` property.", () => {
                 assert.equal(sourceCode.hasBOM, true);
             });
 
-            it("should not has BOM in `text` property.", function() {
+            it("should not has BOM in `text` property.", () => {
                 assert.equal(
                     sourceCode.text,
                     "\"use strict\";\n\nconsole.log(\"This file has [0xEF, 0xBB, 0xBF] as BOM.\");\n");
@@ -181,20 +181,20 @@ describe("SourceCode", function() {
     });
 
 
-    describe("getJSDocComment()", function() {
+    describe("getJSDocComment()", () => {
 
         const sandbox = sinon.sandbox.create(),
             filename = "foo.js";
 
-        beforeEach(function() {
+        beforeEach(() => {
             eslint.reset();
         });
 
-        afterEach(function() {
+        afterEach(() => {
             sandbox.verifyAndRestore();
         });
 
-        it("should not take a JSDoc comment from a FunctionDeclaration parent node when the node is a FunctionExpression", function() {
+        it("should not take a JSDoc comment from a FunctionDeclaration parent node when the node is a FunctionExpression", () => {
 
             const code = [
                 "/** Desc*/",
@@ -222,7 +222,7 @@ describe("SourceCode", function() {
 
         });
 
-        it("should not take a JSDoc comment from a VariableDeclaration parent node when the node is a FunctionExpression inside a NewExpression", function() {
+        it("should not take a JSDoc comment from a VariableDeclaration parent node when the node is a FunctionExpression inside a NewExpression", () => {
 
             const code = [
                 "/** Desc*/",
@@ -250,7 +250,7 @@ describe("SourceCode", function() {
 
         });
 
-        it("should not take a JSDoc comment from a FunctionExpression parent node when the node is a FunctionExpression", function() {
+        it("should not take a JSDoc comment from a FunctionExpression parent node when the node is a FunctionExpression", () => {
 
             const code = [
                 "/** Desc*/",
@@ -280,7 +280,7 @@ describe("SourceCode", function() {
 
         });
 
-        it("should get JSDoc comment for FunctionExpression in a CallExpression", function() {
+        it("should get JSDoc comment for FunctionExpression in a CallExpression", () => {
             const code = [
                 "call(",
                 "  /** Documentation. */",
@@ -311,7 +311,7 @@ describe("SourceCode", function() {
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
         });
 
-        it("should get JSDoc comment for node when the node is a FunctionDeclaration", function() {
+        it("should get JSDoc comment for node when the node is a FunctionDeclaration", () => {
 
             const code = [
                 "/** Desc*/",
@@ -340,7 +340,7 @@ describe("SourceCode", function() {
 
         });
 
-        it("should get JSDoc comment for node when the node is a FunctionDeclaration but its parent is an export", function() {
+        it("should get JSDoc comment for node when the node is a FunctionDeclaration but its parent is an export", () => {
 
             const code = [
                 "/** Desc*/",
@@ -370,7 +370,7 @@ describe("SourceCode", function() {
         });
 
 
-        it("should get JSDoc comment for node when the node is a FunctionDeclaration but not the first statement", function() {
+        it("should get JSDoc comment for node when the node is a FunctionDeclaration but not the first statement", () => {
 
             const code = [
                 "'use strict';",
@@ -401,7 +401,7 @@ describe("SourceCode", function() {
         });
 
 
-        it("should not get JSDoc comment for node when the node is a FunctionDeclaration inside of an IIFE without a JSDoc comment", function() {
+        it("should not get JSDoc comment for node when the node is a FunctionDeclaration inside of an IIFE without a JSDoc comment", () => {
 
             const code = [
                 "/** Desc*/",
@@ -431,7 +431,7 @@ describe("SourceCode", function() {
 
         });
 
-        it("should get JSDoc comment for node when the node is a FunctionDeclaration and there are multiple comments", function() {
+        it("should get JSDoc comment for node when the node is a FunctionDeclaration and there are multiple comments", () => {
 
             const code = [
                 "/* Code is good */",
@@ -461,7 +461,7 @@ describe("SourceCode", function() {
 
         });
 
-        it("should get JSDoc comment for node when the node is a FunctionDeclaration inside of an IIFE", function() {
+        it("should get JSDoc comment for node when the node is a FunctionDeclaration inside of an IIFE", () => {
 
             const code = [
                 "/** Code is good */",
@@ -492,7 +492,7 @@ describe("SourceCode", function() {
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
         });
 
-        it("should get JSDoc comment for node when the node is a FunctionExpression inside of an object literal", function() {
+        it("should get JSDoc comment for node when the node is a FunctionExpression inside of an object literal", () => {
 
             const code = [
                 "/** Code is good */",
@@ -523,7 +523,7 @@ describe("SourceCode", function() {
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
         });
 
-        it("should get JSDoc comment for node when the node is a ArrowFunctionExpression inside of an object literal", function() {
+        it("should get JSDoc comment for node when the node is a ArrowFunctionExpression inside of an object literal", () => {
 
             const code = [
                 "/** Code is good */",
@@ -554,7 +554,7 @@ describe("SourceCode", function() {
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
         });
 
-        it("should get JSDoc comment for node when the node is a FunctionExpression in an assignment", function() {
+        it("should get JSDoc comment for node when the node is a FunctionExpression in an assignment", () => {
 
             const code = [
                 "/** Code is good */",
@@ -583,7 +583,7 @@ describe("SourceCode", function() {
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
         });
 
-        it("should get JSDoc comment for node when the node is a FunctionExpression in an assignment inside an IIFE", function() {
+        it("should get JSDoc comment for node when the node is a FunctionExpression in an assignment inside an IIFE", () => {
 
             const code = [
                 "/** Code is good */",
@@ -616,7 +616,7 @@ describe("SourceCode", function() {
             assert.isTrue(spy.calledTwice, "Event handler should be called.");
         });
 
-        it("should not get JSDoc comment for node when the node is a FunctionExpression in an assignment inside an IIFE without a JSDoc comment", function() {
+        it("should not get JSDoc comment for node when the node is a FunctionExpression in an assignment inside an IIFE without a JSDoc comment", () => {
 
             const code = [
                 "/** Code is good */",
@@ -648,7 +648,7 @@ describe("SourceCode", function() {
             assert.isTrue(spy.calledTwice, "Event handler should be called.");
         });
 
-        it("should not get JSDoc comment for node when the node is a FunctionExpression inside of a CallExpression", function() {
+        it("should not get JSDoc comment for node when the node is a FunctionExpression inside of a CallExpression", () => {
 
             const code = [
                 "/** Code is good */",
@@ -678,7 +678,7 @@ describe("SourceCode", function() {
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
         });
 
-        it("should not get JSDoc comment for node when the node is a FunctionExpression in an assignment inside an IIFE without a JSDoc comment", function() {
+        it("should not get JSDoc comment for node when the node is a FunctionExpression in an assignment inside an IIFE without a JSDoc comment", () => {
 
             const code = [
                 "/**",
@@ -716,7 +716,7 @@ describe("SourceCode", function() {
             assert.isTrue(spy.calledTwice, "Event handler should be called.");
         });
 
-        it("should get JSDoc comment for node when the node is a ClassExpression", function() {
+        it("should get JSDoc comment for node when the node is a ClassExpression", () => {
 
             const code = [
                 "/** Merges two objects together.*/",
@@ -745,7 +745,7 @@ describe("SourceCode", function() {
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
         });
 
-        it("should get JSDoc comment for node when the node is a ClassDeclaration", function() {
+        it("should get JSDoc comment for node when the node is a ClassDeclaration", () => {
 
             const code = [
                 "/** Merges two objects together.*/",
@@ -774,7 +774,7 @@ describe("SourceCode", function() {
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
         });
 
-        it("should not get JSDoc comment for class method even if the class has jsdoc present", function() {
+        it("should not get JSDoc comment for class method even if the class has jsdoc present", () => {
 
             const code = [
                 "/** Merges two objects together.*/",
@@ -803,7 +803,7 @@ describe("SourceCode", function() {
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
         });
 
-        it("should get JSDoc comment for function expression even if function has blank lines on top", function() {
+        it("should get JSDoc comment for function expression even if function has blank lines on top", () => {
 
             const code = [
                 "/** Merges two objects together.*/",
@@ -836,7 +836,7 @@ describe("SourceCode", function() {
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
         });
 
-        it("should not get JSDoc comment for function declaration when the function has blank lines on top", function() {
+        it("should not get JSDoc comment for function declaration when the function has blank lines on top", () => {
 
             const code = [
                 "/** Merges two objects together.*/",
@@ -869,7 +869,7 @@ describe("SourceCode", function() {
 
     });
 
-    describe("getComments()", function() {
+    describe("getComments()", () => {
         const config = { rules: {} };
 
         /**
@@ -889,7 +889,7 @@ describe("SourceCode", function() {
             };
         }
 
-        it("should attach them to all nodes", function() {
+        it("should attach them to all nodes", () => {
             const code = [
                 "// my line comment",
                 "var a = 42;",
@@ -906,7 +906,7 @@ describe("SourceCode", function() {
             eslint.verify(code, config, "", true);
         });
 
-        it("should not attach leading comments from previous node", function() {
+        it("should not attach leading comments from previous node", () => {
             const code = [
                 "function a() {",
                 "    var b = {",
@@ -928,7 +928,7 @@ describe("SourceCode", function() {
             eslint.verify(code, config, "", true);
         });
 
-        it("should not attach duplicate leading comments from previous node", function() {
+        it("should not attach duplicate leading comments from previous node", () => {
             const code = [
                 "//foo",
                 "var zzz /*aaa*/ = 777;",
@@ -946,9 +946,9 @@ describe("SourceCode", function() {
         });
     });
 
-    describe("getLines()", function() {
+    describe("getLines()", () => {
 
-        it("should get proper lines when using \\n as a line break", function() {
+        it("should get proper lines when using \\n as a line break", () => {
             const code = "a;\nb;",
                 ast = espree.parse(code, DEFAULT_CONFIG),
                 sourceCode = new SourceCode(code, ast);
@@ -959,7 +959,7 @@ describe("SourceCode", function() {
             assert.equal(lines[1], "b;");
         });
 
-        it("should get proper lines when using \\r\\n as a line break", function() {
+        it("should get proper lines when using \\r\\n as a line break", () => {
             const code = "a;\r\nb;",
                 ast = espree.parse(code, DEFAULT_CONFIG),
                 sourceCode = new SourceCode(code, ast);
@@ -970,7 +970,7 @@ describe("SourceCode", function() {
             assert.equal(lines[1], "b;");
         });
 
-        it("should get proper lines when using \\r as a line break", function() {
+        it("should get proper lines when using \\r as a line break", () => {
             const code = "a;\rb;",
                 ast = espree.parse(code, DEFAULT_CONFIG),
                 sourceCode = new SourceCode(code, ast);
@@ -981,7 +981,7 @@ describe("SourceCode", function() {
             assert.equal(lines[1], "b;");
         });
 
-        it("should get proper lines when using \\u2028 as a line break", function() {
+        it("should get proper lines when using \\u2028 as a line break", () => {
             const code = "a;\u2028b;",
                 ast = espree.parse(code, DEFAULT_CONFIG),
                 sourceCode = new SourceCode(code, ast);
@@ -992,7 +992,7 @@ describe("SourceCode", function() {
             assert.equal(lines[1], "b;");
         });
 
-        it("should get proper lines when using \\u2029 as a line break", function() {
+        it("should get proper lines when using \\u2029 as a line break", () => {
             const code = "a;\u2029b;",
                 ast = espree.parse(code, DEFAULT_CONFIG),
                 sourceCode = new SourceCode(code, ast);
@@ -1005,35 +1005,35 @@ describe("SourceCode", function() {
 
     });
 
-    describe("getText()", function() {
+    describe("getText()", () => {
 
         let sourceCode,
             ast;
 
-        beforeEach(function() {
+        beforeEach(() => {
             ast = espree.parse(TEST_CODE, DEFAULT_CONFIG);
             sourceCode = new SourceCode(TEST_CODE, ast);
         });
 
-        it("should retrieve all text when used without parameters", function() {
+        it("should retrieve all text when used without parameters", () => {
             const text = sourceCode.getText();
 
             assert.equal(text, TEST_CODE);
         });
 
-        it("should retrieve all text for root node", function() {
+        it("should retrieve all text for root node", () => {
             const text = sourceCode.getText(ast);
 
             assert.equal(text, TEST_CODE);
         });
 
-        it("should clamp to valid range when retrieving characters before start of source", function() {
+        it("should clamp to valid range when retrieving characters before start of source", () => {
             const text = sourceCode.getText(ast, 2, 0);
 
             assert.equal(text, TEST_CODE);
         });
 
-        it("should retrieve all text for binary expression", function() {
+        it("should retrieve all text for binary expression", () => {
 
             const node = ast.body[0].declarations[0].init;
             const text = sourceCode.getText(node);
@@ -1041,7 +1041,7 @@ describe("SourceCode", function() {
             assert.equal(text, "6 * 7");
         });
 
-        it("should retrieve all text plus two characters before for binary expression", function() {
+        it("should retrieve all text plus two characters before for binary expression", () => {
 
             const node = ast.body[0].declarations[0].init;
             const text = sourceCode.getText(node, 2);
@@ -1049,14 +1049,14 @@ describe("SourceCode", function() {
             assert.equal(text, "= 6 * 7");
         });
 
-        it("should retrieve all text plus one character after for binary expression", function() {
+        it("should retrieve all text plus one character after for binary expression", () => {
             const node = ast.body[0].declarations[0].init;
             const text = sourceCode.getText(node, 0, 1);
 
             assert.equal(text, "6 * 7;");
         });
 
-        it("should retrieve all text plus two characters before and one character after for binary expression", function() {
+        it("should retrieve all text plus two characters before and one character after for binary expression", () => {
             const node = ast.body[0].declarations[0].init;
             const text = sourceCode.getText(node, 2, 1);
 
@@ -1066,42 +1066,42 @@ describe("SourceCode", function() {
     });
 
 
-    describe("getNodeByRangeIndex()", function() {
+    describe("getNodeByRangeIndex()", () => {
 
         let sourceCode;
 
-        beforeEach(function() {
+        beforeEach(() => {
             const ast = espree.parse(TEST_CODE, DEFAULT_CONFIG);
 
             sourceCode = new SourceCode(TEST_CODE, ast);
         });
 
-        it("should retrieve a node starting at the given index", function() {
+        it("should retrieve a node starting at the given index", () => {
             const node = sourceCode.getNodeByRangeIndex(4);
 
             assert.equal(node.type, "Identifier");
         });
 
-        it("should retrieve a node containing the given index", function() {
+        it("should retrieve a node containing the given index", () => {
             const node = sourceCode.getNodeByRangeIndex(6);
 
             assert.equal(node.type, "Identifier");
         });
 
-        it("should retrieve a node that is exactly the given index", function() {
+        it("should retrieve a node that is exactly the given index", () => {
             const node = sourceCode.getNodeByRangeIndex(13);
 
             assert.equal(node.type, "Literal");
             assert.equal(node.value, 6);
         });
 
-        it("should retrieve a node ending with the given index", function() {
+        it("should retrieve a node ending with the given index", () => {
             const node = sourceCode.getNodeByRangeIndex(9);
 
             assert.equal(node.type, "Identifier");
         });
 
-        it("should retrieve the deepest node containing the given index", function() {
+        it("should retrieve the deepest node containing the given index", () => {
             let node = sourceCode.getNodeByRangeIndex(14);
 
             assert.equal(node.type, "BinaryExpression");
@@ -1109,7 +1109,7 @@ describe("SourceCode", function() {
             assert.equal(node.type, "VariableDeclaration");
         });
 
-        it("should return null if the index is outside the range of any node", function() {
+        it("should return null if the index is outside the range of any node", () => {
             let node = sourceCode.getNodeByRangeIndex(-1);
 
             assert.isNull(node);
@@ -1117,14 +1117,14 @@ describe("SourceCode", function() {
             assert.isNull(node);
         });
 
-        it("should attach the node's parent", function() {
+        it("should attach the node's parent", () => {
             const node = sourceCode.getNodeByRangeIndex(14);
 
             assert.property(node, "parent");
             assert.equal(node.parent.type, "VariableDeclarator");
         });
 
-        it("should not modify the node when attaching the parent", function() {
+        it("should not modify the node when attaching the parent", () => {
             let node = sourceCode.getNodeByRangeIndex(10);
 
             assert.equal(node.type, "VariableDeclarator");
@@ -1137,7 +1137,7 @@ describe("SourceCode", function() {
 
     });
 
-    describe("isSpaceBetweenTokens()", function() {
+    describe("isSpaceBetweenTokens()", () => {
 
         leche.withData([
             ["let foo = bar;", true],
@@ -1151,9 +1151,9 @@ describe("SourceCode", function() {
             ["a/**/ /**/+b", true],
             ["a/**/\n/**/+b", true],
             ["a +b", true]
-        ], function(code, expected) {
+        ], (code, expected) => {
 
-            it("should return true when there is one space between tokens", function() {
+            it("should return true when there is one space between tokens", () => {
                 const ast = espree.parse(code, DEFAULT_CONFIG),
                     sourceCode = new SourceCode(code, ast);
 
@@ -1169,13 +1169,13 @@ describe("SourceCode", function() {
 
     // need to check that eslint.verify() works with SourceCode
 
-    describe("eslint.verify()", function() {
+    describe("eslint.verify()", () => {
 
         const CONFIG = {
             parserOptions: { ecmaVersion: 6 }
         };
 
-        it("should work when passed a SourceCode object without a config", function() {
+        it("should work when passed a SourceCode object without a config", () => {
             const ast = espree.parse(TEST_CODE, DEFAULT_CONFIG);
 
             const sourceCode = new SourceCode(TEST_CODE, ast),
@@ -1184,14 +1184,14 @@ describe("SourceCode", function() {
             assert.equal(messages.length, 0);
         });
 
-        it("should work when passed a SourceCode object containing ES6 syntax and config", function() {
+        it("should work when passed a SourceCode object containing ES6 syntax and config", () => {
             const sourceCode = new SourceCode("let foo = bar;", AST),
                 messages = eslint.verify(sourceCode, CONFIG);
 
             assert.equal(messages.length, 0);
         });
 
-        it("should report an error when using let and blockBindings is false", function() {
+        it("should report an error when using let and blockBindings is false", () => {
             const sourceCode = new SourceCode("let foo = bar;", AST),
                 messages = eslint.verify(sourceCode, {
                     parserOptions: { ecmaVersion: 6 },

--- a/tests/templates/pr-create.md.ejs.js
+++ b/tests/templates/pr-create.md.ejs.js
@@ -24,9 +24,9 @@ const TEMPLATE_TEXT = fs.readFileSync(path.resolve(__dirname, "../../templates/p
 // Tests
 //------------------------------------------------------------------------------
 
-describe("pr-create.md.ejs", function() {
+describe("pr-create.md.ejs", () => {
 
-    it("should say LGTM when there are no problems with the pull request", function() {
+    it("should say LGTM when there are no problems with the pull request", () => {
         const result = ejs.render(TEMPLATE_TEXT, {
             payload: {
                 sender: {
@@ -40,7 +40,7 @@ describe("pr-create.md.ejs", function() {
         assert.equal(result.trim(), "LGTM");
     });
 
-    it("should mention commit message format when there's one commit and an invalid commit message is found", function() {
+    it("should mention commit message format when there's one commit and an invalid commit message is found", () => {
         const result = ejs.render(TEMPLATE_TEXT, {
             payload: {
                 sender: {
@@ -63,7 +63,7 @@ describe("pr-create.md.ejs", function() {
         assert.ok(result.indexOf("begin with a tag") > -1);
     });
 
-    it("should mention commit message length when there's a message longer than 72 characters", function() {
+    it("should mention commit message length when there's a message longer than 72 characters", () => {
         const result = ejs.render(TEMPLATE_TEXT, {
             payload: {
                 sender: {
@@ -86,7 +86,7 @@ describe("pr-create.md.ejs", function() {
         assert.ok(result.indexOf("72 characters") > -1);
     });
 
-    it("should not mention commit message length when there's a multi-line message with first line not over 72 characters", function() {
+    it("should not mention commit message length when there's a multi-line message with first line not over 72 characters", () => {
         const result = ejs.render(TEMPLATE_TEXT, {
             payload: {
                 sender: {
@@ -109,7 +109,7 @@ describe("pr-create.md.ejs", function() {
         assert.equal(result.trim(), "LGTM");
     });
 
-    it("should not mention missing issue when there's one documentation commit", function() {
+    it("should not mention missing issue when there's one documentation commit", () => {
         const result = ejs.render(TEMPLATE_TEXT, {
             payload: {
                 sender: {
@@ -132,8 +132,8 @@ describe("pr-create.md.ejs", function() {
         assert.equal(result.trim(), "LGTM");
     });
 
-    ["Breaking", "Build", "Chore", "Docs", "Fix", "New", "Update", "Upgrade"].forEach(function(type) {
-        it(`should not mention missing issue or length check when there's one ${type} commit`, function() {
+    ["Breaking", "Build", "Chore", "Docs", "Fix", "New", "Update", "Upgrade"].forEach(type => {
+        it(`should not mention missing issue or length check when there's one ${type} commit`, () => {
             const result = ejs.render(TEMPLATE_TEXT, {
                 payload: {
                     sender: {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This enables `prefer-arrow-callback` on the ESLint codebase.

**Is there anything you'd like reviewers to focus on?**

There are two places where I changed the code manually to avoid other linting errors; I'll leave a review to point them out.

