### PR TITLE
Fix edge case for reporter when number of problems is 99

### DIFF
--- a/lib/formatters/stylish.js
+++ b/lib/formatters/stylish.js
@@ -75,11 +75,19 @@ module.exports = function(results) {
     });
 
     if (total > 0) {
-        output += chalk[summaryColor].bold([
-            "\u2716 ", total, pluralize(" problem", total),
-            " (", errors, pluralize(" error", errors), ", ",
-            warnings, pluralize(" warning", warnings), ")\n"
-        ].join(""));
+        if (total === 99) {
+            output += chalk[summaryColor].bold([
+                "\u2716 You got ", total, pluralize(" problem", total),
+                " but a 🐩  ain't one (", errors, pluralize(" error", errors), ", ", // it's funny because female dogs are called bitches
+                warnings, pluralize(" warning", warnings), ")\n"
+            ].join(""));
+        } else {
+            output += chalk[summaryColor].bold([
+                "\u2716 ", total, pluralize(" problem", total),
+                " (", errors, pluralize(" error", errors), ", ",
+                warnings, pluralize(" warning", warnings), ")\n"
+            ].join(""));
+        }
     }
 
     return total > 0 ? output : "";


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] Other, please explain:

There is an amazing opportunity for making a joke whenever the reporter finds [99 total problems in one's code](https://en.wikipedia.org/wiki/99_Problems).

![image](https://cloud.githubusercontent.com/assets/3150328/21017829/5ad9477a-bd73-11e6-80d6-d5050c028f38.png)


**What changes did you make? (Give an overview)**
Covered special case of 99 total problems by making a pop culture reference.

**Is there anything you'd like reviewers to focus on?**
The emoji of choice.