### PR TITLE
Docs: Enable example highlighting in rules examples (ref #6444)

### DIFF
--- a/docs/rules/arrow-spacing.md
+++ b/docs/rules/arrow-spacing.md
@@ -22,7 +22,7 @@ The default configuration is `{ "before": true, "after": true }`.
 
 `true` means there should be **one or more spaces** and `false` means **no spaces**.
 
-The following patterns are considered problems if `{ "before": true, "after": true }`.
+Examples of **incorrect** code for this rule with the default `{ "before": true, "after": true }` option:
 
 ```js
 /*eslint arrow-spacing: "error"*/
@@ -38,7 +38,7 @@ a=> a;
 () =>{'\n'};
 ```
 
-The following patterns are not considered problems if `{ "before": true, "after": true }`.
+Examples of **correct** code for this rule with the default `{ "before": true, "after": true }` option:
 
 ```js
 /*eslint arrow-spacing: "error"*/
@@ -50,7 +50,18 @@ a => a;
 () => {'\n'};
 ```
 
-The following patterns are not considered problems if `{ "before": false, "after": false }`.
+Examples of **incorrect** code for this rule with the `{ "before": false, "after": false }` option:
+
+```js
+/*eslint arrow-spacing: ["error", { "before": false, "after": false }]*/
+/*eslint-env es6*/
+
+() =>{};
+(a) => {};
+()=> {'\n'};
+```
+
+Examples of **correct** code for this rule with the `{ "before": false, "after": false }` option:
 
 ```js
 /*eslint arrow-spacing: ["error", { "before": false, "after": false }]*/
@@ -58,23 +69,21 @@ The following patterns are not considered problems if `{ "before": false, "after
 
 ()=>{};
 (a)=>{};
-a=>a;
 ()=>{'\n'};
 ```
 
-The following patterns are not considered problems if `{ "before": true, "after": false }`.
+Examples of **incorrect** code for this rule with the `{ "before": false, "after": true }` option:
 
 ```js
-/*eslint arrow-spacing: ["error", { "before": true, "after": false }]*/
+/*eslint arrow-spacing: ["error", { "before": false, "after": true }]*/
 /*eslint-env es6*/
 
 () =>{};
-(a) =>{};
-a =>a;
-() =>{'\n'};
+(a) => {};
+()=>{'\n'};
 ```
 
-The following patterns are not considered problems if `{ "before": false, "after": true }`.
+Examples of **correct** code for this rule with the `{ "before": false, "after": true }` option:
 
 ```js
 /*eslint arrow-spacing: ["error", { "before": false, "after": true }]*/
@@ -82,6 +91,5 @@ The following patterns are not considered problems if `{ "before": false, "after
 
 ()=> {};
 (a)=> {};
-a=> a;
 ()=> {'\n'};
 ```

--- a/docs/rules/constructor-super.md
+++ b/docs/rules/constructor-super.md
@@ -10,7 +10,7 @@ This rule checks whether or not there is a valid `super()` call.
 
 This rule is aimed to flag invalid/missing `super()` calls.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint constructor-super: "error"*/
@@ -38,7 +38,7 @@ class A extends null {
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint constructor-super: "error"*/

--- a/docs/rules/no-arrow-condition.md
+++ b/docs/rules/no-arrow-condition.md
@@ -26,7 +26,7 @@ var x = a <= 1 ? 2 : 3
 
 ## Rule Details
 
-The following patterns are considered warnings:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-arrow-condition: "error"*/

--- a/docs/rules/no-class-assign.md
+++ b/docs/rules/no-class-assign.md
@@ -15,7 +15,7 @@ But the modification is a mistake in most cases.
 
 This rule is aimed to flag modifying variables of class declarations.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-class-assign: "error"*/
@@ -56,7 +56,7 @@ let A = class A {
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-class-assign: "error"*/

--- a/docs/rules/no-comma-dangle.md
+++ b/docs/rules/no-comma-dangle.md
@@ -15,7 +15,7 @@ var foo = {
 
 This rule is aimed at detecting trailing commas in object literals. As such, it will warn whenever it encounters a trailing comma in an object literal.
 
-The following are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 var foo = {
@@ -31,7 +31,7 @@ foo({
 });
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 var foo = {

--- a/docs/rules/no-confusing-arrow.md
+++ b/docs/rules/no-confusing-arrow.md
@@ -15,7 +15,7 @@ var x = a <= 1 ? 2 : 3;
 
 ## Rule Details
 
-The following patterns are considered warnings:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-confusing-arrow: "error"*/
@@ -26,7 +26,7 @@ var x = (a) => 1 ? 2 : 3;
 var x = (a) => (1 ? 2 : 3);
 ```
 
-The following patterns are not considered warnings:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-confusing-arrow: "error"*/
@@ -53,7 +53,7 @@ This rule accepts a single options argument with the following defaults:
 1. `true` relaxes the rule and accepts parenthesis as a valid "confusion-preventing" syntax.
 2. `false` warns even if the expression is wrapped in parenthesis
 
-When `allowParens` is set to `true` following patterns are no longer considered as warnings:
+Examples of **correct** code for this rule with the `{"allowParens": true}` option:
 
 ```js
 /*eslint no-confusing-arrow: ["error", {"allowParens": true}]*/

--- a/docs/rules/no-const-assign.md
+++ b/docs/rules/no-const-assign.md
@@ -9,7 +9,7 @@ Under non ES2015 environment, it might be ignored merely.
 
 This rule is aimed to flag modifying variables that are declared using `const` keyword.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-const-assign: "error"*/
@@ -35,7 +35,7 @@ const a = 0;
 ++a;
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-const-assign: "error"*/

--- a/docs/rules/no-empty-class.md
+++ b/docs/rules/no-empty-class.md
@@ -12,7 +12,7 @@ var foo = /^abc[]/;
 
 This rule is aimed at highlighting possible typos and unexpected behavior in regular expressions which may arise from the use of empty character classes.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 var foo = /^abc[]/;
@@ -22,7 +22,7 @@ var foo = /^abc[]/;
 bar.match(/^abc[]/);
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 var foo = /^abc/;

--- a/docs/rules/no-empty-label.md
+++ b/docs/rules/no-empty-label.md
@@ -9,7 +9,7 @@ Labeled statements are only used in conjunction with labeled break and continue 
 
 This error occurs when a label is used to mark a statement that is not an iteration or switch
 
-The following patterns are considered problems:
+Example of **incorrect** code for this rule:
 
 ```js
 /*eslint no-empty-label: "error"*/
@@ -18,7 +18,7 @@ labeled:
 var x = 10;
 ```
 
-The following patterns are not considered problems:
+Example of **correct** code for this rule:
 
 ```js
 /*eslint no-empty-label: "error"*/

--- a/docs/rules/no-eval.md
+++ b/docs/rules/no-eval.md
@@ -30,7 +30,7 @@ foo("var a = 0");
 this.eval("var a = 0");
 ```
 
-Examples of **incorrect** code for this rule with browser environment:
+Example of additional **incorrect** code for this rule when `browser` environment is set to `true`:
 
 ```js
 /*eslint no-eval: "error"*/
@@ -39,7 +39,7 @@ Examples of **incorrect** code for this rule with browser environment:
 window.eval("var a = 0");
 ```
 
-Examples of **incorrect** code for this rule with node environment:
+Example of additional **incorrect** code for this rule when `node` environment is set to `true`:
 
 ```js
 /*eslint no-eval: "error"*/
@@ -80,7 +80,7 @@ Indirect calls to `eval` are less dangerous than direct calls to `eval` because 
 }
 ```
 
-With this option the following patterns are considered problems:
+Example of **incorrect** code for this rule with the `{"allowIndirect": true}` option:
 
 ```js
 /*eslint no-eval: "error"*/
@@ -90,7 +90,7 @@ var obj = { x: "foo" },
     value = eval("obj." + key);
 ```
 
-With this option the following patterns are not considered problems:
+Examples of **correct** code for this rule with the `{"allowIndirect": true}` option:
 
 ```js
 /*eslint no-eval: "error"*/

--- a/docs/rules/no-extra-strict.md
+++ b/docs/rules/no-extra-strict.md
@@ -17,7 +17,7 @@ The `"use strict";` directive applies to the scope in which it appears and all i
 
 This rule is aimed at preventing unnecessary `"use strict";` directives. As such, it will warn when it encounters a `"use strict";` directive when already in strict mode.
 
-The following patterns are considered problems:
+Example of **incorrect** code for this rule:
 
 ```js
 "use strict";
@@ -28,7 +28,7 @@ The following patterns are considered problems:
 }());
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 "use strict";
@@ -37,8 +37,6 @@ The following patterns are not considered problems:
     var foo = true;
 }());
 ```
-
-
 
 ```js
 (function () {

--- a/docs/rules/no-reserved-keys.md
+++ b/docs/rules/no-reserved-keys.md
@@ -18,7 +18,7 @@ ECMAScript 5 loosened the restriction such that keywords and reserved words can 
 
 This rule is aimed at eliminating the use of ECMAScript 3 keywords and reserved words as object literal keys. As such, it warns whenever an object key would throw an error in an ECMAScript 3 environment.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 var superman = {
@@ -31,7 +31,7 @@ var values = {
 };
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 var superman = {

--- a/docs/rules/no-space-before-semi.md
+++ b/docs/rules/no-space-before-semi.md
@@ -16,7 +16,7 @@ var thing = function () {
 
 This rule prevents the use of spaces before a semicolon in expressions.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 var foo = "bar" ;
@@ -29,7 +29,7 @@ var foo = function() {
 var foo = 1 + 2 ;
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 ;(function(){}());

--- a/docs/rules/no-useless-escape.md
+++ b/docs/rules/no-useless-escape.md
@@ -12,7 +12,7 @@ let baz = /\:/ // same functionality with /:/
 
 This rule flags escapes that can be safely removed without changing behavior.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-useless-escape: "error"*/
@@ -29,7 +29,7 @@ The following patterns are considered problems:
 
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-useless-escape: "error"*/

--- a/docs/rules/no-wrap-func.md
+++ b/docs/rules/no-wrap-func.md
@@ -19,13 +19,13 @@ var bar = (function() {
 
 This rule will raise a warning when it encounters a function expression wrapped in parentheses with no following invoking parentheses.
 
-The following patterns are considered problems:
+Example of **incorrect** code for this rule:
 
 ```js
 var a = (function() {/*...*/});
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 var a = function() {/*...*/};

--- a/docs/rules/object-shorthand.md
+++ b/docs/rules/object-shorthand.md
@@ -111,7 +111,7 @@ While set to `"always"`, `"methods"`, or `"properties"`, shorthand syntax using 
 }
 ```
 
-Examples of **incorrect** code for this rule with the `"avoidQuotes"` option:
+Example of **incorrect** code for this rule with the `"always", { "avoidQuotes": true }` option:
 
 ```js
 /*eslint object-shorthand: ["error", "always", { "avoidQuotes": true }]*/
@@ -122,7 +122,7 @@ var foo = {
 };
 ```
 
-Examples of **correct** code for this rule with the `"avoidQuotes"` option:
+Example of **correct** code for this rule with the `"always", { "avoidQuotes": true }` option:
 
 ```js
 /*eslint object-shorthand: ["error", "always", { "avoidQuotes": true }]*/
@@ -142,7 +142,7 @@ While set to `"always"` or `"methods"`, constructor functions can be ignored wit
 }
 ```
 
-The following will *not* warn when `"ignoreConstructors"` is enabled:
+Example of **correct** code for this rule with the `"always", { "ignoreConstructors": true }` option:
 
 ```js
 /*eslint object-shorthand: ["error", "always", { "ignoreConstructors": true }]*/
@@ -153,7 +153,7 @@ var foo = {
 };
 ```
 
-When set to `"consistent"` the following will warn:
+Example of **incorrect** code for this rule with the `"consistent"` option:
 
 ```js
 /*eslint object-shorthand: [2, "consistent"]*/
@@ -165,7 +165,7 @@ var foo = {
 };
 ```
 
-The following will *not* warn:
+Examples of **correct** code for this rule with the `"consistent"` option:
 
 ```js
 /*eslint object-shorthand: [2, "consistent"]*/
@@ -182,7 +182,7 @@ var bar = {
 };
 ```
 
-When set to `"consistent-as-needed"`, which is very similar to `"consistent"`, the following will warn:
+Example of **incorrect** code with the `"consistent-as-needed"` option, which is very similar to `"consistent"`:
 
 ```js
 /*eslint object-shorthand: [2, "consistent-as-needed"]*/

--- a/docs/rules/semi-spacing.md
+++ b/docs/rules/semi-spacing.md
@@ -41,7 +41,7 @@ The default is `{"before": false, "after": true}`.
 
 This is the default option. It enforces spacing after semicolons and disallows spacing before semicolons.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint semi-spacing: "error"*/
@@ -54,7 +54,7 @@ for (i = 0 ; i < 10 ; i++) {}
 for (i = 0;i < 10;i++) {}
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint semi-spacing: "error"*/
@@ -73,7 +73,7 @@ if (true) {;}
 
 This option enforces spacing before semicolons and disallows spacing after semicolons.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule with the `{"before": true, "after": false}` option:
 
 ```js
 /*eslint semi-spacing: ["error", { "before": true, "after": false }]*/
@@ -86,7 +86,7 @@ for (i = 0;i < 10;i++) {}
 for (i = 0; i < 10; i++) {}
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `{"before": true, "after": false}` option:
 
 ```js
 /*eslint semi-spacing: ["error", { "before": true, "after": false }]*/

--- a/docs/rules/space-after-function-name.md
+++ b/docs/rules/space-after-function-name.md
@@ -21,7 +21,7 @@ Some style guides may require a consistent spacing for function names.
 This rule aims to enforce a consistent spacing after function names. It takes one argument. If it is `"always"` then all function names must be followed by at least one space. If `"never"` then there should be no spaces between the name and the parameter list. The default is `"never"`.
 
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 function foo (x) {
@@ -36,7 +36,7 @@ function bar(x) {
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 function foo(x) {

--- a/docs/rules/space-after-keywords.md
+++ b/docs/rules/space-after-keywords.md
@@ -27,7 +27,7 @@ This rule will enforce consistency of spacing after the keywords `if`, `else`, `
 This rule takes one argument. If it is `"always"` then the keywords must be followed by at least one space. If `"never"`
 then there should be no spaces following. The default is `"always"`.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint space-after-keywords: "error"*/
@@ -45,7 +45,7 @@ do{} while (a);
 if (a) {}
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint space-after-keywords: "error"*/

--- a/docs/rules/space-before-function-parentheses.md
+++ b/docs/rules/space-before-function-parentheses.md
@@ -24,11 +24,9 @@ Style guides may require a space after the `function` keyword for anonymous func
 
 This rule aims to enforce consistent spacing before function parentheses and as such, will warn whenever whitespace doesn't match the preferences specified.
 
-This rule takes one argument. If it is `"always"` then all named functions and anonymous functions must have space before function parentheses. If `"never"` then all named functions and anonymous functions must not have space before function parentheses. If you want different spacing for named and anonymous functions you can pass an configuration object as the rule argument to configure those separately (e. g. `{"anonymous": "always", "named": "never"}`).
+This rule takes one argument. If it is `"always"`, which is the default option, all named functions and anonymous functions must have space before function parentheses. If `"never"` then all named functions and anonymous functions must not have space before function parentheses. If you want different spacing for named and anonymous functions you can pass an configuration object as the rule argument to configure those separately (e. g. `{"anonymous": "always", "named": "never"}`).
 
-The default configuration is `"always"`.
-
-The following patterns are considered problems when configured `"always"`:
+Examples of **incorrect** code for this rule with the default `"always"` option:
 
 ```js
 /*eslint-env es6*/
@@ -58,7 +56,7 @@ var foo = {
 };
 ```
 
-The following patterns are not considered problems when configured `"always"`:
+Examples of **correct** code for this rule with the default `"always"` option:
 
 ```js
 /*eslint-env es6*/
@@ -88,7 +86,7 @@ var foo = {
 };
 ```
 
-The following patterns are considered problems when configured `"never"`:
+Examples of **incorrect** code for this rule with the `"never"` option:
 
 ```js
 /*eslint-env es6*/
@@ -118,7 +116,7 @@ var foo = {
 };
 ```
 
-The following patterns are not considered problems when configured `"never"`:
+Examples of **correct** code for this rule with the `"never"` option:
 
 ```js
 /*eslint-env es6*/
@@ -148,7 +146,7 @@ var foo = {
 };
 ```
 
-The following patterns are considered problems when configured `{"anonymous": "always", "named": "never"}`:
+Examples of **incorrect** code for this rule with the `{"anonymous": "always", "named": "never"}` option:
 
 ```js
 /*eslint-env es6*/
@@ -174,7 +172,7 @@ var foo = {
 };
 ```
 
-The following patterns are not considered problems when configured `{"anonymous": "always", "named": "never"}`:
+Examples of **correct** code for this rule with the `{"anonymous": "always", "named": "never"}` option:
 
 ```js
 /*eslint-env es6*/
@@ -200,7 +198,7 @@ var foo = {
 };
 ```
 
-The following patterns are considered problems when configured `{"anonymous": "never", "named": "always"}`:
+Examples of **incorrect** code for this rule with the `{"anonymous": "never", "named": "always"}` option:
 
 ```js
 /*eslint-env es6*/
@@ -226,7 +224,7 @@ var foo = {
 };
 ```
 
-The following patterns are not considered problems when configured `{"anonymous": "never", "named": "always"}`:
+Examples of **correct** code for this rule with the `{"anonymous": "never", "named": "always"}` option:
 
 ```js
 /*eslint-env es6*/

--- a/docs/rules/space-before-keywords.md
+++ b/docs/rules/space-before-keywords.md
@@ -30,42 +30,7 @@ the keywords `else`, `while` (do...while), `finally` and `catch`. The default va
 This rule will allow keywords to be preceded by an opening curly brace (`{`). If you wish to alter
 this behaviour, consider using the [block-spacing](block-spacing.md) rule.
 
-The following patterns are considered errors when configured `"never"`:
-
-```js
-/*eslint space-before-keywords: ["error", "never"]*/
-
-if (foo) {
-    // ...
-} else {}
-
-do {
-
-}
-while (foo)
-
-try {} finally {}
-
-try {} catch(e) {}
-```
-
-The following patterns are not considered errors when configured `"never"`:
-
-```js
-/*eslint space-before-keywords: ["error", "never"]*/
-
-if (foo) {
-    // ...
-}else {}
-
-do {}while (foo)
-
-try {}finally {}
-
-try{}catch(e) {}
-```
-
-The following patterns are considered errors when configured `"always"`:
+Examples of **incorrect** code for this rule with the default `"always"` option:
 
 ```js
 /*eslint space-before-keywords: ["error", "always"]*/
@@ -84,7 +49,7 @@ function bar() {
 }
 ```
 
-The following patterns are not considered errors when configured `"always"`:
+Examples of **correct** code for this rule with the default `"always"` option:
 
 ```js
 /*eslint space-before-keywords: ["error", "always"]*/
@@ -99,6 +64,41 @@ if (foo) {
 <Foo onClick={function bar() {}} />
 
 for (let foo of ['bar', 'baz', 'qux']) {}
+```
+
+Examples of **incorrect** code for this rule with the `"never"` option:
+
+```js
+/*eslint space-before-keywords: ["error", "never"]*/
+
+if (foo) {
+    // ...
+} else {}
+
+do {
+
+}
+while (foo)
+
+try {} finally {}
+
+try {} catch(e) {}
+```
+
+Examples of **correct** code for this rule with the `"never"` option:
+
+```js
+/*eslint space-before-keywords: ["error", "never"]*/
+
+if (foo) {
+    // ...
+}else {}
+
+do {}while (foo)
+
+try {}finally {}
+
+try{}catch(e) {}
 ```
 
 ## When Not To Use It

--- a/docs/rules/space-in-brackets.md
+++ b/docs/rules/space-in-brackets.md
@@ -33,7 +33,7 @@ Depending on your coding conventions, you can choose either option by specifying
 
 ### "never"
 
-When `"never"` is set, the following patterns are considered problems:
+Examples of **incorrect** code for this rule with the default `"never"` option:
 
 ```js
 /*eslint-env es6*/
@@ -55,7 +55,7 @@ var obj = { baz: {'foo': 'qux'}, bar};
 var obj = {baz: { 'foo': 'qux' }, bar};
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the default `"never"` option:
 
 ```js
 // When options are ["error", "never"]
@@ -97,7 +97,7 @@ var obj = {};
 
 ### "always"
 
-When `"always"` is used, the following patterns are considered problems:
+Examples of **incorrect** code for this rule with the `"always"` option:
 
 ```js
 /*eslint-env es6*/
@@ -128,7 +128,7 @@ var obj = {
   'foo':'bar'};
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `"always"` option:
 
 ```js
 foo[ 'bar' ];
@@ -199,7 +199,7 @@ The following exceptions are available:
 
 In each of the following examples, the `"always"` option is assumed.
 
-When `"singleValue"` is set to `false`, the following patterns are considered problems:
+Examples of **incorrect** code for this rule when `"singleValue"` is set to `false`:
 
 ```js
 var foo = [ 'foo' ];
@@ -212,7 +212,7 @@ var foo = [ [ 1, 2 ] ];
 var foo = [ { 'foo': 'bar' } ];
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule when `"singleValue"` is set to `false`:
 
 ```js
 var foo = ['foo'];
@@ -221,7 +221,7 @@ var foo = [[ 1, 1 ]];
 var foo = [{ 'foo': 'bar' }];
 ```
 
-When `"objectsInArrays"` is set to `false`, the following patterns are considered problems:
+Examples of **incorrect** code when `"objectsInArrays"` is set to `false`:
 
 ```js
 var arr = [ { 'foo': 'bar' } ];
@@ -230,7 +230,8 @@ var arr = [ {
 } ]
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code when `"objectsInArrays"` is set to `false`:
+
 
 ```js
 var arr = [{ 'foo': 'bar' }];
@@ -239,56 +240,56 @@ var arr = [{
 }];
 ```
 
-When `"arraysInArrays"` is set to `false`, the following patterns are considered problems:
+Examples of **incorrect** code when `"arraysInArrays"` is set to `false`:
 
 ```js
 var arr = [ [ 1, 2 ], 2, 3, 4 ];
 var arr = [ [ 1, 2 ], 2, [ 3, 4 ] ];
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code when `"arraysInArrays"` is set to `false`:
 
 ```js
 var arr = [[ 1, 2 ], 2, 3, 4 ];
 var arr = [[ 1, 2 ], 2, [ 3, 4 ]];
 ```
 
-When `"arraysInObjects"` is set to `false`, the following patterns are considered problems:
+Examples of **incorrect** code when `"arraysInObjects"` is set to `false`:
 
 ```js
 var obj = { "foo": [ 1, 2 ] };
 var obj = { "foo": [ "baz", "bar" ] };
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code when `"arraysInObjects"` is set to `false`:
 
 ```js
 var obj = { "foo": [ 1, 2 ]};
 var obj = { "foo": [ "baz", "bar" ]};
 ```
 
-When `"objectsInObjects"` is set to `false`, the following patterns are considered problems:
+Examples of **incorrect** code when `"objectsInObjects"` is set to `false`:
 
 ```js
 var obj = { "foo": { "baz": 1, "bar": 2 } };
 var obj = { "foo": [ "baz", "bar" ], "qux": { "baz": 1, "bar": 2 } };
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code when `"objectsInObjects"` is set to `false`:
 
 ```js
 var obj = { "foo": { "baz": 1, "bar": 2 }};
 var obj = { "foo": [ "baz", "bar" ], "qux": { "baz": 1, "bar": 2 }};
 ```
 
-When `"propertyName"` is set to `false`, the following patterns are considered problems:
+Examples of **incorrect** code when `"propertyName"` is set to `false`:
 
 ```js
 var foo = obj[ 1 ];
 var foo = obj[ bar ];
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code when `"propertyName"` is set to `false`:
 
 ```js
 var foo = obj[bar];

--- a/docs/rules/space-in-parens.md
+++ b/docs/rules/space-in-parens.md
@@ -20,8 +20,8 @@ This rule will enforce consistency of spacing directly inside of parentheses, by
 
 There are two options for this rule:
 
+* `"never"` (default) enforces zero spaces inside of parentheses
 * `"always"` enforces a space inside of parentheses
-* `"never"` enforces zero spaces inside of parentheses (default)
 
 Depending on your coding conventions, you can choose either option by specifying it in your configuration:
 
@@ -29,37 +29,9 @@ Depending on your coding conventions, you can choose either option by specifying
 "space-in-parens": ["error", "always"]
 ```
 
-### "always"
-
-When `"always"` is set, the following patterns are considered problems:
-
-```js
-/*eslint space-in-parens: ["error", "always"]*/
-
-foo( 'bar');
-foo('bar' );
-foo('bar');
-
-var foo = (1 + 2) * 3;
-(function () { return 'bar'; }());
-```
-
-The following patterns are not considered problems:
-
-```js
-/*eslint space-in-parens: ["error", "always"]*/
-
-foo();
-
-foo( 'bar' );
-
-var foo = ( 1 + 2 ) * 3;
-( function () { return 'bar'; }() );
-```
-
 ### "never"
 
-When `"never"` is used, the following patterns are considered problems:
+Examples of **incorrect** code for this rule with the default `"never"` option:
 
 ```js
 /*eslint space-in-parens: ["error", "never"]*/
@@ -72,7 +44,7 @@ var foo = ( 1 + 2 ) * 3;
 ( function () { return 'bar'; }() );
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the default `"never"` option:
 
 ```js
 /*eslint space-in-parens: ["error", "never"]*/
@@ -83,6 +55,34 @@ foo('bar');
 
 var foo = (1 + 2) * 3;
 (function () { return 'bar'; }());
+```
+
+### "always"
+
+Examples of **incorrect** code for this rule with the `"always"` option:
+
+```js
+/*eslint space-in-parens: ["error", "always"]*/
+
+foo( 'bar');
+foo('bar' );
+foo('bar');
+
+var foo = (1 + 2) * 3;
+(function () { return 'bar'; }());
+```
+
+Examples of **correct** code for this rule with the `"always"` option:
+
+```js
+/*eslint space-in-parens: ["error", "always"]*/
+
+foo();
+
+foo( 'bar' );
+
+var foo = ( 1 + 2 ) * 3;
+( function () { return 'bar'; }() );
 ```
 
 ### Exceptions
@@ -91,25 +91,7 @@ An object literal may be used as a third array item to specify exceptions, with 
 
 The following exceptions are available: `["{}", "[]", "()", "empty"]`.
 
-For example, given `"space-in-parens": ["error", "always", { "exceptions": ["{}"] }]`, the following patterns are considered problems:
-
-```js
-/*eslint space-in-parens: ["error", "always", { "exceptions": ["{}"] }]*/
-
-foo( {bar: 'baz'} );
-foo( 1, {bar: 'baz'} );
-```
-
-The following patterns are not considered problems:
-
-```js
-/*eslint space-in-parens: ["error", "always", { "exceptions": ["{}"] }]*/
-
-foo({bar: 'baz'});
-foo( 1, {bar: 'baz'});
-```
-
-Or, given `"space-in-parens": ["error", "never", { "exceptions": ["{}"] }]`, the following patterns are considered problems:
+Examples of **incorrect** code for this rule with the `"never", { "exceptions": ["{}"] }` option:
 
 ```js
 /*eslint space-in-parens: ["error", "never", { "exceptions": ["{}"] }]*/
@@ -118,7 +100,7 @@ foo({bar: 'baz'});
 foo(1, {bar: 'baz'});
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `"never", { "exceptions": ["{}"] }` option:
 
 ```js
 /*eslint space-in-parens: ["error", "never", { "exceptions": ["{}"] }]*/
@@ -127,25 +109,25 @@ foo( {bar: 'baz'} );
 foo(1, {bar: 'baz'} );
 ```
 
-Given `"space-in-parens": ["error", "always", { "exceptions": ["[]"] }]`, the following patterns are considered problems:
+Examples of **incorrect** code for this rule with the `"always", { "exceptions": ["{}"] }` option:
 
 ```js
-/*eslint space-in-parens: ["error", "always", { "exceptions": ["[]"] }]*/
+/*eslint space-in-parens: ["error", "always", { "exceptions": ["{}"] }]*/
 
-foo( [bar, baz] );
-foo( [bar, baz], 1 );
+foo( {bar: 'baz'} );
+foo( 1, {bar: 'baz'} );
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `"always", { "exceptions": ["{}"] }` option:
 
 ```js
-/*eslint space-in-parens: ["error", "always", { "exceptions": ["[]"] }]*/
+/*eslint space-in-parens: ["error", "always", { "exceptions": ["{}"] }]*/
 
-foo([bar, baz]);
-foo([bar, baz], 1 );
+foo({bar: 'baz'});
+foo( 1, {bar: 'baz'});
 ```
 
-Or, given `"space-in-parens": ["error", "never", { "exceptions": ["[]"] }]`, the following patterns are considered problems:
+Examples of **incorrect** code for this rule with the `"never", { "exceptions": ["[]"] }` option:
 
 ```js
 /*eslint space-in-parens: ["error", "never", { "exceptions": ["[]"] }]*/
@@ -154,7 +136,7 @@ foo([bar, baz]);
 foo([bar, baz], 1);
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `"never", { "exceptions": ["[]"] }` option:
 
 ```js
 /*eslint space-in-parens: ["error", "never", { "exceptions": ["[]"] }]*/
@@ -163,25 +145,25 @@ foo( [bar, baz] );
 foo( [bar, baz], 1);
 ```
 
-Given `"space-in-parens": ["error", "always", { "exceptions": ["()"] }]`, the following patterns are considered problems:
+Examples of **incorrect** code for this rule with the `"always", { "exceptions": ["[]"] }` option:
 
 ```js
-/*eslint space-in-parens: ["error", "always", { "exceptions": ["()"] }]*/
+/*eslint space-in-parens: ["error", "always", { "exceptions": ["[]"] }]*/
 
-foo( ( 1 + 2 ) );
-foo( ( 1 + 2 ), 1 );
+foo( [bar, baz] );
+foo( [bar, baz], 1 );
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `"always", { "exceptions": ["[]"] }` option:
 
 ```js
-/*eslint space-in-parens: ["error", "always", { "exceptions": ["()"] }]*/
+/*eslint space-in-parens: ["error", "always", { "exceptions": ["[]"] }]*/
 
-foo(( 1 + 2 ));
-foo(( 1 + 2 ), 1 );
+foo([bar, baz]);
+foo([bar, baz], 1 );
 ```
 
-Or, given `"space-in-parens": ["error", "never", { "exceptions": ["()"] }]`, the following patterns are considered problems:
+Examples of **incorrect** code for this rule with the `"never", { "exceptions": ["()"] }]` option:
 
 ```js
 /*eslint space-in-parens: ["error", "never", { "exceptions": ["()"] }]*/
@@ -190,7 +172,7 @@ foo((1 + 2));
 foo((1 + 2), 1);
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `"never", { "exceptions": ["()"] }]` option:
 
 ```js
 /*eslint space-in-parens: ["error", "never", { "exceptions": ["()"] }]*/
@@ -199,25 +181,27 @@ foo( (1 + 2) );
 foo( (1 + 2), 1);
 ```
 
+Examples of **incorrect** code for this rule with the `"always", { "exceptions": ["()"] }]` option:
+
+```js
+/*eslint space-in-parens: ["error", "always", { "exceptions": ["()"] }]*/
+
+foo( ( 1 + 2 ) );
+foo( ( 1 + 2 ), 1 );
+```
+
+Examples of **correct** code for this rule with the `"always", { "exceptions": ["()"] }]` option:
+
+```js
+/*eslint space-in-parens: ["error", "always", { "exceptions": ["()"] }]*/
+
+foo(( 1 + 2 ));
+foo(( 1 + 2 ), 1 );
+```
+
 The `"empty"` exception concerns empty parentheses, and works the same way as the other exceptions, inverting the first option.
 
-For example, given `"space-in-parens": ["error", "always", { "exceptions": ["empty"] }]`, the following patterns are considered problems:
-
-```js
-/*eslint space-in-parens: ["error", "always", { "exceptions": ["empty"] }]*/
-
-foo( );
-```
-
-The following patterns are not considered problems:
-
-```js
-/*eslint space-in-parens: ["error", "always", { "exceptions": ["empty"] }]*/
-
-foo();
-```
-
-Or, given `"space-in-parens": ["error", "never", { "exceptions": ["empty"] }]`, the following patterns are considered problems:
+Example of **incorrect** code for this rule with the `"never", { "exceptions": ["empty"] }]` option:
 
 ```js
 /*eslint space-in-parens: ["error", "never", { "exceptions": ["empty"] }]*/
@@ -225,7 +209,7 @@ Or, given `"space-in-parens": ["error", "never", { "exceptions": ["empty"] }]`, 
 foo();
 ```
 
-The following patterns are not considered problems:
+Example of **correct** code for this rule with the `"never", { "exceptions": ["empty"] }]` option:
 
 ```js
 /*eslint space-in-parens: ["error", "never", { "exceptions": ["empty"] }]*/
@@ -233,7 +217,25 @@ The following patterns are not considered problems:
 foo( );
 ```
 
-You can include multiple entries in the `"exceptions"` array. For example, given `"space-in-parens": ["error", "always", { "exceptions": ["{}", "[]"] }]`, the following patterns are considered problems:
+Example of **incorrect** code for this rule with the `"always", { "exceptions": ["empty"] }]` option:
+
+```js
+/*eslint space-in-parens: ["error", "always", { "exceptions": ["empty"] }]*/
+
+foo( );
+```
+
+Example of **correct** code for this rule with the `"always", { "exceptions": ["empty"] }]` option:
+
+```js
+/*eslint space-in-parens: ["error", "always", { "exceptions": ["empty"] }]*/
+
+foo();
+```
+
+You can include multiple entries in the `"exceptions"` array.
+
+Examples of **incorrect** code for this rule with the `"always", { "exceptions": ["{}", "[]"] }]` option:
 
 ```js
 /*eslint space-in-parens: ["error", "always", { "exceptions": ["{}", "[]"] }]*/
@@ -243,7 +245,7 @@ baz( 1, [1,2] );
 foo( {bar: 'baz'}, [1, 2] );
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `"always", { "exceptions": ["{}", "[]"] }]` option:
 
 ```js
 /*eslint space-in-parens: ["error", "always", { "exceptions": ["{}", "[]"] }]*/

--- a/docs/rules/space-infix-ops.md
+++ b/docs/rules/space-infix-ops.md
@@ -36,7 +36,7 @@ Set the `int32Hint` option to `true` (default is `false`) to allow write `a|0` w
 var foo = bar|0; // `foo` is forced to be signed 32 bit integer
 ```
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint space-infix-ops: "error"*/
@@ -57,7 +57,7 @@ var {a=0}=bar;
 function foo(a=0) { }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint space-infix-ops: "error"*/

--- a/docs/rules/space-return-throw-case.md
+++ b/docs/rules/space-return-throw-case.md
@@ -8,7 +8,7 @@ Require spaces following `return`, `throw`, and `case`.
 
 ## Rule Details
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint space-return-throw-case: "error"*/
@@ -20,7 +20,7 @@ function f(){ return-a; }
 switch(a){ case'a': break; }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint space-return-throw-case: "error"*/

--- a/docs/rules/space-unary-ops.md
+++ b/docs/rules/space-unary-ops.md
@@ -61,7 +61,7 @@ This rule has three options:
 
 In this case, spacing will be disallowed after a `new` operator and required before/after a `++` operator.
 
-Given the default values `words`: `true`, `nonwords`: `false`, the following patterns are considered problems:
+Examples of **incorrect** code for this rule with the `{"words": true, "nonwords": false}` option:
 
 ```js
 /*eslint space-unary-ops: "error"*/
@@ -92,7 +92,7 @@ function *foo() {
 }
 ```
 
-Given the default values `words`: `true`, `nonwords`: `false`, the following patterns are not considered problems:
+Examples of **correct** code for this rule with the `{"words": true, "nonwords": false}` option:
 
 ```js
 /*eslint space-unary-ops: "error"*/

--- a/docs/rules/space-unary-word-ops.md
+++ b/docs/rules/space-unary-word-ops.md
@@ -6,7 +6,7 @@ Require spaces following unary word operators.
 
 ## Rule Details
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 typeof!a
@@ -24,7 +24,7 @@ new[a][0]
 delete(a.b)
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 delete a.b

--- a/docs/rules/spaced-comment.md
+++ b/docs/rules/spaced-comment.md
@@ -65,7 +65,7 @@ You can also define separate exceptions and markers for block and line comments.
 
 ### always
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule with the `"always"` option:
 
 ```js
 /*eslint spaced-comment: ["error", "always"]*/
@@ -80,7 +80,7 @@ The following patterns are considered problems:
 /* This is a comment with whitespace at the beginning but not the end*/
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `"always"` option:
 
 ```js
 /* eslint spaced-comment: ["error", "always"] */
@@ -108,7 +108,7 @@ This comment has a newline
 
 ### never
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule with the `"never"` option:
 
 ```js
 /*eslint spaced-comment: ["error", "never"]*/
@@ -125,7 +125,7 @@ The following patterns are considered problems:
 /*This is a comment with whitespace at the end */
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `"never"` option:
 
 ```js
 /*eslint spaced-comment: ["error", "never"]*/
@@ -143,7 +143,7 @@ The following patterns are not considered problems:
 
 ### exceptions
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule with the `"always"` option combined with `"exceptions"`:
 
 ```js
 /* eslint spaced-comment: ["error", "always", { "block": { "exceptions": ["-"] } }] */
@@ -177,7 +177,7 @@ The following patterns are considered problems:
 /*-+-+-+-+-+-+-+*/
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `"always"` option combined with `"exceptions"`:
 
 ```js
 /* eslint spaced-comment: ["error", "always", { "exceptions": ["-"] }] */
@@ -225,7 +225,7 @@ The following patterns are not considered problems:
 
 ### markers
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule with the `"always"` option combined with `"markers"`:
 
 ```js
 /* eslint spaced-comment: ["error", "always", { "markers": ["/"] }] */
@@ -243,7 +243,7 @@ The following patterns are considered problems:
 /*!This is a comment with a marker but with whitespace at the end */
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `"always"` option combined with `"markers"`:
 
 ```js
 /* eslint spaced-comment: ["error", "always", { "markers": ["/"] }] */

--- a/docs/rules/spaced-line-comment.md
+++ b/docs/rules/spaced-line-comment.md
@@ -20,7 +20,7 @@ The value is an array of string patterns which are considered exceptions to the 
 It is important to note that the exceptions are ignored if the first argument is `"never"`.
 Exceptions cannot be mixed.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 // When ["never"]
@@ -40,7 +40,7 @@ var foo = 5;
 //------++++++++
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 // When ["always"]

--- a/docs/rules/wrap-regex.md
+++ b/docs/rules/wrap-regex.md
@@ -14,7 +14,7 @@ function a() {
 
 This is used to disambiguate the slash operator and facilitates more readable code.
 
-The following patterns are considered problems:
+Example of **incorrect** code for this rule:
 
 ```js
 /*eslint wrap-regex: "error"*/
@@ -24,7 +24,7 @@ function a() {
 }
 ```
 
-The following patterns are not considered problems:
+Example of **correct** code for this rule:
 
 ```js
 /*eslint wrap-regex: "error"*/


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Some examples showed in the rules docs has outdated examples without highlight so I've updated them in order to enable it. I've also change the order in some examples and change some minimum text to achieve this purpose

**Is there anything you'd like reviewers to focus on?**
Not really

(ref #6444)