### PR TITLE
Fix: syntax errors created by `object-shorthand` autofix (fixes #7574)

### DIFF
--- a/lib/rules/object-shorthand.js
+++ b/lib/rules/object-shorthand.js
@@ -100,6 +100,7 @@ module.exports = {
         const PARAMS = context.options[1] || {};
         const IGNORE_CONSTRUCTORS = PARAMS.ignoreConstructors;
         const AVOID_QUOTES = PARAMS.avoidQuotes;
+        const sourceCode = context.getSourceCode();
 
         //--------------------------------------------------------------------------
         // Helpers
@@ -296,14 +297,19 @@ module.exports = {
                             node,
                             message: "Expected method shorthand.",
                             fix(fixer) {
+
+                                // NOTE: If this rule is enhanced to handle arrow functions as well, this logic needs to be updated.
+                                const functionToken = sourceCode.getTokens(node).find(token => token.type === "Keyword" && token.value === "function");
+
                                 if (node.value.generator) {
-                                    return fixer.replaceTextRange(
-                                        [node.key.range[0], node.value.range[0] + "function*".length],
-                                        `*[${node.key.name}]`
-                                    );
+                                    return fixer.replaceTextRange([sourceCode.getTokenBefore(node.key).range[0], sourceCode.getTokenAfter(functionToken).range[1]], `*[${sourceCode.getText(node.key)}]`);
                                 }
 
-                                return fixer.removeRange([node.key.range[1] + 1, node.value.range[0] + "function".length]);
+                                if (node.value.async) {
+                                    return fixer.replaceTextRange([sourceCode.getTokenBefore(node.key).range[0], functionToken.range[1]], `async [${sourceCode.getText(node.key)}]`);
+                                }
+
+                                return fixer.removeRange([sourceCode.getTokenAfter(node.key).range[1], functionToken.range[1]]);
                             }
                         });
                         return;
@@ -314,14 +320,19 @@ module.exports = {
                         node,
                         message: "Expected method shorthand.",
                         fix(fixer) {
+
+                            // NOTE: If this rule is enhanced to handle arrow functions as well, this logic needs to be updated.
+                            const functionToken = sourceCode.getTokens(node).find(token => token.type === "Keyword" && token.value === "function");
+
                             if (node.value.generator) {
-                                return fixer.replaceTextRange(
-                                    [node.key.range[0], node.value.range[0] + "function*".length],
-                                    `*${node.key.name}`
-                                );
+                                return fixer.replaceTextRange([node.key.range[0], sourceCode.getTokenAfter(functionToken).range[1]], `*${sourceCode.getText(node.key)}`);
                             }
 
-                            return fixer.removeRange([node.key.range[1], node.value.range[0] + "function".length]);
+                            if (node.value.async) {
+                                return fixer.replaceTextRange([node.key.range[0], functionToken.range[1]], `async ${sourceCode.getText(node.key)}`);
+                            }
+
+                            return fixer.removeRange([node.key.range[1], functionToken.range[1]]);
                         }
                     });
                 } else if (node.value.type === "Identifier" && node.key.name === node.value.name && APPLY_TO_PROPS) {

--- a/tests/lib/rules/object-shorthand.js
+++ b/tests/lib/rules/object-shorthand.js
@@ -144,6 +144,11 @@ ruleTester.run("object-shorthand", rule, {
         { code: "doSomething({y: function() {}})", output: "doSomething({y() {}})", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
         { code: "doSomething({[y]: function() {}})", output: "doSomething({[y]() {}})", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
         { code: "doSomething({['y']: function() {}})", output: "doSomething({['y']() {}})", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
+        { code: "({ foo: async function () {} })", output: "({ async foo () {} })", parserOptions: { ecmaVersion: 8 }, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
+        { code: "({ 'foo': async function() {} })", output: "({ async 'foo'() {} })", parserOptions: { ecmaVersion: 8 }, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
+        { code: "({ [foo]: async function() {} })", output: "({ async [foo]() {} })", parserOptions: { ecmaVersion: 8 }, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
+        { code: "({ [foo.bar]: function*() {} })", output: "({ *[foo.bar]() {} })", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
+        { code: "({ [foo   ]: function() {} })", output: "({ [foo   ]() {} })", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
 
         // options
         { code: "var x = {y: function() {}}", output: "var x = {y() {}}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected method shorthand.", type: "Property" }], options: ["methods"] },

--- a/tests/lib/rules/object-shorthand.js
+++ b/tests/lib/rules/object-shorthand.js
@@ -149,6 +149,10 @@ ruleTester.run("object-shorthand", rule, {
         { code: "({ [foo]: async function() {} })", output: "({ async [foo]() {} })", parserOptions: { ecmaVersion: 8 }, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
         { code: "({ [foo.bar]: function*() {} })", output: "({ *[foo.bar]() {} })", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
         { code: "({ [foo   ]: function() {} })", output: "({ [foo   ]() {} })", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
+        { code: "({ [ foo ]: async function() {} })", output: "({ async [foo]() {} })", parserOptions: { ecmaVersion: 8 }, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
+        { code: "({ foo: function *() {} })", output: "({ *foo() {} })", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
+        { code: "({ [  foo   ]: function() {} })", output: "({ [  foo   ]() {} })", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
+        { code: "({ [  foo]: function() {} })", output: "({ [  foo]() {} })", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
 
         // options
         { code: "var x = {y: function() {}}", output: "var x = {y() {}}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected method shorthand.", type: "Property" }], options: ["methods"] },


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

See https://github.com/eslint/eslint/issues/7574

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This fixes several bugs in `object-shorthand`'s autofixing.

* Previously, if an object had a computed key that was anything other than an identifier corresponding to a generator function property, the fixer would output unbalanced square brackets with `undefined` as the property name.

  ```js
  ({ [foo.bar]: function*() {} });

  // was previously fixed to:

  ({ [*[undefined]() {} }); // unexpected `undefined`
  ```
* Previously, the fixer would output invalid syntax if there was a space between a computed property and its closing bracket.
  ```js
  ({ [ foo ]: function() {} });

  // was previously fixed to:

  ({ [ foo () {} }); // no closing ]
  ```
* Previously, the fixer would output invalid syntax for generator functions if there was a space before the star.
  ```js
  ({ foo: function *() {} });

  // was previously fixed to:

  ({ *foo*() {} }); // extra star
  ```
* Previously, the fixer would output incorrect fixes for async functions (https://github.com/eslint/eslint/issues/7574).
  ```js
  ({ foo: async function() {} });

  // was previously fixed to:

  ({ foonction() {} }); // lol `foonction`
  ```

**Is there anything you'd like reviewers to focus on?**

This is a fairly bad bug, since the resulting code after autofixing an async function is still syntactically valid (so the user won't notice the issue), but it does something completely different than before. I'm hoping we can expedite this PR to get the fix into the upcoming release.

However, it is a semver-patch change, so it could also go into a patch release if we decide to create one for this release.