### PR TITLE
Fix: no-obj-calls does not report errors for Reflect (fixes #7700)

### DIFF
--- a/docs/rules/no-obj-calls.md
+++ b/docs/rules/no-obj-calls.md
@@ -6,9 +6,13 @@ The [ECMAScript 5 specification](http://es5.github.io/#x15.8) makes it clear tha
 
 > The Math object does not have a `[[Call]]` internal property; it is not possible to invoke the Math object as a function.
 
+And the [ECMAScript 2015 specification](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-reflect-object) makes it clear that `Reflect` cannot be invoked:
+
+> The Reflect object also does not have a `[[Call]]` internal method; it is not possible to invoke the Reflect object as a function.
+
 ## Rule Details
 
-This rule disallows calling the `Math` and `JSON` objects as functions.
+This rule disallows calling the `Math`, `JSON` and `Reflect` objects as functions.
 
 Examples of **incorrect** code for this rule:
 
@@ -17,6 +21,7 @@ Examples of **incorrect** code for this rule:
 
 var math = Math();
 var json = JSON();
+var reflect = Reflect();
 ```
 
 Examples of **correct** code for this rule:
@@ -28,6 +33,7 @@ function area(r) {
     return Math.PI * r * r;
 }
 var object = JSON.parse("{}");
+var value = Reflect.get({ x: 1, y: 2 }, "x");
 ```
 
 ## Further Reading

--- a/lib/rules/no-obj-calls.js
+++ b/lib/rules/no-obj-calls.js
@@ -28,7 +28,7 @@ module.exports = {
                 if (node.callee.type === "Identifier") {
                     const name = node.callee.name;
 
-                    if (name === "Math" || name === "JSON") {
+                    if (name === "Math" || name === "JSON" || name === "Reflect") {
                         context.report(node, "'{{name}}' is not a function.", { name });
                     }
                 }

--- a/tests/lib/rules/no-obj-calls.js
+++ b/tests/lib/rules/no-obj-calls.js
@@ -24,6 +24,7 @@ ruleTester.run("no-obj-calls", rule, {
     ],
     invalid: [
         { code: "var x = Math();", errors: [{ message: "'Math' is not a function.", type: "CallExpression"}] },
-        { code: "var x = JSON();", errors: [{ message: "'JSON' is not a function.", type: "CallExpression"}] }
+        { code: "var x = JSON();", errors: [{ message: "'JSON' is not a function.", type: "CallExpression"}] },
+        { code: "var x = Reflect();", errors: [{ message: "'Reflect' is not a function.", type: "CallExpression"}] }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request?**

[x] Bug fix

See #7700 

**What changes did you make?**
I updated [`no-obj-calls`](https://github.com/eslint/eslint/blob/master/lib/rules/no-obj-calls.js) to account for the new global `Reflect` introduced in ECMAScript 2015. This reports an error about the Reflect() call, because it's a global object property and not a function.

**Is there anything you'd like reviewers to focus on?**
Nothing in particular


