### PR TITLE
Fix: Curly rule doesn't account for leading comment (fixes #7538)

### DIFF
--- a/docs/rules/curly.md
+++ b/docs/rules/curly.md
@@ -183,6 +183,11 @@ while (true) {
 for (var i = 0; foo; i++) {
     doSomething();
 }
+
+if (foo) {
+    // some comment
+    bar();
+}
 ```
 
 Examples of **correct** code for the `"multi-or-nest"` option:

--- a/lib/rules/curly.js
+++ b/lib/rules/curly.js
@@ -290,7 +290,9 @@ module.exports = {
                 }
             } else if (multiOrNest) {
                 if (hasBlock && body.body.length === 1 && isOneLiner(body.body[0])) {
-                    expected = !!(body.body[0].leadingComments && body.body[0].leadingComments.length);
+                    const leadingComments = sourceCode.getComments(body.body[0]).leading;
+
+                    expected = !!(leadingComments && leadingComments.length);
                 } else if (!isOneLiner(body)) {
                     expected = true;
                 }

--- a/lib/rules/curly.js
+++ b/lib/rules/curly.js
@@ -292,7 +292,7 @@ module.exports = {
                 if (hasBlock && body.body.length === 1 && isOneLiner(body.body[0])) {
                     const leadingComments = sourceCode.getComments(body.body[0]).leading;
 
-                    expected = !!(leadingComments && leadingComments.length);
+                    expected = !!leadingComments.length;
                 } else if (!isOneLiner(body)) {
                     expected = true;
                 }

--- a/lib/rules/curly.js
+++ b/lib/rules/curly.js
@@ -292,7 +292,7 @@ module.exports = {
                 if (hasBlock && body.body.length === 1 && isOneLiner(body.body[0])) {
                     const leadingComments = sourceCode.getComments(body.body[0]).leading;
 
-                    expected = !!leadingComments.length;
+                    expected = leadingComments.length > 0;
                 } else if (!isOneLiner(body)) {
                     expected = true;
                 }

--- a/lib/rules/curly.js
+++ b/lib/rules/curly.js
@@ -290,7 +290,7 @@ module.exports = {
                 }
             } else if (multiOrNest) {
                 if (hasBlock && body.body.length === 1 && isOneLiner(body.body[0])) {
-                    expected = false;
+                    expected = !!(body.body[0].leadingComments && body.body[0].leadingComments.length);
                 } else if (!isOneLiner(body)) {
                     expected = true;
                 }

--- a/tests/lib/rules/curly.js
+++ b/tests/lib/rules/curly.js
@@ -127,6 +127,14 @@ ruleTester.run("curly", rule, {
             options: ["multi-or-nest"]
         },
         {
+            code: "if (foo) { \n // line of comment \n quz = true; \n }",
+            options: ["multi-or-nest"]
+        },
+        {
+            code: "// line of comment \n if (foo) \n quz = true; \n",
+            options: ["multi-or-nest"]
+        },
+        {
             code: "while (true) \n doSomething();",
             options: ["multi-or-nest"]
         },


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Fixes https://github.com/eslint/eslint/issues/7538

**What changes did you make? (Give an overview)**
Fixes the curly rule under the "multi-or-nest" setting, includes tests, and updates docs with an example

**Is there anything you'd like reviewers to focus on?**
This only addresses leading comments and not trailing comments, but I think trailing comment is a bit different because the intent is more ambiguous. For example:

```js
if (foo)
  baz();
  // line of comment
bar();
```

It's unclear if the comment is describing the line above or mis-indented and describing the line below. In my experience, intentional trailing comments are rare.

