### PR TITLE
Update: Show stack trace when plugin is missing

### DIFF
--- a/lib/config/plugins.js
+++ b/lib/config/plugins.js
@@ -132,7 +132,8 @@ module.exports = {
                 err.message = `Failed to load plugin ${pluginName}: ${err.message}`;
                 err.messageTemplate = "plugin-missing";
                 err.messageData = {
-                    pluginName: longName
+                    pluginName: longName,
+                    stackTrace: err.stack
                 };
                 throw err;
             }

--- a/messages/plugin-missing.txt
+++ b/messages/plugin-missing.txt
@@ -1,9 +1,12 @@
-ESLint couldn't find the plugin "<%- pluginName %>". This can happen for a couple different reasons:
+ESLint couldn't find the plugin "<%= pluginName %>". This can happen for a couple different reasons:
 
 1. If ESLint is installed globally, then make sure <%- pluginName %> is also installed globally. A globally-installed ESLint cannot find a locally-installed plugin.
 
 2. If ESLint is installed locally, then it's likely that the plugin isn't installed correctly. Try reinstalling by running the following:
 
-    npm i <%- pluginName %>@latest --save-dev
+    npm i <%= pluginName %>@latest --save-dev
 
 If you still can't figure out the problem, please stop by https://gitter.im/eslint/eslint to chat with the team.
+
+Stack trace:
+<%= stackTrace.split("\n").slice(1).join("\n") %>


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain: Augment pretty CLI error message

**What changes did you make? (Give an overview)**

Showing stack trace in the pretty message template for when a plugin is missing (messages/plugin-missing.txt).

This is the quick/naive implementation of just adding it to the message template. If we want to instead show stack traces on ALL pretty errors (possibly behind a CLI flag?), I can pivot to that instead. I just wanted to get something up for discussion.

**Is there anything you'd like reviewers to focus on?**

Do we want to generalize this to all pretty messages? If so, do we want a CLI flag to hide/show stack traces, to keep the basic error messages readable?