### PR TITLE
Chore: make the `object-shorthand` tests more readable

### DIFF
--- a/tests/lib/rules/object-shorthand.js
+++ b/tests/lib/rules/object-shorthand.js
@@ -16,178 +16,594 @@ const rule = require("../../../lib/rules/object-shorthand"),
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester();
+const PROPERTY_ERROR = { message: "Expected property shorthand.", type: "Property" };
+const METHOD_ERROR = { message: "Expected method shorthand.", type: "Property" };
+const LONGFORM_PROPERTY_ERROR = { message: "Expected longform property syntax.", type: "Property" };
+const LONGFORM_METHOD_ERROR = { message: "Expected longform method syntax.", type: "Property" };
+const LONGFORM_METHOD_STRING_LITERAL_ERROR = { message: "Expected longform method syntax for string literal keys.", type: "Property" };
+const ALL_SHORTHAND_ERROR = { message: "Expected shorthand for all properties.", type: "ObjectExpression" };
+const MIXED_SHORTHAND_ERROR = { message: "Unexpected mix of shorthand and non-shorthand properties.", type: "ObjectExpression" };
+
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
 
 ruleTester.run("object-shorthand", rule, {
     valid: [
-        { code: "var x = {y() {}}", parserOptions: { ecmaVersion: 6 } },
-        { code: "var x = {y}", parserOptions: { ecmaVersion: 6 } },
-        { code: "var x = {a: b}", parserOptions: { ecmaVersion: 6 } },
-        { code: "var x = {a: 'a'}", parserOptions: { ecmaVersion: 6 } },
-        { code: "var x = {'a': 'a'}", parserOptions: { ecmaVersion: 6 } },
-        { code: "var x = {'a': b}", parserOptions: { ecmaVersion: 6 } },
-        { code: "var x = {y(x) {}}", parserOptions: { ecmaVersion: 6 } },
-        { code: "var {x,y,z} = x", parserOptions: { ecmaVersion: 6 } },
-        { code: "var {x: {y}} = z", parserOptions: { ecmaVersion: 6 } },
-        { code: "var x = {*x() {}}", parserOptions: { ecmaVersion: 6 } },
-        { code: "var x = {x: y}", parserOptions: { ecmaVersion: 6 } },
-        { code: "var x = {x: y, y: z}", parserOptions: { ecmaVersion: 6 }},
-        { code: "var x = {x: y, y: z, z: 'z'}", parserOptions: { ecmaVersion: 6 }},
-        { code: "var x = {x() {}, y: z, l(){}}", parserOptions: { ecmaVersion: 6 }},
-        { code: "var x = {x: y, y: z, a: b}", parserOptions: { ecmaVersion: 6 }},
-        { code: "var x = {x: y, y: z, 'a': b}", parserOptions: { ecmaVersion: 6 }},
-        { code: "var x = {x: y, y() {}, z: a}", parserOptions: { ecmaVersion: 6 }},
-        { code: "var x = {[y]: y}", parserOptions: { ecmaVersion: 6 }},
-        { code: "doSomething({x: y})", parserOptions: { ecmaVersion: 6 }},
-        { code: "doSomething({'x': y})", parserOptions: { ecmaVersion: 6 }},
-        { code: "doSomething({x: 'x'})", parserOptions: { ecmaVersion: 6 }},
-        { code: "doSomething({'x': 'x'})", parserOptions: { ecmaVersion: 6 }},
-        { code: "doSomething({y() {}})", parserOptions: { ecmaVersion: 6 }},
-        { code: "doSomething({x: y, y() {}})", parserOptions: { ecmaVersion: 6 }},
-        { code: "doSomething({y() {}, z: a})", parserOptions: { ecmaVersion: 6 }},
-        { code: "!{ a: function a(){} };", parserOptions: { ecmaVersion: 6 } },
+        "var x = {y() {}}",
+        "var x = {y}",
+        "var x = {a: b}",
+        "var x = {a: 'a'}",
+        "var x = {'a': 'a'}",
+        "var x = {'a': b}",
+        "var x = {y(x) {}}",
+        "var {x,y,z} = x",
+        "var {x: {y}} = z",
+        "var x = {*x() {}}",
+        "var x = {x: y}",
+        "var x = {x: y, y: z}",
+        "var x = {x: y, y: z, z: 'z'}",
+        "var x = {x() {}, y: z, l(){}}",
+        "var x = {x: y, y: z, a: b}",
+        "var x = {x: y, y: z, 'a': b}",
+        "var x = {x: y, y() {}, z: a}",
+        "var x = {[y]: y}",
+        "doSomething({x: y})",
+        "doSomething({'x': y})",
+        "doSomething({x: 'x'})",
+        "doSomething({'x': 'x'})",
+        "doSomething({y() {}})",
+        "doSomething({x: y, y() {}})",
+        "doSomething({y() {}, z: a})",
+        "!{ a: function a(){} };",
 
-        // arrows functions are still alright
-        { code: "var x = {y: (x)=>x}", parserOptions: { ecmaVersion: 6 } },
-        { code: "doSomething({y: (x)=>x})", parserOptions: { ecmaVersion: 6 } },
-        { code: "var x = {y: (x)=>x, y: a}", parserOptions: { ecmaVersion: 6 } },
-        { code: "doSomething({x, y: (x)=>x})", parserOptions: { ecmaVersion: 6 } },
+        // arrow functions are still alright
+        "var x = {y: (x)=>x}",
+        "doSomething({y: (x)=>x})",
+        "var x = {y: (x)=>x, y: a}",
+        "doSomething({x, y: (x)=>x})",
 
         // getters and setters are ok
-        { code: "var x = {get y() {}}", parserOptions: { ecmaVersion: 6 } },
-        { code: "var x = {set y(z) {}}", parserOptions: { ecmaVersion: 6 } },
-        { code: "var x = {get y() {}, set y(z) {}}", parserOptions: { ecmaVersion: 6 } },
-        { code: "doSomething({get y() {}})", parserOptions: { ecmaVersion: 6 } },
-        { code: "doSomething({set y(z) {}})", parserOptions: { ecmaVersion: 6 } },
-        { code: "doSomething({get y() {}, set y(z) {}})", parserOptions: { ecmaVersion: 6 } },
+        "var x = {get y() {}}",
+        "var x = {set y(z) {}}",
+        "var x = {get y() {}, set y(z) {}}",
+        "doSomething({get y() {}})",
+        "doSomething({set y(z) {}})",
+        "doSomething({get y() {}, set y(z) {}})",
 
         // object literal computed properties
-        { code: "var x = {[y]: y}", parserOptions: { ecmaVersion: 6 }, options: ["properties"] },
-        { code: "var x = {['y']: 'y'}", parserOptions: { ecmaVersion: 6 }, options: ["properties"] },
-        { code: "var x = {['y']: y}", parserOptions: { ecmaVersion: 6 }, options: ["properties"] },
+        {
+            code: "var x = {[y]: y}",
+            options: ["properties"]
+        },
+        {
+            code: "var x = {['y']: 'y'}",
+            options: ["properties"]
+        },
+        {
+            code: "var x = {['y']: y}",
+            options: ["properties"]
+        },
 
         // object literal computed methods
-        { code: "var x = {[y]() {}}", parserOptions: { ecmaVersion: 6 }, options: ["methods"] },
-        { code: "var x = {[y]: function x() {}}", parserOptions: { ecmaVersion: 6 }, options: ["methods"] },
-        { code: "var x = {[y]: y}", parserOptions: { ecmaVersion: 6 }, options: ["methods"] },
+        {
+            code: "var x = {[y]() {}}",
+            options: ["methods"]
+        },
+        {
+            code: "var x = {[y]: function x() {}}",
+            options: ["methods"]
+        },
+        {
+            code: "var x = {[y]: y}",
+            options: ["methods"]
+        },
 
         // options
-        { code: "var x = {y() {}}", parserOptions: { ecmaVersion: 6 }, options: ["methods"] },
-        { code: "var x = {x, y() {}, a:b}", parserOptions: { ecmaVersion: 6 }, options: ["methods"] },
-        { code: "var x = {y}", parserOptions: { ecmaVersion: 6 }, options: ["properties"] },
-        { code: "var x = {y: {b}}", parserOptions: { ecmaVersion: 6 }, options: ["properties"] },
-        { code: "var x = {a: n, c: d, f: g}", parserOptions: { ecmaVersion: 6 }, options: ["never"] },
-        { code: "var x = {a: function(){}, b: {c: d}}", parserOptions: { ecmaVersion: 6 }, options: ["never"] },
+        {
+            code: "var x = {y() {}}",
+            options: ["methods"]
+        },
+        {
+            code: "var x = {x, y() {}, a:b}",
+            options: ["methods"]
+        },
+        {
+            code: "var x = {y}",
+            options: ["properties"]
+        },
+        {
+            code: "var x = {y: {b}}",
+            options: ["properties"]
+        },
+        {
+            code: "var x = {a: n, c: d, f: g}",
+            options: ["never"]
+        },
+        {
+            code: "var x = {a: function(){}, b: {c: d}}",
+            options: ["never"]
+        },
 
         // ignoreConstructors
-        { code: "var x = {ConstructorFunction: function(){}, a: b}", parserOptions: { ecmaVersion: 6 }, options: ["always", { ignoreConstructors: true }] },
-        { code: "var x = {notConstructorFunction(){}, b: c}", parserOptions: { ecmaVersion: 6 }, options: ["always", { ignoreConstructors: true }] },
-        { code: "var x = {ConstructorFunction: function(){}, a: b}", parserOptions: { ecmaVersion: 6 }, options: ["methods", { ignoreConstructors: true }] },
-        { code: "var x = {notConstructorFunction(){}, b: c}", parserOptions: { ecmaVersion: 6 }, options: ["methods", { ignoreConstructors: true }] },
-        { code: "var x = {ConstructorFunction: function(){}, a: b}", parserOptions: { ecmaVersion: 6 }, options: ["never"] },
-        { code: "var x = {notConstructorFunction: function(){}, b: c}", parserOptions: { ecmaVersion: 6 }, options: ["never"] },
+        {
+            code: "var x = {ConstructorFunction: function(){}, a: b}",
+            options: ["always", { ignoreConstructors: true }]
+        },
+        {
+            code: "var x = {notConstructorFunction(){}, b: c}",
+            options: ["always", { ignoreConstructors: true }]
+        },
+        {
+            code: "var x = {ConstructorFunction: function(){}, a: b}",
+            options: ["methods", { ignoreConstructors: true }]
+        },
+        {
+            code: "var x = {notConstructorFunction(){}, b: c}",
+            options: ["methods", { ignoreConstructors: true }]
+        },
+        {
+            code: "var x = {ConstructorFunction: function(){}, a: b}",
+            options: ["never"]
+        },
+        {
+            code: "var x = {notConstructorFunction: function(){}, b: c}",
+            options: ["never"]
+        },
 
         // avoidQuotes
-        { code: "var x = {'a': function(){}}", parserOptions: { ecmaVersion: 6 }, options: ["always", {avoidQuotes: true}] },
-        { code: "var x = {['a']: function(){}}", parserOptions: { ecmaVersion: 6 }, options: ["methods", {avoidQuotes: true}] },
-        { code: "var x = {'y': y}", parserOptions: { ecmaVersion: 6 }, options: ["properties", {avoidQuotes: true}] },
+        {
+            code: "var x = {'a': function(){}}",
+            options: ["always", { avoidQuotes: true }]
+        },
+        {
+            code: "var x = {['a']: function(){}}",
+            options: ["methods", { avoidQuotes: true }]
+        },
+        {
+            code: "var x = {'y': y}",
+            options: ["properties", { avoidQuotes: true }]
+        },
 
         // ignore object shorthand
-        { code: "let {a, b} = o;", parserOptions: { ecmaVersion: 6 }, options: ["never"] },
-        { code: "var x = {foo: foo, bar: bar, ...baz}", parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } }, options: ["never"] },
+        {
+            code: "let {a, b} = o;",
+            options: ["never"]
+        },
+        {
+            code: "var x = {foo: foo, bar: bar, ...baz}",
+            parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } },
+            options: ["never"]
+        },
 
         // consistent
