### PR TITLE
Fix: `curly` false positive with no-semicolon style

### DIFF
--- a/lib/rules/curly.js
+++ b/lib/rules/curly.js
@@ -74,10 +74,11 @@ module.exports = {
          * @private
          */
         function isCollapsedOneLiner(node) {
-            const before = sourceCode.getTokenBefore(node),
-                last = sourceCode.getLastToken(node);
+            const before = sourceCode.getTokenBefore(node);
+            const last = sourceCode.getLastToken(node);
+            const lastExcludingSemicolon = last.type === "Punctuator" && last.value === ";" ? sourceCode.getTokenBefore(last) : last;
 
-            return before.loc.start.line === last.loc.end.line;
+            return before.loc.start.line === lastExcludingSemicolon.loc.end.line;
         }
 
         /**

--- a/tests/lib/rules/curly.js
+++ b/tests/lib/rules/curly.js
@@ -197,6 +197,12 @@ ruleTester.run("curly", rule, {
         {
             code: "if (true) { foo(); faa(); } else { bar(); }",
             options: ["multi", "consistent"]
+        },
+        {
+
+            // https://github.com/feross/standard/issues/664
+            code: "if (true) foo()\n;[1, 2, 3].bar()",
+            options: ["multi-line"]
         }
     ],
     invalid: [
@@ -800,6 +806,12 @@ ruleTester.run("curly", rule, {
             options: ["multi"],
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Unnecessary { after 'if' condition.", type: "IfStatement" }]
+        },
+        {
+            code: "if (true)\nfoo()\n;[1, 2, 3].bar()",
+            output: "if (true)\n{foo()\n;}[1, 2, 3].bar()",
+            options: ["multi-line"],
+            errors: [{ message: "Expected { after 'if' condition.", type: "IfStatement" }]
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix

**Tell us about your environment**

* **ESLint Version:** 3.9.1
* **Node Version:** 6.9.1
* **npm Version:** 3.10.8

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

(none)

**What did you do? Please include the actual source code causing the issue.**

```js
/* eslint curly: ["error", "multi-line"] */

if (foo) bar()

; [1, 2, 3].map(baz)
```

**What did you expect to happen?**

I expected no errors to be reported, because `bar()` is typically considered to be a single-line statement in this context (even though it has a semicolon on a different line)

**What actually happened? Please include the actual, raw output from ESLint.**

```
3:1 - Expected { after 'if' condition. (curly)
```

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

The rule had a false positive because the semicolon before `[` is considered to be part of the same statement as `bar()`, so `curly` identified `bar()` as a multiline statement. This fixes `curly` to ignore trailing semicolons when determining whether a statement is multiline.

Originally reported here: https://github.com/feross/standard/issues/664

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.