### PR TITLE
Docs: Remove incorrect info about issue requirements from PR guide

### DIFF
--- a/docs/developer-guide/contributing/pull-requests.md
+++ b/docs/developer-guide/contributing/pull-requests.md
@@ -106,8 +106,6 @@ If there are any failing tests, update your code until all tests pass.
 With your code ready to go, this is a good time to double-check your submission to make sure it follows our conventions. Here are the things to check:
 
 * Run `npm run check-commit` to double-check that your commit is formatted correctly.
-* Make sure there is an issue for any pull request you send.
-    * The only exception is for documentation changes.
 * The pull request must have a description. The description should explain what you did and how its effects can be seen.
 * The commit message is properly formatted.
 * The change introduces no functional regression. Be sure to run `npm test` to verify your changes before submitting a pull request.


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

As pointed out in https://github.com/eslint/eslint/issues/7589#issuecomment-260212518, our pull request guide incorrectly states that an issue is required for all non-documentation changes. This removes the reference to that requirement.

**Is there anything you'd like reviewers to focus on?**

We already mention needing an issue for core/breaking changes in ["Getting Started"](https://github.com/eslint/eslint/blob/f80c278a1c64ae8291678bc8f9269d022314da3d/docs/developer-guide/contributing/pull-requests.md#getting-started), so I think we can just remove the reference here.