### PR TITLE
Update: fix in/instanceof handling with `space-infix-ops` (fixes #7525)

### DIFF
--- a/lib/rules/space-infix-ops.js
+++ b/lib/rules/space-infix-ops.js
@@ -57,7 +57,7 @@ module.exports = {
                 const op = tokens[i];
 
                 if (
-                    op.type === "Punctuator" &&
+                    (op.type === "Punctuator" || op.type === "Keyword") &&
                     OPERATORS.indexOf(op.value) >= 0 &&
                     (tokens[i - 1].range[1] >= op.range[0] || op.range[1] >= tokens[i + 1].range[0])
                 ) {

--- a/tests/lib/rules/space-infix-ops.js
+++ b/tests/lib/rules/space-infix-ops.js
@@ -327,6 +327,26 @@ ruleTester.run("space-infix-ops", rule, {
                 column: 2,
                 nodeType: "BinaryExpression"
             }]
-        }
+        },
+        {
+            code: "'foo'in{}",
+            output: "'foo' in {}",
+            errors: [{
+                message: "Infix operators must be spaced.",
+                line: 1,
+                column: 6,
+                nodeType: "BinaryExpression"
+            }]
+        },
+        {
+            code: "'foo'instanceof{}",
+            output: "'foo' instanceof {}",
+            errors: [{
+                message: "Infix operators must be spaced.",
+                line: 1,
+                column: 6,
+                nodeType: "BinaryExpression"
+            }]
+        },
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

See https://github.com/eslint/eslint/issues/7525

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates `space-infix-ops` to handle `in` and `instanceof` correctly. Due to a bug, it previously did not report any cases with `in` or `instanceof` operators.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.

