### PR TITLE
Breaking: Resolve patterns from .eslintignore directory (fixes #6759)

### DIFF
--- a/lib/ignored-paths.js
+++ b/lib/ignored-paths.js
@@ -179,7 +179,7 @@ class IgnoredPaths {
 
         let result = false;
         const absolutePath = path.resolve(this.options.cwd, filepath);
-        const relativePath = pathUtil.getRelativePath(absolutePath, this.options.cwd);
+        const relativePath = pathUtil.getRelativePath(absolutePath, this.baseDir);
 
         if ((typeof category === "undefined") || (category === "default")) {
             result = result || (this.ig.default.filter([relativePath]).length === 0);
@@ -213,15 +213,7 @@ class IgnoredPaths {
 
         const filter = ig.createFilter();
 
-        /**
-         * TODO
-         * 1.
-         * Actually, it should be `this.options.baseDir`, which is the base dir of `ignore-path`,
-         * as well as Line 177.
-         * But doing this leads to a breaking change and fails tests.
-         * Related to #6759
-         */
-        const base = this.options.cwd;
+        const base = this.baseDir;
 
         return function(absolutePath) {
             const relative = pathUtil.getRelativePath(absolutePath, base);

--- a/tests/fixtures/ignored-paths/.eslintignoreForDifferentCwd
+++ b/tests/fixtures/ignored-paths/.eslintignoreForDifferentCwd
@@ -1,0 +1,1 @@
+/undef.js

--- a/tests/lib/ignored-paths.js
+++ b/tests/lib/ignored-paths.js
@@ -342,6 +342,13 @@ describe("IgnoredPaths", () => {
             assert.isFalse(ignoredPaths.contains(getFixturePath("sampleignorepattern")));
 
         });
+
+        it("should resolve relative paths from the ignorePath, not cwd", () => {
+            const ignoredPaths = new IgnoredPaths({ ignore: true, ignorePath: getFixturePath(".eslintignoreForDifferentCwd"), cwd: getFixturePath("subdir") });
+
+            assert.isFalse(ignoredPaths.contains(getFixturePath("subdir/undef.js")));
+            assert.isTrue(ignoredPaths.contains(getFixturePath("undef.js")));
+        });
     });
 
     describe("initialization with ignorePath containing commented lines", () => {
@@ -630,6 +637,17 @@ describe("IgnoredPaths", () => {
 
             assert.isFalse(shouldIgnore(resolve(".hidden")));
             assert.isFalse(shouldIgnore(resolve(".hidden/a")));
+        });
+
+        it("should use the ignorePath's directory as the base to resolve relative paths, not cwd", () => {
+            const cwd = getFixturePath("subdir");
+            const ignoredPaths = new IgnoredPaths({ ignore: true, cwd, ignorePath: getFixturePath(".eslintignoreForDifferentCwd") });
+
+            const shouldIgnore = ignoredPaths.getIgnoredFoldersGlobChecker();
+            const resolve = createResolve(cwd);
+
+            assert.isFalse(shouldIgnore(resolve("undef.js")));
+            assert.isTrue(shouldIgnore(resolve("../undef.js")));
         });
     });
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

https://github.com/eslint/eslint/issues/6759


**What changes did you make? (Give an overview)**
These changes will cause the `ignorePath`'s directory to be used to resolve the patterns in the `ignorePath`, regardless of the `cwd`.  This matches the behavior of `.gitignore`.  I also added two tests which fail without these changes and pass with them.

**Is there anything you'd like reviewers to focus on?**
Not particularly, it's pretty straightforward I think.  @kaelzhang had already called out what needed to be done in a `TODO` comment.
