### PR TITLE
Breaking: no-multi-spaces check around inline comments (fixes #7693)

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -408,7 +408,7 @@ function lintMarkdown(files) {
             // Exclusions for deliberate/widespread violations
             MD001: false, // Header levels should only increment by one level at a time
             MD002: false, // First header should be a h1 header
-            MD007: {      // Unordered list indentation
+            MD007: { // Unordered list indentation
                 indent: 4
             },
             MD012: false, // Multiple consecutive blank lines
@@ -423,7 +423,7 @@ function lintMarkdown(files) {
             MD033: false, // Allow inline HTML
             MD034: false, // Bare URL used
             MD040: false, // Fenced code blocks should have a language specified
-            MD041: false  // First line in file should be a top level header
+            MD041: false // First line in file should be a top level header
         },
         result = markdownlint.sync({
             files,
@@ -1039,7 +1039,7 @@ function runPerformanceTest(title, targets, multiplier, cb) {
     echo("  CPU Speed is %d with multiplier %d", cpuSpeed, multiplier);
 
     time(cmd, 5, 1, [], results => {
-        if (!results || results.length === 0) {  // No results? Something is wrong.
+        if (!results || results.length === 0) { // No results? Something is wrong.
             throw new Error("Performance test failed.");
         }
 

--- a/conf/cli-options.js
+++ b/conf/cli-options.js
@@ -16,7 +16,7 @@ module.exports = {
     extensions: [".js"],
     ignore: true,
     ignorePath: null,
-    parser: "",     // must be empty
+    parser: "", // must be empty
     cache: false,
 
     // in order to honor the cacheFile option if specified

--- a/docs/rules/no-multi-spaces.md
+++ b/docs/rules/no-multi-spaces.md
@@ -61,7 +61,6 @@ This rule's configuration consists of an object with the following properties:
 
 ### ignoreEOLComments
 
-
 Examples of **incorrect** code for this rule with the `{ "ignoreEOLComments": false }` (default) option:
 
 ```js
@@ -98,7 +97,6 @@ var x = 5;      /* multiline
  * comment
  */
 ```
-
 
 ### exceptions
 

--- a/docs/rules/no-multi-spaces.md
+++ b/docs/rules/no-multi-spaces.md
@@ -54,11 +54,55 @@ a ? b: c
 
 ## Options
 
-To avoid contradictions if some other rules require multiple spaces, this rule has an option to ignore certain node types in the abstract syntax tree (AST) of JavaScript code.
+This rule's configuration consists of an object with the following properties:
+
+* `"ignoreEOLComments": false` (defaults to `true`) ignores multiple spaces before comments that occur at the end of lines
+* `"exceptions": { "Property": true }` (`"Property"` is the only node specified by default) specifies nodes to ignore
+
+### ignoreEOLComments
+
+Examples of **correct** code for this rule with the `{ "ignoreEOLComments": true }` (default) option:
+
+```js
+/*eslint no-multi-spaces: ["error", { ignoreEOLComments: true }]*/
+
+var x = 5; // comment
+var x = 5;      // comment
+var x = 5; /* multiline
+ * comment
+ */
+var x = 5;      /* multiline
+ * comment
+ */
+```
+
+Examples of **incorrect** code for this rule with the `{ "ignoreEOLComments": false }` option:
+
+```js
+/*eslint no-multi-spaces: ["error", { ignoreEOLComments: false }]*/
+
+var x = 5;      // comment
+var x = 5;      /* multiline
+ * comment
+ */
+```
+
+Examples of **correct** code for this rule with the `{ "ignoreEOLComments": false }` option:
+
+```js
+/*eslint no-multi-spaces: ["error", { ignoreEOLComments: false }]*/
+
+var x = 5; // comment
+var x = 5; /* multiline
+ * comment
+ */
+```
 
 ### exceptions
 
-The `exceptions` object expects property names to be AST node types as defined by [ESTree](https://github.com/estree/estree). The easiest way to determine the node types for `exceptions` is to use the [online demo](http://eslint.org/parser).
+To avoid contradictions with other rules that require multiple spaces, this rule has an `exceptions` option to ignore certain nodes.
+
+This option is an object that expects property names to be AST node types as defined by [ESTree](https://github.com/estree/estree). The easiest way to determine the node types for `exceptions` is to use the [online demo](http://eslint.org/parser).
 
 Only the `Property` node type is ignored by default, because for the [key-spacing](key-spacing.md) rule some alignment options require multiple spaces in properties of object literals.
 

--- a/docs/rules/no-multi-spaces.md
+++ b/docs/rules/no-multi-spaces.md
@@ -56,12 +56,35 @@ a ? b: c
 
 This rule's configuration consists of an object with the following properties:
 
-* `"ignoreEOLComments": false` (defaults to `true`) ignores multiple spaces before comments that occur at the end of lines
+* `"ignoreEOLComments": true` (defaults to `false`) ignores multiple spaces before comments that occur at the end of lines
 * `"exceptions": { "Property": true }` (`"Property"` is the only node specified by default) specifies nodes to ignore
 
 ### ignoreEOLComments
 
-Examples of **correct** code for this rule with the `{ "ignoreEOLComments": true }` (default) option:
+
+Examples of **incorrect** code for this rule with the `{ "ignoreEOLComments": false }` (default) option:
+
+```js
+/*eslint no-multi-spaces: ["error", { ignoreEOLComments: false }]*/
+
+var x = 5;      // comment
+var x = 5;      /* multiline
+ * comment
+ */
+```
+
+Examples of **correct** code for this rule with the `{ "ignoreEOLComments": false }` (default) option:
+
+```js
+/*eslint no-multi-spaces: ["error", { ignoreEOLComments: false }]*/
+
+var x = 5; // comment
+var x = 5; /* multiline
+ * comment
+ */
+```
+
+Examples of **correct** code for this rule with the `{ "ignoreEOLComments": true }` option:
 
 ```js
 /*eslint no-multi-spaces: ["error", { ignoreEOLComments: true }]*/
@@ -76,27 +99,6 @@ var x = 5;      /* multiline
  */
 ```
 
-Examples of **incorrect** code for this rule with the `{ "ignoreEOLComments": false }` option:
-
-```js
-/*eslint no-multi-spaces: ["error", { ignoreEOLComments: false }]*/
-
-var x = 5;      // comment
-var x = 5;      /* multiline
- * comment
- */
-```
-
-Examples of **correct** code for this rule with the `{ "ignoreEOLComments": false }` option:
-
-```js
-/*eslint no-multi-spaces: ["error", { ignoreEOLComments: false }]*/
-
-var x = 5; // comment
-var x = 5; /* multiline
- * comment
- */
-```
 
 ### exceptions
 

--- a/lib/config/autoconfig.js
+++ b/lib/config/autoconfig.js
@@ -310,7 +310,7 @@ class Registry {
                 ruleSetIdx += 1;
 
                 if (cb) {
-                    cb(totalFilesLinting);  // eslint-disable-line callback-return
+                    cb(totalFilesLinting); // eslint-disable-line callback-return
                 }
             });
 

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -373,7 +373,7 @@ function modifyConfigsFromComments(filename, ast, config, reportingConfig, messa
 
                     // no default
                 }
-            } else {        // comment.type === "Line"
+            } else { // comment.type === "Line"
                 if (match[1] === "eslint-disable-line") {
                     disableReporting(reportingConfig, { line: comment.loc.start.line, column: 0 }, Object.keys(parseListConfig(value)));
                     enableReporting(reportingConfig, comment.loc.end, Object.keys(parseListConfig(value)));
@@ -1002,7 +1002,7 @@ module.exports = (function() {
             severity,
             message,
             line: location.line,
-            column: location.column + 1,   // switch to 1-base instead of 0-base
+            column: location.column + 1, // switch to 1-base instead of 0-base
             nodeType: node && node.type,
             source: sourceCode.lines[location.line - 1] || ""
         };
@@ -1010,7 +1010,7 @@ module.exports = (function() {
         // Define endLine and endColumn if exists.
         if (endLocation) {
             problem.endLine = endLocation.line;
-            problem.endColumn = endLocation.column + 1;   // switch to 1-base instead of 0-base
+            problem.endColumn = endLocation.column + 1; // switch to 1-base instead of 0-base
         }
 
         // ensure there's range and text properties, otherwise it's not a valid fix

--- a/lib/rules/capitalized-comments.js
+++ b/lib/rules/capitalized-comments.js
@@ -18,7 +18,7 @@ const ALWAYS_MESSAGE = "Comments should not begin with a lowercase character",
     NEVER_MESSAGE = "Comments should not begin with an uppercase character",
     DEFAULT_IGNORE_PATTERN = /^\s*(?:eslint|istanbul|jscs|jshint|globals?|exported)\b/,
     WHITESPACE = /\s/g,
-    MAYBE_URL = /^\s*[^:/?#\s]+:\/\/[^?#]/,    // TODO: Combine w/ max-len pattern?
+    MAYBE_URL = /^\s*[^:/?#\s]+:\/\/[^?#]/, // TODO: Combine w/ max-len pattern?
     DEFAULTS = {
         ignorePattern: null,
         ignoreInlineComments: false,
@@ -269,7 +269,7 @@ module.exports = {
                     : NEVER_MESSAGE;
 
                 context.report({
-                    node: null,         // Intentionally using loc instead
+                    node: null, // Intentionally using loc instead
                     loc: comment.loc,
                     message,
                     fix(fixer) {

--- a/lib/rules/id-length.js
+++ b/lib/rules/id-length.js
@@ -96,7 +96,7 @@ module.exports = {
                 const isLong = name.length > maxLength;
 
                 if (!(isShort || isLong) || exceptions[name]) {
-                    return;  // Nothing to report
+                    return; // Nothing to report
                 }
 
                 const isValidExpression = SUPPORTED_EXPRESSIONS[parent.type];

--- a/lib/rules/max-len.js
+++ b/lib/rules/max-len.js
@@ -108,7 +108,7 @@ module.exports = {
                     previousTabStopOffset = tabWidth ? totalOffset % tabWidth : 0,
                     spaceCount = tabWidth - previousTabStopOffset;
 
-                extraCharacterCount += spaceCount - 1;  // -1 for the replaced tab
+                extraCharacterCount += spaceCount - 1; // -1 for the replaced tab
             });
             return Array.from(line).length + extraCharacterCount;
         }

--- a/lib/rules/new-parens.js
+++ b/lib/rules/new-parens.js
@@ -52,7 +52,7 @@ module.exports = {
         return {
             NewExpression(node) {
                 if (node.arguments.length !== 0) {
-                    return;  // shortcut: if there are arguments, there have to be parens
+                    return; // shortcut: if there are arguments, there have to be parens
                 }
 
                 const lastToken = sourceCode.getLastToken(node);

--- a/lib/rules/newline-before-return.js
+++ b/lib/rules/newline-before-return.js
@@ -121,7 +121,7 @@ module.exports = {
             if (tokenBefore) {
                 lineNumTokenBefore = tokenBefore.loc.end.line;
             } else {
-                lineNumTokenBefore = 0;     // global return at beginning of script
+                lineNumTokenBefore = 0; // global return at beginning of script
             }
 
             return lineNumTokenBefore;

--- a/lib/rules/no-multi-spaces.js
+++ b/lib/rules/no-multi-spaces.js
@@ -33,6 +33,9 @@ module.exports = {
                             }
                         },
                         additionalProperties: false
+                    },
+                    ignoreEOLComments: {
+                        type: "boolean"
                     }
                 },
                 additionalProperties: false
@@ -43,8 +46,10 @@ module.exports = {
     create(context) {
 
         // the index of the last comment that was checked
-        const exceptions = { Property: true },
-            options = context.options[0];
+        const sourceCode = context.getSourceCode(),
+            exceptions = { Property: true },
+            options = context.options[0] || {},
+            ignoreEOLComments = options.ignoreEOLComments !== false;
         let hasExceptions = true,
             lastCommentIndex = 0;
 
@@ -57,6 +62,23 @@ module.exports = {
                 }
             });
             hasExceptions = Object.keys(exceptions).length > 0;
+        }
+
+        /**
+         * Checks if a given token is the last token of the line or not.
+         * @param {Token} token The token to check.
+         * @returns {boolean} Whether or not a token is at the end of the line it occurs in.
+         * @private
+         */
+        function isLastTokenOfLine(token) {
+            const nextToken = sourceCode.getTokenAfter(token, { includeComments: true });
+
+            // nextToken is undefined if the comment is the last token in the program.
+            if (!nextToken) {
+                return true;
+            }
+
+            return !astUtils.isTokenOnSameLine(token, nextToken);
         }
 
         /**
@@ -73,7 +95,7 @@ module.exports = {
             while (lastCommentIndex < comments.length) {
                 const comment = comments[lastCommentIndex];
 
-                if (comment.range[0] <= index && index < comment.range[1]) {
+                if (comment.range[0] < index && index < comment.range[1]) {
                     return true;
                 } else if (index > comment.range[1]) {
                     lastCommentIndex++;
@@ -85,6 +107,33 @@ module.exports = {
             return false;
         }
 
+        /**
+         * Formats value of given comment token for error message by truncating its length.
+         * @param {Token} token comment token
+         * @returns {string} formatted value
+         * @private
+         */
+        function formatReportedCommentValue(token) {
+            const valueLines = token.value.split("\n");
+            const value = valueLines[0];
+            const formattedValue = `${value.substring(0, 12)}...`;
+
+            return valueLines.length === 1 && value.length <= 12 ? value : formattedValue;
+        }
+
+        /**
+         * Creates a fix function that removes the multiple spaces between the two tokens
+         * @param {Token} leftToken left token
+         * @param {Token} rightToken right token
+         * @returns {Function} fix function
+         * @private
+         */
+        function createFix(leftToken, rightToken) {
+            return function(fixer) {
+                return fixer.replaceTextRange([leftToken.range[1], rightToken.range[0]], " ");
+            };
+        }
+
         //--------------------------------------------------------------------------
         // Public
         //--------------------------------------------------------------------------
@@ -92,47 +141,44 @@ module.exports = {
         return {
             Program() {
 
-                const sourceCode = context.getSourceCode(),
-                    source = sourceCode.getText(),
+                const source = sourceCode.getText(),
                     allComments = sourceCode.getAllComments(),
                     JOINED_LINEBEAKS = Array.from(astUtils.LINEBREAKS).join(""),
                     pattern = new RegExp(String.raw`[^ \t${JOINED_LINEBEAKS}].? {2,}`, "g");  // note: repeating space
                 let parent;
-
-
-                /**
-                 * Creates a fix function that removes the multiple spaces between the two tokens
-                 * @param {RuleFixer} leftToken left token
-                 * @param {RuleFixer} rightToken right token
-                 * @returns {Function} fix function
-                 * @private
-                 */
-                function createFix(leftToken, rightToken) {
-                    return function(fixer) {
-                        return fixer.replaceTextRange([leftToken.range[1], rightToken.range[0]], " ");
-                    };
-                }
 
                 while (pattern.test(source)) {
 
                     // do not flag anything inside of comments
                     if (!isIndexInComment(pattern.lastIndex, allComments)) {
 
-                        const token = sourceCode.getTokenByRangeStart(pattern.lastIndex);
+                        const token = sourceCode.getTokenByRangeStart(pattern.lastIndex, { includeComments: true });
 
                         if (token) {
-                            const previousToken = sourceCode.getTokenBefore(token);
+                            if (ignoreEOLComments && astUtils.isCommentToken(token) && isLastTokenOfLine(token)) {
+                                return;
+                            }
+
+                            const previousToken = sourceCode.getTokenBefore(token, { includeComments: true });
 
                             if (hasExceptions) {
                                 parent = sourceCode.getNodeByRangeIndex(pattern.lastIndex - 1);
                             }
 
                             if (!parent || !exceptions[parent.type]) {
+                                let value = token.value;
+
+                                if (token.type === "Block") {
+                                    value = `/*${formatReportedCommentValue(token)}*/`;
+                                } else if (token.type === "Line") {
+                                    value = `//${formatReportedCommentValue(token)}`;
+                                }
+
                                 context.report({
                                     node: token,
                                     loc: token.loc.start,
                                     message: "Multiple spaces found before '{{value}}'.",
-                                    data: { value: token.value },
+                                    data: { value },
                                     fix: createFix(previousToken, token)
                                 });
                             }

--- a/lib/rules/no-multi-spaces.js
+++ b/lib/rules/no-multi-spaces.js
@@ -73,7 +73,6 @@ module.exports = {
         function isLastTokenOfLine(token) {
             const nextToken = sourceCode.getTokenAfter(token, { includeComments: true });
 
-console.log(nextToken);
             // nextToken is null if the comment is the last token in the program.
             if (!nextToken) {
                 return true;
@@ -145,7 +144,7 @@ console.log(nextToken);
                 const source = sourceCode.getText(),
                     allComments = sourceCode.getAllComments(),
                     JOINED_LINEBEAKS = Array.from(astUtils.LINEBREAKS).join(""),
-                    pattern = new RegExp(String.raw`[^ \t${JOINED_LINEBEAKS}].? {2,}`, "g");  // note: repeating space
+                    pattern = new RegExp(String.raw`[^ \t${JOINED_LINEBEAKS}].? {2,}`, "g"); // note: repeating space
                 let parent;
 
                 while (pattern.test(source)) {

--- a/lib/rules/no-multi-spaces.js
+++ b/lib/rules/no-multi-spaces.js
@@ -49,7 +49,7 @@ module.exports = {
         const sourceCode = context.getSourceCode(),
             exceptions = { Property: true },
             options = context.options[0] || {},
-            ignoreEOLComments = options.ignoreEOLComments !== false;
+            ignoreEOLComments = options.ignoreEOLComments;
         let hasExceptions = true,
             lastCommentIndex = 0;
 
@@ -73,7 +73,8 @@ module.exports = {
         function isLastTokenOfLine(token) {
             const nextToken = sourceCode.getTokenAfter(token, { includeComments: true });
 
-            // nextToken is undefined if the comment is the last token in the program.
+console.log(nextToken);
+            // nextToken is null if the comment is the last token in the program.
             if (!nextToken) {
                 return true;
             }

--- a/lib/rules/no-unmodified-loop-condition.js
+++ b/lib/rules/no-unmodified-loop-condition.js
@@ -18,7 +18,7 @@ const Traverser = require("../util/traverser"),
 
 const pushAll = Function.apply.bind(Array.prototype.push);
 const SENTINEL_PATTERN = /(?:(?:Call|Class|Function|Member|New|Yield)Expression|Statement|Declaration)$/;
-const LOOP_PATTERN = /^(?:DoWhile|For|While)Statement$/;  // for-in/of statements don't have `test` property.
+const LOOP_PATTERN = /^(?:DoWhile|For|While)Statement$/; // for-in/of statements don't have `test` property.
 const GROUP_PATTERN = /^(?:BinaryExpression|ConditionalExpression)$/;
 const SKIP_PATTERN = /^(?:ArrowFunction|Class|Function)Expression$/;
 const DYNAMIC_PATTERN = /^(?:Call|Member|New|TaggedTemplate|Yield)Expression$/;

--- a/lib/rules/prefer-arrow-callback.js
+++ b/lib/rules/prefer-arrow-callback.js
@@ -159,7 +159,7 @@ module.exports = {
     create(context) {
         const options = context.options[0] || {};
 
-        const allowUnboundThis = options.allowUnboundThis !== false;  // default to true
+        const allowUnboundThis = options.allowUnboundThis !== false; // default to true
         const allowNamedFunctions = options.allowNamedFunctions;
         const sourceCode = context.getSourceCode();
 

--- a/lib/rules/valid-jsdoc.js
+++ b/lib/rules/valid-jsdoc.js
@@ -180,18 +180,18 @@ module.exports = {
             let elements = [];
 
             switch (type.type) {
-                case "TypeApplication":  // {Array.<String>}
+                case "TypeApplication": // {Array.<String>}
                     elements = type.applications[0].type === "UnionType" ? type.applications[0].elements : type.applications;
                     typesToCheck.push(getCurrentExpectedTypes(type));
                     break;
-                case "RecordType":  // {{20:String}}
+                case "RecordType": // {{20:String}}
                     elements = type.fields;
                     break;
-                case "UnionType":  // {String|number|Test}
-                case "ArrayType":  // {[String, number, Test]}
+                case "UnionType": // {String|number|Test}
+                case "ArrayType": // {[String, number, Test]}
                     elements = type.elements;
                     break;
-                case "FieldType":  // Array.<{count: number, votes: number}>
+                case "FieldType": // Array.<{count: number, votes: number}>
                     if (type.value) {
                         typesToCheck.push(getCurrentExpectedTypes(type.value));
                     }

--- a/lib/timing.js
+++ b/lib/timing.js
@@ -98,7 +98,7 @@ function display(data) {
         return ALIGN[index](":", w + 1, "-");
     }).join("|"));
 
-    console.log(table.join("\n"));      // eslint-disable-line no-console
+    console.log(table.join("\n")); // eslint-disable-line no-console
 }
 
 /* istanbul ignore next */

--- a/lib/util/module-resolver.js
+++ b/lib/util/module-resolver.js
@@ -68,7 +68,7 @@ class ModuleResolver {
          * lookup file paths when require() is called. So, we are hooking into the
          * exact same logic that Node.js uses.
          */
-        const result = Module._findPath(name, lookupPaths);   // eslint-disable-line no-underscore-dangle
+        const result = Module._findPath(name, lookupPaths); // eslint-disable-line no-underscore-dangle
 
         if (!result) {
             throw new Error(`Cannot find module '${name}'`);

--- a/tests/lib/config/config-file.js
+++ b/tests/lib/config/config-file.js
@@ -53,7 +53,7 @@ function getFixturePath(filepath) {
  * @private
  */
 function readJSModule(code) {
-    return eval(`var module = {};\n${code}`);  // eslint-disable-line no-eval
+    return eval(`var module = {};\n${code}`); // eslint-disable-line no-eval
 }
 
 /**
@@ -669,7 +669,7 @@ describe("ConfigFile", () => {
                 rules: {
                     a: 2, // from node_modules/eslint-config-a
                     b: 2, // from node_modules/eslint-config-a/node_modules/eslint-config-b
-                    c: 2  // from node_modules/eslint-config-a/node_modules/eslint-config-b/node_modules/eslint-config-c
+                    c: 2 // from node_modules/eslint-config-a/node_modules/eslint-config-b/node_modules/eslint-config-c
                 }
             });
         });
@@ -683,7 +683,7 @@ describe("ConfigFile", () => {
                 globals: {},
                 parserOptions: {},
                 rules: {
-                    a: 2,       // from node_modules/eslint-config-a/index.js
+                    a: 2, // from node_modules/eslint-config-a/index.js
                     relative: 2 // from node_modules/eslint-config-a/relative.js
                 }
             });
@@ -698,7 +698,7 @@ describe("ConfigFile", () => {
                 globals: {},
                 parserOptions: {},
                 rules: {
-                    a: 2,       // from node_modules/eslint-config-a/index.js
+                    a: 2, // from node_modules/eslint-config-a/index.js
                     relative: 2 // from node_modules/eslint-config-a/relative.js
                 }
             });
@@ -741,7 +741,7 @@ describe("ConfigFile", () => {
                     globals: {},
                     parserOptions: {},
                     rules: {
-                        a: 2,       // from node_modules/eslint-config-a/index.js
+                        a: 2, // from node_modules/eslint-config-a/index.js
                         relative: 2 // from node_modules/eslint-config-a/relative.js
                     }
                 });

--- a/tests/lib/config/config-initializer.js
+++ b/tests/lib/config/config-initializer.js
@@ -255,7 +255,7 @@ describe("configInitializer", () => {
                     process.chdir(originalDir);
                     throw err;
                 } finally {
-                    sandbox.restore();  // restore console.log()
+                    sandbox.restore(); // restore console.log()
                 }
             });
 

--- a/tests/lib/ignored-paths.js
+++ b/tests/lib/ignored-paths.js
@@ -85,7 +85,7 @@ function countDefaultPatterns(ignoredPaths) {
     let count = ignoredPaths.defaultPatterns.length;
 
     if (!ignoredPaths.options || (ignoredPaths.options.dotfiles !== true)) {
-        count = count + 2;  // Two patterns for ignoring dotfiles
+        count = count + 2; // Two patterns for ignoring dotfiles
     }
     return count;
 }

--- a/tests/lib/rules/no-await-in-loop.js
+++ b/tests/lib/rules/no-await-in-loop.js
@@ -20,7 +20,7 @@ ruleTester.run("no-await-in-loop", rule, {
         "async function foo() { for (var bar = await baz in qux) {} }",
 
         // While loops
-        "async function foo() { while (true) { async function foo() { await bar; } } }",  // Blocked by a function declaration
+        "async function foo() { while (true) { async function foo() { await bar; } } }", // Blocked by a function declaration
         // For loops
         "async function foo() { for (var i = await bar; i < n; i++) {  } }",
 

--- a/tests/lib/rules/no-else-return.js
+++ b/tests/lib/rules/no-else-return.js
@@ -46,7 +46,7 @@ ruleTester.run("no-else-return", rule, {
             errors: [{ message: "Unnecessary 'else' after 'return'.", type: "ReturnStatement" }] },
         {
             code: "function foo4() { if (true) { if (false) return x; else return y; } else { return z; } }",
-            output: "function foo4() { if (true) { if (false) return x; return y; } else { return z; } }",  // Other case is fixed in the second pass.
+            output: "function foo4() { if (true) { if (false) return x; return y; } else { return z; } }", // Other case is fixed in the second pass.
             errors: [{ message: "Unnecessary 'else' after 'return'.", type: "ReturnStatement" }, { message: "Unnecessary 'else' after 'return'.", type: "BlockStatement" }]
         },
         {
@@ -61,7 +61,7 @@ ruleTester.run("no-else-return", rule, {
         },
         {
             code: "function foo7() { if (true) { if (false) { if (true) return x; else return y; } return w; } else { return z; } }",
-            output: "function foo7() { if (true) { if (false) { if (true) return x; return y; } return w; } else { return z; } }",  // Other case is fixed in the second pass.
+            output: "function foo7() { if (true) { if (false) { if (true) return x; return y; } return w; } else { return z; } }", // Other case is fixed in the second pass.
             errors: [
                 { message: "Unnecessary 'else' after 'return'.", type: "ReturnStatement" },
                 { message: "Unnecessary 'else' after 'return'.", type: "BlockStatement" }
@@ -69,7 +69,7 @@ ruleTester.run("no-else-return", rule, {
         },
         {
             code: "function foo8() { if (true) { if (false) { if (true) return x; else return y; } else { w = x; } } else { return z; } }",
-            output: "function foo8() { if (true) { if (false) { if (true) return x; return y; } else { w = x; } } else { return z; } }",  // Other case is fixed in the second pass.
+            output: "function foo8() { if (true) { if (false) { if (true) return x; return y; } else { w = x; } } else { return z; } }", // Other case is fixed in the second pass.
             errors: [
                 { message: "Unnecessary 'else' after 'return'.", type: "ReturnStatement" },
                 { message: "Unnecessary 'else' after 'return'.", type: "BlockStatement" }

--- a/tests/lib/rules/no-multi-spaces.js
+++ b/tests/lib/rules/no-multi-spaces.js
@@ -74,7 +74,23 @@ ruleTester.run("no-multi-spaces", rule, {
         {
             code: "var  answer = 6 *  7;",
             options: [{ exceptions: { VariableDeclaration: true, BinaryExpression: true } }]
-        }
+        },
+
+        // https://github.com/eslint/eslint/issues/7693
+        "var x = 5;  // comment",
+        "var x = 5;  /* multiline\n * comment\n */",
+        "var x = 5;\n  // comment",
+        "var x = 5;  \n// comment",
+        "var x = 5;\n  /* multiline\n * comment\n */",
+        "var x = 5;  \n/* multiline\n * comment\n */",
+        { code: "var x = 5;  // comment", options: [{ ignoreEOLComments: true }] },
+        { code: "var x = 5;  /* multiline\n * comment\n */", options: [{ ignoreEOLComments: true }] },
+        { code: "var x = 5;\n  // comment", options: [{ ignoreEOLComments: true }] },
+        { code: "var x = 5;  \n// comment", options: [{ ignoreEOLComments: true }] },
+        { code: "var x = 5;\n  /* multiline\n * comment\n */", options: [{ ignoreEOLComments: true }] },
+        { code: "var x = 5;  \n/* multiline\n * comment\n */", options: [{ ignoreEOLComments: true }] },
+        { code: "var x = 5; // comment", options: [{ ignoreEOLComments: false }] },
+        { code: "var x = 5; /* multiline\n * comment\n */", options: [{ ignoreEOLComments: false }] }
     ],
 
     invalid: [
@@ -378,6 +394,143 @@ ruleTester.run("no-multi-spaces", rule, {
             errors: [{
                 message: "Multiple spaces found before '5'.",
                 type: "Numeric"
+            }]
+        },
+
+        // https://github.com/eslint/eslint/issues/7693
+        {
+            code: "var x =  /* comment */ 5;",
+            output: "var x = /* comment */ 5;",
+            options: [{ ignoreEOLComments: false }],
+            errors: [{
+                message: "Multiple spaces found before '/* comment */'.",
+                type: "Block"
+            }]
+        },
+        {
+            code: "var x = /* comment */  5;",
+            output: "var x = /* comment */ 5;",
+            options: [{ ignoreEOLComments: false }],
+            errors: [{
+                message: "Multiple spaces found before '5'.",
+                type: "Numeric"
+            }]
+        },
+        {
+            code: "var x = 5;  // comment",
+            output: "var x = 5; // comment",
+            options: [{ ignoreEOLComments: false }],
+            errors: [{
+                message: "Multiple spaces found before '// comment'.",
+                type: "Line"
+            }]
+        },
+        {
+            code: "var x = 5;  // comment\nvar y = 6;",
+            output: "var x = 5; // comment\nvar y = 6;",
+            options: [{ ignoreEOLComments: false }],
+            errors: [{
+                message: "Multiple spaces found before '// comment'.",
+                type: "Line"
+            }]
+        },
+        {
+            code: "var x = 5;  /* multiline\n * comment\n */",
+            output: "var x = 5; /* multiline\n * comment\n */",
+            options: [{ ignoreEOLComments: false }],
+            errors: [{
+                message: "Multiple spaces found before '/* multiline...*/'.",
+                type: "Block"
+            }]
+        },
+        {
+            code: "var x = 5;  /* multiline\n * comment\n */\nvar y = 6;",
+            output: "var x = 5; /* multiline\n * comment\n */\nvar y = 6;",
+            options: [{ ignoreEOLComments: false }],
+            errors: [{
+                message: "Multiple spaces found before '/* multiline...*/'.",
+                type: "Block"
+            }]
+        },
+        {
+            code: "var x = 5;  // this is a long comment",
+            output: "var x = 5; // this is a long comment",
+            options: [{ ignoreEOLComments: false }],
+            errors: [{
+                message: "Multiple spaces found before '// this is a l...'.",
+                type: "Line"
+            }]
+        },
+        {
+            code: "var x =  /* comment */ 5;  // EOL comment",
+            output: "var x = /* comment */ 5;  // EOL comment",
+            options: [{ ignoreEOLComments: true }],
+            errors: [{
+                message: "Multiple spaces found before '/* comment */'.",
+                type: "Block"
+            }]
+        },
+        {
+            code: "var x =  /* comment */ 5;  // EOL comment\nvar y = 6;",
+            output: "var x = /* comment */ 5;  // EOL comment\nvar y = 6;",
+            options: [{ ignoreEOLComments: true }],
+            errors: [{
+                message: "Multiple spaces found before '/* comment */'.",
+                type: "Block"
+            }]
+        },
+        {
+            code: "var x = /* comment */  5;  /* EOL comment */",
+            output: "var x = /* comment */ 5;  /* EOL comment */",
+            options: [{ ignoreEOLComments: true }],
+            errors: [{
+                message: "Multiple spaces found before '5'.",
+                type: "Numeric"
+            }]
+        },
+        {
+            code: "var x = /* comment */  5;  /* EOL comment */\nvar y = 6;",
+            output: "var x = /* comment */ 5;  /* EOL comment */\nvar y = 6;",
+            options: [{ ignoreEOLComments: true }],
+            errors: [{
+                message: "Multiple spaces found before '5'.",
+                type: "Numeric"
+            }]
+        },
+        {
+            code: "var x =  /*comment without spaces*/ 5;",
+            output: "var x = /*comment without spaces*/ 5;",
+            options: [{ ignoreEOLComments: true }],
+            errors: [{
+                message: "Multiple spaces found before '/*comment with...*/'.",
+                type: "Block"
+            }]
+        },
+        {
+            code: "var x = 5;  //comment without spaces",
+            output: "var x = 5; //comment without spaces",
+            options: [{ ignoreEOLComments: false }],
+            errors: [{
+                message: "Multiple spaces found before '//comment with...'.",
+                type: "Line"
+            }]
+        },
+        {
+            code: "var x = 5;  /*comment without spaces*/",
+            output: "var x = 5; /*comment without spaces*/",
+            options: [{ ignoreEOLComments: false }],
+            errors: [{
+                message: "Multiple spaces found before '/*comment with...*/'.",
+                type: "Block"
+            }]
+        },
+        {
+            code: "var x = 5;  /*comment\n without spaces*/",
+            output: "var x = 5; /*comment\n without spaces*/",
+            options: [{ ignoreEOLComments: false }],
+            errors: [{
+                message: "Multiple spaces found before '/*comment...*/'.",
+                type: "Block"
             }]
         }
     ]

--- a/tests/lib/rules/no-multi-spaces.js
+++ b/tests/lib/rules/no-multi-spaces.js
@@ -77,20 +77,24 @@ ruleTester.run("no-multi-spaces", rule, {
         },
 
         // https://github.com/eslint/eslint/issues/7693
-        "var x = 5;  // comment",
-        "var x = 5;  /* multiline\n * comment\n */",
+        "var x = 5; // comment",
+        "var x = 5; /* multiline\n * comment\n */",
         "var x = 5;\n  // comment",
         "var x = 5;  \n// comment",
         "var x = 5;\n  /* multiline\n * comment\n */",
         "var x = 5;  \n/* multiline\n * comment\n */",
+        { code: "var x = 5; // comment", options: [{ ignoreEOLComments: false }] },
+        { code: "var x = 5; /* multiline\n * comment\n */", options: [{ ignoreEOLComments: false }] },
+        { code: "var x = 5;\n  // comment", options: [{ ignoreEOLComments: false }] },
+        { code: "var x = 5;  \n// comment", options: [{ ignoreEOLComments: false }] },
+        { code: "var x = 5;\n  /* multiline\n * comment\n */", options: [{ ignoreEOLComments: false }] },
+        { code: "var x = 5;  \n/* multiline\n * comment\n */", options: [{ ignoreEOLComments: false }] },
         { code: "var x = 5;  // comment", options: [{ ignoreEOLComments: true }] },
         { code: "var x = 5;  /* multiline\n * comment\n */", options: [{ ignoreEOLComments: true }] },
         { code: "var x = 5;\n  // comment", options: [{ ignoreEOLComments: true }] },
         { code: "var x = 5;  \n// comment", options: [{ ignoreEOLComments: true }] },
         { code: "var x = 5;\n  /* multiline\n * comment\n */", options: [{ ignoreEOLComments: true }] },
-        { code: "var x = 5;  \n/* multiline\n * comment\n */", options: [{ ignoreEOLComments: true }] },
-        { code: "var x = 5; // comment", options: [{ ignoreEOLComments: false }] },
-        { code: "var x = 5; /* multiline\n * comment\n */", options: [{ ignoreEOLComments: false }] }
+        { code: "var x = 5;  \n/* multiline\n * comment\n */", options: [{ ignoreEOLComments: true }] }
     ],
 
     invalid: [
@@ -398,6 +402,62 @@ ruleTester.run("no-multi-spaces", rule, {
         },
 
         // https://github.com/eslint/eslint/issues/7693
+        {
+            code: "var x =  /* comment */ 5;",
+            output: "var x = /* comment */ 5;",
+            errors: [{
+                message: "Multiple spaces found before '/* comment */'.",
+                type: "Block"
+            }]
+        },
+        {
+            code: "var x = /* comment */  5;",
+            output: "var x = /* comment */ 5;",
+            errors: [{
+                message: "Multiple spaces found before '5'.",
+                type: "Numeric"
+            }]
+        },
+        {
+            code: "var x = 5;  // comment",
+            output: "var x = 5; // comment",
+            errors: [{
+                message: "Multiple spaces found before '// comment'.",
+                type: "Line"
+            }]
+        },
+        {
+            code: "var x = 5;  // comment\nvar y = 6;",
+            output: "var x = 5; // comment\nvar y = 6;",
+            errors: [{
+                message: "Multiple spaces found before '// comment'.",
+                type: "Line"
+            }]
+        },
+        {
+            code: "var x = 5;  /* multiline\n * comment\n */",
+            output: "var x = 5; /* multiline\n * comment\n */",
+            errors: [{
+                message: "Multiple spaces found before '/* multiline...*/'.",
+                type: "Block"
+            }]
+        },
+        {
+            code: "var x = 5;  /* multiline\n * comment\n */\nvar y = 6;",
+            output: "var x = 5; /* multiline\n * comment\n */\nvar y = 6;",
+            errors: [{
+                message: "Multiple spaces found before '/* multiline...*/'.",
+                type: "Block"
+            }]
+        },
+        {
+            code: "var x = 5;  // this is a long comment",
+            output: "var x = 5; // this is a long comment",
+            errors: [{
+                message: "Multiple spaces found before '// this is a l...'.",
+                type: "Line"
+            }]
+        },
         {
             code: "var x =  /* comment */ 5;",
             output: "var x = /* comment */ 5;",

--- a/tests/lib/rules/no-self-assign.js
+++ b/tests/lib/rules/no-self-assign.js
@@ -46,7 +46,7 @@ ruleTester.run("no-self-assign", rule, {
         { code: "a[b] = a.b", options: [{ props: true }] },
         { code: "a.b().c = a.b().c", options: [{ props: true }] },
         { code: "b().c = b().c", options: [{ props: true }] },
-        { code: "a[b + 1] = a[b + 1]", options: [{ props: true }] },  // it ignores non-simple computed properties.
+        { code: "a[b + 1] = a[b + 1]", options: [{ props: true }] }, // it ignores non-simple computed properties.
         { code: "a.b = a.b" },
         { code: "a.b.c = a.b.c" },
         { code: "a[b] = a[b]" },

--- a/tests/lib/rules/no-useless-return.js
+++ b/tests/lib/rules/no-useless-return.js
@@ -211,7 +211,7 @@ ruleTester.run("no-useless-return", rule, {
                 }
                 return;
               }
-            `,  // Other case is fixed in the second pass.
+            `, // Other case is fixed in the second pass.
             errors: [
                 { message: "Unnecessary return statement.", type: "ReturnStatement" },
                 { message: "Unnecessary return statement.", type: "ReturnStatement" }
@@ -416,7 +416,7 @@ ruleTester.run("no-useless-return", rule, {
         },
         {
             code: "function foo() { return; return; }",
-            output: "function foo() {  return; }",  // Other case is fixed in the second pass.
+            output: "function foo() {  return; }", // Other case is fixed in the second pass.
             errors: [
                 { message: "Unnecessary return statement.", type: "ReturnStatement" },
                 { message: "Unnecessary return statement.", type: "ReturnStatement" }


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
This PR makes `no-multi-spaces` check for multiple spaces around inline comments (which it currently completely ignores). This change will increase the number of warnings by default. I do think this is the expected behavior though, and in my mind this is a bug fix. Additionally, we decided to add an `ignoreEOLComments` (`false` by default, making it a breaking change).

With the changes made in this PR, the following will now report by default:
```js
var x =      /* comment */ 5;
var x = 5;    // comment
var x = 5;    /* multiline
 * comment
 */
```

While this will not:
```js
var x = /* comment */ 5;
var x = 5; // comment
var x = 5; /* multiline
 * comment
 */
```
With `ignoreEOLComments: false`, the rule will additionally warn about the following:
```js
var x = 5;    // comment
var x = 5;    /* multiline
 * comment
 */
```

**Is there anything you'd like reviewers to focus on?**
Want to make sure everyone agrees that this should be included in a semver-minor release, as it does increase the number of warnings by default.
