### PR TITLE
Update: no-return-await with with complex `return` argument (fixes #7594)

### DIFF
--- a/lib/rules/no-return-await.js
+++ b/lib/rules/no-return-await.js
@@ -27,6 +27,46 @@ module.exports = {
     create(context) {
 
         /**
+         * Reports a found unnecessary `await` expression.
+         * @param {ASTNode} node The node representing the `await` expression to report
+         * @returns {void}
+         */
+        function reportUnnecessaryAwait(node) {
+            context.report({
+                node: context.getSourceCode().getFirstToken(node),
+                loc: node.loc,
+                message,
+            });
+        }
+
+        /**
+        * Finds recursively an `await` expression that is a possible resultant return and is considered unnecessary by the definition of this rule.
+        * This recursion is necessary to cover the cases which `return` argument is formed by comma sequences and/or ternary conditions that could result in an `await` expression.
+        * @param {ASTNode} node A node that is the `return` argument or decendent
+        * @returns {void}
+        */
+        function findUnnecessaryAwait(node) {
+            switch (node.type) {
+                case "AwaitExpression":
+                    reportUnnecessaryAwait(node);
+                    break;
+
+                case "SequenceExpression":
+                    findUnnecessaryAwait(node.expressions[node.expressions.length - 1]);
+                    break;
+
+                case "ConditionalExpression":
+                    findUnnecessaryAwait(node.consequent);
+                    findUnnecessaryAwait(node.alternate);
+                    break;
+
+                default:
+
+                    // Do nothing
+            }
+        }
+
+        /**
         * Determines whether a thrown error from this node will be caught/handled within this function rather than immediately halting
         * this function. For example, a statement in a `try` block will always have an error handler. A statement in
         * a `catch` block will only have an error handler if there is also a `finally` block.
@@ -47,29 +87,13 @@ module.exports = {
 
         return {
             ArrowFunctionExpression(node) {
-                if (node.async && node.body.type === "AwaitExpression") {
-                    const sourceCode = context.getSourceCode();
-                    const loc = node.body.loc;
-
-                    context.report({
-                        node: sourceCode.getFirstToken(node.body),
-                        loc,
-                        message,
-                    });
+                if (node.async) {
+                    findUnnecessaryAwait(node.body);
                 }
             },
             ReturnStatement(node) {
-                const argument = node.argument;
-
-                if (argument && argument.type === "AwaitExpression" && !hasErrorHandler(node)) {
-                    const sourceCode = context.getSourceCode();
-                    const loc = argument.loc;
-
-                    context.report({
-                        node: sourceCode.getFirstToken(argument),
-                        loc,
-                        message,
-                    });
+                if (node.argument && !hasErrorHandler(node)) {
+                    findUnnecessaryAwait(node.argument);
                 }
             },
         };

--- a/lib/rules/no-return-await.js
+++ b/lib/rules/no-return-await.js
@@ -40,33 +40,6 @@ module.exports = {
         }
 
         /**
-        * Finds recursively an `await` expression that is a possible resultant return and is considered unnecessary by the definition of this rule.
-        * This recursion is necessary to cover the cases which `return` argument is formed by comma sequences and/or ternary conditions that could result in an `await` expression.
-        * @param {ASTNode} node A node that is the `return` argument or decendent
-        * @returns {void}
-        */
-        function findUnnecessaryAwait(node) {
-            switch (node.type) {
-                case "AwaitExpression":
-                    reportUnnecessaryAwait(node);
-                    break;
-
-                case "SequenceExpression":
-                    findUnnecessaryAwait(node.expressions[node.expressions.length - 1]);
-                    break;
-
-                case "ConditionalExpression":
-                    findUnnecessaryAwait(node.consequent);
-                    findUnnecessaryAwait(node.alternate);
-                    break;
-
-                default:
-
-                    // Do nothing
-            }
-        }
-
-        /**
         * Determines whether a thrown error from this node will be caught/handled within this function rather than immediately halting
         * this function. For example, a statement in a `try` block will always have an error handler. A statement in
         * a `catch` block will only have an error handler if there is also a `finally` block.
@@ -85,15 +58,35 @@ module.exports = {
             return false;
         }
 
+        /**
+         * Checks if a node is placed in tail call position. Once `return` arguments (or arrow function expressions) can be a complex expression,
+         * an `await` expression could or could not be unnecessary by the definition of this rule. So we're looking for `await` expressions that are in tail position.
+         * @param {ASTNode} node A node representing the `await` expression to check
+         * @returns {boolean} The checking result
+         */
+        function isInTailCallPosition(node) {
+            if (node.parent.type === "ArrowFunctionExpression") {
+                return true;
+            }
+            if (node.parent.type === "ReturnStatement") {
+                return !hasErrorHandler(node.parent);
+            }
+            if (node.parent.type === "ConditionalExpression" && (node === node.parent.consequent || node === node.parent.alternate)) {
+                return isInTailCallPosition(node.parent);
+            }
+            if (node.parent.type === "LogicalExpression" && node === node.parent.right) {
+                return isInTailCallPosition(node.parent);
+            }
+            if (node.parent.type === "SequenceExpression" && node === node.parent.expressions[node.parent.expressions.length - 1]) {
+                return isInTailCallPosition(node.parent);
+            }
+            return false;
+        }
+
         return {
-            ArrowFunctionExpression(node) {
-                if (node.async) {
-                    findUnnecessaryAwait(node.body);
-                }
-            },
-            ReturnStatement(node) {
-                if (node.argument && !hasErrorHandler(node)) {
-                    findUnnecessaryAwait(node.argument);
+            AwaitExpression(node) {
+                if (isInTailCallPosition(node) && !hasErrorHandler(node)) {
+                    reportUnnecessaryAwait(node);
                 }
             },
         };

--- a/tests/lib/rules/no-return-await.js
+++ b/tests/lib/rules/no-return-await.js
@@ -30,6 +30,18 @@ ruleTester.run("no-return-await", rule, {
         "\nasync () => bar()\n",
         "\nasync function foo() {\nif (a) {\n\t\tif (b) {\n\t\t\treturn bar();\n\t\t}\n\t}\n}\n",
         "\nasync () => {\nif (a) {\n\t\tif (b) {\n\t\t\treturn bar();\n\t\t}\n\t}\n}\n",
+        "\nasync function foo() {\n\treturn (await bar(), 0);\n}\n",
+        "\nasync function foo() {\n\treturn (await baz(), await bar(), 0);\n}\n",
+        "\nasync function foo() {\n\treturn (0, 1, (await bar(), 2));\n}\n",
+        "\nasync function foo() {\n\treturn (await bar() ? 0 : 1);\n}\n",
+        "\nasync function foo() {\n\treturn (baz() ? (await bar(), 0) : 1);\n}\n",
+        "\nasync function foo() {\n\treturn (baz() ? 0 : (await bar(), 1));\n}\n",
+        "\nasync () => (await bar(), 0)\n",
+        "\nasync () => (await baz(), await bar(), 0)\n",
+        "\nasync () => (0, 1, (await bar(), 2))\n",
+        "\nasync () => (await bar() ? 0 : 1)\n",
+        "\nasync () => (baz() ? (await bar(), 0) : 1)\n",
+        "\nasync () => (baz() ? 0 : (await bar(), 1))\n",
         `
           async function foo() {
             try {
@@ -81,7 +93,25 @@ ruleTester.run("no-return-await", rule, {
               baz();
             }
           }
+        `,
         `
+          async function foo() {
+            try {
+              return (0, await bar());
+            } catch (e) {
+              baz();
+            }
+          }
+        `,
+        `
+          async function foo() {
+            try {
+              return (qux() ? await bar() : 1);
+            } catch (e) {
+              baz();
+            }
+          }
+        `,
     ],
 
     invalid: [
@@ -90,11 +120,55 @@ ruleTester.run("no-return-await", rule, {
             errors,
         },
         {
+            code: "\nasync function foo() {\n\treturn (0, await bar());\n}\n",
+            errors,
+        },
+        {
+            code: "\nasync function foo() {\n\treturn (0, 1, await bar());\n}\n",
+            errors,
+        },
+        {
+            code: "\nasync function foo() {\n\treturn (0, 1, (2, 3, await bar()));\n}\n",
+            errors,
+        },
+        {
+            code: "\nasync function foo() {\n\treturn (await baz(), 1, await bar());\n}\n",
+            errors,
+        },
+        {
+            code: "\nasync function foo() {\n\treturn (baz() ? await bar() : 1);\n}\n",
+            errors,
+        },
+        {
+            code: "\nasync function foo() {\n\treturn (baz() ? 0 : await bar());\n}\n",
+            errors,
+        },
+        {
+            code: "\nasync function foo() {\n\treturn (baz() ? (0, await bar()) : 1);\n}\n",
+            errors,
+        },
+        {
+            code: "\nasync function foo() {\n\treturn (baz() ? 0 : (1, await bar()));\n}\n",
+            errors,
+        },
+        {
             code: "\nasync () => { return await bar(); }\n",
             errors,
         },
         {
             code: "\nasync () => await bar()\n",
+            errors,
+        },
+        {
+            code: "\nasync () => (0, 1, await bar())\n",
+            errors,
+        },
+        {
+            code: "\nasync () => (baz() ? await bar() : 1)\n",
+            errors,
+        },
+        {
+            code: "\nasync () => (baz() ? 0 : (1, await bar()))\n",
             errors,
         },
         {

--- a/tests/lib/rules/no-return-await.js
+++ b/tests/lib/rules/no-return-await.js
@@ -30,18 +30,30 @@ ruleTester.run("no-return-await", rule, {
         "\nasync () => bar()\n",
         "\nasync function foo() {\nif (a) {\n\t\tif (b) {\n\t\t\treturn bar();\n\t\t}\n\t}\n}\n",
         "\nasync () => {\nif (a) {\n\t\tif (b) {\n\t\t\treturn bar();\n\t\t}\n\t}\n}\n",
-        "\nasync function foo() {\n\treturn (await bar(), 0);\n}\n",
-        "\nasync function foo() {\n\treturn (await baz(), await bar(), 0);\n}\n",
-        "\nasync function foo() {\n\treturn (0, 1, (await bar(), 2));\n}\n",
-        "\nasync function foo() {\n\treturn (await bar() ? 0 : 1);\n}\n",
-        "\nasync function foo() {\n\treturn (baz() ? (await bar(), 0) : 1);\n}\n",
-        "\nasync function foo() {\n\treturn (baz() ? 0 : (await bar(), 1));\n}\n",
-        "\nasync () => (await bar(), 0)\n",
-        "\nasync () => (await baz(), await bar(), 0)\n",
-        "\nasync () => (0, 1, (await bar(), 2))\n",
-        "\nasync () => (await bar() ? 0 : 1)\n",
-        "\nasync () => (baz() ? (await bar(), 0) : 1)\n",
-        "\nasync () => (baz() ? 0 : (await bar(), 1))\n",
+        "\nasync function foo() {\n\treturn (await bar() && a);\n}\n",
+        "\nasync function foo() {\n\treturn (await bar() || a);\n}\n",
+        "\nasync function foo() {\n\treturn (a && await baz() && b);\n}\n",
+        "\nasync function foo() {\n\treturn (await bar(), a);\n}\n",
+        "\nasync function foo() {\n\treturn (await baz(), await bar(), a);\n}\n",
+        "\nasync function foo() {\n\treturn (a, b, (await bar(), c));\n}\n",
+        "\nasync function foo() {\n\treturn (await bar() ? a : b);\n}\n",
+        "\nasync function foo() {\n\treturn ((a && await bar()) ? b : c);\n}\n",
+        "\nasync function foo() {\n\treturn (baz() ? (await bar(), a) : b);\n}\n",
+        "\nasync function foo() {\n\treturn (baz() ? (await bar() && a) : b);\n}\n",
+        "\nasync function foo() {\n\treturn (baz() ? a : (await bar(), b));\n}\n",
+        "\nasync function foo() {\n\treturn (baz() ? a : (await bar() && b));\n}\n",
+        "\nasync () => (await bar(), a)\n",
+        "\nasync () => (await bar() && a)\n",
+        "\nasync () => (await bar() || a)\n",
+        "\nasync () => (a && await bar() && b)\n",
+        "\nasync () => (await baz(), await bar(), a)\n",
+        "\nasync () => (a, b, (await bar(), c))\n",
+        "\nasync () => (await bar() ? a : b)\n",
+        "\nasync () => ((a && await bar()) ? b : c)\n",
+        "\nasync () => (baz() ? (await bar(), a) : b)\n",
+        "\nasync () => (baz() ? (await bar() && a) : b)\n",
+        "\nasync () => (baz() ? a : (await bar(), b))\n",
+        "\nasync () => (baz() ? a : (await bar() && b))\n",
         `
           async function foo() {
             try {
@@ -97,7 +109,7 @@ ruleTester.run("no-return-await", rule, {
         `
           async function foo() {
             try {
-              return (0, await bar());
+              return (a, await bar());
             } catch (e) {
               baz();
             }
@@ -106,7 +118,16 @@ ruleTester.run("no-return-await", rule, {
         `
           async function foo() {
             try {
-              return (qux() ? await bar() : 1);
+              return (qux() ? await bar() : b);
+            } catch (e) {
+              baz();
+            }
+          }
+        `,
+        `
+          async function foo() {
+            try {
+              return (a && await bar());
             } catch (e) {
               baz();
             }
@@ -120,35 +141,59 @@ ruleTester.run("no-return-await", rule, {
             errors,
         },
         {
-            code: "\nasync function foo() {\n\treturn (0, await bar());\n}\n",
+            code: "\nasync function foo() {\n\treturn (a, await bar());\n}\n",
             errors,
         },
         {
-            code: "\nasync function foo() {\n\treturn (0, 1, await bar());\n}\n",
+            code: "\nasync function foo() {\n\treturn (a, b, await bar());\n}\n",
             errors,
         },
         {
-            code: "\nasync function foo() {\n\treturn (0, 1, (2, 3, await bar()));\n}\n",
+            code: "\nasync function foo() {\n\treturn (a && await bar());\n}\n",
             errors,
         },
         {
-            code: "\nasync function foo() {\n\treturn (await baz(), 1, await bar());\n}\n",
+            code: "\nasync function foo() {\n\treturn (a && b && await bar());\n}\n",
             errors,
         },
         {
-            code: "\nasync function foo() {\n\treturn (baz() ? await bar() : 1);\n}\n",
+            code: "\nasync function foo() {\n\treturn (a || await bar());\n}\n",
             errors,
         },
         {
-            code: "\nasync function foo() {\n\treturn (baz() ? 0 : await bar());\n}\n",
+            code: "\nasync function foo() {\n\treturn (a, b, (c, d, await bar()));\n}\n",
             errors,
         },
         {
-            code: "\nasync function foo() {\n\treturn (baz() ? (0, await bar()) : 1);\n}\n",
+            code: "\nasync function foo() {\n\treturn (a, b, (c && await bar()));\n}\n",
             errors,
         },
         {
-            code: "\nasync function foo() {\n\treturn (baz() ? 0 : (1, await bar()));\n}\n",
+            code: "\nasync function foo() {\n\treturn (await baz(), b, await bar());\n}\n",
+            errors,
+        },
+        {
+            code: "\nasync function foo() {\n\treturn (baz() ? await bar() : b);\n}\n",
+            errors,
+        },
+        {
+            code: "\nasync function foo() {\n\treturn (baz() ? a : await bar());\n}\n",
+            errors,
+        },
+        {
+            code: "\nasync function foo() {\n\treturn (baz() ? (a, await bar()) : b);\n}\n",
+            errors,
+        },
+        {
+            code: "\nasync function foo() {\n\treturn (baz() ? a : (b, await bar()));\n}\n",
+            errors,
+        },
+        {
+            code: "\nasync function foo() {\n\treturn (baz() ? (a && await bar()) : b);\n}\n",
+            errors,
+        },
+        {
+            code: "\nasync function foo() {\n\treturn (baz() ? a : (b && await bar()));\n}\n",
             errors,
         },
         {
@@ -160,15 +205,23 @@ ruleTester.run("no-return-await", rule, {
             errors,
         },
         {
-            code: "\nasync () => (0, 1, await bar())\n",
+            code: "\nasync () => (a, b, await bar())\n",
             errors,
         },
         {
-            code: "\nasync () => (baz() ? await bar() : 1)\n",
+            code: "\nasync () => (a && await bar())\n",
             errors,
         },
         {
-            code: "\nasync () => (baz() ? 0 : (1, await bar()))\n",
+            code: "\nasync () => (baz() ? await bar() : b)\n",
+            errors,
+        },
+        {
+            code: "\nasync () => (baz() ? a : (b, await bar()))\n",
+            errors,
+        },
+        {
+            code: "\nasync () => (baz() ? a : (b && await bar()))\n",
             errors,
         },
         {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:


**What rule do you want to change?**
`no-return-await`

**Does this change cause the rule to produce more or fewer warnings?**
More

**Please provide some example code that this change will affect:**

```js
async function foo1() {
  return (0, 1, await bar());
}

async function foo2() {
  return (baz() ? await bar() : 1);
}
```

**What does the rule currently do for this code?**
No warnings.

**What will the rule do after it's changed?**
It will search deeper for the resultant expression in `return` argument so more redundant `await` expressions could be reported. That's done by recursively visit comma sequences and ternary conditions.


See #7594 