### PR TITLE
Fix: handle try/catch correctly in `no-return-await` (fixes #7581)

### DIFF
--- a/lib/rules/no-return-await.js
+++ b/lib/rules/no-return-await.js
@@ -4,6 +4,8 @@
  */
 "use strict";
 
+const astUtils = require("../ast-utils");
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -23,6 +25,24 @@ module.exports = {
     },
 
     create(context) {
+
+        /**
+        * Determines whether a thrown error from this node will be caught/handled within this function rather than immediately halting
+        * this function. For example, a statement in a `try` block will always have an error handler. A statement in
+        * a `catch` block will only have an error handler if there is also a `finally` block.
+        * @param {ASTNode} node A node representing a location where an could be thrown
+        * @returns {boolean} `true` if a thrown error will be caught/handled in this function
+        */
+        function hasErrorHandler(node) {
+            if (astUtils.isFunction(node) || node.type === "Program") {
+                return false;
+            }
+            if (node.parent.type === "TryStatement" && (node === node.parent.block || node === node.parent.handler && node.parent.finalizer)) {
+                return true;
+            }
+            return hasErrorHandler(node.parent);
+        }
+
         return {
             ArrowFunctionExpression(node) {
                 if (node.async && node.body.type === "AwaitExpression") {
@@ -39,7 +59,7 @@ module.exports = {
             ReturnStatement(node) {
                 const argument = node.argument;
 
-                if (argument && argument.type === "AwaitExpression") {
+                if (argument && argument.type === "AwaitExpression" && !hasErrorHandler(node)) {
                     const sourceCode = context.getSourceCode();
                     const loc = argument.loc;
 

--- a/lib/rules/no-return-await.js
+++ b/lib/rules/no-return-await.js
@@ -34,13 +34,15 @@ module.exports = {
         * @returns {boolean} `true` if a thrown error will be caught/handled in this function
         */
         function hasErrorHandler(node) {
-            if (astUtils.isFunction(node) || node.type === "Program") {
-                return false;
+            let ancestor = node;
+
+            while (!astUtils.isFunction(ancestor) && ancestor.type !== "Program") {
+                if (ancestor.parent.type === "TryStatement" && (ancestor === ancestor.parent.block || ancestor === ancestor.parent.handler && ancestor.parent.finalizer)) {
+                    return true;
+                }
+                ancestor = ancestor.parent;
             }
-            if (node.parent.type === "TryStatement" && (node === node.parent.block || node === node.parent.handler && node.parent.finalizer)) {
-                return true;
-            }
-            return hasErrorHandler(node.parent);
+            return false;
         }
 
         return {

--- a/tests/lib/rules/no-return-await.js
+++ b/tests/lib/rules/no-return-await.js
@@ -16,54 +16,148 @@ const RuleTester = require("../../../lib/testers/rule-tester");
 // Tests
 //------------------------------------------------------------------------------
 
+// pending https://github.com/eslint/espree/issues/304, the type should be "Keyword"
+const errors = [{ message: "Redundant use of `await` on a return value.", type: "Identifier"}];
+
 const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2017 } });
 
 ruleTester.run("no-return-await", rule, {
 
     valid: [
-        { code: "\nasync function foo() {\n\tawait bar(); return;\n}\n" },
-        { code: "\nasync function foo() {\n\tconst x = await bar(); return x;\n}\n" },
-        { code: "\nasync () => { return bar(); }\n" },
-        { code: "\nasync () => bar()\n" },
-        { code: "\nasync function foo() {\nif (a) {\n\t\tif (b) {\n\t\t\treturn bar();\n\t\t}\n\t}\n}\n" },
-        { code: "\nasync () => {\nif (a) {\n\t\tif (b) {\n\t\t\treturn bar();\n\t\t}\n\t}\n}\n" },
+        "\nasync function foo() {\n\tawait bar(); return;\n}\n",
+        "\nasync function foo() {\n\tconst x = await bar(); return x;\n}\n",
+        "\nasync () => { return bar(); }\n",
+        "\nasync () => bar()\n",
+        "\nasync function foo() {\nif (a) {\n\t\tif (b) {\n\t\t\treturn bar();\n\t\t}\n\t}\n}\n",
+        "\nasync () => {\nif (a) {\n\t\tif (b) {\n\t\t\treturn bar();\n\t\t}\n\t}\n}\n",
+        `
+          async function foo() {
+            try {
+              return await bar();
+            } catch (e) {
+              baz();
+            }
+          }
+        `,
+        `
+          async function foo() {
+            try {
+              return await bar();
+            } finally {
+              baz();
+            }
+          }
+        `,
+        `
+          async function foo() {
+            try {}
+            catch (e) {
+              return await bar();
+            } finally {
+              baz();
+            }
+          }
+        `,
+        `
+          async function foo() {
+            try {
+              try {}
+              finally {
+                return await bar();
+              }
+            } finally {
+              baz();
+            }
+          }
+        `,
+        `
+          async function foo() {
+            try {
+              try {}
+              catch (e) {
+                return await bar();
+              }
+            } finally {
+              baz();
+            }
+          }
+        `
     ],
 
     invalid: [
         {
             code: "\nasync function foo() {\n\treturn await bar();\n}\n",
-            errors: [{
-                message: "Redundant use of `await` on a return value.",
-                type: "Identifier", // pending https://github.com/eslint/espree/issues/304, should be "Keyword"
-            }],
+            errors,
         },
         {
             code: "\nasync () => { return await bar(); }\n",
-            errors: [{
-                message: "Redundant use of `await` on a return value.",
-                type: "Identifier", // pending https://github.com/eslint/espree/issues/304, should be "Keyword"
-            }],
+            errors,
         },
         {
             code: "\nasync () => await bar()\n",
-            errors: [{
-                message: "Redundant use of `await` on a return value.",
-                type: "Identifier", // pending https://github.com/eslint/espree/issues/304, should be "Keyword"
-            }],
+            errors,
         },
         {
             code: "\nasync function foo() {\nif (a) {\n\t\tif (b) {\n\t\t\treturn await bar();\n\t\t}\n\t}\n}\n",
-            errors: [{
-                message: "Redundant use of `await` on a return value.",
-                type: "Identifier", // pending https://github.com/eslint/espree/issues/304, should be "Keyword"
-            }],
+            errors,
         },
         {
             code: "\nasync () => {\nif (a) {\n\t\tif (b) {\n\t\t\treturn await bar();\n\t\t}\n\t}\n}\n",
-            errors: [{
-                message: "Redundant use of `await` on a return value.",
-                type: "Identifier", // pending https://github.com/eslint/espree/issues/304, should be "Keyword"
-            }],
+            errors,
         },
+        {
+            code: `
+              async function foo() {
+                try {}
+                finally {
+                  return await bar();
+                }
+              }
+            `,
+            errors
+        },
+        {
+            code: `
+              async function foo() {
+                try {}
+                catch (e) {
+                  return await bar();
+                }
+              }
+            `,
+            errors
+        },
+        {
+            code: `
+              try {
+                async function foo() {
+                  return await bar();
+                }
+              } catch (e) {}
+            `,
+            errors
+        },
+        {
+            code: `
+              try {
+                async () => await bar();
+              } catch (e) {}
+            `,
+            errors
+        },
+        {
+            code: `
+              async function foo() {
+                try {}
+                catch (e) {
+                  try {}
+                  catch (e) {
+                    return await bar();
+                  }
+                }
+              }
+            `,
+            errors
+        }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

See https://github.com/eslint/eslint/issues/7581

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

`no-return-await` is intended to flag redundant uses of `await` in returned values. However, if `return await` is used within a `try` block, the `await` is not redundant.

```js
function baz() {
  return Promise.reject('something bad happened');
}

async function foo() {
  try {
    return await baz();
  } catch (err) {
    // error handled
  }
}

async function bar() {
  try {
    return baz();
  } catch (err) {
    // the error won't end up here
  }
}
```

In the above example, `foo()` will return a fulfilled Promise, and `bar()` will return a rejected Promise.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.

