### PR TITLE
Chore: Remove incorrect test from indent.js.

### DIFF
--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -2093,23 +2093,6 @@ ruleTester.run("indent", rule, {
         },
         {
             code:
-            "JSON\n" +
-            "    .stringify(\n" +
-            "        {\n" +
-            "            foo: bar\n" +
-            "        }\n" +
-            "    )\n",
-            options: [4],
-            errors: expectedErrors(
-                [
-                    [3, 4, 8, "ObjectExpression"],
-                    [4, 8, 12, "Property"],
-                    [5, 4, 8, "ObjectExpression"]
-                ]
-            )
-        },
-        {
-            code:
             "TestClass.prototype.method = function () {\n" +
             "  return Promise.resolve(3)\n" +
             "      .then(function (x) {\n" +


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
While working on a bug fix, https://github.com/eslint/eslint/issues/7320, I found that in one of my PR's for the indent rule a few weeks ago, I included an incorrect test and wanted to remove it before the next release in case I/someone else couldn't finish the bug patch before then.

The test should be moved to the `valid` section of the file, however, it is currently failing because of the open issue.

**Is there anything you'd like reviewers to focus on?**
N/A


