### PR TITLE
Chore: Require jsdoc for arrow functions

### DIFF
--- a/packages/eslint-config-eslint/default.yml
+++ b/packages/eslint-config-eslint/default.yml
@@ -21,7 +21,7 @@ rules:
     eol-last: "error"
     eqeqeq: "error"
     func-call-spacing: "error"
-    func-style: ["error", "declaration"]
+    func-style: ["error", "declaration", { "allowArrowFunctions": true }]
     generator-star-spacing: "error"
     guard-for-in: "error"
     key-spacing: ["error", { beforeColon: false, afterColon: true }]
@@ -99,7 +99,11 @@ rules:
     quotes: ["error", "double"]
     quote-props: ["error", "as-needed"]
     radix: "error"
-    require-jsdoc: "error"
+    require-jsdoc: ["error", {
+        require: {
+            ArrowFunctionExpression: true
+        }
+    }]
     semi: "error"
     semi-spacing: ["error", {before: false, after: true}]
     space-before-blocks: "error"


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

* Activate `allowArrowFunctions` option for the `func-style` rule
* Activated `ArrowFunctionExpression` option for the `require-jsdoc` rule

**Is there anything you'd like reviewers to focus on?**

Since the release of ESLint 3.0.0, we have started writing **Arrow functions**. But since we had the `func-style` rule active (with arrow function not allowed), it used to throw errors if we created arrow functions. With this change we can create arrow functions and also make sure they have jsdoc (just like before)


