### PR TITLE
Update: Add `ArrowFunctionExpression` support to `require-jsdoc` rule

### DIFF
--- a/docs/rules/require-jsdoc.md
+++ b/docs/rules/require-jsdoc.md
@@ -23,6 +23,7 @@ This rule requires JSDoc comments for specified nodes. Supported nodes:
 * `"FunctionDeclaration"`
 * `"ClassDeclaration"`
 * `"MethodDefinition"`
+* `"ArrowFunctionExpression"`
 
 ## Options
 
@@ -38,7 +39,8 @@ Default option settings are:
         "require": {
             "FunctionDeclaration": true,
             "MethodDefinition": false,
-            "ClassDeclaration": false
+            "ClassDeclaration": false,
+            "ArrowFunctionExpression": false
         }
     }]
 }
@@ -46,7 +48,7 @@ Default option settings are:
 
 ### require
 
-Examples of **incorrect** code for this rule with the `{ "require": { "FunctionDeclaration": true, "MethodDefinition": true, "ClassDeclaration": true } }` option:
+Examples of **incorrect** code for this rule with the `{ "require": { "FunctionDeclaration": true, "MethodDefinition": true, "ClassDeclaration": true, "ArrowFunctionExpression": true } }` option:
 
 ```js
 /*eslint "require-jsdoc": ["error", {
@@ -61,12 +63,16 @@ function foo() {
     return 10;
 }
 
+var foo = () => {
+    return 10;
+}
+
 class Test{
     getDate(){}
 }
 ```
 
-Examples of **correct** code for this rule with the `{ "require": { "FunctionDeclaration": true, "MethodDefinition": true, "ClassDeclaration": true } }` option:
+Examples of **correct** code for this rule with the `{ "require": { "FunctionDeclaration": true, "MethodDefinition": true, "ClassDeclaration": true, "ArrowFunctionExpression": true } }` option:
 
 ```js
 /*eslint "require-jsdoc": ["error", {
@@ -81,6 +87,22 @@ Examples of **correct** code for this rule with the `{ "require": { "FunctionDec
  * It returns 10
  */
 function foo() {
+    return 10;
+}
+
+/**
+ * It returns test + 10
+ * @params {int} test - some number
+ * @returns {int} sum of test and 10
+ */
+var foo = (test) => {
+    return test + 10;
+}
+
+/**
+ * It returns 10
+ */
+var foo = () => {
     return 10;
 }
 
@@ -105,6 +127,8 @@ class Test{
     */
     getDate(){}
 }
+
+setTimeout(() => {}, 10); // since its an anonymous arrow function
 ```
 
 ## When Not To Use It

--- a/lib/rules/require-jsdoc.js
+++ b/lib/rules/require-jsdoc.js
@@ -27,6 +27,9 @@ module.exports = {
                             },
                             FunctionDeclaration: {
                                 type: "boolean"
+                            },
+                            ArrowFunctionExpression: {
+                                type: "boolean"
                             }
                         },
                         additionalProperties: false
@@ -96,6 +99,11 @@ module.exports = {
             },
             ClassDeclaration(node) {
                 if (options.ClassDeclaration) {
+                    checkJsDoc(node);
+                }
+            },
+            ArrowFunctionExpression(node) {
+                if (options.ArrowFunctionExpression && node.parent.type === "VariableDeclarator") {
                     checkJsDoc(node);
                 }
             }

--- a/tests/lib/rules/require-jsdoc.js
+++ b/tests/lib/rules/require-jsdoc.js
@@ -165,6 +165,33 @@ ruleTester.run("require-jsdoc", rule, {
                     ClassDeclaration: false
                 }
             }]
+        },
+        {
+            code: "/**\n Function doing something\n*/\nvar myFunction = () => {}",
+            parserOptions: { ecmaVersion: 6 },
+            options: [{
+                require: {
+                    ArrowFunctionExpression: true
+                }
+            }]
+        },
+        {
+            code: "/**\n Function doing something\n*/\nvar myFunction = () => () => {}",
+            parserOptions: { ecmaVersion: 6 },
+            options: [{
+                require: {
+                    ArrowFunctionExpression: true
+                }
+            }]
+        },
+        {
+            code: "setTimeout(() => {}, 10);",
+            parserOptions: { ecmaVersion: 6 },
+            options: [{
+                require: {
+                    ArrowFunctionExpression: true
+                }
+            }]
         }
     ],
 
@@ -289,6 +316,32 @@ ruleTester.run("require-jsdoc", rule, {
                 message: "Missing JSDoc comment.",
                 type: "ClassDeclaration"
             }]
-        }
+        },
+        {
+            code: "var myFunction = () => {}",
+            parserOptions: { ecmaVersion: 6 },
+            options: [{
+                require: {
+                    ArrowFunctionExpression: true
+                }
+            }],
+            errors: [{
+                message: "Missing JSDoc comment.",
+                type: "ArrowFunctionExpression"
+            }]
+        },
+        {
+            code: "var myFunction = () => () => {}",
+            parserOptions: { ecmaVersion: 6 },
+            options: [{
+                require: {
+                    ArrowFunctionExpression: true
+                }
+            }],
+            errors: [{
+                message: "Missing JSDoc comment.",
+                type: "ArrowFunctionExpression"
+            }]
+        },
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ x ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What rule do you want to change?**

* Add support for `ArrowFunctionExpression` nodes for `require-jsdoc` rule.

**Does this change cause the rule to produce more or fewer warnings?**

It will produce more warnings only when the option if set to true. By default its false, so out of the box it will not produce more warnings.

**How will the change be implemented? (New option, new default behavior, etc.)?**

* New option
  * Name - `ArrowFunctionExpression`
  * Default - `false`

**Please provide some example code that this change will affect:**

**Valid**

```js
/**
 * It returns 10
 */
var foo = () => {
    return 10;
}

/**
 * It returns 10
 */
var foo = () => () => {
    return 10;
}

setTimeout(() => {}, 10);
```

**Invalid**

```js
var foo = () => {
    return 10;
}
```

**What does the rule currently do for this code?**

Currently, we dont check for arrow functions.

**What will the rule do after it's changed?**

It will only check for arrow functions which are assigned to a variable. It will not check for anonymous arrow functions.