-        { code: "var x = {a: a, b: b}", parserOptions: { ecmaVersion: 6}, options: ["consistent"] },
-        { code: "var x = {a: b, c: d, f: g}", parserOptions: { ecmaVersion: 6}, options: ["consistent"] },
-        { code: "var x = {a, b}", parserOptions: { ecmaVersion: 6}, options: ["consistent"] },
-        { code: "var x = {a, b, get test() { return 1; }}", parserOptions: { ecmaVersion: 6}, options: ["consistent"] },
-        { code: "var x = {...bar}", parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } }, options: ["consistent-as-needed"] },
-        { code: "var x = {foo, bar, ...baz}", parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } }, options: ["consistent"] },
-        { code: "var x = {bar: baz, ...qux}", parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } }, options: ["consistent"] },
-        { code: "var x = {...foo, bar: bar, baz: baz}", parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } }, options: ["consistent"] },
+        {
+            code: "var x = {a: a, b: b}",
+            options: ["consistent"]
+        },
+        {
+            code: "var x = {a: b, c: d, f: g}",
+            options: ["consistent"]
+        },
+        {
+            code: "var x = {a, b}",
+            options: ["consistent"]
+        },
+        {
+            code: "var x = {a, b, get test() { return 1; }}",
+            options: ["consistent"]
+        },
+        {
+            code: "var x = {...bar}",
+            parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } },
+            options: ["consistent-as-needed"]
+        },
+        {
+            code: "var x = {foo, bar, ...baz}",
+            parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } },
+            options: ["consistent"]
+        },
+        {
+            code: "var x = {bar: baz, ...qux}",
+            parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } },
+            options: ["consistent"]
+        },
+        {
+            code: "var x = {...foo, bar: bar, baz: baz}",
+            parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } },
+            options: ["consistent"]
+        },
 
         // consistent-as-needed
