### PR TITLE
Fix: syntax error after `key-spacing` autofix with comment (fixes #7603)

### DIFF
--- a/lib/rules/key-spacing.js
+++ b/lib/rules/key-spacing.js
@@ -417,8 +417,8 @@ module.exports = {
         function report(property, side, whitespace, expected, mode) {
             const diff = whitespace.length - expected,
                 nextColon = getNextColon(property.key),
-                tokenBeforeColon = sourceCode.getTokenBefore(nextColon),
-                tokenAfterColon = sourceCode.getTokenAfter(nextColon),
+                tokenBeforeColon = sourceCode.getTokenOrCommentBefore(nextColon),
+                tokenAfterColon = sourceCode.getTokenOrCommentAfter(nextColon),
                 isKeySide = side === "key",
                 locStart = isKeySide ? tokenBeforeColon.loc.start : tokenAfterColon.loc.start,
                 isExtra = diff > 0,

--- a/tests/lib/rules/key-spacing.js
+++ b/tests/lib/rules/key-spacing.js
@@ -1739,5 +1739,14 @@ ruleTester.run("key-spacing", rule, {
         output: "({ foo:/* comment */bar })",
         options: [{ afterColon: false }],
         errors: [{ message: "Extra space before value for key 'foo'.", line: 1, column: 9, type: "Identifier" }]
+    },
+    {
+        code: "({ foo/*comment*/:/*comment*/bar })",
+        output: "({ foo/*comment*/ : /*comment*/bar })",
+        options: [{ beforeColon: true, afterColon: true }],
+        errors: [
+            { message: "Missing space after key 'foo'.", line: 1, column: 7, type: "Identifier" },
+            { message: "Missing space before value for key 'foo'.", line: 1, column: 19, type: "Identifier"}
+        ]
     }]
 });

--- a/tests/lib/rules/key-spacing.js
+++ b/tests/lib/rules/key-spacing.js
@@ -1728,5 +1728,16 @@ ruleTester.run("key-spacing", rule, {
             { message: "Extra space before value for key 'key2'.", line: 4, column: 14, type: "Literal" },
             { message: "Extra space before value for key 'key3'.", line: 5, column: 14, type: "Literal" }
         ]
+    }, {
+
+        // https://github.com/eslint/eslint/issues/7603
+        code: "({ foo/* comment */ : bar })",
+        output: "({ foo/* comment */: bar })",
+        errors: [{ message: "Extra space after key 'foo'.", line: 1, column: 7, type: "Identifier" }]
+    }, {
+        code: "({ foo: /* comment */bar })",
+        output: "({ foo:/* comment */bar })",
+        options: [{ afterColon: false }],
+        errors: [{ message: "Extra space before value for key 'foo'.", line: 1, column: 9, type: "Identifier" }]
     }]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

https://github.com/eslint/eslint/issues/7603

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates the `key-spacing` autofixer to be aware of comments. Previously, it would remove whitespace from the *token* before/after the colon, but if there was a comment between the token and the colon, it would remove text from the edge of the comment instead, causing a syntax error.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.