### PR TITLE
Docs: Fix code-blocks in spaced-comment docs

### DIFF
--- a/docs/rules/spaced-comment.md
+++ b/docs/rules/spaced-comment.md
@@ -26,7 +26,7 @@ The rule takes two options.
     * The `"exceptions"` value is an array of string patterns which are considered exceptions to the rule.
     Please note that exceptions are ignored if the first argument is `"never"`.
 
-    ```json
+    ```
     "spaced-comment": ["error", "always", { "exceptions": ["-", "+"] }]
     ```
 
@@ -34,7 +34,7 @@ The rule takes two options.
     such as an additional `/`, used to denote documentation read by doxygen, vsdoc, etc. which must have additional characters.
     The `"markers"` array will apply regardless of the value of the first argument, e.g. `"always"` or `"never"`.
 
-    ```json
+    ```
     "spaced-comment": ["error", "always", { "markers": ["/"] }]
     ```
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
I removed the indentation of the JSON code blocks.

**Is there anything you'd like reviewers to focus on?**
Double-check if this really fixes the issue. I don't know how to test it locally, I tried `npm run gensite` but it was running for ages.

Commit message:
The space-comment docs page had indented code blocks with the JSON type. Because
of that they weren't converted to HTML correctly, leaving `json` in plain text
on the page.