### PR TITLE
Fix: correctly handle commented code in `indent` autofixer (fixes #7604)

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -255,20 +255,18 @@ module.exports = {
          * @param {int} lastNodeCheckEndOffset Number of charecters to skip from the end
          * @returns {void}
          */
-        function report(node, needed, gottenSpaces, gottenTabs, loc, isLastNodeCheck, lastNodeCheckEndOffset) {
+        function report(node, needed, gottenSpaces, gottenTabs, loc, isLastNodeCheck) {
             if (gottenSpaces && gottenTabs) {
 
                 // To avoid conflicts with `no-mixed-spaces-and-tabs`, don't report lines that have both spaces and tabs.
                 return;
             }
 
-            lastNodeCheckEndOffset = lastNodeCheckEndOffset || 0;
-
             const desiredIndent = (indentType === "space" ? " " : "\t").repeat(needed);
 
             const textRange = isLastNodeCheck
-                ? [node.range[1] - gottenSpaces - gottenTabs - 1 - lastNodeCheckEndOffset, node.range[1] - 1 - lastNodeCheckEndOffset]
-                : [node.range[0] - gottenSpaces - gottenTabs, node.range[0]];
+                ? [node.range[1] - node.loc.end.column, node.range[1] - node.loc.end.column + gottenSpaces + gottenTabs]
+                : [node.range[0] - node.loc.start.column, node.range[0] - node.loc.start.column + gottenSpaces + gottenTabs];
 
             context.report({
                 node,
@@ -406,13 +404,11 @@ module.exports = {
          */
         function checkLastReturnStatementLineIndent(node, firstLineIndent) {
             const nodeLastToken = sourceCode.getLastToken(node);
-            let lastNodeCheckEndOffset = 0;
             let lastToken = nodeLastToken;
 
             // in case if return statement ends with ');' we have traverse back to ')'
             // otherwise we'll measure indent for ';' and replace ')'
             while (lastToken.value !== ")") {
-                lastNodeCheckEndOffset++;
                 lastToken = sourceCode.getTokenBefore(lastToken);
             }
 
@@ -433,8 +429,7 @@ module.exports = {
                     endIndent.space,
                     endIndent.tab,
                     { line: lastToken.loc.start.line, column: lastToken.loc.start.column },
-                    true,
-                    lastNodeCheckEndOffset
+                    true
                 );
             }
         }

--- a/tests/fixtures/rules/indent/indent-valid-fixture-1.js
+++ b/tests/fixtures/rules/indent/indent-valid-fixture-1.js
@@ -43,7 +43,7 @@ if (a) {
 /**/var b; // NO ERROR: single line multi-line comments followed by code is OK
 /*
  *
- */var b; // ERROR: multi-line comments followed by code is not OK
+*/ var b; // ERROR: multi-line comments followed by code is not OK
 
 var arr = [
   a,

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -3504,6 +3504,32 @@ ruleTester.run("indent", rule, {
             ")",
             parserOptions: {ecmaFeatures: {globalReturn: true}},
             errors: expectedErrors([3, 0, 4, "ReturnStatement"])
+        },
+
+        // https://github.com/eslint/eslint/issues/7604
+        {
+            code:
+            "if (foo) {\n" +
+            "        /* comment */bar();\n" +
+            "}",
+            output:
+            "if (foo) {\n" +
+            "    /* comment */bar();\n" +
+            "}",
+            errors: expectedErrors([2, 4, 8, "ExpressionStatement"])
+        },
+        {
+            code:
+            "foo('bar',\n" +
+            "        /** comment */{\n" +
+            "        ok: true" +
+            "    });",
+            output:
+            "foo('bar',\n" +
+            "    /** comment */{\n" +
+            "        ok: true" +
+            "    });",
+            errors: expectedErrors([2, 4, 8, "ObjectExpression"])
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

See https://github.com/eslint/eslint/issues/7604

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Note: This builds off of https://github.com/eslint/eslint/pull/7596, please merge that first.

Previously, the `indent` autofixer didn't account for comments preceding a node on the same line. As a result, it was counting back by a constant amount from a node, so it would sometimes accidentally splice comments. This updates the fixer to count forward from the start of the line, rather than backward from the node.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.
