### PR TITLE
Update: add fixer for `operator-assignment`

### DIFF
--- a/docs/rules/operator-assignment.md
+++ b/docs/rules/operator-assignment.md
@@ -1,5 +1,7 @@
 # require or disallow assignment operator shorthand where possible (operator-assignment)
 
+(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 JavaScript provides shorthand operators that combine variable assignment and some simple mathematical operations. For example, `x = x + 4` can be shortened to `x += 4`. The supported shorthand forms are as follows:
 
 ```text


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Add autofixing to a rule

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This adds a fixer for [`operator-assignment`](http://eslint.org/docs/rules/operator-assignment).

```js
/* eslint operator-assignment: error */

foo.bar = foo.bar + baz;

// gets fixed to:

foo.bar += baz;
```

```js
/* eslint operator-assignment: [error, "never"] */

foo |= bar;

// gets fixed to:

foo = foo | bar;
```

Caveats:

* The following cases can't be fixed:
  ```js
  /* eslint operator-assignment: error */

  // fixing this would change the execution order of bar.valueOf() and foo.valueOf(),
  // if the function is defined for both of them
  foo = bar * foo;

  // fixing this would cause a `foo.bar` getter to activate only once, instead of twice.
  foo.bar.baz = foo.bar.baz + 5;

  // fixing this would cause bar.toString() to activate only once, instead of twice.
  // (if `bar` is a literal, this restriction is ignored)
  foo[bar] = foo[bar] + 5;
  ```

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.
