### PR TITLE
Fix: `indent` crash on parenthesized global return values (fixes #7573)

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -264,10 +264,10 @@ module.exports = {
 
             lastNodeCheckEndOffset = lastNodeCheckEndOffset || 0;
 
-            const desiredIndent = (indentType === "space" ? " " : "\t").repeat(needed - lastNodeCheckEndOffset);
+            const desiredIndent = (indentType === "space" ? " " : "\t").repeat(needed);
 
             const textRange = isLastNodeCheck
-                ? [node.range[1] - gottenSpaces - gottenTabs - 1, node.range[1] - 1 - lastNodeCheckEndOffset]
+                ? [node.range[1] - gottenSpaces - gottenTabs - 1 - lastNodeCheckEndOffset, node.range[1] - 1 - lastNodeCheckEndOffset]
                 : [node.range[0] - gottenSpaces - gottenTabs, node.range[0]];
 
             context.report({

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -1719,6 +1719,13 @@ ruleTester.run("indent", rule, {
             "    foo\n" +
             ");",
             parserOptions: {ecmaFeatures: {globalReturn: true}}
+        },
+        {
+            code:
+            "return (\n" +
+            "    foo\n" +
+            ")",
+            parserOptions: {ecmaFeatures: {globalReturn: true}}
         }
     ],
     invalid: [
@@ -3483,6 +3490,18 @@ ruleTester.run("indent", rule, {
             "return (\n" +
             "    foo\n" +
             ");",
+            parserOptions: {ecmaFeatures: {globalReturn: true}},
+            errors: expectedErrors([3, 0, 4, "ReturnStatement"])
+        },
+        {
+            code:
+            "return (\n" +
+            "    foo\n" +
+            "    )",
+            output:
+            "return (\n" +
+            "    foo\n" +
+            ")",
             parserOptions: {ecmaFeatures: {globalReturn: true}},
             errors: expectedErrors([3, 0, 4, "ReturnStatement"])
         }

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -1710,6 +1710,15 @@ ruleTester.run("indent", rule, {
             "  );\n" +
             "};",
             options: [2]
+        },
+
+        // https://github.com/eslint/eslint/issues/7573
+        {
+            code:
+            "return (\n" +
+            "    foo\n" +
+            ");",
+            parserOptions: {ecmaFeatures: {globalReturn: true}}
         }
     ],
     invalid: [
@@ -3462,6 +3471,20 @@ ruleTester.run("indent", rule, {
             ");",
             options: [2, {CallExpression: {arguments: 3}}],
             errors: expectedErrors([[2, 6, 2, "BinaryExpression"], [3, 6, 14, "UnaryExpression"], [4, 6, 8, "NewExpression"]])
+        },
+
+        // https://github.com/eslint/eslint/issues/7573
+        {
+            code:
+            "return (\n" +
+            "    foo\n" +
+            "    );",
+            output:
+            "return (\n" +
+            "    foo\n" +
+            ");",
+            parserOptions: {ecmaFeatures: {globalReturn: true}},
+            errors: expectedErrors([3, 0, 4, "ReturnStatement"])
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

See https://github.com/eslint/eslint/issues/7573

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This fixes the `indent` autofixer to avoid throwing an error on global return values.

The autofixer is intended to replace all the indentation before a line with the desired amount of indentation:

```diff
return (
    foo
-    );
+);
```

Due to a bug, when a closing paren was followed by a semicolon, the start index of the fix range was 1 too large, and the length of the replacement text was 1 too small. Normally, these offsets would cancel each other out, resulting in the correct behavior. However, if the correct fix would result in an indentation of 0, this offset caused the replacement text length to be negative, resulting in an error.

This commit updates the fixing logic to avoid the off-by-one error.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.
