### PR TITLE
Chore: Use process.exitCode instead of process.exit() in bin/eslint.js

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -5,7 +5,7 @@
  * @author Nicholas C. Zakas
  */
 
-/* eslint no-console:off, no-process-exit:off */
+/* eslint no-console:off */
 
 "use strict";
 
@@ -36,7 +36,7 @@ const concat = require("concat-stream"),
 // Execution
 //------------------------------------------------------------------------------
 
-process.on("uncaughtException", err => {
+process.once("uncaughtException", err => {
 
     // lazy load
     const lodash = require("lodash");
@@ -51,7 +51,7 @@ process.on("uncaughtException", err => {
         console.log(err.stack);
     }
 
-    process.exit(1);
+    process.exitCode = 1;
 });
 
 if (useStdIn) {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This modifies bin/eslint.js to set process.exitCode rather than using `process.exit()` on an error.

`process.exit()` is [a bit unsafe](https://nodejs.org/api/process.html#process_process_exit_code) as far as logging is concerned; since it exits the process as quickly as possible, it will sometimes cause logs to be dropped.

Based on my manual testing, our [integration tests](https://github.com/eslint/eslint/blob/3e6131eaaa3f9f96263e05dd0bed741a88bdfa1c/tests/bin/eslint.js), and what I understand about how Node processes end, the process exits gracefully on its own after this function ends.

**Is there anything you'd like reviewers to focus on?**

We should make sure that there is nothing that would delay the process from promptly exiting in a situation like this (e.g. pending async operations).