-        { code: "var x = {a, b}", parserOptions: { ecmaVersion: 6}, options: ["consistent-as-needed"] },
-        { code: "var x = {a, b, get test(){return 1;}}", parserOptions: { ecmaVersion: 6}, options: ["consistent-as-needed"] },
-        { code: "var x = {0: 'foo'}", parserOptions: { ecmaVersion: 6}, options: ["consistent-as-needed"] },
-        { code: "var x = {'key': 'baz'}", parserOptions: { ecmaVersion: 6}, options: ["consistent-as-needed"] },
-        { code: "var x = {foo: 'foo'}", parserOptions: { ecmaVersion: 6}, options: ["consistent-as-needed"] },
-        { code: "var x = {[foo]: foo}", parserOptions: { ecmaVersion: 6}, options: ["consistent-as-needed"] },
-        { code: "var x = {foo: function foo() {}}", parserOptions: { ecmaVersion: 6}, options: ["consistent-as-needed"] },
-        { code: "var x = {[foo]: 'foo'}", parserOptions: { ecmaVersion: 6}, options: ["consistent-as-needed"] },
-        { code: "var x = {...bar}", parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } }, options: ["consistent-as-needed"] },
-        { code: "var x = {bar, ...baz}", parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } }, options: ["consistent-as-needed"] },
-        { code: "var x = {bar: baz, ...qux}", parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } }, options: ["consistent-as-needed"] },
-        { code: "var x = {...foo, bar, baz}", parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } }, options: ["consistent-as-needed"] },
+        {
+            code: "var x = {a, b}",
+            options: ["consistent-as-needed"]
+        },
+        {
+            code: "var x = {a, b, get test(){return 1;}}",
+            options: ["consistent-as-needed"]
+        },
+        {
+            code: "var x = {0: 'foo'}",
+            options: ["consistent-as-needed"]
+        },
+        {
+            code: "var x = {'key': 'baz'}",
+            options: ["consistent-as-needed"]
+        },
+        {
+            code: "var x = {foo: 'foo'}",
+            options: ["consistent-as-needed"]
+        },
+        {
+            code: "var x = {[foo]: foo}",
+            options: ["consistent-as-needed"]
+        },
+        {
+            code: "var x = {foo: function foo() {}}",
+            options: ["consistent-as-needed"]
+        },
+        {
+            code: "var x = {[foo]: 'foo'}",
+            options: ["consistent-as-needed"]
+        },
+        {
+            code: "var x = {...bar}",
+            parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } },
+            options: ["consistent-as-needed"]
+        },
+        {
+            code: "var x = {bar, ...baz}",
+            parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } },
+            options: ["consistent-as-needed"]
+        },
+        {
+            code: "var x = {bar: baz, ...qux}",
+            parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } },
+            options: ["consistent-as-needed"]
+        },
+        {
+            code: "var x = {...foo, bar, baz}",
+            parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } },
+            options: ["consistent-as-needed"]
+        }
     ],
     invalid: [
-        { code: "var x = {x: x}", output: "var x = {x}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected property shorthand.", type: "Property" }] },
-        { code: "var x = {'x': x}", output: "var x = {x}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected property shorthand.", type: "Property" }] },
-        { code: "var x = {y: y, x: x}", output: "var x = {y, x}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected property shorthand.", type: "Property" }, { message: "Expected property shorthand.", type: "Property" }] },
-        { code: "var x = {y: z, x: x, a: b}", output: "var x = {y: z, x, a: b}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected property shorthand.", type: "Property" }] },
-        { code: "var x = {y: z,\n x: x,\n a: b\n // comment \n}", output: "var x = {y: z,\n x,\n a: b\n // comment \n}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected property shorthand.", type: "Property" }] },
-        { code: "var x = {y: z,\n a: b,\n // comment \nf: function() {}}", output: "var x = {y: z,\n a: b,\n // comment \nf() {}}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
-        { code: "var x = {a: b,\n/* comment */\ny: y\n }", output: "var x = {a: b,\n/* comment */\ny\n }", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected property shorthand.", type: "Property" }] },
-        { code: "var x = {\n  a: b,\n  /* comment */\n  y: y\n}", output: "var x = {\n  a: b,\n  /* comment */\n  y\n}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected property shorthand.", type: "Property" }] },
-        { code: "var x = {\n  f: function() {\n    /* comment */\n    a(b);\n    }\n  }", output: "var x = {\n  f() {\n    /* comment */\n    a(b);\n    }\n  }", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
-        { code: "var x = {\n  [f]: function() {\n    /* comment */\n    a(b);\n    }\n  }", output: "var x = {\n  [f]() {\n    /* comment */\n    a(b);\n    }\n  }", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
-        { code: "var x = {\n  f: function*() {\n    /* comment */\n    a(b);\n    }\n  }", output: "var x = {\n  *f() {\n    /* comment */\n    a(b);\n    }\n  }", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
-        { code: "var x = {y: function() {}}", output: "var x = {y() {}}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
-        { code: "var x = {y: function*() {}}", output: "var x = {*y() {}}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
-        { code: "var x = {x: y, y: z, a: a}", output: "var x = {x: y, y: z, a}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected property shorthand.", type: "Property" }] },
-        { code: "var x = {ConstructorFunction: function(){}, a: b}", output: "var x = {ConstructorFunction(){}, a: b}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
-        { code: "var x = {x: y, y: z, a: function(){}, b() {}}", output: "var x = {x: y, y: z, a(){}, b() {}}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
-        { code: "var x = {x: x, y: function() {}}", output: "var x = {x, y() {}}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected property shorthand.", type: "Property" }, { message: "Expected method shorthand.", type: "Property" }]},
-        { code: "doSomething({x: x})", output: "doSomething({x})", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected property shorthand.", type: "Property" }] },
-        { code: "doSomething({'x': x})", output: "doSomething({x})", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected property shorthand.", type: "Property" }] },
-        { code: "doSomething({a: 'a', 'x': x})", output: "doSomething({a: 'a', x})", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected property shorthand.", type: "Property" }] },
-        { code: "doSomething({y: function() {}})", output: "doSomething({y() {}})", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
-        { code: "doSomething({[y]: function() {}})", output: "doSomething({[y]() {}})", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
-        { code: "doSomething({['y']: function() {}})", output: "doSomething({['y']() {}})", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
-        { code: "({ foo: async function () {} })", output: "({ async foo () {} })", parserOptions: { ecmaVersion: 8 }, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
-        { code: "({ 'foo': async function() {} })", output: "({ async 'foo'() {} })", parserOptions: { ecmaVersion: 8 }, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
-        { code: "({ [foo]: async function() {} })", output: "({ async [foo]() {} })", parserOptions: { ecmaVersion: 8 }, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
-        { code: "({ [foo.bar]: function*() {} })", output: "({ *[foo.bar]() {} })", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
-        { code: "({ [foo   ]: function() {} })", output: "({ [foo   ]() {} })", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
-        { code: "({ [ foo ]: async function() {} })", output: "({ async [foo]() {} })", parserOptions: { ecmaVersion: 8 }, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
-        { code: "({ foo: function *() {} })", output: "({ *foo() {} })", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
-        { code: "({ [  foo   ]: function() {} })", output: "({ [  foo   ]() {} })", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
-        { code: "({ [  foo]: function() {} })", output: "({ [  foo]() {} })", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
+        {
+            code: "var x = {x: x}",
+            output: "var x = {x}",
+            errors: [PROPERTY_ERROR]
+        },
+        {
+            code: "var x = {'x': x}",
+            output: "var x = {x}",
+            errors: [PROPERTY_ERROR]
+        },
+        {
+            code: "var x = {y: y, x: x}",
+            output: "var x = {y, x}",
+            errors: [PROPERTY_ERROR, PROPERTY_ERROR]
+        },
+        {
+            code: "var x = {y: z, x: x, a: b}",
+            output: "var x = {y: z, x, a: b}",
+            errors: [PROPERTY_ERROR]
+        },
+        {
+            code: "var x = {y: z,\n x: x,\n a: b\n // comment \n}",
+            output: "var x = {y: z,\n x,\n a: b\n // comment \n}",
+            errors: [PROPERTY_ERROR]
+        },
+        {
+            code: "var x = {y: z,\n a: b,\n // comment \nf: function() {}}",
+            output: "var x = {y: z,\n a: b,\n // comment \nf() {}}",
+            errors: [METHOD_ERROR]
+        },
+        {
+            code: "var x = {a: b,\n/* comment */\ny: y\n }",
+            output: "var x = {a: b,\n/* comment */\ny\n }",
+            errors: [PROPERTY_ERROR]
+        },
+        {
+            code: "var x = {\n  a: b,\n  /* comment */\n  y: y\n}",
+            output: "var x = {\n  a: b,\n  /* comment */\n  y\n}",
+            errors: [PROPERTY_ERROR]
+        },
+        {
+            code: "var x = {\n  f: function() {\n    /* comment */\n    a(b);\n    }\n  }",
+            output: "var x = {\n  f() {\n    /* comment */\n    a(b);\n    }\n  }",
+            errors: [METHOD_ERROR]
+        },
+        {
+            code: "var x = {\n  [f]: function() {\n    /* comment */\n    a(b);\n    }\n  }",
+            output: "var x = {\n  [f]() {\n    /* comment */\n    a(b);\n    }\n  }",
+            errors: [METHOD_ERROR]
+        },
+        {
+            code: "var x = {\n  f: function*() {\n    /* comment */\n    a(b);\n    }\n  }",
+            output: "var x = {\n  *f() {\n    /* comment */\n    a(b);\n    }\n  }",
+            errors: [METHOD_ERROR]
+        },
+        {
+            code: "var x = {y: function() {}}",
+            output: "var x = {y() {}}",
+            errors: [METHOD_ERROR]
+        },
+        {
+            code: "var x = {y: function*() {}}",
+            output: "var x = {*y() {}}",
+            errors: [METHOD_ERROR]
+        },
+        {
+            code: "var x = {x: y, y: z, a: a}",
+            output: "var x = {x: y, y: z, a}",
+            errors: [PROPERTY_ERROR]
+        },
+        {
+            code: "var x = {ConstructorFunction: function(){}, a: b}",
+            output: "var x = {ConstructorFunction(){}, a: b}",
+            errors: [METHOD_ERROR]
+        },
+        {
+            code: "var x = {x: y, y: z, a: function(){}, b() {}}",
+            output: "var x = {x: y, y: z, a(){}, b() {}}",
+            errors: [METHOD_ERROR]
+        },
+        {
+            code: "var x = {x: x, y: function() {}}",
+            output: "var x = {x, y() {}}",
+            errors: [PROPERTY_ERROR, METHOD_ERROR]
+        },
+        {
+            code: "doSomething({x: x})",
+            output: "doSomething({x})",
+            errors: [PROPERTY_ERROR]
+        },
+        {
+            code: "doSomething({'x': x})",
+            output: "doSomething({x})",
+            errors: [PROPERTY_ERROR]
+        },
+        {
+            code: "doSomething({a: 'a', 'x': x})",
+            output: "doSomething({a: 'a', x})",
+            errors: [PROPERTY_ERROR]
+        },
+        {
+            code: "doSomething({y: function() {}})",
+            output: "doSomething({y() {}})",
+            errors: [METHOD_ERROR]
+        },
+        {
+            code: "doSomething({[y]: function() {}})",
+            output: "doSomething({[y]() {}})",
+            errors: [METHOD_ERROR]
+        },
+        {
+            code: "doSomething({['y']: function() {}})",
+            output: "doSomething({['y']() {}})",
+            errors: [METHOD_ERROR]
+        },
+        {
+            code: "({ foo: async function () {} })",
+            output: "({ async foo () {} })",
+            parserOptions: { ecmaVersion: 8 },
+            errors: [METHOD_ERROR]
+        },
+        {
+            code: "({ 'foo': async function() {} })",
+            output: "({ async 'foo'() {} })",
+            parserOptions: { ecmaVersion: 8 },
+            errors: [METHOD_ERROR]
+        },
+        {
+            code: "({ [foo]: async function() {} })",
+            output: "({ async [foo]() {} })",
+            parserOptions: { ecmaVersion: 8 },
+            errors: [METHOD_ERROR]
+        },
+        {
+            code: "({ [foo.bar]: function*() {} })",
+            output: "({ *[foo.bar]() {} })",
+            errors: [METHOD_ERROR]
+        },
+        {
+            code: "({ [foo   ]: function() {} })",
+            output: "({ [foo   ]() {} })",
+            errors: [METHOD_ERROR]
+        },
+        {
+            code: "({ [ foo ]: async function() {} })",
+            output: "({ async [foo]() {} })",
+            parserOptions: { ecmaVersion: 8 },
+            errors: [METHOD_ERROR]
+        },
+        {
+            code: "({ foo: function *() {} })",
+            output: "({ *foo() {} })",
+            errors: [METHOD_ERROR]
+        },
+        {
+            code: "({ [  foo   ]: function() {} })",
+            output: "({ [  foo   ]() {} })",
+            errors: [METHOD_ERROR]
+        },
+        {
+            code: "({ [  foo]: function() {} })",
+            output: "({ [  foo]() {} })",
+            errors: [METHOD_ERROR]
+        },
 
         // options
-        { code: "var x = {y: function() {}}", output: "var x = {y() {}}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected method shorthand.", type: "Property" }], options: ["methods"] },
-        { code: "var x = {x, y() {}, z: function() {}}", output: "var x = {x, y() {}, z() {}}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected method shorthand.", type: "Property" }], options: ["methods"] },
-        { code: "var x = {ConstructorFunction: function(){}, a: b}", output: "var x = {ConstructorFunction(){}, a: b}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected method shorthand.", type: "Property" }], options: ["methods"] },
-        { code: "var x = {[y]: function() {}}", output: "var x = {[y]() {}}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected method shorthand.", type: "Property" }], options: ["methods"] },
-        { code: "var x = {x: x}", output: "var x = {x}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected property shorthand.", type: "Property" }], options: ["properties"] },
-        { code: "var x = {a, b, c(){}, x: x}", output: "var x = {a, b, c(){}, x}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected property shorthand.", type: "Property" }], options: ["properties"] },
-        { code: "var x = {y() {}}", output: "var x = {y: function() {}}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected longform method syntax.", type: "Property" }], options: ["never"] },
-        { code: "var x = {*y() {}}", output: "var x = {y: function*() {}}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected longform method syntax.", type: "Property" }], options: ["never"] },
-        { code: "var x = {y}", output: "var x = {y: y}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected longform property syntax.", type: "Property" }], options: ["never"]},
-        { code: "var x = {y, a: b, *x(){}}", output: "var x = {y: y, a: b, x: function*(){}}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected longform property syntax.", type: "Property" }, { message: "Expected longform method syntax.", type: "Property" }], options: ["never"]},
-        { code: "var x = {y: {x}}", output: "var x = {y: {x: x}}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected longform property syntax.", type: "Property" }], options: ["never"]},
-        { code: "var x = {ConstructorFunction(){}, a: b}", output: "var x = {ConstructorFunction: function(){}, a: b}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected longform method syntax.", type: "Property" }], options: ["never"] },
-        { code: "var x = {notConstructorFunction(){}, b: c}", output: "var x = {notConstructorFunction: function(){}, b: c}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected longform method syntax.", type: "Property" }], options: ["never"] },
-        { code: "var x = {foo: foo, bar: baz, ...qux}", output: "var x = {foo, bar: baz, ...qux}", parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } }, errors: [{ message: "Expected property shorthand.", type: "" }], options: ["always"] },
-        { code: "var x = {foo, bar: baz, ...qux}", output: "var x = {foo: foo, bar: baz, ...qux}", parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } }, errors: [{ message: "Expected longform property syntax.", type: "" }], options: ["never"] },
+        {
+            code: "var x = {y: function() {}}",
+            output: "var x = {y() {}}",
+            options: ["methods"],
+            errors: [METHOD_ERROR]
+        },
+        {
+            code: "var x = {x, y() {}, z: function() {}}",
+            output: "var x = {x, y() {}, z() {}}",
+            options: ["methods"],
+            errors: [METHOD_ERROR]
+        },
+        {
+            code: "var x = {ConstructorFunction: function(){}, a: b}",
+            output: "var x = {ConstructorFunction(){}, a: b}",
+            options: ["methods"],
+            errors: [METHOD_ERROR]
+        },
+        {
+            code: "var x = {[y]: function() {}}",
+            output: "var x = {[y]() {}}",
+            options: ["methods"],
+            errors: [METHOD_ERROR]
+        },
+        {
+            code: "var x = {x: x}",
+            output: "var x = {x}",
+            options: ["properties"],
+            errors: [PROPERTY_ERROR]
+        },
+        {
+            code: "var x = {a, b, c(){}, x: x}",
+            output: "var x = {a, b, c(){}, x}",
+            options: ["properties"],
+            errors: [PROPERTY_ERROR]
+        },
+        {
+            code: "var x = {y() {}}",
+            output: "var x = {y: function() {}}",
+            options: ["never"],
+            errors: [LONGFORM_METHOD_ERROR]
+        },
+        {
+            code: "var x = {*y() {}}",
+            output: "var x = {y: function*() {}}",
+            options: ["never"],
+            errors: [LONGFORM_METHOD_ERROR]
+        },
+        {
+            code: "var x = {y}",
+            output: "var x = {y: y}",
+            options: ["never"],
+            errors: [LONGFORM_PROPERTY_ERROR]
+        },
+        {
+            code: "var x = {y, a: b, *x(){}}",
+            output: "var x = {y: y, a: b, x: function*(){}}",
+            options: ["never"],
+            errors: [LONGFORM_PROPERTY_ERROR, LONGFORM_METHOD_ERROR]
+        },
+        {
+            code: "var x = {y: {x}}",
+            output: "var x = {y: {x: x}}",
+            options: ["never"],
+            errors: [LONGFORM_PROPERTY_ERROR]
+        },
+        {
+            code: "var x = {ConstructorFunction(){}, a: b}",
+            output: "var x = {ConstructorFunction: function(){}, a: b}",
+            options: ["never"],
+            errors: [LONGFORM_METHOD_ERROR]
+        },
+        {
+            code: "var x = {notConstructorFunction(){}, b: c}",
+            output: "var x = {notConstructorFunction: function(){}, b: c}",
+            options: ["never"],
+            errors: [LONGFORM_METHOD_ERROR]
+        },
+        {
+            code: "var x = {foo: foo, bar: baz, ...qux}",
+            output: "var x = {foo, bar: baz, ...qux}",
+            parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } },
+            options: ["always"],
+            errors: [PROPERTY_ERROR]
+        },
+        {
+            code: "var x = {foo, bar: baz, ...qux}",
+            output: "var x = {foo: foo, bar: baz, ...qux}",
+            parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } },
+            options: ["never"],
+            errors: [LONGFORM_PROPERTY_ERROR]
+        },
 
         // avoidQuotes
