### PR TITLE
Chore: Ensure JS files are checked out with LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
 # Convert text file line endings to lf
 * text=auto
 
-*.js    text
+*.js    text eol=lf


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain: Ensure JavaScript files are checked out with LF line endings

**What changes did you make? (Give an overview)**

Adding `eol=lf` to .gitattributes for JS files.

Motivation: On my setup, files are checked out with CRLF line endings. eslint-plugin-node has a rule node/shebang which checks for LF line endings. In order to do any development, I have to run `dos2unix` on bin/eslint.js and then stash those changes when checking out other branches. This PR ensures that bin/eslint.js is checked out with LF line endings, so I don't have to work around the node/shebang rule.

**Is there anything you'd like reviewers to focus on?**

Hopefully Travis and AppVeyor will continue to pass. Also feel free to check out this branch locally and make sure `npm run lint` works for you.