### PR TITLE
Docs: Fix example for curly "multi-or-nest" option

### DIFF
--- a/docs/rules/curly.md
+++ b/docs/rules/curly.md
@@ -184,10 +184,9 @@ for (var i = 0; foo; i++) {
     doSomething();
 }
 
-if (foo) {
+if (foo)
     // some comment
     bar();
-}
 ```
 
 Examples of **correct** code for the `"multi-or-nest"` option:
@@ -217,6 +216,11 @@ while (true)
 
 for (var i = 0; foo; i++)
     doSomething();
+
+if (foo) {
+    // some comment
+    bar();
+}
 ```
 
 ### consistent


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Accidentally wrote the wrong example in my previous PR in https://github.com/eslint/eslint/pull/7539. Fixed it so it now correctly shows a good and bad example for having a comment inside an `if` block for the curly "multi-or-nest" option.

**Is there anything you'd like reviewers to focus on?**



