### PR TITLE
Fix: don't validate schemas for disabled rules (fixes #7690)

### DIFF
--- a/lib/config/config-validator.js
+++ b/lib/config/config-validator.js
@@ -64,8 +64,7 @@ function validateRuleOptions(id, options, source) {
     const schema = getRuleOptionsSchema(id);
     let validateRule = validators.rules[id],
         severity,
-        localOptions,
-        validSeverity = true;
+        localOptions;
 
     if (!validateRule && schema) {
         validateRule = schemaValidator(schema, { verbose: true });
@@ -81,7 +80,8 @@ function validateRuleOptions(id, options, source) {
         localOptions = [];
     }
 
-    validSeverity = (
+    const disabledSeverity = severity === 0 || typeof severity === "string" && severity.toLowerCase() === "off";
+    const validSeverity = (
         severity === 0 || severity === 1 || severity === 2 ||
         (typeof severity === "string" && /^(?:off|warn|error)$/i.test(severity))
     );
@@ -90,7 +90,7 @@ function validateRuleOptions(id, options, source) {
         validateRule(localOptions);
     }
 
-    if ((validateRule && validateRule.errors) || !validSeverity) {
+    if ((validateRule && validateRule.errors && !disabledSeverity) || !validSeverity) {
         const message = [
             source, ":\n",
             "\tConfiguration for rule \"", id, "\" is invalid:\n"

--- a/lib/config/config-validator.js
+++ b/lib/config/config-validator.js
@@ -54,6 +54,44 @@ function getRuleOptionsSchema(id) {
 }
 
 /**
+* Validates a rule's severity and returns the severity value. Throws an error if the severity is invalid.
+* @param {options} options The given options for the rule.
+* @returns {number|string} The rule's severity value
+*/
+function validateRuleSeverity(options) {
+    const severity = Array.isArray(options) ? options[0] : options;
+
+    if (severity !== 0 && severity !== 1 && severity !== 2 && !(typeof severity === "string" && /^(?:off|warn|error)$/i.test(severity))) {
+        throw new Error(`\tSeverity should be one of the following: 0 = off, 1 = warn, 2 = error (you passed '${util.inspect(severity).replace(/'/g, "\"").replace(/\n/g, "")}').\n`);
+    }
+
+    return severity;
+}
+
+/**
+* Validates the non-severity options passed to a rule, based on its schema.
+* @param {string} id The rule's unique name
+* @param {array} localOptions The options for the rule, excluding severity
+* @returns {void}
+*/
+function validateRuleSchema(id, localOptions) {
+    const schema = getRuleOptionsSchema(id);
+
+    if (!validators.rules[id] && schema) {
+        validators.rules[id] = schemaValidator(schema, { verbose: true });
+    }
+
+    const validateRule = validators.rules[id];
+
+    if (validateRule) {
+        validateRule(localOptions);
+        if (validateRule.errors) {
+            throw new Error(validateRule.errors.map(error => `\tValue "${error.value}" ${error.message}.\n`).join(""));
+        }
+    }
+}
+
+/**
  * Validates a rule's options against its schema.
  * @param {string} id The rule's unique name.
  * @param {array|number} options The given options for the rule.
@@ -61,58 +99,14 @@ function getRuleOptionsSchema(id) {
  * @returns {void}
  */
 function validateRuleOptions(id, options, source) {
-    const schema = getRuleOptionsSchema(id);
-    let validateRule = validators.rules[id],
-        severity,
-        localOptions;
+    try {
+        const severity = validateRuleSeverity(options);
 
-    if (!validateRule && schema) {
-        validateRule = schemaValidator(schema, { verbose: true });
-        validators.rules[id] = validateRule;
-    }
-
-    // if it's not an array, it should be just a severity
-    if (Array.isArray(options)) {
-        localOptions = options.concat();    // clone
-        severity = localOptions.shift();
-    } else {
-        severity = options;
-        localOptions = [];
-    }
-
-    const disabledSeverity = severity === 0 || typeof severity === "string" && severity.toLowerCase() === "off";
-    const validSeverity = (
-        severity === 0 || severity === 1 || severity === 2 ||
-        (typeof severity === "string" && /^(?:off|warn|error)$/i.test(severity))
-    );
-
-    if (validateRule) {
-        validateRule(localOptions);
-    }
-
-    if ((validateRule && validateRule.errors && !disabledSeverity) || !validSeverity) {
-        const message = [
-            source, ":\n",
-            "\tConfiguration for rule \"", id, "\" is invalid:\n"
-        ];
-
-        if (!validSeverity) {
-            message.push(
-                "\tSeverity should be one of the following: 0 = off, 1 = warn, 2 = error (you passed '",
-                util.inspect(severity).replace(/'/g, "\"").replace(/\n/g, ""),
-                "').\n"
-            );
+        if (severity !== 0 && !(typeof severity === "string" && severity.toLowerCase() === "off")) {
+            validateRuleSchema(id, Array.isArray(options) ? options.slice(1) : []);
         }
-
-        if (validateRule && validateRule.errors) {
-            validateRule.errors.forEach(error => {
-                message.push(
-                    "\tValue \"", error.value, "\" ", error.message, ".\n"
-                );
-            });
-        }
-
-        throw new Error(message.join(""));
+    } catch (err) {
+        throw new Error(`${source}:\n\tConfiguration for rule "${id}" is invalid:\n${err.message}`);
     }
 }
 

--- a/tests/lib/config/config-validator.js
+++ b/tests/lib/config/config-validator.js
@@ -159,7 +159,7 @@ describe("Validator", () => {
         it("should catch invalid rule options", () => {
             const fn = validator.validate.bind(null, { rules: { "mock-rule": [3, "third"] } }, "tests");
 
-            assert.throws(fn, "tests:\n\tConfiguration for rule \"mock-rule\" is invalid:\n\tSeverity should be one of the following: 0 = off, 1 = warn, 2 = error (you passed '3').\n\tValue \"third\" must be an enum value.\n");
+            assert.throws(fn, "tests:\n\tConfiguration for rule \"mock-rule\" is invalid:\n\tSeverity should be one of the following: 0 = off, 1 = warn, 2 = error (you passed '3').\n");
         });
 
         it("should allow for rules with no options", () => {

--- a/tests/lib/config/config-validator.js
+++ b/tests/lib/config/config-validator.js
@@ -71,10 +71,27 @@ function mockNoOptionsRule(context) {
 
 mockNoOptionsRule.schema = [];
 
+const mockRequiredOptionsRule = {
+    meta: {
+        schema: {
+            type: "array",
+            minItems: 1
+        }
+    },
+    create(context) {
+        return {
+            Program(node) {
+                context.report(node, "Expected a validation error.");
+            }
+        };
+    }
+};
+
 describe("Validator", () => {
 
     beforeEach(() => {
         eslint.defineRule("mock-rule", mockRule);
+        eslint.defineRule("mock-required-options-rule", mockRequiredOptionsRule);
     });
 
     describe("validate", () => {
@@ -99,6 +116,12 @@ describe("Validator", () => {
 
         it("should do nothing with a valid config when severity is off", () => {
             const fn = validator.validate.bind(null, { rules: { "mock-rule": ["off", "second"] } }, "tests");
+
+            assert.doesNotThrow(fn);
+        });
+
+        it("should do nothing with an invalid config when severity is off", () => {
+            const fn = validator.validate.bind(null, { rules: { "mock-required-options-rule": "off" } }, "tests");
 
             assert.doesNotThrow(fn);
         });

--- a/tests/lib/config/config-validator.js
+++ b/tests/lib/config/config-validator.js
@@ -126,6 +126,12 @@ describe("Validator", () => {
             assert.doesNotThrow(fn);
         });
 
+        it("should do nothing with an invalid config when severity is an array with 'off'", () => {
+            const fn = validator.validate.bind(null, { rules: { "mock-required-options-rule": ["off"] } }, "tests");
+
+            assert.doesNotThrow(fn);
+        });
+
         it("should do nothing with a valid config when severity is warn", () => {
             const fn = validator.validate.bind(null, { rules: { "mock-rule": ["warn", "second"] } }, "tests");
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix

See https://github.com/eslint/eslint/issues/7690

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates `config-validator.js` to avoid option validation when a rule is disabled. This ensures that `some-rule: off` is always a valid way to disable a rule, and it doesn't throw a schema error if the rule requires options when enabled.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular

