### PR TITLE
Update: add fixer for `sort-imports`

### DIFF
--- a/docs/rules/sort-imports.md
+++ b/docs/rules/sort-imports.md
@@ -1,5 +1,7 @@
 # Import Sorting (sort-imports)
 
+(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 The import statement is used to import members (functions, objects or primitives) that have been exported from an external module. Using a specific member syntax:
 
 ```js

--- a/lib/rules/sort-imports.js
+++ b/lib/rules/sort-imports.js
@@ -39,7 +39,9 @@ module.exports = {
                 },
                 additionalProperties: false
             }
-        ]
+        ],
+
+        fixable: "code"
     },
 
     create(context) {
@@ -47,7 +49,8 @@ module.exports = {
         const configuration = context.options[0] || {},
             ignoreCase = configuration.ignoreCase || false,
             ignoreMemberSort = configuration.ignoreMemberSort || false,
-            memberSyntaxSortOrder = configuration.memberSyntaxSortOrder || ["none", "all", "multiple", "single"];
+            memberSyntaxSortOrder = configuration.memberSyntaxSortOrder || ["none", "all", "multiple", "single"],
+            sourceCode = context.getSourceCode();
         let previousDeclaration = null;
 
         /**
@@ -135,36 +138,43 @@ module.exports = {
                     }
                 }
 
-                // Multiple members of an import declaration should also be sorted alphabetically.
-                if (!ignoreMemberSort && node.specifiers.length > 1) {
-                    let previousSpecifier = null;
-                    let previousSpecifierName = null;
+                if (!ignoreMemberSort) {
+                    const importSpecifiers = node.specifiers.filter(specifier => specifier.type === "ImportSpecifier");
+                    const getSortableName = ignoreCase ? specifier => specifier.local.name.toLowerCase() : specifier => specifier.local.name;
+                    const firstUnsortedIndex = importSpecifiers.map(getSortableName).findIndex((name, index, array) => array[index - 1] > name);
 
-                    for (let i = 0; i < node.specifiers.length; ++i) {
-                        const currentSpecifier = node.specifiers[i];
+                    if (firstUnsortedIndex !== -1) {
+                        context.report({
+                            node: importSpecifiers[firstUnsortedIndex],
+                            message: "Member '{{memberName}}' of the import declaration should be sorted alphabetically.",
+                            data: {memberName: importSpecifiers[firstUnsortedIndex].local.name},
+                            fix(fixer) {
+                                return fixer.replaceTextRange(
+                                    [importSpecifiers[0].range[0], importSpecifiers[importSpecifiers.length - 1].range[1]],
+                                    importSpecifiers
 
-                        if (currentSpecifier.type !== "ImportSpecifier") {
-                            continue;
-                        }
+                                        // Clone the importSpecifiers array to avoid mutating it
+                                        .slice()
 
-                        let currentSpecifierName = currentSpecifier.local.name;
+                                        // Sort the array into the desired order
+                                        .sort((specifierA, specifierB) => {
+                                            const aName = getSortableName(specifierA);
+                                            const bName = getSortableName(specifierB);
 
-                        if (ignoreCase) {
-                            currentSpecifierName = currentSpecifierName.toLowerCase();
-                        }
+                                            return aName > bName ? 1 : -1;
+                                        })
 
-                        if (previousSpecifier && currentSpecifierName < previousSpecifierName) {
-                            context.report({
-                                node: currentSpecifier,
-                                message: "Member '{{memberName}}' of the import declaration should be sorted alphabetically.",
-                                data: {
-                                    memberName: currentSpecifier.local.name
-                                }
-                            });
-                        }
+                                        // Build a string out of the sorted list of import specifiers and the text between the originals
+                                        .reduce((sourceText, specifier, index) => {
+                                            const textAfterSpecifier = index === importSpecifiers.length - 1
+                                                ? ""
+                                                : sourceCode.getText().slice(importSpecifiers[index].range[1], importSpecifiers[index + 1].range[0]);
 
-                        previousSpecifier = currentSpecifier;
-                        previousSpecifierName = currentSpecifierName;
+                                            return sourceText + sourceCode.getText(specifier) + textAfterSpecifier;
+                                        }, "")
+                                );
+                            }
+                        });
                     }
                 }
 

--- a/lib/rules/sort-imports.js
+++ b/lib/rules/sort-imports.js
@@ -149,6 +149,12 @@ module.exports = {
                             message: "Member '{{memberName}}' of the import declaration should be sorted alphabetically.",
                             data: {memberName: importSpecifiers[firstUnsortedIndex].local.name},
                             fix(fixer) {
+                                if (importSpecifiers.some(specifier => sourceCode.getComments(specifier).leading.length || sourceCode.getComments(specifier).trailing.length)) {
+
+                                    // If there are comments in the ImportSpecifier list, don't rearrange the specifiers.
+                                    return null;
+                                }
+
                                 return fixer.replaceTextRange(
                                     [importSpecifiers[0].range[0], importSpecifiers[importSpecifiers.length - 1].range[1]],
                                     importSpecifiers

--- a/tests/lib/rules/sort-imports.js
+++ b/tests/lib/rules/sort-imports.js
@@ -236,23 +236,37 @@ ruleTester.run("sort-imports", rule, {
         },
         {
             code: "import {b, a, d, c} from 'foo.js';",
+            output: "import {a, b, c, d} from 'foo.js';",
             parserOptions,
             errors: [{
                 message: "Member 'a' of the import declaration should be sorted alphabetically.",
-                type: "ImportSpecifier"
-            }, {
-                message: "Member 'c' of the import declaration should be sorted alphabetically.",
                 type: "ImportSpecifier"
             }]
         },
         {
             code: "import {a, B, c, D} from 'foo.js';",
+            output: "import {B, D, a, c} from 'foo.js';",
             parserOptions,
             errors: [{
                 message: "Member 'B' of the import declaration should be sorted alphabetically.",
                 type: "ImportSpecifier"
-            }, {
-                message: "Member 'D' of the import declaration should be sorted alphabetically.",
+            }]
+        },
+        {
+            code: "import /* a */ { /* b */ foo /* c */ , /* d */ bar /* e */ , /* f */ baz /* g */ , /* h */ } /* i */ from 'qux.js';",
+            output: "import /* a */ { /* b */ bar /* c */ , /* d */ baz /* e */ , /* f */ foo /* g */ , /* h */ } /* i */ from 'qux.js';",
+            parserOptions,
+            errors: [{
+                message: "Member 'bar' of the import declaration should be sorted alphabetically.",
+                type: "ImportSpecifier"
+            }]
+        },
+        {
+            code: "import /* a */ foo /* b */ , /* c */ { /* d */ beep /* e */ as /* f */ boop /* g */ , /* h */ bar /* i */ as /* j */ baz /* k */ } from 'qux.js';",
+            output: "import /* a */ foo /* b */ , /* c */ { /* d */ bar /* i */ as /* j */ baz /* g */ , /* h */ beep /* e */ as /* f */ boop /* k */ } from 'qux.js';",
+            parserOptions,
+            errors: [{
+                message: "Member 'baz' of the import declaration should be sorted alphabetically.",
                 type: "ImportSpecifier"
             }]
         }

--- a/tests/lib/rules/sort-imports.js
+++ b/tests/lib/rules/sort-imports.js
@@ -269,6 +269,33 @@ ruleTester.run("sort-imports", rule, {
                 message: "Member 'baz' of the import declaration should be sorted alphabetically.",
                 type: "ImportSpecifier"
             }]
+        },
+        {
+            code: `
+              import {
+                boop,
+                foo,
+                zoo,
+                baz as qux,
+                bar,
+                beep
+              } from 'foo.js';
+            `,
+            output: `
+              import {
+                bar,
+                beep,
+                boop,
+                foo,
+                baz as qux,
+                zoo
+              } from 'foo.js';
+            `,
+            parserOptions,
+            errors: [{
+                message: "Member 'qux' of the import declaration should be sorted alphabetically.",
+                type: "ImportSpecifier"
+            }]
         }
     ]
 });

--- a/tests/lib/rules/sort-imports.js
+++ b/tests/lib/rules/sort-imports.js
@@ -253,20 +253,38 @@ ruleTester.run("sort-imports", rule, {
             }]
         },
         {
-            code: "import /* a */ { /* b */ foo /* c */ , /* d */ bar /* e */ , /* f */ baz /* g */ , /* h */ } /* i */ from 'qux.js';",
-            output: "import /* a */ { /* b */ bar /* c */ , /* d */ baz /* e */ , /* f */ foo /* g */ , /* h */ } /* i */ from 'qux.js';",
+            code: "import {zzzzz, /* comment */ aaaaa} from 'foo.js';",
+            output: "import {zzzzz, /* comment */ aaaaa} from 'foo.js';", // not fixed due to comment
             parserOptions,
             errors: [{
-                message: "Member 'bar' of the import declaration should be sorted alphabetically.",
+                message: "Member 'aaaaa' of the import declaration should be sorted alphabetically.",
                 type: "ImportSpecifier"
             }]
         },
         {
-            code: "import /* a */ foo /* b */ , /* c */ { /* d */ beep /* e */ as /* f */ boop /* g */ , /* h */ bar /* i */ as /* j */ baz /* k */ } from 'qux.js';",
-            output: "import /* a */ foo /* b */ , /* c */ { /* d */ bar /* i */ as /* j */ baz /* g */ , /* h */ beep /* e */ as /* f */ boop /* k */ } from 'qux.js';",
+            code: "import {zzzzz /* comment */, aaaaa} from 'foo.js';",
+            output: "import {zzzzz /* comment */, aaaaa} from 'foo.js';", // not fixed due to comment
             parserOptions,
             errors: [{
-                message: "Member 'baz' of the import declaration should be sorted alphabetically.",
+                message: "Member 'aaaaa' of the import declaration should be sorted alphabetically.",
+                type: "ImportSpecifier"
+            }]
+        },
+        {
+            code: "import {/* comment */ zzzzz, aaaaa} from 'foo.js';",
+            output: "import {/* comment */ zzzzz, aaaaa} from 'foo.js';", // not fixed due to comment
+            parserOptions,
+            errors: [{
+                message: "Member 'aaaaa' of the import declaration should be sorted alphabetically.",
+                type: "ImportSpecifier"
+            }]
+        },
+        {
+            code: "import {zzzzz, aaaaa /* comment */} from 'foo.js';",
+            output: "import {zzzzz, aaaaa /* comment */} from 'foo.js';", // not fixed due to comment
+            parserOptions,
+            errors: [{
+                message: "Member 'aaaaa' of the import declaration should be sorted alphabetically.",
                 type: "ImportSpecifier"
             }]
         },


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[x] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This adds a fixer for [`sort-imports`](http://eslint.org/docs/rules/sort-imports).

It only sorts `ImportSpecifiers`, and does not sort multiple import statements. Sorting multiple import statements would cause the evaluation order of the imported files to change.

This also makes a slight change to the `sort-imports` rule; it reports at most one specifier from a given import statement. This allows the entire list of specifiers to be sorted as a whole. For example:

```js
import {foo, baz, bar} from 'qux.js';

// Previously, both 'baz' and 'bar' would have been reported. Now, only 'baz' will be reported.
// However, this statement will be correctly autofixed to:

import {bar, baz, foo} from 'qux.js';
```

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.