### PR TITLE
Test output even if errors is just a number

### DIFF
--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -471,12 +471,12 @@ RuleTester.prototype = {
                     }
                 }
 
-                if (item.hasOwnProperty("output")) {
-                    const fixResult = SourceCodeFixer.applyFixes(eslint.getSourceCode(), messages);
+            }
 
-                    assert.equal(fixResult.output, item.output, "Output is incorrect.");
-                }
+            if (item.hasOwnProperty("output")) {
+                const fixResult = SourceCodeFixer.applyFixes(eslint.getSourceCode(), messages);
 
+                assert.equal(fixResult.output, item.output, "Output is incorrect.");
             }
 
             assertASTDidntChange(result.beforeAST, result.afterAST);


### PR DESCRIPTION
If the `errors` field is just a number, then ESLint is currently ignoring the `output` field.  This makes it easy to accidentally not test the output of a rule's auto-fix.