### PR TITLE
Fix: captialized-comments fatal error fixed (fixes #7663)

### DIFF
--- a/lib/rules/capitalized-comments.js
+++ b/lib/rules/capitalized-comments.js
@@ -232,6 +232,10 @@ module.exports = {
             const commentWordCharsOnly = commentWithoutAsterisks
                 .replace(WHITESPACE, "");
 
+            if (commentWordCharsOnly.length === 0) {
+                return true;
+            }
+
             const firstWordChar = commentWordCharsOnly[0];
 
             if (!LETTER_PATTERN.test(firstWordChar)) {

--- a/tests/lib/rules/capitalized-comments.js
+++ b/tests/lib/rules/capitalized-comments.js
@@ -41,6 +41,17 @@ ruleTester.run("capitalized-comments", rule, {
         "//\u03A0",
         "/* Uppercase\nsecond line need not be uppercase */",
 
+        // No options: Skips comments that only contain whitespace
+        "// ",
+        "//\t",
+        "/* */",
+        "/*\t*/",
+        "/*\n*/",
+        "/*\r*/",
+        "/*\r\n*/",
+        "/*\u2028*/",
+        "/*\u2029*/",
+
         // No options: non-alphabetical is okay
         "//123",
         "// 123",


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

https://github.com/eslint/eslint/issues/7663

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Added a test to confirm that `// ` would cause `capitalized-comments` to terminate `eslint` with a `TypeError`.

Added code to make sure that `firstWordChar` is an empty string rather than `undefined` in that case, thus avoiding the `TypeError`.

**Is there anything you'd like reviewers to focus on?**

Nope, nothing in particular.

Fix issue where comments containing a single space would cause eslint to
terminate with a TypeError.