### PR TITLE
New: `no-return-await` rule. (fixes #7537)

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -800,7 +800,7 @@ target.checkRuleFiles = function() {
 
         // check for default configuration
         if (!isInConfig()) {
-            console.error("Missing default setting for %s in eslint.json", basename);
+            console.error("Missing default setting for %s in conf/eslint.json", basename);
             errors++;
         }
 

--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -91,6 +91,7 @@
         "no-restricted-properties": "off",
         "no-restricted-syntax": "off",
         "no-return-assign": "off",
+        "no-return-await": "off",
         "no-script-url": "off",
         "no-self-assign": "error",
         "no-self-compare": "off",

--- a/docs/rules/no-return-await.md
+++ b/docs/rules/no-return-await.md
@@ -1,0 +1,41 @@
+# Disallows unnecessary `return await` (no-return-await)
+
+Inside an `async function`, `return await` is useless. Since the return value of an `async function` is always wrapped in `Promise.resolve`, `return await` doesn't actually do anything except add extra time before the overarching Promise resolves or rejects. This pattern is almost certainly due to programmer ignorance of the return semantics of `async function`s.
+
+## Rule Details
+
+This rule aims to prevent a likely common performance hazard due to a lack of understanding of the semantics of `async function`.
+
+The following patterns are considered warnings:
+
+```js
+async function foo() {
+  return await bar();
+}
+```
+
+The following patterns are not warnings:
+
+```js
+async function foo() {
+  return bar();
+}
+
+async function foo() {
+  await bar();
+  return;
+}
+
+async function foo() {
+  const x = await bar();
+  return x;
+}
+```
+
+## When Not To Use It
+
+If you want to use `await` to denote a value that is a thenable, even when it is not necessary; or if you do not want the performance benefit of avoiding `return await`, you can turn off this rule.
+
+## Further Reading
+
+[`async function` on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function)

--- a/lib/rules/no-return-await.js
+++ b/lib/rules/no-return-await.js
@@ -1,0 +1,55 @@
+/**
+ * @fileoverview Disallows unnecessary `return await`
+ * @author Jordan Harband
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+const message = "Redundant use of `await` on a return value.";
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "disallow unnecessary `return await`",
+            category: "Best Practices",
+            recommended: false // TODO: set to true
+        },
+        fixable: false,
+        schema: [
+        ]
+    },
+
+    create(context) {
+        return {
+            ArrowFunctionExpression(node) {
+                if (node.async && node.body.type === "AwaitExpression") {
+                    const sourceCode = context.getSourceCode();
+                    const loc = node.body.loc;
+
+                    context.report({
+                        node: sourceCode.getFirstToken(node.body),
+                        loc,
+                        message,
+                    });
+                }
+            },
+            ReturnStatement(node) {
+                const argument = node.argument;
+
+                if (argument && argument.type === "AwaitExpression") {
+                    const sourceCode = context.getSourceCode();
+                    const loc = argument.loc;
+
+                    context.report({
+                        node: sourceCode.getFirstToken(argument),
+                        loc,
+                        message,
+                    });
+                }
+            },
+        };
+    }
+};

--- a/tests/lib/rules/no-return-await.js
+++ b/tests/lib/rules/no-return-await.js
@@ -1,0 +1,69 @@
+/**
+ * @fileoverview Disallows unnecessary `return await`
+ * @author Jordan Harband
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../lib/rules/no-return-await");
+const RuleTester = require("../../../lib/testers/rule-tester");
+
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2017 } });
+
+ruleTester.run("no-return-await", rule, {
+
+    valid: [
+        { code: "\nasync function foo() {\n\tawait bar(); return;\n}\n" },
+        { code: "\nasync function foo() {\n\tconst x = await bar(); return x;\n}\n" },
+        { code: "\nasync () => { return bar(); }\n" },
+        { code: "\nasync () => bar()\n" },
+        { code: "\nasync function foo() {\nif (a) {\n\t\tif (b) {\n\t\t\treturn bar();\n\t\t}\n\t}\n}\n" },
+        { code: "\nasync () => {\nif (a) {\n\t\tif (b) {\n\t\t\treturn bar();\n\t\t}\n\t}\n}\n" },
+    ],
+
+    invalid: [
+        {
+            code: "\nasync function foo() {\n\treturn await bar();\n}\n",
+            errors: [{
+                message: "Redundant use of `await` on a return value.",
+                type: "Identifier", // pending https://github.com/eslint/espree/issues/304, should be "Keyword"
+            }],
+        },
+        {
+            code: "\nasync () => { return await bar(); }\n",
+            errors: [{
+                message: "Redundant use of `await` on a return value.",
+                type: "Identifier", // pending https://github.com/eslint/espree/issues/304, should be "Keyword"
+            }],
+        },
+        {
+            code: "\nasync () => await bar()\n",
+            errors: [{
+                message: "Redundant use of `await` on a return value.",
+                type: "Identifier", // pending https://github.com/eslint/espree/issues/304, should be "Keyword"
+            }],
+        },
+        {
+            code: "\nasync function foo() {\nif (a) {\n\t\tif (b) {\n\t\t\treturn await bar();\n\t\t}\n\t}\n}\n",
+            errors: [{
+                message: "Redundant use of `await` on a return value.",
+                type: "Identifier", // pending https://github.com/eslint/espree/issues/304, should be "Keyword"
+            }],
+        },
+        {
+            code: "\nasync () => {\nif (a) {\n\t\tif (b) {\n\t\t\treturn await bar();\n\t\t}\n\t}\n}\n",
+            errors: [{
+                message: "Redundant use of `await` on a return value.",
+                type: "Identifier", // pending https://github.com/eslint/espree/issues/304, should be "Keyword"
+            }],
+        },
+    ]
+});


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[x] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**Please describe what the rule should do:**
Inside an `async function`, `return await` is useless. Since the return value of an `async function` is always wrapped in `Promise.resolve`, `return await` doesn't actually do anything except add an extra tick before the overarching promise resolves/rejects. This pattern is almost certainly due to programmer ignorance of the return semantics of `async function`s.

**What category of rule is this? (place an "X" next to just one item)**

[ ] Enforces code style
[ ] Warns about a potential error
[x] Suggests an alternate way of doing something
[ ] Other (please specify:)

**Provide 2-3 code examples that this rule will warn about:**

```js
async function foo() {
  return await bar;
}
```

in favor of:
```js
async function foo() {
  return bar;
}
```

**Why should this rule be included in ESLint (instead of a plugin)?**
People are very anxious to use `await`, and will likely overuse it. This rule prevents a common hazard, and also helps educate developers about how `async function` works.

**What changes did you make? (Give an overview)**
I added a rule file, a test file, and a docs file. The rule checks for return statements whose argument is an await expression.

**Is there anything you'd like reviewers to focus on?**
¯\\\_(ツ)_/¯