### PR TITLE
Update: fix false positive/negative of yoda rule (fixes #7676)

### DIFF
--- a/lib/rules/yoda.js
+++ b/lib/rules/yoda.js
@@ -103,7 +103,11 @@ function same(a, b) {
             // x[0] = x[0]
             // x[y] = x[y]
             // x.y = x.y
-            return same(a.object, b.object) && same(a.property, b.property);
+            return (
+                a.computed === b.computed &&
+                same(a.object, b.object) &&
+                same(a.property, b.property)
+            );
 
         case "ThisExpression":
             return true;

--- a/lib/rules/yoda.js
+++ b/lib/rules/yoda.js
@@ -62,11 +62,12 @@ function looksLikeLiteral(node) {
  * @param {ASTNode} node Node to normalize.
  * @param {number} [defaultValue] The default value to be returned if the node
  *                                is not a Literal.
- * @returns {ASTNode} The original node if the node is already a Literal, or a
- *                    normalized Literal node with the negative number as the
- *                    value if the node represents a negative number literal,
- *                    otherwise null if the node cannot be converted to a
- *                    normalized literal.
+ * @returns {ASTNode} One of the following options.
+ *  1. The original node if the node is already a Literal
+ *  2. A normalized Literal node with the negative number as the value if the
+ *     node represents a negative number literal.
+ *  3. The Literal node which has the `defaultValue` argument if it exists.
+ *  4. Otherwise `null`.
  */
 function getNormalizedLiteral(node, defaultValue) {
     if (node.type === "Literal") {

--- a/lib/rules/yoda.js
+++ b/lib/rules/yoda.js
@@ -5,6 +5,12 @@
 "use strict";
 
 //--------------------------------------------------------------------------
+// Requirements
+//--------------------------------------------------------------------------
+
+const astUtils = require("../ast-utils");
+
+//--------------------------------------------------------------------------
 // Helpers
 //--------------------------------------------------------------------------
 
@@ -108,7 +114,16 @@ function same(a, b) {
         case "Literal":
             return a.value === b.value;
 
-        case "MemberExpression":
+        case "MemberExpression": {
+            const nameA = astUtils.getStaticPropertyName(a);
+
+            // x.y = x["y"]
+            if (nameA) {
+                return (
+                    same(a.object, b.object) &&
+                    nameA === astUtils.getStaticPropertyName(b)
+                );
+            }
 
             // x[0] = x[0]
             // x[y] = x[y]
@@ -118,6 +133,7 @@ function same(a, b) {
                 same(a.object, b.object) &&
                 same(a.property, b.property)
             );
+        }
 
         case "ThisExpression":
             return true;

--- a/lib/rules/yoda.js
+++ b/lib/rules/yoda.js
@@ -54,13 +54,15 @@ function looksLikeLiteral(node) {
 /**
  * Attempts to derive a Literal node from nodes that are treated like literals.
  * @param {ASTNode} node Node to normalize.
+ * @param {number} [defaultValue] The default value to be returned if the node
+ *                                is not a Literal.
  * @returns {ASTNode} The original node if the node is already a Literal, or a
  *                    normalized Literal node with the negative number as the
  *                    value if the node represents a negative number literal,
  *                    otherwise null if the node cannot be converted to a
  *                    normalized literal.
  */
-function getNormalizedLiteral(node) {
+function getNormalizedLiteral(node, defaultValue) {
     if (node.type === "Literal") {
         return node;
     }
@@ -70,6 +72,14 @@ function getNormalizedLiteral(node) {
             type: "Literal",
             value: -node.argument.value,
             raw: `-${node.argument.value}`
+        };
+    }
+
+    if (defaultValue) {
+        return {
+            type: "Literal",
+            value: defaultValue,
+            raw: String(defaultValue)
         };
     }
 
@@ -182,7 +192,7 @@ module.exports = {
 
                 return (node.operator === "&&" &&
                     (leftLiteral = getNormalizedLiteral(left.left)) &&
-                    (rightLiteral = getNormalizedLiteral(right.right)) &&
+                    (rightLiteral = getNormalizedLiteral(right.right, Number.POSITIVE_INFINITY)) &&
                     leftLiteral.value <= rightLiteral.value &&
                     same(left.right, right.left));
             }
@@ -195,7 +205,7 @@ module.exports = {
                 let leftLiteral, rightLiteral;
 
                 return (node.operator === "||" &&
-                    (leftLiteral = getNormalizedLiteral(left.right)) &&
+                    (leftLiteral = getNormalizedLiteral(left.right, Number.NEGATIVE_INFINITY)) &&
                     (rightLiteral = getNormalizedLiteral(right.left)) &&
                     leftLiteral.value <= rightLiteral.value &&
                     same(left.left, right.right));

--- a/tests/lib/rules/yoda.js
+++ b/tests/lib/rules/yoda.js
@@ -68,6 +68,18 @@ ruleTester.run("yoda", rule, {
         }, {
             code: "if (0 <= this.prop && this.prop <= 1) {}",
             options: ["never", { exceptRange: true }]
+        }, {
+            code: "if (0 <= index && index < list.length) {}",
+            options: ["never", { exceptRange: true }]
+        }, {
+            code: "if (ZERO <= index && index < 100) {}",
+            options: ["never", { exceptRange: true }]
+        }, {
+            code: "if (value <= MIN || 10 < value) {}",
+            options: ["never", { exceptRange: true }]
+        }, {
+            code: "if (value <= 0 || MAX < value) {}",
+            options: ["never", { exceptRange: true }]
         },
 
         // onlyEquality

--- a/tests/lib/rules/yoda.js
+++ b/tests/lib/rules/yoda.js
@@ -80,6 +80,9 @@ ruleTester.run("yoda", rule, {
         }, {
             code: "if (value <= 0 || MAX < value) {}",
             options: ["never", { exceptRange: true }]
+        }, {
+            code: "if (0 <= a.b && a[\"b\"] <= 100) {}",
+            options: ["never", { exceptRange: true }]
         },
 
         // onlyEquality

--- a/tests/lib/rules/yoda.js
+++ b/tests/lib/rules/yoda.js
@@ -287,6 +287,17 @@ ruleTester.run("yoda", rule, {
             ]
         },
         {
+            code: "if (0 <= a[b] && a.b < 1) {}",
+            output: "if (a[b] >= 0 && a.b < 1) {}",
+            options: ["never", { exceptRange: true }],
+            errors: [
+                {
+                    message: "Expected literal to be on the right side of <=.",
+                    type: "BinaryExpression"
+                }
+            ]
+        },
+        {
             code: "if (0 <= a[b()] && a[b()] < 1) {}",
             output: "if (a[b()] >= 0 && a[b()] < 1) {}",
             options: ["never", { exceptRange: true }],


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

See #7676 for the template.

**What changes did you make? (Give an overview)**

The `yoda` rule has a false positive and a false negative.
This PR fixes those bugs.

- c62b847c9d84363663d267c6804700735ffe29b4 fixed the false negative about computed properties in the range check.

  ```js
  /*eslint yoda: [error, never, {exceptRange: true}] */
  if (0 <= a.b && a[b] < 10) {}
  ```

  The `yoda` rule has been handling `a.b` and `a[b]` as the same then it determines the condition is a range check wrongly. As the result, it should warn the `0 <= a.b` but does not warn it. After this PR is applied, the `yoda` rule will warn the `0 <= a.b` correctly. (semver-minor)

- bf9982f71f47488d9d165bf88722c34ee28d933e fixed the false positive about variables in the range check.

  ```js
  /*eslint yoda: [error, never, {exceptRange: true}] */
  if (0 <= index && index < list.length) {}
  ```

  The `yoda` rule has not been handling `0 <= index && index < list.length` as a range check wrongly. As the result, it should not warn `0 <= index` but warns it. After this PR is applied, the `yoda` rule will ignore the `0 <= index && index < list.length` correctly. (semver-patch)

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.
