### PR TITLE
Fix: no-useless-return stack overflow on unreachable loops (fixes #7583)

### DIFF
--- a/lib/rules/no-useless-return.js
+++ b/lib/rules/no-useless-return.js
@@ -107,6 +107,7 @@ module.exports = {
 
     create(context) {
         const segmentInfoMap = new WeakMap();
+        const usedUnreachableSegments = new WeakSet();
         let scopeInfo = null;
 
         /**
@@ -175,8 +176,10 @@ module.exports = {
          */
         function markReturnStatementsOnSegmentAsUsed(segment) {
             if (!segment.reachable) {
+                usedUnreachableSegments.add(segment);
                 segment.allPrevSegments
                     .filter(isReturned)
+                    .filter(prevSegment => !usedUnreachableSegments.has(prevSegment))
                     .forEach(markReturnStatementsOnSegmentAsUsed);
                 return;
             }

--- a/tests/lib/rules/no-useless-return.js
+++ b/tests/lib/rules/no-useless-return.js
@@ -148,6 +148,15 @@ ruleTester.run("no-useless-return", rule, {
             else return;
             return 5;
           }
+        `,
+
+        // https://github.com/eslint/eslint/issues/7583
+        `
+          function foo() {
+            return;
+            while (foo) return;
+            foo;
+          }
         `
     ],
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

See https://github.com/eslint/eslint/issues/7583

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

When `no-useless-return` encounters an unreachable code path segment, it backtracks from that code path segment until it finds a segment that is reachable. If that reachable segment is a `return` statement, the `return` statement is considered to not be useless.

If an entire loop was unreachable, the rule would continue "backtracking" in circles forever, because it was always able to find an unreachable code path segment preceding the current one. This resulted in a stack overflow.

```js
/* eslint no-useless-return: error */

function foo() {
  return;
  while (bar) baz;
  qux;
}
```

This fix makes the rule keep track of segments that it has checked, so that it won't go in circles and check the same segment twice.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular

