### PR TITLE
Update: add fixer for `no-unneeded-ternary`

### DIFF
--- a/docs/rules/no-unneeded-ternary.md
+++ b/docs/rules/no-unneeded-ternary.md
@@ -1,5 +1,7 @@
 # disallow ternary operators when simpler alternatives exist (no-unneeded-ternary)
 
+(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 It's a common mistake in JavaScript to use a conditional expression to select between two Boolean values instead of using ! to convert the test to a Boolean.
 Here are some examples:
 

--- a/lib/ast-utils.js
+++ b/lib/ast-utils.js
@@ -1050,5 +1050,31 @@ module.exports = {
     */
     getRangeIndexFromLocation(sourceCode, loc) {
         return getLineIndices(sourceCode)[loc.line - 1] + loc.column;
+    },
+
+    /**
+    * Gets the parenthesized text of a node. This is similar to sourceCode.getText(node), but it also includes any parentheses
+    * surrounding the node.
+    * @param {SourceCode} sourceCode The source code object
+    * @param {ASTNode} node An expression node
+    * @returns {string} The text representing the node, with all surrounding parentheses included
+    */
+    getParenthesisedText(sourceCode, node) {
+        let leftToken = sourceCode.getFirstToken(node);
+        let rightToken = sourceCode.getLastToken(node);
+
+        while (
+            sourceCode.getTokenBefore(leftToken) &&
+            sourceCode.getTokenBefore(leftToken).type === "Punctuator" &&
+            sourceCode.getTokenBefore(leftToken).value === "(" &&
+            sourceCode.getTokenAfter(rightToken) &&
+            sourceCode.getTokenAfter(rightToken).type === "Punctuator" &&
+            sourceCode.getTokenAfter(rightToken).value === ")"
+        ) {
+            leftToken = sourceCode.getTokenBefore(leftToken);
+            rightToken = sourceCode.getTokenAfter(rightToken);
+        }
+
+        return sourceCode.getText().slice(leftToken.range[0], rightToken.range[1]);
     }
 };

--- a/lib/rules/no-unneeded-ternary.js
+++ b/lib/rules/no-unneeded-ternary.js
@@ -117,8 +117,10 @@ module.exports = {
                                 return fixer.replaceText(node, invertExpression(node.test));
                             }
 
-                            // Replace `foo ? true : false` with `foo`, but only if `foo` is guaranteed to be a boolean.
-                            return isBooleanExpression(node.test) ? fixer.replaceText(node, astUtils.getParenthesisedText(sourceCode, node.test)) : null;
+                            // Replace `foo ? true : false` with `foo` if `foo` is guaranteed to be a boolean, or `!!foo` otherwise.
+                            const expressionText = astUtils.getParenthesisedText(sourceCode, node.test);
+
+                            return fixer.replaceText(node, isBooleanExpression(node.test) ? expressionText : `!!(${expressionText})`);
                         }
                     });
                 } else if (!defaultAssignment && matchesDefaultAssignment(node)) {

--- a/lib/rules/no-unneeded-ternary.js
+++ b/lib/rules/no-unneeded-ternary.js
@@ -117,7 +117,7 @@ module.exports = {
                                 return fixer.replaceText(node, invertExpression(node.test));
                             }
 
-                            // Replace `foo ? true : false` with `a === 1`, but only if `foo` is guaranteed to be a boolean.
+                            // Replace `foo ? true : false` with `foo`, but only if `foo` is guaranteed to be a boolean.
                             return isBooleanExpression(node.test) ? fixer.replaceText(node, astUtils.getParenthesisedText(sourceCode, node.test)) : null;
                         }
                     });

--- a/lib/rules/no-unneeded-ternary.js
+++ b/lib/rules/no-unneeded-ternary.js
@@ -9,6 +9,14 @@ const astUtils = require("../ast-utils");
 
 // Operators that always result in a boolean value
 const BOOLEAN_OPERATORS = new Set(["==", "===", "!=", "!==", ">", ">=", "<", "<=", "in", "instanceof"]);
