### PR TITLE
Update: rewrite `indent` (fixes #1801, #3737, #3845, #6007, ...16 more)

### DIFF
--- a/docs/rules/indent.md
+++ b/docs/rules/indent.md
@@ -71,17 +71,18 @@ This rule has an object option:
 * `"SwitchCase"` (default: 0) enforces indentation level for `case` clauses in `switch` statements
 * `"VariableDeclarator"` (default: 1) enforces indentation level for `var` declarators; can also take an object to define separate rules for `var`, `let` and `const` declarations.
 * `"outerIIFEBody"` (default: 1) enforces indentation level for file-level IIFEs.
-* `"MemberExpression"` (off by default) enforces indentation level for multi-line property chains (except in variable declarations and assignments)
+* `"MemberExpression"` (default: 1) enforces indentation level for multi-line property chains (except in variable declarations and assignments). This can also be set to `"off"` to disable checking for MemberExpression indentation.
 * `"FunctionDeclaration"` takes an object to define rules for function declarations.
-    * `parameters` (off by default) enforces indentation level for parameters in a function declaration. This can either be a number indicating indentation level, or the string `"first"` indicating that all parameters of the declaration must be aligned with the first parameter.
+    * `parameters` (default: 1) enforces indentation level for parameters in a function declaration. This can either be a number indicating indentation level, or the string `"first"` indicating that all parameters of the declaration must be aligned with the first parameter. This can also be set to `"off"` to disable checking for FunctionDeclaration parameters.
     * `body` (default: 1) enforces indentation level for the body of a function declaration.
 * `"FunctionExpression"` takes an object to define rules for function expressions.
-    * `parameters` (off by default) enforces indentation level for parameters in a function expression. This can either be a number indicating indentation level, or the string `"first"` indicating that all parameters of the expression must be aligned with the first parameter.
+    * `parameters` (default: 1) enforces indentation level for parameters in a function expression. This can either be a number indicating indentation level, or the string `"first"` indicating that all parameters of the expression must be aligned with the first parameter. This can also be set to `"off"` to disable checking for FunctionExpression parameters.
     * `body` (default: 1) enforces indentation level for the body of a function expression.
 * `"CallExpression"` takes an object to define rules for function call expressions.
-    * `arguments` (off by default) enforces indentation level for arguments in a call expression. This can either be a number indicating indentation level, or the string `"first"` indicating that all arguments of the expression must be aligned with the first argument.
-* `"ArrayExpression"` (default: 1) enforces indentation level for elements in arrays. It can also be set to the string `"first"`, indicating that all the elements in the array should be aligned with the first element.
-* `"ObjectExpression"` (default: 1) enforces indentation level for properties in objects. It can be set to the string `"first"`, indicating that all properties in the object should be aligned with the first property.
+    * `arguments` (default: 1) enforces indentation level for arguments in a call expression. This can either be a number indicating indentation level, or the string `"first"` indicating that all arguments of the expression must be aligned with the first argument. This can also be set to `"off"` to disable checking for CallExpression arguments.
+* `"ArrayExpression"` (default: 1) enforces indentation level for elements in arrays. It can also be set to the string `"first"`, indicating that all the elements in the array should be aligned with the first element. This can also be set to `"off"` to disable checking for array elements.
+* `"ObjectExpression"` (default: 1) enforces indentation level for properties in objects. It can be set to the string `"first"`, indicating that all properties in the object should be aligned with the first property. This can also be set to `"off"` to disable checking for object properties.
+* `"flatTernaryExpressions": true` (`false` by default) requires no indentation for ternary expressions which are nested in other ternary expressions.
 
 Level of indentation denotes the multiple of the indent specified. Example:
 
@@ -520,6 +521,56 @@ Examples of **correct** code for this rule with the `2, { "ObjectExpression": "f
 
 var foo = { bar: 1,
             baz: 2 };
+```
+
+### flatTernaryExpressions
+
+Examples of **incorrect** code for this rule with the default `4, { "flatTernaryExpressions": false }` option:
+
+```js
+/*eslint indent: ["error", 4, { "flatTernaryExpressions": false }]*/
+
+foo
+    ? bar
+    : baz
+    ? qux
+    : boop;
+```
+
+Examples of **correct** code for this rule with the default `4, { "flatTernaryExpressions": false }` option:
+
+```js
+/*eslint indent: ["error", 4, { "flatTernaryExpressions": false }]*/
+
+foo
+    ? bar
+    : baz
+        ? qux
+        : boop;
+```
+
+Examples of **incorrect** code for this rule with the `4, { "flatTernaryExpressions": true }` option:
+
+```js
+/*eslint indent: ["error", 4, { "flatTernaryExpressions": true }]*/
+
+foo
+    ? bar
+    : baz
+        ? qux
+        : boop;
+```
+
+Examples of **correct** code for this rule with the `4, { "flatTernaryExpressions": true }` option:
+
+```js
+/*eslint indent: ["error", 4, { "flatTernaryExpressions": true }]*/
+
+foo
+    ? bar
+    : baz
+    ? qux
+    : boop;
 ```
 
 

--- a/lib/config/autoconfig.js
+++ b/lib/config/autoconfig.js
@@ -37,11 +37,11 @@ const MAX_CONFIG_COMBINATIONS = 17, // 16 combinations + 1 for severity only
  * @param   {number}     errorCount    The number of errors encountered when linting with the config
  */
 
- /**
-  * This callback is used to measure execution status in a progress bar
-  * @callback progressCallback
-  * @param {number} The total number of times the callback will be called.
-  */
+/**
+ * This callback is used to measure execution status in a progress bar
+ * @callback progressCallback
+ * @param {number} The total number of times the callback will be called.
+ */
 
 /**
  * Create registryItems for rules

--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -368,18 +368,18 @@ function getLookupPath(configFilePath) {
 function getEslintCoreConfigPath(name) {
     if (name === "eslint:recommended") {
 
-       /*
-        * Add an explicit substitution for eslint:recommended to
-        * conf/eslint-recommended.js.
-        */
+        /*
+         * Add an explicit substitution for eslint:recommended to
+         * conf/eslint-recommended.js.
+         */
         return path.resolve(__dirname, "../../conf/eslint-recommended.js");
     }
 
     if (name === "eslint:all") {
 
-       /*
-        * Add an explicit substitution for eslint:all to conf/eslint-all.js
-        */
+        /*
+         * Add an explicit substitution for eslint:all to conf/eslint-all.js
+         */
         return path.resolve(__dirname, "../../conf/eslint-all.js");
     }
 

--- a/lib/config/config-rule.js
+++ b/lib/config/config-rule.js
@@ -168,16 +168,16 @@ function combinePropertyObjects(objArr1, objArr2) {
     return res;
 }
 
- /**
-  * Creates a new instance of a rule configuration set
-  *
-  * A rule configuration set is an array of configurations that are valid for a
-  * given rule.  For example, the configuration set for the "semi" rule could be:
-  *
-  * ruleConfigSet.ruleConfigs // -> [[2], [2, "always"], [2, "never"]]
-  *
-  * Rule configuration set class
-  */
+/**
+ * Creates a new instance of a rule configuration set
+ *
+ * A rule configuration set is an array of configurations that are valid for a
+ * given rule.  For example, the configuration set for the "semi" rule could be:
+ *
+ * ruleConfigSet.ruleConfigs // -> [[2], [2, "always"], [2, "never"]]
+ *
+ * Rule configuration set class
+ */
 class RuleConfigSet {
 
     /**

--- a/lib/rules/comma-spacing.js
+++ b/lib/rules/comma-spacing.js
@@ -87,8 +87,8 @@ module.exports = {
 
                 },
                 message: options[dir]
-                  ? "A space is required {{dir}} ','."
-                  : "There should be no space {{dir}} ','.",
+                    ? "A space is required {{dir}} ','."
+                    : "There should be no space {{dir}} ','.",
                 data: {
                     dir
                 }

--- a/lib/rules/comma-style.js
+++ b/lib/rules/comma-style.js
@@ -202,7 +202,7 @@ module.exports = {
                      */
                     if (astUtils.isCommaToken(commaToken)) {
                         validateCommaItemSpacing(previousItemToken, commaToken,
-                                currentItemToken, reportItem);
+                            currentItemToken, reportItem);
                     }
 
                     if (item) {

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -672,7 +672,21 @@ module.exports = {
          */
         function addBlocklessNodeIndent(node, parent) {
             if (node.type !== "BlockStatement") {
-                offsets.setDesiredOffsets(getTokensAndComments(node), sourceCode.getFirstToken(parent), 1);
+                const firstParentToken = sourceCode.getFirstToken(parent);
+
+                offsets.setDesiredOffsets(getTokensAndComments(node), firstParentToken, 1);
+
+                /*
+                 * For blockless nodes with semicolon-first style, don't indent the semicolon.
+                 * e.g.
+                 * if (foo) bar()
+                 * ; [1, 2, 3].map(foo)
+                 */
+                const lastToken = sourceCode.getLastToken(node);
+
+                if (astUtils.isSemicolonToken(lastToken)) {
+                    offsets.matchIndentOf(firstParentToken, lastToken);
+                }
             }
         }
 

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -563,7 +563,6 @@ module.exports = {
         function addBlockIndent(node) {
 
             let blockIndentLevel;
-            const tokens = getTokensAndComments(node);
 
             if (node.parent && isOuterIIFE(node.parent)) {
                 blockIndentLevel = options.outerIIFEBody;
@@ -591,11 +590,10 @@ module.exports = {
              *     baz(); // Tokens in the block should get matched against the `if` statement, even though the opening curly is indented.
              * }
              */
+            const tokens = getTokensAndComments(node);
             const tokenToMatchAgainst = tokenInfo.isFirstTokenOfLine(tokens[0]) ? tokens[0] : sourceCode.getFirstToken(node.parent);
 
-            if (tokenToMatchAgainst !== tokens[0]) {
-                offsets.matchIndentOf(tokenToMatchAgainst, tokens[0]);
-            }
+            offsets.matchIndentOf(tokenToMatchAgainst, tokens[0]);
             offsets.setDesiredOffsets(tokens, tokens[0], blockIndentLevel);
             offsets.matchIndentOf(tokenToMatchAgainst, tokens[tokens.length - 1]);
         }

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -722,22 +722,6 @@ module.exports = {
         }
 
         /**
-        * Checks the indentation of `IfStatement` nodes.
-        * @param {ASTNode} node An `IfStatement` node
-        * @returns {void}
-        */
-        function addIfStatementIndent(node) {
-            addBlocklessNodeIndent(node.consequent, node);
-            if (node.alternate) {
-                if (node.alternate.type === "IfStatement") {
-                    addIfStatementIndent(node.alternate, node);
-                } else {
-                    addBlocklessNodeIndent(node.alternate, node);
-                }
-            }
-        }
-
-        /**
         * Checks the indentation for nodes that are like function calls (`CallExpression` and `NewExpression`)
         * @param {ASTNode} node A CallExpression or NewExpression node
         * @returns {void}
@@ -878,7 +862,12 @@ module.exports = {
                 addFunctionParamsIndent(node, options.FunctionExpression.parameters);
             },
 
-            IfStatement: addIfStatementIndent,
+            IfStatement(node) {
+                addBlocklessNodeIndent(node.consequent, node);
+                if (node.alternate && node.alternate.type !== "IfStatement") {
+                    addBlocklessNodeIndent(node.alternate, node);
+                }
+            },
 
             ImportDeclaration(node) {
                 if (node.specifiers.some(specifier => specifier.type === "ImportSpecifier")) {

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -8,11 +8,230 @@
 
 "use strict";
 
-//------------------------------------------------------------------------------
-// Requirements
-//------------------------------------------------------------------------------
-
+const lodash = require("lodash");
 const astUtils = require("../ast-utils");
+
+/**
+ * A helper class to get token-based info related to indentation
+ */
+class TokenInfo {
+
+    /**
+     * @param {SourceCode} sourceCode A SourceCode object
+     */
+    constructor(sourceCode) {
+        this.sourceCode = sourceCode;
+        this.firstTokensByLineNumber = sourceCode.tokensAndComments.reduce((map, token) => {
+            if (!map.has(token.loc.start.line)) {
+                map.set(token.loc.start.line, token);
+            }
+            if (!map.has(token.loc.end.line)) {
+                map.set(token.loc.end.line, token);
+            }
+            return map;
+        }, new Map());
+    }
+
+    /**
+     * Gets all tokens and comments
+     * @returns {Token[]} A list of all tokens and comments
+     */
+    getAllTokens() {
+        return this.sourceCode.tokensAndComments;
+    }
+
+    /**
+    * Gets the first token on a given token's line
+    * @param {Token|ASTNode} token a node or token
+    * @returns {Token} The first token on the given line
+    */
+    getFirstTokenOfLine(token) {
+        return this.firstTokensByLineNumber.get(token.loc.start.line);
+    }
+
+    /**
+    * Determines whether a token is the first token in its line
+    * @param {Token} token The token
+    * @returns {boolean} `true` if the token is the first on its line
+    */
+    isFirstTokenOfLine(token) {
+        return this.getFirstTokenOfLine(token) === token;
+    }
+
+    /**
+     * Get the actual indent of a token
+     * @param {Token} token Token to examine. This should be the first token on its line.
+     * @returns {string} The indentation characters that precede the token
+     */
+    getTokenIndent(token) {
+        return this.sourceCode.text.slice(token.range[0] - token.loc.start.column, token.range[0]);
+    }
+}
+
+/**
+ * A class to store information on desired offsets of tokens from each other
+ */
+class OffsetStorage {
+
+    /**
+     * @param {TokenInfo} tokenInfo a TokenInfo instance
+     * @param {string} indentType The desired type of indentation (either "space" or "tab")
+     * @param {number} indentSize The desired size of each indentation level
+     */
+    constructor(tokenInfo, indentType, indentSize) {
+        this.tokenInfo = tokenInfo;
+        this.indentType = indentType;
+        this.indentSize = indentSize;
+        this.desiredOffsets = tokenInfo.getAllTokens().reduce((map, token) => map.set(token, { offset: 0, from: null }), new WeakMap());
+        this.lockedFirstTokens = new WeakMap();
+        this.desiredIndentCache = new WeakMap();
+        this.ignoredTokens = new WeakSet();
+    }
+
+    /**
+    * Sets the indent of one token to match the indent of another.
+    * @param {Token} baseToken The first token
+    * @param {Token} offsetToken The second token, whose indent should be matched to the first token
+    * @returns {void}
+    */
+    matchIndentOf(baseToken, offsetToken) {
+        if (baseToken !== offsetToken) {
+            this.desiredOffsets.set(offsetToken, { offset: 0, from: baseToken });
+        }
+    }
+
+    /**
+     * Sets the offset column of token B to match the offset column of token A.
+     * This is different from matchIndentOf because it matches a *column*, even if baseToken is not
+     * the first token on its line.
+     * @param {Token} baseToken The first token
+     * @param {Token} offsetToken The second token, whose offset should be matched to the first token
+     * @returns {void}
+     */
+    matchOffsetOf(baseToken, offsetToken) {
+
+        /*
+         * lockedFirstTokens is a map from a token whose indentation is controlled by the "first" option to
+         * the token that it depends on. For example, with the `ArrayExpression: first` option, the first
+         * token of each element in the array after the first will be mapped to the first token of the first
+         * element. The desired indentation of each of these tokens is computed based on the desired indentation
+         * of the "first" element, rather than through the normal offset mechanism.
+         */
+        this.lockedFirstTokens.set(offsetToken, baseToken);
+    }
+
+    /**
+    * Sets the desired offset of a token
+    * @param {Token} token The token
+    * @param {Token} offsetFrom The token that this is offset from
+    * @param {number} offset The desired indent level
+    * @returns {void}
+    */
+    setDesiredOffset(token, offsetFrom, offset) {
+        if (offsetFrom && token.loc.start.line === offsetFrom.loc.start.line) {
+            this.matchIndentOf(offsetFrom, token);
+        } else {
+            this.desiredOffsets.set(token, { offset, from: offsetFrom });
+        }
+    }
+
+    /**
+    * Sets the desired offset of multiple tokens
+    * @param {Token[]} tokens A list of tokens. These tokens should be consecutive.
+    * @param {Token} offsetFrom The token that this is offset from
+    * @param {number} offset The desired indent level
+    * @returns {void}
+    */
+    setDesiredOffsets(tokens, offsetFrom, offset) {
+
+        /*
+         * TODO: (not-an-aardvark) This function is the main performance holdup for this rule. It works
+         * by setting the desired offset of each token to the given amount relative to the parent, but it's
+         * frequently called with a large list of tokens, and it takes time to set the offset for each token
+         * individually. Since the tokens are always consecutive, it might be possible to improve performance
+         * here by changing the data structure used to store offsets (e.g. allowing a *range* of tokens to
+         * be offset rather than offsetting each token individually).
+         */
+        tokens.forEach(token => this.setDesiredOffset(token, offsetFrom, offset));
+    }
+
+    /**
+    * Gets the desired indent of a token
+    * @param {Token} token The token
+    * @returns {number} The desired indent of the token
+    */
+    getDesiredIndent(token) {
+        if (!this.desiredIndentCache.has(token)) {
+
+            if (this.ignoredTokens.has(token)) {
+
+                // If the token is ignored, use the actual indent of the token as the desired indent.
+                // This ensures that no errors are reported for this token.
+                this.desiredIndentCache.set(token, this.tokenInfo.getTokenIndent(token).length / this.indentSize);
+            } else if (this.lockedFirstTokens.has(token)) {
+                const firstToken = this.lockedFirstTokens.get(token);
+
+                this.desiredIndentCache.set(token,
+
+                    // (indentation for the first element's line)
+                    this.getDesiredIndent(this.tokenInfo.getFirstTokenOfLine(firstToken)) +
+
+                        // (space between the start of the first element's line and the first element)
+                        (firstToken.loc.start.column - this.tokenInfo.getFirstTokenOfLine(firstToken).loc.start.column) / this.indentSize
+                );
+            } else {
+                const offsetInfo = this.desiredOffsets.get(token);
+
+                this.desiredIndentCache.set(token, offsetInfo.offset + (offsetInfo.from ? this.getDesiredIndent(offsetInfo.from) : 0));
+            }
+        }
+        return this.desiredIndentCache.get(token);
+    }
+
+    /**
+    * Ignores a token, preventing it from being reported.
+    * @param {Token} token The token
+    * @returns {void}
+    */
+    ignoreToken(token) {
+        if (this.tokenInfo.isFirstTokenOfLine(token)) {
+            this.ignoredTokens.add(token);
+        }
+    }
+
+    /**
+     * Gets the first token that the given token's indentation is dependent on
+     * @param {Token} token The token
+     * @returns {Token} The token that the given token depends on, or `null` if the given token is at the top level
+     */
+    getFirstDependency(token) {
+        return this.desiredOffsets.get(token).from;
+    }
+
+    /**
+     * Increases the offset for a token from its parent by the given amount
+     * @param {Token} token The token whose offset should be increased
+     * @param {number} amount The number of indent levels that the offset should increase by
+     * @returns {void}
+     */
+    increaseOffset(token, amount) {
+        const currentOffsetInfo = this.desiredOffsets.get(token);
+
+        this.desiredOffsets.set(token, { offset: currentOffsetInfo.offset + amount, from: currentOffsetInfo.from });
+    }
+}
+
+const ELEMENT_LIST_SCHEMA = {
+    oneOf: [
+        {
+            type: "integer",
+            minimum: 0
+        },
+        {
+            enum: ["first", "off"]
+        }
+    ]
+};
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -68,7 +287,8 @@ module.exports = {
                                         type: "integer",
                                         minimum: 0
                                     }
-                                }
+                                },
+                                additionalProperties: false
                             }
                         ]
                     },
@@ -77,86 +297,49 @@ module.exports = {
                         minimum: 0
                     },
                     MemberExpression: {
-                        type: "integer",
-                        minimum: 0
+                        oneOf: [
+                            {
+                                type: "integer",
+                                minimum: 0
+                            },
+                            {
+                                enum: ["off"]
+                            }
+                        ]
                     },
                     FunctionDeclaration: {
                         type: "object",
                         properties: {
-                            parameters: {
-                                oneOf: [
-                                    {
-                                        type: "integer",
-                                        minimum: 0
-                                    },
-                                    {
-                                        enum: ["first"]
-                                    }
-                                ]
-                            },
+                            parameters: ELEMENT_LIST_SCHEMA,
                             body: {
                                 type: "integer",
                                 minimum: 0
                             }
-                        }
+                        },
+                        additionalProperties: false
                     },
                     FunctionExpression: {
                         type: "object",
                         properties: {
-                            parameters: {
-                                oneOf: [
-                                    {
-                                        type: "integer",
-                                        minimum: 0
-                                    },
-                                    {
-                                        enum: ["first"]
-                                    }
-                                ]
-                            },
+                            parameters: ELEMENT_LIST_SCHEMA,
                             body: {
                                 type: "integer",
                                 minimum: 0
                             }
-                        }
+                        },
+                        additionalProperties: false
                     },
                     CallExpression: {
                         type: "object",
                         properties: {
-                            parameters: {
-                                oneOf: [
-                                    {
-                                        type: "integer",
-                                        minimum: 0
-                                    },
-                                    {
-                                        enum: ["first"]
-                                    }
-                                ]
-                            }
-                        }
+                            arguments: ELEMENT_LIST_SCHEMA
+                        },
+                        additionalProperties: false
                     },
-                    ArrayExpression: {
-                        oneOf: [
-                            {
-                                type: "integer",
-                                minimum: 0
-                            },
-                            {
-                                enum: ["first"]
-                            }
-                        ]
-                    },
-                    ObjectExpression: {
-                        oneOf: [
-                            {
-                                type: "integer",
-                                minimum: 0
-                            },
-                            {
-                                enum: ["first"]
-                            }
-                        ]
+                    ArrayExpression: ELEMENT_LIST_SCHEMA,
+                    ObjectExpression: ELEMENT_LIST_SCHEMA,
+                    flatTernaryExpressions: {
+                        type: "boolean"
                     }
                 },
                 additionalProperties: false
@@ -166,7 +349,7 @@ module.exports = {
 
     create(context) {
         const DEFAULT_VARIABLE_INDENT = 1;
-        const DEFAULT_PARAMETER_INDENT = null; // For backwards compatibility, don't check parameter indentation unless specified in the config
+        const DEFAULT_PARAMETER_INDENT = 1;
         const DEFAULT_FUNCTION_BODY_INDENT = 1;
 
         let indentType = "space";
@@ -178,7 +361,7 @@ module.exports = {
                 let: DEFAULT_VARIABLE_INDENT,
                 const: DEFAULT_VARIABLE_INDENT
             },
-            outerIIFEBody: null,
+            outerIIFEBody: 1,
             FunctionDeclaration: {
                 parameters: DEFAULT_PARAMETER_INDENT,
                 body: DEFAULT_FUNCTION_BODY_INDENT
@@ -190,68 +373,56 @@ module.exports = {
             CallExpression: {
                 arguments: DEFAULT_PARAMETER_INDENT
             },
+            MemberExpression: 1,
             ArrayExpression: 1,
-            ObjectExpression: 1
+            ObjectExpression: 1,
+            ArrayPattern: 1,
+            ObjectPattern: 1,
+            flatTernaryExpressions: false
         };
 
-        const sourceCode = context.getSourceCode();
+        /*
+         * General rule strategy:
+         * 1. Create a tree, where each node of the tree is a token or comment and each edge of the tree is an indentation offset
+         *    between tokens. (This is stored as a hashmap in `desiredOffsets`, which maps each token to an object containing
+         *    offset amount and a parent token. For example, a token in an element in an array will have
+         *    {offset: 1, from: openingBracket} to indicate that the token should be offset by 1 indentation level from the opening
+         *    bracket.) All offsets are initialized to 0 at the start.
+         * 2. As the AST is traversed, modify the offsets of tokens accordingly. For example, when entering a BlockStatement, offset
+         *    all of the tokens in the BlockStatement by 1 from the opening curly brace of the BlockStatement.
+         * 3. After traversing the AST, calculate the expected indentation levels of every token in the file according to the
+         *    `desiredOffsets` map. (Note: The indentation of some tokens with the "first" option is computed a bit differently,
+         *    using the `lockedFirstTokens` map).
+         * 4. For each token, compare the expected indentation to the actual indentation in the file, and report the token if
+         *    the two values are not equal.
+         */
 
         if (context.options.length) {
             if (context.options[0] === "tab") {
                 indentSize = 1;
                 indentType = "tab";
-            } else /* istanbul ignore else : this will be caught by options validation */ if (typeof context.options[0] === "number") {
+            } else if (typeof context.options[0] === "number") {
                 indentSize = context.options[0];
                 indentType = "space";
             }
 
             if (context.options[1]) {
-                const opts = context.options[1];
+                lodash.merge(options, context.options[1]);
 
-                options.SwitchCase = opts.SwitchCase || 0;
-                const variableDeclaratorRules = opts.VariableDeclarator;
-
-                if (typeof variableDeclaratorRules === "number") {
+                if (typeof options.VariableDeclarator === "number") {
                     options.VariableDeclarator = {
-                        var: variableDeclaratorRules,
-                        let: variableDeclaratorRules,
-                        const: variableDeclaratorRules
+                        var: options.VariableDeclarator,
+                        let: options.VariableDeclarator,
+                        const: options.VariableDeclarator
                     };
-                } else if (typeof variableDeclaratorRules === "object") {
-                    Object.assign(options.VariableDeclarator, variableDeclaratorRules);
-                }
-
-                if (typeof opts.outerIIFEBody === "number") {
-                    options.outerIIFEBody = opts.outerIIFEBody;
-                }
-
-                if (typeof opts.MemberExpression === "number") {
-                    options.MemberExpression = opts.MemberExpression;
-                }
-
-                if (typeof opts.FunctionDeclaration === "object") {
-                    Object.assign(options.FunctionDeclaration, opts.FunctionDeclaration);
-                }
-
-                if (typeof opts.FunctionExpression === "object") {
-                    Object.assign(options.FunctionExpression, opts.FunctionExpression);
-                }
-
-                if (typeof opts.CallExpression === "object") {
-                    Object.assign(options.CallExpression, opts.CallExpression);
-                }
-
-                if (typeof opts.ArrayExpression === "number" || typeof opts.ArrayExpression === "string") {
-                    options.ArrayExpression = opts.ArrayExpression;
-                }
-
-                if (typeof opts.ObjectExpression === "number" || typeof opts.ObjectExpression === "string") {
-                    options.ObjectExpression = opts.ObjectExpression;
                 }
             }
         }
 
-        const caseIndentStore = {};
+        const sourceCode = context.getSourceCode();
+        const tokenInfo = new TokenInfo(sourceCode);
+        const offsets = new OffsetStorage(tokenInfo, indentType, indentSize);
+        const parameterParens = new WeakSet();
 
         /**
          * Creates an error message for a line, given the expected/actual indentation.
@@ -266,9 +437,7 @@ module.exports = {
             const foundTabsWord = `tab${actualTabs === 1 ? "" : "s"}`; // e.g. "tabs"
             let foundStatement;
 
-            if (actualSpaces > 0 && actualTabs > 0) {
-                foundStatement = `${actualSpaces} ${foundSpacesWord} and ${actualTabs} ${foundTabsWord}`; // e.g. "1 space and 2 tabs"
-            } else if (actualSpaces > 0) {
+            if (actualSpaces > 0) {
 
                 // Abbreviate the message if the expected indentation is also spaces.
                 // e.g. 'Expected 4 spaces but found 2' rather than 'Expected 4 spaces but found 2 spaces'
@@ -284,268 +453,45 @@ module.exports = {
 
         /**
          * Reports a given indent violation
-         * @param {ASTNode} node Node violating the indent rule
-         * @param {int} needed Expected indentation character count
+         * @param {Token} token Node violating the indent rule
+         * @param {int} neededIndentLevel Expected indentation level
          * @param {int} gottenSpaces Indentation space count in the actual node/code
          * @param {int} gottenTabs Indentation tab count in the actual node/code
-         * @param {Object=} loc Error line and column location
-         * @param {boolean} isLastNodeCheck Is the error for last node check
-         * @param {int} lastNodeCheckEndOffset Number of charecters to skip from the end
          * @returns {void}
          */
-        function report(node, needed, gottenSpaces, gottenTabs, loc, isLastNodeCheck) {
-            if (gottenSpaces && gottenTabs) {
-
-                // To avoid conflicts with `no-mixed-spaces-and-tabs`, don't report lines that have both spaces and tabs.
-                return;
-            }
-
-            const desiredIndent = (indentType === "space" ? " " : "\t").repeat(needed);
-
-            const textRange = isLastNodeCheck
-                ? [node.range[1] - node.loc.end.column, node.range[1] - node.loc.end.column + gottenSpaces + gottenTabs]
-                : [node.range[0] - node.loc.start.column, node.range[0] - node.loc.start.column + gottenSpaces + gottenTabs];
+        function report(token, neededIndentLevel) {
+            const actualIndent = Array.from(tokenInfo.getTokenIndent(token));
+            const numSpaces = actualIndent.filter(char => char === " ").length;
+            const numTabs = actualIndent.filter(char => char === "\t").length;
+            const neededChars = neededIndentLevel * indentSize;
 
             context.report({
-                node,
-                loc,
-                message: createErrorMessage(needed, gottenSpaces, gottenTabs),
-                fix: fixer => fixer.replaceTextRange(textRange, desiredIndent)
+                node: token,
+                message: createErrorMessage(neededChars, numSpaces, numTabs),
+                loc: { line: token.loc.start.line, column: token.loc.start.column },
+                fix(fixer) {
+                    const range = [token.range[0] - token.loc.start.column, token.range[0]];
+                    const newText = (indentType === "space" ? " " : "\t").repeat(neededChars);
+
+                    return fixer.replaceTextRange(range, newText);
+                }
             });
         }
 
         /**
-         * Get the actual indent of node
-         * @param {ASTNode|Token} node Node to examine
-         * @param {boolean} [byLastLine=false] get indent of node's last line
-         * @param {boolean} [excludeCommas=false] skip comma on start of line
-         * @returns {Object} The node's indent. Contains keys `space` and `tab`, representing the indent of each character. Also
-         contains keys `goodChar` and `badChar`, where `goodChar` is the amount of the user's desired indentation character, and
-         `badChar` is the amount of the other indentation character.
+         * Checks if a token's indentation is correct
+         * @param {Token} token Token to examine
+         * @param {int} desiredIndentLevel needed indent level
+         * @returns {boolean} `true` if the token's indentation is correct
          */
-        function getNodeIndent(node, byLastLine) {
-            const token = byLastLine ? sourceCode.getLastToken(node) : sourceCode.getFirstToken(node);
-            const srcCharsBeforeNode = sourceCode.getText(token, token.loc.start.column).split("");
-            const indentChars = srcCharsBeforeNode.slice(0, srcCharsBeforeNode.findIndex(char => char !== " " && char !== "\t"));
-            const spaces = indentChars.filter(char => char === " ").length;
-            const tabs = indentChars.filter(char => char === "\t").length;
+        function validateTokenIndent(token, desiredIndentLevel) {
+            const indentation = tokenInfo.getTokenIndent(token);
+            const expectedChar = indentType === "space" ? " " : "\t";
 
-            return {
-                space: spaces,
-                tab: tabs,
-                goodChar: indentType === "space" ? spaces : tabs,
-                badChar: indentType === "space" ? tabs : spaces
-            };
-        }
+            return indentation === expectedChar.repeat(desiredIndentLevel * indentSize) ||
 
-        /**
-         * Checks node is the first in its own start line. By default it looks by start line.
-         * @param {ASTNode} node The node to check
-         * @param {boolean} [byEndLocation=false] Lookup based on start position or end
-         * @returns {boolean} true if its the first in the its start line
-         */
-        function isNodeFirstInLine(node, byEndLocation) {
-            const firstToken = byEndLocation === true ? sourceCode.getLastToken(node, 1) : sourceCode.getTokenBefore(node),
-                startLine = byEndLocation === true ? node.loc.end.line : node.loc.start.line,
-                endLine = firstToken ? firstToken.loc.end.line : -1;
-
-            return startLine !== endLine;
-        }
-
-        /**
-         * Check indent for node
-         * @param {ASTNode} node Node to check
-         * @param {int} neededIndent needed indent
-         * @param {boolean} [excludeCommas=false] skip comma on start of line
-         * @returns {void}
-         */
-        function checkNodeIndent(node, neededIndent) {
-            const actualIndent = getNodeIndent(node, false);
-
-            if (
-                node.type !== "ArrayExpression" &&
-                node.type !== "ObjectExpression" &&
-                (actualIndent.goodChar !== neededIndent || actualIndent.badChar !== 0) &&
-                isNodeFirstInLine(node)
-            ) {
-                report(node, neededIndent, actualIndent.space, actualIndent.tab);
-            }
-
-            if (node.type === "IfStatement" && node.alternate) {
-                const elseToken = sourceCode.getTokenBefore(node.alternate);
-
-                checkNodeIndent(elseToken, neededIndent);
-
-                if (!isNodeFirstInLine(node.alternate)) {
-                    checkNodeIndent(node.alternate, neededIndent);
-                }
-            }
-
-            if (node.type === "TryStatement" && node.handler) {
-                const catchToken = sourceCode.getFirstToken(node.handler);
-
-                checkNodeIndent(catchToken, neededIndent);
-            }
-
-            if (node.type === "TryStatement" && node.finalizer) {
-                const finallyToken = sourceCode.getTokenBefore(node.finalizer);
-
-                checkNodeIndent(finallyToken, neededIndent);
-            }
-
-            if (node.type === "DoWhileStatement") {
-                const whileToken = sourceCode.getTokenAfter(node.body);
-
-                checkNodeIndent(whileToken, neededIndent);
-            }
-        }
-
-        /**
-         * Check indent for nodes list
-         * @param {ASTNode[]} nodes list of node objects
-         * @param {int} indent needed indent
-         * @param {boolean} [excludeCommas=false] skip comma on start of line
-         * @returns {void}
-         */
-        function checkNodesIndent(nodes, indent) {
-            nodes.forEach(node => checkNodeIndent(node, indent));
-        }
-
-        /**
-         * Check last node line indent this detects, that block closed correctly
-         * @param {ASTNode} node Node to examine
-         * @param {int} lastLineIndent needed indent
-         * @returns {void}
-         */
-        function checkLastNodeLineIndent(node, lastLineIndent) {
-            const lastToken = sourceCode.getLastToken(node);
-            const endIndent = getNodeIndent(lastToken, true);
-
-            if ((endIndent.goodChar !== lastLineIndent || endIndent.badChar !== 0) && isNodeFirstInLine(node, true)) {
-                report(
-                    node,
-                    lastLineIndent,
-                    endIndent.space,
-                    endIndent.tab,
-                    { line: lastToken.loc.start.line, column: lastToken.loc.start.column },
-                    true
-                );
-            }
-        }
-
-        /**
-         * Check last node line indent this detects, that block closed correctly
-         * This function for more complicated return statement case, where closing parenthesis may be followed by ';'
-         * @param {ASTNode} node Node to examine
-         * @param {int} firstLineIndent first line needed indent
-         * @returns {void}
-         */
-        function checkLastReturnStatementLineIndent(node, firstLineIndent) {
-
-            // in case if return statement ends with ');' we have traverse back to ')'
-            // otherwise we'll measure indent for ';' and replace ')'
-            const lastToken = sourceCode.getLastToken(node, astUtils.isClosingParenToken);
-            const textBeforeClosingParenthesis = sourceCode.getText(lastToken, lastToken.loc.start.column).slice(0, -1);
-
-            if (textBeforeClosingParenthesis.trim()) {
-
-                // There are tokens before the closing paren, don't report this case
-                return;
-            }
-
-            const endIndent = getNodeIndent(lastToken, true);
-
-            if (endIndent.goodChar !== firstLineIndent) {
-                report(
-                    node,
-                    firstLineIndent,
-                    endIndent.space,
-                    endIndent.tab,
-                    { line: lastToken.loc.start.line, column: lastToken.loc.start.column },
-                    true
-                );
-            }
-        }
-
-        /**
-         * Check first node line indent is correct
-         * @param {ASTNode} node Node to examine
-         * @param {int} firstLineIndent needed indent
-         * @returns {void}
-         */
-        function checkFirstNodeLineIndent(node, firstLineIndent) {
-            const startIndent = getNodeIndent(node, false);
-
-            if ((startIndent.goodChar !== firstLineIndent || startIndent.badChar !== 0) && isNodeFirstInLine(node)) {
-                report(
-                    node,
-                    firstLineIndent,
-                    startIndent.space,
-                    startIndent.tab,
-                    { line: node.loc.start.line, column: node.loc.start.column }
-                );
-            }
-        }
-
-        /**
-         * Returns a parent node of given node based on a specified type
-         * if not present then return null
-         * @param {ASTNode} node node to examine
-         * @param {string} type type that is being looked for
-         * @param {string} stopAtList end points for the evaluating code
-         * @returns {ASTNode|void} if found then node otherwise null
-         */
-        function getParentNodeByType(node, type, stopAtList) {
-            let parent = node.parent;
-
-            if (!stopAtList) {
-                stopAtList = ["Program"];
-            }
-
-            while (parent.type !== type && stopAtList.indexOf(parent.type) === -1 && parent.type !== "Program") {
-                parent = parent.parent;
-            }
-
-            return parent.type === type ? parent : null;
-        }
-
-        /**
-         * Returns the VariableDeclarator based on the current node
-         * if not present then return null
-         * @param {ASTNode} node node to examine
-         * @returns {ASTNode|void} if found then node otherwise null
-         */
-        function getVariableDeclaratorNode(node) {
-            return getParentNodeByType(node, "VariableDeclarator");
-        }
-
-        /**
-         * Check to see if the node is part of the multi-line variable declaration.
-         * Also if its on the same line as the varNode
-         * @param {ASTNode} node node to check
-         * @param {ASTNode} varNode variable declaration node to check against
-         * @returns {boolean} True if all the above condition satisfy
-         */
-        function isNodeInVarOnTop(node, varNode) {
-            return varNode &&
-                varNode.parent.loc.start.line === node.loc.start.line &&
-                varNode.parent.declarations.length > 1;
-        }
-
-        /**
-         * Check to see if the argument before the callee node is multi-line and
-         * there should only be 1 argument before the callee node
-         * @param {ASTNode} node node to check
-         * @returns {boolean} True if arguments are multi-line
-         */
-        function isArgBeforeCalleeNodeMultiline(node) {
-            const parent = node.parent;
-
-            if (parent.arguments.length >= 2 && parent.arguments[1] === node) {
-                return parent.arguments[0].loc.end.line > parent.arguments[0].loc.start.line;
-            }
-
-            return false;
+                // To avoid conflicts with no-mixed-spaces-and-tabs, don't report mixed spaces and tabs.
+                indentation.includes(" ") && indentation.includes("\t");
         }
 
         /**
@@ -554,257 +500,41 @@ module.exports = {
          * @returns {boolean} True if the node is the outer IIFE
          */
         function isOuterIIFE(node) {
-            const parent = node.parent;
-            let stmt = parent.parent;
 
             /*
-             * Verify that the node is an IIEF
+             * Verify that the node is an IIFE
              */
-            if (
-                parent.type !== "CallExpression" ||
-                parent.callee !== node) {
-
+            if (!node.parent || node.parent.type !== "CallExpression" || node.parent.callee !== node) {
                 return false;
             }
 
             /*
-             * Navigate legal ancestors to determine whether this IIEF is outer
+             * Navigate legal ancestors to determine whether this IIFE is outer.
+             * A "legal ancestor" is an expression or statement that causes the function to get executed immediately.
+             * For example, `!(function(){})()` is an outer IIFE even though it is preceded by a ! operator.
              */
+            let statement = node.parent && node.parent.parent;
+
             while (
-                stmt.type === "UnaryExpression" && (
-                    stmt.operator === "!" ||
-                    stmt.operator === "~" ||
-                    stmt.operator === "+" ||
-                    stmt.operator === "-") ||
-                stmt.type === "AssignmentExpression" ||
-                stmt.type === "LogicalExpression" ||
-                stmt.type === "SequenceExpression" ||
-                stmt.type === "VariableDeclarator") {
-
-                stmt = stmt.parent;
+                statement.type === "UnaryExpression" && ["!", "~", "+", "-"].indexOf(statement.operator) > -1 ||
+                statement.type === "AssignmentExpression" ||
+                statement.type === "LogicalExpression" ||
+                statement.type === "SequenceExpression" ||
+                statement.type === "VariableDeclarator"
+            ) {
+                statement = statement.parent;
             }
 
-            return ((
-                    stmt.type === "ExpressionStatement" ||
-                    stmt.type === "VariableDeclaration") &&
-                stmt.parent && stmt.parent.type === "Program"
-            );
+            return (statement.type === "ExpressionStatement" || statement.type === "VariableDeclaration") && statement.parent.type === "Program";
         }
 
         /**
-         * Check indent for function block content
-         * @param {ASTNode} node A BlockStatement node that is inside of a function.
-         * @returns {void}
-         */
-        function checkIndentInFunctionBlock(node) {
-
-            /*
-             * Search first caller in chain.
-             * Ex.:
-             *
-             * Models <- Identifier
-             *   .User
-             *   .find()
-             *   .exec(function() {
-             *   // function body
-             * });
-             *
-             * Looks for 'Models'
-             */
-            const calleeNode = node.parent; // FunctionExpression
-            let indent;
-
-            if (calleeNode.parent &&
-                (calleeNode.parent.type === "Property" ||
-                calleeNode.parent.type === "ArrayExpression")) {
-
-                // If function is part of array or object, comma can be put at left
-                indent = getNodeIndent(calleeNode, false, false).goodChar;
-            } else {
-
-                // If function is standalone, simple calculate indent
-                indent = getNodeIndent(calleeNode).goodChar;
-            }
-
-            if (calleeNode.parent.type === "CallExpression") {
-                const calleeParent = calleeNode.parent;
-
-                if (calleeNode.type !== "FunctionExpression" && calleeNode.type !== "ArrowFunctionExpression") {
-                    if (calleeParent && calleeParent.loc.start.line < node.loc.start.line) {
-                        indent = getNodeIndent(calleeParent).goodChar;
-                    }
-                } else {
-                    if (isArgBeforeCalleeNodeMultiline(calleeNode) &&
-                        calleeParent.callee.loc.start.line === calleeParent.callee.loc.end.line &&
-                        !isNodeFirstInLine(calleeNode)) {
-                        indent = getNodeIndent(calleeParent).goodChar;
-                    }
-                }
-            }
-
-            // function body indent should be indent + indent size, unless this
-            // is a FunctionDeclaration, FunctionExpression, or outer IIFE and the corresponding options are enabled.
-            let functionOffset = indentSize;
-
-            if (options.outerIIFEBody !== null && isOuterIIFE(calleeNode)) {
-                functionOffset = options.outerIIFEBody * indentSize;
-            } else if (calleeNode.type === "FunctionExpression") {
-                functionOffset = options.FunctionExpression.body * indentSize;
-            } else if (calleeNode.type === "FunctionDeclaration") {
-                functionOffset = options.FunctionDeclaration.body * indentSize;
-            }
-            indent += functionOffset;
-
-            // check if the node is inside a variable
-            const parentVarNode = getVariableDeclaratorNode(node);
-
-            if (parentVarNode && isNodeInVarOnTop(node, parentVarNode)) {
-                indent += indentSize * options.VariableDeclarator[parentVarNode.parent.kind];
-            }
-
-            if (node.body.length > 0) {
-                checkNodesIndent(node.body, indent);
-            }
-
-            checkLastNodeLineIndent(node, indent - functionOffset);
-        }
-
-
-        /**
-         * Checks if the given node starts and ends on the same line
-         * @param {ASTNode} node The node to check
-         * @returns {boolean} Whether or not the block starts and ends on the same line.
-         */
-        function isSingleLineNode(node) {
-            const lastToken = sourceCode.getLastToken(node),
-                startLine = node.loc.start.line,
-                endLine = lastToken.loc.end.line;
-
-            return startLine === endLine;
-        }
-
-        /**
-         * Check to see if the first element inside an array is an object and on the same line as the node
-         * If the node is not an array then it will return false.
-         * @param {ASTNode} node node to check
-         * @returns {boolean} success/failure
-         */
-        function isFirstArrayElementOnSameLine(node) {
-            if (node.type === "ArrayExpression" && node.elements[0]) {
-                return node.elements[0].loc.start.line === node.loc.start.line && node.elements[0].type === "ObjectExpression";
-            }
-            return false;
-
-        }
-
-        /**
-         * Check indent for array block content or object block content
-         * @param {ASTNode} node node to examine
-         * @returns {void}
-         */
-        function checkIndentInArrayOrObjectBlock(node) {
-
-            // Skip inline
-            if (isSingleLineNode(node)) {
-                return;
-            }
-
-            let elements = (node.type === "ArrayExpression") ? node.elements : node.properties;
-
-            // filter out empty elements example would be [ , 2] so remove first element as espree considers it as null
-            elements = elements.filter(elem => elem !== null);
-
-            let nodeIndent;
-            let elementsIndent;
-            const parentVarNode = getVariableDeclaratorNode(node);
-
-            // TODO - come up with a better strategy in future
-            if (isNodeFirstInLine(node)) {
-                const parent = node.parent;
-
-                nodeIndent = getNodeIndent(parent).goodChar;
-                if (!parentVarNode || parentVarNode.loc.start.line !== node.loc.start.line) {
-                    if (parent.type !== "VariableDeclarator" || parentVarNode === parentVarNode.parent.declarations[0]) {
-                        if (parent.type === "VariableDeclarator" && parentVarNode.loc.start.line === parent.loc.start.line) {
-                            nodeIndent = nodeIndent + (indentSize * options.VariableDeclarator[parentVarNode.parent.kind]);
-                        } else if (parent.type === "ObjectExpression" || parent.type === "ArrayExpression") {
-                            const parentElements = node.parent.type === "ObjectExpression" ? node.parent.properties : node.parent.elements;
-
-                            if (parentElements[0] && parentElements[0].loc.start.line === parent.loc.start.line && parentElements[0].loc.end.line !== parent.loc.start.line) {
-
-                                /*
-                                 * If the first element of the array spans multiple lines, don't increase the expected indentation of the rest.
-                                 * e.g. [{
-                                 *        foo: 1
-                                 *      },
-                                 *      {
-                                 *        bar: 1
-                                 *      }]
-                                 * the second object is not indented.
-                                 */
-                            } else if (typeof options[parent.type] === "number") {
-                                nodeIndent += options[parent.type] * indentSize;
-                            } else {
-                                nodeIndent = parentElements[0].loc.start.column;
-                            }
-                        } else if (parent.type === "CallExpression" || parent.type === "NewExpression") {
-                            if (typeof options.CallExpression.arguments === "number") {
-                                nodeIndent += options.CallExpression.arguments * indentSize;
-                            } else if (options.CallExpression.arguments === "first") {
-                                if (parent.arguments.indexOf(node) !== -1) {
-                                    nodeIndent = parent.arguments[0].loc.start.column;
-                                }
-                            } else {
-                                nodeIndent += indentSize;
-                            }
-                        } else if (parent.type === "LogicalExpression" || parent.type === "ArrowFunctionExpression") {
-                            nodeIndent += indentSize;
-                        }
-                    }
-                } else if (!parentVarNode && !isFirstArrayElementOnSameLine(parent) && parent.type !== "MemberExpression" && parent.type !== "ExpressionStatement" && parent.type !== "AssignmentExpression" && parent.type !== "Property") {
-                    nodeIndent = nodeIndent + indentSize;
-                }
-
-                checkFirstNodeLineIndent(node, nodeIndent);
-            } else {
-                nodeIndent = getNodeIndent(node).goodChar;
-            }
-
-            if (options[node.type] === "first") {
-                elementsIndent = elements.length ? elements[0].loc.start.column : 0; // If there are no elements, elementsIndent doesn't matter.
-            } else {
-                elementsIndent = nodeIndent + indentSize * options[node.type];
-            }
-
-            /*
-             * Check if the node is a multiple variable declaration; if so, then
-             * make sure indentation takes that into account.
-             */
-            if (isNodeInVarOnTop(node, parentVarNode)) {
-                elementsIndent += indentSize * options.VariableDeclarator[parentVarNode.parent.kind];
-            }
-
-            checkNodesIndent(elements, elementsIndent);
-
-            if (elements.length > 0) {
-
-                // Skip last block line check if last item in same line
-                if (elements[elements.length - 1].loc.end.line === node.loc.end.line) {
-                    return;
-                }
-            }
-
-            checkLastNodeLineIndent(node, nodeIndent + (isNodeInVarOnTop(node, parentVarNode) ? options.VariableDeclarator[parentVarNode.parent.kind] * indentSize : 0));
-        }
-
-        /**
-         * Check if the node or node body is a BlockStatement or not
-         * @param {ASTNode} node node to test
-         * @returns {boolean} True if it or its body is a block statement
-         */
-        function isNodeBodyBlock(node) {
-            return node.type === "BlockStatement" || node.type === "ClassBody" || (node.body && node.body.type === "BlockStatement") ||
-                (node.consequent && node.consequent.type === "BlockStatement");
+        * Gets all tokens and comments for a node
+        * @param {ASTNode} node The node
+        * @returns {Token[]} A list of tokens and comments
+        */
+        function getTokensAndComments(node) {
+            return sourceCode.getTokens(node, { includeComments: true });
         }
 
         /**
@@ -812,308 +542,518 @@ module.exports = {
          * @param {ASTNode} node node to check
          * @returns {void}
          */
-        function blockIndentationCheck(node) {
+        function addBlockIndent(node) {
 
-            // Skip inline blocks
-            if (isSingleLineNode(node)) {
-                return;
+            let blockIndentLevel;
+            const tokens = getTokensAndComments(node);
+
+            if (node.parent && isOuterIIFE(node.parent)) {
+                blockIndentLevel = options.outerIIFEBody;
+            } else if (node.parent && (node.parent.type === "FunctionExpression" || node.parent.type === "ArrowFunctionExpression")) {
+                blockIndentLevel = options.FunctionExpression.body;
+            } else if (node.parent && node.parent.type === "FunctionDeclaration") {
+                blockIndentLevel = options.FunctionDeclaration.body;
+            } else {
+                blockIndentLevel = 1;
             }
-
-            if (node.parent && (
-                    node.parent.type === "FunctionExpression" ||
-                    node.parent.type === "FunctionDeclaration" ||
-                    node.parent.type === "ArrowFunctionExpression"
-            )) {
-                checkIndentInFunctionBlock(node);
-                return;
-            }
-
-            let indent;
-            let nodesToCheck = [];
 
             /*
-             * For this statements we should check indent from statement beginning,
-             * not from the beginning of the block.
+             * If the block starts on its own line, then match the tokens in the block against the opening curly of the block.
+             * Otherwise, match the token in the block against the tokens in the block's parent.
+             *
+             * For example:
+             * function foo() {
+             *   {
+             *      // (random block, tokens should get matched against the { that opens the block)
+             *      foo;
+             *   }
+             *
+             * if (foo &&
+             *     bar) {
+             *     baz(); // Tokens in the block should get matched against the `if` statement, even though the opening curly is indented.
+             * }
              */
-            const statementsWithProperties = [
-                "IfStatement", "WhileStatement", "ForStatement", "ForInStatement", "ForOfStatement", "DoWhileStatement", "ClassDeclaration", "TryStatement"
-            ];
+            const tokenToMatchAgainst = tokenInfo.isFirstTokenOfLine(tokens[0]) ? tokens[0] : sourceCode.getFirstToken(node.parent);
 
-            if (node.parent && statementsWithProperties.indexOf(node.parent.type) !== -1 && isNodeBodyBlock(node)) {
-                indent = getNodeIndent(node.parent).goodChar;
-            } else if (node.parent && node.parent.type === "CatchClause") {
-                indent = getNodeIndent(node.parent.parent).goodChar;
-            } else {
-                indent = getNodeIndent(node).goodChar;
+            if (tokenToMatchAgainst !== tokens[0]) {
+                offsets.matchIndentOf(tokenToMatchAgainst, tokens[0]);
             }
-
-            if (node.type === "IfStatement" && node.consequent.type !== "BlockStatement") {
-                nodesToCheck = [node.consequent];
-            } else if (Array.isArray(node.body)) {
-                nodesToCheck = node.body;
-            } else {
-                nodesToCheck = [node.body];
-            }
-
-            if (nodesToCheck.length > 0) {
-                checkNodesIndent(nodesToCheck, indent + indentSize);
-            }
-
-            if (node.type === "BlockStatement") {
-                checkLastNodeLineIndent(node, indent);
-            }
+            offsets.setDesiredOffsets(tokens, tokens[0], blockIndentLevel);
+            offsets.matchIndentOf(tokenToMatchAgainst, tokens[tokens.length - 1]);
         }
 
         /**
-         * Filter out the elements which are on the same line of each other or the node.
-         * basically have only 1 elements from each line except the variable declaration line.
-         * @param {ASTNode} node Variable declaration node
-         * @returns {ASTNode[]} Filtered elements
-         */
-        function filterOutSameLineVars(node) {
-            return node.declarations.reduce((finalCollection, elem) => {
-                const lastElem = finalCollection[finalCollection.length - 1];
+        * Check indentation for lists of elements (arrays, objects, function params)
+        * @param {Token[]} tokens list of tokens
+        * @param {ASTNode[]} elements List of elements that should be offset
+        * @param {number|string} offset The amount that the elements should be offset
+        * @returns {void}
+        */
+        function addElementListIndent(tokens, elements, offset) {
 
-                if ((elem.loc.start.line !== node.loc.start.line && !lastElem) ||
-                    (lastElem && lastElem.loc.start.line !== elem.loc.start.line)) {
-                    finalCollection.push(elem);
+            /**
+            * Gets the first token of a given element, including surrounding parentheses.
+            * @param {ASTNode} element A node in the `elements` list
+            * @returns {Token} The first token of this element
+            */
+            function getFirstToken(element) {
+                let token = sourceCode.getTokenBefore(element);
+
+                while (astUtils.isOpeningParenToken(token) && token !== tokens[0]) {
+                    token = sourceCode.getTokenBefore(token);
                 }
 
-                return finalCollection;
-            }, []);
+                return sourceCode.getTokenAfter(token);
+            }
+
+            // Run through all the tokens in the list, and offset them by one indent level (mainly for comments, other things will end up overridden)
+            // FIXME: (not-an-aardvark) This isn't performant at all.
+            offsets.setDesiredOffsets(tokens, tokens[0], offset === "first" ? 1 : offset);
+            offsets.matchIndentOf(tokens[0], tokens[tokens.length - 1]);
+
+            // If the preference is "first" but there is no first element (e.g. sparse arrays w/ empty first slot), fall back to 1 level.
+            if (offset === "first" && elements.length && !elements[0]) {
+                return;
+            }
+
+            elements.forEach((element, index) => {
+                if (offset === "off") {
+                    offsets.ignoreToken(getFirstToken(element));
+                }
+                if (index === 0 || !element) {
+                    return;
+                }
+                if (offset === "first" && tokenInfo.isFirstTokenOfLine(getFirstToken(element))) {
+                    offsets.matchOffsetOf(getFirstToken(elements[0]), getFirstToken(element));
+                } else {
+                    const previousElement = elements[index - 1];
+                    const firstTokenOfPreviousElement = previousElement && getFirstToken(previousElement);
+
+                    if (previousElement && previousElement.loc.end.line > tokens[0].loc.end.line) {
+                        offsets.matchIndentOf(firstTokenOfPreviousElement, getFirstToken(elements[index]));
+                    }
+                }
+            });
         }
 
         /**
-         * Check indentation for variable declarations
+         * Check indent for array block content or object block content
          * @param {ASTNode} node node to examine
          * @returns {void}
          */
-        function checkIndentInVariableDeclarations(node) {
-            const elements = filterOutSameLineVars(node);
-            const nodeIndent = getNodeIndent(node).goodChar;
-            const lastElement = elements[elements.length - 1];
+        function addArrayOrObjectIndent(node) {
+            const tokens = getTokensAndComments(node);
 
-            const elementsIndent = nodeIndent + indentSize * options.VariableDeclarator[node.kind];
-
-            checkNodesIndent(elements, elementsIndent);
-
-            // Only check the last line if there is any token after the last item
-            if (sourceCode.getLastToken(node).loc.end.line <= lastElement.loc.end.line) {
-                return;
-            }
-
-            const tokenBeforeLastElement = sourceCode.getTokenBefore(lastElement);
-
-            if (tokenBeforeLastElement.value === ",") {
-
-                // Special case for comma-first syntax where the semicolon is indented
-                checkLastNodeLineIndent(node, getNodeIndent(tokenBeforeLastElement).goodChar);
-            } else {
-                checkLastNodeLineIndent(node, elementsIndent - indentSize);
-            }
+            addElementListIndent(tokens, node.elements || node.properties, options[node.type]);
         }
 
         /**
          * Check and decide whether to check for indentation for blockless nodes
          * Scenarios are for or while statements without braces around them
          * @param {ASTNode} node node to examine
+         * @param {ASTNode} parent The parent of the node to examine
          * @returns {void}
          */
-        function blockLessNodes(node) {
-            if (node.body.type !== "BlockStatement") {
-                blockIndentationCheck(node);
+        function addBlocklessNodeIndent(node, parent) {
+            if (node.type !== "BlockStatement") {
+                offsets.setDesiredOffsets(getTokensAndComments(node), sourceCode.getFirstToken(parent), 1);
             }
         }
 
         /**
-         * Returns the expected indentation for the case statement
-         * @param {ASTNode} node node to examine
-         * @param {int} [switchIndent] indent for switch statement
-         * @returns {int} indent size
-         */
-        function expectedCaseIndent(node, switchIndent) {
-            const switchNode = (node.type === "SwitchStatement") ? node : node.parent;
-            let caseIndent;
+        * Checks the indentation of a function's parameters
+        * @param {ASTNode} node The node
+        * @param {number} paramsIndent The indentation level option for the parameters
+        * @returns {void}
+        */
+        function addFunctionParamsIndent(node, paramsIndent) {
+            const openingParen = node.params.length ? sourceCode.getTokenBefore(node.params[0]) : sourceCode.getTokenBefore(node.body, 1);
+            const closingParen = sourceCode.getTokenBefore(node.body);
+            const nodeTokens = getTokensAndComments(node);
+            const openingParenIndex = lodash.sortedIndexBy(nodeTokens, openingParen, token => token.range[0]);
+            const closingParenIndex = lodash.sortedIndexBy(nodeTokens, closingParen, token => token.range[0]);
+            const paramTokens = nodeTokens.slice(openingParenIndex, closingParenIndex + 1);
 
-            if (caseIndentStore[switchNode.loc.start.line]) {
-                return caseIndentStore[switchNode.loc.start.line];
-            }
-            if (typeof switchIndent === "undefined") {
-                switchIndent = getNodeIndent(switchNode).goodChar;
-            }
+            parameterParens.add(paramTokens[0]);
+            parameterParens.add(paramTokens[paramTokens.length - 1]);
 
-            if (switchNode.cases.length > 0 && options.SwitchCase === 0) {
-                caseIndent = switchIndent;
+            addElementListIndent(paramTokens, node.params, paramsIndent);
+        }
+
+        /**
+        * Adds indentation for the right-hand side of binary/logical expressions.
+        * @param {ASTNode} node A BinaryExpression or LogicalExpression node
+        * @returns {void}
+        */
+        function addBinaryOrLogicalExpressionIndent(node) {
+            const tokens = getTokensAndComments(node);
+            const operator = sourceCode.getFirstTokenBetween(node.left, node.right, token => token.value === node.operator);
+            const firstTokenAfterOperator = sourceCode.getTokenAfter(operator);
+            const tokensAfterOperator = tokens.slice(lodash.sortedIndexBy(tokens, firstTokenAfterOperator, token => token.range[0]));
+
+            /*
+             * For backwards compatibility, don't check BinaryExpression indents, e.g.
+             * var foo = bar &&
+             *                   baz;
+             */
+
+            offsets.ignoreToken(operator);
+            offsets.ignoreToken(tokensAfterOperator[0]);
+            offsets.setDesiredOffset(tokensAfterOperator[0], sourceCode.getFirstToken(node), 1);
+            offsets.setDesiredOffsets(tokensAfterOperator, tokensAfterOperator[0], 1);
+        }
+
+        /**
+        * Checks the indentation of `IfStatement` nodes.
+        * @param {ASTNode} node An `IfStatement` node
+        * @returns {void}
+        */
+        function addIfStatementIndent(node) {
+            addBlocklessNodeIndent(node.consequent, node);
+            if (node.alternate) {
+                if (node.alternate.type === "IfStatement") {
+                    addIfStatementIndent(node.alternate, node);
+                } else {
+                    addBlocklessNodeIndent(node.alternate, node);
+                }
+            }
+        }
+
+        /**
+        * Checks the indentation for nodes that are like function calls (`CallExpression` and `NewExpression`)
+        * @param {ASTNode} node A CallExpression or NewExpression node
+        * @returns {void}
+        */
+        function addFunctionCallIndent(node) {
+            let openingParen;
+
+            if (node.arguments.length) {
+                openingParen = sourceCode.getFirstTokenBetween(node.callee, node.arguments[0], astUtils.isOpeningParenToken);
             } else {
-                caseIndent = switchIndent + (indentSize * options.SwitchCase);
+                openingParen = sourceCode.getLastToken(node, 1);
             }
+            const callExpressionTokens = getTokensAndComments(node);
+            const tokens = callExpressionTokens.slice(lodash.sortedIndexBy(callExpressionTokens, openingParen, token => token.range[0]));
 
-            caseIndentStore[switchNode.loc.start.line] = caseIndent;
-            return caseIndent;
+            parameterParens.add(tokens[0]);
+            parameterParens.add(tokens[tokens.length - 1]);
+            offsets.matchIndentOf(sourceCode.getLastToken(node.callee), openingParen);
 
+            addElementListIndent(tokens, node.arguments, options.CallExpression.arguments);
         }
 
         /**
-         * Checks wether a return statement is wrapped in ()
-         * @param {ASTNode} node node to examine
-         * @returns {boolean} the result
-         */
-        function isWrappedInParenthesis(node) {
-            const regex = /^return\s*?\(\s*?\);*?/;
+        * Checks the indentation of ClassDeclarations and ClassExpressions
+        * @param {ASTNode} node A ClassDeclaration or ClassExpression node
+        * @returns {void}
+        */
+        function addClassIndent(node) {
+            const tokens = getTokensAndComments(node);
 
-            const statementWithoutArgument = sourceCode.getText(node).replace(
-                sourceCode.getText(node.argument), "");
+            offsets.setDesiredOffsets(tokens, tokens[0], 1);
+            offsets.matchIndentOf(tokens[0], tokens[tokens.length - 1]);
+        }
 
-            return regex.test(statementWithoutArgument);
+        /**
+        * Checks the indentation of parenthesized values, given a list of tokens in a program
+        * @param {Token[]} tokens A list of tokens
+        * @returns {void}
+        */
+        function addParensIndent(tokens) {
+            const parenStack = [];
+            const parenPairs = [];
+
+            tokens.forEach(nextToken => {
+
+                // Accumulate a list of parenthesis pairs
+                if (astUtils.isOpeningParenToken(nextToken)) {
+                    parenStack.push(nextToken);
+                } else if (astUtils.isClosingParenToken(nextToken)) {
+                    parenPairs.unshift({ left: parenStack.pop(), right: nextToken });
+                }
+            });
+
+            parenPairs.forEach(pair => {
+                const leftParen = pair.left;
+                const rightParen = pair.right;
+
+                // We only want to handle parens around expressions, so exclude parentheses that are in function parameters and function call arguments.
+                if (!parameterParens.has(leftParen) && !parameterParens.has(rightParen)) {
+                    offsets.setDesiredOffset(sourceCode.getTokenAfter(leftParen), leftParen, 1);
+                }
+
+                offsets.matchIndentOf(leftParen, rightParen);
+            });
         }
 
         return {
-            Program(node) {
-                if (node.body.length > 0) {
+            ArrayExpression: addArrayOrObjectIndent,
+            ArrayPattern: addArrayOrObjectIndent,
 
-                    // Root nodes should have no indent
-                    checkNodesIndent(node.body, getNodeIndent(node).goodChar);
+            ArrowFunctionExpression(node) {
+                addFunctionParamsIndent(node, options.FunctionExpression.parameters);
+                if (node.body.type !== "BlockStatement") {
+                    offsets.setDesiredOffsets(getTokensAndComments(node.body), sourceCode.getFirstToken(node), 1);
                 }
             },
 
-            ClassBody: blockIndentationCheck,
+            AssignmentExpression(node) {
+                const operator = sourceCode.getFirstTokenBetween(node.left, node.right, token => token.value === node.operator);
+                const nodeTokens = getTokensAndComments(node);
+                const tokensFromOperator = nodeTokens.slice(lodash.sortedIndexBy(nodeTokens, operator, token => token.range[0]));
 
-            BlockStatement: blockIndentationCheck,
+                offsets.setDesiredOffsets(tokensFromOperator, sourceCode.getFirstToken(node.left), 1);
+                offsets.ignoreToken(tokensFromOperator[0]);
+                offsets.ignoreToken(tokensFromOperator[1]);
+            },
 
-            WhileStatement: blockLessNodes,
+            BinaryExpression: addBinaryOrLogicalExpressionIndent,
 
-            ForStatement: blockLessNodes,
+            BlockStatement: addBlockIndent,
 
-            ForInStatement: blockLessNodes,
+            CallExpression: addFunctionCallIndent,
 
-            ForOfStatement: blockLessNodes,
+            ClassDeclaration: addClassIndent,
 
-            DoWhileStatement: blockLessNodes,
+            ClassExpression: addClassIndent,
 
-            IfStatement(node) {
-                if (node.consequent.type !== "BlockStatement" && node.consequent.loc.start.line > node.loc.start.line) {
-                    blockIndentationCheck(node);
+            ConditionalExpression(node) {
+                const tokens = getTokensAndComments(node);
+
+                if (!(node.parent.type === "ConditionalExpression" && options.flatTernaryExpressions)) {
+                    offsets.setDesiredOffsets(tokens, tokens[0], 1);
                 }
             },
 
-            VariableDeclaration(node) {
-                if (node.declarations[node.declarations.length - 1].loc.start.line > node.declarations[0].loc.start.line) {
-                    checkIndentInVariableDeclarations(node);
+            DoWhileStatement: node => addBlocklessNodeIndent(node.body, node),
+
+            ExportNamedDeclaration(node) {
+                if (node.declaration === null) {
+                    addElementListIndent(getTokensAndComments(node).slice(1), node.specifiers, 1);
                 }
             },
 
-            ObjectExpression(node) {
-                checkIndentInArrayOrObjectBlock(node);
-            },
+            ForInStatement: node => addBlocklessNodeIndent(node.body, node),
 
-            ArrayExpression(node) {
-                checkIndentInArrayOrObjectBlock(node);
-            },
+            ForOfStatement: node => addBlocklessNodeIndent(node.body, node),
 
-            MemberExpression(node) {
+            ForStatement(node) {
+                const forOpeningParen = sourceCode.getFirstToken(node, 1);
 
-                if (typeof options.MemberExpression === "undefined") {
-                    return;
+                if (node.init) {
+                    offsets.setDesiredOffsets(getTokensAndComments(node.init), forOpeningParen, 1);
                 }
-
-                if (isSingleLineNode(node)) {
-                    return;
+                if (node.test) {
+                    offsets.setDesiredOffsets(getTokensAndComments(node.test), forOpeningParen, 1);
                 }
-
-                // The typical layout of variable declarations and assignments
-                // alter the expectation of correct indentation. Skip them.
-                // TODO: Add appropriate configuration options for variable
-                // declarations and assignments.
-                if (getParentNodeByType(node, "VariableDeclarator", ["FunctionExpression", "ArrowFunctionExpression"])) {
-                    return;
+                if (node.update) {
+                    offsets.setDesiredOffsets(getTokensAndComments(node.update), forOpeningParen, 1);
                 }
-
-                if (getParentNodeByType(node, "AssignmentExpression", ["FunctionExpression"])) {
-                    return;
-                }
-
-                const propertyIndent = getNodeIndent(node).goodChar + indentSize * options.MemberExpression;
-
-                const checkNodes = [node.property];
-
-                const dot = context.getTokenBefore(node.property);
-
-                if (dot.type === "Punctuator" && dot.value === ".") {
-                    checkNodes.push(dot);
-                }
-
-                checkNodesIndent(checkNodes, propertyIndent);
-            },
-
-            SwitchStatement(node) {
-
-                // Switch is not a 'BlockStatement'
-                const switchIndent = getNodeIndent(node).goodChar;
-                const caseIndent = expectedCaseIndent(node, switchIndent);
-
-                checkNodesIndent(node.cases, caseIndent);
-
-
-                checkLastNodeLineIndent(node, switchIndent);
-            },
-
-            SwitchCase(node) {
-
-                // Skip inline cases
-                if (isSingleLineNode(node)) {
-                    return;
-                }
-                const caseIndent = expectedCaseIndent(node);
-
-                checkNodesIndent(node.consequent, caseIndent + indentSize);
+                addBlocklessNodeIndent(node.body, node);
             },
 
             FunctionDeclaration(node) {
-                if (isSingleLineNode(node)) {
-                    return;
-                }
-                if (options.FunctionDeclaration.parameters === "first" && node.params.length) {
-                    checkNodesIndent(node.params.slice(1), node.params[0].loc.start.column);
-                } else if (options.FunctionDeclaration.parameters !== null) {
-                    checkNodesIndent(node.params, getNodeIndent(node).goodChar + indentSize * options.FunctionDeclaration.parameters);
-                }
+                addFunctionParamsIndent(node, options.FunctionDeclaration.parameters);
             },
 
             FunctionExpression(node) {
-                if (isSingleLineNode(node)) {
-                    return;
-                }
-                if (options.FunctionExpression.parameters === "first" && node.params.length) {
-                    checkNodesIndent(node.params.slice(1), node.params[0].loc.start.column);
-                } else if (options.FunctionExpression.parameters !== null) {
-                    checkNodesIndent(node.params, getNodeIndent(node).goodChar + indentSize * options.FunctionExpression.parameters);
+                addFunctionParamsIndent(node, options.FunctionExpression.parameters);
+            },
+
+            IfStatement: addIfStatementIndent,
+
+            ImportDeclaration(node) {
+                if (node.specifiers.some(specifier => specifier.type === "ImportSpecifier")) {
+                    const openingCurly = sourceCode.getFirstToken(node, astUtils.isOpeningBraceToken);
+                    const closingCurly = sourceCode.getLastToken(node, astUtils.isClosingBraceToken);
+                    const specifierTokens = sourceCode.getTokensBetween(openingCurly, closingCurly, 1);
+
+                    addElementListIndent(specifierTokens, node.specifiers.filter(specifier => specifier.type === "ImportSpecifier"), 1);
                 }
             },
 
-            ReturnStatement(node) {
-                if (isSingleLineNode(node)) {
-                    return;
+            LogicalExpression: addBinaryOrLogicalExpressionIndent,
+
+            MemberExpression(node) {
+                const firstNonObjectToken = sourceCode.getFirstTokenBetween(node.object, node.property, astUtils.isNotClosingParenToken);
+                const tokensToIndent = node.computed ? [sourceCode.getTokenAfter(firstNonObjectToken)] : [firstNonObjectToken, sourceCode.getTokenAfter(firstNonObjectToken)];
+
+                if (node.computed) {
+                    offsets.matchIndentOf(firstNonObjectToken, sourceCode.getLastToken(node));
                 }
 
-                const firstLineIndent = getNodeIndent(node).goodChar;
+                offsets.setDesiredOffsets(tokensToIndent, tokensToIndent[0], 0);
 
-                // in case if return statement is wrapped in parenthesis
-                if (isWrappedInParenthesis(node)) {
-                    checkLastReturnStatementLineIndent(node, firstLineIndent);
+                if (typeof options.MemberExpression !== "number") {
+                    tokensToIndent.forEach(token => {
+                        offsets.matchIndentOf(tokenInfo.getFirstTokenOfLine(token), token);
+                        offsets.ignoreToken(token);
+                    });
+                } else if (node.object.loc.end.line === node.property.loc.start.line) {
+                    offsets.setDesiredOffsets(tokensToIndent, tokenInfo.getFirstTokenOfLine(sourceCode.getLastToken(node.object)), options.MemberExpression);
                 } else {
-                    checkNodeIndent(node, firstLineIndent);
+                    offsets.setDesiredOffsets(tokensToIndent, sourceCode.getFirstToken(node.object), options.MemberExpression);
                 }
             },
 
-            CallExpression(node) {
-                if (isSingleLineNode(node)) {
-                    return;
+            NewExpression(node) {
+
+                // Only indent the arguments if the NewExpression has parens (e.g. `new Foo(bar)` or `new Foo()`, but not `new Foo`
+                if (node.arguments.length > 0 || astUtils.isClosingParenToken(sourceCode.getLastToken(node)) && astUtils.isOpeningParenToken(sourceCode.getLastToken(node, 1))) {
+                    addFunctionCallIndent(node);
                 }
-                if (options.CallExpression.arguments === "first" && node.arguments.length) {
-                    checkNodesIndent(node.arguments.slice(1), node.arguments[0].loc.start.column);
-                } else if (options.CallExpression.arguments !== null) {
-                    checkNodesIndent(node.arguments, getNodeIndent(node).goodChar + indentSize * options.CallExpression.arguments);
+            },
+
+            ObjectExpression: addArrayOrObjectIndent,
+            ObjectPattern: addArrayOrObjectIndent,
+
+            Property(node) {
+                if (!node.computed && !node.shorthand && !node.method && node.kind === "init") {
+                    const colon = sourceCode.getFirstTokenBetween(node.key, node.value, astUtils.isColonToken);
+
+                    offsets.ignoreToken(sourceCode.getTokenAfter(colon));
                 }
+            },
+
+            SwitchStatement(node) {
+                const tokens = getTokensAndComments(node);
+                const openingCurlyIndex = tokens.findIndex(token => token.range[0] >= node.discriminant.range[1] && astUtils.isOpeningBraceToken(token));
+
+                offsets.setDesiredOffsets(tokens.slice(openingCurlyIndex + 1, -1), tokens[openingCurlyIndex], options.SwitchCase);
+
+                const caseKeywords = new WeakSet(node.cases.map(switchCase => sourceCode.getFirstToken(switchCase)));
+                const lastCaseKeyword = node.cases.length && sourceCode.getFirstToken(node.cases[node.cases.length - 1]);
+                const casesWithBlocks = new WeakSet(
+                    node.cases
+                        .filter(switchCase => switchCase.consequent.length === 1 && switchCase.consequent[0].type === "BlockStatement")
+                        .map(switchCase => sourceCode.getFirstToken(switchCase))
+                );
+                let lastAnchor = tokens[openingCurlyIndex];
+
+                tokens.slice(openingCurlyIndex + 1, -1).forEach(token => {
+                    if (caseKeywords.has(token)) {
+                        lastAnchor = token;
+                    } else if (lastAnchor === lastCaseKeyword && (token.type === "Line" || token.type === "Block")) {
+                        offsets.ignoreToken(token);
+                    } else if (!casesWithBlocks.has(lastAnchor)) {
+                        offsets.setDesiredOffset(token, lastAnchor, 1);
+                    }
+                });
+            },
+
+            TemplateLiteral(node) {
+                const tokens = getTokensAndComments(node);
+
+                offsets.setDesiredOffsets(getTokensAndComments(node.quasis[0]), tokens[0], 0);
+                node.expressions.forEach((expression, index) => {
+                    const previousQuasi = node.quasis[index];
+                    const nextQuasi = node.quasis[index + 1];
+                    const tokenToAlignFrom = previousQuasi.loc.start.line === previousQuasi.loc.end.line ? sourceCode.getFirstToken(previousQuasi) : null;
+
+                    offsets.setDesiredOffsets(sourceCode.getTokensBetween(previousQuasi, nextQuasi), tokenToAlignFrom, 1);
+                    offsets.setDesiredOffset(sourceCode.getFirstToken(nextQuasi), tokenToAlignFrom, 0);
+                });
+            },
+
+            VariableDeclaration(node) {
+                offsets.setDesiredOffsets(getTokensAndComments(node), sourceCode.getFirstToken(node), options.VariableDeclarator[node.kind]);
+                const lastToken = sourceCode.getLastToken(node);
+
+                if (astUtils.isSemicolonToken(lastToken)) {
+                    offsets.ignoreToken(lastToken);
+                }
+            },
+
+            VariableDeclarator(node) {
+                if (node.init) {
+                    offsets.ignoreToken(sourceCode.getFirstToken(node.init));
+                }
+            },
+
+            "VariableDeclarator:exit"(node) {
+
+                /*
+                 * VariableDeclarator indentation is a bit different from other forms of indentation, in that the
+                 * indentation of an opening bracket sometimes won't match that of a closing bracket. For example,
+                 * the following indentations are correct:
+                 *
+                 * var foo = {
+                 *   ok: true
+                 * };
+                 *
+                 * var foo = {
+                 *     ok: true,
+                 *   },
+                 *   bar = 1;
+                 *
+                 * Account for when exiting the AST (after indentations have already been set for the nodes in
+                 * the declaration) by manually increasing the indentation level of the tokens in the first declarator if the
+                 * parent declaration has more than one declarator.
+                 */
+                if (node.parent.declarations.length > 1 && node.parent.declarations[0] === node && node.init) {
+                    const valueTokens = new Set(getTokensAndComments(node.init));
+
+                    valueTokens.forEach(token => {
+                        if (!valueTokens.has(offsets.getFirstDependency(token))) {
+                            offsets.increaseOffset(token, options.VariableDeclarator[node.parent.kind]);
+                        }
+                    });
+                }
+            },
+
+            WhileStatement: node => addBlocklessNodeIndent(node.body, node),
+
+            "Program:exit"() {
+                addParensIndent(sourceCode.ast.tokens);
+
+                /*
+                 * Create a Map from (tokenOrComment) => (precedingToken).
+                 * This is necessary because sourceCode.getTokenBefore does not handle a comment as an argument correctly.
+                 */
+                const precedingTokens = sourceCode.ast.comments.reduce((commentMap, comment) => {
+                    const tokenOrCommentBefore = sourceCode.getTokenOrCommentBefore(comment);
+
+                    return commentMap.set(comment, commentMap.has(tokenOrCommentBefore) ? commentMap.get(tokenOrCommentBefore) : tokenOrCommentBefore);
+                }, new WeakMap());
+
+                sourceCode.lines.forEach((line, lineIndex) => {
+                    const lineNumber = lineIndex + 1;
+
+                    if (!tokenInfo.firstTokensByLineNumber.has(lineNumber)) {
+
+                        // Don't check indentation on blank lines
+                        return;
+                    }
+
+                    const firstTokenofLine = tokenInfo.firstTokensByLineNumber.get(lineNumber);
+
+                    if (firstTokenofLine.loc.start.line !== lineNumber) {
+
+                        // Don't check the indentation of multi-line tokens (e.g. template literals or block comments) twice.
+                        return;
+                    }
+
+                    // If the token matches the expected expected indentation, don't report it.
+                    if (validateTokenIndent(firstTokenofLine, offsets.getDesiredIndent(firstTokenofLine))) {
+                        return;
+                    }
+
+                    if (astUtils.isCommentToken(firstTokenofLine)) {
+                        const tokenBefore = precedingTokens.get(firstTokenofLine);
+                        const tokenAfter = tokenBefore ? sourceCode.getTokenAfter(tokenBefore) : sourceCode.ast.tokens[0];
+
+                        // If a comment matches the expected indentation of the token immediately before or after, don't report it.
+                        if (
+                            tokenBefore && validateTokenIndent(firstTokenofLine, offsets.getDesiredIndent(tokenBefore)) ||
+                            tokenAfter && validateTokenIndent(firstTokenofLine, offsets.getDesiredIndent(tokenAfter))
+                        ) {
+                            return;
+                        }
+                    }
+
+                    // Otherwise, report the token/comment.
+                    report(firstTokenofLine, offsets.getDesiredIndent(firstTokenofLine));
+                });
             }
 
         };

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -8,8 +8,29 @@
 
 "use strict";
 
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
 const lodash = require("lodash");
 const astUtils = require("../ast-utils");
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+/*
+ * General rule strategy:
+ * 1. An OffsetStorage instance stores a map of desired offsets, where each token has a specified offset from another
+ *    specified token or to the first column.
+ * 2. As the AST is traversed, modify the desired offsets of tokens accordingly. For example, when entering a
+ *    BlockStatement, offset all of the tokens in the BlockStatement by 1 indent level from the opening curly
+ *    brace of the BlockStatement.
+ * 3. After traversing the AST, calculate the expected indentation levels of every token according to the
+ *    OffsetStorage container.
+ * 4. For each line, compare the expected indentation of the first token to the actual indentation in the file,
+ *    and report the token if the two values are not equal.
+ */
 
 /**
  * A helper class to get token-based info related to indentation
@@ -247,10 +268,6 @@ const ELEMENT_LIST_SCHEMA = {
     ]
 };
 
-//------------------------------------------------------------------------------
-// Rule Definition
-//------------------------------------------------------------------------------
-
 module.exports = {
     meta: {
         docs: {
@@ -394,22 +411,6 @@ module.exports = {
             ObjectPattern: 1,
             flatTernaryExpressions: false
         };
-
-        /*
-         * General rule strategy:
-         * 1. Create a tree, where each node of the tree is a token or comment and each edge of the tree is an indentation offset
-         *    between tokens. (This is stored as a hashmap in `desiredOffsets`, which maps each token to an object containing
-         *    offset amount and a parent token. For example, a token in an element in an array will have
-         *    {offset: 1, from: openingBracket} to indicate that the token should be offset by 1 indentation level from the opening
-         *    bracket.) All offsets are initialized to 0 at the start.
-         * 2. As the AST is traversed, modify the offsets of tokens accordingly. For example, when entering a BlockStatement, offset
-         *    all of the tokens in the BlockStatement by 1 from the opening curly brace of the BlockStatement.
-         * 3. After traversing the AST, calculate the expected indentation levels of every token in the file according to the
-         *    `desiredOffsets` map. (Note: The indentation of some tokens with the "first" option is computed a bit differently,
-         *    using the `lockedFirstTokens` map).
-         * 4. For each token, compare the expected indentation to the actual indentation in the file, and report the token if
-         *    the two values are not equal.
-         */
 
         if (context.options.length) {
             if (context.options[0] === "tab") {

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -1043,34 +1043,34 @@ module.exports = {
                         return;
                     }
 
-                    const firstTokenofLine = tokenInfo.firstTokensByLineNumber.get(lineNumber);
+                    const firstTokenOfLine = tokenInfo.firstTokensByLineNumber.get(lineNumber);
 
-                    if (firstTokenofLine.loc.start.line !== lineNumber) {
+                    if (firstTokenOfLine.loc.start.line !== lineNumber) {
 
                         // Don't check the indentation of multi-line tokens (e.g. template literals or block comments) twice.
                         return;
                     }
 
                     // If the token matches the expected expected indentation, don't report it.
-                    if (validateTokenIndent(firstTokenofLine, offsets.getDesiredIndent(firstTokenofLine))) {
+                    if (validateTokenIndent(firstTokenOfLine, offsets.getDesiredIndent(firstTokenOfLine))) {
                         return;
                     }
 
-                    if (astUtils.isCommentToken(firstTokenofLine)) {
-                        const tokenBefore = precedingTokens.get(firstTokenofLine);
+                    if (astUtils.isCommentToken(firstTokenOfLine)) {
+                        const tokenBefore = precedingTokens.get(firstTokenOfLine);
                         const tokenAfter = tokenBefore ? sourceCode.getTokenAfter(tokenBefore) : sourceCode.ast.tokens[0];
 
                         // If a comment matches the expected indentation of the token immediately before or after, don't report it.
                         if (
-                            tokenBefore && validateTokenIndent(firstTokenofLine, offsets.getDesiredIndent(tokenBefore)) ||
-                            tokenAfter && validateTokenIndent(firstTokenofLine, offsets.getDesiredIndent(tokenAfter))
+                            tokenBefore && validateTokenIndent(firstTokenOfLine, offsets.getDesiredIndent(tokenBefore)) ||
+                            tokenAfter && validateTokenIndent(firstTokenOfLine, offsets.getDesiredIndent(tokenAfter))
                         ) {
                             return;
                         }
                     }
 
                     // Otherwise, report the token/comment.
-                    report(firstTokenofLine, offsets.getDesiredIndent(firstTokenofLine));
+                    report(firstTokenOfLine, offsets.getDesiredIndent(firstTokenOfLine));
                 });
             }
 

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -82,9 +82,24 @@ class OffsetStorage {
         this.tokenInfo = tokenInfo;
         this.indentType = indentType;
         this.indentSize = indentSize;
-        this.desiredOffsets = tokenInfo.getAllTokens().reduce((map, token) => map.set(token, { offset: 0, from: null }), new WeakMap());
-        this.lockedFirstTokens = new WeakMap();
-        this.desiredIndentCache = new WeakMap();
+
+        /*
+         * desiredOffsets, lockedFirstTokens, and desiredIndentCache conceptually map tokens to something else.
+         * However, they're implemented as objects with range indices as keys because this improves performance as of Node 7.
+         * This uses the assumption that no two tokens start at the same index in the program.
+         *
+         * The values of the desiredOffsets map are objects with the schema { offset: number, from: Token|null }.
+         * These objects should not be mutated or exposed outside of OffsetStorage.
+         */
+        const NO_OFFSET = { offset: 0, from: null };
+
+        this.desiredOffsets = tokenInfo.getAllTokens().reduce((desiredOffsets, token) => {
+            desiredOffsets[token.range[0]] = NO_OFFSET;
+
+            return desiredOffsets;
+        }, Object.create(null));
+        this.lockedFirstTokens = Object.create(null);
+        this.desiredIndentCache = Object.create(null);
         this.ignoredTokens = new WeakSet();
     }
 
@@ -96,7 +111,7 @@ class OffsetStorage {
     */
     matchIndentOf(baseToken, offsetToken) {
         if (baseToken !== offsetToken) {
-            this.desiredOffsets.set(offsetToken, { offset: 0, from: baseToken });
+            this.desiredOffsets[offsetToken.range[0]] = { offset: 0, from: baseToken };
         }
     }
 
@@ -117,7 +132,7 @@ class OffsetStorage {
          * element. The desired indentation of each of these tokens is computed based on the desired indentation
          * of the "first" element, rather than through the normal offset mechanism.
          */
-        this.lockedFirstTokens.set(offsetToken, baseToken);
+        this.lockedFirstTokens[offsetToken.range[0]] = baseToken;
     }
 
     /**
@@ -131,7 +146,7 @@ class OffsetStorage {
         if (offsetFrom && token.loc.start.line === offsetFrom.loc.start.line) {
             this.matchIndentOf(offsetFrom, token);
         } else {
-            this.desiredOffsets.set(token, { offset, from: offsetFrom });
+            this.desiredOffsets[token.range[0]] = { offset, from: offsetFrom };
         }
     }
 
@@ -161,31 +176,30 @@ class OffsetStorage {
     * @returns {number} The desired indent of the token
     */
     getDesiredIndent(token) {
-        if (!this.desiredIndentCache.has(token)) {
+        if (!(token.range[0] in this.desiredIndentCache)) {
 
             if (this.ignoredTokens.has(token)) {
 
                 // If the token is ignored, use the actual indent of the token as the desired indent.
                 // This ensures that no errors are reported for this token.
-                this.desiredIndentCache.set(token, this.tokenInfo.getTokenIndent(token).length / this.indentSize);
-            } else if (this.lockedFirstTokens.has(token)) {
-                const firstToken = this.lockedFirstTokens.get(token);
+                this.desiredIndentCache[token.range[0]] = this.tokenInfo.getTokenIndent(token).length / this.indentSize;
+            } else if (token.range[0] in this.lockedFirstTokens) {
+                const firstToken = this.lockedFirstTokens[token.range[0]];
 
-                this.desiredIndentCache.set(token,
+                this.desiredIndentCache[token.range[0]] =
 
                     // (indentation for the first element's line)
                     this.getDesiredIndent(this.tokenInfo.getFirstTokenOfLine(firstToken)) +
 
                         // (space between the start of the first element's line and the first element)
-                        (firstToken.loc.start.column - this.tokenInfo.getFirstTokenOfLine(firstToken).loc.start.column) / this.indentSize
-                );
+                        (firstToken.loc.start.column - this.tokenInfo.getFirstTokenOfLine(firstToken).loc.start.column) / this.indentSize;
             } else {
-                const offsetInfo = this.desiredOffsets.get(token);
+                const offsetInfo = this.desiredOffsets[token.range[0]];
 
-                this.desiredIndentCache.set(token, offsetInfo.offset + (offsetInfo.from ? this.getDesiredIndent(offsetInfo.from) : 0));
+                this.desiredIndentCache[token.range[0]] = offsetInfo.offset + (offsetInfo.from ? this.getDesiredIndent(offsetInfo.from) : 0);
             }
         }
-        return this.desiredIndentCache.get(token);
+        return this.desiredIndentCache[token.range[0]];
     }
 
     /**
@@ -205,7 +219,7 @@ class OffsetStorage {
      * @returns {Token} The token that the given token depends on, or `null` if the given token is at the top level
      */
     getFirstDependency(token) {
-        return this.desiredOffsets.get(token).from;
+        return this.desiredOffsets[token.range[0]].from;
     }
 
     /**
@@ -215,9 +229,9 @@ class OffsetStorage {
      * @returns {void}
      */
     increaseOffset(token, amount) {
-        const currentOffsetInfo = this.desiredOffsets.get(token);
+        const currentOffsetInfo = this.desiredOffsets[token.range[0]];
 
-        this.desiredOffsets.set(token, { offset: currentOffsetInfo.offset + amount, from: currentOffsetInfo.from });
+        this.desiredOffsets[token.range[0]] = { offset: currentOffsetInfo.offset + amount, from: currentOffsetInfo.from };
     }
 }
 

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -468,7 +468,10 @@ module.exports = {
             context.report({
                 node: token,
                 message: createErrorMessage(neededChars, numSpaces, numTabs),
-                loc: { line: token.loc.start.line, column: token.loc.start.column },
+                loc: {
+                    start: { line: token.loc.start.line, column: 0 },
+                    end: { line: token.loc.start.line, column: token.loc.start.column }
+                },
                 fix(fixer) {
                     const range = [token.range[0] - token.loc.start.column, token.range[0]];
                     const newText = (indentType === "space" ? " " : "\t").repeat(neededChars);

--- a/lib/rules/newline-before-return.js
+++ b/lib/rules/newline-before-return.js
@@ -50,8 +50,8 @@ module.exports = {
 
             if (node.parent.body) {
                 return Array.isArray(node.parent.body)
-                  ? node.parent.body[0] === node
-                  : node.parent.body === node;
+                    ? node.parent.body[0] === node
+                    : node.parent.body === node;
             }
 
             if (parentType === "IfStatement") {

--- a/lib/rules/no-inner-declarations.js
+++ b/lib/rules/no-inner-declarations.js
@@ -64,10 +64,8 @@ module.exports = {
 
             if (!valid) {
                 context.report({ node, message: "Move {{type}} declaration to {{body}} root.", data: {
-                    type: (node.type === "FunctionDeclaration"
-                            ? "function" : "variable"),
-                    body: (body.type === "Program"
-                            ? "program" : "function body")
+                    type: (node.type === "FunctionDeclaration" ? "function" : "variable"),
+                    body: (body.type === "Program" ? "program" : "function body")
                 } });
             }
         }

--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -413,7 +413,7 @@ class RuleTester {
             const messages = result.messages;
 
             assert.equal(messages.length, 0, util.format("Should have no errors but had %d: %s",
-                        messages.length, util.inspect(messages)));
+                messages.length, util.inspect(messages)));
 
             assertASTDidntChange(result.beforeAST, result.afterAST);
         }
@@ -461,9 +461,13 @@ class RuleTester {
                 assert.equal(messages.length, item.errors, util.format("Should have %d error%s but had %d: %s",
                     item.errors, item.errors === 1 ? "" : "s", messages.length, util.inspect(messages)));
             } else {
-                assert.equal(messages.length, item.errors.length,
-                    util.format("Should have %d error%s but had %d: %s",
-                    item.errors.length, item.errors.length === 1 ? "" : "s", messages.length, util.inspect(messages)));
+                assert.equal(
+                    messages.length, item.errors.length,
+                    util.format(
+                        "Should have %d error%s but had %d: %s",
+                        item.errors.length, item.errors.length === 1 ? "" : "s", messages.length, util.inspect(messages)
+                    )
+                );
 
                 for (let i = 0, l = item.errors.length; i < l; i++) {
                     assert.ok(!("fatal" in messages[i]), `A fatal parsing error occurred: ${messages[i].message}`);

--- a/tests/bin/eslint.js
+++ b/tests/bin/eslint.js
@@ -156,9 +156,9 @@ describe("bin/eslint.js", () => {
                     assert.isTrue(fs.existsSync(CACHE_PATH), "Cache file should exist at the given location");
 
                     assert.doesNotThrow(
-                      () => JSON.parse(fs.readFileSync(CACHE_PATH, "utf8")),
-                      SyntaxError,
-                      "Cache file should contain valid JSON"
+                        () => JSON.parse(fs.readFileSync(CACHE_PATH, "utf8")),
+                        SyntaxError,
+                        "Cache file should contain valid JSON"
                     );
                 });
             });
@@ -224,9 +224,9 @@ describe("bin/eslint.js", () => {
                 return assertExitCode(child, 0).then(() => {
                     assert.isTrue(fs.existsSync(CACHE_PATH), "Cache file should exist at the given location");
                     assert.doesNotThrow(
-                      () => JSON.parse(fs.readFileSync(CACHE_PATH, "utf8")),
-                      SyntaxError,
-                      "Cache file should contain valid JSON"
+                        () => JSON.parse(fs.readFileSync(CACHE_PATH, "utf8")),
+                        SyntaxError,
+                        "Cache file should contain valid JSON"
                     );
                 });
             });

--- a/tests/fixtures/rules/indent/indent-invalid-fixture-1.js
+++ b/tests/fixtures/rules/indent/indent-invalid-fixture-1.js
@@ -3,7 +3,7 @@ if (a) {
   var d = e
     * f;
     var e = f; // <-
-// NO ERROR: DON'T VALIDATE EMPTY OR COMMENT ONLY LINES
+// ->
   function g() {
     if (h) {
       var i = j;
@@ -26,7 +26,7 @@ if (a) {
     u++;
   }
 
-    for (;;) { // <- Fix this when issue #3737 gets resolved
+    for (;;) {
       v++; // <-
   }
 
@@ -43,7 +43,7 @@ if (a) {
 /**/var b; // NO ERROR: single line multi-line comments followed by code is OK
 /*
  *
- */ var b; // ERROR: multi-line comments followed by code is not OK
+ */ var b; // NO ERROR: multi-line comments followed by code is OK
 
 var arr = [
   a,
@@ -141,16 +141,16 @@ a.b('hi')
 if ( a ) {
   if ( b ) {
 d.e(f) // ->
-  .g() // NO ERROR: DON'T VALIDATE MULTILINE STATEMENTS
-  .h(); // NO ERROR: DON'T VALIDATE MULTILINE STATEMENTS
+  .g() // ->
+  .h(); // ->
 
     i.j(m)
       .k() // NO ERROR: DON'T VALIDATE MULTILINE STATEMENTS
       .l(); // NO ERROR: DON'T VALIDATE MULTILINE STATEMENTS
 
       n.o(p) // <-
-        .q() // NO ERROR: DON'T VALIDATE MULTILINE STATEMENTS
-        .r(); // NO ERROR: DON'T VALIDATE MULTILINE STATEMENTS
+        .q() // <-
+        .r(); // <-
   }
 }
 
@@ -189,7 +189,7 @@ if ( a
 var x; // ->
   var c,
     d = function(a,
-                  b) {
+                  b) { // <-
     a; // ->
       b;
         c; // <-
@@ -224,11 +224,11 @@ a(
 a({ d: 1 });
 
 aa(
-   b({ // NO ERROR: aligned with previous opening paren
-     c: d,
+   b({ // NO ERROR: CallExpression args not linted by default
+    c: d, // ->
      e: f,
      f: g
-   })
+  }) // ->
 );
 
 aaaaaa(
@@ -242,10 +242,10 @@ aaaaaa(
 a(b, c,
   d, e,
     f, g  // NO ERROR: alignment of arguments of callExpression not checked
-  );  // NO ERROR: this has nothing to do with indentation, this is CallExpression spacing
+  );  // <-
 
 a(
-  ); // NO ERROR: this has nothing to do with indentation, this is CallExpression spacing
+  ); // <-
 
 aaaaaa(
   b,
@@ -293,7 +293,7 @@ $(b)
 
 a
   .b('c',
-           'd'); // NO ERROR: this has nothing to do with indentation, this is CallExpression spacing
+           'd'); // NO ERROR: CallExpression args not linted by default
 
 a
   .b('c', [ 'd', function(e) {
@@ -415,7 +415,7 @@ a( "very very long multi line" +
   b();
 a(); // ->
     c(); // <-
-});
+    }); // <-
 
 a = function(content, dom) {
   b();
@@ -439,9 +439,9 @@ b(); // ->
 
 a('This is a terribly long description youll ' +
   'have to read', function () {
-  b();
-  c();
-});
+    b(); // <-
+    c(); // <-
+  }); // <-
 
 if (
   array.some(function(){
@@ -496,8 +496,8 @@ function test() {
 function a(b) {
   switch(x) {
     case 1:
-        {
-        a();
+        { // <-
+      a(); // ->
       }
       break;
     default:

--- a/tests/fixtures/rules/indent/indent-valid-fixture-1.js
+++ b/tests/fixtures/rules/indent/indent-valid-fixture-1.js
@@ -3,7 +3,7 @@ if (a) {
   var d = e
     * f;
   var e = f; // <-
-// NO ERROR: DON'T VALIDATE EMPTY OR COMMENT ONLY LINES
+  // ->
   function g() {
     if (h) {
       var i = j;
@@ -26,9 +26,9 @@ if (a) {
     u++;
   }
 
-  for (;;) { // <- Fix this when issue #3737 gets resolved
-      v++; // <-
-    }
+  for (;;) {
+    v++; // <-
+  }
 
   if ( w ) {
     x++;
@@ -43,7 +43,7 @@ if (a) {
 /**/var b; // NO ERROR: single line multi-line comments followed by code is OK
 /*
  *
-*/ var b; // ERROR: multi-line comments followed by code is not OK
+ */ var b; // NO ERROR: multi-line comments followed by code is OK
 
 var arr = [
   a,
@@ -141,16 +141,16 @@ a.b('hi')
 if ( a ) {
   if ( b ) {
     d.e(f) // ->
-  .g() // NO ERROR: DON'T VALIDATE MULTILINE STATEMENTS
-  .h(); // NO ERROR: DON'T VALIDATE MULTILINE STATEMENTS
+      .g() // ->
+      .h(); // ->
 
     i.j(m)
       .k() // NO ERROR: DON'T VALIDATE MULTILINE STATEMENTS
       .l(); // NO ERROR: DON'T VALIDATE MULTILINE STATEMENTS
 
     n.o(p) // <-
-        .q() // NO ERROR: DON'T VALIDATE MULTILINE STATEMENTS
-        .r(); // NO ERROR: DON'T VALIDATE MULTILINE STATEMENTS
+      .q() // <-
+      .r(); // <-
   }
 }
 
@@ -189,7 +189,7 @@ if ( a
   var x; // ->
   var c,
     d = function(a,
-                  b) {
+      b) { // <-
       a; // ->
       b;
       c; // <-
@@ -224,11 +224,11 @@ a(
 a({ d: 1 });
 
 aa(
-   b({ // NO ERROR: aligned with previous opening paren
-     c: d,
+   b({ // NO ERROR: CallExpression args not linted by default
+     c: d, // ->
      e: f,
      f: g
-   })
+   }) // ->
 );
 
 aaaaaa(
@@ -242,10 +242,10 @@ aaaaaa(
 a(b, c,
   d, e,
     f, g  // NO ERROR: alignment of arguments of callExpression not checked
-  );  // NO ERROR: this has nothing to do with indentation, this is CallExpression spacing
+);  // <-
 
 a(
-  ); // NO ERROR: this has nothing to do with indentation, this is CallExpression spacing
+); // <-
 
 aaaaaa(
   b,
@@ -293,7 +293,7 @@ $(b)
 
 a
   .b('c',
-           'd'); // NO ERROR: this has nothing to do with indentation, this is CallExpression spacing
+           'd'); // NO ERROR: CallExpression args not linted by default
 
 a
   .b('c', [ 'd', function(e) {
@@ -415,7 +415,7 @@ a( "very very long multi line" +
   b();
   a(); // ->
   c(); // <-
-});
+}); // <-
 
 a = function(content, dom) {
   b();
@@ -439,9 +439,9 @@ a = function(content, dom) {
 
 a('This is a terribly long description youll ' +
   'have to read', function () {
-  b();
-  c();
-});
+  b(); // <-
+  c(); // <-
+}); // <-
 
 if (
   array.some(function(){
@@ -496,14 +496,14 @@ function test() {
 function a(b) {
   switch(x) {
     case 1:
-      {
-          a();
-        }
+      { // <-
+        a(); // ->
+      }
       break;
     default:
-      {
-        b();
-      }
+    {
+      b();
+    }
   }
 }
 

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -1415,7 +1415,7 @@ describe("CLIEngine", () => {
                 assert.equal(report.results[0].messages[0].severity, 1);
             });
 
-             // Project configuration - second level package.json
+            // Project configuration - second level package.json
             it("should return zero messages when executing with local package.json that overrides parent package.json", () => {
 
                 engine = new CLIEngine({

--- a/tests/lib/code-path-analysis/code-path-analyzer.js
+++ b/tests/lib/code-path-analysis/code-path-analyzer.js
@@ -476,7 +476,7 @@ describe("CodePathAnalyzer", () => {
 
                     if (count === 1) {
 
-                            // connect path: "update" -> "test"
+                        // connect path: "update" -> "test"
                         assert(node.parent.type === "ForStatement");
                     } else if (count === 2) {
                         assert(node.type === "ForStatement");
@@ -502,7 +502,7 @@ describe("CodePathAnalyzer", () => {
 
                     if (count === 1) {
 
-                            // connect path: "right" -> "left"
+                        // connect path: "right" -> "left"
                         assert(node.parent.type === "ForInStatement");
                     } else if (count === 2) {
                         assert(node.type === "ForInStatement");
@@ -528,7 +528,7 @@ describe("CodePathAnalyzer", () => {
 
                     if (count === 1) {
 
-                            // connect path: "right" -> "left"
+                        // connect path: "right" -> "left"
                         assert(node.parent.type === "ForOfStatement");
                     } else if (count === 2) {
                         assert(node.type === "ForOfStatement");

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -2901,8 +2901,7 @@ describe("eslint", () => {
             assert.equal(messages[0].ruleId, "no-alert");
         });
 
-        it("should report a violation for global variable declarations",
-        () => {
+        it("should report a violation for global variable declarations", () => {
             const code = [
                 "/* global foo */"
             ].join("\n");

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -3026,6 +3026,14 @@ ruleTester.run("indent", rule, {
                 ];
             `,
             options: [4, { MemberExpression: 1 }]
+        },
+        {
+            code: unIndent`
+                if (foo)
+                    bar;
+                else if (baz)
+                    qux;
+            `
         }
     ],
 

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -3034,6 +3034,13 @@ ruleTester.run("indent", rule, {
                 else if (baz)
                     qux;
             `
+        },
+        {
+            code: unIndent`
+                if (foo) bar()
+
+                ; [1, 2, 3].map(baz)
+            `
         }
     ],
 
@@ -6211,6 +6218,19 @@ ruleTester.run("indent", rule, {
             `,
             options: [2, { CallExpression: { arguments: "first" } }],
             errors: expectedErrors([[2, 2, 24, "Identifier"], [3, 2, 24, "Identifier"]])
+        },
+        {
+            code: unIndent`
+                if (foo) bar()
+
+                    ; [1, 2, 3].map(baz)
+            `,
+            output: unIndent`
+                if (foo) bar()
+
+                ; [1, 2, 3].map(baz)
+            `,
+            errors: expectedErrors([3, 0, 4, "Punctuator"])
         }
     ]
 });

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -52,1776 +52,2359 @@ function expectedErrors(indentType, errors) {
     });
 }
 
+/**
+* Prevents leading spaces in a multiline template literal from appearing in the resulting string
+* @param {string[]} strings The strings in the template literal
+* @returns {string} The template literal, with spaces removed from all lines
+*/
+function unIndent(strings) {
+    const templateValue = strings[0];
+    const lines = templateValue.replace(/^\n/, "").replace(/\n\s*$/, "").split("\n");
+    const lineIndents = lines.filter(line => line.trim()).map(line => line.match(/ */)[0].length);
+    const minLineIndent = Math.min.apply(null, lineIndents);
+
+    return lines.map(line => line.slice(minLineIndent)).join("\n");
+}
+
 const ruleTester = new RuleTester();
 
 ruleTester.run("indent", rule, {
     valid: [
         {
-            code:
-            "bridge.callHandler(\n" +
-            "  'getAppVersion', 'test23', function(responseData) {\n" +
-            "    window.ah.mobileAppVersion = responseData;\n" +
-            "  }\n" +
-            ");\n",
+            code: unIndent`
+                bridge.callHandler(
+                  'getAppVersion', 'test23', function(responseData) {
+                    window.ah.mobileAppVersion = responseData;
+                  }
+                );
+            `,
             options: [2]
         },
         {
-            code:
-            "var a = [\n" +
-            "  , /*{\n" +
-            "  }, */{\n" +
-            "    name: 'foo',\n" +
-            "  }\n" +
-            "];\n",
+            code: unIndent`
+                bridge.callHandler(
+                  'getAppVersion', 'test23', function(responseData) {
+                    window.ah.mobileAppVersion = responseData;
+                  });
+            `,
             options: [2]
         },
         {
-            code:
-            "bridge.callHandler(\n" +
-            "  'getAppVersion', 'test23', function(responseData) {\n" +
-            "    window.ah.mobileAppVersion = responseData;\n" +
-            "  });\n",
+            code: unIndent`
+                bridge.callHandler(
+                  'getAppVersion',
+                  null,
+                  function responseCallback(responseData) {
+                    window.ah.mobileAppVersion = responseData;
+                  }
+                );
+            `,
             options: [2]
         },
         {
-            code:
-            "bridge.callHandler(\n" +
-            "  'getAppVersion',\n" +
-            "  null,\n" +
-            "  function responseCallback(responseData) {\n" +
-            "    window.ah.mobileAppVersion = responseData;\n" +
-            "  }\n" +
-            ");\n",
+            code: unIndent`
+                bridge.callHandler(
+                  'getAppVersion',
+                  null,
+                  function responseCallback(responseData) {
+                    window.ah.mobileAppVersion = responseData;
+                  });
+            `,
             options: [2]
         },
         {
-            code:
-            "bridge.callHandler(\n" +
-            "  'getAppVersion',\n" +
-            "  null,\n" +
-            "  function responseCallback(responseData) {\n" +
-            "    window.ah.mobileAppVersion = responseData;\n" +
-            "  });\n",
-            options: [2]
-        },
-        {
-            code:
-            "function doStuff(keys) {\n" +
-            "    _.forEach(\n" +
-            "        keys,\n" +
-            "        key => {\n" +
-            "            doSomething(key);\n" +
-            "        }\n" +
-            "   );\n" +
-            "}\n",
+            code: unIndent`
+                function doStuff(keys) {
+                    _.forEach(
+                        keys,
+                        key => {
+                            doSomething(key);
+                        }
+                    );
+                }
+            `,
             options: [4],
             parserOptions: { ecmaVersion: 6 }
         },
         {
-            code:
-            "example(\n" +
-            "    function () {\n" +
-            "        console.log('example');\n" +
-            "    }\n" +
-            ");\n",
+            code: unIndent`
+                example(
+                    function () {
+                        console.log('example');
+                    }
+                );
+            `,
             options: [4]
         },
         {
-            code:
-            "let foo = somethingList\n" +
-            "    .filter(x => {\n" +
-            "        return x;\n" +
-            "    })\n" +
-            "    .map(x => {\n" +
-            "        return 100 * x;\n" +
-            "    });\n",
+            code: unIndent`
+                let foo = somethingList
+                    .filter(x => {
+                        return x;
+                    })
+                    .map(x => {
+                        return 100 * x;
+                    });
+            `,
             options: [4],
             parserOptions: { ecmaVersion: 6 }
         },
         {
-            code:
-            "var x = 0 &&\n" +
-            "    {\n" +
-            "        a: 1,\n" +
-            "        b: 2\n" +
-            "    };",
+            code: unIndent`
+                var x = 0 &&
+                    {
+                        a: 1,
+                        b: 2
+                    };
+            `,
             options: [4]
         },
         {
-            code:
-            "var x = 0 &&\n" +
-            "\t{\n" +
-            "\t\ta: 1,\n" +
-            "\t\tb: 2\n" +
-            "\t};",
+            code: unIndent`
+                var x = 0 &&
+                \t{
+                \t\ta: 1,
+                \t\tb: 2
+                \t};
+            `,
             options: ["tab"]
         },
         {
-            code:
-            "var x = 0 &&\n" +
-            "    {\n" +
-            "        a: 1,\n" +
-            "        b: 2\n" +
-            "    }||\n" +
-            "    {\n" +
-            "        c: 3,\n" +
-            "        d: 4\n" +
-            "    };",
+            code: unIndent`
+                var x = 0 &&
+                    {
+                        a: 1,
+                        b: 2
+                    }||
+                    {
+                        c: 3,
+                        d: 4
+                    };
+            `,
             options: [4]
         },
         {
-            code:
-            "var x = [\n" +
-            "    'a',\n" +
-            "    'b',\n" +
-            "    'c'\n" +
-            "];",
+            code: unIndent`
+                var x = [
+                    'a',
+                    'b',
+                    'c'
+                ];
+            `,
             options: [4]
         },
         {
-            code:
-            "var x = ['a',\n" +
-            "    'b',\n" +
-            "    'c',\n" +
-            "];",
+            code: unIndent`
+                var x = ['a',
+                    'b',
+                    'c',
+                ];
+            `,
             options: [4]
         },
         {
-            code:
-            "var x = 0 && 1;",
+            code: "var x = 0 && 1;",
             options: [4]
         },
         {
-            code:
-            "var x = 0 && { a: 1, b: 2 };",
+            code: "var x = 0 && { a: 1, b: 2 };",
             options: [4]
         },
         {
-            code:
-            "var x = 0 &&\n" +
-            "    (\n" +
-            "        1\n" +
-            "    );",
+            code: unIndent`
+                var x = 0 &&
+                    (
+                        1
+                    );
+            `,
             options: [4]
         },
         {
-            code:
-            "var x = 0 && { a: 1, b: 2 };",
+            code: "var x = 0 && { a: 1, b: 2 };",
             options: [4]
         },
         {
-            code:
-            "require('http').request({hostname: 'localhost',\n" +
-            "  port: 80}, function(res) {\n" +
-            "  res.end();\n" +
-            "});\n",
+            code: unIndent`
+                require('http').request({hostname: 'localhost',
+                  port: 80}, function(res) {
+                  res.end();
+                });
+            `,
             options: [2]
         },
         {
-            code:
-            "function test() {\n" +
-            "  return client.signUp(email, PASSWORD, { preVerified: true })\n" +
-            "    .then(function (result) {\n" +
-            "      // hi\n" +
-            "    })\n" +
-            "    .then(function () {\n" +
-            "      return FunctionalHelpers.clearBrowserState(self, {\n" +
-            "        contentServer: true,\n" +
-            "        contentServer1: true\n" +
-            "      });\n" +
-            "    });\n" +
-            "}",
+            code: unIndent`
+                function test() {
+                  return client.signUp(email, PASSWORD, { preVerified: true })
+                    .then(function (result) {
+                      // hi
+                    })
+                    .then(function () {
+                      return FunctionalHelpers.clearBrowserState(self, {
+                        contentServer: true,
+                        contentServer1: true
+                      });
+                    });
+                }
+            `,
             options: [2]
         },
         {
-            code:
-            "it('should... some lengthy test description that is forced to be' +\n" +
-            "  'wrapped into two lines since the line length limit is set', () => {\n" +
-            "  expect(true).toBe(true);\n" +
-            "});\n",
+            code: unIndent`
+                it('should... some lengthy test description that is forced to be' +
+                  'wrapped into two lines since the line length limit is set', () => {
+                  expect(true).toBe(true);
+                });
+            `,
             options: [2],
             parserOptions: { ecmaVersion: 6 }
         },
         {
-            code:
-            "function test() {\n" +
-            "    return client.signUp(email, PASSWORD, { preVerified: true })\n" +
-            "        .then(function (result) {\n" +
-            "            var x = 1;\n" +
-            "            var y = 1;\n" +
-            "        }, function(err){\n" +
-            "            var o = 1 - 2;\n" +
-            "            var y = 1 - 2;\n" +
-            "            return true;\n" +
-            "        })\n" +
-            "}",
+            code: unIndent`
+                function test() {
+                    return client.signUp(email, PASSWORD, { preVerified: true })
+                        .then(function (result) {
+                            var x = 1;
+                            var y = 1;
+                        }, function(err){
+                            var o = 1 - 2;
+                            var y = 1 - 2;
+                            return true;
+                        })
+                }
+            `,
             options: [4]
         },
         {
-            code:
-            "function test() {\n" +
-            "    return client.signUp(email, PASSWORD, { preVerified: true })\n" +
-            "    .then(function (result) {\n" +
-            "        var x = 1;\n" +
-            "        var y = 1;\n" +
-            "    }, function(err){\n" +
-            "        var o = 1 - 2;\n" +
-            "        var y = 1 - 2;\n" +
-            "        return true;\n" +
-            "    });\n" +
-            "}",
+            code: unIndent`
+                function test() {
+                    return client.signUp(email, PASSWORD, { preVerified: true })
+                    .then(function (result) {
+                        var x = 1;
+                        var y = 1;
+                    }, function(err){
+                        var o = 1 - 2;
+                        var y = 1 - 2;
+                        return true;
+                    });
+                }
+            `,
             options: [4, { MemberExpression: 0 }]
         },
 
         {
-            code:
-            "// hi",
+            code: "// hi",
             options: [2, { VariableDeclarator: 1, SwitchCase: 1 }]
         },
         {
-            code:
-            "var Command = function() {\n" +
-            "  var fileList = [],\n" +
-            "      files = []\n" +
-            "\n" +
-            "  files.concat(fileList)\n" +
-            "};\n",
+            code: unIndent`
+                var Command = function() {
+                  var fileList = [],
+                      files = []
+
+                  files.concat(fileList)
+                };
+            `,
             options: [2, { VariableDeclarator: { var: 2, let: 2, const: 3 } }]
         },
         {
-            code:
-                "  ",
+            code: "  ",
             options: [2, { VariableDeclarator: 1, SwitchCase: 1 }]
         },
         {
-            code:
-            "if(data) {\n" +
-            "  console.log('hi');\n" +
-            "  b = true;};",
+            code: unIndent`
+                if(data) {
+                  console.log('hi');
+                  b = true;};
+            `,
             options: [2, { VariableDeclarator: 1, SwitchCase: 1 }]
         },
         {
-            code:
-            "foo = () => {\n" +
-            "  console.log('hi');\n" +
-            "  return true;};",
+            code: unIndent`
+                foo = () => {
+                  console.log('hi');
+                  return true;};
+            `,
             options: [2, { VariableDeclarator: 1, SwitchCase: 1 }],
             parserOptions: { ecmaVersion: 6 }
         },
         {
-            code:
-            "function test(data) {\n" +
-            "  console.log('hi');\n" +
-            "  return true;};",
+            code: unIndent`
+                function test(data) {
+                  console.log('hi');
+                  return true;};
+            `,
             options: [2, { VariableDeclarator: 1, SwitchCase: 1 }]
         },
         {
-            code:
-            "var test = function(data) {\n" +
-            "  console.log('hi');\n" +
-            "};",
+            code: unIndent`
+                var test = function(data) {
+                  console.log('hi');
+                };
+            `,
             options: [2, { VariableDeclarator: 1, SwitchCase: 1 }]
         },
         {
-            code:
-            "arr.forEach(function(data) {\n" +
-            "  otherdata.forEach(function(zero) {\n" +
-            "    console.log('hi');\n" +
-            "  }) });",
+            code: unIndent`
+                arr.forEach(function(data) {
+                  otherdata.forEach(function(zero) {
+                    console.log('hi');
+                  }) });
+            `,
             options: [2, { VariableDeclarator: 1, SwitchCase: 1 }]
         },
         {
-            code:
-            "a = [\n" +
-            "    ,3\n" +
-            "]",
+            code: unIndent`
+                a = [
+                    ,3
+                ]
+            `,
             options: [4, { VariableDeclarator: 1, SwitchCase: 1 }]
         },
         {
-            code:
-            "[\n" +
-            "  ['gzip', 'gunzip'],\n" +
-            "  ['gzip', 'unzip'],\n" +
-            "  ['deflate', 'inflate'],\n" +
-            "  ['deflateRaw', 'inflateRaw'],\n" +
-            "].forEach(function(method) {\n" +
-            "  console.log(method);\n" +
-            "});\n",
+            code: unIndent`
+                [
+                  ['gzip', 'gunzip'],
+                  ['gzip', 'unzip'],
+                  ['deflate', 'inflate'],
+                  ['deflateRaw', 'inflateRaw'],
+                ].forEach(function(method) {
+                  console.log(method);
+                });
+            `,
             options: [2, { SwitchCase: 1, VariableDeclarator: 2 }]
         },
         {
-            code:
-            "test(123, {\n" +
-            "    bye: {\n" +
-            "        hi: [1,\n" +
-            "            {\n" +
-            "                b: 2\n" +
-            "            }\n" +
-            "        ]\n" +
-            "    }\n" +
-            "});",
+            code: unIndent`
+                test(123, {
+                    bye: {
+                        hi: [1,
+                            {
+                                b: 2
+                            }
+                        ]
+                    }
+                });
+            `,
             options: [4, { VariableDeclarator: 1, SwitchCase: 1 }]
         },
         {
-            code:
-            "var xyz = 2,\n" +
-            "    lmn = [\n" +
-            "        {\n" +
-            "            a: 1\n" +
-            "        }\n" +
-            "    ];",
+            code: unIndent`
+                var xyz = 2,
+                    lmn = [
+                        {
+                            a: 1
+                        }
+                    ];
+            `,
             options: [4, { VariableDeclarator: 1, SwitchCase: 1 }]
         },
         {
-            code:
-            "lmn = [{\n" +
-            "    a: 1\n" +
-            "},\n" +
-            "{\n" +
-            "    b: 2\n" +
-            "}," +
-            "{\n" +
-            "    x: 2\n" +
-            "}];",
+            code: unIndent`
+                lmnn = [{
+                    a: 1
+                },
+                {
+                    b: 2
+                }, {
+                    x: 2
+                }];
+            `,
             options: [4, { VariableDeclarator: 1, SwitchCase: 1 }]
         },
         {
-            code:
-            "abc({\n" +
-            "    test: [\n" +
-            "        [\n" +
-            "            c,\n" +
-            "            xyz,\n" +
-            "            2\n" +
-            "        ].join(',')\n" +
-            "    ]\n" +
-            "});",
+            code: unIndent`
+                [{
+                    foo: 1
+                }, {
+                    foo: 2
+                }, {
+                    foo: 3
+                }]
+            `
+        },
+        {
+            code: unIndent`
+                foo([
+                    bar
+                ], [
+                    baz
+                ], [
+                    qux
+                ]);
+            `
+        },
+        {
+            code: unIndent`
+                abc({
+                    test: [
+                        [
+                            c,
+                            xyz,
+                            2
+                        ].join(',')
+                    ]
+                });
+            `,
             options: [4, { VariableDeclarator: 1, SwitchCase: 1 }]
         },
         {
-            code:
-            "abc = {\n" +
-            "  test: [\n" +
-            "    [\n" +
-            "      c,\n" +
-            "      xyz,\n" +
-            "      2\n" +
-            "    ]\n" +
-            "  ]\n" +
-            "};",
+            code: unIndent`
+                abc = {
+                  test: [
+                    [
+                      c,
+                      xyz,
+                      2
+                    ]
+                  ]
+                };
+            `,
             options: [2, { VariableDeclarator: 1, SwitchCase: 1 }]
         },
         {
-            code:
-            "abc(\n" +
-            "  {\n" +
-            "    a: 1,\n" +
-            "    b: 2\n" +
-            "  }\n" +
-            ");",
+            code: unIndent`
+                abc(
+                  {
+                    a: 1,
+                    b: 2
+                  }
+                );
+            `,
             options: [2, { VariableDeclarator: 1, SwitchCase: 1 }]
         },
         {
-            code:
-            "abc({\n" +
-            "    a: 1,\n" +
-            "    b: 2\n" +
-            "});",
+            code: unIndent`
+                abc({
+                    a: 1,
+                    b: 2
+                });
+            `,
             options: [4, { VariableDeclarator: 1, SwitchCase: 1 }]
         },
         {
-            code:
-            "var abc = \n" +
-            "  [\n" +
-            "    c,\n" +
-            "    xyz,\n" +
-            "    {\n" +
-            "      a: 1,\n" +
-            "      b: 2\n" +
-            "    }\n" +
-            "  ];",
+            code: unIndent`
+                var abc =
+                  [
+                    c,
+                    xyz,
+                    {
+                      a: 1,
+                      b: 2
+                    }
+                  ];
+            `,
             options: [2, { VariableDeclarator: 1, SwitchCase: 1 }]
         },
         {
-            code:
-            "var abc = [\n" +
-            "  c,\n" +
-            "  xyz,\n" +
-            "  {\n" +
-            "    a: 1,\n" +
-            "    b: 2\n" +
-            "  }\n" +
-            "];",
+            code: unIndent`
+                var abc = [
+                  c,
+                  xyz,
+                  {
+                    a: 1,
+                    b: 2
+                  }
+                ];
+            `,
             options: [2, { VariableDeclarator: 1, SwitchCase: 1 }]
         },
         {
-            code:
-            "var abc = 5,\n" +
-            "    c = 2,\n" +
-            "    xyz = \n" +
-            "    {\n" +
-            "      a: 1,\n" +
-            "      b: 2\n" +
-            "    };",
+            code: unIndent`
+                var abc = 5,
+                    c = 2,
+                    xyz =
+                    {
+                      a: 1,
+                      b: 2
+                    };
+            `,
             options: [2, { VariableDeclarator: 2, SwitchCase: 1 }]
         },
         {
-            code:
-            "var abc = \n" +
-            "    {\n" +
-            "      a: 1,\n" +
-            "      b: 2\n" +
-            "    };",
-            options: [2, { VariableDeclarator: 2, SwitchCase: 1 }]
-        },
-        {
-            code:
-            "var a = new abc({\n" +
-            "        a: 1,\n" +
-            "        b: 2\n" +
-            "    }),\n" +
-            "    b = 2;",
-            options: [4, { VariableDeclarator: 1, SwitchCase: 1 }]
-        },
-        {
-            code:
-            "var a = 2,\n" +
-            "  c = {\n" +
-            "    a: 1,\n" +
-            "    b: 2\n" +
-            "  },\n" +
-            "  b = 2;",
-            options: [2, { VariableDeclarator: 1, SwitchCase: 1 }]
-        },
-        {
-            code:
-            "var x = 2,\n" +
-            "    y = {\n" +
-            "      a: 1,\n" +
-            "      b: 2\n" +
-            "    },\n" +
-            "    b = 2;",
-            options: [2, { VariableDeclarator: 2, SwitchCase: 1 }]
-        },
-        {
-            code:
-            "var e = {\n" +
-            "      a: 1,\n" +
-            "      b: 2\n" +
-            "    },\n" +
-            "    b = 2;",
-            options: [2, { VariableDeclarator: 2, SwitchCase: 1 }]
-        },
-        {
-            code:
-            "var a = {\n" +
-            "  a: 1,\n" +
-            "  b: 2\n" +
-            "};",
-            options: [2, { VariableDeclarator: 2, SwitchCase: 1 }]
-        },
-        {
-            code:
-            "function test() {\n" +
-            "  if (true ||\n " +
-            "            false){\n" +
-            "    console.log(val);\n" +
-            "  }\n" +
-            "}",
-            options: [2, { VariableDeclarator: 2, SwitchCase: 1 }]
-        },
-        {
-            code:
-            "for (var val in obj)\n" +
-            "  if (true)\n" +
-            "    console.log(val);",
-            options: [2, { VariableDeclarator: 2, SwitchCase: 1 }]
-        },
-        {
-            code:
-            "if(true)\n" +
-            "  if (true)\n" +
-            "    if (true)\n" +
-            "      console.log(val);",
-            options: [2, { VariableDeclarator: 2, SwitchCase: 1 }]
-        },
-        {
-            code:
-            "function hi(){     var a = 1;\n" +
-            "  y++;                   x++;\n" +
-            "}",
-            options: [2, { VariableDeclarator: 2, SwitchCase: 1 }]
-        },
-        {
-            code:
-            "for(;length > index; index++)if(NO_HOLES || index in self){\n" +
-            "  x++;\n" +
-            "}",
-            options: [2, { VariableDeclarator: 2, SwitchCase: 1 }]
-        },
-        {
-            code:
-            "function test(){\n" +
-            "  switch(length){\n" +
-            "    case 1: return function(a){\n" +
-            "      return fn.call(that, a);\n" +
-            "    };\n" +
-            "  }\n" +
-            "}",
-            options: [2, { VariableDeclarator: 2, SwitchCase: 1 }]
-        },
-        {
-            code:
-            "var geometry = 2,\n" +
-            "rotate = 2;",
-            options: [2, { VariableDeclarator: 0 }]
-        },
-        {
-            code:
-            "var geometry,\n" +
-            "    rotate;",
-            options: [4, { VariableDeclarator: 1 }]
-        },
-        {
-            code:
-            "var geometry,\n" +
-            "\trotate;",
-            options: ["tab", { VariableDeclarator: 1 }]
-        },
-        {
-            code:
-            "var geometry,\n" +
-            "  rotate;",
+            code: unIndent`
+                var foo = 1,
+                  bar =
+                    2
+            `,
             options: [2, { VariableDeclarator: 1 }]
         },
         {
-            code:
-            "var geometry,\n" +
-            "    rotate;",
+            code: unIndent`
+                var foo = 1,
+                    bar = 2,
+                    baz = 3
+                ;
+            `,
+            options: [2, { VariableDeclarator: { var: 2 } }]
+        },
+        {
+            code: unIndent`
+                var foo = 1,
+                    bar = 2,
+                    baz = 3
+                    ;
+            `,
+            options: [2, { VariableDeclarator: { var: 2 } }]
+        },
+        {
+            code: unIndent`
+                var abc =
+                    {
+                      a: 1,
+                      b: 2
+                    };
+            `,
+            options: [2, { VariableDeclarator: 2, SwitchCase: 1 }]
+        },
+        {
+            code: unIndent`
+                var a = new abc({
+                        a: 1,
+                        b: 2
+                    }),
+                    b = 2;
+            `,
+            options: [4, { VariableDeclarator: 1, SwitchCase: 1 }]
+        },
+        {
+            code: unIndent`
+                var a = 2,
+                  c = {
+                    a: 1,
+                    b: 2
+                  },
+                  b = 2;
+            `,
+            options: [2, { VariableDeclarator: 1, SwitchCase: 1 }]
+        },
+        {
+            code: unIndent`
+                var x = 2,
+                    y = {
+                      a: 1,
+                      b: 2
+                    },
+                    b = 2;
+            `,
+            options: [2, { VariableDeclarator: 2, SwitchCase: 1 }]
+        },
+        {
+            code: unIndent`
+                var e = {
+                      a: 1,
+                      b: 2
+                    },
+                    b = 2;
+            `,
+            options: [2, { VariableDeclarator: 2, SwitchCase: 1 }]
+        },
+        {
+            code: unIndent`
+                var a = {
+                  a: 1,
+                  b: 2
+                };
+            `,
+            options: [2, { VariableDeclarator: 2, SwitchCase: 1 }]
+        },
+        {
+            code: unIndent`
+                function test() {
+                  if (true ||
+                            false){
+                    console.log(val);
+                  }
+                }
+            `,
+            options: [2, { VariableDeclarator: 2, SwitchCase: 1 }]
+        },
+        {
+            code: unIndent`
+                var foo = bar ||
+                    !(
+                        baz
+                    );
+            `
+        },
+        {
+            code: unIndent`
+                for (var foo = 1;
+                    foo < 10;
+                    foo++) {}
+            `
+        },
+        {
+            code: unIndent`
+                for (
+                    var foo = 1;
+                    foo < 10;
+                    foo++
+                ) {}
+            `
+        },
+        {
+            code: unIndent`
+                for (var val in obj)
+                  if (true)
+                    console.log(val);
+            `,
+            options: [2, { VariableDeclarator: 2, SwitchCase: 1 }]
+        },
+        {
+            code: unIndent`
+                if(true)
+                  if (true)
+                    if (true)
+                      console.log(val);
+            `,
+            options: [2, { VariableDeclarator: 2, SwitchCase: 1 }]
+        },
+        {
+            code: unIndent`
+                function hi(){     var a = 1;
+                  y++;                   x++;
+                }
+            `,
+            options: [2, { VariableDeclarator: 2, SwitchCase: 1 }]
+        },
+        {
+            code: unIndent`
+                for(;length > index; index++)if(NO_HOLES || index in self){
+                  x++;
+                }
+            `,
+            options: [2, { VariableDeclarator: 2, SwitchCase: 1 }]
+        },
+        {
+            code: unIndent`
+                function test(){
+                  switch(length){
+                    case 1: return function(a){
+                      return fn.call(that, a);
+                    };
+                  }
+                }
+            `,
+            options: [2, { VariableDeclarator: 2, SwitchCase: 1 }]
+        },
+        {
+            code: unIndent`
+                var geometry = 2,
+                rotate = 2;
+            `,
+            options: [2, { VariableDeclarator: 0 }]
+        },
+        {
+            code: unIndent`
+                var geometry,
+                    rotate;
+            `,
+            options: [4, { VariableDeclarator: 1 }]
+        },
+        {
+            code: unIndent`
+                var geometry,
+                \trotate;
+            `,
+            options: ["tab", { VariableDeclarator: 1 }]
+        },
+        {
+            code: unIndent`
+                var geometry,
+                  rotate;
+            `,
+            options: [2, { VariableDeclarator: 1 }]
+        },
+        {
+            code: unIndent`
+                var geometry,
+                    rotate;
+            `,
             options: [2, { VariableDeclarator: 2 }]
         },
         {
-            code:
-            "let geometry,\n" +
-            "    rotate;",
+            code: unIndent`
+                let geometry,
+                    rotate;
+            `,
             options: [2, { VariableDeclarator: 2 }],
             parserOptions: { ecmaVersion: 6 }
         },
         {
-            code:
-            "const geometry = 2,\n" +
-            "    rotate = 3;",
+            code: unIndent`
+                const geometry = 2,
+                    rotate = 3;
+            `,
             options: [2, { VariableDeclarator: 2 }],
             parserOptions: { ecmaVersion: 6 }
         },
         {
-            code:
-            "var geometry, box, face1, face2, colorT, colorB, sprite, padding, maxWidth,\n" +
-            "  height, rotate;",
+            code: unIndent`
+                var geometry, box, face1, face2, colorT, colorB, sprite, padding, maxWidth,
+                  height, rotate;
+            `,
             options: [2, { SwitchCase: 1 }]
         },
         {
-            code:
-            "var geometry, box, face1, face2, colorT, colorB, sprite, padding, maxWidth;",
+            code: "var geometry, box, face1, face2, colorT, colorB, sprite, padding, maxWidth;",
             options: [2, { SwitchCase: 1 }]
         },
         {
-            code:
-            "if (1 < 2){\n" +
-            "//hi sd \n" +
-            "}",
+            code: unIndent`
+                if (1 < 2){
+                //hi sd
+                }
+            `,
             options: [2]
         },
         {
-            code:
-            "while (1 < 2){\n" +
-            "  //hi sd \n" +
-            "}",
+            code: unIndent`
+                while (1 < 2){
+                  //hi sd
+                }
+            `,
             options: [2]
         },
         {
-            code:
-            "while (1 < 2) console.log('hi');",
+            code: "while (1 < 2) console.log('hi');",
             options: [2]
         },
 
         {
-            code:
-            "[a, b,\n" +
-            "    c].forEach((index) => {\n" +
-            "        index;\n" +
-            "    });\n",
+            code: unIndent`
+                [a, boop,
+                    c].forEach((index) => {
+                        index;
+                    });
+            `,
             options: [4],
             parserOptions: { ecmaVersion: 6 }
         },
         {
-            code:
-            "[a, b, c].forEach((index) => {\n" +
-            "    index;\n" +
-            "});\n",
+            code: unIndent`
+                [a, b,
+                    c].forEach(function(index){
+                        return index;
+                    });
+            `,
             options: [4],
             parserOptions: { ecmaVersion: 6 }
         },
         {
-            code:
-            "[a, b, c].forEach(function(index){\n" +
-            "    return index;\n" +
-            "});\n",
+            code: unIndent`
+                [a, b, c].forEach((index) => {
+                    index;
+                });
+            `,
             options: [4],
             parserOptions: { ecmaVersion: 6 }
         },
         {
-            code:
-            "switch (x) {\n" +
-            "    case \"foo\":\n" +
-            "        a();\n" +
-            "        break;\n" +
-            "    case \"bar\":\n" +
-            "        switch (y) {\n" +
-            "            case \"1\":\n" +
-            "                break;\n" +
-            "            case \"2\":\n" +
-            "                a = 6;\n" +
-            "                break;\n" +
-            "        }\n" +
-            "    case \"test\":\n" +
-            "        break;\n" +
-            "}",
+            code: unIndent`
+                [a, b, c].forEach(function(index){
+                    return index;
+                });
+            `,
+            options: [4],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: unIndent`
+                (foo)
+                    .bar([
+                        baz
+                    ]);
+            `,
+            options: [4, { MemberExpression: 1 }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: unIndent`
+                switch (x) {
+                    case "foo":
+                        a();
+                        break;
+                    case "bar":
+                        switch (y) {
+                            case "1":
+                                break;
+                            case "2":
+                                a = 6;
+                                break;
+                        }
+                    case "test":
+                        break;
+                }
+            `,
             options: [4, { SwitchCase: 1 }]
         },
         {
-            code:
-            "switch (x) {\n" +
-            "        case \"foo\":\n" +
-            "            a();\n" +
-            "            break;\n" +
-            "        case \"bar\":\n" +
-            "            switch (y) {\n" +
-            "                    case \"1\":\n" +
-            "                        break;\n" +
-            "                    case \"2\":\n" +
-            "                        a = 6;\n" +
-            "                        break;\n" +
-            "            }\n" +
-            "        case \"test\":\n" +
-            "            break;\n" +
-            "}",
+            code: unIndent`
+                switch (x) {
+                        case "foo":
+                            a();
+                            break;
+                        case "bar":
+                            switch (y) {
+                                    case "1":
+                                        break;
+                                    case "2":
+                                        a = 6;
+                                        break;
+                            }
+                        case "test":
+                            break;
+                }
+            `,
             options: [4, { SwitchCase: 2 }]
         },
         {
-            code:
-            "switch (a) {\n" +
-            "case \"foo\":\n" +
-            "    a();\n" +
-            "    break;\n" +
-            "case \"bar\":\n" +
-            "    switch(x){\n" +
-            "    case '1':\n" +
-            "        break;\n" +
-            "    case '2':\n" +
-            "        a = 6;\n" +
-            "        break;\n" +
-            "    }\n" +
-            "}"
+            code: unIndent`
+                switch (a) {
+                case "foo":
+                    a();
+                    break;
+                case "bar":
+                    switch(x){
+                    case '1':
+                        break;
+                    case '2':
+                        a = 6;
+                        break;
+                    }
+                }
+            `
         },
         {
-            code:
-            "switch (a) {\n" +
-            "case \"foo\":\n" +
-            "    a();\n" +
-            "    break;\n" +
-            "case \"bar\":\n" +
-            "    if(x){\n" +
-            "        a = 2;\n" +
-            "    }\n" +
-            "    else{\n" +
-            "        a = 6;\n" +
-            "    }\n" +
-            "}"
+            code: unIndent`
+                switch (a) {
+                case "foo":
+                    a();
+                    break;
+                case "bar":
+                    if(x){
+                        a = 2;
+                    }
+                    else{
+                        a = 6;
+                    }
+                }
+            `
         },
         {
-            code:
-            "switch (a) {\n" +
-            "case \"foo\":\n" +
-            "    a();\n" +
-            "    break;\n" +
-            "case \"bar\":\n" +
-            "    if(x){\n" +
-            "        a = 2;\n" +
-            "    }\n" +
-            "    else\n" +
-            "        a = 6;\n" +
-            "}"
+            code: unIndent`
+                switch (a) {
+                case "foo":
+                    a();
+                    break;
+                case "bar":
+                    if(x){
+                        a = 2;
+                    }
+                    else
+                        a = 6;
+                }
+            `
         },
         {
-            code:
-            "switch (a) {\n" +
-            "case \"foo\":\n" +
-            "    a();\n" +
-            "    break;\n" +
-            "case \"bar\":\n" +
-            "    a(); break;\n" +
-            "case \"baz\":\n" +
-            "    a(); break;\n" +
-            "}"
+            code: unIndent`
+                switch (a) {
+                case "foo":
+                    a();
+                    break;
+                case "bar":
+                    a(); break;
+                case "baz":
+                    a(); break;
+                }
+            `
         },
         {
-            code: "switch (0) {\n}"
+            code: unIndent`
+                switch (0) {
+                }
+            `
         },
         {
-            code:
-            "function foo() {\n" +
-            "    var a = \"a\";\n" +
-            "    switch(a) {\n" +
-            "    case \"a\":\n" +
-            "        return \"A\";\n" +
-            "    case \"b\":\n" +
-            "        return \"B\";\n" +
-            "    }\n" +
-            "}\n" +
-            "foo();"
+            code: unIndent`
+                function foo() {
+                    var a = "a";
+                    switch(a) {
+                    case "a":
+                        return "A";
+                    case "b":
+                        return "B";
+                    }
+                }
+                foo();
+            `
         },
         {
-            code:
-            "switch(value){\n" +
-            "    case \"1\":\n" +
-            "    case \"2\":\n" +
-            "        a();\n" +
-            "        break;\n" +
-            "    default:\n" +
-            "        a();\n" +
-            "        break;\n" +
-            "}\n" +
-            "switch(value){\n" +
-            "    case \"1\":\n" +
-            "        a();\n" +
-            "        break;\n" +
-            "    case \"2\":\n" +
-            "        break;\n" +
-            "    default:\n" +
-            "        break;\n" +
-            "}",
+            code: unIndent`
+                switch(value){
+                    case "1":
+                    case "2":
+                        a();
+                        break;
+                    default:
+                        a();
+                        break;
+                }
+                switch(value){
+                    case "1":
+                        a();
+                        break;
+                    case "2":
+                        break;
+                    default:
+                        break;
+                }
+            `,
             options: [4, { SwitchCase: 1 }]
         },
         {
-            code:
-                "var obj = {foo: 1, bar: 2};\n" +
-                "with (obj) {\n" +
-                "    console.log(foo + bar);\n" +
-                "}\n"
+            code: unIndent`
+                var obj = {foo: 1, bar: 2};
+                with (obj) {
+                    console.log(foo + bar);
+                }
+            `
         },
         {
-            code:
-                "if (a) {\n" +
-                "    (1 + 2 + 3);\n" + // no error on this line
-                "}"
+            code: unIndent`
+                if (a) {
+                    (1 + 2 + 3); // no error on this line
+                }
+            `
         },
         {
-            code:
-                "switch(value){ default: a(); break; }\n"
+            code: "switch(value){ default: a(); break; }"
         },
         {
-            code: "import {addons} from 'react/addons'\nimport React from 'react'",
+            code: unIndent`
+                import {addons} from 'react/addons'
+                import React from 'react'
+            `,
             options: [2],
             parserOptions: { sourceType: "module" }
         },
         {
-            code:
-            "var a = 1,\n" +
-            "    b = 2,\n" +
-            "    c = 3;\n",
+            code: unIndent`
+                import {
+                    foo,
+                    bar,
+                    baz
+                } from 'qux';
+            `,
+            parserOptions: { sourceType: "module" }
+        },
+        {
+            code: unIndent`
+                var a = 1,
+                    b = 2,
+                    c = 3;
+            `,
             options: [4]
         },
         {
-            code:
-            "var a = 1\n" +
-            "   ,b = 2\n" +
-            "   ,c = 3;\n",
+            code: unIndent`
+                var a = 1
+                    ,b = 2
+                    ,c = 3;
+            `,
             options: [4]
         },
         {
-            code: "while (1 < 2) console.log('hi')\n",
+            code: "while (1 < 2) console.log('hi')",
             options: [2]
         },
         {
-            code:
-                "function salutation () {\n" +
-                "  switch (1) {\n" +
-                "    case 0: return console.log('hi')\n" +
-                "    case 1: return console.log('hey')\n" +
-                "  }\n" +
-                "}\n",
+            code: unIndent`
+                function salutation () {
+                  switch (1) {
+                    case 0: return console.log('hi')
+                    case 1: return console.log('hey')
+                  }
+                }
+            `,
             options: [2, { SwitchCase: 1 }]
         },
         {
-            code:
-                "var items = [\n" +
-                "  {\n" +
-                "    foo: 'bar'\n" +
-                "  }\n" +
-                "];\n",
+            code: unIndent`
+                var items = [
+                  {
+                    foo: 'bar'
+                  }
+                ];
+            `,
             options: [2, { VariableDeclarator: 2 }]
         },
         {
-            code:
-                "const a = 1,\n" +
-                "      b = 2;\n" +
-                "const items1 = [\n" +
-                "  {\n" +
-                "    foo: 'bar'\n" +
-                "  }\n" +
-                "];\n" +
-                "const items2 = Items(\n" +
-                "  {\n" +
-                "    foo: 'bar'\n" +
-                "  }\n" +
-                ");\n",
+            code: unIndent`
+                const a = 1,
+                      b = 2;
+                const items1 = [
+                  {
+                    foo: 'bar'
+                  }
+                ];
+                const items2 = Items(
+                  {
+                    foo: 'bar'
+                  }
+                );
+            `,
             options: [2, { VariableDeclarator: 3 }],
             parserOptions: { ecmaVersion: 6 }
 
         },
         {
-            code:
-                "const geometry = 2,\n" +
-                "      rotate = 3;\n" +
-                "var a = 1,\n" +
-                "  b = 2;\n" +
-                "let light = true,\n" +
-                "    shadow = false;",
+            code: unIndent`
+                const geometry = 2,
+                      rotate = 3;
+                var a = 1,
+                  b = 2;
+                let light = true,
+                    shadow = false;
+            `,
             options: [2, { VariableDeclarator: { const: 3, let: 2 } }],
             parserOptions: { ecmaVersion: 6 }
         },
         {
-            code:
-            "const abc = 5,\n" +
-            "      c = 2,\n" +
-            "      xyz = \n" +
-            "      {\n" +
-            "        a: 1,\n" +
-            "        b: 2\n" +
-            "      };\n" +
-            "let abc2 = 5,\n" +
-            "  c2 = 2,\n" +
-            "  xyz2 = \n" +
-            "  {\n" +
-            "    a: 1,\n" +
-            "    b: 2\n" +
-            "  };\n" +
-            "var abc3 = 5,\n" +
-            "    c3 = 2,\n" +
-            "    xyz3 = \n" +
-            "    {\n" +
-            "      a: 1,\n" +
-            "      b: 2\n" +
-            "    };\n",
+            code: unIndent`
+                const abc = 5,
+                      c = 2,
+                      xyz =
+                      {
+                        a: 1,
+                        b: 2
+                      };
+                let abc2 = 5,
+                  c2 = 2,
+                  xyz2 =
+                  {
+                    a: 1,
+                    b: 2
+                  };
+                var abc3 = 5,
+                    c3 = 2,
+                    xyz3 =
+                    {
+                      a: 1,
+                      b: 2
+                    };
+            `,
             options: [2, { VariableDeclarator: { var: 2, const: 3 }, SwitchCase: 1 }],
             parserOptions: { ecmaVersion: 6 }
         },
         {
-            code:
-                "module.exports =\n" +
-                "{\n" +
-                "  'Unit tests':\n" +
-                "  {\n" +
-                "    rootPath: './',\n" +
-                "    environment: 'node',\n" +
-                "    tests:\n" +
-                "    [\n" +
-                "      'test/test-*.js'\n" +
-                "    ],\n" +
-                "    sources:\n" +
-                "    [\n" +
-                "      '*.js',\n" +
-                "      'test/**.js'\n" +
-                "    ]\n" +
-                "  }\n" +
-                "};",
+            code: unIndent`
+                module.exports = {
+                  'Unit tests':
+                  {
+                    rootPath: './',
+                    environment: 'node',
+                    tests:
+                    [
+                      'test/test-*.js'
+                    ],
+                    sources:
+                    [
+                      '*.js',
+                      'test/**.js'
+                    ]
+                  }
+                };
+            `,
             options: [2]
         },
         {
-            code:
-                "var path     = require('path')\n" +
-                "  , crypto    = require('crypto')\n" +
-                "  ;\n",
+            code: unIndent`
+                foo =
+                  bar;
+            `,
             options: [2]
         },
         {
-            code:
-                "var a = 1\n" +
-                "   ,b = 2\n" +
-                "   ;"
+            code: unIndent`
+                foo = (
+                  bar
+                );
+            `,
+            options: [2]
         },
         {
-            code:
-                "export function create (some,\n" +
-                "                        argument) {\n" +
-                "  return Object.create({\n" +
-                "    a: some,\n" +
-                "    b: argument\n" +
-                "  });\n" +
-                "};",
+            code: unIndent`
+                var path     = require('path')
+                  , crypto    = require('crypto')
+                  ;
+            `,
+            options: [2]
+        },
+        {
+            code: unIndent`
+                var a = 1
+                    ,b = 2
+                    ;
+            `
+        },
+        {
+            code: unIndent`
+                export function create (some,
+                                        argument) {
+                  return Object.create({
+                    a: some,
+                    b: argument
+                  });
+                };
+            `,
             parserOptions: { sourceType: "module" },
-            options: [2]
+            options: [2, { FunctionDeclaration: { parameters: "first" } }]
         },
         {
-            code:
-                "export function create (id, xfilter, rawType,\n" +
-                "                        width=defaultWidth, height=defaultHeight,\n" +
-                "                        footerHeight=defaultFooterHeight,\n" +
-                "                        padding=defaultPadding) {\n" +
-                "  // ... function body, indented two spaces\n" +
-                "}\n",
+            code: unIndent`
+                export function create (id, xfilter, rawType,
+                                        width=defaultWidth, height=defaultHeight,
+                                        footerHeight=defaultFooterHeight,
+                                        padding=defaultPadding) {
+                  // ... function body, indented two spaces
+                }
+            `,
             parserOptions: { sourceType: "module" },
+            options: [2, { FunctionDeclaration: { parameters: "first" } }]
+        },
+        {
+            code: unIndent`
+                var obj = {
+                  foo: function () {
+                    return new p()
+                      .then(function (ok) {
+                        return ok;
+                      }, function () {
+                        // ignore things
+                      });
+                  }
+                };
+            `,
             options: [2]
         },
         {
-            code:
-                "var obj = {\n" +
-                "  foo: function () {\n" +
-                "    return new p()\n" +
-                "      .then(function (ok) {\n" +
-                "        return ok;\n" +
-                "      }, function () {\n" +
-                "        // ignore things\n" +
-                "      });\n" +
-                "  }\n" +
-                "};\n",
+            code: unIndent`
+                a.b()
+                  .c(function(){
+                    var a;
+                  }).d.e;
+            `,
             options: [2]
         },
         {
-            code:
-                "a.b()\n" +
-                "  .c(function(){\n" +
-                "    var a;\n" +
-                "  }).d.e;\n",
-            options: [2]
-        },
-        {
-            code:
-                "const YO = 'bah',\n" +
-                "      TE = 'mah'\n" +
-                "\n" +
-                "var res,\n" +
-                "    a = 5,\n" +
-                "    b = 4\n",
+            code: unIndent`
+                const YO = 'bah',
+                      TE = 'mah'
+
+                var res,
+                    a = 5,
+                    b = 4
+            `,
             parserOptions: { ecmaVersion: 6 },
             options: [2, { VariableDeclarator: { var: 2, let: 2, const: 3 } }]
         },
         {
-            code:
-                "const YO = 'bah',\n" +
-                "      TE = 'mah'\n" +
-                "\n" +
-                "var res,\n" +
-                "    a = 5,\n" +
-                "    b = 4\n" +
-                "\n" +
-                "if (YO) console.log(TE)",
+            code: unIndent`
+                const YO = 'bah',
+                      TE = 'mah'
+
+                var res,
+                    a = 5,
+                    b = 4
+
+                if (YO) console.log(TE)
+            `,
             parserOptions: { ecmaVersion: 6 },
             options: [2, { VariableDeclarator: { var: 2, let: 2, const: 3 } }]
         },
         {
-            code:
-                "var foo = 'foo',\n" +
-                "  bar = 'bar',\n" +
-                "  baz = function() {\n" +
-                "      \n" +
-                "  }\n" +
-                "\n" +
-                "function hello () {\n" +
-                "    \n" +
-                "}\n",
+            code: unIndent`
+                var foo = 'foo',
+                  bar = 'bar',
+                  baz = function() {
+
+                  }
+
+                function hello () {
+
+                }
+            `,
             options: [2]
         },
         {
-            code:
-                "var obj = {\n" +
-                "  send: function () {\n" +
-                "    return P.resolve({\n" +
-                "      type: 'POST'\n" +
-                "    })\n" +
-                "      .then(function () {\n" +
-                "        return true;\n" +
-                "      }, function () {\n" +
-                "        return false;\n" +
-                "      });\n" +
-                "  }\n" +
-                "};\n",
+            code: unIndent`
+                var obj = {
+                  send: function () {
+                    return P.resolve({
+                      type: 'POST'
+                    })
+                      .then(function () {
+                        return true;
+                      }, function () {
+                        return false;
+                      });
+                  }
+                };
+            `,
             options: [2]
         },
         {
-            code:
-                "var obj = {\n" +
-                "  send: function () {\n" +
-                "    return P.resolve({\n" +
-                "      type: 'POST'\n" +
-                "    })\n" +
-                "    .then(function () {\n" +
-                "      return true;\n" +
-                "    }, function () {\n" +
-                "      return false;\n" +
-                "    });\n" +
-                "  }\n" +
-                "};\n",
+            code: unIndent`
+                var obj = {
+                  send: function () {
+                    return P.resolve({
+                      type: 'POST'
+                    })
+                    .then(function () {
+                      return true;
+                    }, function () {
+                      return false;
+                    });
+                  }
+                };
+            `,
             options: [2, { MemberExpression: 0 }]
         },
         {
-            code:
-                "const someOtherFunction = argument => {\n" +
-                "        console.log(argument);\n" +
-                "    },\n" +
-                "    someOtherValue = 'someOtherValue';\n",
+            code: unIndent`
+                const someOtherFunction = argument => {
+                        console.log(argument);
+                    },
+                    someOtherValue = 'someOtherValue';
+            `,
             parserOptions: { ecmaVersion: 6 }
         },
         {
-            code:
-            "[\n" +
-            "  'a',\n" +
-            "  'b'\n" +
-            "].sort().should.deepEqual([\n" +
-            "  'x',\n" +
-            "  'y'\n" +
-            "]);\n",
+            code: unIndent`
+                [
+                  'a',
+                  'b'
+                ].sort().should.deepEqual([
+                  'x',
+                  'y'
+                ]);
+            `,
             options: [2]
         },
         {
-            code:
-            "var a = 1,\n" +
-            "    B = class {\n" +
-            "      constructor(){}\n" +
-            "      a(){}\n" +
-            "      get b(){}\n" +
-            "    };",
+            code: unIndent`
+                var a = 1,
+                    B = class {
+                      constructor(){}
+                      a(){}
+                      get b(){}
+                    };
+            `,
             options: [2, { VariableDeclarator: 2, SwitchCase: 1 }],
             parserOptions: { ecmaVersion: 6 }
         },
         {
-            code:
-            "var a = 1,\n" +
-            "    B = \n" +
-            "    class {\n" +
-            "      constructor(){}\n" +
-            "      a(){}\n" +
-            "      get b(){}\n" +
-            "    },\n" +
-            "    c = 3;",
+            code: unIndent`
+                var a = 1,
+                    B =
+                    class {
+                      constructor(){}
+                      a(){}
+                      get b(){}
+                    },
+                    c = 3;
+            `,
             options: [2, { VariableDeclarator: 2, SwitchCase: 1 }],
             parserOptions: { ecmaVersion: 6 }
         },
         {
-            code:
-            "class A{\n" +
-            "    constructor(){}\n" +
-            "    a(){}\n" +
-            "    get b(){}\n" +
-            "}",
+            code: unIndent`
+                class A{
+                    constructor(){}
+                    a(){}
+                    get b(){}
+                }
+            `,
             options: [4, { VariableDeclarator: 1, SwitchCase: 1 }],
             parserOptions: { ecmaVersion: 6 }
         },
         {
-            code:
-            "var A = class {\n" +
-            "    constructor(){}\n" +
-            "    a(){}\n" +
-            "    get b(){}\n" +
-            "}",
+            code: unIndent`
+                var A = class {
+                    constructor(){}
+                    a(){}
+                    get b(){}
+                }
+            `,
             options: [4, { VariableDeclarator: 1, SwitchCase: 1 }],
             parserOptions: { ecmaVersion: 6 }
         },
         {
-            code:
-            "var a = {\n" +
-            "  some: 1\n" +
-            ", name: 2\n" +
-            "};\n",
+            code: unIndent`
+                var a = {
+                  some: 1
+                  , name: 2
+                };
+            `,
             options: [2]
         },
         {
-            code:
-            "a.c = {\n" +
-            "    aa: function() {\n" +
-            "        'test1';\n" +
-            "        return 'aa';\n" +
-            "    }\n" +
-            "    , bb: function() {\n" +
-            "        return this.bb();\n" +
-            "    }\n" +
-            "};\n",
+            code: unIndent`
+                a.c = {
+                    aa: function() {
+                        'test1';
+                        return 'aa';
+                    }
+                    , bb: function() {
+                        return this.bb();
+                    }
+                };
+            `,
             options: [4]
         },
         {
-            code:
-            "var a =\n" +
-            "{\n" +
-            "    actions:\n" +
-            "    [\n" +
-            "        {\n" +
-            "            name: 'compile'\n" +
-            "        }\n" +
-            "    ]\n" +
-            "};\n",
+            code: unIndent`
+                var a =
+                {
+                    actions:
+                    [
+                        {
+                            name: 'compile'
+                        }
+                    ]
+                };
+            `,
             options: [4, { VariableDeclarator: 0, SwitchCase: 1 }]
         },
         {
-            code:
-            "var a =\n" +
-            "[\n" +
-            "    {\n" +
-            "        name: 'compile'\n" +
-            "    }\n" +
-            "];\n",
+            code: unIndent`
+                var a =
+                [
+                    {
+                        name: 'compile'
+                    }
+                ];
+            `,
             options: [4, { VariableDeclarator: 0, SwitchCase: 1 }]
         },
         {
-            code:
-            "const func = function (opts) {\n" +
-            "    return Promise.resolve()\n" +
-            "    .then(() => {\n" +
-            "        [\n" +
-            "            'ONE', 'TWO'\n" +
-            "        ].forEach(command => { doSomething(); });\n" +
-            "    });\n" +
-            "};",
+            code: unIndent`
+                const func = function (opts) {
+                    return Promise.resolve()
+                    .then(() => {
+                        [
+                            'ONE', 'TWO'
+                        ].forEach(command => { doSomething(); });
+                    });
+                };
+            `,
             parserOptions: { ecmaVersion: 6 },
             options: [4, { MemberExpression: 0 }]
         },
         {
-            code:
-            "const func = function (opts) {\n" +
-            "    return Promise.resolve()\n" +
-            "        .then(() => {\n" +
-            "            [\n" +
-            "                'ONE', 'TWO'\n" +
-            "            ].forEach(command => { doSomething(); });\n" +
-            "        });\n" +
-            "};",
+            code: unIndent`
+                const func = function (opts) {
+                    return Promise.resolve()
+                        .then(() => {
+                            [
+                                'ONE', 'TWO'
+                            ].forEach(command => { doSomething(); });
+                        });
+                };
+            `,
             parserOptions: { ecmaVersion: 6 },
             options: [4]
         },
         {
-            code:
-            "var haveFun = function () {\n" +
-            "    SillyFunction(\n" +
-            "        {\n" +
-            "            value: true,\n" +
-            "        },\n" +
-            "        {\n" +
-            "            _id: true,\n" +
-            "        }\n" +
-            "    );\n" +
-            "};",
+            code: unIndent`
+                var haveFun = function () {
+                    SillyFunction(
+                        {
+                            value: true,
+                        },
+                        {
+                            _id: true,
+                        }
+                    );
+                };
+            `,
             options: [4]
         },
         {
-            code:
-            "var haveFun = function () {\n" +
-            "    new SillyFunction(\n" +
-            "        {\n" +
-            "            value: true,\n" +
-            "        },\n" +
-            "        {\n" +
-            "            _id: true,\n" +
-            "        }\n" +
-            "    );\n" +
-            "};",
+            code: unIndent`
+                var haveFun = function () {
+                    new SillyFunction(
+                        {
+                            value: true,
+                        },
+                        {
+                            _id: true,
+                        }
+                    );
+                };
+            `,
             options: [4]
         },
         {
-            code:
-            "let object1 = {\n" +
-            "  doThing() {\n" +
-            "    return _.chain([])\n" +
-            "      .map(v => (\n" +
-            "        {\n" +
-            "          value: true,\n" +
-            "        }\n" +
-            "      ))\n" +
-            "      .value();\n" +
-            "  }\n" +
-            "};",
+            code: unIndent`
+                let object1 = {
+                  doThing() {
+                    return _.chain([])
+                      .map(v => (
+                        {
+                          value: true,
+                        }
+                      ))
+                      .value();
+                  }
+                };
+            `,
             parserOptions: { ecmaVersion: 6 },
             options: [2]
         },
         {
-            code:
-            "class Foo\n" +
-            "  extends Bar {\n" +
-            "  baz() {}\n" +
-            "}",
+            code: unIndent`
+                var foo = {
+                    bar: 1,
+                    baz: {
+                      qux: 2
+                    }
+                  },
+                  bar = 1;
+            `,
+            options: [2]
+        },
+        {
+            code: unIndent`
+                class Foo
+                  extends Bar {
+                  baz() {}
+                }
+            `,
             parserOptions: { ecmaVersion: 6 },
             options: [2]
         },
         {
-            code:
-            "class Foo extends\n" +
-            "  Bar {\n" +
-            "  baz() {}\n" +
-            "}",
+            code: unIndent`
+                class Foo extends
+                  Bar {
+                  baz() {}
+                }
+            `,
             parserOptions: { ecmaVersion: 6 },
             options: [2]
         },
         {
-            code:
-            "fs.readdirSync(path.join(__dirname, '../rules')).forEach(name => {\n" +
-            "  files[name] = foo;\n" +
-            "});",
+            code: unIndent`
+                fs.readdirSync(path.join(__dirname, '../rules')).forEach(name => {
+                  files[name] = foo;
+                });
+            `,
             options: [2, { outerIIFEBody: 0 }],
             parserOptions: { ecmaVersion: 6 }
         },
         {
-            code:
-            "(function(){\n" +
-            "function foo(x) {\n" +
-            "  return x + 1;\n" +
-            "}\n" +
-            "})();",
+            code: unIndent`
+                (function(){
+                function foo(x) {
+                  return x + 1;
+                }
+                })();
+            `,
             options: [2, { outerIIFEBody: 0 }]
         },
         {
-            code:
-            "(function(){\n" +
-            "        function foo(x) {\n" +
-            "            return x + 1;\n" +
-            "        }\n" +
-            "})();",
+            code: unIndent`
+                (function(){
+                        function foo(x) {
+                            return x + 1;
+                        }
+                })();
+            `,
             options: [4, { outerIIFEBody: 2 }]
         },
         {
-            code:
-            "(function(x, y){\n" +
-            "function foo(x) {\n" +
-            "  return x + 1;\n" +
-            "}\n" +
-            "})(1, 2);",
+            code: unIndent`
+                (function(x, y){
+                function foo(x) {
+                  return x + 1;
+                }
+                })(1, 2);
+            `,
             options: [2, { outerIIFEBody: 0 }]
         },
         {
-            code:
-            "(function(){\n" +
-            "function foo(x) {\n" +
-            "  return x + 1;\n" +
-            "}\n" +
-            "}());",
+            code: unIndent`
+                (function(){
+                function foo(x) {
+                  return x + 1;
+                }
+                }());
+            `,
             options: [2, { outerIIFEBody: 0 }]
         },
         {
-            code:
-            "!function(){\n" +
-            "function foo(x) {\n" +
-            "  return x + 1;\n" +
-            "}\n" +
-            "}();",
+            code: unIndent`
+                !function(){
+                function foo(x) {
+                  return x + 1;
+                }
+                }();
+            `,
             options: [2, { outerIIFEBody: 0 }]
         },
         {
-            code:
-            "!function(){\n" +
-            "\t\t\tfunction foo(x) {\n" +
-            "\t\t\t\treturn x + 1;\n" +
-            "\t\t\t}\n" +
-            "}();",
+            code: unIndent`
+                !function(){
+                \t\t\tfunction foo(x) {
+                \t\t\t\treturn x + 1;
+                \t\t\t}
+                }();
+            `,
             options: ["tab", { outerIIFEBody: 3 }]
         },
         {
-            code:
-            "var out = function(){\n" +
-            "  function fooVar(x) {\n" +
-            "    return x + 1;\n" +
-            "  }\n" +
-            "};",
+            code: unIndent`
+                var out = function(){
+                  function fooVar(x) {
+                    return x + 1;
+                  }
+                };
+            `,
             options: [2, { outerIIFEBody: 0 }]
         },
         {
-            code:
-            "var ns = function(){\n" +
-            "function fooVar(x) {\n" +
-            "  return x + 1;\n" +
-            "}\n" +
-            "}();",
+            code: unIndent`
+                var ns = function(){
+                function fooVar(x) {
+                  return x + 1;
+                }
+                }();
+            `,
             options: [2, { outerIIFEBody: 0 }]
         },
         {
-            code:
-            "ns = function(){\n" +
-            "function fooVar(x) {\n" +
-            "  return x + 1;\n" +
-            "}\n" +
-            "}();",
+            code: unIndent`
+                ns = function(){
+                function fooVar(x) {
+                  return x + 1;
+                }
+                }();
+            `,
             options: [2, { outerIIFEBody: 0 }]
         },
         {
-            code:
-            "var ns = (function(){\n" +
-            "function fooVar(x) {\n" +
-            "  return x + 1;\n" +
-            "}\n" +
-            "}(x));",
+            code: unIndent`
+                var ns = (function(){
+                function fooVar(x) {
+                  return x + 1;
+                }
+                }(x));
+            `,
             options: [2, { outerIIFEBody: 0 }]
         },
         {
-            code:
-            "var ns = (function(){\n" +
-            "        function fooVar(x) {\n" +
-            "            return x + 1;\n" +
-            "        }\n" +
-            "}(x));",
+            code: unIndent`
+                var ns = (function(){
+                        function fooVar(x) {
+                            return x + 1;
+                        }
+                }(x));
+            `,
             options: [4, { outerIIFEBody: 2 }]
         },
         {
-            code:
-            "var obj = {\n" +
-            "  foo: function() {\n" +
-            "    return true;\n" +
-            "  }\n" +
-            "};",
+            code: unIndent`
+                var obj = {
+                  foo: function() {
+                    return true;
+                  }
+                };
+            `,
             options: [2, { outerIIFEBody: 0 }]
         },
         {
-            code:
-            "while (\n" +
-            "  function() {\n" +
-            "    return true;\n" +
-            "  }()) {\n" +
-            "\n" +
-            "  x = x + 1;\n" +
-            "};",
+            code: unIndent`
+                while (
+                  function() {
+                    return true;
+                  }()) {
+
+                  x = x + 1;
+                };
+            `,
             options: [2, { outerIIFEBody: 20 }]
         },
         {
-            code:
-            "(() => {\n" +
-            "function foo(x) {\n" +
-            "  return x + 1;\n" +
-            "}\n" +
-            "})();",
+            code: unIndent`
+                (() => {
+                function foo(x) {
+                  return x + 1;
+                }
+                })();
+            `,
             parserOptions: { ecmaVersion: 6 },
             options: [2, { outerIIFEBody: 0 }]
         },
         {
-            code:
-            "function foo() {\n" +
-            "}",
+            code: unIndent`
+                function foo() {
+                }
+            `,
             options: ["tab", { outerIIFEBody: 0 }]
         },
         {
-            code:
-            ";(() => {\n" +
-            "function foo(x) {\n" +
-            "  return x + 1;\n" +
-            "}\n" +
-            "})();",
+            code: unIndent`
+                ;(() => {
+                function foo(x) {
+                  return x + 1;
+                }
+                })();
+            `,
             parserOptions: { ecmaVersion: 6 },
             options: [2, { outerIIFEBody: 0 }]
         },
         {
-            code:
-            "if(data) {\n" +
-            "  console.log('hi');\n" +
-            "}",
+            code: unIndent`
+                if(data) {
+                  console.log('hi');
+                }
+            `,
             options: [2, { outerIIFEBody: 0 }]
         },
         {
-            code:
-            "Buffer.length",
+            code: "Buffer.length",
             options: [4, { MemberExpression: 1 }]
         },
         {
-            code:
-            "Buffer\n" +
-            "    .indexOf('a')\n" +
-            "    .toString()",
+            code: unIndent`
+                Buffer
+                    .indexOf('a')
+                    .toString()
+            `,
             options: [4, { MemberExpression: 1 }]
         },
         {
-            code:
-            "Buffer.\n" +
-            "    length",
+            code: unIndent`
+                Buffer.
+                    length
+            `,
             options: [4, { MemberExpression: 1 }]
         },
         {
-            code:
-            "Buffer\n" +
-            "    .foo\n" +
-            "    .bar",
+            code: unIndent`
+                Buffer
+                    .foo
+                    .bar
+            `,
             options: [4, { MemberExpression: 1 }]
         },
         {
-            code:
-            "Buffer\n" +
-            "\t.foo\n" +
-            "\t.bar",
+            code: unIndent`
+                Buffer
+                \t.foo
+                \t.bar
+            `,
             options: ["tab", { MemberExpression: 1 }]
         },
         {
-            code:
-            "Buffer\n" +
-            "    .foo\n" +
-            "    .bar",
+            code: unIndent`
+                Buffer
+                    .foo
+                    .bar
+            `,
             options: [2, { MemberExpression: 2 }]
         },
         {
-            code:
-            "MemberExpression\n" +
-            ".is" +
-            "  .off" +
-            "    .by" +
-            " .default();",
-            options: [4]
+            code: unIndent`
+                MemberExpression
+                .can
+                  .be
+                    .turned
+                 .off();
+            `,
+            options: [4, { MemberExpression: "off" }]
         },
         {
-            code:
-            "foo = bar.baz()\n" +
-            "        .bip();",
+            code: unIndent`
+                foo = bar.baz()
+                    .bip();
+            `,
             options: [4, { MemberExpression: 1 }]
         },
         {
-            code:
-            "if (foo) {\n" +
-            "  bar();\n" +
-            "} else if (baz) {\n" +
-            "  foobar();\n" +
-            "} else if (qux) {\n" +
-            "  qux();\n" +
-            "}",
+            code: unIndent`
+                if (foo) {
+                  bar();
+                } else if (baz) {
+                  foobar();
+                } else if (qux) {
+                  qux();
+                }
+            `,
             options: [2]
         },
         {
-            code:
-            "function foo(aaa,\n" +
-            "  bbb, ccc, ddd) {\n" +
-            "    bar();\n" +
-            "}",
+            code: unIndent`
+                function foo(aaa,
+                  bbb, ccc, ddd) {
+                    bar();
+                }
+            `,
             options: [2, { FunctionDeclaration: { parameters: 1, body: 2 } }]
         },
         {
-            code:
-            "function foo(aaa, bbb,\n" +
-            "      ccc, ddd) {\n" +
-            "  bar();\n" +
-            "}",
+            code: unIndent`
+                function foo(aaa, bbb,
+                      ccc, ddd) {
+                  bar();
+                }
+            `,
             options: [2, { FunctionDeclaration: { parameters: 3, body: 1 } }]
         },
         {
-            code:
-            "function foo(aaa,\n" +
-            "    bbb,\n" +
-            "    ccc) {\n" +
-            "            bar();\n" +
-            "}",
+            code: unIndent`
+                function foo(aaa,
+                    bbb,
+                    ccc) {
+                            bar();
+                }
+            `,
             options: [4, { FunctionDeclaration: { parameters: 1, body: 3 } }]
         },
         {
-            code:
-            "function foo(aaa,\n" +
-            "             bbb, ccc,\n" +
-            "             ddd, eee, fff) {\n" +
-            "  bar();\n" +
-            "}",
+            code: unIndent`
+                function foo(aaa,
+                             bbb, ccc,
+                             ddd, eee, fff) {
+                  bar();
+                }
+            `,
             options: [2, { FunctionDeclaration: { parameters: "first", body: 1 } }]
         },
         {
-            code:
-            "function foo(aaa, bbb)\n" +
-            "{\n" +
-            "      bar();\n" +
-            "}",
+            code: unIndent`
+                function foo(aaa, bbb)
+                {
+                      bar();
+                }
+            `,
             options: [2, { FunctionDeclaration: { body: 3 } }]
         },
         {
-            code:
-            "function foo(\n" +
-            "  aaa,\n" +
-            "  bbb) {\n" +
-            "    bar();\n" +
-            "}",
+            code: unIndent`
+                function foo(
+                  aaa,
+                  bbb) {
+                    bar();
+                }
+            `,
             options: [2, { FunctionDeclaration: { parameters: "first", body: 2 } }]
         },
         {
-            code:
-            "var foo = function(aaa,\n" +
-            "    bbb,\n" +
-            "    ccc,\n" +
-            "    ddd) {\n" +
-            "bar();\n" +
-            "}",
+            code: unIndent`
+                var foo = function(aaa,
+                    bbb,
+                    ccc,
+                    ddd) {
+                bar();
+                }
+            `,
             options: [2, { FunctionExpression: { parameters: 2, body: 0 } }]
         },
         {
-            code:
-            "var foo = function(aaa,\n" +
-            "  bbb,\n" +
-            "  ccc) {\n" +
-            "                    bar();\n" +
-            "}",
+            code: unIndent`
+                var foo = function(aaa,
+                  bbb,
+                  ccc) {
+                                    bar();
+                }
+            `,
             options: [2, { FunctionExpression: { parameters: 1, body: 10 } }]
         },
         {
-            code:
-            "var foo = function(aaa,\n" +
-            "                   bbb, ccc, ddd,\n" +
-            "                   eee, fff) {\n" +
-            "    bar();\n" +
-            "}",
+            code: unIndent`
+                var foo = function(aaa,
+                                   bbb, ccc, ddd,
+                                   eee, fff) {
+                    bar();
+                }
+            `,
             options: [4, { FunctionExpression: { parameters: "first", body: 1 } }]
         },
         {
-            code:
-            "var foo = function(\n" +
-            "  aaa, bbb, ccc,\n" +
-            "  ddd, eee) {\n" +
-            "      bar();\n" +
-            "}",
+            code: unIndent`
+                var foo = function(
+                  aaa, bbb, ccc,
+                  ddd, eee) {
+                      bar();
+                }
+            `,
             options: [2, { FunctionExpression: { parameters: "first", body: 3 } }]
         },
         {
-            code:
-            "function foo() {\n" +
-            "  bar();\n" +
-            "  \tbaz();\n" +
-            "\t   \t\t\t  \t\t\t  \t   \tqux();\n" +
-            "}",
+            code: unIndent`
+                foo.bar(
+                      baz, qux, function() {
+                            qux;
+                      }
+                );
+            `,
+            options: [2, { FunctionExpression: { body: 3 }, CallExpression: { arguments: 3 } }]
+        },
+        {
+            code: unIndent`
+                function foo() {
+                  bar();
+                  \tbaz();
+                \t   \t\t\t  \t\t\t  \t   \tqux();
+                }
+            `,
             options: [2]
         },
         {
-            code:
-            "function foo() {\n" +
-            "  function bar() {\n" +
-            "    baz();\n" +
-            "  }\n" +
-            "}",
+            code: unIndent`
+                function foo() {
+                  function bar() {
+                    baz();
+                  }
+                }
+            `,
             options: [2, { FunctionDeclaration: { body: 1 } }]
         },
         {
-            code:
-            "function foo() {\n" +
-            "  bar();\n" +
-            "   \t\t}",
+            code: unIndent`
+                function foo() {
+                  bar();
+                   \t\t}
+            `,
             options: [2]
         },
         {
-            code:
-            "function foo() {\n" +
-            "  function bar(baz,\n" +
-            "      qux) {\n" +
-            "    foobar();\n" +
-            "  }\n" +
-            "}",
+            code: unIndent`
+                function foo() {
+                  function bar(baz,
+                      qux) {
+                    foobar();
+                  }
+                }
+            `,
             options: [2, { FunctionDeclaration: { body: 1, parameters: 2 } }]
         },
         {
-            code:
-            "function foo() {\n" +
-            "  var bar = function(baz,\n" +
-            "        qux) {\n" +
-            "    foobar();\n" +
-            "  };\n" +
-            "}",
+            code: unIndent`
+                ((
+                    foo
+                ))
+            `,
+            options: [4]
+        },
+
+        // ternary expressions (https://github.com/eslint/eslint/issues/7420)
+        {
+            code: unIndent`
+                foo
+                  ? bar
+                  : baz
+            `,
+            options: [2]
+        },
+        {
+            code: unIndent`
+                foo = (bar ?
+                  baz :
+                  qux
+                );
+            `,
+            options: [2]
+        },
+        {
+            code: unIndent`
+                [
+                    foo ?
+                        bar :
+                        baz,
+                    qux
+                ];
+            `
+        },
+        {
+
+            // Checking comments:
+            // https://github.com/eslint/eslint/issues/3845, https://github.com/eslint/eslint/issues/6571
+            code: unIndent`
+                foo();
+                // Line
+                /* multiline
+                  Line */
+                bar();
+                // trailing comment
+            `,
+            options: [2]
+        },
+        {
+            code: unIndent`
+                switch (foo) {
+                  case bar:
+                    baz();
+                    // call the baz function
+                }
+            `,
+            options: [2, { SwitchCase: 1 }]
+        },
+        {
+            code: unIndent`
+                switch (foo) {
+                  case bar:
+                    baz();
+                  // no default
+                }
+            `,
+            options: [2, { SwitchCase: 1 }]
+        },
+        {
+            code: unIndent`
+                [
+                    // no elements
+                ]
+            `
+        },
+        {
+
+            // Destructuring assignments:
+            // https://github.com/eslint/eslint/issues/6813
+            code: unIndent`
+                var {
+                  foo,
+                  bar,
+                  baz: qux,
+                  foobar: baz = foobar
+                } = qux;
+            `,
+            options: [2],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: unIndent`
+                var [
+                  foo,
+                  bar,
+                  baz,
+                  foobar = baz
+                ] = qux;
+            `,
+            options: [2],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+
+            // https://github.com/eslint/eslint/issues/7233
+            code: unIndent`
+                var folder = filePath
+                    .foo()
+                    .bar;
+            `,
+            options: [2, { MemberExpression: 2 }]
+        },
+        {
+            code: unIndent`
+                for (const foo of bar)
+                  baz();
+            `,
+            options: [2],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: unIndent`
+                var x = () =>
+                  5;
+            `,
+            options: [2],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+
+            // Don't lint the indentation of the first token after a :
+            code: unIndent`
+                ({code:
+                  "foo.bar();"})
+            `,
+            options: [2]
+        },
+        {
+
+            // Don't lint the indentation of the first token after a :
+            code: unIndent`
+                ({code:
+                "foo.bar();"})
+            `,
+            options: [2]
+        },
+        {
+
+            // Comments in switch cases
+            code: unIndent`
+                switch (foo) {
+                  // comment
+                  case study:
+                    // comment
+                    bar();
+                  case closed:
+                    /* multiline comment
+                    */
+                }
+            `,
+            options: [2, { SwitchCase: 1 }]
+        },
+        {
+
+            // Comments in switch cases
+            code: unIndent`
+                switch (foo) {
+                  // comment
+                  case study:
+                  // the comment can also be here
+                  case closed:
+                }
+            `,
+            options: [2, { SwitchCase: 1 }]
+        },
+        {
+
+            // BinaryExpressions with parens
+            code: unIndent`
+                foo && (
+                    bar
+                )
+            `,
+            options: [4]
+        },
+        {
+
+            // BinaryExpressions with parens
+            code: unIndent`
+                foo && ((
+                    bar
+                ))
+            `,
+            options: [4]
+        },
+        {
+            code: unIndent`
+                foo &&
+                    (
+                        bar
+                    )
+            `,
+            options: [4]
+        },
+        {
+            code: unIndent`
+                foo =
+                    bar;
+            `,
+            options: [4]
+        },
+        {
+            code: unIndent`
+                function foo() {
+                  var bar = function(baz,
+                        qux) {
+                    foobar();
+                  };
+                }
+            `,
             options: [2, { FunctionExpression: { parameters: 3 } }]
         },
         {
-            code:
-            "function foo() {\n" +
-            "  return (bar === 1 || bar === 2 &&\n" +
-            "    (/Function/.test(grandparent.type))) &&\n" +
-            "    directives(parent).indexOf(node) >= 0;\n" +
-            "}",
+            code: unIndent`
+                function foo() {
+                    return (bar === 1 || bar === 2 &&
+                        (/Function/.test(grandparent.type))) &&
+                        directives(parent).indexOf(node) >= 0;
+                }
+            `
+        },
+        {
+            code: unIndent`
+                function foo() {
+                    return (foo === bar || (
+                        baz === qux && (
+                            foo === foo ||
+                            bar === bar ||
+                            baz === baz
+                        )
+                    ))
+                }
+            `,
+            options: [4]
+        },
+        {
+            code: unIndent`
+                if (
+                    foo === 1 ||
+                    bar === 1 ||
+                    // comment
+                    (baz === 1 && qux === 1)
+                ) {}
+            `
+        },
+        {
+            code: unIndent`
+                foo =
+                  (bar + baz);
+            `,
             options: [2]
         },
         {
-            code:
-            "function foo() {\n" +
-            "  return (bar === 1 || bar === 2) &&\n" +
-            "    (z === 3 || z === 4);\n" +
-            "}",
+            code: unIndent`
+                function foo() {
+                  return (bar === 1 || bar === 2) &&
+                    (z === 3 || z === 4);
+                }
+            `,
             options: [2]
         },
         {
-            code:
-            "function foo() {\n" +
-            "  return ((bar === 1 || bar === 2) &&\n" +
-            "    (z === 3 || z === 4)\n" +
-            "  );\n" +
-            "}",
+            code: unIndent`
+                /* comment */ if (foo) {
+                  bar();
+                }
+            `,
             options: [2]
         },
         {
-            code:
-            "function foo() {\n" +
-            "  return ((bar === 1 || bar === 2) &&\n" +
-            "    (z === 3 || z === 4));\n" +
-            "}",
+
+            // Comments at the end of if blocks that have `else` blocks can either refer to the lines above or below them
+            code: unIndent`
+                if (foo) {
+                  bar();
+                // Otherwise, if foo is false, do baz.
+                // baz is very important.
+                } else {
+                  baz();
+                }
+            `,
             options: [2]
-        }, {
-            code:
-            "foo(\n" +
-            "  bar,\n" +
-            "  baz,\n" +
-            "  qux\n" +
-            ");",
+        },
+        {
+            code: unIndent`
+                function foo() {
+                  return ((bar === 1 || bar === 2) &&
+                    (z === 3 || z === 4));
+                }
+            `,
+            options: [2]
+        },
+        {
+            code: unIndent`
+                foo(
+                  bar,
+                  baz,
+                  qux
+                );
+            `,
             options: [2, { CallExpression: { arguments: 1 } }]
-        }, {
-            code:
-            "foo(\n" +
-            "\tbar,\n" +
-            "\tbaz,\n" +
-            "\tqux\n" +
-            ");",
+        },
+        {
+            code: unIndent`
+                foo(
+                \tbar,
+                \tbaz,
+                \tqux
+                );
+            `,
             options: ["tab", { CallExpression: { arguments: 1 } }]
-        }, {
-            code:
-            "foo(bar,\n" +
-            "        baz,\n" +
-            "        qux);",
+        },
+        {
+            code: unIndent`
+                foo(bar,
+                        baz,
+                        qux);
+            `,
             options: [4, { CallExpression: { arguments: 2 } }]
-        }, {
-            code:
-            "foo(\n" +
-            "bar,\n" +
-            "baz,\n" +
-            "qux\n" +
-            ");",
+        },
+        {
+            code: unIndent`
+                foo(
+                bar,
+                baz,
+                qux
+                );
+            `,
             options: [2, { CallExpression: { arguments: 0 } }]
-        }, {
-            code:
-            "foo(bar,\n" +
-            "    baz,\n" +
-            "    qux\n" +
-            ");",
+        },
+        {
+            code: unIndent`
+                foo(bar,
+                    baz,
+                    qux
+                );
+            `,
             options: [2, { CallExpression: { arguments: "first" } }]
-        }, {
-            code:
-            "foo(bar, baz,\n" +
-            "    qux, barbaz,\n" +
-            "    barqux, bazqux);",
+        },
+        {
+            code: unIndent`
+                foo(bar, baz,
+                    qux, barbaz,
+                    barqux, bazqux);
+            `,
             options: [2, { CallExpression: { arguments: "first" } }]
-        }, {
-            code:
-            "foo(\n" +
-            "                        bar, baz,\n" +
-            "                        qux);",
-            options: [2, { CallExpression: { arguments: "first" } }]
-        }, {
-            code:
-            "foo(bar,\n" +
-            "        1 + 2,\n" +
-            "        !baz,\n" +
-            "        new Car('!')\n" +
-            ");",
+        },
+        {
+            code: unIndent`
+                foo(bar,
+                        1 + 2,
+                        !baz,
+                        new Car('!')
+                );
+            `,
             options: [2, { CallExpression: { arguments: 4 } }]
+        },
+        {
+            code: unIndent`
+                foo(
+                    (bar)
+                );
+            `
+        },
+        {
+            code: unIndent`
+                foo(
+                    (bar)
+                );
+            `,
+            options: [4, { CallExpression: { arguments: 1 } }]
         },
 
         // https://github.com/eslint/eslint/issues/7484
         {
-            code:
-            "var foo = function() {\n" +
-            "  return bar(\n" +
-            "    [{\n" +
-            "    }].concat(baz)\n" +
-            "  );\n" +
-            "};",
+            code: unIndent`
+                var foo = function() {
+                  return bar(
+                    [{
+                    }].concat(baz)
+                  );
+                };
+            `,
             options: [2]
         },
 
         // https://github.com/eslint/eslint/issues/7573
         {
-            code:
-            "return (\n" +
-            "    foo\n" +
-            ");",
+            code: unIndent`
+                return (
+                    foo
+                );
+            `,
             parserOptions: { ecmaFeatures: { globalReturn: true } }
         },
         {
-            code:
-            "return (\n" +
-            "    foo\n" +
-            ")",
+            code: unIndent`
+                return (
+                    foo
+                )
+            `,
             parserOptions: { ecmaFeatures: { globalReturn: true } }
         },
         {
-            code:
-            "var foo = [\n" +
-            "    bar,\n" +
-            "    baz\n" +
-            "]"
+            code: unIndent`
+                var foo = [
+                    bar,
+                    baz
+                ]
+            `
         },
         {
-            code:
-            "var foo = [bar,\n" +
-            "    baz,\n" +
-            "    qux\n" +
-            "]"
+            code: unIndent`
+                var foo = [bar,
+                    baz,
+                    qux
+                ]
+            `
         },
         {
-            code:
-            "var foo = [bar,\n" +
-            "baz,\n" +
-            "qux\n" +
-            "]",
+            code: unIndent`
+                var foo = [bar,
+                baz,
+                qux
+                ]
+            `,
             options: [2, { ArrayExpression: 0 }]
         },
         {
-            code:
-            "var foo = [bar,\n" +
-            "                baz,\n" +
-            "                qux\n" +
-            "]",
+            code: unIndent`
+                var foo = [bar,
+                                baz,
+                                qux
+                ]
+            `,
             options: [2, { ArrayExpression: 8 }]
         },
         {
-            code:
-            "var foo = [bar,\n" +
-            "           baz,\n" +
-            "           qux\n" +
-            "]",
+            code: unIndent`
+                var foo = [bar,
+                           baz,
+                           qux
+                ]
+            `,
             options: [2, { ArrayExpression: "first" }]
         },
         {
-            code:
-            "var foo = [bar,\n" +
-            "           baz, qux\n" +
-            "]",
+            code: unIndent`
+                var foo = [bar,
+                           baz, qux
+                ]
+            `,
             options: [2, { ArrayExpression: "first" }]
         },
         {
-            code:
-            "var foo = [\n" +
-            "        { bar: 1,\n" +
-            "          baz: 2 },\n" +
-            "        { bar: 3,\n" +
-            "          qux: 4 }\n" +
-            "]",
+            code: unIndent`
+                var foo = [
+                        { bar: 1,
+                          baz: 2 },
+                        { bar: 3,
+                          baz: 4 }
+                ]
+            `,
             options: [4, { ArrayExpression: 2, ObjectExpression: "first" }]
         },
         {
-            code:
-            "var foo = {\n" +
-            "bar: 1,\n" +
-            "baz: 2\n" +
-            "};",
+            code: unIndent`
+                var foo = {
+                bar: 1,
+                baz: 2
+                };
+            `,
             options: [2, { ObjectExpression: 0 }]
         },
         {
-            code:
-            "var foo = { foo: 1, bar: 2,\n" +
-            "            baz: 3 }",
+            code: unIndent`
+                var foo = { foo: 1, bar: 2,
+                            baz: 3 }
+            `,
             options: [2, { ObjectExpression: "first" }]
         },
         {
-            code:
-            "var foo = [\n" +
-            "        {\n" +
-            "            foo: 1\n" +
-            "        }\n" +
-            "]",
+            code: unIndent`
+                var foo = [
+                        {
+                            foo: 1
+                        }
+                ]
+            `,
             options: [4, { ArrayExpression: 2 }]
         },
         {
-            code:
-            "function foo() {\n" +
-            "  [\n" +
-            "          foo\n" +
-            "  ]\n" +
-            "}",
+            code: unIndent`
+                function foo() {
+                  [
+                          foo
+                  ]
+                }
+            `,
             options: [2, { ArrayExpression: 4 }]
         },
         {
@@ -1841,479 +2424,1065 @@ ruleTester.run("indent", rule, {
             options: [2, { ObjectExpression: 1 }]
         },
         {
-            code:
-            "var foo = [\n" +
-            "  [\n" +
-            "    1\n" +
-            "  ]\n" +
-            "]",
+            code: unIndent`
+                var foo = [
+                  [
+                    1
+                  ]
+                ]
+            `,
             options: [2, { ArrayExpression: "first" }]
         },
         {
-            code:
-            "var foo = [ 1,\n" +
-            "            [\n" +
-            "              2\n" +
-            "            ]\n" +
-            "];",
+            code: unIndent`
+                var foo = [ 1,
+                            [
+                              2
+                            ]
+                ];
+            `,
             options: [2, { ArrayExpression: "first" }]
         },
         {
-            code:
-            "var foo = bar(1,\n" +
-            "              [ 2,\n" +
-            "                3\n" +
-            "              ]\n" +
-            ");",
+            code: unIndent`
+                var foo = bar(1,
+                              [ 2,
+                                3
+                              ]
+                );
+            `,
             options: [4, { ArrayExpression: "first", CallExpression: { arguments: "first" } }]
         },
         {
-            code:
-            "var foo =\n" +
-            "    [\n" +
-            "    ]()",
+            code: unIndent`
+                var foo =
+                    [
+                    ]()
+            `,
             options: [4, { CallExpression: { arguments: "first" }, ArrayExpression: "first" }]
         },
 
         // https://github.com/eslint/eslint/issues/7732
         {
-            code:
-            "const lambda = foo => {\n" +
-            "  Object.assign({},\n" +
-            "    filterName,\n" +
-            "    {\n" +
-            "      display\n" +
-            "    }\n" +
-            "  );" +
-            "}",
+            code: unIndent`
+                const lambda = foo => {
+                  Object.assign({},
+                    filterName,
+                    {
+                      display
+                    }
+                  );
+                }
+            `,
             options: [2, { ObjectExpression: 1 }],
             parserOptions: { ecmaVersion: 6 }
         },
         {
-            code:
-            "const lambda = foo => {\n" +
-            "  Object.assign({},\n" +
-            "    filterName,\n" +
-            "    {\n" +
-            "      display\n" +
-            "    }\n" +
-            "  );" +
-            "}",
+            code: unIndent`
+                const lambda = foo => {
+                  Object.assign({},
+                    filterName,
+                    {
+                      display
+                    }
+                  );
+                }
+            `,
             options: [2, { ObjectExpression: "first" }],
             parserOptions: { ecmaVersion: 6 }
         },
 
         // https://github.com/eslint/eslint/issues/7733
         {
-            code:
-            "var foo = function() {\n" +
-            "\twindow.foo('foo',\n" +
-            "\t\t{\n" +
-            "\t\t\tfoo: 'bar'," +
-            "\t\t\tbar: {\n" +
-            "\t\t\t\tfoo: 'bar'\n" +
-            "\t\t\t}\n" +
-            "\t\t}\n" +
-            "\t);\n" +
-            "}",
+            code: unIndent`
+                var foo = function() {
+                \twindow.foo('foo',
+                \t\t{
+                \t\t\tfoo: 'bar',
+                \t\t\tbar: {
+                \t\t\t\tfoo: 'bar'
+                \t\t\t}
+                \t\t}
+                \t);
+                }
+            `,
             options: ["tab"]
         },
         {
-            code:
-            "echo = spawn('cmd.exe',\n" +
-            "             ['foo', 'bar',\n" +
-            "              'baz']);",
+            code: unIndent`
+                echo = spawn('cmd.exe',
+                             ['foo', 'bar',
+                              'baz']);
+            `,
             options: [2, { ArrayExpression: "first", CallExpression: { arguments: "first" } }]
+        },
+        {
+            code: unIndent`
+                if (foo)
+                  bar();
+                // Otherwise, if foo is false, do baz.
+                // baz is very important.
+                else {
+                  baz();
+                }
+            `,
+            options: [2]
+        },
+        {
+            code: unIndent`
+                if (
+                    foo && bar ||
+                    baz && qux // This line is ignored because BinaryExpressions are not checked.
+                ) {
+                    qux();
+                }
+            `,
+            options: [4]
+        },
+        {
+            code: unIndent`
+                var foo =
+                        1;
+            `,
+            options: [4, { VariableDeclarator: 2 }]
+        },
+        {
+            code: unIndent`
+                var foo = 1,
+                    bar =
+                    2;
+            `,
+            options: [4]
+        },
+        {
+            code: unIndent`
+                switch (foo) {
+                  case bar:
+                  {
+                    baz();
+                  }
+                }
+            `,
+            options: [2, { SwitchCase: 1 }]
+        },
+
+        // Template curlies
+        {
+            code: unIndent`
+                \`foo\${
+                  bar}\`
+            `,
+            options: [2],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: unIndent`
+                \`foo\${
+                  \`bar\${
+                    baz}\`}\`
+            `,
+            options: [2],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: unIndent`
+                \`foo\${
+                  \`bar\${
+                    baz
+                  }\`
+                }\`
+            `,
+            options: [2],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: unIndent`
+                \`foo\${
+                  (
+                    bar
+                  )
+                }\`
+            `,
+            options: [2],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+
+            code: unIndent`
+                function foo() {
+                    \`foo\${bar}baz\${
+                        qux}foo\${
+                        bar}baz\`
+                }
+            `,
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+
+            // https://github.com/eslint/eslint/issues/7320
+            code: unIndent`
+                JSON
+                    .stringify(
+                        {
+                            ok: true
+                        }
+                    );
+            `
+        },
+
+        // Don't check AssignmentExpression assignments
+        {
+            code: unIndent`
+                foo =
+                    bar =
+                    baz;
+            `
+        },
+        {
+            code: unIndent`
+                foo =
+                bar =
+                    baz;
+            `
+        },
+        {
+            code: unIndent`
+                function foo() {
+                    const template = \`this indentation is not checked
+                because it's part of a template literal.\`;
+                }
+            `,
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: unIndent`
+                function foo() {
+                    const template = \`the indentation of a \${
+                        node.type
+                    } node is checked.\`;
+                }
+            `,
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+
+            // https://github.com/eslint/eslint/issues/7320
+            code: unIndent`
+                JSON
+                    .stringify(
+                        {
+                            test: 'test'
+                        }
+                    );
+            `,
+            options: [4, { CallExpression: { arguments: 1 } }]
+        },
+        {
+            code: unIndent`
+                [
+                    foo,
+                    // comment
+                    // another comment
+                    bar
+                ]
+            `
+        },
+        {
+            code: unIndent`
+                if (foo) {
+                    /* comment */ bar();
+                }
+            `
+        },
+        {
+            code: unIndent`
+                function foo() {
+                    return (
+                        1
+                    );
+                }
+            `
+        },
+        {
+            code: unIndent`
+                function foo() {
+                    return (
+                        1
+                    )
+                }
+            `
+        },
+        {
+            code: unIndent`
+                if (
+                    foo &&
+                    !(
+                        bar
+                    )
+                ) {}
+            `
+        },
+        {
+
+            // https://github.com/eslint/eslint/issues/6007
+            code: unIndent`
+                var abc = [
+                  (
+                    ''
+                  ),
+                  def,
+                ]
+            `,
+            options: [2]
+        },
+        {
+            code: unIndent`
+                var abc = [
+                  (
+                    ''
+                  ),
+                  (
+                    'bar'
+                  )
+                ]
+            `,
+            options: [2]
+        },
+        {
+
+            // https://github.com/eslint/eslint/issues/6670
+            code: unIndent`
+                function f() {
+                    return asyncCall()
+                        .then(
+                            'some string',
+                            [
+                                1,
+                                2,
+                                3
+                            ]
+                        );
+                }
+            `
+        },
+        {
+
+            // https://github.com/eslint/eslint/issues/6670
+            code: unIndent`
+                function f() {
+                    return asyncCall()
+                        .then(
+                            'some string',
+                            [
+                                1,
+                                2,
+                                3
+                            ]
+                        );
+                }
+            `,
+            options: [4, { MemberExpression: 1 }]
+        },
+
+        // https://github.com/eslint/eslint/issues/7242
+        {
+            code: unIndent`
+                var x = [
+                    [1],
+                    [2]
+                ]
+            `
+        },
+        {
+            code: unIndent`
+                var y = [
+                    {a: 1},
+                    {b: 2}
+                ]
+            `
+        },
+        {
+
+            // https://github.com/eslint/eslint/issues/7522
+            code: unIndent`
+                foo(
+                )
+            `
+        },
+        {
+
+            // https://github.com/eslint/eslint/issues/7616
+            code: unIndent`
+                foo(
+                    bar,
+                    {
+                        baz: 1
+                    }
+                )
+            `,
+            options: [4, { CallExpression: { arguments: "first" } }]
+        },
+        {
+            code: "new Foo"
+        },
+        {
+            code: "new (Foo)"
+        },
+        {
+            code: unIndent`
+                if (Foo) {
+                    new Foo
+                }
+            `
+        },
+        {
+            code: unIndent`
+                export {
+                    foo,
+                    bar,
+                    baz
+                }
+            `,
+            parserOptions: { sourceType: "module" }
+        },
+        {
+            code: unIndent`
+                foo
+                    ? bar
+                    : baz
+            `,
+            options: [4, { flatTernaryExpressions: true }]
+        },
+        {
+            code: unIndent`
+                foo ?
+                    bar :
+                    baz
+            `,
+            options: [4, { flatTernaryExpressions: true }]
+        },
+        {
+            code: unIndent`
+                foo ?
+                    bar
+                    : baz
+            `,
+            options: [4, { flatTernaryExpressions: true }]
+        },
+        {
+            code: unIndent`
+                foo
+                    ? bar :
+                    baz
+            `,
+            options: [4, { flatTernaryExpressions: true }]
+        },
+        {
+            code: unIndent`
+                foo
+                    ? bar
+                    : baz
+                    ? qux
+                    : foobar
+                    ? boop
+                    : beep
+            `,
+            options: [4, { flatTernaryExpressions: true }]
+        },
+        {
+            code: unIndent`
+                foo ?
+                    bar :
+                    baz ?
+                    qux :
+                    foobar ?
+                    boop :
+                    beep
+            `,
+            options: [4, { flatTernaryExpressions: true }]
+        },
+        {
+            code: unIndent`
+                foo
+                    ? bar
+                    : baz
+                        ? qux
+                        : foobar
+                            ? boop
+                            : beep
+            `,
+            options: [4, { flatTernaryExpressions: false }]
+        },
+        {
+            code: unIndent`
+                foo ?
+                    bar :
+                    baz ?
+                        qux :
+                        foobar ?
+                            boop :
+                            beep
+            `,
+            options: [4, { flatTernaryExpressions: false }]
+        },
+        {
+            code: "[,]",
+            options: [2, { ArrayExpression: "first" }]
+        },
+        {
+            code: unIndent`
+                [
+                    ,
+                    foo
+                ]
+            `,
+            options: [4, { ArrayExpression: "first" }]
+        },
+        {
+            code: "[sparse, , array];",
+            options: [2, { ArrayExpression: "first" }]
+        },
+        {
+            code: unIndent`
+                foo.bar('baz', function(err) {
+                  qux;
+                });
+            `,
+            options: [2, { CallExpression: { arguments: "first" } }]
+        },
+        {
+            code: unIndent`
+                foo.bar(function() {
+                  cookies;
+                }).baz(function() {
+                  cookies;
+                });
+            `,
+            options: [2, { MemberExpression: 1 }]
+        },
+        {
+            code: unIndent`
+                foo.bar().baz(function() {
+                  cookies;
+                }).qux(function() {
+                  cookies;
+                });
+            `,
+            options: [2, { MemberExpression: 1 }]
+        },
+        {
+            code: unIndent`
+                (
+                  {
+                    foo: 1,
+                    baz: 2
+                  }
+                );
+            `,
+            options: [2, { ObjectExpression: "first" }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: unIndent`
+                foo(() => {
+                    bar;
+                }, () => {
+                    baz;
+                })
+            `,
+            options: [4, { CallExpression: { arguments: "first" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: unIndent`
+                [ foop,
+                  bar ].forEach(function() {
+                    baz;
+                  })
+            `,
+            options: [2, { ArrayExpression: "first", MemberExpression: 1 }]
+        },
+        {
+            code: unIndent`
+                foo = bar[
+                    baz
+                ];
+            `
+        },
+        {
+            code: unIndent`
+                foo[
+                    bar
+                ];
+            `,
+            options: [4, { MemberExpression: 1 }]
+        },
+        {
+            code: unIndent`
+                foo[
+                    (
+                        bar
+                    )
+                ];
+            `,
+            options: [4, { MemberExpression: 1 }]
         }
     ],
+
+
     invalid: [
         {
-            code:
-                "var a = b;\n" +
-                "if (a) {\n" +
-                "b();\n" +
-                "}\n",
+            code: unIndent`
+                var a = b;
+                if (a) {
+                b();
+                }
+            `,
             options: [2],
-            errors: expectedErrors([[3, 2, 0, "ExpressionStatement"]]),
-            output:
-                "var a = b;\n" +
-                "if (a) {\n" +
-                "  b();\n" +
-                "}\n"
+            errors: expectedErrors([[3, 2, 0, "Identifier"]]),
+            output: unIndent`
+                var a = b;
+                if (a) {
+                  b();
+                }
+            `
         },
         {
-            code:
-            "require('http').request({hostname: 'localhost',\n" +
-            "                  port: 80}, function(res) {\n" +
-            "  res.end();\n" +
-            "});\n",
-            output:
-            "require('http').request({hostname: 'localhost',\n" +
-            "  port: 80}, function(res) {\n" +
-            "  res.end();\n" +
-            "});\n",
+            code: unIndent`
+                require('http').request({hostname: 'localhost',
+                                  port: 80}, function(res) {
+                    res.end();
+                  });
+            `,
+            output: unIndent`
+                require('http').request({hostname: 'localhost',
+                  port: 80}, function(res) {
+                  res.end();
+                });
+            `,
             options: [2],
-            errors: expectedErrors([[2, 2, 18, "Property"]])
+            errors: expectedErrors([[2, 2, 18, "Identifier"], [3, 2, 4, "Identifier"], [4, 0, 2, "Punctuator"]])
         },
         {
-            code:
-                "if (array.some(function(){\n" +
-                "  return true;\n" +
-                "})) {\n" +
-                "a++; // ->\n" +
-                "  b++;\n" +
-                "    c++; // <-\n" +
-                "}\n",
-            output:
-                "if (array.some(function(){\n" +
-                "  return true;\n" +
-                "})) {\n" +
-                "  a++; // ->\n" +
-                "  b++;\n" +
-                "  c++; // <-\n" +
-                "}\n",
+            code: unIndent`
+                if (array.some(function(){
+                  return true;
+                })) {
+                a++; // ->
+                  b++;
+                    c++; // <-
+                }
+            `,
+            output: unIndent`
+                if (array.some(function(){
+                  return true;
+                })) {
+                  a++; // ->
+                  b++;
+                  c++; // <-
+                }
+            `,
             options: [2],
-            errors: expectedErrors([[4, 2, 0, "ExpressionStatement"], [6, 2, 4, "ExpressionStatement"]])
+            errors: expectedErrors([[4, 2, 0, "Identifier"], [6, 2, 4, "Identifier"]])
         },
         {
-            code: "if (a){\n\tb=c;\n\t\tc=d;\ne=f;\n}",
-            output: "if (a){\n\tb=c;\n\tc=d;\n\te=f;\n}",
+            code: unIndent`
+                if (a){
+                \tb=c;
+                \t\tc=d;
+                e=f;
+                }
+            `,
+            output: unIndent`
+                if (a){
+                \tb=c;
+                \tc=d;
+                \te=f;
+                }
+            `,
             options: ["tab"],
-            errors: expectedErrors("tab", [[3, 1, 2, "ExpressionStatement"], [4, 1, 0, "ExpressionStatement"]])
+            errors: expectedErrors("tab", [[3, 1, 2, "Identifier"], [4, 1, 0, "Identifier"]])
         },
         {
-            code: "if (a){\n    b=c;\n      c=d;\n e=f;\n}",
-            output: "if (a){\n    b=c;\n    c=d;\n    e=f;\n}",
+            code: unIndent`
+                if (a){
+                    b=c;
+                      c=d;
+                 e=f;
+                }
+            `,
+            output: unIndent`
+                if (a){
+                    b=c;
+                    c=d;
+                    e=f;
+                }
+            `,
             options: [4],
-            errors: expectedErrors([[3, 4, 6, "ExpressionStatement"], [4, 4, 1, "ExpressionStatement"]])
+            errors: expectedErrors([[3, 4, 6, "Identifier"], [4, 4, 1, "Identifier"]])
         },
         {
             code: fixture,
             output: fixedFixture,
-            options: [2, { SwitchCase: 1, MemberExpression: 1 }],
+            options: [2, { SwitchCase: 1, MemberExpression: 1, CallExpression: { arguments: "off" } }],
             errors: expectedErrors([
-                [5, 2, 4, "VariableDeclaration"],
-                [10, 4, 6, "BlockStatement"],
-                [11, 2, 4, "BlockStatement"],
-                [15, 4, 2, "ExpressionStatement"],
-                [16, 2, 4, "BlockStatement"],
-                [23, 2, 4, "BlockStatement"],
-                [29, 2, 4, "ForStatement"],
-                [31, 4, 2, "BlockStatement"],
-                [36, 4, 6, "ExpressionStatement"],
-                [38, 2, 4, "BlockStatement"],
-                [39, 4, 2, "ExpressionStatement"],
-                [40, 2, 0, "BlockStatement"],
-                [46, 0, 1, "VariableDeclaration"],
-                [54, 2, 4, "BlockStatement"],
-                [114, 4, 2, "VariableDeclaration"],
-                [120, 4, 6, "VariableDeclaration"],
-                [124, 4, 2, "BreakStatement"],
-                [134, 4, 6, "BreakStatement"],
+                [5, 2, 4, "Keyword"],
+                [6, 2, 0, "Line"],
+                [10, 4, 6, "Punctuator"],
+                [11, 2, 4, "Punctuator"],
+
+                [15, 4, 2, "Identifier"],
+                [16, 2, 4, "Punctuator"],
+                [23, 2, 4, "Punctuator"],
+                [29, 2, 4, "Keyword"],
+                [30, 4, 6, "Identifier"],
+                [36, 4, 6, "Identifier"],
+                [38, 2, 4, "Punctuator"],
+                [39, 4, 2, "Identifier"],
+                [40, 2, 0, "Punctuator"],
+                [54, 2, 4, "Punctuator"],
+                [114, 4, 2, "Keyword"],
+                [120, 4, 6, "Keyword"],
+                [124, 4, 2, "Keyword"],
+                [134, 4, 6, "Keyword"],
                 [138, 2, 3, "Punctuator"],
                 [139, 2, 3, "Punctuator"],
-                [143, 4, 0, "ExpressionStatement"],
-                [151, 4, 6, "ExpressionStatement"],
-                [159, 4, 2, "ExpressionStatement"],
-                [161, 4, 6, "ExpressionStatement"],
-                [175, 2, 0, "ExpressionStatement"],
-                [177, 2, 4, "ExpressionStatement"],
-                [189, 2, 0, "VariableDeclaration"],
-                [193, 6, 4, "ExpressionStatement"],
-                [195, 6, 8, "ExpressionStatement"],
-                [304, 4, 6, "ExpressionStatement"],
-                [306, 4, 8, "ExpressionStatement"],
-                [307, 2, 4, "BlockStatement"],
-                [308, 2, 4, "VariableDeclarator"],
+                [143, 4, 0, "Identifier"],
+                [144, 6, 2, "Punctuator"],
+                [145, 6, 2, "Punctuator"],
+                [151, 4, 6, "Identifier"],
+                [152, 6, 8, "Punctuator"],
+                [153, 6, 8, "Punctuator"],
+                [159, 4, 2, "Identifier"],
+                [161, 4, 6, "Identifier"],
+                [175, 2, 0, "Identifier"],
+                [177, 2, 4, "Identifier"],
+                [189, 2, 0, "Keyword"],
+                [192, 6, 18, "Identifier"],
+                [193, 6, 4, "Identifier"],
+                [195, 6, 8, "Identifier"],
+                [228, 5, 4, "Identifier"],
+                [231, 3, 2, "Punctuator"],
+                [245, 0, 2, "Punctuator"],
+                [248, 0, 2, "Punctuator"],
+                [304, 4, 6, "Identifier"],
+                [306, 4, 8, "Identifier"],
+                [307, 2, 4, "Punctuator"],
+                [308, 2, 4, "Identifier"],
                 [311, 4, 6, "Identifier"],
                 [312, 4, 6, "Identifier"],
                 [313, 4, 6, "Identifier"],
-                [314, 2, 4, "ArrayExpression"],
-                [315, 2, 4, "VariableDeclarator"],
-                [318, 4, 6, "Property"],
-                [319, 4, 6, "Property"],
-                [320, 4, 6, "Property"],
-                [321, 2, 4, "ObjectExpression"],
-                [322, 2, 4, "VariableDeclarator"],
-                [326, 2, 1, "Literal"],
-                [327, 2, 1, "Literal"],
-                [328, 2, 1, "Literal"],
-                [329, 2, 1, "Literal"],
-                [330, 2, 1, "Literal"],
-                [331, 2, 1, "Literal"],
-                [332, 2, 1, "Literal"],
-                [333, 2, 1, "Literal"],
-                [334, 2, 1, "Literal"],
-                [335, 2, 1, "Literal"],
-                [340, 2, 4, "ExpressionStatement"],
-                [341, 2, 0, "ExpressionStatement"],
-                [344, 2, 4, "ExpressionStatement"],
-                [345, 2, 0, "ExpressionStatement"],
-                [348, 2, 4, "ExpressionStatement"],
-                [349, 2, 0, "ExpressionStatement"],
-                [355, 2, 0, "ExpressionStatement"],
-                [357, 2, 4, "ExpressionStatement"],
-                [361, 4, 6, "ExpressionStatement"],
-                [362, 2, 4, "BlockStatement"],
-                [363, 2, 4, "VariableDeclarator"],
-                [368, 2, 0, "SwitchCase"],
-                [370, 2, 4, "SwitchCase"],
-                [374, 4, 6, "VariableDeclaration"],
-                [376, 4, 2, "VariableDeclaration"],
-                [383, 2, 0, "ExpressionStatement"],
-                [385, 2, 4, "ExpressionStatement"],
-                [390, 2, 0, "ExpressionStatement"],
-                [392, 2, 4, "ExpressionStatement"],
-                [409, 2, 0, "ExpressionStatement"],
-                [410, 2, 4, "ExpressionStatement"],
-                [416, 2, 0, "ExpressionStatement"],
-                [417, 2, 4, "ExpressionStatement"],
-                [422, 2, 4, "ExpressionStatement"],
-                [423, 2, 0, "ExpressionStatement"],
-                [427, 2, 6, "ExpressionStatement"],
-                [428, 2, 8, "ExpressionStatement"],
-                [429, 2, 4, "ExpressionStatement"],
-                [430, 0, 4, "BlockStatement"],
-                [433, 2, 4, "ExpressionStatement"],
-                [434, 0, 4, "BlockStatement"],
-                [437, 2, 0, "ExpressionStatement"],
-                [438, 0, 4, "BlockStatement"],
-                [451, 2, 0, "ExpressionStatement"],
-                [453, 2, 4, "ExpressionStatement"],
-                [499, 6, 8, "BlockStatement"],
-                [500, 10, 8, "ExpressionStatement"],
-                [501, 8, 6, "BlockStatement"],
-                [506, 6, 8, "BlockStatement"]
+                [314, 2, 4, "Punctuator"],
+                [315, 2, 4, "Identifier"],
+                [318, 4, 6, "Identifier"],
+                [319, 4, 6, "Identifier"],
+                [320, 4, 6, "Identifier"],
+                [321, 2, 4, "Punctuator"],
+                [322, 2, 4, "Identifier"],
+                [326, 2, 1, "Numeric"],
+                [327, 2, 1, "Numeric"],
+                [328, 2, 1, "Numeric"],
+                [329, 2, 1, "Numeric"],
+                [330, 2, 1, "Numeric"],
+                [331, 2, 1, "Numeric"],
+                [332, 2, 1, "Numeric"],
+                [333, 2, 1, "Numeric"],
+                [334, 2, 1, "Numeric"],
+                [335, 2, 1, "Numeric"],
+                [340, 2, 4, "Identifier"],
+                [341, 2, 0, "Identifier"],
+                [344, 2, 4, "Identifier"],
+                [345, 2, 0, "Identifier"],
+                [348, 2, 4, "Identifier"],
+                [349, 2, 0, "Identifier"],
+                [355, 2, 0, "Identifier"],
+                [357, 2, 4, "Identifier"],
+                [361, 4, 6, "Identifier"],
+                [362, 2, 4, "Punctuator"],
+                [363, 2, 4, "Identifier"],
+                [368, 2, 0, "Keyword"],
+                [370, 2, 4, "Keyword"],
+                [374, 4, 6, "Keyword"],
+                [376, 4, 2, "Keyword"],
+                [383, 2, 0, "Identifier"],
+                [385, 2, 4, "Identifier"],
+                [390, 2, 0, "Identifier"],
+                [392, 2, 4, "Identifier"],
+                [409, 2, 0, "Identifier"],
+                [410, 2, 4, "Identifier"],
+                [416, 2, 0, "Identifier"],
+                [417, 2, 4, "Identifier"],
+                [418, 0, 4, "Punctuator"],
+                [422, 2, 4, "Identifier"],
+                [423, 2, 0, "Identifier"],
+                [427, 2, 6, "Identifier"],
+                [428, 2, 8, "Identifier"],
+                [429, 2, 4, "Identifier"],
+                [430, 0, 4, "Punctuator"],
+                [433, 2, 4, "Identifier"],
+                [434, 0, 4, "Punctuator"],
+                [437, 2, 0, "Identifier"],
+                [438, 0, 4, "Punctuator"],
+                [442, 2, 4, "Identifier"],
+                [443, 2, 4, "Identifier"],
+                [444, 0, 2, "Punctuator"],
+                [451, 2, 0, "Identifier"],
+                [453, 2, 4, "Identifier"],
+                [499, 6, 8, "Punctuator"],
+                [500, 8, 6, "Identifier"],
+                [504, 4, 6, "Punctuator"],
+                [505, 6, 8, "Identifier"],
+                [506, 4, 8, "Punctuator"]
             ])
         },
         {
-            code:
-                "switch(value){\n" +
-                "    case \"1\":\n" +
-                "        a();\n" +
-                "    break;\n" +
-                "    case \"2\":\n" +
-                "        a();\n" +
-                "    break;\n" +
-                "    default:\n" +
-                "        a();\n" +
-                "        break;\n" +
-                "}",
-            output:
-                "switch(value){\n" +
-                "    case \"1\":\n" +
-                "        a();\n" +
-                "        break;\n" +
-                "    case \"2\":\n" +
-                "        a();\n" +
-                "        break;\n" +
-                "    default:\n" +
-                "        a();\n" +
-                "        break;\n" +
-                "}",
+            code: unIndent`
+                switch(value){
+                    case "1":
+                        a();
+                    break;
+                    case "2":
+                        a();
+                    break;
+                    default:
+                        a();
+                        break;
+                }
+            `,
+            output: unIndent`
+                switch(value){
+                    case "1":
+                        a();
+                        break;
+                    case "2":
+                        a();
+                        break;
+                    default:
+                        a();
+                        break;
+                }
+            `,
             options: [4, { SwitchCase: 1 }],
-            errors: expectedErrors([[4, 8, 4, "BreakStatement"], [7, 8, 4, "BreakStatement"]])
+            errors: expectedErrors([[4, 8, 4, "Keyword"], [7, 8, 4, "Keyword"]])
         },
         {
-            code:
-            "var x = 0 &&\n" +
-            "    {\n" +
-            "       a: 1,\n" +
-            "          b: 2\n" +
-            "    };",
-            output:
-            "var x = 0 &&\n" +
-            "    {\n" +
-            "        a: 1,\n" +
-            "        b: 2\n" +
-            "    };",
+            code: unIndent`
+                var x = 0 &&
+                    {
+                       a: 1,
+                          b: 2
+                    };
+            `,
+            output: unIndent`
+                var x = 0 &&
+                    {
+                        a: 1,
+                        b: 2
+                    };
+            `,
             options: [4],
-            errors: expectedErrors([[3, 8, 7, "Property"], [4, 8, 10, "Property"]])
+            errors: expectedErrors([[3, 8, 7, "Identifier"], [4, 8, 10, "Identifier"]])
         },
         {
-            code:
-                "switch(value){\n" +
-                "    case \"1\":\n" +
-                "        a();\n" +
-                "        break;\n" +
-                "    case \"2\":\n" +
-                "        a();\n" +
-                "        break;\n" +
-                "    default:\n" +
-                "    break;\n" +
-                "}",
-            output:
-                "switch(value){\n" +
-                "    case \"1\":\n" +
-                "        a();\n" +
-                "        break;\n" +
-                "    case \"2\":\n" +
-                "        a();\n" +
-                "        break;\n" +
-                "    default:\n" +
-                "        break;\n" +
-                "}",
+            code: unIndent`
+                switch(value){
+                    case "1":
+                        a();
+                        break;
+                    case "2":
+                        a();
+                        break;
+                    default:
+                    break;
+                }
+            `,
+            output: unIndent`
+                switch(value){
+                    case "1":
+                        a();
+                        break;
+                    case "2":
+                        a();
+                        break;
+                    default:
+                        break;
+                }
+            `,
             options: [4, { SwitchCase: 1 }],
-            errors: expectedErrors([9, 8, 4, "BreakStatement"])
+            errors: expectedErrors([9, 8, 4, "Keyword"])
         },
         {
-            code:
-                "switch(value){\n" +
-                "    case \"1\":\n" +
-                "    case \"2\":\n" +
-                "        a();\n" +
-                "        break;\n" +
-                "    default:\n" +
-                "        break;\n" +
-                "}\n" +
-                "switch(value){\n" +
-                "    case \"1\":\n" +
-                "    break;\n" +
-                "    case \"2\":\n" +
-                "        a();\n" +
-                "    break;\n" +
-                "    default:\n" +
-                "        a();\n" +
-                "    break;\n" +
-                "}",
-            output:
-                "switch(value){\n" +
-                "    case \"1\":\n" +
-                "    case \"2\":\n" +
-                "        a();\n" +
-                "        break;\n" +
-                "    default:\n" +
-                "        break;\n" +
-                "}\n" +
-                "switch(value){\n" +
-                "    case \"1\":\n" +
-                "        break;\n" +
-                "    case \"2\":\n" +
-                "        a();\n" +
-                "        break;\n" +
-                "    default:\n" +
-                "        a();\n" +
-                "        break;\n" +
-                "}",
+            code: unIndent`
+                switch(value){
+                    case "1":
+                    case "2":
+                        a();
+                        break;
+                    default:
+                        break;
+                }
+                switch(value){
+                    case "1":
+                    break;
+                    case "2":
+                        a();
+                    break;
+                    default:
+                        a();
+                    break;
+                }
+            `,
+            output: unIndent`
+                switch(value){
+                    case "1":
+                    case "2":
+                        a();
+                        break;
+                    default:
+                        break;
+                }
+                switch(value){
+                    case "1":
+                        break;
+                    case "2":
+                        a();
+                        break;
+                    default:
+                        a();
+                        break;
+                }
+            `,
             options: [4, { SwitchCase: 1 }],
-            errors: expectedErrors([[11, 8, 4, "BreakStatement"], [14, 8, 4, "BreakStatement"], [17, 8, 4, "BreakStatement"]])
+            errors: expectedErrors([[11, 8, 4, "Keyword"], [14, 8, 4, "Keyword"], [17, 8, 4, "Keyword"]])
         },
         {
-            code:
-                "switch(value){\n" +
-                "case \"1\":\n" +
-                "        a();\n" +
-                "        break;\n" +
-                "    case \"2\":\n" +
-                "        break;\n" +
-                "    default:\n" +
-                "        break;\n" +
-                "}",
-            output:
-                "switch(value){\n" +
-                "case \"1\":\n" +
-                "    a();\n" +
-                "    break;\n" +
-                "case \"2\":\n" +
-                "    break;\n" +
-                "default:\n" +
-                "    break;\n" +
-                "}",
+            code: unIndent`
+                switch(value){
+                case "1":
+                        a();
+                        break;
+                    case "2":
+                        break;
+                    default:
+                        break;
+                }
+            `,
+            output: unIndent`
+                switch(value){
+                case "1":
+                    a();
+                    break;
+                case "2":
+                    break;
+                default:
+                    break;
+                }
+            `,
             options: [4],
             errors: expectedErrors([
-                [3, 4, 8, "ExpressionStatement"],
-                [4, 4, 8, "BreakStatement"],
-                [5, 0, 4, "SwitchCase"],
-                [6, 4, 8, "BreakStatement"],
-                [7, 0, 4, "SwitchCase"],
-                [8, 4, 8, "BreakStatement"]
+                [3, 4, 8, "Identifier"],
+                [4, 4, 8, "Keyword"],
+                [5, 0, 4, "Keyword"],
+                [6, 4, 8, "Keyword"],
+                [7, 0, 4, "Keyword"],
+                [8, 4, 8, "Keyword"]
             ])
         },
         {
-            code:
-                "var obj = {foo: 1, bar: 2};\n" +
-                "with (obj) {\n" +
-                "console.log(foo + bar);\n" +
-                "}\n",
-            output:
-                "var obj = {foo: 1, bar: 2};\n" +
-                "with (obj) {\n" +
-                "    console.log(foo + bar);\n" +
-                "}\n",
-            errors: expectedErrors([3, 4, 0, "ExpressionStatement"])
+            code: unIndent`
+                var obj = {foo: 1, bar: 2};
+                with (obj) {
+                console.log(foo + bar);
+                }
+            `,
+            output: unIndent`
+                var obj = {foo: 1, bar: 2};
+                with (obj) {
+                    console.log(foo + bar);
+                }
+            `,
+            errors: expectedErrors([3, 4, 0, "Identifier"])
         },
         {
-            code:
-                "switch (a) {\n" +
-                "case '1':\n" +
-                "b();\n" +
-                "break;\n" +
-                "default:\n" +
-                "c();\n" +
-                "break;\n" +
-                "}\n",
-            output:
-                "switch (a) {\n" +
-                "    case '1':\n" +
-                "        b();\n" +
-                "        break;\n" +
-                "    default:\n" +
-                "        c();\n" +
-                "        break;\n" +
-                "}\n",
+            code: unIndent`
+                switch (a) {
+                case '1':
+                b();
+                break;
+                default:
+                c();
+                break;
+                }
+            `,
+            output: unIndent`
+                switch (a) {
+                    case '1':
+                        b();
+                        break;
+                    default:
+                        c();
+                        break;
+                }
+            `,
             options: [4, { SwitchCase: 1 }],
             errors: expectedErrors([
-                [2, 4, 0, "SwitchCase"],
-                [3, 8, 0, "ExpressionStatement"],
-                [4, 8, 0, "BreakStatement"],
-                [5, 4, 0, "SwitchCase"],
-                [6, 8, 0, "ExpressionStatement"],
-                [7, 8, 0, "BreakStatement"]
+                [2, 4, 0, "Keyword"],
+                [3, 8, 0, "Identifier"],
+                [4, 8, 0, "Keyword"],
+                [5, 4, 0, "Keyword"],
+                [6, 8, 0, "Identifier"],
+                [7, 8, 0, "Keyword"]
             ])
         },
         {
-            code:
-            "var foo = function(){\n" +
-            "    foo\n" +
-            "          .bar\n" +
-            "}",
-            output:
-            "var foo = function(){\n" +
-            "    foo\n" +
-            "        .bar\n" +
-            "}",
+            code: unIndent`
+                var foo = function(){
+                    foo
+                          .bar
+                }
+            `,
+            output: unIndent`
+                var foo = function(){
+                    foo
+                        .bar
+                }
+            `,
             options: [4, { MemberExpression: 1 }],
             errors: expectedErrors(
                 [3, 8, 10, "Punctuator"]
             )
         },
         {
-            code:
-            "var foo = function(){\n" +
-            "    foo\n" +
-            "             .bar\n" +
-            "}",
-            output:
-            "var foo = function(){\n" +
-            "    foo\n" +
-            "            .bar\n" +
-            "}",
+            code: unIndent`
+                var foo = function(){
+                    foo
+                             .bar
+                }
+            `,
+            output: unIndent`
+                var foo = function(){
+                    foo
+                            .bar
+                }
+            `,
             options: [4, { MemberExpression: 2 }],
             errors: expectedErrors(
                 [3, 12, 13, "Punctuator"]
             )
         },
         {
-            code:
-            "var foo = () => {\n" +
-            "    foo\n" +
-            "             .bar\n" +
-            "}",
-            output:
-            "var foo = () => {\n" +
-            "    foo\n" +
-            "            .bar\n" +
-            "}",
+            code: unIndent`
+                var foo = () => {
+                    foo
+                             .bar
+                }
+            `,
+            output: unIndent`
+                var foo = () => {
+                    foo
+                            .bar
+                }
+            `,
             options: [4, { MemberExpression: 2 }],
             parserOptions: { ecmaVersion: 6 },
             errors: expectedErrors(
@@ -2321,466 +3490,558 @@ ruleTester.run("indent", rule, {
             )
         },
         {
-            code:
-            "TestClass.prototype.method = function () {\n" +
-            "  return Promise.resolve(3)\n" +
-            "      .then(function (x) {\n" +
-            "        return x;\n" +
-            "      });\n" +
-            "};",
-            output:
-            "TestClass.prototype.method = function () {\n" +
-            "  return Promise.resolve(3)\n" +
-            "    .then(function (x) {\n" +
-            "        return x;\n" +
-            "      });\n" +
-            "};",
+            code: unIndent`
+                TestClass.prototype.method = function () {
+                  return Promise.resolve(3)
+                      .then(function (x) {
+                      return x;
+                    });
+                };
+            `,
+            output: unIndent`
+                TestClass.prototype.method = function () {
+                  return Promise.resolve(3)
+                    .then(function (x) {
+                      return x;
+                    });
+                };
+            `,
             options: [2, { MemberExpression: 1 }],
             parserOptions: { ecmaVersion: 6 },
-            errors: expectedErrors(
-                [
-                    [3, 4, 6, "Punctuator"]
-                ]
-            )
+            errors: expectedErrors([3, 4, 6, "Punctuator"])
         },
         {
-            code:
-                "while (a) \n" +
-                "b();",
-            output:
-                "while (a) \n" +
-                "    b();",
+            code: unIndent`
+                while (a)
+                b();
+            `,
+            output: unIndent`
+                while (a)
+                    b();
+            `,
             options: [4],
             errors: expectedErrors([
-                [2, 4, 0, "ExpressionStatement"]
+                [2, 4, 0, "Identifier"]
             ])
         },
         {
-            code:
-            "for (;;) \n" +
-            "b();",
-            output:
-            "for (;;) \n" +
-            "    b();",
-            options: [4],
+            code: unIndent`
+                lmn = [{
+                        a: 1
+                    },
+                    {
+                        b: 2
+                    },
+                    {
+                        x: 2
+                }];
+            `,
+            output: unIndent`
+                lmn = [{
+                    a: 1
+                },
+                {
+                    b: 2
+                },
+                {
+                    x: 2
+                }];
+            `,
             errors: expectedErrors([
-                [2, 4, 0, "ExpressionStatement"]
+                [2, 4, 8, "Identifier"],
+                [3, 0, 4, "Punctuator"],
+                [4, 0, 4, "Punctuator"],
+                [5, 4, 8, "Identifier"],
+                [6, 0, 4, "Punctuator"],
+                [7, 0, 4, "Punctuator"],
+                [8, 4, 8, "Identifier"]
             ])
         },
         {
-            code:
-            "for (a in x) \n" +
-            "b();",
-            output:
-            "for (a in x) \n" +
-            "    b();",
+            code: unIndent`
+                for (var foo = 1;
+                foo < 10;
+                foo++) {}
+            `,
+            output: unIndent`
+                for (var foo = 1;
+                    foo < 10;
+                    foo++) {}
+            `,
+            errors: expectedErrors([[2, 4, 0, "Identifier"], [3, 4, 0, "Identifier"]])
+        },
+        {
+            code: unIndent`
+                for (
+                var foo = 1;
+                foo < 10;
+                foo++
+                    ) {}
+            `,
+            output: unIndent`
+                for (
+                    var foo = 1;
+                    foo < 10;
+                    foo++
+                ) {}
+            `,
+            errors: expectedErrors([[2, 4, 0, "Keyword"], [3, 4, 0, "Identifier"], [4, 4, 0, "Identifier"], [5, 0, 4, "Punctuator"]])
+        },
+        {
+            code: unIndent`
+                for (;;)
+                b();
+            `,
+            output: unIndent`
+                for (;;)
+                    b();
+            `,
             options: [4],
             errors: expectedErrors([
-                [2, 4, 0, "ExpressionStatement"]
+                [2, 4, 0, "Identifier"]
             ])
         },
         {
-            code:
-            "do \n" +
-            "b();\n" +
-            "while(true)",
-            output:
-            "do \n" +
-            "    b();\n" +
-            "while(true)",
+            code: unIndent`
+                for (a in x)
+                b();
+            `,
+            output: unIndent`
+                for (a in x)
+                    b();
+            `,
             options: [4],
             errors: expectedErrors([
-                [2, 4, 0, "ExpressionStatement"]
+                [2, 4, 0, "Identifier"]
             ])
         },
         {
-            code:
-            "if(true) \n" +
-            "b();",
-            output:
-            "if(true) \n" +
-            "    b();",
+            code: unIndent`
+                do
+                b();
+                while(true)
+            `,
+            output: unIndent`
+                do
+                    b();
+                while(true)
+            `,
             options: [4],
             errors: expectedErrors([
-                [2, 4, 0, "ExpressionStatement"]
+                [2, 4, 0, "Identifier"]
             ])
         },
         {
-            code:
-            "var test = {\n" +
-            "      a: 1,\n" +
-            "    b: 2\n" +
-            "    };\n",
-            output:
-            "var test = {\n" +
-            "  a: 1,\n" +
-            "  b: 2\n" +
-            "};\n",
+            code: unIndent`
+                if(true)
+                b();
+            `,
+            output: unIndent`
+                if(true)
+                    b();
+            `,
+            options: [4],
+            errors: expectedErrors([
+                [2, 4, 0, "Identifier"]
+            ])
+        },
+        {
+            code: unIndent`
+                var test = {
+                      a: 1,
+                    b: 2
+                    };
+            `,
+            output: unIndent`
+                var test = {
+                  a: 1,
+                  b: 2
+                };
+            `,
             options: [2],
             errors: expectedErrors([
-                [2, 2, 6, "Property"],
-                [3, 2, 4, "Property"],
-                [4, 0, 4, "ObjectExpression"]
+                [2, 2, 6, "Identifier"],
+                [3, 2, 4, "Identifier"],
+                [4, 0, 4, "Punctuator"]
             ])
         },
         {
-            code:
-            "var a = function() {\n" +
-            "      a++;\n" +
-            "    b++;\n" +
-            "          c++;\n" +
-            "    },\n" +
-            "    b;\n",
-            output:
-            "var a = function() {\n" +
-            "        a++;\n" +
-            "        b++;\n" +
-            "        c++;\n" +
-            "    },\n" +
-            "    b;\n",
+            code: unIndent`
+                var a = function() {
+                      a++;
+                    b++;
+                          c++;
+                    },
+                    b;
+            `,
+            output: unIndent`
+                var a = function() {
+                        a++;
+                        b++;
+                        c++;
+                    },
+                    b;
+            `,
             options: [4],
             errors: expectedErrors([
-                [2, 8, 6, "ExpressionStatement"],
-                [3, 8, 4, "ExpressionStatement"],
-                [4, 8, 10, "ExpressionStatement"]
+                [2, 8, 6, "Identifier"],
+                [3, 8, 4, "Identifier"],
+                [4, 8, 10, "Identifier"]
             ])
         },
         {
-            code:
-            "var a = 1,\n" +
-            "b = 2,\n" +
-            "c = 3;\n",
-            output:
-            "var a = 1,\n" +
-            "    b = 2,\n" +
-            "    c = 3;\n",
+            code: unIndent`
+                var a = 1,
+                b = 2,
+                c = 3;
+            `,
+            output: unIndent`
+                var a = 1,
+                    b = 2,
+                    c = 3;
+            `,
             options: [4],
             errors: expectedErrors([
-                [2, 4, 0, "VariableDeclarator"],
-                [3, 4, 0, "VariableDeclarator"]
+                [2, 4, 0, "Identifier"],
+                [3, 4, 0, "Identifier"]
             ])
         },
         {
-            code:
-            "[a, b, \nc].forEach((index) => {\n" +
-            "  index;\n" +
-            "});\n",
-            output:
-            "[a, b, \n" +
-            "    c].forEach((index) => {\n" +
-            "    index;\n" +
-            "});\n",
+            code: unIndent`
+                [a, b,
+                c].forEach((index) => {
+                  index;
+                });
+            `,
+            output: unIndent`
+                [a, b,
+                    c].forEach((index) => {
+                        index;
+                    });
+            `,
             options: [4],
             parserOptions: { ecmaVersion: 6 },
             errors: expectedErrors([
                 [2, 4, 0, "Identifier"],
-                [3, 4, 2, "ExpressionStatement"]
+                [3, 8, 2, "Identifier"],
+                [4, 4, 0, "Punctuator"]
             ])
         },
         {
-            code:
-            "[a, b, \nc].forEach(function(index){\n" +
-            "  return index;\n" +
-            "});\n",
-            output:
-            "[a, b, \n" +
-            "    c].forEach(function(index){\n" +
-            "    return index;\n" +
-            "});\n",
+            code: unIndent`
+                [a, b,
+                c].forEach(function(index){
+                  return index;
+                });
+            `,
+            output: unIndent`
+                [a, b,
+                    c].forEach(function(index){
+                        return index;
+                    });
+            `,
             options: [4],
             parserOptions: { ecmaVersion: 6 },
             errors: expectedErrors([
                 [2, 4, 0, "Identifier"],
-                [3, 4, 2, "ReturnStatement"]
+                [3, 8, 2, "Keyword"],
+                [4, 4, 0, "Punctuator"]
             ])
         },
         {
-            code:
-            "[a, b, \nc].forEach(function(index){\n" +
-            "    return index;\n" +
-            "});\n",
-            output:
-            "[a, b, \n" +
-            "    c].forEach(function(index){\n" +
-            "    return index;\n" +
-            "});\n",
-            options: [4],
-            parserOptions: { ecmaVersion: 6 },
-            errors: expectedErrors([[2, 4, 0, "Identifier"]])
-        },
-        {
-            code:
-            "[a, b, c].forEach((index) => {\n" +
-            "  index;\n" +
-            "});\n",
-            output:
-            "[a, b, c].forEach((index) => {\n" +
-            "    index;\n" +
-            "});\n",
+            code: unIndent`
+                [a, b, c].forEach(function(index){
+                  return index;
+                });
+            `,
+            output: unIndent`
+                [a, b, c].forEach(function(index){
+                    return index;
+                });
+            `,
             options: [4],
             parserOptions: { ecmaVersion: 6 },
             errors: expectedErrors([
-                [2, 4, 2, "ExpressionStatement"]
+                [2, 4, 2, "Keyword"]
             ])
         },
         {
-            code:
-            "[a, b, c].forEach(function(index){\n" +
-            "  return index;\n" +
-            "});\n",
-            output:
-            "[a, b, c].forEach(function(index){\n" +
-            "    return index;\n" +
-            "});\n",
+            code: unIndent`
+                (foo)
+                    .bar([
+                    baz
+                ]);
+            `,
+            output: unIndent`
+                (foo)
+                    .bar([
+                        baz
+                    ]);
+            `,
+            options: [4, { MemberExpression: 1 }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: expectedErrors([[3, 8, 4, "Identifier"], [4, 4, 0, "Punctuator"]])
+        },
+        {
+            code: unIndent`
+                var x = ['a',
+                         'b',
+                         'c'
+                ];
+            `,
+            output: unIndent`
+                var x = ['a',
+                    'b',
+                    'c'
+                ];
+            `,
+            options: [4],
+            errors: expectedErrors([
+                [2, 4, 9, "String"],
+                [3, 4, 9, "String"]
+            ])
+        },
+        {
+            code: unIndent`
+                var x = [
+                         'a',
+                         'b',
+                         'c'
+                ];
+            `,
+            output: unIndent`
+                var x = [
+                    'a',
+                    'b',
+                    'c'
+                ];
+            `,
+            options: [4],
+            errors: expectedErrors([
+                [2, 4, 9, "String"],
+                [3, 4, 9, "String"],
+                [4, 4, 9, "String"]
+            ])
+        },
+        {
+            code: unIndent`
+                var x = [
+                         'a',
+                         'b',
+                         'c',
+                'd'];
+            `,
+            output: unIndent`
+                var x = [
+                    'a',
+                    'b',
+                    'c',
+                    'd'];
+            `,
+            options: [4],
+            errors: expectedErrors([
+                [2, 4, 9, "String"],
+                [3, 4, 9, "String"],
+                [4, 4, 9, "String"],
+                [5, 4, 0, "String"]
+            ])
+        },
+        {
+            code: unIndent`
+                var x = [
+                         'a',
+                         'b',
+                         'c'
+                  ];
+            `,
+            output: unIndent`
+                var x = [
+                    'a',
+                    'b',
+                    'c'
+                ];
+            `,
             options: [4],
             parserOptions: { ecmaVersion: 6 },
             errors: expectedErrors([
-                [2, 4, 2, "ReturnStatement"]
+                [2, 4, 9, "String"],
+                [3, 4, 9, "String"],
+                [4, 4, 9, "String"],
+                [5, 0, 2, "Punctuator"]
             ])
         },
         {
-            code:
-            "var x = ['a',\n" +
-            "         'b',\n" +
-            "         'c'\n" +
-            "];",
-            output:
-            "var x = ['a',\n" +
-            "    'b',\n" +
-            "    'c'\n" +
-            "];",
-            options: [4],
-            errors: expectedErrors([
-                [2, 4, 9, "Literal"],
-                [3, 4, 9, "Literal"]
-            ])
-        },
-        {
-            code:
-            "var x = [\n" +
-            "         'a',\n" +
-            "         'b',\n" +
-            "         'c'\n" +
-            "];",
-            output:
-            "var x = [\n" +
-            "    'a',\n" +
-            "    'b',\n" +
-            "    'c'\n" +
-            "];",
-            options: [4],
-            errors: expectedErrors([
-                [2, 4, 9, "Literal"],
-                [3, 4, 9, "Literal"],
-                [4, 4, 9, "Literal"]
-            ])
-        },
-        {
-            code:
-            "var x = [\n" +
-            "         'a',\n" +
-            "         'b',\n" +
-            "         'c',\n" +
-            "'d'];",
-            output:
-            "var x = [\n" +
-            "    'a',\n" +
-            "    'b',\n" +
-            "    'c',\n" +
-            "    'd'];",
-            options: [4],
-            errors: expectedErrors([
-                [2, 4, 9, "Literal"],
-                [3, 4, 9, "Literal"],
-                [4, 4, 9, "Literal"],
-                [5, 4, 0, "Literal"]
-            ])
-        },
-        {
-            code:
-            "var x = [\n" +
-            "         'a',\n" +
-            "         'b',\n" +
-            "         'c'\n" +
-            "  ];",
-            output:
-            "var x = [\n" +
-            "    'a',\n" +
-            "    'b',\n" +
-            "    'c'\n" +
-            "];",
-            options: [4],
-            parserOptions: { ecmaVersion: 6 },
-            errors: expectedErrors([
-                [2, 4, 9, "Literal"],
-                [3, 4, 9, "Literal"],
-                [4, 4, 9, "Literal"],
-                [5, 0, 2, "ArrayExpression"]
-            ])
-        },
-        {
-            code: "while (1 < 2)\nconsole.log('foo')\n  console.log('bar')",
-            output: "while (1 < 2)\n  console.log('foo')\nconsole.log('bar')",
+            code: unIndent`
+                while (1 < 2)
+                console.log('foo')
+                  console.log('bar')
+            `,
+            output: unIndent`
+                while (1 < 2)
+                  console.log('foo')
+                console.log('bar')
+            `,
             options: [2],
             errors: expectedErrors([
-                [2, 2, 0, "ExpressionStatement"],
-                [3, 0, 2, "ExpressionStatement"]
+                [2, 2, 0, "Identifier"],
+                [3, 0, 2, "Identifier"]
             ])
         },
         {
-            code:
-            "function salutation () {\n" +
-            "  switch (1) {\n" +
-            "  case 0: return console.log('hi')\n" +
-            "    case 1: return console.log('hey')\n" +
-            "  }\n" +
-            "}\n",
-            output:
-            "function salutation () {\n" +
-            "  switch (1) {\n" +
-            "    case 0: return console.log('hi')\n" +
-            "    case 1: return console.log('hey')\n" +
-            "  }\n" +
-            "}\n",
+            code: unIndent`
+                function salutation () {
+                  switch (1) {
+                  case 0: return console.log('hi')
+                    case 1: return console.log('hey')
+                  }
+                }
+            `,
+            output: unIndent`
+                function salutation () {
+                  switch (1) {
+                    case 0: return console.log('hi')
+                    case 1: return console.log('hey')
+                  }
+                }
+            `,
             options: [2, { SwitchCase: 1 }],
             errors: expectedErrors([
-                [3, 4, 2, "SwitchCase"]
+                [3, 4, 2, "Keyword"]
             ])
         },
         {
-            code:
-            "var geometry, box, face1, face2, colorT, colorB, sprite, padding, maxWidth,\n" +
-            "height, rotate;",
-            output:
-            "var geometry, box, face1, face2, colorT, colorB, sprite, padding, maxWidth,\n" +
-            "  height, rotate;",
+            code: unIndent`
+                var geometry, box, face1, face2, colorT, colorB, sprite, padding, maxWidth,
+                height, rotate;
+            `,
+            output: unIndent`
+                var geometry, box, face1, face2, colorT, colorB, sprite, padding, maxWidth,
+                  height, rotate;
+            `,
             options: [2, { SwitchCase: 1 }],
             errors: expectedErrors([
-                [2, 2, 0, "VariableDeclarator"]
+                [2, 2, 0, "Identifier"]
             ])
         },
         {
-            code:
-            "switch (a) {\n" +
-            "case '1':\n" +
-            "b();\n" +
-            "break;\n" +
-            "default:\n" +
-            "c();\n" +
-            "break;\n" +
-            "}\n",
-            output:
-            "switch (a) {\n" +
-            "        case '1':\n" +
-            "            b();\n" +
-            "            break;\n" +
-            "        default:\n" +
-            "            c();\n" +
-            "            break;\n" +
-            "}\n",
+            code: unIndent`
+                switch (a) {
+                case '1':
+                b();
+                break;
+                default:
+                c();
+                break;
+                }
+            `,
+            output: unIndent`
+                switch (a) {
+                        case '1':
+                            b();
+                            break;
+                        default:
+                            c();
+                            break;
+                }
+            `,
             options: [4, { SwitchCase: 2 }],
             errors: expectedErrors([
-                [2, 8, 0, "SwitchCase"],
-                [3, 12, 0, "ExpressionStatement"],
-                [4, 12, 0, "BreakStatement"],
-                [5, 8, 0, "SwitchCase"],
-                [6, 12, 0, "ExpressionStatement"],
-                [7, 12, 0, "BreakStatement"]
+                [2, 8, 0, "Keyword"],
+                [3, 12, 0, "Identifier"],
+                [4, 12, 0, "Keyword"],
+                [5, 8, 0, "Keyword"],
+                [6, 12, 0, "Identifier"],
+                [7, 12, 0, "Keyword"]
             ])
         },
         {
-            code:
-            "var geometry,\n" +
-            "rotate;",
-            output:
-            "var geometry,\n" +
-            "  rotate;",
+            code: unIndent`
+                var geometry,
+                rotate;
+            `,
+            output: unIndent`
+                var geometry,
+                  rotate;
+            `,
             options: [2, { VariableDeclarator: 1 }],
             errors: expectedErrors([
-                [2, 2, 0, "VariableDeclarator"]
+                [2, 2, 0, "Identifier"]
             ])
         },
         {
-            code:
-            "var geometry,\n" +
-            "  rotate;",
-            output:
-            "var geometry,\n" +
-            "    rotate;",
+            code: unIndent`
+                var geometry,
+                  rotate;
+            `,
+            output: unIndent`
+                var geometry,
+                    rotate;
+            `,
             options: [2, { VariableDeclarator: 2 }],
             errors: expectedErrors([
-                [2, 4, 2, "VariableDeclarator"]
+                [2, 4, 2, "Identifier"]
             ])
         },
         {
-            code:
-            "var geometry,\n" +
-            "\trotate;",
-            output:
-            "var geometry,\n" +
-            "\t\trotate;",
+            code: unIndent`
+                var geometry,
+                \trotate;
+            `,
+            output: unIndent`
+                var geometry,
+                \t\trotate;
+            `,
             options: ["tab", { VariableDeclarator: 2 }],
             errors: expectedErrors("tab", [
-                [2, 2, 1, "VariableDeclarator"]
+                [2, 2, 1, "Identifier"]
             ])
         },
         {
-            code:
-            "let geometry,\n" +
-            "  rotate;",
-            output:
-            "let geometry,\n" +
-            "    rotate;",
+            code: unIndent`
+                let geometry,
+                  rotate;
+            `,
+            output: unIndent`
+                let geometry,
+                    rotate;
+            `,
             options: [2, { VariableDeclarator: 2 }],
             parserOptions: { ecmaVersion: 6 },
             errors: expectedErrors([
-                [2, 4, 2, "VariableDeclarator"]
+                [2, 4, 2, "Identifier"]
             ])
         },
         {
-            code:
-            "if(true)\n" +
-            "  if (true)\n" +
-            "    if (true)\n" +
-            "    console.log(val);",
-            output:
-            "if(true)\n" +
-            "  if (true)\n" +
-            "    if (true)\n" +
-            "      console.log(val);",
+            code: unIndent`
+                if(true)
+                  if (true)
+                    if (true)
+                    console.log(val);
+            `,
+            output: unIndent`
+                if(true)
+                  if (true)
+                    if (true)
+                      console.log(val);
+            `,
             options: [2, { VariableDeclarator: 2, SwitchCase: 1 }],
             errors: expectedErrors([
-                [4, 6, 4, "ExpressionStatement"]
+                [4, 6, 4, "Identifier"]
             ])
         },
         {
-            code:
-            "var a = {\n" +
-            "    a: 1,\n" +
-            "    b: 2\n" +
-            "}",
-            output:
-            "var a = {\n" +
-            "  a: 1,\n" +
-            "  b: 2\n" +
-            "}",
-            options: [2, { VariableDeclarator: 2, SwitchCase: 1 }],
-            errors: expectedErrors([
-                [2, 2, 4, "Property"],
-                [3, 2, 4, "Property"]
-            ])
-        },
-        {
-            code:
-            "var a = [\n" +
-            "    a,\n" +
-            "    b\n" +
-            "]",
-            output:
-            "var a = [\n" +
-            "  a,\n" +
-            "  b\n" +
-            "]",
+            code: unIndent`
+                var a = {
+                    a: 1,
+                    b: 2
+                }
+            `,
+            output: unIndent`
+                var a = {
+                  a: 1,
+                  b: 2
+                }
+            `,
             options: [2, { VariableDeclarator: 2, SwitchCase: 1 }],
             errors: expectedErrors([
                 [2, 2, 4, "Identifier"],
@@ -2788,16 +4049,37 @@ ruleTester.run("indent", rule, {
             ])
         },
         {
-            code:
-            "let a = [\n" +
-            "    a,\n" +
-            "    b\n" +
-            "]",
-            output:
-            "let a = [\n" +
-            "  a,\n" +
-            "  b\n" +
-            "]",
+            code: unIndent`
+                var a = [
+                    a,
+                    b
+                ]
+            `,
+            output: unIndent`
+                var a = [
+                  a,
+                  b
+                ]
+            `,
+            options: [2, { VariableDeclarator: 2, SwitchCase: 1 }],
+            errors: expectedErrors([
+                [2, 2, 4, "Identifier"],
+                [3, 2, 4, "Identifier"]
+            ])
+        },
+        {
+            code: unIndent`
+                let a = [
+                    a,
+                    b
+                ]
+            `,
+            output: unIndent`
+                let a = [
+                  a,
+                  b
+                ]
+            `,
             options: [2, { VariableDeclarator: { let: 2 }, SwitchCase: 1 }],
             parserOptions: { ecmaVersion: 6 },
             errors: expectedErrors([
@@ -2806,396 +4088,456 @@ ruleTester.run("indent", rule, {
             ])
         },
         {
-            code:
-            "var a = new Test({\n" +
-            "      a: 1\n" +
-            "  }),\n" +
-            "    b = 4;\n",
-            output:
-            "var a = new Test({\n" +
-            "        a: 1\n" +
-            "    }),\n" +
-            "    b = 4;\n",
+            code: unIndent`
+                var a = new Test({
+                      a: 1
+                  }),
+                    b = 4;
+            `,
+            output: unIndent`
+                var a = new Test({
+                        a: 1
+                    }),
+                    b = 4;
+            `,
             options: [4],
             errors: expectedErrors([
-                [2, 8, 6, "Property"],
-                [3, 4, 2, "ObjectExpression"]
+                [2, 8, 6, "Identifier"],
+                [3, 4, 2, "Punctuator"]
             ])
         },
         {
-            code:
-            "var a = new Test({\n" +
-            "      a: 1\n" +
-            "    }),\n" +
-            "    b = 4;\n" +
-            "const c = new Test({\n" +
-            "      a: 1\n" +
-            "    }),\n" +
-            "    d = 4;\n",
-            output:
-            "var a = new Test({\n" +
-            "      a: 1\n" +
-            "    }),\n" +
-            "    b = 4;\n" +
-            "const c = new Test({\n" +
-            "    a: 1\n" +
-            "  }),\n" +
-            "  d = 4;\n",
+            code: unIndent`
+                var a = new Test({
+                      a: 1
+                    }),
+                    b = 4;
+                const c = new Test({
+                      a: 1
+                    }),
+                    d = 4;
+            `,
+            output: unIndent`
+                var a = new Test({
+                      a: 1
+                    }),
+                    b = 4;
+                const c = new Test({
+                    a: 1
+                  }),
+                  d = 4;
+            `,
             options: [2, { VariableDeclarator: { var: 2 } }],
             parserOptions: { ecmaVersion: 6 },
             errors: expectedErrors([
-                [6, 4, 6, "Property"],
-                [7, 2, 4, "ObjectExpression"],
-                [8, 2, 4, "VariableDeclarator"]
+                [6, 4, 6, "Identifier"],
+                [7, 2, 4, "Punctuator"],
+                [8, 2, 4, "Identifier"]
             ])
         },
         {
-            code:
-            "var abc = 5,\n" +
-            "    c = 2,\n" +
-            "    xyz = \n" +
-            "     {\n" +
-            "       a: 1,\n" +
-            "        b: 2\n" +
-            "     };",
-            output:
-            "var abc = 5,\n" +
-            "    c = 2,\n" +
-            "    xyz = \n" +
-            "    {\n" +
-            "      a: 1,\n" +
-            "      b: 2\n" +
-            "    };",
+            code: unIndent`
+                var abc = 5,
+                    c = 2,
+                    xyz =
+                    {
+                      a: 1,
+                       b: 2
+                    };
+            `,
+            output: unIndent`
+                var abc = 5,
+                    c = 2,
+                    xyz =
+                    {
+                      a: 1,
+                      b: 2
+                    };
+            `,
             options: [2, { VariableDeclarator: 2, SwitchCase: 1 }],
-            errors: expectedErrors([
-                [4, 4, 5, "ObjectExpression"],
-                [5, 6, 7, "Property"],
-                [6, 6, 8, "Property"],
-                [7, 4, 5, "ObjectExpression"]
-            ])
+            errors: expectedErrors([6, 6, 7, "Identifier"])
         },
         {
-            code:
-            "var abc = \n" +
-            "     {\n" +
-            "       a: 1,\n" +
-            "        b: 2\n" +
-            "     };",
-            output:
-            "var abc = \n" +
-            "    {\n" +
-            "      a: 1,\n" +
-            "      b: 2\n" +
-            "    };",
+            code: unIndent`
+                var abc =
+                     {
+                       a: 1,
+                        b: 2
+                     };
+            `,
+            output: unIndent`
+                var abc =
+                     {
+                       a: 1,
+                       b: 2
+                     };
+            `,
             options: [2, { VariableDeclarator: 2, SwitchCase: 1 }],
-            errors: expectedErrors([
-                [2, 4, 5, "ObjectExpression"],
-                [3, 6, 7, "Property"],
-                [4, 6, 8, "Property"],
-                [5, 4, 5, "ObjectExpression"]
-            ])
+            errors: expectedErrors([4, 7, 8, "Identifier"])
         },
         {
-            code:
-                "var path     = require('path')\n" +
-                " , crypto    = require('crypto')\n" +
-                ";\n",
-            output:
-                "var path     = require('path')\n" +
-                " , crypto    = require('crypto')\n" +
-                " ;\n",
+            code: unIndent`
+                var foo = {
+                    bar: 1,
+                    baz: {
+                        qux: 2
+                      }
+                  },
+                  bar = 1;
+            `,
+            output: unIndent`
+                var foo = {
+                    bar: 1,
+                    baz: {
+                      qux: 2
+                    }
+                  },
+                  bar = 1;
+            `,
+            options: [2],
+            errors: expectedErrors([[4, 6, 8, "Identifier"], [5, 4, 6, "Punctuator"]])
+        },
+        {
+            code: unIndent`
+                var path     = require('path')
+                 , crypto    = require('crypto')
+                ;
+            `,
+            output: unIndent`
+                var path     = require('path')
+                  , crypto    = require('crypto')
+                ;
+            `,
             options: [2],
             errors: expectedErrors([
-                [3, 1, 0, "VariableDeclaration"]
+                [2, 2, 1, "Punctuator"]
             ])
         },
         {
-            code:
-                "var a = 1\n" +
-                "   ,b = 2\n" +
-                ";",
-            output:
-                "var a = 1\n" +
-                "   ,b = 2\n" +
-                "   ;",
+            code: unIndent`
+                var a = 1
+                   ,b = 2
+                ;
+            `,
+            output: unIndent`
+                var a = 1
+                    ,b = 2
+                ;
+            `,
             errors: expectedErrors([
-                [3, 3, 0, "VariableDeclaration"]
+                [2, 4, 3, "Punctuator"]
             ])
         },
         {
-            code:
-            "class A{\n" +
-            "  constructor(){}\n" +
-            "    a(){}\n" +
-            "    get b(){}\n" +
-            "}",
-            output:
-            "class A{\n" +
-            "    constructor(){}\n" +
-            "    a(){}\n" +
-            "    get b(){}\n" +
-            "}",
+            code: unIndent`
+                class A{
+                  constructor(){}
+                    a(){}
+                    get b(){}
+                }
+            `,
+            output: unIndent`
+                class A{
+                    constructor(){}
+                    a(){}
+                    get b(){}
+                }
+            `,
             options: [4, { VariableDeclarator: 1, SwitchCase: 1 }],
             parserOptions: { ecmaVersion: 6 },
-            errors: expectedErrors([[2, 4, 2, "MethodDefinition"]])
+            errors: expectedErrors([[2, 4, 2, "Identifier"]])
         },
         {
-            code:
-            "var A = class {\n" +
-            "  constructor(){}\n" +
-            "    a(){}\n" +
-            "  get b(){}\n" +
-            "};",
-            output:
-            "var A = class {\n" +
-            "    constructor(){}\n" +
-            "    a(){}\n" +
-            "    get b(){}\n" +
-            "};",
+            code: unIndent`
+                var A = class {
+                  constructor(){}
+                    a(){}
+                  get b(){}
+                };
+            `,
+            output: unIndent`
+                var A = class {
+                    constructor(){}
+                    a(){}
+                    get b(){}
+                };
+            `,
             options: [4, { VariableDeclarator: 1, SwitchCase: 1 }],
             parserOptions: { ecmaVersion: 6 },
-            errors: expectedErrors([[2, 4, 2, "MethodDefinition"], [4, 4, 2, "MethodDefinition"]])
+            errors: expectedErrors([[2, 4, 2, "Identifier"], [4, 4, 2, "Identifier"]])
         },
         {
-            code:
-            "var a = 1,\n" +
-            "    B = class {\n" +
-            "    constructor(){}\n" +
-            "      a(){}\n" +
-            "      get b(){}\n" +
-            "    };",
-            output:
-            "var a = 1,\n" +
-            "    B = class {\n" +
-            "      constructor(){}\n" +
-            "      a(){}\n" +
-            "      get b(){}\n" +
-            "    };",
+            code: unIndent`
+                var a = 1,
+                    B = class {
+                    constructor(){}
+                      a(){}
+                      get b(){}
+                    };
+            `,
+            output: unIndent`
+                var a = 1,
+                    B = class {
+                      constructor(){}
+                      a(){}
+                      get b(){}
+                    };
+            `,
             options: [2, { VariableDeclarator: 2, SwitchCase: 1 }],
             parserOptions: { ecmaVersion: 6 },
-            errors: expectedErrors([[3, 6, 4, "MethodDefinition"]])
+            errors: expectedErrors([[3, 6, 4, "Identifier"]])
         },
         {
-            code:
-            "{\n" +
-            "    if(a){\n" +
-            "        foo();\n" +
-            "    }\n" +
-            "  else{\n" +
-            "        bar();\n" +
-            "    }\n" +
-            "}\n",
-            output:
-            "{\n" +
-            "    if(a){\n" +
-            "        foo();\n" +
-            "    }\n" +
-            "    else{\n" +
-            "        bar();\n" +
-            "    }\n" +
-            "}\n",
+            code: unIndent`
+                {
+                    if(a){
+                        foo();
+                    }
+                  else{
+                        bar();
+                    }
+                }
+            `,
+            output: unIndent`
+                {
+                    if(a){
+                        foo();
+                    }
+                    else{
+                        bar();
+                    }
+                }
+            `,
             options: [4],
             errors: expectedErrors([[5, 4, 2, "Keyword"]])
         },
         {
-            code:
-            "{\n" +
-            "    if(a){\n" +
-            "        foo();\n" +
-            "    }\n" +
-            "  else\n" +
-            "        bar();\n" +
-            "    \n" +
-            "}\n",
-            output:
-            "{\n" +
-            "    if(a){\n" +
-            "        foo();\n" +
-            "    }\n" +
-            "    else\n" +
-            "        bar();\n" +
-            "    \n" +
-            "}\n",
+            code: unIndent`
+                {
+                    if(a){
+                        foo();
+                    }
+                  else
+                        bar();
+
+                }
+            `,
+            output: unIndent`
+                {
+                    if(a){
+                        foo();
+                    }
+                    else
+                        bar();
+
+                }
+            `,
             options: [4],
             errors: expectedErrors([[5, 4, 2, "Keyword"]])
         },
         {
-            code:
-            "{\n" +
-            "    if(a)\n" +
-            "        foo();\n" +
-            "  else\n" +
-            "        bar();\n" +
-            "}\n",
-            output:
-            "{\n" +
-            "    if(a)\n" +
-            "        foo();\n" +
-            "    else\n" +
-            "        bar();\n" +
-            "}\n",
+            code: unIndent`
+                {
+                    if(a)
+                        foo();
+                  else
+                        bar();
+                }
+            `,
+            output: unIndent`
+                {
+                    if(a)
+                        foo();
+                    else
+                        bar();
+                }
+            `,
             options: [4],
             errors: expectedErrors([[4, 4, 2, "Keyword"]])
         },
         {
-            code:
-            "(function(){\n" +
-            "  function foo(x) {\n" +
-            "    return x + 1;\n" +
-            "  }\n" +
-            "})();",
-            output:
-            "(function(){\n" +
-            "function foo(x) {\n" +
-            "    return x + 1;\n" +
-            "  }\n" +
-            "})();",
+            code: unIndent`
+                (function(){
+                  function foo(x) {
+                    return x + 1;
+                  }
+                })();
+            `,
+            output: unIndent`
+                (function(){
+                function foo(x) {
+                  return x + 1;
+                }
+                })();
+            `,
             options: [2, { outerIIFEBody: 0 }],
-            errors: expectedErrors([[2, 0, 2, "FunctionDeclaration"]])
+            errors: expectedErrors([[2, 0, 2, "Keyword"], [3, 2, 4, "Keyword"], [4, 0, 2, "Punctuator"]])
         },
         {
-            code:
-            "(function(){\n" +
-            "    function foo(x) {\n" +
-            "        return x + 1;\n" +
-            "    }\n" +
-            "})();",
-            output:
-            "(function(){\n" +
-            "        function foo(x) {\n" +
-            "        return x + 1;\n" +
-            "    }\n" +
-            "})();",
+            code: unIndent`
+                (function(){
+                    function foo(x) {
+                        return x + 1;
+                    }
+                })();
+            `,
+            output: unIndent`
+                (function(){
+                        function foo(x) {
+                            return x + 1;
+                        }
+                })();
+            `,
             options: [4, { outerIIFEBody: 2 }],
-            errors: expectedErrors([[2, 8, 4, "FunctionDeclaration"]])
+            errors: expectedErrors([[2, 8, 4, "Keyword"], [3, 12, 8, "Keyword"], [4, 8, 4, "Punctuator"]])
         },
         {
-            code:
-            "if(data) {\n" +
-            "console.log('hi');\n" +
-            "}",
-            output:
-            "if(data) {\n" +
-            "  console.log('hi');\n" +
-            "}",
+            code: unIndent`
+                if(data) {
+                console.log('hi');
+                }
+            `,
+            output: unIndent`
+                if(data) {
+                  console.log('hi');
+                }
+            `,
             options: [2, { outerIIFEBody: 0 }],
-            errors: expectedErrors([[2, 2, 0, "ExpressionStatement"]])
+            errors: expectedErrors([[2, 2, 0, "Identifier"]])
         },
         {
-            code:
-            "var ns = function(){\n" +
-            "    function fooVar(x) {\n" +
-            "        return x + 1;\n" +
-            "    }\n" +
-            "}(x);",
-            output:
-            "var ns = function(){\n" +
-            "        function fooVar(x) {\n" +
-            "        return x + 1;\n" +
-            "    }\n" +
-            "}(x);",
+            code: unIndent`
+                var ns = function(){
+                    function fooVar(x) {
+                        return x + 1;
+                    }
+                }(x);
+            `,
+            output: unIndent`
+                var ns = function(){
+                        function fooVar(x) {
+                            return x + 1;
+                        }
+                }(x);
+            `,
             options: [4, { outerIIFEBody: 2 }],
-            errors: expectedErrors([[2, 8, 4, "FunctionDeclaration"]])
+            errors: expectedErrors([[2, 8, 4, "Keyword"], [3, 12, 8, "Keyword"], [4, 8, 4, "Punctuator"]])
         },
         {
-            code:
-            "var obj = {\n" +
-            "  foo: function() {\n" +
-            "  return true;\n" +
-            "  }()\n" +
-            "};\n",
-            output:
-            "var obj = {\n" +
-            "  foo: function() {\n" +
-            "    return true;\n" +
-            "  }()\n" +
-            "};\n",
+            code: unIndent`
+                var obj = {
+                  foo: function() {
+                  return true;
+                  }()
+                };
+            `,
+            output: unIndent`
+                var obj = {
+                  foo: function() {
+                    return true;
+                  }()
+                };
+            `,
             options: [2, { outerIIFEBody: 0 }],
-            errors: expectedErrors([[3, 4, 2, "ReturnStatement"]])
+            errors: expectedErrors([[3, 4, 2, "Keyword"]])
         },
         {
-            code:
-            "typeof function() {\n" +
-            "    function fooVar(x) {\n" +
-            "      return x + 1;\n" +
-            "    }\n" +
-            "}();",
-            output:
-            "typeof function() {\n" +
-            "  function fooVar(x) {\n" +
-            "      return x + 1;\n" +
-            "    }\n" +
-            "}();",
+            code: unIndent`
+                typeof function() {
+                    function fooVar(x) {
+                      return x + 1;
+                    }
+                }();
+            `,
+            output: unIndent`
+                typeof function() {
+                  function fooVar(x) {
+                    return x + 1;
+                  }
+                }();
+            `,
             options: [2, { outerIIFEBody: 2 }],
-            errors: expectedErrors([[2, 2, 4, "FunctionDeclaration"]])
+            errors: expectedErrors([[2, 2, 4, "Keyword"], [3, 4, 6, "Keyword"], [4, 2, 4, "Punctuator"]])
         },
         {
-            code:
-            "{\n" +
-            "\t!function(x) {\n" +
-            "\t\t\t\treturn x + 1;\n" +
-            "\t}()\n" +
-            "};",
-            output:
-            "{\n" +
-            "\t!function(x) {\n" +
-            "\t\treturn x + 1;\n" +
-            "\t}()\n" +
-            "};",
+            code: unIndent`
+                {
+                \t!function(x) {
+                \t\t\t\treturn x + 1;
+                \t}()
+                };
+            `,
+            output: unIndent`
+                {
+                \t!function(x) {
+                \t\treturn x + 1;
+                \t}()
+                };
+            `,
             options: ["tab", { outerIIFEBody: 3 }],
-            errors: expectedErrors("tab", [[3, 2, 4, "ReturnStatement"]])
+            errors: expectedErrors("tab", [[3, 2, 4, "Keyword"]])
         },
         {
-            code:
-            "Buffer\n" +
-            ".toString()",
-            output:
-            "Buffer\n" +
-            "    .toString()",
+            code: unIndent`
+                Buffer
+                .toString()
+            `,
+            output: unIndent`
+                Buffer
+                    .toString()
+            `,
             options: [4, { MemberExpression: 1 }],
             errors: expectedErrors([[2, 4, 0, "Punctuator"]])
         },
         {
-            code:
-            "Buffer\n" +
-            "    .indexOf('a')\n" +
-            ".toString()",
-            output:
-            "Buffer\n" +
-            "    .indexOf('a')\n" +
-            "    .toString()",
+            code: unIndent`
+                Buffer
+                    .indexOf('a')
+                .toString()
+            `,
+            output: unIndent`
+                Buffer
+                    .indexOf('a')
+                    .toString()
+            `,
             options: [4, { MemberExpression: 1 }],
             errors: expectedErrors([[3, 4, 0, "Punctuator"]])
         },
         {
-            code:
-            "Buffer.\n" +
-            "length",
-            output:
-            "Buffer.\n" +
-            "    length",
+            code: unIndent`
+                Buffer.
+                length
+            `,
+            output: unIndent`
+                Buffer.
+                    length
+            `,
             options: [4, { MemberExpression: 1 }],
             errors: expectedErrors([[2, 4, 0, "Identifier"]])
         },
         {
-            code:
-            "Buffer.\n" +
-            "\t\tlength",
-            output:
-            "Buffer.\n" +
-            "\tlength",
+            code: unIndent`
+                Buffer.
+                \t\tlength
+            `,
+            output: unIndent`
+                Buffer.
+                \tlength
+            `,
             options: ["tab", { MemberExpression: 1 }],
             errors: expectedErrors("tab", [[2, 1, 2, "Identifier"]])
         },
         {
-            code:
-            "Buffer\n" +
-            "  .foo\n" +
-            "  .bar",
-            output:
-            "Buffer\n" +
-            "    .foo\n" +
-            "    .bar",
+            code: unIndent`
+                Buffer
+                  .foo
+                  .bar
+            `,
+            output: unIndent`
+                Buffer
+                    .foo
+                    .bar
+            `,
             options: [2, { MemberExpression: 2 }],
             errors: expectedErrors([[2, 4, 2, "Punctuator"], [3, 4, 2, "Punctuator"]])
         },
@@ -3203,737 +4545,1664 @@ ruleTester.run("indent", rule, {
 
             // Indentation with multiple else statements: https://github.com/eslint/eslint/issues/6956
 
-            code:
-            "if (foo) bar();\n" +
-            "else if (baz) foobar();\n" +
-            "  else if (qux) qux();",
-            output:
-            "if (foo) bar();\n" +
-            "else if (baz) foobar();\n" +
-            "else if (qux) qux();",
+            code: unIndent`
+                if (foo) bar();
+                else if (baz) foobar();
+                  else if (qux) qux();
+            `,
+            output: unIndent`
+                if (foo) bar();
+                else if (baz) foobar();
+                else if (qux) qux();
+            `,
             options: [2],
             errors: expectedErrors([3, 0, 2, "Keyword"])
         },
         {
-            code:
-            "if (foo) bar();\n" +
-            "else if (baz) foobar();\n" +
-            "  else qux();",
-            output:
-            "if (foo) bar();\n" +
-            "else if (baz) foobar();\n" +
-            "else qux();",
+            code: unIndent`
+                if (foo) bar();
+                else if (baz) foobar();
+                  else qux();
+            `,
+            output: unIndent`
+                if (foo) bar();
+                else if (baz) foobar();
+                else qux();
+            `,
             options: [2],
             errors: expectedErrors([3, 0, 2, "Keyword"])
         },
         {
-            code:
-            "foo();\n" +
-            "  if (baz) foobar();\n" +
-            "  else qux();",
-            output:
-            "foo();\n" +
-            "if (baz) foobar();\n" +
-            "else qux();",
+            code: unIndent`
+                foo();
+                  if (baz) foobar();
+                  else qux();
+            `,
+            output: unIndent`
+                foo();
+                if (baz) foobar();
+                else qux();
+            `,
             options: [2],
-            errors: expectedErrors([[2, 0, 2, "IfStatement"], [3, 0, 2, "Keyword"]])
+            errors: expectedErrors([[2, 0, 2, "Keyword"], [3, 0, 2, "Keyword"]])
         },
         {
-            code:
-            "if (foo) bar();\n" +
-            "else if (baz) foobar();\n" +
-            "     else if (bip) {\n" +
-            "       qux();\n" +
-            "     }",
-            output:
-            "if (foo) bar();\n" +
-            "else if (baz) foobar();\n" +
-            "else if (bip) {\n" +
-            "       qux();\n" + // (fixed on the next pass)
-            "     }",
+            code: unIndent`
+                if (foo) bar();
+                else if (baz) foobar();
+                     else if (bip) {
+                       qux();
+                     }
+            `,
+            output: unIndent`
+                if (foo) bar();
+                else if (baz) foobar();
+                else if (bip) {
+                  qux();
+                }
+            `,
             options: [2],
-            errors: expectedErrors([3, 0, 5, "Keyword"])
+            errors: expectedErrors([[3, 0, 5, "Keyword"], [4, 2, 7, "Identifier"], [5, 0, 5, "Punctuator"]])
         },
         {
-            code:
-            "if (foo) bar();\n" +
-            "else if (baz) {\n" +
-            "    foobar();\n" +
-            "     } else if (boop) {\n" +
-            "       qux();\n" +
-            "     }",
-            output:
-            "if (foo) bar();\n" +
-            "else if (baz) {\n" +
-            "  foobar();\n" +
-            "} else if (boop) {\n" +
-            "       qux();\n" + // (fixed on the next pass)
-            "     }",
+            code: unIndent`
+                if (foo) bar();
+                else if (baz) {
+                    foobar();
+                     } else if (boop) {
+                       qux();
+                     }
+            `,
+            output: unIndent`
+                if (foo) bar();
+                else if (baz) {
+                  foobar();
+                } else if (boop) {
+                  qux();
+                }
+            `,
             options: [2],
-            errors: expectedErrors([[3, 2, 4, "ExpressionStatement"], [4, 0, 5, "BlockStatement"]])
+            errors: expectedErrors([[3, 2, 4, "Identifier"], [4, 0, 5, "Punctuator"], [5, 2, 7, "Identifier"], [6, 0, 5, "Punctuator"]])
         },
         {
-            code:
-            "function foo(aaa,\n" +
-            "    bbb, ccc, ddd) {\n" +
-            "      bar();\n" +
-            "}",
-            output:
-            "function foo(aaa,\n" +
-            "  bbb, ccc, ddd) {\n" +
-            "    bar();\n" +
-            "}",
+            code: unIndent`
+                function foo(aaa,
+                    bbb, ccc, ddd) {
+                      bar();
+                }
+            `,
+            output: unIndent`
+                function foo(aaa,
+                  bbb, ccc, ddd) {
+                    bar();
+                }
+            `,
             options: [2, { FunctionDeclaration: { parameters: 1, body: 2 } }],
-            errors: expectedErrors([[2, 2, 4, "Identifier"], [3, 4, 6, "ExpressionStatement"]])
+            errors: expectedErrors([[2, 2, 4, "Identifier"], [3, 4, 6, "Identifier"]])
         },
         {
-            code:
-            "function foo(aaa, bbb,\n" +
-            "  ccc, ddd) {\n" +
-            "bar();\n" +
-            "}",
-            output:
-            "function foo(aaa, bbb,\n" +
-            "      ccc, ddd) {\n" +
-            "  bar();\n" +
-            "}",
+            code: unIndent`
+                function foo(aaa, bbb,
+                  ccc, ddd) {
+                bar();
+                }
+            `,
+            output: unIndent`
+                function foo(aaa, bbb,
+                      ccc, ddd) {
+                  bar();
+                }
+            `,
             options: [2, { FunctionDeclaration: { parameters: 3, body: 1 } }],
-            errors: expectedErrors([[2, 6, 2, "Identifier"], [3, 2, 0, "ExpressionStatement"]])
+            errors: expectedErrors([[2, 6, 2, "Identifier"], [3, 2, 0, "Identifier"]])
         },
         {
-            code:
-            "function foo(aaa,\n" +
-            "        bbb,\n" +
-            "  ccc) {\n" +
-            "      bar();\n" +
-            "}",
-            output:
-            "function foo(aaa,\n" +
-            "    bbb,\n" +
-            "    ccc) {\n" +
-            "            bar();\n" +
-            "}",
+            code: unIndent`
+                function foo(aaa,
+                        bbb,
+                  ccc) {
+                      bar();
+                }
+            `,
+            output: unIndent`
+                function foo(aaa,
+                    bbb,
+                    ccc) {
+                            bar();
+                }
+            `,
             options: [4, { FunctionDeclaration: { parameters: 1, body: 3 } }],
-            errors: expectedErrors([[2, 4, 8, "Identifier"], [3, 4, 2, "Identifier"], [4, 12, 6, "ExpressionStatement"]])
+            errors: expectedErrors([[2, 4, 8, "Identifier"], [3, 4, 2, "Identifier"], [4, 12, 6, "Identifier"]])
         },
         {
-            code:
-            "function foo(aaa,\n" +
-            "  bbb, ccc,\n" +
-            "                   ddd, eee, fff) {\n" +
-            "   bar();\n" +
-            "}",
-            output:
-            "function foo(aaa,\n" +
-            "             bbb, ccc,\n" +
-            "             ddd, eee, fff) {\n" +
-            "  bar();\n" +
-            "}",
+            code: unIndent`
+                function foo(aaa,
+                  bbb, ccc,
+                                   ddd, eee, fff) {
+                   bar();
+                }
+            `,
+            output: unIndent`
+                function foo(aaa,
+                             bbb, ccc,
+                             ddd, eee, fff) {
+                  bar();
+                }
+            `,
             options: [2, { FunctionDeclaration: { parameters: "first", body: 1 } }],
-            errors: expectedErrors([[2, 13, 2, "Identifier"], [3, 13, 19, "Identifier"], [4, 2, 3, "ExpressionStatement"]])
+            errors: expectedErrors([[2, 13, 2, "Identifier"], [3, 13, 19, "Identifier"], [4, 2, 3, "Identifier"]])
         },
         {
-            code:
-            "function foo(aaa, bbb)\n" +
-            "{\n" +
-            "bar();\n" +
-            "}",
-            output:
-            "function foo(aaa, bbb)\n" +
-            "{\n" +
-            "      bar();\n" +
-            "}",
+            code: unIndent`
+                function foo(aaa, bbb)
+                {
+                bar();
+                }
+            `,
+            output: unIndent`
+                function foo(aaa, bbb)
+                {
+                      bar();
+                }
+            `,
             options: [2, { FunctionDeclaration: { body: 3 } }],
-            errors: expectedErrors([3, 6, 0, "ExpressionStatement"])
+            errors: expectedErrors([3, 6, 0, "Identifier"])
         },
         {
-            code:
-            "function foo(\n" +
-            "aaa,\n" +
-            "    bbb) {\n" +
-            "bar();\n" +
-            "}",
-            output:
-            "function foo(\n" +
-            "aaa,\n" +
-            "bbb) {\n" +
-            "    bar();\n" +
-            "}",
+            code: unIndent`
+                function foo(
+                aaa,
+                    bbb) {
+                bar();
+                }
+            `,
+            output: unIndent`
+                function foo(
+                  aaa,
+                  bbb) {
+                    bar();
+                }
+            `,
             options: [2, { FunctionDeclaration: { parameters: "first", body: 2 } }],
-            errors: expectedErrors([[3, 0, 4, "Identifier"], [4, 4, 0, "ExpressionStatement"]])
+            errors: expectedErrors([[2, 2, 0, "Identifier"], [3, 2, 4, "Identifier"], [4, 4, 0, "Identifier"]])
         },
         {
-            code:
-            "var foo = function(aaa,\n" +
-            "  bbb,\n" +
-            "    ccc,\n" +
-            "      ddd) {\n" +
-            "  bar();\n" +
-            "}",
-            output:
-            "var foo = function(aaa,\n" +
-            "    bbb,\n" +
-            "    ccc,\n" +
-            "    ddd) {\n" +
-            "bar();\n" +
-            "}",
+            code: unIndent`
+                var foo = function(aaa,
+                  bbb,
+                    ccc,
+                      ddd) {
+                  bar();
+                }
+            `,
+            output: unIndent`
+                var foo = function(aaa,
+                    bbb,
+                    ccc,
+                    ddd) {
+                bar();
+                }
+            `,
             options: [2, { FunctionExpression: { parameters: 2, body: 0 } }],
-            errors: expectedErrors([[2, 4, 2, "Identifier"], [4, 4, 6, "Identifier"], [5, 0, 2, "ExpressionStatement"]])
+            errors: expectedErrors([[2, 4, 2, "Identifier"], [4, 4, 6, "Identifier"], [5, 0, 2, "Identifier"]])
         },
         {
-            code:
-            "var foo = function(aaa,\n" +
-            "   bbb,\n" +
-            " ccc) {\n" +
-            "  bar();\n" +
-            "}",
-            output:
-            "var foo = function(aaa,\n" +
-            "  bbb,\n" +
-            "  ccc) {\n" +
-            "                    bar();\n" +
-            "}",
+            code: unIndent`
+                var foo = function(aaa,
+                   bbb,
+                 ccc) {
+                  bar();
+                }
+            `,
+            output: unIndent`
+                var foo = function(aaa,
+                  bbb,
+                  ccc) {
+                                    bar();
+                }
+            `,
             options: [2, { FunctionExpression: { parameters: 1, body: 10 } }],
-            errors: expectedErrors([[2, 2, 3, "Identifier"], [3, 2, 1, "Identifier"], [4, 20, 2, "ExpressionStatement"]])
+            errors: expectedErrors([[2, 2, 3, "Identifier"], [3, 2, 1, "Identifier"], [4, 20, 2, "Identifier"]])
         },
         {
-            code:
-            "var foo = function(aaa,\n" +
-            "  bbb, ccc, ddd,\n" +
-            "                        eee, fff) {\n" +
-            "        bar();\n" +
-            "}",
-            output:
-            "var foo = function(aaa,\n" +
-            "                   bbb, ccc, ddd,\n" +
-            "                   eee, fff) {\n" +
-            "    bar();\n" +
-            "}",
+            code: unIndent`
+                var foo = function(aaa,
+                  bbb, ccc, ddd,
+                                        eee, fff) {
+                        bar();
+                }
+            `,
+            output: unIndent`
+                var foo = function(aaa,
+                                   bbb, ccc, ddd,
+                                   eee, fff) {
+                    bar();
+                }
+            `,
             options: [4, { FunctionExpression: { parameters: "first", body: 1 } }],
-            errors: expectedErrors([[2, 19, 2, "Identifier"], [3, 19, 24, "Identifier"], [4, 4, 8, "ExpressionStatement"]])
+            errors: expectedErrors([[2, 19, 2, "Identifier"], [3, 19, 24, "Identifier"], [4, 4, 8, "Identifier"]])
         },
         {
-            code:
-            "var foo = function(\n" +
-            "aaa, bbb, ccc,\n" +
-            "    ddd, eee) {\n" +
-            "  bar();\n" +
-            "}",
-            output:
-            "var foo = function(\n" +
-            "aaa, bbb, ccc,\n" +
-            "ddd, eee) {\n" +
-            "      bar();\n" +
-            "}",
+            code: unIndent`
+                var foo = function(
+                aaa, bbb, ccc,
+                    ddd, eee) {
+                  bar();
+                }
+            `,
+            output: unIndent`
+                var foo = function(
+                  aaa, bbb, ccc,
+                  ddd, eee) {
+                      bar();
+                }
+            `,
             options: [2, { FunctionExpression: { parameters: "first", body: 3 } }],
-            errors: expectedErrors([[3, 0, 4, "Identifier"], [4, 6, 2, "ExpressionStatement"]])
+            errors: expectedErrors([[2, 2, 0, "Identifier"], [3, 2, 4, "Identifier"], [4, 6, 2, "Identifier"]])
         },
         {
-            code:
-            "var foo = bar;\n" +
-            "\t\t\tvar baz = qux;",
-            output:
-            "var foo = bar;\n" +
-            "var baz = qux;",
+            code: unIndent`
+                var foo = bar;
+                \t\t\tvar baz = qux;
+            `,
+            output: unIndent`
+                var foo = bar;
+                var baz = qux;
+            `,
             options: [2],
-            errors: expectedErrors([2, "0 spaces", "3 tabs", "VariableDeclaration"])
+            errors: expectedErrors([2, "0 spaces", "3 tabs", "Keyword"])
         },
         {
-            code:
-            "function foo() {\n" +
-            "\tbar();\n" +
-            "  baz();\n" +
-            "              qux();\n" +
-            "}",
-            output:
-            "function foo() {\n" +
-            "\tbar();\n" +
-            "\tbaz();\n" +
-            "\tqux();\n" +
-            "}",
+            code: unIndent`
+                function foo() {
+                \tbar();
+                  baz();
+                              qux();
+                }
+            `,
+            output: unIndent`
+                function foo() {
+                \tbar();
+                \tbaz();
+                \tqux();
+                }
+            `,
             options: ["tab"],
-            errors: expectedErrors("tab", [[3, "1 tab", "2 spaces", "ExpressionStatement"], [4, "1 tab", "14 spaces", "ExpressionStatement"]])
+            errors: expectedErrors("tab", [[3, "1 tab", "2 spaces", "Identifier"], [4, "1 tab", "14 spaces", "Identifier"]])
         },
         {
-            code:
-            "function foo() {\n" +
-            "  bar();\n" +
-            "\t\t}",
-            output:
-            "function foo() {\n" +
-            "  bar();\n" +
-            "}",
+            code: unIndent`
+                function foo() {
+                  bar();
+                \t\t}
+            `,
+            output: unIndent`
+                function foo() {
+                  bar();
+                }
+            `,
             options: [2],
-            errors: expectedErrors([[3, "0 spaces", "2 tabs", "BlockStatement"]])
+            errors: expectedErrors([[3, "0 spaces", "2 tabs", "Punctuator"]])
         },
         {
-            code:
-            "function foo() {\n" +
-            "  function bar() {\n" +
-            "        baz();\n" +
-            "  }\n" +
-            "}",
-            output:
-            "function foo() {\n" +
-            "  function bar() {\n" +
-            "    baz();\n" +
-            "  }\n" +
-            "}",
+            code: unIndent`
+                function foo() {
+                  function bar() {
+                        baz();
+                  }
+                }
+            `,
+            output: unIndent`
+                function foo() {
+                  function bar() {
+                    baz();
+                  }
+                }
+            `,
             options: [2, { FunctionDeclaration: { body: 1 } }],
-            errors: expectedErrors([3, 4, 8, "ExpressionStatement"])
+            errors: expectedErrors([3, 4, 8, "Identifier"])
         },
         {
-            code:
-            "function foo() {\n" +
-            "  function bar(baz,\n" +
-            "    qux) {\n" +
-            "    foobar();\n" +
-            "  }\n" +
-            "}",
-            output:
-            "function foo() {\n" +
-            "  function bar(baz,\n" +
-            "      qux) {\n" +
-            "    foobar();\n" +
-            "  }\n" +
-            "}",
+            code: unIndent`
+                function foo() {
+                  function bar(baz,
+                    qux) {
+                    foobar();
+                  }
+                }
+            `,
+            output: unIndent`
+                function foo() {
+                  function bar(baz,
+                      qux) {
+                    foobar();
+                  }
+                }
+            `,
             options: [2, { FunctionDeclaration: { body: 1, parameters: 2 } }],
             errors: expectedErrors([3, 6, 4, "Identifier"])
         },
         {
-            code:
-            "function foo() {\n" +
-            "  var bar = function(baz,\n" +
-            "          qux) {\n" +
-            "    foobar();\n" +
-            "  };\n" +
-            "}",
-            output:
-            "function foo() {\n" +
-            "  var bar = function(baz,\n" +
-            "        qux) {\n" +
-            "    foobar();\n" +
-            "  };\n" +
-            "}",
+            code: unIndent`
+                function foo() {
+                  var bar = function(baz,
+                          qux) {
+                    foobar();
+                  };
+                }
+            `,
+            output: unIndent`
+                function foo() {
+                  var bar = function(baz,
+                        qux) {
+                    foobar();
+                  };
+                }
+            `,
             options: [2, { FunctionExpression: { parameters: 3 } }],
             errors: expectedErrors([3, 8, 10, "Identifier"])
         },
         {
-            code:
-            "{\n" +
-            "    try {\n" +
-            "    }\n" +
-            "catch (err) {\n" +
-            "    }\n" +
-            "finally {\n" +
-            "    }\n" +
-            "}",
-            output:
-            "{\n" +
-            "    try {\n" +
-            "    }\n" +
-            "    catch (err) {\n" +
-            "    }\n" +
-            "    finally {\n" +
-            "    }\n" +
-            "}",
+            code: unIndent`
+                foo.bar(
+                      baz, qux, function() {
+                        qux;
+                      }
+                );
+            `,
+            output: unIndent`
+                foo.bar(
+                      baz, qux, function() {
+                            qux;
+                      }
+                );
+            `,
+            options: [2, { FunctionExpression: { body: 3 }, CallExpression: { arguments: 3 } }],
+            errors: expectedErrors([3, 12, 8, "Identifier"])
+        },
+        {
+            code: unIndent`
+                {
+                    try {
+                    }
+                catch (err) {
+                    }
+                finally {
+                    }
+                }
+            `,
+            output: unIndent`
+                {
+                    try {
+                    }
+                    catch (err) {
+                    }
+                    finally {
+                    }
+                }
+            `,
             errors: expectedErrors([
                 [4, 4, 0, "Keyword"],
                 [6, 4, 0, "Keyword"]
             ])
         },
         {
-            code:
-            "{\n" +
-            "    do {\n" +
-            "    }\n" +
-            "while (true)\n" +
-            "}",
-            output:
-            "{\n" +
-            "    do {\n" +
-            "    }\n" +
-            "    while (true)\n" +
-            "}",
+            code: unIndent`
+                {
+                    do {
+                    }
+                while (true)
+                }
+            `,
+            output: unIndent`
+                {
+                    do {
+                    }
+                    while (true)
+                }
+            `,
             errors: expectedErrors([4, 4, 0, "Keyword"])
         },
         {
-            code:
-            "function foo() {\n" +
-            "  bar();\n" +
-            "\t\t}",
-            output:
-            "function foo() {\n" +
-            "  bar();\n" +
-            "}",
+            code: unIndent`
+                function foo() {
+                  bar();
+                \t\t}
+            `,
+            output: unIndent`
+                function foo() {
+                  bar();
+                }
+            `,
             options: [2],
-            errors: expectedErrors([[3, "0 spaces", "2 tabs", "BlockStatement"]])
+            errors: expectedErrors([[3, "0 spaces", "2 tabs", "Punctuator"]])
         },
         {
-            code:
-            "function foo() {\n" +
-            "  return (\n" +
-            "    1\n" +
-            "    )\n" +
-            "}",
-            output:
-            "function foo() {\n" +
-            "  return (\n" +
-            "    1\n" +
-            "  )\n" +
-            "}",
+            code: unIndent`
+                function foo() {
+                  return (
+                    1
+                    )
+                }
+            `,
+            output: unIndent`
+                function foo() {
+                  return (
+                    1
+                  )
+                }
+            `,
             options: [2],
-            errors: expectedErrors([[4, "2 spaces", "4", "ReturnStatement"]])
+            errors: expectedErrors([[4, 2, 4, "Punctuator"]])
         },
         {
-            code:
-            "function foo() {\n" +
-            "  return (\n" +
-            "    1\n" +
-            "    );\n" +
-            "}",
-            output:
-            "function foo() {\n" +
-            "  return (\n" +
-            "    1\n" +
-            "  );\n" +
-            "}",
+            code: unIndent`
+                function foo() {
+                  return (
+                    1
+                    );
+                }
+            `,
+            output: unIndent`
+                function foo() {
+                  return (
+                    1
+                  );
+                }
+            `,
             options: [2],
-            errors: expectedErrors([[4, "2 spaces", "4", "ReturnStatement"]])
+            errors: expectedErrors([[4, 2, 4, "Punctuator"]])
         },
         {
-            code:
-            "function foo() {\n" +
-            "  bar();\n" +
-            "\t\t}",
-            output:
-            "function foo() {\n" +
-            "  bar();\n" +
-            "}",
+            code: unIndent`
+                function foo() {
+                  bar();
+                \t\t}
+            `,
+            output: unIndent`
+                function foo() {
+                  bar();
+                }
+            `,
             options: [2],
-            errors: expectedErrors([[3, "0 spaces", "2 tabs", "BlockStatement"]])
+            errors: expectedErrors([[3, "0 spaces", "2 tabs", "Punctuator"]])
         },
         {
-            code:
-            "function test(){\n" +
-            "  switch(length){\n" +
-            "    case 1: return function(a){\n" +
-            "    return fn.call(that, a);\n" +
-            "    };\n" +
-            "  }\n" +
-            "}",
-            output:
-            "function test(){\n" +
-            "  switch(length){\n" +
-            "    case 1: return function(a){\n" +
-            "      return fn.call(that, a);\n" +
-            "    };\n" +
-            "  }\n" +
-            "}",
+            code: unIndent`
+                function test(){
+                  switch(length){
+                    case 1: return function(a){
+                    return fn.call(that, a);
+                    };
+                  }
+                }
+            `,
+            output: unIndent`
+                function test(){
+                  switch(length){
+                    case 1: return function(a){
+                      return fn.call(that, a);
+                    };
+                  }
+                }
+            `,
             options: [2, { VariableDeclarator: 2, SwitchCase: 1 }],
-            errors: expectedErrors([[4, "6 spaces", "4", "ReturnStatement"]])
+            errors: expectedErrors([[4, 6, 4, "Keyword"]])
         },
         {
-            code:
-            "function foo() {\n" +
-            "   return 1\n" +
-            "}",
-            output:
-            "function foo() {\n" +
-            "  return 1\n" +
-            "}",
+            code: unIndent`
+                function foo() {
+                   return 1
+                }
+            `,
+            output: unIndent`
+                function foo() {
+                  return 1
+                }
+            `,
             options: [2],
-            errors: expectedErrors([[2, "2 spaces", "3", "ReturnStatement"]])
+            errors: expectedErrors([[2, 2, 3, "Keyword"]])
         },
         {
-            code:
-            "function foo() {\n" +
-            "   return 1;\n" +
-            "}",
-            output:
-            "function foo() {\n" +
-            "  return 1;\n" +
-            "}",
-            options: [2],
-            errors: expectedErrors([[2, "2 spaces", "3", "ReturnStatement"]])
-        },
-        {
-            code:
-            "foo(\n" +
-            "bar,\n" +
-            "  baz,\n" +
-            "    qux);",
-            output:
-            "foo(\n" +
-            "  bar,\n" +
-            "  baz,\n" +
-            "  qux);",
+            code: unIndent`
+                foo(
+                bar,
+                  baz,
+                    qux);
+            `,
+            output: unIndent`
+                foo(
+                  bar,
+                  baz,
+                  qux);
+            `,
             options: [2, { CallExpression: { arguments: 1 } }],
             errors: expectedErrors([[2, 2, 0, "Identifier"], [4, 2, 4, "Identifier"]])
         },
         {
-            code:
-            "foo(\n" +
-            "\tbar,\n" +
-            "\tbaz);",
-            output:
-            "foo(\n" +
-            "    bar,\n" +
-            "    baz);",
+            code: unIndent`
+                foo(
+                \tbar,
+                \tbaz);
+            `,
+            output: unIndent`
+                foo(
+                    bar,
+                    baz);
+            `,
             options: [2, { CallExpression: { arguments: 2 } }],
             errors: expectedErrors([[2, "4 spaces", "1 tab", "Identifier"], [3, "4 spaces", "1 tab", "Identifier"]])
         },
         {
-            code:
-            "foo(bar,\n" +
-            "\t\tbaz,\n" +
-            "\t\tqux);",
-            output:
-            "foo(bar,\n" +
-            "\tbaz,\n" +
-            "\tqux);",
+            code: unIndent`
+                foo(bar,
+                \t\tbaz,
+                \t\tqux);
+            `,
+            output: unIndent`
+                foo(bar,
+                \tbaz,
+                \tqux);
+            `,
             options: ["tab", { CallExpression: { arguments: 1 } }],
             errors: expectedErrors("tab", [[2, 1, 2, "Identifier"], [3, 1, 2, "Identifier"]])
         },
         {
-            code:
-            "foo(bar, baz,\n" +
-            "         qux);",
-            output:
-            "foo(bar, baz,\n" +
-            "    qux);",
+            code: unIndent`
+                foo(bar, baz,
+                         qux);
+            `,
+            output: unIndent`
+                foo(bar, baz,
+                    qux);
+            `,
             options: [2, { CallExpression: { arguments: "first" } }],
             errors: expectedErrors([2, 4, 9, "Identifier"])
         },
         {
-            code:
-            "foo(\n" +
-            "          bar,\n" +
-            "    baz);",
-            output:
-            "foo(\n" +
-            "          bar,\n" +
-            "          baz);",
+            code: unIndent`
+                foo(
+                          bar,
+                    baz);
+            `,
+            output: unIndent`
+                foo(
+                  bar,
+                  baz);
+            `,
             options: [2, { CallExpression: { arguments: "first" } }],
-            errors: expectedErrors([3, 10, 4, "Identifier"])
+            errors: expectedErrors([[2, 2, 10, "Identifier"], [3, 2, 4, "Identifier"]])
         },
         {
-            code:
-            "foo(bar,\n" +
-            "  1 + 2,\n" +
-            "              !baz,\n" +
-            "        new Car('!')\n" +
-            ");",
-            output:
-            "foo(bar,\n" +
-            "      1 + 2,\n" +
-            "      !baz,\n" +
-            "      new Car('!')\n" +
-            ");",
+            code: unIndent`
+                foo(bar,
+                  1 + 2,
+                              !baz,
+                        new Car('!')
+                );
+            `,
+            output: unIndent`
+                foo(bar,
+                      1 + 2,
+                      !baz,
+                      new Car('!')
+                );
+            `,
             options: [2, { CallExpression: { arguments: 3 } }],
-            errors: expectedErrors([[2, 6, 2, "BinaryExpression"], [3, 6, 14, "UnaryExpression"], [4, 6, 8, "NewExpression"]])
+            errors: expectedErrors([[2, 6, 2, "Numeric"], [3, 6, 14, "Punctuator"], [4, 6, 8, "Keyword"]])
         },
 
         // https://github.com/eslint/eslint/issues/7573
         {
-            code:
-            "return (\n" +
-            "    foo\n" +
-            "    );",
-            output:
-            "return (\n" +
-            "    foo\n" +
-            ");",
+            code: unIndent`
+                return (
+                    foo
+                    );
+            `,
+            output: unIndent`
+                return (
+                    foo
+                );
+            `,
             parserOptions: { ecmaFeatures: { globalReturn: true } },
-            errors: expectedErrors([3, 0, 4, "ReturnStatement"])
+            errors: expectedErrors([3, 0, 4, "Punctuator"])
         },
         {
-            code:
-            "return (\n" +
-            "    foo\n" +
-            "    )",
-            output:
-            "return (\n" +
-            "    foo\n" +
-            ")",
+            code: unIndent`
+                return (
+                    foo
+                    )
+            `,
+            output: unIndent`
+                return (
+                    foo
+                )
+            `,
             parserOptions: { ecmaFeatures: { globalReturn: true } },
-            errors: expectedErrors([3, 0, 4, "ReturnStatement"])
+            errors: expectedErrors([3, 0, 4, "Punctuator"])
         },
 
         // https://github.com/eslint/eslint/issues/7604
         {
-            code:
-            "if (foo) {\n" +
-            "        /* comment */bar();\n" +
-            "}",
-            output:
-            "if (foo) {\n" +
-            "    /* comment */bar();\n" +
-            "}",
-            errors: expectedErrors([2, 4, 8, "ExpressionStatement"])
+            code: unIndent`
+                if (foo) {
+                        /* comment */bar();
+                }
+            `,
+            output: unIndent`
+                if (foo) {
+                    /* comment */bar();
+                }
+            `,
+            errors: expectedErrors([2, 4, 8, "Block"])
         },
         {
-            code:
-            "foo('bar',\n" +
-            "        /** comment */{\n" +
-            "        ok: true" +
-            "    });",
-            output:
-            "foo('bar',\n" +
-            "    /** comment */{\n" +
-            "        ok: true" +
-            "    });",
-            errors: expectedErrors([2, 4, 8, "ObjectExpression"])
+            code: unIndent`
+                foo('bar',
+                        /** comment */{
+                        ok: true
+                    });
+            `,
+            output: unIndent`
+                foo('bar',
+                    /** comment */{
+                        ok: true
+                    });
+            `,
+            errors: expectedErrors([2, 4, 8, "Block"])
         },
         {
-            code:
-            "var foo = [\n" +
-            "           bar,\n" +
-            "  baz\n" +
-            "          ]",
-            output:
-            "var foo = [\n" +
-            "    bar,\n" +
-            "    baz\n" +
-            "]",
-            errors: expectedErrors([[2, 4, 11, "Identifier"], [3, 4, 2, "Identifier"], [4, 0, 10, "ArrayExpression"]])
+            code: unIndent`
+                foo(
+                (bar)
+                );
+            `,
+            output: unIndent`
+                foo(
+                    (bar)
+                );
+            `,
+            options: [4, { CallExpression: { arguments: 1 } }],
+            errors: expectedErrors([2, 4, 0, "Punctuator"])
         },
         {
-            code:
-            "var foo = [bar,\n" +
-            "baz,\n" +
-            "    qux\n" +
-            "]",
-            output:
-            "var foo = [bar,\n" +
-            "    baz,\n" +
-            "    qux\n" +
-            "]",
+            code: unIndent`
+                ((
+                foo
+                ))
+            `,
+            output: unIndent`
+                ((
+                    foo
+                ))
+            `,
+            options: [4],
+            errors: expectedErrors([2, 4, 0, "Identifier"])
+        },
+
+        // ternary expressions (https://github.com/eslint/eslint/issues/7420)
+        {
+            code: unIndent`
+                foo
+                ? bar
+                    : baz
+            `,
+            output: unIndent`
+                foo
+                  ? bar
+                  : baz
+            `,
+            options: [2],
+            errors: expectedErrors([[2, 2, 0, "Punctuator"], [3, 2, 4, "Punctuator"]])
+        },
+        {
+            code: unIndent`
+                [
+                    foo ?
+                        bar :
+                        baz,
+                        qux
+                ]
+            `,
+            output: unIndent`
+                [
+                    foo ?
+                        bar :
+                        baz,
+                    qux
+                ]
+            `,
+            errors: expectedErrors([5, 4, 8, "Identifier"])
+        },
+        {
+
+            // Checking comments:
+            // https://github.com/eslint/eslint/issues/6571
+            code: unIndent`
+                foo();
+                  // comment
+                    /* multiline
+                  comment */
+                bar();
+                 // trailing comment
+            `,
+            output: unIndent`
+                foo();
+                // comment
+                /* multiline
+                  comment */
+                bar();
+                // trailing comment
+            `,
+            options: [2],
+            errors: expectedErrors([[2, 0, 2, "Line"], [3, 0, 4, "Block"], [6, 0, 1, "Line"]])
+        },
+        {
+            code: "  // comment",
+            output: "// comment",
+            errors: expectedErrors([1, 0, 2, "Line"])
+        },
+        {
+            code: unIndent`
+                foo
+                  // comment
+            `,
+            output: unIndent`
+                foo
+                // comment
+            `,
+            errors: expectedErrors([2, 0, 2, "Line"])
+        },
+        {
+            code: unIndent`
+                  // comment
+                foo
+            `,
+            output: unIndent`
+                // comment
+                foo
+            `,
+            errors: expectedErrors([1, 0, 2, "Line"])
+        },
+        {
+            code: unIndent`
+                [
+                        // no elements
+                ]
+            `,
+            output: unIndent`
+                [
+                    // no elements
+                ]
+            `,
+            errors: expectedErrors([2, 4, 8, "Line"])
+        },
+        {
+
+            // Destructuring assignments:
+            // https://github.com/eslint/eslint/issues/6813
+            code: unIndent`
+                var {
+                foo,
+                  bar,
+                    baz: qux,
+                      foobar: baz = foobar
+                  } = qux;
+            `,
+            output: unIndent`
+                var {
+                  foo,
+                  bar,
+                  baz: qux,
+                  foobar: baz = foobar
+                } = qux;
+            `,
+            options: [2],
+            parserOptions: { ecmaVersion: 6 },
+            errors: expectedErrors([[2, 2, 0, "Identifier"], [4, 2, 4, "Identifier"], [5, 2, 6, "Identifier"], [6, 0, 2, "Punctuator"]])
+        },
+        {
+            code: unIndent`
+                var foo = [
+                           bar,
+                  baz
+                          ]
+            `,
+            output: unIndent`
+                var foo = [
+                    bar,
+                    baz
+                ]
+            `,
+            errors: expectedErrors([[2, 4, 11, "Identifier"], [3, 4, 2, "Identifier"], [4, 0, 10, "Punctuator"]])
+        },
+        {
+            code: unIndent`
+                var foo = [bar,
+                baz,
+                    qux
+                ]
+            `,
+            output: unIndent`
+                var foo = [bar,
+                    baz,
+                    qux
+                ]
+            `,
             errors: expectedErrors([2, 4, 0, "Identifier"])
         },
         {
-            code:
-            "var foo = [bar,\n" +
-            "  baz,\n" +
-            "  qux\n" +
-            "]",
-            output:
-            "var foo = [bar,\n" +
-            "baz,\n" +
-            "qux\n" +
-            "]",
+            code: unIndent`
+                var foo = [bar,
+                  baz,
+                  qux
+                ]
+            `,
+            output: unIndent`
+                var foo = [bar,
+                baz,
+                qux
+                ]
+            `,
             options: [2, { ArrayExpression: 0 }],
             errors: expectedErrors([[2, 0, 2, "Identifier"], [3, 0, 2, "Identifier"]])
         },
         {
-            code:
-            "var foo = [bar,\n" +
-            "  baz,\n" +
-            "  qux\n" +
-            "]",
-            output:
-            "var foo = [bar,\n" +
-            "                baz,\n" +
-            "                qux\n" +
-            "]",
+            code: unIndent`
+                var foo = [bar,
+                  baz,
+                  qux
+                ]
+            `,
+            output: unIndent`
+                var foo = [bar,
+                                baz,
+                                qux
+                ]
+            `,
             options: [2, { ArrayExpression: 8 }],
             errors: expectedErrors([[2, 16, 2, "Identifier"], [3, 16, 2, "Identifier"]])
         },
         {
-            code:
-            "var foo = [bar,\n" +
-            "    baz,\n" +
-            "    qux\n" +
-            "]",
-            output:
-            "var foo = [bar,\n" +
-            "           baz,\n" +
-            "           qux\n" +
-            "]",
+            code: unIndent`
+                var foo = [bar,
+                    baz,
+                    qux
+                ]
+            `,
+            output: unIndent`
+                var foo = [bar,
+                           baz,
+                           qux
+                ]
+            `,
             options: [2, { ArrayExpression: "first" }],
             errors: expectedErrors([[2, 11, 4, "Identifier"], [3, 11, 4, "Identifier"]])
         },
         {
-            code:
-            "var foo = [bar,\n" +
-            "    baz, qux\n" +
-            "]",
-            output:
-            "var foo = [bar,\n" +
-            "           baz, qux\n" +
-            "]",
+            code: unIndent`
+                var foo = [bar,
+                    baz, qux
+                ]
+            `,
+            output: unIndent`
+                var foo = [bar,
+                           baz, qux
+                ]
+            `,
             options: [2, { ArrayExpression: "first" }],
             errors: expectedErrors([2, 11, 4, "Identifier"])
         },
         {
-            code:
-            "var foo = [\n" +
-            "        { bar: 1,\n" +
-            "            baz: 2 },\n" +
-            "        { bar: 3,\n" +
-            "            qux: 4 }\n" +
-            "]",
-            output:
-            "var foo = [\n" +
-            "        { bar: 1,\n" +
-            "          baz: 2 },\n" +
-            "        { bar: 3,\n" +
-            "          qux: 4 }\n" +
-            "]",
+            code: unIndent`
+                var foo = [
+                        { bar: 1,
+                            baz: 2 },
+                        { bar: 3,
+                            qux: 4 }
+                ]
+            `,
+            output: unIndent`
+                var foo = [
+                        { bar: 1,
+                          baz: 2 },
+                        { bar: 3,
+                          qux: 4 }
+                ]
+            `,
             options: [4, { ArrayExpression: 2, ObjectExpression: "first" }],
-            errors: expectedErrors([[3, 10, 12, "Property"], [5, 10, 12, "Property"]])
+            errors: expectedErrors([[3, 10, 12, "Identifier"], [5, 10, 12, "Identifier"]])
         },
         {
-            code:
-            "var foo = {\n" +
-            "  bar: 1,\n" +
-            "  baz: 2\n" +
-            "};",
-            output:
-            "var foo = {\n" +
-            "bar: 1,\n" +
-            "baz: 2\n" +
-            "};",
+            code: unIndent`
+                var foo = {
+                  bar: 1,
+                  baz: 2
+                };
+            `,
+            output: unIndent`
+                var foo = {
+                bar: 1,
+                baz: 2
+                };
+            `,
             options: [2, { ObjectExpression: 0 }],
-            errors: expectedErrors([[2, 0, 2, "Property"], [3, 0, 2, "Property"]])
+            errors: expectedErrors([[2, 0, 2, "Identifier"], [3, 0, 2, "Identifier"]])
         },
         {
-            code:
-            "var quux = { foo: 1, bar: 2,\n" +
-            "baz: 3 }",
-            output:
-            "var quux = { foo: 1, bar: 2,\n" +
-            "             baz: 3 }",
+            code: unIndent`
+                var quux = { foo: 1, bar: 2,
+                baz: 3 }
+            `,
+            output: unIndent`
+                var quux = { foo: 1, bar: 2,
+                             baz: 3 }
+            `,
             options: [2, { ObjectExpression: "first" }],
-            errors: expectedErrors([2, 13, 0, "Property"])
+            errors: expectedErrors([2, 13, 0, "Identifier"])
         },
         {
-            code:
-            "function foo() {\n" +
-            "    [\n" +
-            "            foo\n" +
-            "    ]\n" +
-            "}",
-            output:
-            "function foo() {\n" +
-            "  [\n" +
-            "            foo\n" +
-            "    ]\n" +
-            "}",
+            code: unIndent`
+                function foo() {
+                    [
+                            foo
+                    ]
+                }
+            `,
+            output: unIndent`
+                function foo() {
+                  [
+                          foo
+                  ]
+                }
+            `,
             options: [2, { ArrayExpression: 4 }],
-            errors: expectedErrors([2, 2, 4, "ExpressionStatement"])
+            errors: expectedErrors([[2, 2, 4, "Punctuator"], [3, 10, 12, "Identifier"], [4, 2, 4, "Punctuator"]])
         },
         {
-            code:
-            "echo = spawn('cmd.exe',\n" +
-            "            ['foo', 'bar',\n" +
-            "             'baz']);",
-            output:
-            "echo = spawn('cmd.exe',\n" +
-            "             ['foo', 'bar',\n" +
-            "             'baz']);",
+            code: unIndent`
+                var [
+                foo,
+                  bar,
+                    baz,
+                      foobar = baz
+                  ] = qux;
+            `,
+            output: unIndent`
+                var [
+                  foo,
+                  bar,
+                  baz,
+                  foobar = baz
+                ] = qux;
+            `,
+            options: [2],
+            parserOptions: { ecmaVersion: 6 },
+            errors: expectedErrors([[2, 2, 0, "Identifier"], [4, 2, 4, "Identifier"], [5, 2, 6, "Identifier"], [6, 0, 2, "Punctuator"]])
+        },
+        {
+            code: unIndent`
+                import {
+                foo,
+                  bar,
+                    baz
+                } from 'qux';
+            `,
+            output: unIndent`
+                import {
+                    foo,
+                    bar,
+                    baz
+                } from 'qux';
+            `,
+            parserOptions: { sourceType: "module" },
+            errors: expectedErrors([[2, 4, 0, "Identifier"], [3, 4, 2, "Identifier"]])
+        },
+        {
+
+            // https://github.com/eslint/eslint/issues/7233
+            code: unIndent`
+                var folder = filePath
+                  .foo()
+                      .bar;
+            `,
+            output: unIndent`
+                var folder = filePath
+                    .foo()
+                    .bar;
+            `,
+            options: [2, { MemberExpression: 2 }],
+            errors: expectedErrors([[2, 4, 2, "Punctuator"], [3, 4, 6, "Punctuator"]])
+        },
+        {
+            code: unIndent`
+                for (const foo of bar)
+                    baz();
+            `,
+            output: unIndent`
+                for (const foo of bar)
+                  baz();
+            `,
+            options: [2],
+            parserOptions: { ecmaVersion: 6 },
+            errors: expectedErrors([2, 2, 4, "Identifier"])
+        },
+        {
+            code: unIndent`
+                var x = () =>
+                    5;
+            `,
+            output: unIndent`
+                var x = () =>
+                  5;
+            `,
+            options: [2],
+            parserOptions: { ecmaVersion: 6 },
+            errors: expectedErrors([2, 2, 4, "Numeric"])
+        },
+        {
+
+            // BinaryExpressions with parens
+            code: unIndent`
+                foo && (
+                        bar
+                )
+            `,
+            output: unIndent`
+                foo && (
+                    bar
+                )
+            `,
+            options: [4],
+            errors: expectedErrors([2, 4, 8, "Identifier"])
+        },
+
+        // Template curlies
+        {
+            code: unIndent`
+                \`foo\${
+                bar}\`
+            `,
+            output: unIndent`
+                \`foo\${
+                  bar}\`
+            `,
+            options: [2],
+            parserOptions: { ecmaVersion: 6 },
+            errors: expectedErrors([2, 2, 0, "Identifier"])
+        },
+        {
+            code: unIndent`
+                \`foo\${
+                    \`bar\${
+                baz}\`}\`
+            `,
+            output: unIndent`
+                \`foo\${
+                  \`bar\${
+                    baz}\`}\`
+            `,
+            options: [2],
+            parserOptions: { ecmaVersion: 6 },
+            errors: expectedErrors([[2, 2, 4, "Template"], [3, 4, 0, "Identifier"]])
+        },
+        {
+            code: unIndent`
+                \`foo\${
+                    \`bar\${
+                  baz
+                    }\`
+                  }\`
+            `,
+            output: unIndent`
+                \`foo\${
+                  \`bar\${
+                    baz
+                  }\`
+                }\`
+            `,
+            options: [2],
+            parserOptions: { ecmaVersion: 6 },
+            errors: expectedErrors([[2, 2, 4, "Template"], [3, 4, 2, "Identifier"], [4, 2, 4, "Template"], [5, 0, 2, "Template"]])
+        },
+        {
+            code: unIndent`
+                \`foo\${
+                (
+                  bar
+                )
+                }\`
+            `,
+            output: unIndent`
+                \`foo\${
+                  (
+                    bar
+                  )
+                }\`
+            `,
+            options: [2],
+            parserOptions: { ecmaVersion: 6 },
+            errors: expectedErrors([[2, 2, 0, "Punctuator"], [3, 4, 2, "Identifier"], [4, 2, 0, "Punctuator"]])
+        },
+        {
+            code: unIndent`
+                function foo() {
+                    \`foo\${bar}baz\${
+                qux}foo\${
+                  bar}baz\`
+                }
+            `,
+            output: unIndent`
+                function foo() {
+                    \`foo\${bar}baz\${
+                        qux}foo\${
+                        bar}baz\`
+                }
+            `,
+            parserOptions: { ecmaVersion: 6 },
+            errors: expectedErrors([[3, 8, 0, "Identifier"], [4, 8, 2, "Identifier"]])
+        },
+        {
+            code: unIndent`
+                function foo() {
+                    const template = \`the indentation of
+                a curly element in a \${
+                        node.type
+                    } node is checked.\`;
+                }
+            `,
+            output: unIndent`
+                function foo() {
+                    const template = \`the indentation of
+                a curly element in a \${
+                    node.type
+                } node is checked.\`;
+                }
+            `,
+            errors: expectedErrors([[4, 4, 8, "Identifier"], [5, 0, 4, "Template"]]),
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: unIndent`
+                function foo() {
+                    const template = \`this time the
+                closing curly is at the end of the line \${
+                            foo}
+                        so the spaces before this line aren't removed.\`;
+                }
+            `,
+            output: unIndent`
+                function foo() {
+                    const template = \`this time the
+                closing curly is at the end of the line \${
+                    foo}
+                        so the spaces before this line aren't removed.\`;
+                }
+            `,
+            errors: expectedErrors([4, 4, 12, "Identifier"]),
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+
+            // https://github.com/eslint/eslint/issues/1801
+            // Note: This issue also mentioned checking the indentation for the 2 below. However,
+            // this is intentionally ignored because everyone seems to have a different idea of how
+            // BinaryExpressions should be indented.
+            code: unIndent`
+                if (true) {
+                    a = (
+                1 +
+                        2);
+                }
+            `,
+            output: unIndent`
+                if (true) {
+                    a = (
+                        1 +
+                        2);
+                }
+            `,
+            errors: expectedErrors([3, 8, 0, "Numeric"])
+        },
+        {
+
+            // https://github.com/eslint/eslint/issues/3737
+            code: unIndent`
+                if (true) {
+                    for (;;) {
+                      b();
+                  }
+                }
+            `,
+            output: unIndent`
+                if (true) {
+                  for (;;) {
+                    b();
+                  }
+                }
+            `,
+            options: [2],
+            errors: expectedErrors([[2, 2, 4, "Keyword"], [3, 4, 6, "Identifier"]])
+        },
+        {
+
+            // https://github.com/eslint/eslint/issues/6670
+            code: unIndent`
+                function f() {
+                    return asyncCall()
+                    .then(
+                               'some string',
+                              [
+                              1,
+                         2,
+                                                   3
+                                      ]
+                );
+                 }
+            `,
+            output: unIndent`
+                function f() {
+                    return asyncCall()
+                        .then(
+                            'some string',
+                            [
+                                1,
+                                2,
+                                3
+                            ]
+                        );
+                }
+            `,
+            options: [4, { MemberExpression: 1, CallExpression: { arguments: 1 } }],
+            errors: expectedErrors([
+                [3, 8, 4, "Punctuator"],
+                [4, 12, 15, "String"],
+                [5, 12, 14, "Punctuator"],
+                [6, 16, 14, "Numeric"],
+                [7, 16, 9, "Numeric"],
+                [8, 16, 35, "Numeric"],
+                [9, 12, 22, "Punctuator"],
+                [10, 8, 0, "Punctuator"],
+                [11, 0, 1, "Punctuator"]
+            ])
+        },
+
+        // https://github.com/eslint/eslint/issues/7242
+        {
+            code: unIndent`
+                var x = [
+                      [1],
+                  [2]
+                ]
+            `,
+            output: unIndent`
+                var x = [
+                    [1],
+                    [2]
+                ]
+            `,
+            errors: expectedErrors([[2, 4, 6, "Punctuator"], [3, 4, 2, "Punctuator"]])
+        },
+        {
+            code: unIndent`
+                var y = [
+                      {a: 1},
+                  {b: 2}
+                ]
+            `,
+            output: unIndent`
+                var y = [
+                    {a: 1},
+                    {b: 2}
+                ]
+            `,
+            errors: expectedErrors([[2, 4, 6, "Punctuator"], [3, 4, 2, "Punctuator"]])
+        },
+        {
+            code: unIndent`
+                echo = spawn('cmd.exe',
+                            ['foo', 'bar',
+                             'baz']);
+            `,
+            output: unIndent`
+                echo = spawn('cmd.exe',
+                             ['foo', 'bar',
+                              'baz']);
+            `,
             options: [2, { ArrayExpression: "first", CallExpression: { arguments: "first" } }],
-            errors: expectedErrors([2, 13, 12, "ArrayExpression"])
+            errors: expectedErrors([[2, 13, 12, "Punctuator"], [3, 14, 13, "String"]])
+        },
+        {
+
+            // https://github.com/eslint/eslint/issues/7522
+            code: unIndent`
+                foo(
+                  )
+            `,
+            output: unIndent`
+                foo(
+                )
+            `,
+            errors: expectedErrors([2, 0, 2, "Punctuator"])
+        },
+        {
+
+            // https://github.com/eslint/eslint/issues/7616
+            code: unIndent`
+                foo(
+                        bar,
+                    {
+                        baz: 1
+                    }
+                )
+            `,
+            output: unIndent`
+                foo(
+                    bar,
+                    {
+                        baz: 1
+                    }
+                )
+            `,
+            options: [4, { CallExpression: { arguments: "first" } }],
+            errors: expectedErrors([[2, 4, 8, "Identifier"]])
+        },
+        {
+            code: "  new Foo",
+            output: "new Foo",
+            errors: expectedErrors([1, 0, 2, "Keyword"])
+        },
+        {
+            code: unIndent`
+                export {
+                foo,
+                        bar,
+                  baz
+                }
+            `,
+            output: unIndent`
+                export {
+                    foo,
+                    bar,
+                    baz
+                }
+            `,
+            parserOptions: { sourceType: "module" },
+            errors: expectedErrors([[2, 4, 0, "Identifier"], [3, 4, 8, "Identifier"], [4, 4, 2, "Identifier"]])
+        },
+        {
+            code: unIndent`
+                foo
+                    ? bar
+                : baz
+            `,
+            output: unIndent`
+                foo
+                    ? bar
+                    : baz
+            `,
+            options: [4, { flatTernaryExpressions: true }],
+            errors: expectedErrors([3, 4, 0, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                foo ?
+                    bar :
+                baz
+            `,
+            output: unIndent`
+                foo ?
+                    bar :
+                    baz
+            `,
+            options: [4, { flatTernaryExpressions: true }],
+            errors: expectedErrors([3, 4, 0, "Identifier"])
+        },
+        {
+            code: unIndent`
+                foo ?
+                    bar
+                  : baz
+            `,
+            output: unIndent`
+                foo ?
+                    bar
+                    : baz
+            `,
+            options: [4, { flatTernaryExpressions: true }],
+            errors: expectedErrors([3, 4, 2, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                foo
+                    ? bar :
+                baz
+            `,
+            output: unIndent`
+                foo
+                    ? bar :
+                    baz
+            `,
+            options: [4, { flatTernaryExpressions: true }],
+            errors: expectedErrors([3, 4, 0, "Identifier"])
+        },
+        {
+            code: unIndent`
+                foo
+                    ? bar
+                    : baz
+                        ? qux
+                        : foobar
+                            ? boop
+                            : beep
+            `,
+            output: unIndent`
+                foo
+                    ? bar
+                    : baz
+                    ? qux
+                    : foobar
+                    ? boop
+                    : beep
+            `,
+            options: [4, { flatTernaryExpressions: true }],
+            errors: expectedErrors([
+                [4, 4, 8, "Punctuator"],
+                [5, 4, 8, "Punctuator"],
+                [6, 4, 12, "Punctuator"],
+                [7, 4, 12, "Punctuator"]
+            ])
+        },
+        {
+            code: unIndent`
+                foo ?
+                    bar :
+                    baz ?
+                        qux :
+                        foobar ?
+                            boop :
+                            beep
+            `,
+            output: unIndent`
+                foo ?
+                    bar :
+                    baz ?
+                    qux :
+                    foobar ?
+                    boop :
+                    beep
+            `,
+            options: [4, { flatTernaryExpressions: true }],
+            errors: expectedErrors([
+                [4, 4, 8, "Identifier"],
+                [5, 4, 8, "Identifier"],
+                [6, 4, 12, "Identifier"],
+                [7, 4, 12, "Identifier"]
+            ])
+        },
+        {
+            code: unIndent`
+                foo
+                    ? bar
+                    : baz
+                    ? qux
+                    : foobar
+                    ? boop
+                    : beep
+            `,
+            output: unIndent`
+                foo
+                    ? bar
+                    : baz
+                        ? qux
+                        : foobar
+                            ? boop
+                            : beep
+            `,
+            options: [4, { flatTernaryExpressions: false }],
+            errors: expectedErrors([
+                [4, 8, 4, "Punctuator"],
+                [5, 8, 4, "Punctuator"],
+                [6, 12, 4, "Punctuator"],
+                [7, 12, 4, "Punctuator"]
+            ])
+        },
+        {
+            code: unIndent`
+                foo ?
+                    bar :
+                    baz ?
+                    qux :
+                    foobar ?
+                    boop :
+                    beep
+            `,
+            output: unIndent`
+                foo ?
+                    bar :
+                    baz ?
+                        qux :
+                        foobar ?
+                            boop :
+                            beep
+            `,
+            options: [4, { flatTernaryExpressions: false }],
+            errors: expectedErrors([
+                [4, 8, 4, "Identifier"],
+                [5, 8, 4, "Identifier"],
+                [6, 12, 4, "Identifier"],
+                [7, 12, 4, "Identifier"]
+            ])
+        },
+        {
+            code: unIndent`
+                foo.bar('baz', function(err) {
+                          qux;
+                });
+            `,
+            output: unIndent`
+                foo.bar('baz', function(err) {
+                  qux;
+                });
+            `,
+            options: [2, { CallExpression: { arguments: "first" } }],
+            errors: expectedErrors([2, 2, 10, "Identifier"])
+        },
+        {
+            code: unIndent`
+                foo.bar(function() {
+                  cookies;
+                }).baz(function() {
+                    cookies;
+                  });
+            `,
+            output: unIndent`
+                foo.bar(function() {
+                  cookies;
+                }).baz(function() {
+                  cookies;
+                });
+            `,
+            options: [2, { MemberExpression: 1 }],
+            errors: expectedErrors([[4, 2, 4, "Identifier"], [5, 0, 2, "Punctuator"]])
+        },
+        {
+            code: unIndent`
+                foo.bar().baz(function() {
+                  cookies;
+                }).qux(function() {
+                    cookies;
+                  });
+            `,
+            output: unIndent`
+                foo.bar().baz(function() {
+                  cookies;
+                }).qux(function() {
+                  cookies;
+                });
+            `,
+            options: [2, { MemberExpression: 1 }],
+            errors: expectedErrors([[4, 2, 4, "Identifier"], [5, 0, 2, "Punctuator"]])
+        },
+        {
+            code: unIndent`
+                [ foop,
+                  bar ].forEach(function() {
+                  baz;
+                })
+            `,
+            output: unIndent`
+                [ foop,
+                  bar ].forEach(function() {
+                    baz;
+                  })
+            `,
+            options: [2, { ArrayExpression: "first", MemberExpression: 1 }],
+            errors: expectedErrors([[3, 4, 2, "Identifier"], [4, 2, 0, "Punctuator"]])
+        },
+        {
+            code: unIndent`
+                foo[
+                    bar
+                    ];
+            `,
+            output: unIndent`
+                foo[
+                    bar
+                ];
+            `,
+            options: [4, { MemberExpression: 1 }],
+            errors: expectedErrors([3, 0, 4, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                foo({
+                bar: 1,
+                baz: 2
+                })
+            `,
+            output: unIndent`
+                foo({
+                    bar: 1,
+                    baz: 2
+                })
+            `,
+            options: [4, { ObjectExpression: "first" }],
+            errors: expectedErrors([[2, 4, 0, "Identifier"], [3, 4, 0, "Identifier"]])
+        },
+        {
+            code: unIndent`
+                foo(
+                                        bar, baz,
+                                        qux);
+            `,
+            output: unIndent`
+                foo(
+                  bar, baz,
+                  qux);
+            `,
+            options: [2, { CallExpression: { arguments: "first" } }],
+            errors: expectedErrors([[2, 2, 24, "Identifier"], [3, 2, 24, "Identifier"]])
         }
     ]
 });

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -48,7 +48,7 @@ function expectedErrors(indentType, errors) {
 
             message = `Expected indentation of ${err[1]} ${chars} but found ${err[2]}.`;
         }
-        return { message, type: err[3], line: err[0] };
+        return { message, type: err[3], line: err[0], endLine: err[0], column: 1, endColumn: parseInt(err[2], 10) + 1 };
     });
 }
 

--- a/tests/lib/rules/no-constant-condition.js
+++ b/tests/lib/rules/no-constant-condition.js
@@ -43,7 +43,7 @@ ruleTester.run("no-constant-condition", rule, {
         "if (void a || a);",
         "if (a || void a);",
 
-         // #5693
+        // #5693
         "if(xyz === 'str1' && abc==='str2'){}",
         "if(xyz === 'str1' || abc==='str2'){}",
         "if(xyz === 'str1' || abc==='str2' && pqr === 5){}",
@@ -98,11 +98,11 @@ ruleTester.run("no-constant-condition", rule, {
         { code: "if(a && void x);", errors: [{ message: "Unexpected constant condition.", type: "IfStatement" }] },
 
         // #5693
-         { code: "if(false && abc==='str'){}", errors: [{ message: "Unexpected constant condition.", type: "IfStatement" }] },
-         { code: "if(true || abc==='str'){}", errors: [{ message: "Unexpected constant condition.", type: "IfStatement" }] },
-         { code: "if(abc==='str' || true){}", errors: [{ message: "Unexpected constant condition.", type: "IfStatement" }] },
-         { code: "if(abc==='str' || true || def ==='str'){}", errors: [{ message: "Unexpected constant condition.", type: "IfStatement" }] },
-         { code: "if(false || true){}", errors: [{ message: "Unexpected constant condition.", type: "IfStatement" }] },
-         { code: "if(typeof abc==='str' || true){}", errors: [{ message: "Unexpected constant condition.", type: "IfStatement" }] }
+        { code: "if(false && abc==='str'){}", errors: [{ message: "Unexpected constant condition.", type: "IfStatement" }] },
+        { code: "if(true || abc==='str'){}", errors: [{ message: "Unexpected constant condition.", type: "IfStatement" }] },
+        { code: "if(abc==='str' || true){}", errors: [{ message: "Unexpected constant condition.", type: "IfStatement" }] },
+        { code: "if(abc==='str' || true || def ==='str'){}", errors: [{ message: "Unexpected constant condition.", type: "IfStatement" }] },
+        { code: "if(false || true){}", errors: [{ message: "Unexpected constant condition.", type: "IfStatement" }] },
+        { code: "if(typeof abc==='str' || true){}", errors: [{ message: "Unexpected constant condition.", type: "IfStatement" }] }
     ]
 });

--- a/tests/lib/util/source-code.js
+++ b/tests/lib/util/source-code.js
@@ -149,9 +149,9 @@ describe("SourceCode", () => {
         describe("when it read a UTF-8 file (has BOM), SourceCode", () => {
             const UTF8_FILE = path.resolve(__dirname, "../../fixtures/utf8-bom.js");
             const text = fs.readFileSync(
-                    UTF8_FILE,
-                    "utf8"
-                ).replace(/\r\n/g, "\n"); // <-- For autocrlf of "git for Windows"
+                UTF8_FILE,
+                "utf8"
+            ).replace(/\r\n/g, "\n"); // <-- For autocrlf of "git for Windows"
             let sourceCode;
 
             beforeEach(() => {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

Fixes https://github.com/eslint/eslint/issues/1801, fixes https://github.com/eslint/eslint/issues/3737, fixes https://github.com/eslint/eslint/issues/3845, fixes https://github.com/eslint/eslint/issues/6007, fixes https://github.com/eslint/eslint/issues/6571, fixes https://github.com/eslint/eslint/issues/6670, fixes https://github.com/eslint/eslint/issues/6813, fixes https://github.com/eslint/eslint/issues/7242, fixes https://github.com/eslint/eslint/issues/7274, fixes https://github.com/eslint/eslint/issues/7320, fixes https://github.com/eslint/eslint/issues/7420, fixes https://github.com/eslint/eslint/issues/7522, fixes https://github.com/eslint/eslint/issues/7616, fixes https://github.com/eslint/eslint/issues/7641, fixes https://github.com/eslint/eslint/issues/7662, fixes https://github.com/eslint/eslint/issues/7771, fixes https://github.com/eslint/eslint/issues/7892, fixes https://github.com/eslint/eslint/issues/8011, fixes https://github.com/eslint/eslint/issues/8038, fixes https://github.com/eslint/eslint/issues/8144

**What changes did you make? (Give an overview)**

The existing implementation of `indent` had a lot of bugs (see above list). It worked by detecting a node type (e.g. `ObjectExpression`), and then ensuring that the indentation around the object satisfies certain constraints (e.g. the properties of the `ObjectExpression` are offset by 4 spaces from the opening bracket). This approach had a number of disadvantages:

- Since it only checked indentation according to an explicit list of patterns, there were a lot of cases where it accidentally didn't check the indentation at all. For example, there was no check for the indentation of a closing `)` in a `CallExpression`, so the rule just silently ignored incorrect indentation in these cases. (https://github.com/eslint/eslint/issues/7522)
- there were a lot of nodes where indentation wasn't checked at all. For example, it didn't check indentation for ternary expressions (https://github.com/eslint/eslint/issues/7420) or destructuring assignments (https://github.com/eslint/eslint/issues/6813).
- Since it could only check indent patterns on nodes, it couldn't check the indentation of comments (https://github.com/eslint/eslint/issues/3845, https://github.com/eslint/eslint/issues/6571) or optional tokens such as parentheses around an expression (https://github.com/eslint/eslint/issues/7522)

This commit rewrites the `indent` rule. The new strategy is based on tokens rather than nodes:

1. Create a hashmap (`OffsetStorage#desiredOffsets`). The keys are all the tokens and comments in the file, and the values are objects containing information for a specific offset, measured in indent levels, from a either a specific token or the first column. For example, an element in an array will have `{offset: 1, from: openingCurly}` to indicate that it is offset by one indentation level from the opening curly brace. All the offsets are initialized to 0 at the start.
1. As the AST is traversed, modify the offsets of tokens accordingly. For example, when entering a `BlockStatement`, offset all of the tokens in the `BlockStatement` by 1 from the opening curly brace of the `BlockStatement`.
1. After traversing the AST, calculate the expected indentation levels of every token in the file (according to the `desiredOffsets` map).
1. For each token, compare the expected indentation to the actual indentation in the file, and report the token if the two values are not equal.

This has the following advantages:

- It is guaranteed to check the indentation of every single token in the file, with the exception of some tokens that are explicitly ignored*. This ensures that no tokens end up unexpectedly being ignored.
- Since tokens/comments are used instead of nodes, there are no unchecked "stray tokens".
- All nodes are evaluated in a context-free manner. In other words, each node only has to set an offset for its own children, without worrying about what how much indentation the node itself has or what the node's parents are.
- The rule ends up with an expected indentation map for the entire file at once, and so it can fix the entire file in one pass. (The previous implementation often required multiple passes. For example, if a node was misaligned with its parent in the previous implementation, the node would get fixed, even if the node's position was actually correct and the parent was off.)

*There are a few cases where the new implementation explicitly ignores lines. I decided to do this because there is a huge amount of inconsistency in what people seem to prefer for these cases. In the future, we might want to stop ignoring these cases so that the indentation of all lines is checked. One such case is:

```js
({
  foo:
  bar
});

// versus

({
  foo:
    bar
});
```

Comments are treated a bit differently from tokens in that they can have several different indentations. This is because it can be difficult to tell what the comment is referring to. For example:

```js
if (foo) {
  doSomething();
  // comment about the doSomething() call
} else if (bar.baz()) {
  doSomethingElse();
}

// versus

if (foo) {
  doSomething();
// comment about the bar.baz() call
} else if (bar.baz()) {
  doSomethingElse();
}
```

Specifically, a comment is allowed to have one of three indentations:

1. The same indentation as the token right before it
1. The same indentation as the token right after it
1. The computed indentation for the comment itself

**Is there anything you'd like reviewers to focus on?**

As mentioned above, the new implementation checks a lot of cases that the old implementation did not check. Based on past experience with fixing bugs in the `indent` rule, I anticipate that this will break quite a lot of builds. We might want to consider holding this off until we release a major version.


I labeled this pull request as "evaluating". A lot of the bugs fixed by this issue are marked as "accepted", but some of them are not. We should also figure out how to manage ecosystem impact when we release this (see the paragraph above).

(This isn't an accurate measure of complexity, but the diff line count for this PR is a bit misleading; this change actually reduces the size of the `indent` rule by about 50 lines. The 2500 additional lines in the diff are mostly tests.)