### PR TITLE
Update: add fixer for `operator-linebreak`

### DIFF
--- a/docs/rules/operator-linebreak.md
+++ b/docs/rules/operator-linebreak.md
@@ -1,5 +1,7 @@
 # enforce consistent linebreak style for operators (operator-linebreak)
 
+(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 When a statement is too long to fit on a single line, line breaks are generally inserted next to the operators separating expressions. The first style coming to mind would be to place the operator at the end of the line, following the english punctuation rules.
 
 ```js

--- a/lib/rules/operator-linebreak.js
+++ b/lib/rules/operator-linebreak.js
@@ -84,6 +84,11 @@ module.exports = {
 
                 if (hasLinebreakBefore !== hasLinebreakAfter && desiredStyle !== "none") {
 
+                    // If there is a comment before and after the operator, don't do a fix.
+                    if (sourceCode.getTokenOrCommentBefore(operatorToken) !== tokenBefore && sourceCode.getTokenOrCommentAfter(operatorToken) !== tokenAfter) {
+                        return null;
+                    }
+
                     /*
                      * If there is only one linebreak and it's on the wrong side of the operator, swap the text before and after the operator.
                      * foo &&

--- a/lib/rules/operator-linebreak.js
+++ b/lib/rules/operator-linebreak.js
@@ -11,6 +11,8 @@ const astUtils = require("../ast-utils");
 // Rule Definition
 //------------------------------------------------------------------------------
 
+const LINEBREAK_REGEX = /\r\n|\r|\n|\u2028|\u2029/g;
+
 module.exports = {
     meta: {
         docs: {
@@ -38,7 +40,9 @@ module.exports = {
                 },
                 additionalProperties: false
             }
-        ]
+        ],
+
+        fixable: "code"
     },
 
     create(context) {
@@ -61,6 +65,56 @@ module.exports = {
         //--------------------------------------------------------------------------
         // Helpers
         //--------------------------------------------------------------------------
+
+        /**
+        * Gets a fixer function to fix rule issues
+        * @param {Token} operatorToken The operator token of an expression
+        * @param {string} desiredStyle The style for the rule. One of 'before', 'after', 'none'
+        * @returns {Function} A fixer function
+        */
+        function getFixer(operatorToken, desiredStyle) {
+            return fixer => {
+                const tokenBefore = sourceCode.getTokenBefore(operatorToken);
+                const tokenAfter = sourceCode.getTokenAfter(operatorToken);
+                const textBefore = sourceCode.text.slice(tokenBefore.range[1], operatorToken.range[0]);
+                const textAfter = sourceCode.text.slice(operatorToken.range[1], tokenAfter.range[0]);
+                const hasLinebreakBefore = !astUtils.isTokenOnSameLine(tokenBefore, operatorToken);
+                const hasLinebreakAfter = !astUtils.isTokenOnSameLine(operatorToken, tokenAfter);
+                let newTextBefore, newTextAfter;
+
+                if (hasLinebreakBefore !== hasLinebreakAfter && desiredStyle !== "none") {
+
+                    /*
+                     * If there is only one linebreak and it's on the wrong side of the operator, swap the text before and after the operator.
+                     * foo &&
+                     *           bar
+                     * would get fixed to
+                     * foo
+                     *        && bar
+                     */
+                    newTextBefore = textAfter;
+                    newTextAfter = textBefore;
+                } else {
+
+                    // Otherwise, if no linebreak is desired and no comments interfere, replace the linebreaks with empty strings.
+                    newTextBefore = desiredStyle === "before" || textBefore.trim() ? textBefore : textBefore.replace(LINEBREAK_REGEX, "");
+                    newTextAfter = desiredStyle === "after" || textAfter.trim() ? textAfter : textAfter.replace(LINEBREAK_REGEX, "");
+
+                    // If there was no change (due to interfering comments), don't output a fix.
+                    if (newTextBefore === textBefore && newTextAfter === textAfter) {
+                        return null;
+                    }
+                }
+
+                if (newTextAfter === "" && tokenAfter.type === "Punctuator" && "+-".includes(operatorToken.value) && tokenAfter.value === operatorToken.value) {
+
+                    // To avoid accidentally creating a ++ or -- operator, insert a space if the operator is a +/- and the following token is a unary +/-.
+                    newTextAfter += " ";
+                }
+
+                return fixer.replaceTextRange([tokenBefore.range[1], tokenAfter.range[0]], newTextBefore + operatorToken.value + newTextAfter);
+            };
+        }
 
         /**
          * Checks the operator placement
@@ -87,6 +141,7 @@ module.exports = {
             const operator = operatorToken.value;
             const operatorStyleOverride = styleOverrides[operator];
             const style = operatorStyleOverride || globalStyle;
+            const fix = getFixer(operatorToken, style);
 
             // if single line
             if (astUtils.isTokenOnSameLine(leftToken, operatorToken) &&
@@ -107,7 +162,8 @@ module.exports = {
                     message: "Bad line breaking before and after '{{operator}}'.",
                     data: {
                         operator
-                    }
+                    },
+                    fix
                 });
 
             } else if (style === "before" && astUtils.isTokenOnSameLine(leftToken, operatorToken)) {
@@ -121,7 +177,8 @@ module.exports = {
                     message: "'{{operator}}' should be placed at the beginning of the line.",
                     data: {
                         operator
-                    }
+                    },
+                    fix
                 });
 
             } else if (style === "after" && astUtils.isTokenOnSameLine(operatorToken, rightToken)) {
@@ -135,7 +192,8 @@ module.exports = {
                     message: "'{{operator}}' should be placed at the end of the line.",
                     data: {
                         operator
-                    }
+                    },
+                    fix
                 });
 
             } else if (style === "none") {
@@ -149,7 +207,8 @@ module.exports = {
                     message: "There should be no line break before or after '{{operator}}'.",
                     data: {
                         operator
-                    }
+                    },
+                    fix
                 });
 
             }

--- a/tests/lib/rules/operator-linebreak.js
+++ b/tests/lib/rules/operator-linebreak.js
@@ -454,6 +454,17 @@ ruleTester.run("operator-linebreak", rule, {
             output: "foo\n+//comment\nbar",
             options: ["before"],
             errors: [{ message: util.format(BAD_LN_BRK_MSG, "+"), type: "BinaryExpression", line: 2, column: 2 }]
+        },
+        {
+            code: "foo /* a */ \n+ /* b */ bar",
+            output: "foo /* a */ \n+ /* b */ bar", // Not fixed because there is a comment on both sides
+            errors: [{ message: util.format(AFTER_MSG, "+"), type: "BinaryExpression", line: 2, column: 2 }]
+        },
+        {
+            code: "foo /* a */ +\n /* b */ bar",
+            output: "foo /* a */ +\n /* b */ bar", // Not fixed because there is a comment on both sides
+            options: ["before"],
+            errors: [{ message: util.format(BEFORE_MSG, "+"), type: "BinaryExpression", line: 1, column: 14 }]
         }
     ]
 });

--- a/tests/lib/rules/operator-linebreak.js
+++ b/tests/lib/rules/operator-linebreak.js
@@ -69,6 +69,7 @@ ruleTester.run("operator-linebreak", rule, {
     invalid: [
         {
             code: "1\n+ 1",
+            output: "1 +\n1",
             errors: [{
                 message: util.format(AFTER_MSG, "+"),
                 type: "BinaryExpression",
@@ -78,6 +79,7 @@ ruleTester.run("operator-linebreak", rule, {
         },
         {
             code: "1 + 2 \n + 3",
+            output: "1 + 2 + \n 3",
             errors: [{
                 message: util.format(AFTER_MSG, "+"),
                 type: "BinaryExpression",
@@ -87,6 +89,7 @@ ruleTester.run("operator-linebreak", rule, {
         },
         {
             code: "1\n+\n1",
+            output: "1+\n1",
             errors: [{
                 message: util.format(BAD_LN_BRK_MSG, "+"),
                 type: "BinaryExpression",
@@ -96,6 +99,7 @@ ruleTester.run("operator-linebreak", rule, {
         },
         {
             code: "1 + (1\n+ 1)",
+            output: "1 + (1 +\n1)",
             errors: [{
                 message: util.format(AFTER_MSG, "+"),
                 type: "BinaryExpression",
@@ -105,6 +109,7 @@ ruleTester.run("operator-linebreak", rule, {
         },
         {
             code: "f(1\n+ 1);",
+            output: "f(1 +\n1);",
             errors: [{
                 message: util.format(AFTER_MSG, "+"),
                 type: "BinaryExpression",
@@ -114,6 +119,7 @@ ruleTester.run("operator-linebreak", rule, {
         },
         {
             code: "1 \n || 1",
+            output: "1 || \n 1",
             errors: [{
                 message: util.format(AFTER_MSG, "||"),
                 type: "LogicalExpression",
@@ -123,6 +129,7 @@ ruleTester.run("operator-linebreak", rule, {
         },
         {
             code: "a\n += 1",
+            output: "a +=\n 1",
             errors: [{
                 message: util.format(AFTER_MSG, "+="),
                 type: "AssignmentExpression",
@@ -132,6 +139,7 @@ ruleTester.run("operator-linebreak", rule, {
         },
         {
             code: "var a\n = 1",
+            output: "var a =\n 1",
             errors: [{
                 message: util.format(AFTER_MSG, "="),
                 type: "VariableDeclarator",
@@ -141,6 +149,7 @@ ruleTester.run("operator-linebreak", rule, {
         },
         {
             code: "(b)\n*\n(c)",
+            output: "(b)*\n(c)",
             errors: [{
                 message: util.format(BAD_LN_BRK_MSG, "*"),
                 type: "BinaryExpression",
@@ -150,6 +159,7 @@ ruleTester.run("operator-linebreak", rule, {
         },
         {
             code: "answer = everything ?\n  42 :\n  foo;",
+            output: "answer = everything\n  ? 42\n  : foo;",
             errors: [{
                 message: util.format(BEFORE_MSG, "?"),
                 type: "ConditionalExpression",
@@ -166,6 +176,7 @@ ruleTester.run("operator-linebreak", rule, {
 
         {
             code: "answer = everything \n?  42 \n:  foo;",
+            output: "answer = everything  ? \n42  : \nfoo;",
             options: ["after"],
             errors: [{
                 message: util.format(AFTER_MSG, "?"),
@@ -183,6 +194,7 @@ ruleTester.run("operator-linebreak", rule, {
 
         {
             code: "1 +\n1",
+            output: "1\n+ 1",
             options: ["before"],
             errors: [{
                 message: util.format(BEFORE_MSG, "+"),
@@ -193,6 +205,7 @@ ruleTester.run("operator-linebreak", rule, {
         },
         {
             code: "f(1 +\n1);",
+            output: "f(1\n+ 1);",
             options: ["before"],
             errors: [{
                 message: util.format(BEFORE_MSG, "+"),
@@ -203,6 +216,7 @@ ruleTester.run("operator-linebreak", rule, {
         },
         {
             code: "1 || \n 1",
+            output: "1 \n || 1",
             options: ["before"],
             errors: [{
                 message: util.format(BEFORE_MSG, "||"),
@@ -213,6 +227,7 @@ ruleTester.run("operator-linebreak", rule, {
         },
         {
             code: "a += \n1",
+            output: "a \n+= 1",
             options: ["before"],
             errors: [{
                 message: util.format(BEFORE_MSG, "+="),
@@ -223,6 +238,7 @@ ruleTester.run("operator-linebreak", rule, {
         },
         {
             code: "var a = \n1",
+            output: "var a \n= 1",
             options: ["before"],
             errors: [{
                 message: util.format(BEFORE_MSG, "="),
@@ -233,6 +249,7 @@ ruleTester.run("operator-linebreak", rule, {
         },
         {
             code: "answer = everything ?\n  42 :\n  foo;",
+            output: "answer = everything\n  ? 42\n  : foo;",
             options: ["before"],
             errors: [{
                 message: util.format(BEFORE_MSG, "?"),
@@ -250,6 +267,7 @@ ruleTester.run("operator-linebreak", rule, {
 
         {
             code: "1 +\n1",
+            output: "1 +1",
             options: ["none"],
             errors: [{
                 message: util.format(NONE_MSG, "+"),
@@ -260,6 +278,7 @@ ruleTester.run("operator-linebreak", rule, {
         },
         {
             code: "1\n+1",
+            output: "1+1",
             options: ["none"],
             errors: [{
                 message: util.format(NONE_MSG, "+"),
@@ -270,6 +289,7 @@ ruleTester.run("operator-linebreak", rule, {
         },
         {
             code: "f(1 +\n1);",
+            output: "f(1 +1);",
             options: ["none"],
             errors: [{
                 message: util.format(NONE_MSG, "+"),
@@ -280,6 +300,7 @@ ruleTester.run("operator-linebreak", rule, {
         },
         {
             code: "f(1\n+ 1);",
+            output: "f(1+ 1);",
             options: ["none"],
             errors: [{
                 message: util.format(NONE_MSG, "+"),
@@ -290,6 +311,7 @@ ruleTester.run("operator-linebreak", rule, {
         },
         {
             code: "1 || \n 1",
+            output: "1 ||  1",
             options: ["none"],
             errors: [{
                 message: util.format(NONE_MSG, "||"),
@@ -300,6 +322,7 @@ ruleTester.run("operator-linebreak", rule, {
         },
         {
             code: "1 \n || 1",
+            output: "1  || 1",
             options: ["none"],
             errors: [{
                 message: util.format(NONE_MSG, "||"),
@@ -310,6 +333,7 @@ ruleTester.run("operator-linebreak", rule, {
         },
         {
             code: "a += \n1",
+            output: "a += 1",
             options: ["none"],
             errors: [{
                 message: util.format(NONE_MSG, "+="),
@@ -320,6 +344,7 @@ ruleTester.run("operator-linebreak", rule, {
         },
         {
             code: "a \n+= 1",
+            output: "a += 1",
             options: ["none"],
             errors: [{
                 message: util.format(NONE_MSG, "+="),
@@ -330,6 +355,7 @@ ruleTester.run("operator-linebreak", rule, {
         },
         {
             code: "var a = \n1",
+            output: "var a = 1",
             options: ["none"],
             errors: [{
                 message: util.format(NONE_MSG, "="),
@@ -340,6 +366,7 @@ ruleTester.run("operator-linebreak", rule, {
         },
         {
             code: "var a \n = 1",
+            output: "var a  = 1",
             options: ["none"],
             errors: [{
                 message: util.format(NONE_MSG, "="),
@@ -350,6 +377,7 @@ ruleTester.run("operator-linebreak", rule, {
         },
         {
             code: "answer = everything ?\n  42 \n:  foo;",
+            output: "answer = everything ?  42 :  foo;",
             options: ["none"],
             errors: [{
                 message: util.format(NONE_MSG, "?"),
@@ -365,7 +393,8 @@ ruleTester.run("operator-linebreak", rule, {
             }]
         },
         {
-            code: "answer = everything\n?\n42\n:\nfoo;",
+            code: "answer = everything\n?\n42 + 43\n:\nfoo;",
+            output: "answer = everything?42 + 43:foo;",
             options: ["none"],
             errors: [{
                 message: util.format(BAD_LN_BRK_MSG, "?"),
@@ -382,6 +411,7 @@ ruleTester.run("operator-linebreak", rule, {
         },
         {
             code: "foo +=\n42;\nbar -=\n12\n+ 5;",
+            output: "foo +=42;\nbar -=\n12\n+ 5;",
             options: ["after", { overrides: { "+=": "none", "+": "before" } }],
             errors: [{
                 message: util.format(NONE_MSG, "+="),
@@ -392,6 +422,7 @@ ruleTester.run("operator-linebreak", rule, {
         },
         {
             code: "answer = everything\n?\n42\n:\nfoo;",
+            output: "answer = everything\n?\n42\n:foo;",
             options: ["after", { overrides: { "?": "ignore", ":": "before" } }],
             errors: [{
                 message: util.format(BAD_LN_BRK_MSG, ":"),
@@ -399,6 +430,30 @@ ruleTester.run("operator-linebreak", rule, {
                 line: 4,
                 column: 2
             }]
+        },
+        {
+
+            // Insert an additional space to avoid changing the operator to ++ or --.
+            code: "foo+\n+bar",
+            output: "foo\n+ +bar",
+            options: ["before"],
+            errors: [{ message: util.format(BEFORE_MSG, "+"), type: "BinaryExpression", line: 1, column: 5 }]
+        },
+        {
+            code: "foo //comment\n&& bar",
+            output: "foo && //comment\nbar",
+            errors: [{ message: util.format(AFTER_MSG, "&&"), type: "LogicalExpression", line: 2, column: 3 }]
+        },
+        {
+            code: "foo//comment\n+\nbar",
+            output: "foo//comment\n+\nbar",
+            errors: [{ message: util.format(BAD_LN_BRK_MSG, "+"), type: "BinaryExpression", line: 2, column: 2 }]
+        },
+        {
+            code: "foo\n+//comment\nbar",
+            output: "foo\n+//comment\nbar",
+            options: ["before"],
+            errors: [{ message: util.format(BAD_LN_BRK_MSG, "+"), type: "BinaryExpression", line: 2, column: 2 }]
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Add autofixing to a rule
<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This adds a fixer for [`operator-linebreak`](http://eslint.org/docs/rules/operator-linebreak). The fixer modifies the whitespace around an operator to ensure that the operator is in the right place.

```js
/* eslint operator-linebreak: [error, "after"] */

foo
  && bar;

// gets fixed to:

foo &&
  bar;
```

The fixer can handle comments when there is a single linebreak around the operator, but it doesn't perform a fix when there is a comment and two linebreaks around the operator.

```js
/* eslint operator-linebreak: [error, "after"] */

foo // comment
  && bar;

// gets fixed to:

foo && // comment
  bar;

// ---

foo
&&
bar;

// gets fixed to:

foo &&
bar;

// ---

foo // comment
&& bar; // does not get fixed
```

When the operator is a `+` or `-`, and the following token is a unary `+` or `-`, the fixer inserts a space to avoid creating a `++` or `--` token.

```js
/* eslint operator-linebreak: [error, "before"] */

foo +
+bar; // i.e. foo + (+bar)

// gets fixed to:

foo
+ +bar;
```

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
