### PR TITLE
Fix: Prevent `quotes` from fixing templates to directives (fixes #7610)

### DIFF
--- a/lib/rules/quotes.js
+++ b/lib/rules/quotes.js
@@ -268,6 +268,15 @@ module.exports = {
                             description: settings.description,
                         },
                         fix(fixer) {
+                            if (isPartOfDirectivePrologue(node)) {
+
+                                /*
+                                 * TemplateLiterals in a directive prologue aren't actually directives, but if they're
+                                 * in the directive prologue, then fixing them might turn them into directives and change
+                                 * the behavior of the code.
+                                 */
+                                return null;
+                            }
                             return fixer.replaceText(node, settings.convert(sourceCode.getText(node)));
                         }
                     });

--- a/tests/lib/rules/quotes.js
+++ b/tests/lib/rules/quotes.js
@@ -235,5 +235,43 @@ ruleTester.run("quotes", rule, {
                 { message: "Strings must use backtick.", type: "Literal" },
             ],
         },
+
+        // https://github.com/eslint/eslint/issues/7610
+        {
+            code: "`use strict`;",
+            output: "`use strict`;",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Strings must use doublequote.", type: "TemplateLiteral" }]
+        },
+        {
+            code: "function foo() { `use strict`; foo(); }",
+            output: "function foo() { `use strict`; foo(); }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Strings must use doublequote.", type: "TemplateLiteral" }]
+        },
+        {
+            code: "foo = function() { `use strict`; foo(); }",
+            output: "foo = function() { `use strict`; foo(); }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Strings must use doublequote.", type: "TemplateLiteral" }]
+        },
+        {
+            code: "() => { `use strict`; foo(); }",
+            output: "() => { `use strict`; foo(); }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Strings must use doublequote.", type: "TemplateLiteral" }]
+        },
+        {
+            code: "() => { foo(); `use strict`; }",
+            output: "() => { foo(); \"use strict\"; }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Strings must use doublequote.", type: "TemplateLiteral" }]
+        },
+        {
+            code: "foo(); `use strict`;",
+            output: "foo(); \"use strict\";",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Strings must use doublequote.", type: "TemplateLiteral" }]
+        }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix

See https://github.com/eslint/eslint/issues/7610

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates `quotes` to avoid fixing template literals that are in directive position, so that the fixer doesn't accidentally enable strict mode.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.