+const OPERATOR_INVERSES = {
+    "==": "!=",
+    "!=": "==",
+    "===": "!==",
+    "!==": "==="
+
+    // Operators like < and >= are not true inverses, since both will return false with NaN.
+};
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -53,6 +61,21 @@ module.exports = {
         }
 
         /**
+         * Creates an expression that represents the boolean inverse of the expression represented by the original node
+         * @param {ASTNode} node A node representing an expression
+         * @returns {string} A string representing an inverted expression
+         */
+        function invertExpression(node) {
+            if (node.type === "BinaryExpression" && Object.prototype.hasOwnProperty.call(OPERATOR_INVERSES, node.operator)) {
+                const operatorToken = sourceCode.getTokensBetween(node.left, node.right).find(token => token.value === node.operator);
+
+                return sourceCode.getText().slice(node.range[0], operatorToken.range[0]) + OPERATOR_INVERSES[node.operator] + sourceCode.getText().slice(operatorToken.range[1], node.range[1]);
+            }
+
+            return `!(${astUtils.getParenthesisedText(sourceCode, node)})`;
+        }
+
+        /**
          * Tests if a given node always evaluates to a boolean value
          * @param {ASTNode} node - An expression node
          * @returns {boolean} True if it is determined that the node will always evaluate to a boolean value
@@ -83,6 +106,18 @@ module.exports = {
                         loc: node.consequent.loc.start,
                         message: "Unnecessary use of boolean literals in conditional expression.",
                         fix(fixer) {
+                            if (node.consequent.value === node.alternate.value) {
+
+                                // Replace `foo ? true : true` with just `true`, but don't replace `foo() ? true : true`
+                                return node.test.type === "Identifier" ? fixer.replaceText(node, node.consequent.value.toString()) : null;
+                            }
+                            if (node.alternate.value) {
+
+                                // Replace `foo() ? false : true` with `!(foo())`
+                                return fixer.replaceText(node, invertExpression(node.test));
+                            }
+
+                            // Replace `foo ? true : false` with `a === 1`, but only if `foo` is guaranteed to be a boolean.
                             return isBooleanExpression(node.test) ? fixer.replaceText(node, astUtils.getParenthesisedText(sourceCode, node.test)) : null;
                         }
                     });

--- a/lib/rules/no-unneeded-ternary.js
+++ b/lib/rules/no-unneeded-ternary.js
@@ -7,6 +7,9 @@
 
 const astUtils = require("../ast-utils");
 
+// Operators that always result in a boolean value
+const BOOLEAN_OPERATORS = new Set(["==", "===", "!=", "!==", ">", ">=", "<", "<=", "in", "instanceof"]);
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -50,6 +53,16 @@ module.exports = {
         }
 
         /**
+         * Tests if a given node always evaluates to a boolean value
+         * @param {ASTNode} node - An expression node
+         * @returns {boolean} True if it is determined that the node will always evaluate to a boolean value
+         */
+        function isBooleanExpression(node) {
+            return node.type === "BinaryExpression" && BOOLEAN_OPERATORS.has(node.operator) ||
+                node.type === "UnaryExpression" && node.operator === "!";
+        }
+
+        /**
          * Test if the node matches the pattern id ? id : expression
          * @param {ASTNode} node - The ConditionalExpression to check.
          * @returns {boolean} True if the pattern is matched, and false otherwise
@@ -69,7 +82,9 @@ module.exports = {
                         node,
                         loc: node.consequent.loc.start,
                         message: "Unnecessary use of boolean literals in conditional expression.",
-                        fix: fixer => fixer.replaceText(node, astUtils.getParenthesisedText(sourceCode, node.test))
+                        fix(fixer) {
+                            return isBooleanExpression(node.test) ? fixer.replaceText(node, astUtils.getParenthesisedText(sourceCode, node.test)) : null;
+                        }
                     });
                 } else if (!defaultAssignment && matchesDefaultAssignment(node)) {
                     context.report({

--- a/lib/rules/no-unneeded-ternary.js
+++ b/lib/rules/no-unneeded-ternary.js
@@ -72,7 +72,10 @@ module.exports = {
                 return sourceCode.getText().slice(node.range[0], operatorToken.range[0]) + OPERATOR_INVERSES[node.operator] + sourceCode.getText().slice(operatorToken.range[1], node.range[1]);
             }
 
-            return `!(${astUtils.getParenthesisedText(sourceCode, node)})`;
+            if (astUtils.getPrecedence(node) < astUtils.getPrecedence({ type: "UnaryExpression" })) {
+                return `!(${astUtils.getParenthesisedText(sourceCode, node)})`;
+            }
+            return `!${astUtils.getParenthesisedText(sourceCode, node)}`;
         }
 
         /**
@@ -118,9 +121,8 @@ module.exports = {
                             }
 
                             // Replace `foo ? true : false` with `foo` if `foo` is guaranteed to be a boolean, or `!!foo` otherwise.
-                            const expressionText = astUtils.getParenthesisedText(sourceCode, node.test);
 
-                            return fixer.replaceText(node, isBooleanExpression(node.test) ? expressionText : `!!(${expressionText})`);
+                            return fixer.replaceText(node, isBooleanExpression(node.test) ? astUtils.getParenthesisedText(sourceCode, node.test) : `!${invertExpression(node.test)}`);
                         }
                     });
                 } else if (!defaultAssignment && matchesDefaultAssignment(node)) {

--- a/lib/rules/no-unneeded-ternary.js
+++ b/lib/rules/no-unneeded-ternary.js
@@ -5,6 +5,8 @@
 
 "use strict";
 
+const astUtils = require("../ast-utils");
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -27,12 +29,15 @@ module.exports = {
                 },
                 additionalProperties: false
             }
-        ]
+        ],
+
+        fixable: "code"
     },
 
     create(context) {
         const options = context.options[0] || {};
         const defaultAssignment = options.defaultAssignment !== false;
+        const sourceCode = context.getSourceCode();
 
         /**
          * Test if the node is a boolean literal
@@ -60,9 +65,19 @@ module.exports = {
 
             ConditionalExpression(node) {
                 if (isBooleanLiteral(node.alternate) && isBooleanLiteral(node.consequent)) {
-                    context.report({ node, loc: node.consequent.loc.start, message: "Unnecessary use of boolean literals in conditional expression." });
+                    context.report({
+                        node,
+                        loc: node.consequent.loc.start,
+                        message: "Unnecessary use of boolean literals in conditional expression.",
+                        fix: fixer => fixer.replaceText(node, astUtils.getParenthesisedText(sourceCode, node.test))
+                    });
                 } else if (!defaultAssignment && matchesDefaultAssignment(node)) {
-                    context.report({ node, loc: node.consequent.loc.start, message: "Unnecessary use of conditional expression for default assignment." });
+                    context.report({
+                        node,
+                        loc: node.consequent.loc.start,
+                        message: "Unnecessary use of conditional expression for default assignment.",
+                        fix: fixer => fixer.replaceText(node, `${astUtils.getParenthesisedText(sourceCode, node.test)} || ${astUtils.getParenthesisedText(sourceCode, node.alternate)}`)
+                    });
                 }
             }
         };

--- a/tests/lib/ast-utils.js
+++ b/tests/lib/ast-utils.js
@@ -904,4 +904,21 @@ describe("ast-utils", () => {
             });
         });
     });
+
+    describe("getParenthesisedText", () => {
+        const expectedResults = {
+            "(((foo))); bar;": "(((foo)))",
+            "(/* comment */(((foo.bar())))); baz();": "(/* comment */(((foo.bar()))))",
+            "(foo, bar)": "(foo, bar)"
+        };
+
+        Object.keys(expectedResults).forEach(key => {
+            it(`should return ${expectedResults[key]} for ${key}`, () => {
+                const ast = espree.parse(key, {tokens: true, comment: true, range: true, loc: true});
+                const sourceCode = new SourceCode(key, ast);
+
+                assert.strictEqual(astUtils.getParenthesisedText(sourceCode, ast.body[0].expression), expectedResults[key]);
+            });
+        });
+    });
 });

