### PR TITLE
Fix: incorrect location for `no-useless-escape` errors (fixes #7643)

### DIFF
--- a/lib/ast-utils.js
+++ b/lib/ast-utils.js
@@ -1031,12 +1031,10 @@ module.exports = {
 
         /*
          * lineIndices is a sorted list of indices of the first character of each line.
-         * To figure out which line rangeIndex is on, determine the index at which rangeIndex would
+         * To figure out which line rangeIndex is on, determine the last index at which rangeIndex could
          * be inserted into lineIndices to keep the list sorted.
-         * When the character is at the start of a line, lineIndices will contain rangeIndex, so it would be
-         * inserted one character too early. To ensure that the correct line is returned in this case, add 1 to rangeIndex.
          */
-        const lineNumber = lodash.sortedIndex(lineIndices, rangeIndex + 1);
+        const lineNumber = lodash.sortedLastIndex(lineIndices, rangeIndex);
 
         return {line: lineNumber, column: rangeIndex - lineIndices[lineNumber - 1]};
 

--- a/lib/ast-utils.js
+++ b/lib/ast-utils.js
@@ -10,6 +10,7 @@
 //------------------------------------------------------------------------------
 
 const esutils = require("esutils");
+const lodash = require("lodash");
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -227,6 +228,25 @@ function getOpeningParenOfParams(node, sourceCode) {
     }
 
     return token;
+}
+
+const lineIndexCache = new WeakMap();
+
+/**
+ * Gets the range index for the first character in each of the lines of `sourceCode`.
+ * @param {SourceCode} sourceCode A sourceCode object
+ * @returns {number[]} The indices of the first characters in the each of the lines of the code
+ */
+function getLineIndices(sourceCode) {
+
+    if (!lineIndexCache.has(sourceCode)) {
+        const lineIndices = (sourceCode.text.match(/[^\r\n\u2028\u2029]*(\r\n|\r|\n|\u2028|\u2029)/g) || [])
+            .reduce((indices, line) => indices.concat(indices[indices.length - 1] + line.length), [0]);
+
+        // Store the sourceCode object in a WeakMap to avoid iterating over all of the lines every time a sourceCode object is passed in.
+        lineIndexCache.set(sourceCode, lineIndices);
+    }
+    return lineIndexCache.get(sourceCode);
 }
 
 //------------------------------------------------------------------------------
@@ -998,5 +1018,39 @@ module.exports = {
             start: Object.assign({}, start),
             end: Object.assign({}, end),
         };
+    },
+
+    /*
+    * Converts a range index into a (line, column) pair.
+    * @param {SourceCode} sourceCode A SourceCode object
+    * @param {number} rangeIndex The range index of a character in a file
+    * @returns {Object} A {line, column} location object with a 0-indexed column
+    */
+    getLocationFromRangeIndex(sourceCode, rangeIndex) {
+        const lineIndices = getLineIndices(sourceCode);
+
+        /*
+         * lineIndices is a sorted list of indices of the first character of each line.
+         * To figure out which line rangeIndex is on, determine the index at which rangeIndex would
+         * be inserted into lineIndices to keep the list sorted.
+         * When the character is at the start of a line, lineIndices will contain rangeIndex, so it would be
+         * inserted one character too early. To ensure that the correct line is returned in this case, add 1 to rangeIndex.
+         */
+        const lineNumber = lodash.sortedIndex(lineIndices, rangeIndex + 1);
+
+        return {line: lineNumber, column: rangeIndex - lineIndices[lineNumber - 1]};
+
+    },
+
+    /**
+    * Converts a (line, column) pair into a range index.
+    * @param {SourceCode} sourceCode A SourceCode object
+    * @param {Object} loc A line/column location
+    * @param {number} loc.line The line number of the location (1-indexed)
+    * @param {number} loc.column The column number of the location (0-indexed)
+    * @returns {number} The range index of the location in the file.
+    */
+    getRangeIndexFromLocation(sourceCode, loc) {
+        return getLineIndices(sourceCode)[loc.line - 1] + loc.column;
     }
 };

