### PR TITLE
Chore: "Error type should be" assertion in rule-tester (fixes 6106)

### DIFF
--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -446,7 +446,7 @@ RuleTester.prototype = {
                         }
 
                         if (item.errors[i].type) {
-                            assert.equal(messages[i].nodeType, item.errors[i].type, `Error type should be ${item.errors[i].type}`);
+                            assert.equal(messages[i].nodeType, item.errors[i].type, `Error type should be ${item.errors[i].type}, found ${messages[i].nodeType}`);
                         }
 
                         if (item.errors[i].hasOwnProperty("line")) {

--- a/tests/lib/testers/rule-tester.js
+++ b/tests/lib/testers/rule-tester.js
@@ -192,7 +192,7 @@ describe("RuleTester", () => {
                     { code: "eval(foo)", errors: [{ message: "eval sucks.", type: "CallExpression2"}] }
                 ]
             });
-        }, /Error type should be CallExpression2/);
+        }, /Error type should be CallExpression2, found CallExpression/);
     });
 
     it("should throw an error if invalid code specifies wrong line", () => {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X ] Other, please explain: Change in rule-tester.

[issue 6106](https://github.com/eslint/eslint/issues/6106)

**What changes did you make? (Give an overview)**
Removed the overwriting message in the assert.equal statement.

**Is there anything you'd like reviewers to focus on?**



