### PR TITLE
Fix: Allow duplicated let declarations in `prefer-const` (fixes #7712)

### DIFF
--- a/lib/rules/prefer-const.js
+++ b/lib/rules/prefer-const.js
@@ -91,6 +91,17 @@ function getIdentifierIfShouldBeConst(variable, ignoreReadBeforeAssign) {
         return null;
     }
 
+    /*
+     * Due to a bug in acorn, code such as `let foo = 1; let foo = 2;` will not throw a syntax error. As a sanity
+     * check, make sure that the variable only has one declaration. After the parsing bug is fixed, this check
+     * will no longer be necessary, because variables declared with `let` or `const` should always have exactly one
+     * declaration.
+     * https://github.com/ternjs/acorn/issues/487
+     */
+    if (variable.defs.length > 1) {
+        return null;
+    }
+
     // Finds the unique WriteReference.
     let writer = null;
     let isReadBeforeInit = false;

--- a/tests/lib/rules/prefer-const.js
+++ b/tests/lib/rules/prefer-const.js
@@ -97,10 +97,7 @@ ruleTester.run("prefer-const", rule, {
         // https://github.com/eslint/eslint/issues/7712
         // https://github.com/ternjs/acorn/issues/487
         // This should be a SyntaxError, but espree parses it correctly. Don't throw an error if the variable has multiple declarations.
-        {
-            code: "let foo; const foo = 1;",
-            parserOptions: {ecmaVersion: 6}
-        }
+        "let foo; const foo = 1;"
 
     ],
     invalid: [

--- a/tests/lib/rules/prefer-const.js
+++ b/tests/lib/rules/prefer-const.js
@@ -94,6 +94,14 @@ ruleTester.run("prefer-const", rule, {
             options: [{ignoreReadBeforeAssign: true}]
         },
 
+        // https://github.com/eslint/eslint/issues/7712
+        // https://github.com/ternjs/acorn/issues/487
+        // This should be a SyntaxError, but espree parses it correctly. Don't throw an error if the variable has multiple declarations.
+        {
+            code: "let foo; const foo = 1;",
+            parserOptions: {ecmaVersion: 6},
+            errors: [{ message: "'foo' is never reassigned. Use 'const' instead.", type: "Identifier" }]
+        }
 
     ],
     invalid: [

--- a/tests/lib/rules/prefer-const.js
+++ b/tests/lib/rules/prefer-const.js
@@ -99,8 +99,7 @@ ruleTester.run("prefer-const", rule, {
         // This should be a SyntaxError, but espree parses it correctly. Don't throw an error if the variable has multiple declarations.
         {
             code: "let foo; const foo = 1;",
-            parserOptions: {ecmaVersion: 6},
-            errors: [{ message: "'foo' is never reassigned. Use 'const' instead.", type: "Identifier" }]
+            parserOptions: {ecmaVersion: 6}
         }
 
     ],


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix

See https://github.com/eslint/eslint/issues/7712

**What changes did you make? (Give an overview)**

Due to https://github.com/ternjs/acorn/issues/487, espree does not throw a syntax error for duplicate `let` or `const` declarations. Previously, the `prefer-const` rule assumed that a `let` variable would always have exactly one declaration. This adds a sanity check to avoid reporting (and possibly creating incorrect autofixes from) a `let` variable if it has more than one declaration.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.