### PR TITLE
Docs: Fix a typo in array-bracket-spacing documentation

### DIFF
--- a/docs/rules/array-bracket-spacing.md
+++ b/docs/rules/array-bracket-spacing.md
@@ -172,7 +172,7 @@ var foo = [{ 'foo': 'bar' }];
 
 ### objectsInArrays
 
-Examples of **incorrect**  this rule with the `"always", { "objectsInArrays": false }` options:
+Examples of **incorrect** code for this rule with the `"always", { "objectsInArrays": false }` options:
 
 ```js
 /*eslint array-bracket-spacing: ["error", "always", { "objectsInArrays": false }]*/


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**
[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
This fixes a spelling error in the array-bracket-spacing docs.

**Is there anything you'd like reviewers to focus on?**
No, nothing in particular


