### PR TITLE
Fix: Allow \u2028 and \u2029 as string escapes in no-useless-escape

### DIFF
--- a/lib/rules/no-useless-escape.js
+++ b/lib/rules/no-useless-escape.js
@@ -24,7 +24,7 @@ function union(setA, setB) {
     }());
 }
 
-const VALID_STRING_ESCAPES = new Set("\\nrvtbfux\n\r");
+const VALID_STRING_ESCAPES = new Set("\\nrvtbfux\n\r\u2028\u2029");
 const REGEX_GENERAL_ESCAPES = new Set("\\bcdDfnrsStvwWxu0123456789");
 const REGEX_CHARCLASS_ESCAPES = union(REGEX_GENERAL_ESCAPES, new Set("]"));
 const REGEX_NON_CHARCLASS_ESCAPES = union(REGEX_GENERAL_ESCAPES, new Set("^/.$*+?[{}|()B"));

--- a/tests/lib/rules/no-useless-escape.js
+++ b/tests/lib/rules/no-useless-escape.js
@@ -102,7 +102,10 @@ ruleTester.run("no-useless-escape", rule, {
         "var foo = /\\1/", // \x01 character (octal literal)
         "var foo = /(a)\\1/", // backreference
         "var foo = /(a)\\12/", // backreference
-        "var foo = /[\\0]/" // null character in character class
+        "var foo = /[\\0]/", // null character in character class
+
+        "var foo = 'foo \\\u2028 bar'",
+        "var foo = 'foo \\\u2029 bar'"
     ],
 
     invalid: [


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix

**Tell us about your environment**

* **ESLint Version:** master
* **Node Version:** 7.2.0
* **npm Version:** 3.10.9

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

none

**What did you do? Please include the actual source code causing the issue.**

```js
/* eslint no-useless-escape: error */

var foo = "foo\ bar"; // Note: There is a \u2028 character after the backslash.
```

**What did you expect to happen?**

No errors.

**What actually happened? Please include the actual, raw output from ESLint.**

```
3:15  error  Unnecessary escape character: \   no-useless-escape
```

**What changes did you make? (Give an overview)**

This updates `no-useless-escape` to treat the \u2028 and \u2029 linebreak characters as valid escapes.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