-        { code: "var x = {a: a}", output: "var x = {a}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected property shorthand.", type: "Property" }], options: ["always", {avoidQuotes: true}] },
-        { code: "var x = {a: function(){}}", output: "var x = {a(){}}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected method shorthand.", type: "Property" }], options: ["methods", {avoidQuotes: true}] },
-        { code: "var x = {[a]: function(){}}", output: "var x = {[a](){}}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected method shorthand.", type: "Property" }], options: ["methods", {avoidQuotes: true}] },
-        { code: "var x = {'a'(){}}", output: "var x = {'a': function(){}}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected longform method syntax for string literal keys.", type: "Property" }], options: ["always", {avoidQuotes: true}] },
-        { code: "var x = {['a'](){}}", output: "var x = {['a']: function(){}}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected longform method syntax for string literal keys.", type: "Property" }], options: ["methods", {avoidQuotes: true}] },
+        {
+            code: "var x = {a: a}",
+            output: "var x = {a}",
+            options: ["always", { avoidQuotes: true }],
+            errors: [PROPERTY_ERROR]
+        },
+        {
+            code: "var x = {a: function(){}}",
+            output: "var x = {a(){}}",
+            options: ["methods", { avoidQuotes: true }],
+            errors: [METHOD_ERROR]
+        },
+        {
+            code: "var x = {[a]: function(){}}",
+            output: "var x = {[a](){}}",
+            options: ["methods", { avoidQuotes: true }],
+            errors: [METHOD_ERROR]
+        },
+        {
+            code: "var x = {'a'(){}}",
+            output: "var x = {'a': function(){}}",
+            options: ["always", { avoidQuotes: true }],
+            errors: [LONGFORM_METHOD_STRING_LITERAL_ERROR]
+        },
+        {
+            code: "var x = {['a'](){}}",
+            output: "var x = {['a']: function(){}}",
+            options: ["methods", { avoidQuotes: true }],
+            errors: [LONGFORM_METHOD_STRING_LITERAL_ERROR]
+        },
 
         // consistent
