### PR TITLE
Update: Add support for flow type import/export declarations

### DIFF
--- a/lib/rules/no-duplicate-imports.js
+++ b/lib/rules/no-duplicate-imports.js
@@ -23,18 +23,47 @@ function getValue(node) {
 }
 
 /**
+ * Returns the optional importKind of the module imported or re-exported.
+ *
+ * @param {ASTNode} node - A node to get.
+ * @returns {string} the importKind of the module, or "value" if no importKind.
+ */
+function getImportKind(node) {
+    if (node && node.importKind) {
+        return node.importKind.trim();
+    }
+
+    return "value";
+}
+
+/**
+ * Returns the optional importKind of the module imported or re-exported.
+ *
+ * @param {ASTNode} node - A node to get.
+ * @returns {string} the importKind of the module, or "value" if no importKind.
+ */
+function getExportKind(node) {
+    if (node && node.exportKind) {
+        return node.exportKind.trim();
+    }
+
+    return "value";
+}
+
+/**
  * Checks if the name of the import or export exists in the given array, and reports if so.
  *
  * @param {RuleContext} context - The ESLint rule context object.
  * @param {ASTNode} node - A node to get.
  * @param {string} value - The name of the imported or exported module.
+ * @param {string} kind - the kind of the imported or exported module (value|type)
  * @param {string[]} array - The array containing other imports or exports in the file.
  * @param {string} message - A message to be reported after the name of the module
  *
  * @returns {void} No return value
  */
-function checkAndReport(context, node, value, array, message) {
-    if (array.indexOf(value) !== -1) {
+function checkAndReport(context, node, value, kind, array, message) {
+    if (array.some(obj => obj.value === value && obj.kind === kind)) {
         context.report({
             node,
             message: "'{{module}}' {{message}}",
@@ -64,15 +93,16 @@ function checkAndReport(context, node, value, array, message) {
 function handleImports(context, includeExports, importsInFile, exportsInFile) {
     return function(node) {
         const value = getValue(node);
+        const kind = getImportKind(node);
 
         if (value) {
-            checkAndReport(context, node, value, importsInFile, "import is duplicated.");
+            checkAndReport(context, node, value, kind, importsInFile, "import is duplicated.");
 
             if (includeExports) {
-                checkAndReport(context, node, value, exportsInFile, "import is duplicated as export.");
+                checkAndReport(context, node, value, kind, exportsInFile, "import is duplicated as export.");
             }
 
-            importsInFile.push(value);
+            importsInFile.push({ value, kind });
         }
     };
 }
@@ -89,12 +119,13 @@ function handleImports(context, includeExports, importsInFile, exportsInFile) {
 function handleExports(context, importsInFile, exportsInFile) {
     return function(node) {
         const value = getValue(node);
+        const kind = getExportKind(node);
 
         if (value) {
-            checkAndReport(context, node, value, exportsInFile, "export is duplicated.");
-            checkAndReport(context, node, value, importsInFile, "export is duplicated as import.");
+            checkAndReport(context, node, value, kind, exportsInFile, "export is duplicated.");
+            checkAndReport(context, node, value, kind, importsInFile, "export is duplicated as import.");
 
-            exportsInFile.push(value);
+            exportsInFile.push({ value, kind });
         }
     };
 }

--- a/lib/rules/no-duplicate-imports.js
+++ b/lib/rules/no-duplicate-imports.js
@@ -37,10 +37,10 @@ function getImportKind(node) {
 }
 
 /**
- * Returns the optional importKind of the module imported or re-exported.
+ * Returns the optional exportKind of the module imported or re-exported.
  *
  * @param {ASTNode} node - A node to get.
- * @returns {string} the importKind of the module, or "value" if no importKind.
+ * @returns {string} the exportKind of the module, or "value" if no exportKind.
  */
 function getExportKind(node) {
     if (node && node.exportKind) {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Other, please explain:
  - This is kind of a bug fix, but not really.

**What changes did you make? (Give an overview)**

A lot of large companies are using FlowType now, which allows you to import/export type definitions via a `type` keyword in the declaration.
```js
import type { FooType } from 'path/to/thing';
export type BarType = {
    type: string,
    foos: Array<FooType>,
};
```
The issue is that these type imports cannot be consolidated into a single import declaration, which means that if you want some function in a file, and a type in a file, it is required that you have an import declaration for each. This breaks the `no-duplicate-imports` rule. We want the following example to not error.
```js
import Foo from 'path/to/foo';
import type { FooType } from 'path/to/foo';
```

The changes shouldn't be noticeable to people not using Flow, but for those who are they will now be able to use this rule without issue.

**Is there anything you'd like reviewers to focus on?**

As far as I could tell there was no good way to add a plugin to a test suite, so I couldn't actually add any new tests for the Flow syntax since it requires the flow parser. The current tests still pass, and I verified the code works in our large Pinterest webapp codebase.
