### PR TITLE
Build: include links to rule pages in release blogpost

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -159,7 +159,8 @@ function execSilent(cmd) {
  * @private
  */
 function generateBlogPost(releaseInfo) {
-    const output = ejs.render(cat("./templates/blogpost.md.ejs"), releaseInfo),
+    const ruleList = ls("lib/rules").map(ruleFileName => ruleFileName.replace(/\.js$/, "")).sort((ruleA, ruleB) => ruleB.length - ruleA.length);
+    const output = ejs.render(cat("./templates/blogpost.md.ejs"), Object.assign({ruleList}, releaseInfo)),
         now = new Date(),
         month = now.getMonth() + 1,
         day = now.getDate(),

--- a/Makefile.js
+++ b/Makefile.js
@@ -159,7 +159,17 @@ function execSilent(cmd) {
  * @private
  */
 function generateBlogPost(releaseInfo) {
-    const ruleList = ls("lib/rules").map(ruleFileName => ruleFileName.replace(/\.js$/, "")).sort((ruleA, ruleB) => ruleB.length - ruleA.length);
+    const ruleList = ls("lib/rules")
+
+        // Strip the .js extension
+        .map(ruleFileName => ruleFileName.replace(/\.js$/, ""))
+
+        /*
+         * Sort by length descending. This ensures that rule names which are substrings of other rule names are not
+         * matched incorrectly. For example, the string "no-undefined" should get matched with the `no-undefined` rule,
+         * instead of getting matched with the `no-undef` rule followed by the string "ined".
+         */
+        .sort((ruleA, ruleB) => ruleB.length - ruleA.length);
     const output = ejs.render(cat("./templates/blogpost.md.ejs"), Object.assign({ruleList}, releaseInfo)),
         now = new Date(),
         month = now.getMonth() + 1,

--- a/templates/blogpost.md.ejs
+++ b/templates/blogpost.md.ejs
@@ -10,9 +10,13 @@ tags:
 We just pushed ESLint v<%- version %>, which is a <%- type %> release upgrade of ESLint. This release <% if (type !== "patch") { %>adds some new features and<% } %> fixes several bugs found in the previous release. <% if (type === "major") { %>This release also has some breaking changes, so please read the following closely. <% } %>
 
 <%
+const RULE_REGEX = new RegExp(ruleList.map(ruleName => `\`?${ruleName}\`?`).join("|"), "g");
+
 function linkify(line) {
-    line = line.replace(/#(\d+)/g, "[#$1](https://github.com/eslint/eslint/issues/$1)");
-    return line.replace(/([a-z0-9]+)/, "[$1](https://github.com/eslint/eslint/commit/$1)");
+    return line
+        .replace(/#(\d+)/g, "[#$1](https://github.com/eslint/eslint/issues/$1)")
+        .replace(/([a-z0-9]+)/, "[$1](https://github.com/eslint/eslint/commit/$1)")
+        .replace(RULE_REGEX, "[$&](/docs/rules/$&)");
 }
 
 function outputList(items) {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

If a commit message contains a string that matches one of ESLint's rule names, it will automatically get converted to a link to the rule's documentation page when generating the blogpost.

For example, the following changelog

```markdown
* 1234567 Fix: `no-undef` bug
* 7654321 Update: add option to no-unused-vars
* aaaaaaa Chore: refactor `no-undefined`
```

...will now get converted to this in the blogpost:

```markdown
* 1234567 Fix: [`no-undef`](/docs/rules/no-undef) bug
* 7654321 Update: add option to [no-unused-vars](/docs/rules/no-unused-vars)
* aaaaaaa Chore: refactor [`no-undefined`](/docs/rules/no-undefined)
```

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.