-        { code: "var x = {a: a, b}", parserOptions: { ecmaVersion: 6}, errors: [{ message: "Unexpected mix of shorthand and non-shorthand properties.", type: "" }], options: ["consistent"] },
-        { code: "var x = {b, c: d, f: g}", parserOptions: { ecmaVersion: 6}, errors: [{ message: "Unexpected mix of shorthand and non-shorthand properties.", type: "" }], options: ["consistent"] },
-        { code: "var x = {foo, bar: baz, ...qux}", parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } }, errors: [{ message: "Unexpected mix of shorthand and non-shorthand properties.", type: "" }], options: ["consistent"] },
+        {
+            code: "var x = {a: a, b}",
+            options: ["consistent"],
+            errors: [MIXED_SHORTHAND_ERROR]
+        },
+        {
+            code: "var x = {b, c: d, f: g}",
+            options: ["consistent"],
+            errors: [MIXED_SHORTHAND_ERROR]
+        },
+        {
+            code: "var x = {foo, bar: baz, ...qux}",
+            parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } },
+            options: ["consistent"],
+            errors: [MIXED_SHORTHAND_ERROR]
+        },
 
         // consistent-as-needed
-        { code: "var x = {a: a, b: b}", parserOptions: { ecmaVersion: 6}, errors: [{ message: "Expected shorthand for all properties.", type: "" }], options: ["consistent-as-needed"] },
-        { code: "var x = {a, z: function z(){}}", parserOptions: { ecmaVersion: 6}, errors: [{ message: "Unexpected mix of shorthand and non-shorthand properties.", type: "" }], options: ["consistent-as-needed"] },
-        { code: "var x = {foo: function() {}}", parserOptions: { ecmaVersion: 6}, errors: [{ message: "Expected shorthand for all properties.", type: "" }], options: ["consistent-as-needed"] },
-        { code: "var x = {a: a, b: b, ...baz}", parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } }, errors: [{ message: "Expected shorthand for all properties.", type: "" }], options: ["consistent-as-needed"] },
-        { code: "var x = {foo, bar: bar, ...qux}", parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } }, errors: [{ message: "Unexpected mix of shorthand and non-shorthand properties.", type: "" }], options: ["consistent-as-needed"] }
+        {
+            code: "var x = {a: a, b: b}",
+            options: ["consistent-as-needed"],
+            errors: [ALL_SHORTHAND_ERROR]
+        },
+        {
+            code: "var x = {a, z: function z(){}}",
+            options: ["consistent-as-needed"],
+            errors: [MIXED_SHORTHAND_ERROR]
+
+        },
+        {
+            code: "var x = {foo: function() {}}",
+            options: ["consistent-as-needed"],
+            errors: [ALL_SHORTHAND_ERROR]
+        },
+        {
+            code: "var x = {a: a, b: b, ...baz}",
+            parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } },
+            options: ["consistent-as-needed"],
+            errors: [ALL_SHORTHAND_ERROR]
+        },
+        {
+            code: "var x = {foo, bar: bar, ...qux}",
+            parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } },
+            options: ["consistent-as-needed"],
+            errors: [MIXED_SHORTHAND_ERROR]
+        }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This cleans up the `object-shorthand` tests by adding some whitespace, using default parserOptions to reduce clutter, and creating constants for the errors. The rule itself is not changed.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.
