### PR TITLE
Lint staged

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,3 +16,6 @@ indent_size = disabled
 
 [docs/rules/no-trailing-spaces.md]
 trim_trailing_whitespace = false
+
+[*.json]
+indent_size = 2

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,21 @@
+{
+  "default": true,
+  "MD001": false,
+  "MD002": false,
+  "MD007": {
+    "indent": 4
+  },
+  "MD012": false,
+  "MD013": false,
+  "MD014": false,
+  "MD019": false,
+  "MD021": false,
+  "MD024": false,
+  "MD026": false,
+  "MD029": false,
+  "MD030": false,
+  "MD033": false,
+  "MD034": false,
+  "MD040": false,
+  "MD041": false
+}

--- a/Makefile.js
+++ b/Makefile.js
@@ -402,32 +402,9 @@ function getBranches() {
  * @private
  */
 function lintMarkdown(files) {
-    const config = {
-            default: true,
-
-            // Exclusions for deliberate/widespread violations
-            MD001: false, // Header levels should only increment by one level at a time
-            MD002: false, // First header should be a h1 header
-            MD007: {      // Unordered list indentation
-                indent: 4
-            },
-            MD012: false, // Multiple consecutive blank lines
-            MD013: false, // Line length
-            MD014: false, // Dollar signs used before commands without showing output
-            MD019: false, // Multiple spaces after hash on atx style header
-            MD021: false, // Multiple spaces inside hashes on closed atx style header
-            MD024: false, // Multiple headers with the same content
-            MD026: false, // Trailing punctuation in header
-            MD029: false, // Ordered list item prefix
-            MD030: false, // Spaces after list markers
-            MD033: false, // Allow inline HTML
-            MD034: false, // Bare URL used
-            MD040: false, // Fenced code blocks should have a language specified
-            MD041: false  // First line in file should be a top level header
-        },
-        result = markdownlint.sync({
+    const result = markdownlint.sync({
             files,
-            config,
+            config: require("./.markdownlint.json"),
             resultVersion: 1
         }),
         resultString = result.toString(),

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "test": "node Makefile.js test",
     "lint": "node Makefile.js lint",
+    "lint-staged": "lint-staged",
     "release": "node Makefile.js release",
     "ci-release": "node Makefile.js ciRelease",
     "alpharelease": "node Makefile.js prerelease -- alpha",
@@ -21,6 +22,12 @@
     "profile": "beefy tests/bench/bench.js --open -- -t brfs -t ./tests/bench/xform-rules.js -r espree",
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "check-commit": "node Makefile.js checkGitCommit"
+  },
+  "pre-commit": "lint-staged",
+  "lint-staged": {
+    "*.js": "node bin/eslint.js --rulesdir lib/internal-rules/",
+    "*.json": "jsonlint",
+    "*.md": "markdownlint"
   },
   "files": [
     "LICENSE",
@@ -88,6 +95,7 @@
     "gh-got": "^2.2.0",
     "istanbul": "^0.4.0",
     "jsdoc": "^3.3.0-beta1",
+    "jsonlint": "^1.6.2",
     "karma": "^0.13.22",
     "karma-babel-preprocessor": "^6.0.1",
     "karma-mocha": "^1.0.1",
@@ -95,12 +103,15 @@
     "karma-phantomjs-launcher": "^1.0.0",
     "leche": "^2.1.1",
     "linefix": "^0.1.1",
+    "lint-staged": "^3.2.1",
     "load-perf": "^0.2.0",
     "markdownlint": "^0.3.1",
+    "markdownlint-cli": "^0.2.0",
     "mocha": "^2.4.5",
     "mock-fs": "^3.12.1",
     "npm-license": "^0.3.2",
     "phantomjs-prebuilt": "^2.1.7",
+    "pre-commit": "^1.1.3",
     "proxyquire": "^1.7.10",
     "semver": "^5.0.3",
     "shelljs-nodecli": "~0.1.0",


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] Other, please explain:

**What changes did you make? (Give an overview)**

Introduced https://github.com/okonet/lint-staged as a pre-commit hook. Lint-staged allows running appropriate linters only on git staged (that are added to the index and about to go into commit).

I've added a basic configuration to run linters for 3 different file types: 

- `*.js` -- using `bin/eslint.js --rulesdir lib/internal-rules/`, 
- `*.json` -- using https://github.com/zaach/jsonlint
- `*.md` -- using https://github.com/igorshubovych/markdownlint-cli

The benefit of running linters in the pre-commit is that linters will only run on changed files that the author is about to commit. This makes it very fast and prevents badly formatted commits. Relying on CI for that is still a good idea but the feedback loop is just too long (time from the commit to the failed CI might be minutes or even hours).

**Is there anything you'd like reviewers to focus on?**

The question is if this should be an opt-in/out behavior. I could add and configure https://github.com/ta2edchimp/opt-cli.

Thoughts?

