### PR TITLE
Update: fix false negative of `quotes` with \n in template (fixes #7646)

### DIFF
--- a/lib/rules/quotes.js
+++ b/lib/rules/quotes.js
@@ -258,7 +258,11 @@ module.exports = {
                     return;
                 }
 
-                const shouldWarn = node.quasis.length === 1 && (node.quasis[0].value.cooked.indexOf("\n") === -1);
+                /*
+                 * A warning should be produced if the template literal only has one TemplateElement, and has no unescaped newlines.
+                 * An unescaped newline is a newline preceded by an odd number of backslashes.
+                 */
+                const shouldWarn = node.quasis.length === 1 && !/(^|[^\\])(\\\\)*[\r\n\u2028\u2029]/.test(node.quasis[0].value.raw);
 
                 if (shouldWarn) {
                     context.report({

--- a/lib/rules/quotes.js
+++ b/lib/rules/quotes.js
@@ -260,7 +260,7 @@ module.exports = {
 
                 /*
                  * A warning should be produced if the template literal only has one TemplateElement, and has no unescaped newlines.
-                 * An unescaped newline is a newline preceded by an odd number of backslashes.
+                 * An unescaped newline is a newline preceded by an even number of backslashes.
                  */
                 const shouldWarn = node.quasis.length === 1 && !/(^|[^\\])(\\\\)*[\r\n\u2028\u2029]/.test(node.quasis[0].value.raw);
 

--- a/tests/lib/rules/quotes.js
+++ b/tests/lib/rules/quotes.js
@@ -38,6 +38,16 @@ ruleTester.run("quotes", rule, {
 
         // Backticks are only okay if they have substitutions, contain a line break, or are tagged
         { code: "var foo = `back\ntick`;", options: ["single"], parserOptions: { ecmaVersion: 6 }},
+        { code: "var foo = `back\rtick`;", options: ["single"], parserOptions: { ecmaVersion: 6 }},
+        { code: "var foo = `back\u2028tick`;", options: ["single"], parserOptions: { ecmaVersion: 6 }},
+        { code: "var foo = `back\u2029tick`;", options: ["single"], parserOptions: { ecmaVersion: 6 }},
+        {
+            code: "var foo = `back\\\\\ntick`;", // 2 backslashes followed by a newline
+            options: ["single"],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        { code: "var foo = `back\\\\\\\\\ntick`;", options: ["single"], parserOptions: { ecmaVersion: 6 }},
+        { code: "var foo = `\n`;", options: ["single"], parserOptions: { ecmaVersion: 6 }},
         { code: "var foo = `back${x}tick`;", options: ["double"], parserOptions: { ecmaVersion: 6 }},
         { code: "var foo = tag`backtick`;", options: ["double"], parserOptions: { ecmaVersion: 6 }},
 
@@ -270,6 +280,26 @@ ruleTester.run("quotes", rule, {
         {
             code: "foo(); `use strict`;",
             output: "foo(); \"use strict\";",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Strings must use doublequote.", type: "TemplateLiteral" }]
+        },
+
+        // https://github.com/eslint/eslint/issues/7646
+        {
+            code: "var foo = `foo\\nbar`;",
+            output: "var foo = \"foo\\nbar\";",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Strings must use doublequote.", type: "TemplateLiteral" }]
+        },
+        {
+            code: "var foo = `foo\\\nbar`;", // 1 backslash followed by a newline
+            output: "var foo = \"foo\\\nbar\";",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Strings must use doublequote.", type: "TemplateLiteral" }]
+        },
+        {
+            code: "var foo = `foo\\\\\\\nbar`;", // 3 backslashes followed by a newline
+            output: "var foo = \"foo\\\\\\\nbar\";",
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Strings must use doublequote.", type: "TemplateLiteral" }]
         }


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix

See https://github.com/eslint/eslint/issues/7646

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates the newline detection in `quotes`. `quotes` needs to detect whether a raw template literal contains a newline, so that it can determine whether it should suggest that the template literal be fixed to another quote type. However, it previously detected newlines by searching for LF characters in the *cooked* `TemplateElement` value. As a result, if the template literally contained `\n`, it wouldn't get reported.

The previous behavior also had a few other bugs:

* It incorrectly reported/fixed template literals that contained other characters recognized as newlines in JS (`\r`, `\u2028`, or `\u2029`), if they didn't contain LF characters.
* It failed to report template literals with *escaped* newlines. These can be replaced with single/double quotes without breaking the code.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.
