### PR TITLE
Chore: ensure that files in tests/conf are linted

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -527,7 +527,7 @@ target.lint = function() {
     }
 
     echo("Validating JavaScript test files");
-    lastReturn = exec(ESLINT + testCache + TEST_FILES);
+    lastReturn = exec(`${ESLINT}${testCache}"tests/**/*.js"`);
     if (lastReturn.code !== 0) {
         errors++;
     }

--- a/tests/.eslintrc.yml
+++ b/tests/.eslintrc.yml
@@ -1,0 +1,2 @@
+env:
+  mocha: true

--- a/tests/bin/.eslintrc.yml
+++ b/tests/bin/.eslintrc.yml
@@ -1,2 +1,0 @@
-env:
-    mocha: true

--- a/tests/conf/eslint-all.js
+++ b/tests/conf/eslint-all.js
@@ -9,32 +9,30 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-var assert = require("chai").assert,
-    eslintAll = require("../../conf/eslint-all"),
-    rules = eslintAll.rules;
+const assert = require("chai").assert;
+const eslintAll = require("../../conf/eslint-all");
+const rules = eslintAll.rules;
 
-describe("eslint-all", function() {
-    it("should only include rules", function() {
-        var ruleNames = Object.keys(rules);
+describe("eslint-all", () => {
+    it("should only include rules", () => {
+        const ruleNames = Object.keys(rules);
 
         assert.notInclude(ruleNames, ".eslintrc.yml");
 
     });
 
-    it("should return all rules", function() {
-        var ruleNames = Object.keys(rules);
-        var count = ruleNames.length;
-        var someRule = "yoda";
+    it("should return all rules", () => {
+        const ruleNames = Object.keys(rules);
+        const count = ruleNames.length;
+        const someRule = "yoda";
 
         assert.include(ruleNames, someRule);
         assert.isAbove(count, 200);
     });
 
-    it("should configure all rules as errors", function() {
-        var ruleNames = Object.keys(rules);
-        var nonErrorRules = ruleNames.filter(function (ruleName) {
-            return rules[ruleName] !== "error";
-        });
+    it("should configure all rules as errors", () => {
+        const ruleNames = Object.keys(rules);
+        const nonErrorRules = ruleNames.filter(ruleName => rules[ruleName] !== "error");
 
         assert.equal(nonErrorRules.length, 0);
     });

--- a/tests/lib/.eslintrc
+++ b/tests/lib/.eslintrc
@@ -1,2 +1,0 @@
-env:
-    mocha: true

--- a/tests/templates/.eslintrc
+++ b/tests/templates/.eslintrc
@@ -1,2 +1,0 @@
-env:
-    mocha: true


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This fixes an issue where files in `tests/conf` weren't getting linted. It also gets rid of a few redundant `.eslintrc` files that only contain `{env: {mocha: true}}` in favor of a single file in `tests/`.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.
