### PR TITLE
Update: avoid creating gratuitous whitespace in `arrow-body-style` fixer

### DIFF
--- a/lib/rules/arrow-body-style.js
+++ b/lib/rules/arrow-body-style.js
@@ -124,7 +124,7 @@ module.exports = {
                              */
                             return fixer.replaceText(
                                 arrowBody,
-                                (textBeforeReturn + textBetweenReturnAndValue).replace(/^ *$/, "") + returnValueText + (textAfterValue + textAfterReturnStatement).replace(/^ *$/, "")
+                                (textBeforeReturn + textBetweenReturnAndValue).replace(/^\s*$/, "") + returnValueText + (textAfterValue + textAfterReturnStatement).replace(/^\s*$/, "")
                             );
                         }
                     });

--- a/tests/lib/rules/arrow-body-style.js
+++ b/tests/lib/rules/arrow-body-style.js
@@ -285,6 +285,42 @@ ruleTester.run("arrow-body-style", rule, {
             errors: [
                 { line: 1, column: 17, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
             ]
-        }
+        },
+        {
+            code: `
+              var foo = () => {
+                return foo
+                  .bar;
+              };
+            `,
+            output: `
+              var foo = () => foo
+                  .bar;
+            `,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                { line: 2, column: 31, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
+            ]
+        },
+        {
+            code: `
+              var foo = () => {
+                return {
+                  bar: 1,
+                  baz: 2
+                };
+              };
+            `,
+            output: `
+              var foo = () => ({
+                  bar: 1,
+                  baz: 2
+                });
+            `,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                { line: 2, column: 31, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
+            ]
+        },
     ]
 });

--- a/tests/lib/rules/arrow-body-style.js
+++ b/tests/lib/rules/arrow-body-style.js
@@ -93,7 +93,7 @@ ruleTester.run("arrow-body-style", rule, {
         },
         {
             code: "var foo = () => {\nreturn 0;\n};",
-            output: "var foo = () => \n 0\n;",
+            output: "var foo = () => 0;",
             parserOptions: { ecmaVersion: 6 },
             options: ["never"],
             errors: [
@@ -260,6 +260,30 @@ ruleTester.run("arrow-body-style", rule, {
             options: ["always"],
             errors: [
                 { line: 1, column: 60, type: "ArrowFunctionExpression", message: "Expected block statement surrounding arrow body." }
+            ]
+        },
+        {
+            code: "var foo = () => {\nreturn bar;\n};",
+            output: "var foo = () => bar;",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                { line: 1, column: 17, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
+            ]
+        },
+        {
+            code: "var foo = () => {\nreturn bar;};",
+            output: "var foo = () => bar;",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                { line: 1, column: 17, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
+            ]
+        },
+        {
+            code: "var foo = () => {return bar;\n};",
+            output: "var foo = () => bar;",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                { line: 1, column: 17, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
             ]
         }
     ]


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Changes an existing rule

**What rule do you want to change?**

[`arrow-body-style`](http://eslint.org/docs/rules/arrow-body-style)

**Does this change cause the rule to produce more or fewer warnings?**

The same amount

**How will the change be implemented? (New option, new default behavior, etc.)?**

This will change the default behavior.

**Please provide some example code that this change will affect:**

```js
/* eslint arrow-body-style: "error" */

foo(bar => {
  return baz;
}, qux);
```

**What does the rule currently do for this code?**

It reports an error. With the `--fix` option, it fixes the code to:

```js
foo(bar => 
   baz
, qux);
```

**What will the rule do after it's changed?**

It will still report an error. With the `--fix` option, it will fix the code to:

```js
foo(bar => baz, qux);
```

This version of the fix is more idiomatic, and it avoids unexpected whitespace around the resulting expression.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates the `arrow-body-style` fixer to remove whitespace when converting an arrow block body to an expression. It will only do this if there are no non-whitespace characters between the `{` and the `return` statement/between the expression and the `}`, so lines with comments will be unaffected.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.

