### PR TITLE
Docs: add missing quote mark (+=" → "+=")

### DIFF
--- a/docs/rules/operator-linebreak.md
+++ b/docs/rules/operator-linebreak.md
@@ -173,10 +173,10 @@ answer = everything ? 42 : foo;
 
 ### overrides
 
-Examples of additional **correct** code for this rule with the `{ "overrides": { +=": "before" } }` option:
+Examples of additional **correct** code for this rule with the `{ "overrides": { "+=": "before" } }` option:
 
 ```js
-/*eslint operator-linebreak: ["error", "after", { "overrides": { +=": "before" } }]*/
+/*eslint operator-linebreak: ["error", "after", { "overrides": { "+=": "before" } }]*/
 
 var thing
   += 'thing';


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
In the documentation examples for the `operator-linebreak` rule, fixed a property key with a missing quote mark.  `+="` → `"+="`


**Is there anything you'd like reviewers to focus on?**
No.