--- a/lib/rules/no-useless-escape.js
+++ b/lib/rules/no-useless-escape.js
@@ -5,6 +5,8 @@
 
 "use strict";
 
+const astUtils = require("../ast-utils");
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -81,6 +83,7 @@ module.exports = {
     },
 
     create(context) {
+        const sourceCode = context.getSourceCode();
 
         /**
          * Reports a node
@@ -92,10 +95,7 @@ module.exports = {
         function report(node, startOffset, character) {
             context.report({
                 node,
-                loc: {
-                    line: node.loc.start.line,
-                    column: node.loc.start.column + startOffset
-                },
+                loc: astUtils.getLocationFromRangeIndex(sourceCode, astUtils.getRangeIndexFromLocation(sourceCode, node.loc.start) + startOffset),
                 message: "Unnecessary escape character: \\{{character}}.",
                 data: {character}
             });
@@ -135,7 +135,7 @@ module.exports = {
             }
 
             if (isUnnecessaryEscape && !isQuoteEscape) {
-                report(node, match.index, match[0].slice(1));
+                report(node, match.index + 1, match[0].slice(1));
             }
         }
 
@@ -147,8 +147,6 @@ module.exports = {
          */
         function check(node) {
             const isTemplateElement = node.type === "TemplateElement";
-            const value = isTemplateElement ? node.value.raw : node.raw;
-            const pattern = /\\[^\d]/g;
 
             if (isTemplateElement && node.parent && node.parent.parent && node.parent.parent.type === "TaggedTemplateExpression") {
 
@@ -166,6 +164,8 @@ module.exports = {
                     return;
                 }
 
+                const value = isTemplateElement ? node.value.raw : node.raw.slice(1, -1);
+                const pattern = /\\[^\d]/g;
                 let match;
 
                 while ((match = pattern.exec(value))) {

--- a/tests/lib/rules/no-useless-escape.js
+++ b/tests/lib/rules/no-useless-escape.js
@@ -132,9 +132,9 @@ ruleTester.run("no-useless-escape", rule, {
             errors: [{ line: 1, column: 13, message: "Unnecessary escape character: \\d.", type: "Literal"}]
         },
         { code: "var foo = '\\`';", errors: [{ line: 1, column: 12, message: "Unnecessary escape character: \\`.", type: "Literal"}] },
-        { code: "var foo = `\\\"`;", parserOptions: {ecmaVersion: 6}, errors: [{ line: 1, column: 11, message: "Unnecessary escape character: \\\".", type: "TemplateElement"}] },
-        { code: "var foo = `\\'`;", parserOptions: {ecmaVersion: 6}, errors: [{ line: 1, column: 11, message: "Unnecessary escape character: \\'.", type: "TemplateElement"}] },
-        { code: "var foo = `\\#`;", parserOptions: {ecmaVersion: 6}, errors: [{ line: 1, column: 11, message: "Unnecessary escape character: \\#.", type: "TemplateElement"}] },
+        { code: "var foo = `\\\"`;", parserOptions: {ecmaVersion: 6}, errors: [{ line: 1, column: 12, message: "Unnecessary escape character: \\\".", type: "TemplateElement"}] },
+        { code: "var foo = `\\'`;", parserOptions: {ecmaVersion: 6}, errors: [{ line: 1, column: 12, message: "Unnecessary escape character: \\'.", type: "TemplateElement"}] },
+        { code: "var foo = `\\#`;", parserOptions: {ecmaVersion: 6}, errors: [{ line: 1, column: 12, message: "Unnecessary escape character: \\#.", type: "TemplateElement"}] },
         {
             code: "var foo = '\\`foo\\`';",
             errors: [
@@ -146,22 +146,22 @@ ruleTester.run("no-useless-escape", rule, {
             code: "var foo = `\\\"${foo}\\\"`;",
             parserOptions: {ecmaVersion: 6},
             errors: [
-                { line: 1, column: 11, message: "Unnecessary escape character: \\\".", type: "TemplateElement"},
-                { line: 1, column: 19, message: "Unnecessary escape character: \\\".", type: "TemplateElement"},
+                { line: 1, column: 12, message: "Unnecessary escape character: \\\".", type: "TemplateElement"},
+                { line: 1, column: 20, message: "Unnecessary escape character: \\\".", type: "TemplateElement"},
             ]
         },
         {
             code: "var foo = `\\'${foo}\\'`;",
             parserOptions: {ecmaVersion: 6},
             errors: [
-                { line: 1, column: 11, message: "Unnecessary escape character: \\'.", type: "TemplateElement"},
-                { line: 1, column: 19, message: "Unnecessary escape character: \\'.", type: "TemplateElement"}
+                { line: 1, column: 12, message: "Unnecessary escape character: \\'.", type: "TemplateElement"},
+                { line: 1, column: 20, message: "Unnecessary escape character: \\'.", type: "TemplateElement"}
             ]
         },
         {
             code: "var foo = `\\#${foo}`;",
             parserOptions: {ecmaVersion: 6},
-            errors: [{ line: 1, column: 11, message: "Unnecessary escape character: \\#.", type: "TemplateElement"}]
+            errors: [{ line: 1, column: 12, message: "Unnecessary escape character: \\#.", type: "TemplateElement"}]
         },
         {
             code: "let foo = '\\ ';",
@@ -177,21 +177,21 @@ ruleTester.run("no-useless-escape", rule, {
             code: "var foo = `\\$\\{{${foo}`;",
             parserOptions: {ecmaVersion: 6},
             errors: [
-                { line: 1, column: 11, message: "Unnecessary escape character: \\$.", type: "TemplateElement"},
+                { line: 1, column: 12, message: "Unnecessary escape character: \\$.", type: "TemplateElement"},
             ]
         },
         {
             code: "var foo = `\\$a${foo}`;",
             parserOptions: {ecmaVersion: 6},
             errors: [
-                { line: 1, column: 11, message: "Unnecessary escape character: \\$.", type: "TemplateElement"},
+                { line: 1, column: 12, message: "Unnecessary escape character: \\$.", type: "TemplateElement"},
             ]
         },
         {
             code: "var foo = `a\\{{${foo}`;",
             parserOptions: {ecmaVersion: 6},
             errors: [
-                { line: 1, column: 12, message: "Unnecessary escape character: \\{.", type: "TemplateElement"},
+                { line: 1, column: 13, message: "Unnecessary escape character: \\{.", type: "TemplateElement"},
             ]
         },
         {
@@ -265,6 +265,11 @@ ruleTester.run("no-useless-escape", rule, {
         {
             code: String.raw`var foo = /[a\^]/`,
             errors: [{ line: 1, column: 14, message: "Unnecessary escape character: \\^.", type: "Literal" }]
+        },
+        {
+            code: "`multiline template\nliteral with useless \\escape`",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ line: 2, column: 22, message: "Unnecessary escape character: \\e.", type: "TemplateElement" }]
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

See https://github.com/eslint/eslint/issues/7643.

**What changes did you make? (Give an overview)**

* Add `getLocationFromRangeIndex` and `getRangeIndexFromLocation` functions to `ast-utils`. This allows a rule to easily convert `{line: 5, column: 3}` to an absolute index in the file, and vice versa.
* Fix an off-by-one bug in the error locations for template literals. This was happening because we use the same logic to parse escape characters in `TemplateElement` nodes and string literals. However, we were parsing `node.value.raw` for string literals, which includes the surrounding quotes. `TemplateElement` nodes do not have surrounding quotes, so their error location ended up being off by one.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.