--- a/tests/lib/ast-utils.js
+++ b/tests/lib/ast-utils.js
@@ -914,7 +914,7 @@ describe("ast-utils", () => {
 
         Object.keys(expectedResults).forEach(key => {
             it(`should return ${expectedResults[key]} for ${key}`, () => {
-                const ast = espree.parse(key, {tokens: true, comment: true, range: true, loc: true});
+                const ast = espree.parse(key, { tokens: true, comment: true, range: true, loc: true });
                 const sourceCode = new SourceCode(key, ast);
 
                 assert.strictEqual(astUtils.getParenthesisedText(sourceCode, ast.body[0].expression), expectedResults[key]);

--- a/tests/lib/rules/no-unneeded-ternary.js
+++ b/tests/lib/rules/no-unneeded-ternary.js
@@ -57,6 +57,16 @@ ruleTester.run("no-unneeded-ternary", rule, {
             }]
         },
         {
+            code: "var a = x ? true : false;",
+            output: "var a = !!(x);",
+            errors: [{
+                message: "Unnecessary use of boolean literals in conditional expression.",
+                type: "ConditionalExpression",
+                line: 1,
+                column: 13
+            }]
+        },
+        {
             code: "var a = x === 1 ? false : true;",
             output: "var a = x !== 1;",
             errors: [{

--- a/tests/lib/rules/no-unneeded-ternary.js
+++ b/tests/lib/rules/no-unneeded-ternary.js
@@ -57,6 +57,66 @@ ruleTester.run("no-unneeded-ternary", rule, {
             }]
         },
         {
+            code: "var a = x === 1 ? false : true;",
+            output: "var a = x !== 1;",
+            errors: [{
+                message: "Unnecessary use of boolean literals in conditional expression.",
+                type: "ConditionalExpression",
+                line: 1,
+                column: 19
+            }]
+        },
+        {
+            code: "var a = x != 1 ? false : true;",
+            output: "var a = x == 1;",
+            errors: [{
+                message: "Unnecessary use of boolean literals in conditional expression.",
+                type: "ConditionalExpression",
+                line: 1,
+                column: 18
+            }]
+        },
+        {
+            code: "var a = foo() ? false : true;",
+            output: "var a = !(foo());",
+            errors: [{
+                message: "Unnecessary use of boolean literals in conditional expression.",
+                type: "ConditionalExpression",
+                line: 1,
+                column: 17
+            }]
+        },
+        {
+            code: "var a = x instanceof foo ? false : true;",
+            output: "var a = !(x instanceof foo);",
+            errors: [{
+                message: "Unnecessary use of boolean literals in conditional expression.",
+                type: "ConditionalExpression",
+                line: 1,
+                column: 28
+            }]
+        },
+        {
+            code: "var a = foo ? false : false;",
+            output: "var a = false;",
+            errors: [{
+                message: "Unnecessary use of boolean literals in conditional expression.",
+                type: "ConditionalExpression",
+                line: 1,
+                column: 15
+            }]
+        },
+        {
+            code: "var a = foo() ? false : false;",
+            output: "var a = foo() ? false : false;",
+            errors: [{
+                message: "Unnecessary use of boolean literals in conditional expression.",
+                type: "ConditionalExpression",
+                line: 1,
+                column: 17
+            }]
+        },
+        {
             code: "var a = x instanceof foo ? true : false;",
             output: "var a = x instanceof foo;",
             errors: [{

--- a/tests/lib/rules/no-unneeded-ternary.js
+++ b/tests/lib/rules/no-unneeded-ternary.js
@@ -38,6 +38,7 @@ ruleTester.run("no-unneeded-ternary", rule, {
     invalid: [
         {
             code: "var a = x === 2 ? true : false;",
+            output: "var a = x === 2;",
             errors: [{
                 message: "Unnecessary use of boolean literals in conditional expression.",
                 type: "ConditionalExpression",
@@ -47,12 +48,24 @@ ruleTester.run("no-unneeded-ternary", rule, {
         },
         {
             code: "var a = foo ? foo : 'No';",
+            output: "var a = foo || 'No';",
             options: [{ defaultAssignment: false }],
             errors: [{
                 message: "Unnecessary use of conditional expression for default assignment.",
                 type: "ConditionalExpression",
                 line: 1,
                 column: 15
+            }]
+        },
+        {
+            code: "var a = ((foo)) ? (((((foo))))) : ((((((((((((((bar))))))))))))));",
+            output: "var a = ((foo)) || ((((((((((((((bar))))))))))))));",
+            options: [{ defaultAssignment: false }],
+            errors: [{
+                message: "Unnecessary use of conditional expression for default assignment.",
+                type: "ConditionalExpression",
+                line: 1,
+                column: 24
             }]
         }
     ]

--- a/tests/lib/rules/no-unneeded-ternary.js
+++ b/tests/lib/rules/no-unneeded-ternary.js
@@ -47,6 +47,36 @@ ruleTester.run("no-unneeded-ternary", rule, {
             }]
         },
         {
+            code: "var a = x >= 2 ? true : false;",
+            output: "var a = x >= 2;",
+            errors: [{
+                message: "Unnecessary use of boolean literals in conditional expression.",
+                type: "ConditionalExpression",
+                line: 1,
+                column: 18
+            }]
+        },
+        {
+            code: "var a = x instanceof foo ? true : false;",
+            output: "var a = x instanceof foo;",
+            errors: [{
+                message: "Unnecessary use of boolean literals in conditional expression.",
+                type: "ConditionalExpression",
+                line: 1,
+                column: 28
+            }]
+        },
+        {
+            code: "var a = !foo ? true : false;",
+            output: "var a = !foo;",
+            errors: [{
+                message: "Unnecessary use of boolean literals in conditional expression.",
+                type: "ConditionalExpression",
+                line: 1,
+                column: 16
+            }]
+        },
+        {
             code: "var a = foo ? foo : 'No';",
             output: "var a = foo || 'No';",
             options: [{ defaultAssignment: false }],

--- a/tests/lib/rules/no-unneeded-ternary.js
+++ b/tests/lib/rules/no-unneeded-ternary.js
@@ -58,7 +58,7 @@ ruleTester.run("no-unneeded-ternary", rule, {
         },
         {
             code: "var a = x ? true : false;",
-            output: "var a = !!(x);",
+            output: "var a = !!x;",
             errors: [{
                 message: "Unnecessary use of boolean literals in conditional expression.",
                 type: "ConditionalExpression",
@@ -88,12 +88,32 @@ ruleTester.run("no-unneeded-ternary", rule, {
         },
         {
             code: "var a = foo() ? false : true;",
-            output: "var a = !(foo());",
+            output: "var a = !foo();",
             errors: [{
                 message: "Unnecessary use of boolean literals in conditional expression.",
                 type: "ConditionalExpression",
                 line: 1,
                 column: 17
+            }]
+        },
+        {
+            code: "var a = !foo() ? false : true;",
+            output: "var a = !!foo();",
+            errors: [{
+                message: "Unnecessary use of boolean literals in conditional expression.",
+                type: "ConditionalExpression",
+                line: 1,
+                column: 18
+            }]
+        },
+        {
+            code: "var a = foo + bar ? false : true;",
+            output: "var a = !(foo + bar);",
+            errors: [{
+                message: "Unnecessary use of boolean literals in conditional expression.",
+                type: "ConditionalExpression",
+                line: 1,
+                column: 21
             }]
         },
         {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[x] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This adds a fixer for `no-unneeded-ternary`.

```js
var foo = bar === 1 ? true : false;
var baz = qux ? qux : boop;

// gets fixed to:

var foo = bar === 1;
var baz = qux || boop;
```

This also adds a helper method to `ast-utils`: `getParenthesisedText()`, to avoid duplicating code for fixers in a lot of different rules.

**Is there anything you'd like reviewers to focus on?**

We should make sure this fix doesn't produce any syntax errors or change behavior of code, e.g. due to ASI.
