### PR TITLE
New: `no-boolean-trap` rule

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -5,6 +5,7 @@
         "no-alert": "off",
         "no-array-constructor": "off",
         "no-bitwise": "off",
+        "no-boolean-trap": "off",
         "no-caller": "off",
         "no-case-declarations": "error",
         "no-catch-shadow": "off",

--- a/docs/rules/no-boolean-trap.md
+++ b/docs/rules/no-boolean-trap.md
@@ -1,0 +1,37 @@
+# disallow boolean trap (no-boolean-trap)
+
+This rule disallows passing `Boolean` literals as arguments in function call expressions, a practice known as *boolean traps* or *flag arguments*
+
+## Rule Details
+
+This rule disallows use of boolean traps.
+
+```js
+// disallowed
+volumeSlider.setValue(90, false);
+volumeSlider.setValue.apply(null, [false]);
+volumeSlider.setValue.call(null, 90, false);
+const set90 = volumeSlider.setValue.bind(null, 90, false);
+
+// allowed
+const animateTransition = false;
+volumeSlider.setValue(90, animateTransition);
+
+// allowed
+volumeSlider.setValue(90, { animation: false } );
+
+// allowed
+// create a function for each responsibility
+volumeSlider.setValue(90);
+// and
+volumeSlider.animateSetValue(90);
+```
+
+## Options
+
+None
+
+## Further Reading
+
+* [hall of api shame: boolean trap](https://ariya.io/2011/08/hall-of-api-shame-boolean-trap)
+* [Clean Code, "Flag Arguments", p41](http://www.goodreads.com/book/show/3735293-clean-code)

--- a/lib/rules/no-boolean-trap.js
+++ b/lib/rules/no-boolean-trap.js
@@ -1,0 +1,51 @@
+/**
+ * @fileoverview disallow boolean traps
+ * @author Morgan Roderick
+ */
+"use strict";
+
+/**
+ * Determines if the argument is a literal boolean, or an Array containing a literal boolean
+ * @param  {Object}  argument [description]
+ * @returns {boolean}          `true` is a literal boolean value, or an array containing a literal boolean value
+ */
+function isBooleanArgument(argument) {
+
+    // when used with Function.prototype.apply
+    if (argument.type === "ArrayExpression") {
+        return argument.elements.some(isBooleanArgument);
+    }
+
+    return argument.type === "Literal" && typeof argument.value === "boolean";
+}
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "disallow boolean traps",
+            category: "Best Practices",
+            recommended: false
+        },
+        schema: []
+    },
+
+    create(context) {
+        return {
+            CallExpression: node => {
+                const badArguments = node.arguments.filter(isBooleanArgument);
+
+                badArguments.forEach(argument => {
+                    context.report({
+                        node,
+                        loc: argument.loc,
+                        message: "Unexpected boolean trap"
+                    });
+                });
+            }
+        };
+    }
+};

--- a/tests/lib/rules/no-boolean-trap.js
+++ b/tests/lib/rules/no-boolean-trap.js
@@ -1,0 +1,69 @@
+/**
+ * @fileoverview Tests for max-len rule.
+ * @author Matt DuVall <http://www.mattduvall.com>
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+const rule = require("../../../lib/rules/no-boolean-trap"),
+    RuleTester = require("../../../lib/testers/rule-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester();
+const callTemplates = [
+    "someFunc({value});",
+    "someFunc.apply(null, {value});",
+    "someFunc.call(null, {value})",
+    "someFunc.bind(someFunc, {value})"
+];
+
+const allowedValues = [
+    "0",
+    "1",
+    "'true'",
+    "'false'",
+    "{}",
+    "[]",
+    "['true']",
+    "['false']",
+    "new Date(0)",
+    "null",
+    "undefined"
+];
+const disallowedValues = [
+    "true",
+    "false"
+];
+
+const validExpressions = [];
+
+allowedValues.forEach(value => {
+    callTemplates.forEach(template => {
+        validExpressions.push(template.replace("{value}", value));
+    });
+});
+
+const invalidExpressions = [];
+
+disallowedValues.forEach(value => {
+    callTemplates.forEach(template => {
+        invalidExpressions.push({
+            code: template.replace("{value}", value),
+            errors: [{
+                message: "Unexpected boolean trap",
+                type: "CallExpression"
+            }]
+        });
+    });
+});
+
+ruleTester.run("no-boolean-trap", rule, {
+    valid: validExpressions,
+    invalid: invalidExpressions
+});


### PR DESCRIPTION
#### What is the purpose of this pull request? (put an "X" next to item)

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[x] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

#### What category of rule is this? (place an "X" next to just one item)

[ ] Enforces code style
[ ] Warns about a potential error
[x] Suggests an alternate way of doing something
[ ] Other (please specify:)

Provide 2-3 code examples that this rule will warn about:

```javascript
// disallowed
volumeSlider.setValue(90, false);
volumeSlider.setValue.apply(null, [false]);
volumeSlider.setValue.call(null, 90, false);
const set90 = volumeSlider.setValue.bind(null, 90, false);

// allowed
const shouldAnimateTransition = false;

volumeSlider.setValue(90, shouldAnimateTransition);
volumeSlider.setValue.apply(null, [shouldAnimateTransition]);
volumeSlider.setValue.call(null, 90, shouldAnimateTransition);
const set90 = volumeSlider.setValue.bind(null, 90, shouldAnimateTransition);
```

#### Why should this rule be included in ESLint (instead of a plugin)?

Boolean traps are a code smell, and far too common. Disallowing them will help developers improve their API design.

See:

* [hall of api shame: boolean trap](https://ariya.io/2011/08/hall-of-api-shame-boolean-trap)
* [Clean Code, "Flag Arguments", p41](http://www.goodreads.com/book/show/3735293-clean-code)

I don't feel strongly about `no-boolean-trap` being included in ESLint. If it seems relevant to maintainers, then let us add it. Otherwise, I am more than happy to release it as a plugin.

#### What changes did you make? (Give an overview)

I implemented a new rule: `no-boolean-trap`

#### Is there anything you'd like reviewers to focus on?

Does the documentation explain the practice of avoiding boolean traps sufficiently? (I didn't want developers to have to read an essay paraphrasing the two linked resources).

