### PR TITLE
Chore: Avoid parserOptions boilerplate in tests for ES6 rules

### DIFF
--- a/tests/lib/rules/arrow-body-style.js
+++ b/tests/lib/rules/arrow-body-style.js
@@ -15,41 +15,40 @@ const rule = require("../../../lib/rules/arrow-body-style"),
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
 
 ruleTester.run("arrow-body-style", rule, {
     valid: [
-        { code: "var foo = () => {};", parserOptions: { ecmaVersion: 6 } },
-        { code: "var foo = () => 0;", parserOptions: { ecmaVersion: 6 } },
-        { code: "var addToB = (a) => { b =  b + a };", parserOptions: { ecmaVersion: 6 } },
-        { code: "var foo = () => { /* do nothing */ };", parserOptions: { ecmaVersion: 6 } },
-        { code: "var foo = () => {\n /* do nothing */ \n};", parserOptions: { ecmaVersion: 6 } },
-        { code: "var foo = (retv, name) => {\nretv[name] = true;\nreturn retv;\n};", parserOptions: { ecmaVersion: 6 } },
-        { code: "var foo = () => ({});", parserOptions: { ecmaVersion: 6 } },
-        { code: "var foo = () => bar();", parserOptions: { ecmaVersion: 6 } },
-        { code: "var foo = () => { bar(); };", parserOptions: { ecmaVersion: 6 } },
-        { code: "var foo = () => { b = a };", parserOptions: { ecmaVersion: 6 } },
-        { code: "var foo = () => { bar: 1 };", parserOptions: { ecmaVersion: 6 } },
-        { code: "var foo = () => { return 0; };", parserOptions: { ecmaVersion: 6 }, options: ["always"] },
-        { code: "var foo = () => { return bar(); };", parserOptions: { ecmaVersion: 6 }, options: ["always"] },
-        { code: "var foo = () => 0;", parserOptions: { ecmaVersion: 6 }, options: ["never"] },
-        { code: "var foo = () => ({ foo: 0 });", parserOptions: { ecmaVersion: 6 }, options: ["never"] },
-        { code: "var foo = () => {};", parserOptions: { ecmaVersion: 6 }, options: ["as-needed", {requireReturnForObjectLiteral: true }] },
-        { code: "var foo = () => 0;", parserOptions: { ecmaVersion: 6 }, options: ["as-needed", {requireReturnForObjectLiteral: true }] },
-        { code: "var addToB = (a) => { b =  b + a };", parserOptions: { ecmaVersion: 6 }, options: ["as-needed", {requireReturnForObjectLiteral: true }] },
-        { code: "var foo = () => { /* do nothing */ };", parserOptions: { ecmaVersion: 6 }, options: ["as-needed", {requireReturnForObjectLiteral: true }] },
-        { code: "var foo = () => {\n /* do nothing */ \n};", parserOptions: { ecmaVersion: 6 }, options: ["as-needed", {requireReturnForObjectLiteral: true }] },
-        { code: "var foo = (retv, name) => {\nretv[name] = true;\nreturn retv;\n};", parserOptions: { ecmaVersion: 6 }, options: ["as-needed", {requireReturnForObjectLiteral: true }] },
-        { code: "var foo = () => bar();", parserOptions: { ecmaVersion: 6 }, options: ["as-needed", {requireReturnForObjectLiteral: true }] },
-        { code: "var foo = () => { bar(); };", parserOptions: { ecmaVersion: 6 }, options: ["as-needed", {requireReturnForObjectLiteral: true }] },
-        { code: "var addToB = (a) => { b =  b + a };", parserOptions: { ecmaVersion: 6 }, options: ["as-needed", {requireReturnForObjectLiteral: true }] },
-        { code: "var foo = () => { return { bar: 0 }; };", parserOptions: { ecmaVersion: 6 }, options: ["as-needed", {requireReturnForObjectLiteral: true }] }
+        "var foo = () => {};",
+        "var foo = () => 0;",
+        "var addToB = (a) => { b =  b + a };",
+        "var foo = () => { /* do nothing */ };",
+        "var foo = () => {\n /* do nothing */ \n};",
+        "var foo = (retv, name) => {\nretv[name] = true;\nreturn retv;\n};",
+        "var foo = () => ({});",
+        "var foo = () => bar();",
+        "var foo = () => { bar(); };",
+        "var foo = () => { b = a };",
+        "var foo = () => { bar: 1 };",
+        { code: "var foo = () => { return 0; };", options: ["always"] },
+        { code: "var foo = () => { return bar(); };", options: ["always"] },
+        { code: "var foo = () => 0;", options: ["never"] },
+        { code: "var foo = () => ({ foo: 0 });", options: ["never"] },
+        { code: "var foo = () => {};", options: ["as-needed", {requireReturnForObjectLiteral: true }] },
+        { code: "var foo = () => 0;", options: ["as-needed", {requireReturnForObjectLiteral: true }] },
+        { code: "var addToB = (a) => { b =  b + a };", options: ["as-needed", {requireReturnForObjectLiteral: true }] },
+        { code: "var foo = () => { /* do nothing */ };", options: ["as-needed", {requireReturnForObjectLiteral: true }] },
+        { code: "var foo = () => {\n /* do nothing */ \n};", options: ["as-needed", {requireReturnForObjectLiteral: true }] },
+        { code: "var foo = (retv, name) => {\nretv[name] = true;\nreturn retv;\n};", options: ["as-needed", {requireReturnForObjectLiteral: true }] },
+        { code: "var foo = () => bar();", options: ["as-needed", {requireReturnForObjectLiteral: true }] },
+        { code: "var foo = () => { bar(); };", options: ["as-needed", {requireReturnForObjectLiteral: true }] },
+        { code: "var addToB = (a) => { b =  b + a };", options: ["as-needed", {requireReturnForObjectLiteral: true }] },
+        { code: "var foo = () => { return { bar: 0 }; };", options: ["as-needed", {requireReturnForObjectLiteral: true }] }
     ],
     invalid: [
         {
             code: "var foo = () => 0;",
             output: "var foo = () => {return 0};",
-            parserOptions: { ecmaVersion: 6 },
             options: ["always"],
             errors: [
                 { line: 1, column: 17, type: "ArrowFunctionExpression", message: "Expected block statement surrounding arrow body." }
@@ -58,7 +57,6 @@ ruleTester.run("arrow-body-style", rule, {
         {
             code: "var foo = () => ({});",
             output: "var foo = () => {return ({})};",
-            parserOptions: { ecmaVersion: 6 },
             options: ["always"],
             errors: [
                 { line: 1, column: 18, type: "ArrowFunctionExpression", message: "Expected block statement surrounding arrow body." }
@@ -67,7 +65,6 @@ ruleTester.run("arrow-body-style", rule, {
         {
             code: "var foo = () => { return 0; };",
             output: "var foo = () => 0;",
-            parserOptions: { ecmaVersion: 6 },
             options: ["as-needed"],
             errors: [
                 { line: 1, column: 17, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
@@ -76,7 +73,6 @@ ruleTester.run("arrow-body-style", rule, {
         {
             code: "var foo = () => { return 0 };",
             output: "var foo = () => 0;",
-            parserOptions: { ecmaVersion: 6 },
             options: ["as-needed"],
             errors: [
                 { line: 1, column: 17, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
@@ -85,7 +81,6 @@ ruleTester.run("arrow-body-style", rule, {
         {
             code: "var foo = () => { return bar(); };",
             output: "var foo = () => bar();",
-            parserOptions: { ecmaVersion: 6 },
             options: ["as-needed"],
             errors: [
                 { line: 1, column: 17, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
@@ -94,7 +89,6 @@ ruleTester.run("arrow-body-style", rule, {
         {
             code: "var foo = () => {\nreturn 0;\n};",
             output: "var foo = () => 0;",
-            parserOptions: { ecmaVersion: 6 },
             options: ["never"],
             errors: [
                 { line: 1, column: 17, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
@@ -103,7 +97,6 @@ ruleTester.run("arrow-body-style", rule, {
         {
             code: "var foo = () => { return { bar: 0 }; };",
             output: "var foo = () => ({ bar: 0 });",
-            parserOptions: { ecmaVersion: 6 },
             options: ["as-needed"],
             errors: [
                 { line: 1, column: 17, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
@@ -112,7 +105,6 @@ ruleTester.run("arrow-body-style", rule, {
         {
             code: "var foo = () => { return; };",
             output: "var foo = () => { return; };", // not fixed
-            parserOptions: { ecmaVersion: 6 },
             options: ["as-needed", {requireReturnForObjectLiteral: true}],
             errors: [
                 { line: 1, column: 17, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
@@ -121,7 +113,6 @@ ruleTester.run("arrow-body-style", rule, {
         {
             code: "var foo = () => { return ( /* a */ {ok: true} /* b */ ) };",
             output: "var foo = () => ( /* a */ {ok: true} /* b */ );",
-            parserOptions: { ecmaVersion: 6 },
             options: ["as-needed"],
             errors: [
                 { line: 1, column: 17, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
@@ -130,7 +121,6 @@ ruleTester.run("arrow-body-style", rule, {
         {
             code: "var foo = () => { return '{' };",
             output: "var foo = () => '{';",
-            parserOptions: { ecmaVersion: 6 },
             options: ["as-needed"],
             errors: [
                 { line: 1, column: 17, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
@@ -139,7 +129,6 @@ ruleTester.run("arrow-body-style", rule, {
         {
             code: "var foo = () => { return { bar: 0 }.bar; };",
             output: "var foo = () => ({ bar: 0 }.bar);",
-            parserOptions: { ecmaVersion: 6 },
             options: ["as-needed"],
             errors: [
                 { line: 1, column: 17, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
@@ -148,7 +137,6 @@ ruleTester.run("arrow-body-style", rule, {
         {
             code: "var foo = (retv, name) => {\nretv[name] = true;\nreturn retv;\n};",
             output: "var foo = (retv, name) => {\nretv[name] = true;\nreturn retv;\n};", // not fixed
-            parserOptions: { ecmaVersion: 6 },
             options: ["never"],
             errors: [
                 { line: 1, column: 27, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
@@ -157,7 +145,6 @@ ruleTester.run("arrow-body-style", rule, {
         {
             code: "var foo = () => { return 0; };",
             output: "var foo = () => 0;",
-            parserOptions: { ecmaVersion: 6 },
             options: ["as-needed", {requireReturnForObjectLiteral: true }],
             errors: [
                 { line: 1, column: 17, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
@@ -166,7 +153,6 @@ ruleTester.run("arrow-body-style", rule, {
         {
             code: "var foo = () => { return bar(); };",
             output: "var foo = () => bar();",
-            parserOptions: { ecmaVersion: 6 },
             options: ["as-needed", {requireReturnForObjectLiteral: true }],
             errors: [
                 { line: 1, column: 17, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
@@ -175,7 +161,6 @@ ruleTester.run("arrow-body-style", rule, {
         {
             code: "var foo = () => ({});",
             output: "var foo = () => {return ({})};",
-            parserOptions: { ecmaVersion: 6 },
             options: ["as-needed", {requireReturnForObjectLiteral: true }],
             errors: [
                 { line: 1, column: 18, type: "ArrowFunctionExpression", message: "Expected block statement surrounding arrow body." }
@@ -184,7 +169,6 @@ ruleTester.run("arrow-body-style", rule, {
         {
             code: "var foo = () => ({ bar: 0 });",
             output: "var foo = () => {return ({ bar: 0 })};",
-            parserOptions: { ecmaVersion: 6 },
             options: ["as-needed", {requireReturnForObjectLiteral: true }],
             errors: [
                 { line: 1, column: 18, type: "ArrowFunctionExpression", message: "Expected block statement surrounding arrow body." }
@@ -193,7 +177,6 @@ ruleTester.run("arrow-body-style", rule, {
         {
             code: "var foo = () => (((((((5)))))));",
             output: "var foo = () => {return (((((((5)))))))};",
-            parserOptions: { ecmaVersion: 6 },
             options: ["always"],
             errors: [
                 { line: 1, column: 24, type: "ArrowFunctionExpression", message: "Expected block statement surrounding arrow body." }
@@ -208,7 +191,6 @@ ruleTester.run("arrow-body-style", rule, {
             output:
             "var foo = () => { return bar }\n" +
             "[1, 2, 3].map(foo)",
-            parserOptions: { ecmaVersion: 6 },
             options: ["never"],
             errors: [
                 { line: 1, column: 17, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
@@ -223,7 +205,6 @@ ruleTester.run("arrow-body-style", rule, {
             output:
             "var foo = () => { return bar }\n" +
             "(1).toString();",
-            parserOptions: { ecmaVersion: 6 },
             options: ["never"],
             errors: [
                 { line: 1, column: 17, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
@@ -238,7 +219,6 @@ ruleTester.run("arrow-body-style", rule, {
             output:
             "var foo = () => bar;\n" +
             "[1, 2, 3].map(foo)",
-            parserOptions: { ecmaVersion: 6 },
             options: ["never"],
             errors: [
                 { line: 1, column: 17, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
@@ -247,7 +227,6 @@ ruleTester.run("arrow-body-style", rule, {
         {
             code: "var foo = /* a */ ( /* b */ ) /* c */ => /* d */ { /* e */ return /* f */ 5 /* g */ ; /* h */ } /* i */ ;",
             output: "var foo = /* a */ ( /* b */ ) /* c */ => /* d */  /* e */  /* f */ 5 /* g */  /* h */  /* i */ ;",
-            parserOptions: { ecmaVersion: 6 },
             options: ["as-needed"],
             errors: [
                 { line: 1, column: 50, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
@@ -256,7 +235,6 @@ ruleTester.run("arrow-body-style", rule, {
         {
             code: "var foo = /* a */ ( /* b */ ) /* c */ => /* d */ ( /* e */ 5 /* f */ ) /* g */ ;",
             output: "var foo = /* a */ ( /* b */ ) /* c */ => /* d */ {return ( /* e */ 5 /* f */ )} /* g */ ;",
-            parserOptions: { ecmaVersion: 6 },
             options: ["always"],
             errors: [
                 { line: 1, column: 60, type: "ArrowFunctionExpression", message: "Expected block statement surrounding arrow body." }
@@ -265,7 +243,6 @@ ruleTester.run("arrow-body-style", rule, {
         {
             code: "var foo = () => {\nreturn bar;\n};",
             output: "var foo = () => bar;",
-            parserOptions: { ecmaVersion: 6 },
             errors: [
                 { line: 1, column: 17, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
             ]
@@ -273,7 +250,6 @@ ruleTester.run("arrow-body-style", rule, {
         {
             code: "var foo = () => {\nreturn bar;};",
             output: "var foo = () => bar;",
-            parserOptions: { ecmaVersion: 6 },
             errors: [
                 { line: 1, column: 17, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
             ]
@@ -281,7 +257,6 @@ ruleTester.run("arrow-body-style", rule, {
         {
             code: "var foo = () => {return bar;\n};",
             output: "var foo = () => bar;",
-            parserOptions: { ecmaVersion: 6 },
             errors: [
                 { line: 1, column: 17, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
             ]
@@ -297,7 +272,6 @@ ruleTester.run("arrow-body-style", rule, {
               var foo = () => foo
                   .bar;
             `,
-            parserOptions: { ecmaVersion: 6 },
             errors: [
                 { line: 2, column: 31, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
             ]
@@ -317,7 +291,6 @@ ruleTester.run("arrow-body-style", rule, {
                   baz: 2
                 });
             `,
-            parserOptions: { ecmaVersion: 6 },
             errors: [
                 { line: 2, column: 31, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
             ]

--- a/tests/lib/rules/arrow-parens.js
+++ b/tests/lib/rules/arrow-parens.js
@@ -30,57 +30,57 @@ function parser(name) {
 //------------------------------------------------------------------------------
 // Tests
 //------------------------------------------------------------------------------
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
 
 const valid = [
 
     // "always" (by default)
-    { code: "() => {}", parserOptions: { ecmaVersion: 6 } },
-    { code: "(a) => {}", parserOptions: { ecmaVersion: 6 } },
-    { code: "(a) => a", parserOptions: { ecmaVersion: 6 } },
-    { code: "(a) => {\n}", parserOptions: { ecmaVersion: 6 } },
-    { code: "a.then((foo) => {});", parserOptions: { ecmaVersion: 6 } },
-    { code: "a.then((foo) => { if (true) {}; });", parserOptions: { ecmaVersion: 6 } },
+    "() => {}",
+    "(a) => {}",
+    "(a) => a",
+    "(a) => {\n}",
+    "a.then((foo) => {});",
+    "a.then((foo) => { if (true) {}; });",
     { code: "a.then(async (foo) => { if (true) {}; });", parserOptions: { ecmaVersion: 8 } },
 
     // "always" (explicit)
-    { code: "() => {}", options: ["always"], parserOptions: { ecmaVersion: 6 } },
-    { code: "(a) => {}", options: ["always"], parserOptions: { ecmaVersion: 6 } },
-    { code: "(a) => a", options: ["always"], parserOptions: { ecmaVersion: 6 } },
-    { code: "(a) => {\n}", options: ["always"], parserOptions: { ecmaVersion: 6 } },
-    { code: "a.then((foo) => {});", options: ["always"], parserOptions: { ecmaVersion: 6 } },
-    { code: "a.then((foo) => { if (true) {}; });", options: ["always"], parserOptions: { ecmaVersion: 6 } },
+    { code: "() => {}", options: ["always"] },
+    { code: "(a) => {}", options: ["always"] },
+    { code: "(a) => a", options: ["always"] },
+    { code: "(a) => {\n}", options: ["always"] },
+    { code: "a.then((foo) => {});", options: ["always"] },
+    { code: "a.then((foo) => { if (true) {}; });", options: ["always"] },
     { code: "a.then(async (foo) => { if (true) {}; });", options: ["always"], parserOptions: { ecmaVersion: 8 } },
 
     // "as-needed"
-    { code: "() => {}", options: ["as-needed"], parserOptions: { ecmaVersion: 6 } },
-    { code: "a => {}", options: ["as-needed"], parserOptions: { ecmaVersion: 6 } },
-    { code: "a => a", options: ["as-needed"], parserOptions: { ecmaVersion: 6 } },
-    { code: "([a, b]) => {}", options: ["as-needed"], parserOptions: { ecmaVersion: 6 } },
-    { code: "({ a, b }) => {}", options: ["as-needed"], parserOptions: { ecmaVersion: 6 } },
-    { code: "(a = 10) => {}", options: ["as-needed"], parserOptions: { ecmaVersion: 6 } },
-    { code: "(...a) => a[0]", options: ["as-needed"], parserOptions: { ecmaVersion: 6 } },
-    { code: "(a, b) => {}", options: ["as-needed"], parserOptions: { ecmaVersion: 6 } },
+    { code: "() => {}", options: ["as-needed"] },
+    { code: "a => {}", options: ["as-needed"] },
+    { code: "a => a", options: ["as-needed"] },
+    { code: "([a, b]) => {}", options: ["as-needed"] },
+    { code: "({ a, b }) => {}", options: ["as-needed"] },
+    { code: "(a = 10) => {}", options: ["as-needed"] },
+    { code: "(...a) => a[0]", options: ["as-needed"] },
+    { code: "(a, b) => {}", options: ["as-needed"] },
     { code: "async ([a, b]) => {}", options: ["as-needed"], parserOptions: { ecmaVersion: 8 } },
     { code: "async (a, b) => {}", options: ["as-needed"], parserOptions: { ecmaVersion: 8 } },
-    { code: "(a: T) => a", options: ["as-needed"], parserOptions: { ecmaVersion: 6 }, parser: parser("identifer-type") },
-    { code: "(a): T => a", options: ["as-needed"], parserOptions: { ecmaVersion: 6 }, parser: parser("return-type") },
+    { code: "(a: T) => a", options: ["as-needed"], parser: parser("identifer-type") },
+    { code: "(a): T => a", options: ["as-needed"], parser: parser("return-type") },
 
     // "as-needed", { "requireForBlockBody": true }
-    { code: "() => {}", options: ["as-needed", {requireForBlockBody: true}], parserOptions: { ecmaVersion: 6 } },
-    { code: "a => a", options: ["as-needed", {requireForBlockBody: true}], parserOptions: { ecmaVersion: 6 } },
-    { code: "([a, b]) => {}", options: ["as-needed", {requireForBlockBody: true}], parserOptions: { ecmaVersion: 6 } },
-    { code: "([a, b]) => a", options: ["as-needed", {requireForBlockBody: true}], parserOptions: { ecmaVersion: 6 } },
-    { code: "({ a, b }) => {}", options: ["as-needed", {requireForBlockBody: true}], parserOptions: { ecmaVersion: 6 } },
-    { code: "({ a, b }) => a + b", options: ["as-needed", {requireForBlockBody: true}], parserOptions: { ecmaVersion: 6 } },
-    { code: "(a = 10) => {}", options: ["as-needed", {requireForBlockBody: true}], parserOptions: { ecmaVersion: 6 } },
-    { code: "(...a) => a[0]", options: ["as-needed", {requireForBlockBody: true}], parserOptions: { ecmaVersion: 6 } },
-    { code: "(a, b) => {}", options: ["as-needed", {requireForBlockBody: true}], parserOptions: { ecmaVersion: 6 } },
-    { code: "a => ({})", options: ["as-needed", {requireForBlockBody: true}], parserOptions: { ecmaVersion: 6 } },
+    { code: "() => {}", options: ["as-needed", {requireForBlockBody: true}] },
+    { code: "a => a", options: ["as-needed", {requireForBlockBody: true}] },
+    { code: "([a, b]) => {}", options: ["as-needed", {requireForBlockBody: true}] },
+    { code: "([a, b]) => a", options: ["as-needed", {requireForBlockBody: true}] },
+    { code: "({ a, b }) => {}", options: ["as-needed", {requireForBlockBody: true}] },
+    { code: "({ a, b }) => a + b", options: ["as-needed", {requireForBlockBody: true}] },
+    { code: "(a = 10) => {}", options: ["as-needed", {requireForBlockBody: true}] },
+    { code: "(...a) => a[0]", options: ["as-needed", {requireForBlockBody: true}] },
+    { code: "(a, b) => {}", options: ["as-needed", {requireForBlockBody: true}] },
+    { code: "a => ({})", options: ["as-needed", {requireForBlockBody: true}] },
     { code: "async a => ({})", options: ["as-needed", {requireForBlockBody: true}], parserOptions: { ecmaVersion: 8 } },
     { code: "async a => a", options: ["as-needed", {requireForBlockBody: true}], parserOptions: { ecmaVersion: 8 } },
-    { code: "(a: T) => a", options: ["as-needed", {requireForBlockBody: true}], parserOptions: { ecmaVersion: 6 }, parser: parser("identifer-type") },
-    { code: "(a): T => a", options: ["as-needed", {requireForBlockBody: true}], parserOptions: { ecmaVersion: 6 }, parser: parser("return-type") },
+    { code: "(a: T) => a", options: ["as-needed", {requireForBlockBody: true}], parser: parser("identifer-type") },
+    { code: "(a): T => a", options: ["as-needed", {requireForBlockBody: true}], parser: parser("return-type") },
 ];
 
 const message = "Expected parentheses around arrow function argument.";
@@ -95,7 +95,6 @@ const invalid = [
     {
         code: "a => {}",
         output: "(a) => {}",
-        parserOptions: { ecmaVersion: 6 },
         errors: [{
             line: 1,
             column: 1,
@@ -106,7 +105,6 @@ const invalid = [
     {
         code: "a => a",
         output: "(a) => a",
-        parserOptions: { ecmaVersion: 6 },
         errors: [{
             line: 1,
             column: 1,
@@ -117,7 +115,6 @@ const invalid = [
     {
         code: "a => {\n}",
         output: "(a) => {\n}",
-        parserOptions: { ecmaVersion: 6 },
         errors: [{
             line: 1,
             column: 1,
@@ -128,7 +125,6 @@ const invalid = [
     {
         code: "a.then(foo => {});",
         output: "a.then((foo) => {});",
-        parserOptions: { ecmaVersion: 6 },
         errors: [{
             line: 1,
             column: 8,
@@ -139,7 +135,6 @@ const invalid = [
     {
         code: "a.then(foo => a);",
         output: "a.then((foo) => a);",
-        parserOptions: { ecmaVersion: 6 },
         errors: [{
             line: 1,
             column: 8,
@@ -150,7 +145,6 @@ const invalid = [
     {
         code: "a(foo => { if (true) {}; });",
         output: "a((foo) => { if (true) {}; });",
-        parserOptions: { ecmaVersion: 6 },
         errors: [{
             line: 1,
             column: 3,
@@ -175,7 +169,6 @@ const invalid = [
         code: "(a) => a",
         output: "a => a",
         options: ["as-needed"],
-        parserOptions: { ecmaVersion: 6 },
         errors: [{
             line: 1,
             column: 1,
@@ -201,7 +194,6 @@ const invalid = [
         code: "a => {}",
         output: "(a) => {}",
         options: ["as-needed", {requireForBlockBody: true}],
-        parserOptions: { ecmaVersion: 6 },
         errors: [{
             line: 1,
             column: 1,
@@ -213,7 +205,6 @@ const invalid = [
         code: "(a) => a",
         output: "a => a",
         options: ["as-needed", {requireForBlockBody: true}],
-        parserOptions: { ecmaVersion: 6 },
         errors: [{
             line: 1,
             column: 1,

--- a/tests/lib/rules/arrow-spacing.js
+++ b/tests/lib/rules/arrow-spacing.js
@@ -16,96 +16,72 @@ const rule = require("../../../lib/rules/arrow-spacing"),
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
 
 const valid = [
     {
-        parserOptions: { ecmaVersion: 6 },
         code: "a => a",
         options: [{ after: true, before: true }]
     },
     {
-        parserOptions: { ecmaVersion: 6 },
         code: "() => {}",
         options: [{ after: true, before: true }]
     },
     {
-        parserOptions: { ecmaVersion: 6 },
         code: "(a) => {}",
         options: [{ after: true, before: true }]
     },
     {
-        parserOptions: { ecmaVersion: 6 },
         code: "a=> a",
         options: [{ after: true, before: false }]
     },
     {
-        parserOptions: { ecmaVersion: 6 },
         code: "()=> {}",
         options: [{ after: true, before: false }]
     },
     {
-        parserOptions: { ecmaVersion: 6 },
         code: "(a)=> {}",
         options: [{ after: true, before: false }]
     },
     {
-        parserOptions: { ecmaVersion: 6 },
         code: "a =>a",
         options: [{ after: false, before: true }]
     },
     {
-        parserOptions: { ecmaVersion: 6 },
         code: "() =>{}",
         options: [{ after: false, before: true }]
     },
     {
-        parserOptions: { ecmaVersion: 6 },
         code: "(a) =>{}",
         options: [{ after: false, before: true }]
     },
     {
-        parserOptions: { ecmaVersion: 6 },
         code: "a=>a",
         options: [{ after: false, before: false }]
     },
     {
-        parserOptions: { ecmaVersion: 6 },
         code: "()=>{}",
         options: [{ after: false, before: false }]
     },
     {
-        parserOptions: { ecmaVersion: 6 },
         code: "(a)=>{}",
         options: [{ after: false, before: false }]
     },
     {
-        parserOptions: { ecmaVersion: 6 },
         code: "a => a",
         options: [{}]
     },
     {
-        parserOptions: { ecmaVersion: 6 },
         code: "() => {}",
         options: [{}]
     },
     {
-        parserOptions: { ecmaVersion: 6 },
         code: "(a) => {}",
         options: [{}]
     },
-    {
-        parserOptions: { ecmaVersion: 6 },
-        code: "(a) =>\n{}"
-    },
-    {
-        parserOptions: { ecmaVersion: 6 },
-        code: "(a) =>\r\n{}"
-    },
-    {
-        parserOptions: { ecmaVersion: 6 },
-        code: "(a) =>\n    0"
-    }
+    "(a) =>\n{}",
+    "(a) =>\r\n{}",
+    "(a) =>\n    0"
 ];
 
 
@@ -114,7 +90,6 @@ const invalid = [
         code: "a=>a",
         output: "a => a",
         options: [{ after: true, before: true }],
-        parserOptions: { ecmaVersion: 6 },
         errors: [
             { column: 1, line: 1, type: "Identifier" },
             { column: 4, line: 1, type: "Identifier" }
@@ -124,7 +99,6 @@ const invalid = [
         code: "()=>{}",
         output: "() => {}",
         options: [{ after: true, before: true }],
-        parserOptions: { ecmaVersion: 6 },
         errors: [
             { column: 2, line: 1, type: "Punctuator" },
             { column: 5, line: 1, type: "Punctuator" }
@@ -134,7 +108,6 @@ const invalid = [
         code: "(a)=>{}",
         output: "(a) => {}",
         options: [{ after: true, before: true }],
-        parserOptions: { ecmaVersion: 6 },
         errors: [
             { column: 3, line: 1, type: "Punctuator" },
             { column: 6, line: 1, type: "Punctuator" }
@@ -144,7 +117,6 @@ const invalid = [
         code: "a=> a",
         output: "a =>a",
         options: [{ after: false, before: true }],
-        parserOptions: { ecmaVersion: 6 },
         errors: [
             { column: 1, line: 1, type: "Identifier" },
             { column: 5, line: 1, type: "Identifier" }
@@ -154,7 +126,6 @@ const invalid = [
         code: "()=> {}",
         output: "() =>{}",
         options: [{ after: false, before: true }],
-        parserOptions: { ecmaVersion: 6 },
         errors: [
             { column: 2, line: 1, type: "Punctuator" },
             { column: 6, line: 1, type: "Punctuator" }
@@ -164,7 +135,6 @@ const invalid = [
         code: "(a)=> {}",
         output: "(a) =>{}",
         options: [{ after: false, before: true }],
-        parserOptions: { ecmaVersion: 6 },
         errors: [
             { column: 3, line: 1, type: "Punctuator" },
             { column: 7, line: 1, type: "Punctuator" }
@@ -174,7 +144,6 @@ const invalid = [
         code: "a=>  a",
         output: "a =>a",
         options: [{ after: false, before: true }],
-        parserOptions: { ecmaVersion: 6 },
         errors: [
             { column: 1, line: 1, type: "Identifier" },
             { column: 6, line: 1, type: "Identifier" }
@@ -184,7 +153,6 @@ const invalid = [
         code: "()=>  {}",
         output: "() =>{}",
         options: [{ after: false, before: true }],
-        parserOptions: { ecmaVersion: 6 },
         errors: [
             { column: 2, line: 1, type: "Punctuator" },
             { column: 7, line: 1, type: "Punctuator" }
@@ -194,7 +162,6 @@ const invalid = [
         code: "(a)=>  {}",
         output: "(a) =>{}",
         options: [{ after: false, before: true }],
-        parserOptions: { ecmaVersion: 6 },
         errors: [
             { column: 3, line: 1, type: "Punctuator" },
             { column: 8, line: 1, type: "Punctuator" }
@@ -204,7 +171,6 @@ const invalid = [
         code: "a =>a",
         output: "a=> a",
         options: [{ after: true, before: false }],
-        parserOptions: { ecmaVersion: 6 },
         errors: [
             { column: 1, line: 1, type: "Identifier" },
             { column: 5, line: 1, type: "Identifier" }
@@ -214,7 +180,6 @@ const invalid = [
         code: "() =>{}",
         output: "()=> {}",
         options: [{ after: true, before: false }],
-        parserOptions: { ecmaVersion: 6 },
         errors: [
             { column: 2, line: 1, type: "Punctuator" },
             { column: 6, line: 1, type: "Punctuator" }
@@ -224,7 +189,6 @@ const invalid = [
         code: "(a) =>{}",
         output: "(a)=> {}",
         options: [{ after: true, before: false }],
-        parserOptions: { ecmaVersion: 6 },
         errors: [
             { column: 3, line: 1, type: "Punctuator" },
             { column: 7, line: 1, type: "Punctuator" }
@@ -234,7 +198,6 @@ const invalid = [
         code: "a  =>a",
         output: "a=> a",
         options: [{ after: true, before: false }],
-        parserOptions: { ecmaVersion: 6 },
         errors: [
             { column: 1, line: 1, type: "Identifier" },
             { column: 6, line: 1, type: "Identifier" }
@@ -244,7 +207,6 @@ const invalid = [
         code: "()  =>{}",
         output: "()=> {}",
         options: [{ after: true, before: false }],
-        parserOptions: { ecmaVersion: 6 },
         errors: [
             { column: 2, line: 1, type: "Punctuator" },
             { column: 7, line: 1, type: "Punctuator" }
@@ -254,7 +216,6 @@ const invalid = [
         code: "(a)  =>{}",
         output: "(a)=> {}",
         options: [{ after: true, before: false }],
-        parserOptions: { ecmaVersion: 6 },
         errors: [
             { column: 3, line: 1, type: "Punctuator" },
             { column: 8, line: 1, type: "Punctuator" }
@@ -264,7 +225,6 @@ const invalid = [
         code: "a => a",
         output: "a=>a",
         options: [{ after: false, before: false }],
-        parserOptions: { ecmaVersion: 6 },
         errors: [
             { column: 1, line: 1, type: "Identifier" },
             { column: 6, line: 1, type: "Identifier" }
@@ -274,7 +234,6 @@ const invalid = [
         code: "() => {}",
         output: "()=>{}",
         options: [{ after: false, before: false }],
-        parserOptions: { ecmaVersion: 6 },
         errors: [
             { column: 2, line: 1, type: "Punctuator" },
             { column: 7, line: 1, type: "Punctuator" }
@@ -284,7 +243,6 @@ const invalid = [
         code: "(a) => {}",
         output: "(a)=>{}",
         options: [{ after: false, before: false }],
-        parserOptions: { ecmaVersion: 6 },
         errors: [
             { column: 3, line: 1, type: "Punctuator" },
             { column: 8, line: 1, type: "Punctuator" }
@@ -294,7 +252,6 @@ const invalid = [
         code: "a  =>  a",
         output: "a=>a",
         options: [{ after: false, before: false }],
-        parserOptions: { ecmaVersion: 6 },
         errors: [
             { column: 1, line: 1, type: "Identifier" },
             { column: 8, line: 1, type: "Identifier" }
@@ -304,7 +261,6 @@ const invalid = [
         code: "()  =>  {}",
         output: "()=>{}",
         options: [{ after: false, before: false }],
-        parserOptions: { ecmaVersion: 6 },
         errors: [
             { column: 2, line: 1, type: "Punctuator" },
             { column: 9, line: 1, type: "Punctuator" }
@@ -314,7 +270,6 @@ const invalid = [
         code: "(a)  =>  {}",
         output: "(a)=>{}",
         options: [{ after: false, before: false }],
-        parserOptions: { ecmaVersion: 6 },
         errors: [
             { column: 3, line: 1, type: "Punctuator" },
             { column: 10, line: 1, type: "Punctuator" }
@@ -324,7 +279,6 @@ const invalid = [
         code: "(a)  =>\n{}",
         output: "(a)  =>{}",
         options: [{ after: false }],
-        parserOptions: { ecmaVersion: 6 },
         errors: [
             { column: 1, line: 2, type: "Punctuator" }
         ]
@@ -334,7 +288,6 @@ const invalid = [
     {
         code: "(a = ()=>0)=>1",
         output: "(a = () => 0) => 1",
-        parserOptions: { ecmaVersion: 6 },
         errors: [
             { column: 7, line: 1, message: "Missing space before =>." },
             { column: 10, line: 1, message: "Missing space after =>." },
@@ -345,7 +298,6 @@ const invalid = [
     {
         code: "(a = ()=>0)=>(1)",
         output: "(a = () => 0) => (1)",
-        parserOptions: { ecmaVersion: 6 },
         errors: [
             { column: 7, line: 1, message: "Missing space before =>." },
             { column: 10, line: 1, message: "Missing space after =>." },

--- a/tests/lib/rules/constructor-super.js
+++ b/tests/lib/rules/constructor-super.js
@@ -16,218 +16,188 @@ const RuleTester = require("../../../lib/testers/rule-tester");
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
 
 ruleTester.run("constructor-super", rule, {
     valid: [
 
         // non derived classes.
-        { code: "class A { }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A { constructor() { } }", parserOptions: { ecmaVersion: 6 } },
+        "class A { }",
+        "class A { constructor() { } }",
 
         // inherit from non constructors.
         // those are valid if we don't define the constructor.
-        { code: "class A extends null { }", parserOptions: { ecmaVersion: 6 } },
+        "class A extends null { }",
 
         // derived classes.
-        { code: "class A extends B { }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A extends B { constructor() { super(); } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A extends B { constructor() { if (true) { super(); } else { super(); } } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A extends (class B {}) { constructor() { super(); } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A extends (B = C) { constructor() { super(); } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A extends (B || C) { constructor() { super(); } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A extends (a ? B : C) { constructor() { super(); } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A extends (B, C) { constructor() { super(); } }", parserOptions: { ecmaVersion: 6 } },
+        "class A extends B { }",
+        "class A extends B { constructor() { super(); } }",
+        "class A extends B { constructor() { if (true) { super(); } else { super(); } } }",
+        "class A extends (class B {}) { constructor() { super(); } }",
+        "class A extends (B = C) { constructor() { super(); } }",
+        "class A extends (B || C) { constructor() { super(); } }",
+        "class A extends (a ? B : C) { constructor() { super(); } }",
+        "class A extends (B, C) { constructor() { super(); } }",
 
         // nested.
-        { code: "class A { constructor() { class B extends C { constructor() { super(); } } } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A extends B { constructor() { super(); class C extends D { constructor() { super(); } } } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A extends B { constructor() { super(); class C { constructor() { } } } }", parserOptions: { ecmaVersion: 6 } },
+        "class A { constructor() { class B extends C { constructor() { super(); } } } }",
+        "class A extends B { constructor() { super(); class C extends D { constructor() { super(); } } } }",
+        "class A extends B { constructor() { super(); class C { constructor() { } } } }",
 
         // ignores out of constructors.
-        { code: "class A { b() { super(); } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "function a() { super(); }", parserOptions: { ecmaVersion: 6 } },
+        "class A { b() { super(); } }",
+        "function a() { super(); }",
 
         // multi code path.
-        { code: "class A extends B { constructor() { a ? super() : super(); } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A extends B { constructor() { if (a) super(); else super(); } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A extends B { constructor() { switch (a) { case 0: super(); break; default: super(); } } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A extends B { constructor() { try {} finally { super(); } } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A extends B { constructor() { if (a) throw Error(); super(); } }", parserOptions: { ecmaVersion: 6 } },
+        "class A extends B { constructor() { a ? super() : super(); } }",
+        "class A extends B { constructor() { if (a) super(); else super(); } }",
+        "class A extends B { constructor() { switch (a) { case 0: super(); break; default: super(); } } }",
+        "class A extends B { constructor() { try {} finally { super(); } } }",
+        "class A extends B { constructor() { if (a) throw Error(); super(); } }",
 
         // returning value is a substitute of 'super()'.
-        { code: "class A extends B { constructor() { if (true) return a; super(); } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A extends null { constructor() { return a; } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A { constructor() { return a; } }", parserOptions: { ecmaVersion: 6 } },
+        "class A extends B { constructor() { if (true) return a; super(); } }",
+        "class A extends null { constructor() { return a; } }",
+        "class A { constructor() { return a; } }",
 
         // https://github.com/eslint/eslint/issues/5261
-        { code: "class A extends B { constructor(a) { super(); for (const b of a) { this.a(); } } }", parserOptions: { ecmaVersion: 6 } },
+        "class A extends B { constructor(a) { super(); for (const b of a) { this.a(); } } }",
 
         // https://github.com/eslint/eslint/issues/5319
-        { code: "class Foo extends Object { constructor(method) { super(); this.method = method || function() {}; } }", parserOptions: { ecmaVersion: 6 } },
+        "class Foo extends Object { constructor(method) { super(); this.method = method || function() {}; } }",
 
         // https://github.com/eslint/eslint/issues/5394
-        {
-            code: [
-                "class A extends Object {",
-                "    constructor() {",
-                "        super();",
-                "        for (let i = 0; i < 0; i++);",
-                "    }",
-                "}"
-            ].join("\n"),
-            parserOptions: {ecmaVersion: 6}
-        },
+        [
+            "class A extends Object {",
+            "    constructor() {",
+            "        super();",
+            "        for (let i = 0; i < 0; i++);",
+            "    }",
+            "}"
+        ].join("\n"),
 
         // https://github.com/eslint/eslint/issues/5894
-        { code: "class A { constructor() { return; super(); } }", parserOptions: {ecmaVersion: 6} }
+        "class A { constructor() { return; super(); } }"
     ],
     invalid: [
 
         // non derived classes.
         {
             code: "class A { constructor() { super(); } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Unexpected 'super()'.", type: "CallExpression"}]
         },
 
         // inherit from non constructors.
         {
             code: "class A extends null { constructor() { super(); } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Unexpected 'super()' because 'super' is not a constructor.", type: "CallExpression"}]
         },
         {
             code: "class A extends null { constructor() { } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Expected to call 'super()'.", type: "MethodDefinition"}]
         },
         {
             code: "class A extends 100 { constructor() { super(); } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Unexpected 'super()' because 'super' is not a constructor.", type: "CallExpression"}]
         },
         {
             code: "class A extends 'test' { constructor() { super(); } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Unexpected 'super()' because 'super' is not a constructor.", type: "CallExpression"}]
         },
 
         // derived classes.
         {
             code: "class A extends B { constructor() { } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Expected to call 'super()'.", type: "MethodDefinition"}]
         },
         {
             code: "class A extends B { constructor() { for (var a of b) super.foo(); } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Expected to call 'super()'.", type: "MethodDefinition"}]
         },
 
         // nested execution scope.
         {
             code: "class A extends B { constructor() { function c() { super(); } } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Expected to call 'super()'.", type: "MethodDefinition"}]
         },
         {
             code: "class A extends B { constructor() { var c = function() { super(); } } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Expected to call 'super()'.", type: "MethodDefinition"}]
         },
         {
             code: "class A extends B { constructor() { var c = () => super(); } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Expected to call 'super()'.", type: "MethodDefinition"}]
         },
         {
             code: "class A extends B { constructor() { class C extends D { constructor() { super(); } } } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Expected to call 'super()'.", type: "MethodDefinition", column: 21}]
         },
         {
             code: "class A extends B { constructor() { var C = class extends D { constructor() { super(); } } } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Expected to call 'super()'.", type: "MethodDefinition", column: 21}]
         },
         {
             code: "class A extends B { constructor() { super(); class C extends D { constructor() { } } } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Expected to call 'super()'.", type: "MethodDefinition", column: 66}]
         },
         {
             code: "class A extends B { constructor() { super(); var C = class extends D { constructor() { } } } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Expected to call 'super()'.", type: "MethodDefinition", column: 72}]
         },
 
         // lacked in some code path.
         {
             code: "class A extends B { constructor() { if (a) super(); } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Lacked a call of 'super()' in some code paths.", type: "MethodDefinition"}]
         },
         {
             code: "class A extends B { constructor() { if (a); else super(); } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Lacked a call of 'super()' in some code paths.", type: "MethodDefinition"}]
         },
         {
             code: "class A extends B { constructor() { a && super(); } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Lacked a call of 'super()' in some code paths.", type: "MethodDefinition"}]
         },
         {
             code: "class A extends B { constructor() { switch (a) { case 0: super(); } } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Lacked a call of 'super()' in some code paths.", type: "MethodDefinition"}]
         },
         {
             code: "class A extends B { constructor() { switch (a) { case 0: break; default: super(); } } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Lacked a call of 'super()' in some code paths.", type: "MethodDefinition"}]
         },
         {
             code: "class A extends B { constructor() { try { super(); } catch (err) {} } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Lacked a call of 'super()' in some code paths.", type: "MethodDefinition"}]
         },
         {
             code: "class A extends B { constructor() { try { a; } catch (err) { super(); } } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Lacked a call of 'super()' in some code paths.", type: "MethodDefinition"}]
         },
         {
             code: "class A extends B { constructor() { if (a) return; super(); } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Lacked a call of 'super()' in some code paths.", type: "MethodDefinition"}]
         },
 
         // duplicate.
         {
             code: "class A extends B { constructor() { super(); super(); } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Unexpected duplicate 'super()'.", type: "CallExpression", column: 46}]
         },
         {
             code: "class A extends B { constructor() { super() || super(); } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Unexpected duplicate 'super()'.", type: "CallExpression", column: 48}]
         },
         {
             code: "class A extends B { constructor() { if (a) super(); super(); } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Unexpected duplicate 'super()'.", type: "CallExpression", column: 53}]
         },
         {
             code: "class A extends B { constructor() { switch (a) { case 0: super(); default: super(); } } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Unexpected duplicate 'super()'.", type: "CallExpression", column: 76}]
         },
         {
             code: "class A extends B { constructor(a) { while (a) super(); } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [
                 { message: "Lacked a call of 'super()' in some code paths.", type: "MethodDefinition"},
                 { message: "Unexpected duplicate 'super()'.", type: "CallExpression", column: 48}
@@ -237,7 +207,6 @@ ruleTester.run("constructor-super", rule, {
         // ignores `super()` on unreachable paths.
         {
             code: "class A extends B { constructor() { return; super(); } }",
-            parserOptions: {ecmaVersion: 6},
             errors: [{ message: "Expected to call 'super()'.", type: "MethodDefinition"}]
         }
     ]

--- a/tests/lib/rules/generator-star-spacing.js
+++ b/tests/lib/rules/generator-star-spacing.js
@@ -16,60 +16,25 @@ const rule = require("../../../lib/rules/generator-star-spacing"),
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
 
 ruleTester.run("generator-star-spacing", rule, {
 
     valid: [
 
         // Default ("before")
-        {
-            code: "function foo(){}"
-        },
-        {
-            code: "function *foo(){}",
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "function *foo(arg1, arg2){}",
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "var foo = function *foo(){};",
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "var foo = function *(){};",
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "var foo = { *foo(){} };",
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "var foo = {*foo(){} };",
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "class Foo { *foo(){} }",
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "class Foo {*foo(){} }",
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "class Foo { static *foo(){} }",
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "var foo = {*[ foo ](){} };",
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "class Foo {*[ foo ](){} }",
-            parserOptions: { ecmaVersion: 6 }
-        },
+        "function foo(){}",
+        "function *foo(){}",
+        "function *foo(arg1, arg2){}",
+        "var foo = function *foo(){};",
+        "var foo = function *(){};",
+        "var foo = { *foo(){} };",
+        "var foo = {*foo(){} };",
+        "class Foo { *foo(){} }",
+        "class Foo {*foo(){} }",
+        "class Foo { static *foo(){} }",
+        "var foo = {*[ foo ](){} };",
+        "class Foo {*[ foo ](){} }",
 
         // "before"
         {
@@ -78,58 +43,47 @@ ruleTester.run("generator-star-spacing", rule, {
         },
         {
             code: "function *foo(){}",
-            options: ["before"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["before"]
         },
         {
             code: "function *foo(arg1, arg2){}",
-            options: ["before"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["before"]
         },
         {
             code: "var foo = function *foo(){};",
-            options: ["before"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["before"]
         },
         {
             code: "var foo = function *(){};",
-            options: ["before"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["before"]
         },
         {
             code: "var foo = { *foo(){} };",
-            options: ["before"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["before"]
         },
         {
             code: "var foo = {*foo(){} };",
-            options: ["before"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["before"]
         },
         {
             code: "class Foo { *foo(){} }",
-            options: ["before"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["before"]
         },
         {
             code: "class Foo {*foo(){} }",
-            options: ["before"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["before"]
         },
         {
             code: "class Foo { static *foo(){} }",
-            options: ["before"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["before"]
         },
         {
             code: "class Foo {*[ foo ](){} }",
-            options: ["before"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["before"]
         },
         {
             code: "var foo = {*[ foo ](){} };",
-            options: ["before"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["before"]
         },
 
         // "after"
@@ -139,58 +93,47 @@ ruleTester.run("generator-star-spacing", rule, {
         },
         {
             code: "function* foo(){}",
-            options: ["after"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["after"]
         },
         {
             code: "function* foo(arg1, arg2){}",
-            options: ["after"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["after"]
         },
         {
             code: "var foo = function* foo(){};",
-            options: ["after"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["after"]
         },
         {
             code: "var foo = function* (){};",
-            options: ["after"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["after"]
         },
         {
             code: "var foo = {* foo(){} };",
-            options: ["after"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["after"]
         },
         {
             code: "var foo = { * foo(){} };",
-            options: ["after"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["after"]
         },
         {
             code: "class Foo {* foo(){} }",
-            options: ["after"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["after"]
         },
         {
             code: "class Foo { * foo(){} }",
-            options: ["after"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["after"]
         },
         {
             code: "class Foo { static* foo(){} }",
-            options: ["after"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["after"]
         },
         {
             code: "var foo = {* [foo](){} };",
-            options: ["after"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["after"]
         },
         {
             code: "class Foo {* [foo](){} }",
-            options: ["after"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["after"]
         },
 
         // "both"
@@ -200,58 +143,47 @@ ruleTester.run("generator-star-spacing", rule, {
         },
         {
             code: "function * foo(){}",
-            options: ["both"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["both"]
         },
         {
             code: "function * foo(arg1, arg2){}",
-            options: ["both"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["both"]
         },
         {
             code: "var foo = function * foo(){};",
-            options: ["both"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["both"]
         },
         {
             code: "var foo = function * (){};",
-            options: ["both"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["both"]
         },
         {
             code: "var foo = { * foo(){} };",
-            options: ["both"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["both"]
         },
         {
             code: "var foo = {* foo(){} };",
-            options: ["both"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["both"]
         },
         {
             code: "class Foo { * foo(){} }",
-            options: ["both"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["both"]
         },
         {
             code: "class Foo {* foo(){} }",
-            options: ["both"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["both"]
         },
         {
             code: "class Foo { static * foo(){} }",
-            options: ["both"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["both"]
         },
         {
             code: "var foo = {* [foo](){} };",
-            options: ["both"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["both"]
         },
         {
             code: "class Foo {* [foo](){} }",
-            options: ["both"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["both"]
         },
 
         // "neither"
@@ -261,58 +193,47 @@ ruleTester.run("generator-star-spacing", rule, {
         },
         {
             code: "function*foo(){}",
-            options: ["neither"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["neither"]
         },
         {
             code: "function*foo(arg1, arg2){}",
-            options: ["neither"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["neither"]
         },
         {
             code: "var foo = function*foo(){};",
-            options: ["neither"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["neither"]
         },
         {
             code: "var foo = function*(){};",
-            options: ["neither"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["neither"]
         },
         {
             code: "var foo = {*foo(){} };",
-            options: ["neither"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["neither"]
         },
         {
             code: "var foo = { *foo(){} };",
-            options: ["neither"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["neither"]
         },
         {
             code: "class Foo {*foo(){} }",
-            options: ["neither"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["neither"]
         },
         {
             code: "class Foo { *foo(){} }",
-            options: ["neither"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["neither"]
         },
         {
             code: "class Foo { static*foo(){} }",
-            options: ["neither"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["neither"]
         },
         {
             code: "var foo = {*[ foo ](){} };",
-            options: ["neither"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["neither"]
         },
         {
             code: "class Foo {*[ foo ](){} }",
-            options: ["neither"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["neither"]
         },
 
         // {"before": true, "after": false}
@@ -322,48 +243,39 @@ ruleTester.run("generator-star-spacing", rule, {
         },
         {
             code: "function *foo(){}",
-            options: [{before: true, after: false}],
-            parserOptions: { ecmaVersion: 6 }
+            options: [{before: true, after: false}]
         },
         {
             code: "function *foo(arg1, arg2){}",
-            options: [{before: true, after: false}],
-            parserOptions: { ecmaVersion: 6 }
+            options: [{before: true, after: false}]
         },
         {
             code: "var foo = function *foo(){};",
-            options: [{before: true, after: false}],
-            parserOptions: { ecmaVersion: 6 }
+            options: [{before: true, after: false}]
         },
         {
             code: "var foo = function *(){};",
-            options: [{before: true, after: false}],
-            parserOptions: { ecmaVersion: 6 }
+            options: [{before: true, after: false}]
         },
         {
             code: "var foo = { *foo(){} };",
-            options: [{before: true, after: false}],
-            parserOptions: { ecmaVersion: 6 }
+            options: [{before: true, after: false}]
         },
         {
             code: "var foo = {*foo(){} };",
-            options: [{before: true, after: false}],
-            parserOptions: { ecmaVersion: 6 }
+            options: [{before: true, after: false}]
         },
         {
             code: "class Foo { *foo(){} }",
-            options: [{before: true, after: false}],
-            parserOptions: { ecmaVersion: 6 }
+            options: [{before: true, after: false}]
         },
         {
             code: "class Foo {*foo(){} }",
-            options: [{before: true, after: false}],
-            parserOptions: { ecmaVersion: 6 }
+            options: [{before: true, after: false}]
         },
         {
             code: "class Foo { static *foo(){} }",
-            options: [{before: true, after: false}],
-            parserOptions: { ecmaVersion: 6 }
+            options: [{before: true, after: false}]
         },
 
         // {"before": false, "after": true}
@@ -373,48 +285,39 @@ ruleTester.run("generator-star-spacing", rule, {
         },
         {
             code: "function* foo(){}",
-            options: [{before: false, after: true}],
-            parserOptions: { ecmaVersion: 6 }
+            options: [{before: false, after: true}]
         },
         {
             code: "function* foo(arg1, arg2){}",
-            options: [{before: false, after: true}],
-            parserOptions: { ecmaVersion: 6 }
+            options: [{before: false, after: true}]
         },
         {
             code: "var foo = function* foo(){};",
-            options: [{before: false, after: true}],
-            parserOptions: { ecmaVersion: 6 }
+            options: [{before: false, after: true}]
         },
         {
             code: "var foo = function* (){};",
-            options: [{before: false, after: true}],
-            parserOptions: { ecmaVersion: 6 }
+            options: [{before: false, after: true}]
         },
         {
             code: "var foo = {* foo(){} };",
-            options: [{before: false, after: true}],
-            parserOptions: { ecmaVersion: 6 }
+            options: [{before: false, after: true}]
         },
         {
             code: "var foo = { * foo(){} };",
-            options: [{before: false, after: true}],
-            parserOptions: { ecmaVersion: 6 }
+            options: [{before: false, after: true}]
         },
         {
             code: "class Foo {* foo(){} }",
-            options: [{before: false, after: true}],
-            parserOptions: { ecmaVersion: 6 }
+            options: [{before: false, after: true}]
         },
         {
             code: "class Foo { * foo(){} }",
-            options: [{before: false, after: true}],
-            parserOptions: { ecmaVersion: 6 }
+            options: [{before: false, after: true}]
         },
         {
             code: "class Foo { static* foo(){} }",
-            options: [{before: false, after: true}],
-            parserOptions: { ecmaVersion: 6 }
+            options: [{before: false, after: true}]
         },
 
         // {"before": true, "after": true}
@@ -424,48 +327,39 @@ ruleTester.run("generator-star-spacing", rule, {
         },
         {
             code: "function * foo(){}",
-            options: [{before: true, after: true}],
-            parserOptions: { ecmaVersion: 6 }
+            options: [{before: true, after: true}]
         },
         {
             code: "function * foo(arg1, arg2){}",
-            options: [{before: true, after: true}],
-            parserOptions: { ecmaVersion: 6 }
+            options: [{before: true, after: true}]
         },
         {
             code: "var foo = function * foo(){};",
-            options: [{before: true, after: true}],
-            parserOptions: { ecmaVersion: 6 }
+            options: [{before: true, after: true}]
         },
         {
             code: "var foo = function * (){};",
-            options: [{before: true, after: true}],
-            parserOptions: { ecmaVersion: 6 }
+            options: [{before: true, after: true}]
         },
         {
             code: "var foo = { * foo(){} };",
-            options: [{before: true, after: true}],
-            parserOptions: { ecmaVersion: 6 }
+            options: [{before: true, after: true}]
         },
         {
             code: "var foo = {* foo(){} };",
-            options: [{before: true, after: true}],
-            parserOptions: { ecmaVersion: 6 }
+            options: [{before: true, after: true}]
         },
         {
             code: "class Foo { * foo(){} }",
-            options: [{before: true, after: true}],
-            parserOptions: { ecmaVersion: 6 }
+            options: [{before: true, after: true}]
         },
         {
             code: "class Foo {* foo(){} }",
-            options: [{before: true, after: true}],
-            parserOptions: { ecmaVersion: 6 }
+            options: [{before: true, after: true}]
         },
         {
             code: "class Foo { static * foo(){} }",
-            options: [{before: true, after: true}],
-            parserOptions: { ecmaVersion: 6 }
+            options: [{before: true, after: true}]
         },
 
         // {"before": false, "after": false}
@@ -475,48 +369,39 @@ ruleTester.run("generator-star-spacing", rule, {
         },
         {
             code: "function*foo(){}",
-            options: [{before: false, after: false}],
-            parserOptions: { ecmaVersion: 6 }
+            options: [{before: false, after: false}]
         },
         {
             code: "function*foo(arg1, arg2){}",
-            options: [{before: false, after: false}],
-            parserOptions: { ecmaVersion: 6 }
+            options: [{before: false, after: false}]
         },
         {
             code: "var foo = function*foo(){};",
-            options: [{before: false, after: false}],
-            parserOptions: { ecmaVersion: 6 }
+            options: [{before: false, after: false}]
         },
         {
             code: "var foo = function*(){};",
-            options: [{before: false, after: false}],
-            parserOptions: { ecmaVersion: 6 }
+            options: [{before: false, after: false}]
         },
         {
             code: "var foo = {*foo(){} };",
-            options: [{before: false, after: false}],
-            parserOptions: { ecmaVersion: 6 }
+            options: [{before: false, after: false}]
         },
         {
             code: "var foo = { *foo(){} };",
-            options: [{before: false, after: false}],
-            parserOptions: { ecmaVersion: 6 }
+            options: [{before: false, after: false}]
         },
         {
             code: "class Foo {*foo(){} }",
-            options: [{before: false, after: false}],
-            parserOptions: { ecmaVersion: 6 }
+            options: [{before: false, after: false}]
         },
         {
             code: "class Foo { *foo(){} }",
-            options: [{before: false, after: false}],
-            parserOptions: { ecmaVersion: 6 }
+            options: [{before: false, after: false}]
         },
         {
             code: "class Foo { static*foo(){} }",
-            options: [{before: false, after: false}],
-            parserOptions: { ecmaVersion: 6 }
+            options: [{before: false, after: false}]
         },
 
         // https://github.com/eslint/eslint/issues/7101#issuecomment-246080531
@@ -552,7 +437,6 @@ ruleTester.run("generator-star-spacing", rule, {
         {
             code: "function*foo(){}",
             output: "function *foo(){}",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Missing space before *.",
                 type: "Punctuator"
@@ -561,7 +445,6 @@ ruleTester.run("generator-star-spacing", rule, {
         {
             code: "function* foo(arg1, arg2){}",
             output: "function *foo(arg1, arg2){}",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Missing space before *.",
                 type: "Punctuator"
@@ -573,7 +456,6 @@ ruleTester.run("generator-star-spacing", rule, {
         {
             code: "var foo = function*foo(){};",
             output: "var foo = function *foo(){};",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Missing space before *.",
                 type: "Punctuator"
@@ -582,7 +464,6 @@ ruleTester.run("generator-star-spacing", rule, {
         {
             code: "var foo = function* (){};",
             output: "var foo = function *(){};",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Missing space before *.",
                 type: "Punctuator"
@@ -594,7 +475,6 @@ ruleTester.run("generator-star-spacing", rule, {
         {
             code: "var foo = {* foo(){} };",
             output: "var foo = {*foo(){} };",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Unexpected space after *.",
                 type: "Punctuator"
@@ -603,7 +483,6 @@ ruleTester.run("generator-star-spacing", rule, {
         {
             code: "class Foo {* foo(){} }",
             output: "class Foo {*foo(){} }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Unexpected space after *.",
                 type: "Punctuator"
@@ -612,7 +491,6 @@ ruleTester.run("generator-star-spacing", rule, {
         {
             code: "class Foo { static* foo(){} }",
             output: "class Foo { static *foo(){} }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Missing space before *.",
                 type: "Punctuator"
@@ -627,7 +505,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "function*foo(){}",
             output: "function *foo(){}",
             options: ["before"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Missing space before *.",
                 type: "Punctuator"
@@ -637,7 +514,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "function* foo(arg1, arg2){}",
             output: "function *foo(arg1, arg2){}",
             options: ["before"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Missing space before *.",
                 type: "Punctuator"
@@ -650,7 +526,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "var foo = function*foo(){};",
             output: "var foo = function *foo(){};",
             options: ["before"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Missing space before *.",
                 type: "Punctuator"
@@ -660,7 +535,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "var foo = function* (){};",
             output: "var foo = function *(){};",
             options: ["before"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Missing space before *.",
                 type: "Punctuator"
@@ -673,7 +547,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "var foo = {* foo(){} };",
             output: "var foo = {*foo(){} };",
             options: ["before"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Unexpected space after *.",
                 type: "Punctuator"
@@ -683,7 +556,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "class Foo {* foo(){} }",
             output: "class Foo {*foo(){} }",
             options: ["before"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Unexpected space after *.",
                 type: "Punctuator"
@@ -693,7 +565,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "var foo = {* [ foo ](){} };",
             output: "var foo = {*[ foo ](){} };",
             options: ["before"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Unexpected space after *.",
                 type: "Punctuator"
@@ -703,7 +574,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "class Foo {* [ foo ](){} }",
             output: "class Foo {*[ foo ](){} }",
             options: ["before"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Unexpected space after *.",
                 type: "Punctuator"
@@ -715,7 +585,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "function*foo(){}",
             output: "function* foo(){}",
             options: ["after"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Missing space after *.",
                 type: "Punctuator"
@@ -725,7 +594,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "function *foo(arg1, arg2){}",
             output: "function* foo(arg1, arg2){}",
             options: ["after"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Unexpected space before *.",
                 type: "Punctuator"
@@ -738,7 +606,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "var foo = function *foo(){};",
             output: "var foo = function* foo(){};",
             options: ["after"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Unexpected space before *.",
                 type: "Punctuator"
@@ -751,7 +618,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "var foo = function *(){};",
             output: "var foo = function* (){};",
             options: ["after"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Unexpected space before *.",
                 type: "Punctuator"
@@ -764,7 +630,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "var foo = { *foo(){} };",
             output: "var foo = { * foo(){} };",
             options: ["after"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Missing space after *.",
                 type: "Punctuator"
@@ -774,7 +639,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "class Foo { *foo(){} }",
             output: "class Foo { * foo(){} }",
             options: ["after"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Missing space after *.",
                 type: "Punctuator"
@@ -784,7 +648,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "class Foo { static *foo(){} }",
             output: "class Foo { static* foo(){} }",
             options: ["after"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Unexpected space before *.",
                 type: "Punctuator"
@@ -797,7 +660,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "var foo = { *[foo](){} };",
             output: "var foo = { * [foo](){} };",
             options: ["after"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Missing space after *.",
                 type: "Punctuator"
@@ -807,7 +669,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "class Foo { *[foo](){} }",
             output: "class Foo { * [foo](){} }",
             options: ["after"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Missing space after *.",
                 type: "Punctuator"
@@ -819,7 +680,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "function*foo(){}",
             output: "function * foo(){}",
             options: ["both"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Missing space before *.",
                 type: "Punctuator"
@@ -832,7 +692,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "function*foo(arg1, arg2){}",
             output: "function * foo(arg1, arg2){}",
             options: ["both"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Missing space before *.",
                 type: "Punctuator"
@@ -845,7 +704,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "var foo = function*foo(){};",
             output: "var foo = function * foo(){};",
             options: ["both"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Missing space before *.",
                 type: "Punctuator"
@@ -858,7 +716,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "var foo = function*(){};",
             output: "var foo = function * (){};",
             options: ["both"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Missing space before *.",
                 type: "Punctuator"
@@ -871,7 +728,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "var foo = {*foo(){} };",
             output: "var foo = {* foo(){} };",
             options: ["both"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Missing space after *.",
                 type: "Punctuator"
@@ -881,7 +737,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "class Foo {*foo(){} }",
             output: "class Foo {* foo(){} }",
             options: ["both"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Missing space after *.",
                 type: "Punctuator"
@@ -891,7 +746,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "class Foo { static*foo(){} }",
             output: "class Foo { static * foo(){} }",
             options: ["both"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Missing space before *.",
                 type: "Punctuator"
@@ -904,7 +758,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "var foo = {*[foo](){} };",
             output: "var foo = {* [foo](){} };",
             options: ["both"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Missing space after *.",
                 type: "Punctuator"
@@ -914,7 +767,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "class Foo {*[foo](){} }",
             output: "class Foo {* [foo](){} }",
             options: ["both"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Missing space after *.",
                 type: "Punctuator"
@@ -926,7 +778,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "function * foo(){}",
             output: "function*foo(){}",
             options: ["neither"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Unexpected space before *.",
                 type: "Punctuator"
@@ -939,7 +790,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "function * foo(arg1, arg2){}",
             output: "function*foo(arg1, arg2){}",
             options: ["neither"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Unexpected space before *.",
                 type: "Punctuator"
@@ -952,7 +802,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "var foo = function * foo(){};",
             output: "var foo = function*foo(){};",
             options: ["neither"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Unexpected space before *.",
                 type: "Punctuator"
@@ -965,7 +814,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "var foo = function * (){};",
             output: "var foo = function*(){};",
             options: ["neither"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Unexpected space before *.",
                 type: "Punctuator"
@@ -978,7 +826,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "var foo = { * foo(){} };",
             output: "var foo = { *foo(){} };",
             options: ["neither"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Unexpected space after *.",
                 type: "Punctuator"
@@ -988,7 +835,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "class Foo { * foo(){} }",
             output: "class Foo { *foo(){} }",
             options: ["neither"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Unexpected space after *.",
                 type: "Punctuator"
@@ -998,7 +844,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "class Foo { static * foo(){} }",
             output: "class Foo { static*foo(){} }",
             options: ["neither"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Unexpected space before *.",
                 type: "Punctuator"
@@ -1011,7 +856,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "var foo = { * [ foo ](){} };",
             output: "var foo = { *[ foo ](){} };",
             options: ["neither"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Unexpected space after *.",
                 type: "Punctuator"
@@ -1021,7 +865,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "class Foo { * [ foo ](){} }",
             output: "class Foo { *[ foo ](){} }",
             options: ["neither"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Unexpected space after *.",
                 type: "Punctuator"
@@ -1033,7 +876,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "function*foo(){}",
             output: "function *foo(){}",
             options: [{before: true, after: false}],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Missing space before *.",
                 type: "Punctuator"
@@ -1043,7 +885,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "function* foo(arg1, arg2){}",
             output: "function *foo(arg1, arg2){}",
             options: [{before: true, after: false}],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Missing space before *.",
                 type: "Punctuator"
@@ -1056,7 +897,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "var foo = function*foo(){};",
             output: "var foo = function *foo(){};",
             options: [{before: true, after: false}],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Missing space before *.",
                 type: "Punctuator"
@@ -1066,7 +906,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "var foo = function* (){};",
             output: "var foo = function *(){};",
             options: [{before: true, after: false}],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Missing space before *.",
                 type: "Punctuator"
@@ -1079,7 +918,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "var foo = {* foo(){} };",
             output: "var foo = {*foo(){} };",
             options: [{before: true, after: false}],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Unexpected space after *.",
                 type: "Punctuator"
@@ -1089,7 +927,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "class Foo {* foo(){} }",
             output: "class Foo {*foo(){} }",
             options: [{before: true, after: false}],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Unexpected space after *.",
                 type: "Punctuator"
@@ -1101,7 +938,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "function*foo(){}",
             output: "function* foo(){}",
             options: [{before: false, after: true}],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Missing space after *.",
                 type: "Punctuator"
@@ -1111,7 +947,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "function *foo(arg1, arg2){}",
             output: "function* foo(arg1, arg2){}",
             options: [{before: false, after: true}],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Unexpected space before *.",
                 type: "Punctuator"
@@ -1124,7 +959,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "var foo = function *foo(){};",
             output: "var foo = function* foo(){};",
             options: [{before: false, after: true}],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Unexpected space before *.",
                 type: "Punctuator"
@@ -1137,7 +971,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "var foo = function *(){};",
             output: "var foo = function* (){};",
             options: [{before: false, after: true}],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Unexpected space before *.",
                 type: "Punctuator"
@@ -1150,7 +983,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "var foo = { *foo(){} };",
             output: "var foo = { * foo(){} };",
             options: [{before: false, after: true}],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Missing space after *.",
                 type: "Punctuator"
@@ -1160,7 +992,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "class Foo { *foo(){} }",
             output: "class Foo { * foo(){} }",
             options: [{before: false, after: true}],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Missing space after *.",
                 type: "Punctuator"
@@ -1170,7 +1001,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "class Foo { static *foo(){} }",
             output: "class Foo { static* foo(){} }",
             options: [{before: false, after: true}],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Unexpected space before *.",
                 type: "Punctuator"
@@ -1185,7 +1015,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "function*foo(){}",
             output: "function * foo(){}",
             options: [{before: true, after: true}],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Missing space before *.",
                 type: "Punctuator"
@@ -1198,7 +1027,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "function*foo(arg1, arg2){}",
             output: "function * foo(arg1, arg2){}",
             options: [{before: true, after: true}],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Missing space before *.",
                 type: "Punctuator"
@@ -1211,7 +1039,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "var foo = function*foo(){};",
             output: "var foo = function * foo(){};",
             options: [{before: true, after: true}],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Missing space before *.",
                 type: "Punctuator"
@@ -1224,7 +1051,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "var foo = function*(){};",
             output: "var foo = function * (){};",
             options: [{before: true, after: true}],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Missing space before *.",
                 type: "Punctuator"
@@ -1237,7 +1063,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "var foo = {*foo(){} };",
             output: "var foo = {* foo(){} };",
             options: [{before: true, after: true}],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Missing space after *.",
                 type: "Punctuator"
@@ -1247,7 +1072,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "class Foo {*foo(){} }",
             output: "class Foo {* foo(){} }",
             options: [{before: true, after: true}],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Missing space after *.",
                 type: "Punctuator"
@@ -1257,7 +1081,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "class Foo { static*foo(){} }",
             output: "class Foo { static * foo(){} }",
             options: [{before: true, after: true}],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Missing space before *.",
                 type: "Punctuator"
@@ -1272,7 +1095,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "function * foo(){}",
             output: "function*foo(){}",
             options: [{before: false, after: false}],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Unexpected space before *.",
                 type: "Punctuator"
@@ -1285,7 +1107,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "function * foo(arg1, arg2){}",
             output: "function*foo(arg1, arg2){}",
             options: [{before: false, after: false}],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Unexpected space before *.",
                 type: "Punctuator"
@@ -1298,7 +1119,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "var foo = function * foo(){};",
             output: "var foo = function*foo(){};",
             options: [{before: false, after: false}],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Unexpected space before *.",
                 type: "Punctuator"
@@ -1311,7 +1131,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "var foo = function * (){};",
             output: "var foo = function*(){};",
             options: [{before: false, after: false}],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Unexpected space before *.",
                 type: "Punctuator"
@@ -1324,7 +1143,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "var foo = { * foo(){} };",
             output: "var foo = { *foo(){} };",
             options: [{before: false, after: false}],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Unexpected space after *.",
                 type: "Punctuator"
@@ -1334,7 +1152,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "class Foo { * foo(){} }",
             output: "class Foo { *foo(){} }",
             options: [{before: false, after: false}],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Unexpected space after *.",
                 type: "Punctuator"
@@ -1344,7 +1161,6 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "class Foo { static * foo(){} }",
             output: "class Foo { static*foo(){} }",
             options: [{before: false, after: false}],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Unexpected space before *.",
                 type: "Punctuator"

--- a/tests/lib/rules/no-class-assign.js
+++ b/tests/lib/rules/no-class-assign.js
@@ -16,58 +16,51 @@ const RuleTester = require("../../../lib/testers/rule-tester");
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
 
 ruleTester.run("no-class-assign", rule, {
     valid: [
-        {code: "class A { } foo(A);", parserOptions: { ecmaVersion: 6 }},
-        {code: "let A = class A { }; foo(A);", parserOptions: { ecmaVersion: 6 }},
-        {code: "class A { b(A) { A = 0; } }", parserOptions: { ecmaVersion: 6 }},
-        {code: "class A { b() { let A; A = 0; } }", parserOptions: { ecmaVersion: 6 }},
-        {code: "let A = class { b() { A = 0; } }", parserOptions: { ecmaVersion: 6 }},
+        "class A { } foo(A);",
+        "let A = class A { }; foo(A);",
+        "class A { b(A) { A = 0; } }",
+        "class A { b() { let A; A = 0; } }",
+        "let A = class { b() { A = 0; } }",
 
         // ignores non class.
-        {code: "var x = 0; x = 1;"},
-        {code: "let x = 0; x = 1;", parserOptions: { ecmaVersion: 6 }},
-        {code: "const x = 0; x = 1;", parserOptions: { ecmaVersion: 6 }},
-        {code: "function x() {} x = 1;"},
-        {code: "function foo(x) { x = 1; }"},
-        {code: "try {} catch (x) { x = 1; }"}
+        "var x = 0; x = 1;",
+        "let x = 0; x = 1;",
+        "const x = 0; x = 1;",
+        "function x() {} x = 1;",
+        "function foo(x) { x = 1; }",
+        "try {} catch (x) { x = 1; }"
     ],
     invalid: [
         {
             code: "class A { } A = 0;",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{message: "'A' is a class.", type: "Identifier"}]
         },
         {
             code: "class A { } ({A}) = 0;",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{message: "'A' is a class.", type: "Identifier"}]
         },
         {
             code: "class A { } ({b: A = 0}) = {};",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{message: "'A' is a class.", type: "Identifier"}]
         },
         {
             code: "A = 0; class A { }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{message: "'A' is a class.", type: "Identifier"}]
         },
         {
             code: "class A { b() { A = 0; } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{message: "'A' is a class.", type: "Identifier"}]
         },
         {
             code: "let A = class A { b() { A = 0; } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{message: "'A' is a class.", type: "Identifier"}]
         },
         {
             code: "class A { } A = 0; A = 1;",
-            parserOptions: { ecmaVersion: 6 },
             errors: [
                 {message: "'A' is a class.", type: "Identifier", line: 1, column: 13},
                 {message: "'A' is a class.", type: "Identifier", line: 1, column: 20}

--- a/tests/lib/rules/no-confusing-arrow.js
+++ b/tests/lib/rules/no-confusing-arrow.js
@@ -13,24 +13,10 @@ const rule = require("../../../lib/rules/no-confusing-arrow"),
     RuleTester = require("../../../lib/testers/rule-tester");
 
 //------------------------------------------------------------------------------
-// Helpers
-//------------------------------------------------------------------------------
-
-/**
- * Extends a rule object to include support for arrow functions
- * @param {Object} obj - rule object
- * @returns {Object} object extend to include ES6 features
- */
-function addArrowFunctions(obj) {
-    obj.parserOptions = { ecmaVersion: 6 };
-    return obj;
-}
-
-//------------------------------------------------------------------------------
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
 
 ruleTester.run("no-confusing-arrow", rule, {
     valid: [
@@ -38,7 +24,7 @@ ruleTester.run("no-confusing-arrow", rule, {
         { code: "var x = a => { return 1 ? 2 : 3; }" },
         { code: "var x = (a) => { return 1 ? 2 : 3; }" },
         { code: "var x = a => (1 ? 2 : 3)", options: [{ allowParens: true }]}
-    ].map(addArrowFunctions),
+    ],
     invalid: [
         {
             code: "a => 1 ? 2 : 3",
@@ -56,5 +42,5 @@ ruleTester.run("no-confusing-arrow", rule, {
             code: "var x = a => (1 ? 2 : 3)",
             errors: [{ message: "Arrow function used ambiguously with a conditional expression." }]
         }
-    ].map(addArrowFunctions)
+    ]
 });

--- a/tests/lib/rules/no-const-assign.js
+++ b/tests/lib/rules/no-const-assign.js
@@ -16,64 +16,56 @@ const RuleTester = require("../../../lib/testers/rule-tester");
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
 
 ruleTester.run("no-const-assign", rule, {
     valid: [
-        {code: "const x = 0; { let x; x = 1; }", parserOptions: { ecmaVersion: 6 }},
-        {code: "const x = 0; function a(x) { x = 1; }", parserOptions: { ecmaVersion: 6 }},
-        {code: "const x = 0; foo(x);", parserOptions: { ecmaVersion: 6 }},
-        {code: "for (const x in [1,2,3]) { foo(x); }", parserOptions: { ecmaVersion: 6 }},
-        {code: "for (const x of [1,2,3]) { foo(x); }", parserOptions: { ecmaVersion: 6 }},
-        {code: "const x = {key: 0}; x.key = 1;", parserOptions: { ecmaVersion: 6 }},
+        "const x = 0; { let x; x = 1; }",
+        "const x = 0; function a(x) { x = 1; }",
+        "const x = 0; foo(x);",
+        "for (const x in [1,2,3]) { foo(x); }",
+        "for (const x of [1,2,3]) { foo(x); }",
+        "const x = {key: 0}; x.key = 1;",
 
         // ignores non constant.
-        {code: "var x = 0; x = 1;"},
-        {code: "let x = 0; x = 1;", parserOptions: { ecmaVersion: 6 }},
-        {code: "function x() {} x = 1;"},
-        {code: "function foo(x) { x = 1; }"},
-        {code: "class X {} X = 1;", parserOptions: { ecmaVersion: 6 }},
-        {code: "try {} catch (x) { x = 1; }"}
+        "var x = 0; x = 1;",
+        "let x = 0; x = 1;",
+        "function x() {} x = 1;",
+        "function foo(x) { x = 1; }",
+        "class X {} X = 1;",
+        "try {} catch (x) { x = 1; }"
     ],
     invalid: [
         {
             code: "const x = 0; x = 1;",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{message: "'x' is constant.", type: "Identifier"}]
         },
         {
             code: "const {a: x} = {a: 0}; x = 1;",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{message: "'x' is constant.", type: "Identifier"}]
         },
         {
             code: "const x = 0; ({x}) = {x: 1};",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{message: "'x' is constant.", type: "Identifier"}]
         },
         {
             code: "const x = 0; ({a: x = 1}) = {};",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{message: "'x' is constant.", type: "Identifier"}]
         },
         {
             code: "const x = 0; x += 1;",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{message: "'x' is constant.", type: "Identifier"}]
         },
         {
             code: "const x = 0; ++x;",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{message: "'x' is constant.", type: "Identifier"}]
         },
         {
             code: "for (const i = 0; i < 10; ++i) { foo(i); }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{message: "'i' is constant.", type: "Identifier"}]
         },
         {
             code: "const x = 0; x = 1; x = 2;",
-            parserOptions: { ecmaVersion: 6 },
             errors: [
                 {message: "'x' is constant.", type: "Identifier", line: 1, column: 14},
                 {message: "'x' is constant.", type: "Identifier", line: 1, column: 21}
@@ -81,17 +73,14 @@ ruleTester.run("no-const-assign", rule, {
         },
         {
             code: "const x = 0; function foo() { x = x + 1; }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{message: "'x' is constant.", type: "Identifier"}]
         },
         {
             code: "const x = 0; function foo(a) { x = a; }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{message: "'x' is constant.", type: "Identifier"}]
         },
         {
             code: "const x = 0; while (true) { x = x + 1; }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{message: "'x' is constant.", type: "Identifier"}]
         }
     ]

--- a/tests/lib/rules/no-dupe-class-members.js
+++ b/tests/lib/rules/no-dupe-class-members.js
@@ -16,53 +16,48 @@ const RuleTester = require("../../../lib/testers/rule-tester");
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
 
 ruleTester.run("no-dupe-class-members", rule, {
     valid: [
-        {code: "class A { foo() {} bar() {} }", parserOptions: { ecmaVersion: 6 }},
-        {code: "class A { static foo() {} foo() {} }", parserOptions: { ecmaVersion: 6 }},
-        {code: "class A { get foo() {} set foo(value) {} }", parserOptions: { ecmaVersion: 6 }},
-        {code: "class A { static foo() {} get foo() {} set foo(value) {} }", parserOptions: { ecmaVersion: 6 }},
-        {code: "class A { foo() { } } class B { foo() { } }", parserOptions: { ecmaVersion: 6 }},
-        {code: "class A { [foo]() {} foo() {} }", parserOptions: { ecmaVersion: 6 }},
-        {code: "class A { 'foo'() {} 'bar'() {} baz() {} }", parserOptions: { ecmaVersion: 6 }},
-        {code: "class A { *'foo'() {} *'bar'() {} *baz() {} }", parserOptions: { ecmaVersion: 6 }},
-        {code: "class A { get 'foo'() {} get 'bar'() {} get baz() {} }", parserOptions: { ecmaVersion: 6 }},
-        {code: "class A { 1() {} 2() {} }", parserOptions: { ecmaVersion: 6 }}
+        "class A { foo() {} bar() {} }",
+        "class A { static foo() {} foo() {} }",
+        "class A { get foo() {} set foo(value) {} }",
+        "class A { static foo() {} get foo() {} set foo(value) {} }",
+        "class A { foo() { } } class B { foo() { } }",
+        "class A { [foo]() {} foo() {} }",
+        "class A { 'foo'() {} 'bar'() {} baz() {} }",
+        "class A { *'foo'() {} *'bar'() {} *baz() {} }",
+        "class A { get 'foo'() {} get 'bar'() {} get baz() {} }",
+        "class A { 1() {} 2() {} }"
     ],
     invalid: [
         {
             code: "class A { foo() {} foo() {} }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [
                 {type: "MethodDefinition", line: 1, column: 20, message: "Duplicate name 'foo'."}
             ]
         },
         {
             code: "!class A { foo() {} foo() {} };",
-            parserOptions: { ecmaVersion: 6 },
             errors: [
                 {type: "MethodDefinition", line: 1, column: 21, message: "Duplicate name 'foo'."}
             ]
         },
         {
             code: "class A { 'foo'() {} 'foo'() {} }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [
                 {type: "MethodDefinition", line: 1, column: 22, message: "Duplicate name 'foo'."}
             ]
         },
         {
             code: "class A { 10() {} 1e1() {} }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [
                 {type: "MethodDefinition", line: 1, column: 19, message: "Duplicate name '10'."}
             ]
         },
         {
             code: "class A { foo() {} foo() {} foo() {} }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [
                 {type: "MethodDefinition", line: 1, column: 20, message: "Duplicate name 'foo'."},
                 {type: "MethodDefinition", line: 1, column: 29, message: "Duplicate name 'foo'."}
@@ -70,21 +65,18 @@ ruleTester.run("no-dupe-class-members", rule, {
         },
         {
             code: "class A { static foo() {} static foo() {} }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [
                 {type: "MethodDefinition", line: 1, column: 27, message: "Duplicate name 'foo'."}
             ]
         },
         {
             code: "class A { foo() {} get foo() {} }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [
                 {type: "MethodDefinition", line: 1, column: 20, message: "Duplicate name 'foo'."}
             ]
         },
         {
             code: "class A { set foo(value) {} foo() {} }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [
                 {type: "MethodDefinition", line: 1, column: 29, message: "Duplicate name 'foo'."}
             ]

--- a/tests/lib/rules/no-duplicate-imports.js
+++ b/tests/lib/rules/no-duplicate-imports.js
@@ -16,67 +16,57 @@ const rule = require("../../../lib/rules/no-duplicate-imports"),
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({ parserOptions: { sourceType: "module" } });
 
 ruleTester.run("no-duplicate-imports", rule, {
     valid: [
-        { code: "import os from \"os\";\nimport fs from \"fs\";", parserOptions: { sourceType: "module" } },
-        { code: "import { merge } from \"lodash-es\";", parserOptions: { sourceType: "module" } },
-        { code: "import _, { merge } from \"lodash-es\";", parserOptions: { sourceType: "module" } },
-        { code: "import * as Foobar from \"async\";", parserOptions: { sourceType: "module" } },
-        { code: "import \"foo\"", parserOptions: { sourceType: "module" } },
-        { code: "import os from \"os\";\nexport { something } from \"os\";", parserOptions: { sourceType: "module" } },
+        "import os from \"os\";\nimport fs from \"fs\";",
+        "import { merge } from \"lodash-es\";",
+        "import _, { merge } from \"lodash-es\";",
+        "import * as Foobar from \"async\";",
+        "import \"foo\"",
+        "import os from \"os\";\nexport { something } from \"os\";",
         {
             code: "import os from \"os\";\nexport { hello } from \"hello\";",
-            parserOptions: { sourceType: "module" },
             options: [{ includeExports: true }]
         },
         {
             code: "import os from \"os\";\nexport * from \"hello\";",
-            parserOptions: { sourceType: "module" },
             options: [{ includeExports: true }]
         },
         {
             code: "import os from \"os\";\nexport { hello as hi } from \"hello\";",
-            parserOptions: { sourceType: "module" },
             options: [{ includeExports: true }]
         },
         {
             code: "import os from \"os\";\nexport default function(){};",
-            parserOptions: { sourceType: "module" },
             options: [{ includeExports: true }]
         },
         {
             code: "import { merge } from \"lodash-es\";\nexport { merge as lodashMerge }",
-            parserOptions: { sourceType: "module" },
             options: [{ includeExports: true }]
         }
     ],
     invalid: [
         {
             code: "import \"fs\";\nimport \"fs\"",
-            parserOptions: { sourceType: "module" },
             errors: [{ message: "'fs' import is duplicated.", type: "ImportDeclaration" }]
         },
         {
             code: "import { merge } from \"lodash-es\";import { find } from \"lodash-es\";",
-            parserOptions: { sourceType: "module" },
             errors: [{ message: "'lodash-es' import is duplicated.", type: "ImportDeclaration" }]
         },
         {
             code: "import { merge } from \"lodash-es\";import _ from \"lodash-es\";",
-            parserOptions: { sourceType: "module" },
             errors: [{ message: "'lodash-es' import is duplicated.", type: "ImportDeclaration" }]
         },
         {
             code: "export { os } from \"os\";\nexport { something } from \"os\";",
-            parserOptions: { sourceType: "module" },
             options: [{ includeExports: true }],
             errors: [{ message: "'os' export is duplicated.", type: "ExportNamedDeclaration" }]
         },
         {
             code: "import os from \"os\"; export { os as foobar } from \"os\";\nexport { something } from \"os\";",
-            parserOptions: { sourceType: "module" },
             options: [{ includeExports: true }],
             errors: [
                 { message: "'os' export is duplicated as import.", type: "ExportNamedDeclaration" },
@@ -86,13 +76,11 @@ ruleTester.run("no-duplicate-imports", rule, {
         },
         {
             code: "import os from \"os\";\nexport { something } from \"os\";",
-            parserOptions: { sourceType: "module" },
             options: [{ includeExports: true }],
             errors: [{ message: "'os' export is duplicated as import.", type: "ExportNamedDeclaration" }]
         },
         {
             code: "import os from \"os\";\nexport * from \"os\";",
-            parserOptions: { sourceType: "module" },
             options: [{ includeExports: true }],
             errors: [{ message: "'os' export is duplicated as import.", type: "ExportAllDeclaration" }]
         }

--- a/tests/lib/rules/no-new-symbol.js
+++ b/tests/lib/rules/no-new-symbol.js
@@ -16,23 +16,21 @@ const rule = require("../../../lib/rules/no-new-symbol"),
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({ env: { es6: true } });
 
 ruleTester.run("no-new-symbol", rule, {
     valid: [
-        {code: "var foo = Symbol('foo');", env: {es6: true} },
-        {code: "function bar(Symbol) { var baz = new Symbol('baz');}", env: {es6: true} },
-        {code: "function Symbol() {} new Symbol();", env: {es6: true} }
+        "var foo = Symbol('foo');",
+        "function bar(Symbol) { var baz = new Symbol('baz');}",
+        "function Symbol() {} new Symbol();",
     ],
     invalid: [
         {
             code: "var foo = new Symbol('foo');",
-            env: {es6: true},
             errors: [{ message: "`Symbol` cannot be called as a constructor."}]
         },
         {
             code: "function bar() { return function Symbol() {}; } var baz = new Symbol('baz');",
-            env: {es6: true},
             errors: [{ message: "`Symbol` cannot be called as a constructor."}]
         }
     ]

--- a/tests/lib/rules/no-restricted-imports.js
+++ b/tests/lib/rules/no-restricted-imports.js
@@ -16,56 +16,49 @@ const rule = require("../../../lib/rules/no-restricted-imports"),
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({ parserOptions: { sourceType: "module" } });
 
 ruleTester.run("no-restricted-imports", rule, {
     valid: [
-        { code: "import os from \"os\";", options: ["osx"], parserOptions: { sourceType: "module" } },
-        { code: "import fs from \"fs\";", options: ["crypto"], parserOptions: { sourceType: "module" } },
-        { code: "import path from \"path\";", options: ["crypto", "stream", "os"], parserOptions: { sourceType: "module" } },
-        { code: "import async from \"async\";", parserOptions: { sourceType: "module" } },
-        { code: "import \"foo\"", options: ["crypto"], parserOptions: { sourceType: "module" } },
-        { code: "import \"foo/bar\";", options: ["foo"], parserOptions: { sourceType: "module" } },
-        { code: "import withPaths from \"foo/bar\";", options: [{ paths: ["foo", "bar"] }], parserOptions: { sourceType: "module" } },
-        { code: "import withPatterns from \"foo/bar\";", options: [{ patterns: ["foo/c*"] }], parserOptions: { sourceType: "module" } },
+        { code: "import os from \"os\";", options: ["osx"] },
+        { code: "import fs from \"fs\";", options: ["crypto"] },
+        { code: "import path from \"path\";", options: ["crypto", "stream", "os"] },
+        "import async from \"async\";",
+        { code: "import \"foo\"", options: ["crypto"] },
+        { code: "import \"foo/bar\";", options: ["foo"] },
+        { code: "import withPaths from \"foo/bar\";", options: [{ paths: ["foo", "bar"] }] },
+        { code: "import withPatterns from \"foo/bar\";", options: [{ patterns: ["foo/c*"] }] },
         {
             code: "import withPatternsAndPaths from \"foo/bar\";",
-            options: [{ paths: ["foo"], patterns: ["foo/c*"] }],
-            parserOptions: { sourceType: "module" }
+            options: [{ paths: ["foo"], patterns: ["foo/c*"] }]
         },
         {
             code: "import withGitignores from \"foo/bar\";",
-            options: [{ patterns: ["foo/*", "!foo/bar"] }],
-            parserOptions: { sourceType: "module" }
+            options: [{ patterns: ["foo/*", "!foo/bar"] }]
         }
     ],
     invalid: [{
-        code: "import \"fs\"", options: ["fs"], parserOptions: { sourceType: "module" },
+        code: "import \"fs\"", options: ["fs"],
         errors: [{ message: "'fs' import is restricted from being used.", type: "ImportDeclaration"}]
     }, {
         code: "import os from \"os \";",
         options: ["fs", "crypto ", "stream", "os"],
-        parserOptions: { sourceType: "module" },
         errors: [{ message: "'os' import is restricted from being used.", type: "ImportDeclaration"}]
     }, {
         code: "import \"foo/bar\";",
         options: ["foo/bar"],
-        parserOptions: { sourceType: "module" },
         errors: [{ message: "'foo/bar' import is restricted from being used.", type: "ImportDeclaration"}]
     }, {
         code: "import withPaths from \"foo/bar\";",
         options: [{ paths: ["foo/bar"] }],
-        parserOptions: { sourceType: "module" },
         errors: [{ message: "'foo/bar' import is restricted from being used.", type: "ImportDeclaration"}]
     }, {
         code: "import withPatterns from \"foo/bar\";",
         options: [{ patterns: ["foo/*"] }],
-        parserOptions: { sourceType: "module" },
         errors: [{ message: "'foo/bar' import is restricted from being used by a pattern.", type: "ImportDeclaration"}]
     }, {
         code: "import withGitignores from \"foo/bar\";",
         options: [{ patterns: ["foo/*", "!foo/baz"] }],
-        parserOptions: { sourceType: "module" },
         errors: [{ message: "'foo/bar' import is restricted from being used by a pattern.", type: "ImportDeclaration"}]
     }]
 });

--- a/tests/lib/rules/no-this-before-super.js
+++ b/tests/lib/rules/no-this-before-super.js
@@ -16,7 +16,7 @@ const RuleTester = require("../../../lib/testers/rule-tester");
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
 
 ruleTester.run("no-this-before-super", rule, {
     valid: [
@@ -25,44 +25,44 @@ ruleTester.run("no-this-before-super", rule, {
          * if the class has no extends or `extends null`, just ignore.
          * those classes cannot call `super()`.
          */
-        { code: "class A { }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A { constructor() { } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A { constructor() { this.b = 0; } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A { constructor() { this.b(); } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A extends null { }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A extends null { constructor() { } }", parserOptions: { ecmaVersion: 6 } },
+        "class A { }",
+        "class A { constructor() { } }",
+        "class A { constructor() { this.b = 0; } }",
+        "class A { constructor() { this.b(); } }",
+        "class A extends null { }",
+        "class A extends null { constructor() { } }",
 
         // allows `this`/`super` after `super()`.
-        { code: "class A extends B { }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A extends B { constructor() { super(); } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A extends B { constructor() { super(); this.c = this.d; } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A extends B { constructor() { super(); this.c(); } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A extends B { constructor() { super(); super.c(); } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A extends B { constructor() { if (true) { super(); } else { super(); } this.c(); } }", parserOptions: { ecmaVersion: 6 } },
+        "class A extends B { }",
+        "class A extends B { constructor() { super(); } }",
+        "class A extends B { constructor() { super(); this.c = this.d; } }",
+        "class A extends B { constructor() { super(); this.c(); } }",
+        "class A extends B { constructor() { super(); super.c(); } }",
+        "class A extends B { constructor() { if (true) { super(); } else { super(); } this.c(); } }",
 
         // allows `this`/`super` in nested executable scopes, even if before `super()`.
-        { code: "class A extends B { constructor() { class B extends C { constructor() { super(); this.d = 0; } } super(); } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A extends B { constructor() { var B = class extends C { constructor() { super(); this.d = 0; } }; super(); } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A extends B { constructor() { function c() { this.d(); } super(); } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A extends B { constructor() { var c = function c() { this.d(); }; super(); } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A extends B { constructor() { var c = () => this.d(); super(); } }", parserOptions: { ecmaVersion: 6 } },
+        "class A extends B { constructor() { class B extends C { constructor() { super(); this.d = 0; } } super(); } }",
+        "class A extends B { constructor() { var B = class extends C { constructor() { super(); this.d = 0; } }; super(); } }",
+        "class A extends B { constructor() { function c() { this.d(); } super(); } }",
+        "class A extends B { constructor() { var c = function c() { this.d(); }; super(); } }",
+        "class A extends B { constructor() { var c = () => this.d(); super(); } }",
 
         // ignores out of constructors.
-        { code: "class A { b() { this.c = 0; } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A extends B { c() { this.d = 0; } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "function a() { this.b = 0; }", parserOptions: { ecmaVersion: 6 } },
+        "class A { b() { this.c = 0; } }",
+        "class A extends B { c() { this.d = 0; } }",
+        "function a() { this.b = 0; }",
 
         // multi code path.
-        { code: "class A extends B { constructor() { if (a) { super(); this.a(); } else { super(); this.b(); } } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A extends B { constructor() { if (a) super(); else super(); this.a(); } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A extends B { constructor() { try { super(); } finally {} this.a(); } }", parserOptions: { ecmaVersion: 6 } },
+        "class A extends B { constructor() { if (a) { super(); this.a(); } else { super(); this.b(); } } }",
+        "class A extends B { constructor() { if (a) super(); else super(); this.a(); } }",
+        "class A extends B { constructor() { try { super(); } finally {} this.a(); } }",
 
         // https://github.com/eslint/eslint/issues/5261
-        { code: "class A extends B { constructor(a) { super(); for (const b of a) { this.a(); } } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A extends B { constructor(a) { for (const b of a) { foo(b); } super(); } }", parserOptions: { ecmaVersion: 6 } },
+        "class A extends B { constructor(a) { super(); for (const b of a) { this.a(); } } }",
+        "class A extends B { constructor(a) { for (const b of a) { foo(b); } super(); } }",
 
         // https://github.com/eslint/eslint/issues/5319
-        { code: "class A extends B { constructor(a) { super(); this.a = a && function(){} && this.foo; } }", parserOptions: { ecmaVersion: 6 } },
+        "class A extends B { constructor(a) { super(); this.a = a && function(){} && this.foo; } }",
 
         // https://github.com/eslint/eslint/issues/5394
         {
@@ -74,93 +74,78 @@ ruleTester.run("no-this-before-super", rule, {
                 "        this;",
                 "    }",
                 "}"
-            ].join("\n"),
-            parserOptions: {ecmaVersion: 6}
+            ].join("\n")
         },
 
         // https://github.com/eslint/eslint/issues/5894
-        { code: "class A { constructor() { return; this; } }", parserOptions: {ecmaVersion: 6} },
-        { code: "class A extends B { constructor() { return; this; } }", parserOptions: {ecmaVersion: 6} }
+        "class A { constructor() { return; this; } }",
+        "class A extends B { constructor() { return; this; } }"
     ],
     invalid: [
 
         // disallows all `this`/`super` if `super()` is missing.
         {
             code: "class A extends B { constructor() { this.c = 0; } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'this' is not allowed before 'super()'.", type: "ThisExpression"}]
         },
         {
             code: "class A extends B { constructor() { this.c(); } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'this' is not allowed before 'super()'.", type: "ThisExpression"}]
         },
         {
             code: "class A extends B { constructor() { super.c(); } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'super' is not allowed before 'super()'.", type: "Super"}]
         },
 
         // disallows `this`/`super` before `super()`.
         {
             code: "class A extends B { constructor() { this.c = 0; super(); } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'this' is not allowed before 'super()'.", type: "ThisExpression"}]
         },
         {
             code: "class A extends B { constructor() { this.c(); super(); } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'this' is not allowed before 'super()'.", type: "ThisExpression"}]
         },
         {
             code: "class A extends B { constructor() { super.c(); super(); } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'super' is not allowed before 'super()'.", type: "Super"}]
         },
 
         // disallows `this`/`super` in arguments of `super()`.
         {
             code: "class A extends B { constructor() { super(this.c); } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'this' is not allowed before 'super()'.", type: "ThisExpression"}]
         },
         {
             code: "class A extends B { constructor() { super(this.c()); } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'this' is not allowed before 'super()'.", type: "ThisExpression"}]
         },
         {
             code: "class A extends B { constructor() { super(super.c()); } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'super' is not allowed before 'super()'.", type: "Super"}]
         },
 
         // even if is nested, reports correctly.
         {
             code: "class A extends B { constructor() { class C extends D { constructor() { super(); this.e(); } } this.f(); super(); } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'this' is not allowed before 'super()'.", type: "ThisExpression", column: 96}]
         },
         {
             code: "class A extends B { constructor() { class C extends D { constructor() { this.e(); super(); } } super(); this.f(); } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'this' is not allowed before 'super()'.", type: "ThisExpression", column: 73}]
         },
 
         // multi code path.
         {
             code: "class A extends B { constructor() { if (a) super(); this.a(); } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'this' is not allowed before 'super()'.", type: "ThisExpression"}]
         },
         {
             code: "class A extends B { constructor() { try { super(); } finally { this.a; } } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'this' is not allowed before 'super()'.", type: "ThisExpression"}]
         },
         {
             code: "class A extends B { constructor() { try { super(); } catch (err) { } this.a; } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'this' is not allowed before 'super()'.", type: "ThisExpression"}]
         }
     ]

--- a/tests/lib/rules/no-useless-computed-key.js
+++ b/tests/lib/rules/no-useless-computed-key.js
@@ -16,75 +16,66 @@ const rule = require("../../../lib/rules/no-useless-computed-key"),
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
 
 ruleTester.run("no-useless-computed-key", rule, {
     valid: [
-        { code: "({ 'a': 0, b(){} })", env: { es6: true } },
-        { code: "({ [x]: 0 });", env: { es6: true } },
-        { code: "({ a: 0, [b](){} })", env: { es6: true } }
+        "({ 'a': 0, b(){} })",
+        "({ [x]: 0 });",
+        "({ a: 0, [b](){} })"
     ],
     invalid: [
         {
             code: "({ ['0']: 0 })",
             output: "({ '0': 0 })",
-            env: {es6: true},
             errors: [{
                 message: "Unnecessarily computed property ['0'] found.", type: "Property"
             }]
         }, {
             code: "({ ['0+1,234']: 0 })",
             output: "({ '0+1,234': 0 })",
-            env: {es6: true},
             errors: [{
                 message: "Unnecessarily computed property ['0+1,234'] found.", type: "Property"
             }]
         }, {
             code: "({ [0]: 0 })",
             output: "({ 0: 0 })",
-            env: {es6: true},
             errors: [{
                 message: "Unnecessarily computed property [0] found.", type: "Property"
             }]
         }, {
             code: "({ ['x']: 0 })",
             output: "({ 'x': 0 })",
-            env: {es6: true},
             errors: [{
                 message: "Unnecessarily computed property ['x'] found.", type: "Property"
             }]
         }, {
             code: "({ ['x']() {} })",
             output: "({ 'x'() {} })",
-            env: {es6: true},
             errors: [{
                 message: "Unnecessarily computed property ['x'] found.", type: "Property"
             }]
         }, {
             code: "({ [/* this comment prevents a fix */ 'x']: 0 })",
             output: "({ [/* this comment prevents a fix */ 'x']: 0 })",
-            env: {es6: true},
             errors: [{
                 message: "Unnecessarily computed property ['x'] found.", type: "Property"
             }]
         }, {
             code: "({ ['x' /* this comment also prevents a fix */]: 0 })",
             output: "({ ['x' /* this comment also prevents a fix */]: 0 })",
-            env: {es6: true},
             errors: [{
                 message: "Unnecessarily computed property ['x'] found.", type: "Property"
             }]
         }, {
             code: "({ [('x')]: 0 })",
             output: "({ 'x': 0 })",
-            env: {es6: true},
             errors: [{
                 message: "Unnecessarily computed property ['x'] found.", type: "Property"
             }]
         }, {
             code: "({ *['x']() {} })",
             output: "({ *'x'() {} })",
-            env: {es6: true},
             errors: [{
                 message: "Unnecessarily computed property ['x'] found.", type: "Property"
             }]

--- a/tests/lib/rules/no-useless-constructor.js
+++ b/tests/lib/rules/no-useless-constructor.js
@@ -16,124 +16,64 @@ const RuleTester = require("../../../lib/testers/rule-tester");
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
 const error = {message: "Useless constructor.", type: "MethodDefinition"};
 
 ruleTester.run("no-useless-constructor", rule, {
     valid: [
-        {
-            code: "class A { }",
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "class A { constructor(){ doSomething(); } }",
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "class A { constructor(){ super('foo'); } }",
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "class A extends B { constructor(){} }",
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "class A extends B { constructor(){ super('foo'); } }",
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "class A extends B { constructor(foo, bar){ super(foo, bar, 1); } }",
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "class A extends B { constructor(){ super(); doSomething(); } }",
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "class A extends B { constructor(...args){ super(...args); doSomething(); } }",
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "class A { dummyMethod(){ doSomething(); } }",
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "class A extends B.C { constructor() { super(foo); } }",
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "class A extends B.C { constructor([a, b, c]) { super(...arguments); } }",
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "class A extends B.C { constructor(a = f()) { super(...arguments); } }",
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "class A extends B { constructor(a, b, c) { super(a, b); } }",
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "class A extends B { constructor(foo, bar){ super(foo); } }",
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "class A extends B { constructor(test) { super(); } }",
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "class A extends B { constructor() { foo; } }",
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "class A extends B { constructor(foo, bar) { super(bar); } }",
-            parserOptions: { ecmaVersion: 6 }
-        }
+        "class A { }",
+        "class A { constructor(){ doSomething(); } }",
+        "class A { constructor(){ super('foo'); } }",
+        "class A extends B { constructor(){} }",
+        "class A extends B { constructor(){ super('foo'); } }",
+        "class A extends B { constructor(foo, bar){ super(foo, bar, 1); } }",
+        "class A extends B { constructor(){ super(); doSomething(); } }",
+        "class A extends B { constructor(...args){ super(...args); doSomething(); } }",
+        "class A { dummyMethod(){ doSomething(); } }",
+        "class A extends B.C { constructor() { super(foo); } }",
+        "class A extends B.C { constructor([a, b, c]) { super(...arguments); } }",
+        "class A extends B.C { constructor(a = f()) { super(...arguments); } }",
+        "class A extends B { constructor(a, b, c) { super(a, b); } }",
+        "class A extends B { constructor(foo, bar){ super(foo); } }",
+        "class A extends B { constructor(test) { super(); } }",
+        "class A extends B { constructor() { foo; } }",
+        "class A extends B { constructor(foo, bar) { super(bar); } }"
     ],
     invalid: [
         {
             code: "class A { constructor(){} }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [error]
         },
         {
             code: "class A { 'constructor'(){} }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [error]
         },
         {
             code: "class A extends B { constructor() { super(); } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [error]
         },
         {
             code: "class A extends B { constructor(foo){ super(foo); } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [error]
         },
         {
             code: "class A extends B { constructor(foo, bar){ super(foo, bar); } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [error]
         },
         {
             code: "class A extends B { constructor(...args){ super(...args); } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [error]
         },
         {
             code: "class A extends B.C { constructor() { super(...arguments); } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [error]
         },
         {
             code: "class A extends B { constructor(a, b, ...c) { super(...arguments); } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [error]
         },
         {
             code: "class A extends B { constructor(a, b, ...c) { super(a, b, ...c); } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [error]
         }
     ]

--- a/tests/lib/rules/no-useless-rename.js
+++ b/tests/lib/rules/no-useless-rename.js
@@ -12,128 +12,107 @@
 const rule = require("../../../lib/rules/no-useless-rename"),
     RuleTester = require("../../../lib/testers/rule-tester");
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6, sourceType: "module" } });
 
 ruleTester.run("no-useless-rename", rule, {
     valid: [
-        { code: "let {foo} = obj;", parserOptions: { ecmaVersion: 6 } },
-        { code: "let {foo: bar} = obj;", parserOptions: { ecmaVersion: 6 } },
-        { code: "let {foo: bar, baz: qux} = obj;", parserOptions: { ecmaVersion: 6 } },
-        { code: "let {foo: {bar: baz}} = obj;", parserOptions: { ecmaVersion: 6 } },
-        { code: "let {foo, bar: {baz: qux}} = obj;", parserOptions: { ecmaVersion: 6 } },
-        { code: "let {'foo': bar} = obj;", parserOptions: { ecmaVersion: 6 } },
-        { code: "let {'foo': bar, 'baz': qux} = obj;", parserOptions: { ecmaVersion: 6 } },
-        { code: "let {'foo': {'bar': baz}} = obj;", parserOptions: { ecmaVersion: 6 } },
-        { code: "let {foo, 'bar': {'baz': qux}} = obj;", parserOptions: { ecmaVersion: 6 } },
-        { code: "let {['foo']: bar} = obj;", parserOptions: { ecmaVersion: 6 } },
-        { code: "let {['foo']: bar, ['baz']: qux} = obj;", parserOptions: { ecmaVersion: 6 } },
-        { code: "let {['foo']: {['bar']: baz}} = obj;", parserOptions: { ecmaVersion: 6 } },
-        { code: "let {foo, ['bar']: {['baz']: qux}} = obj;", parserOptions: { ecmaVersion: 6 } },
-        { code: "let {[foo]: foo} = obj;", parserOptions: { ecmaVersion: 6 } },
-        { code: "let {['foo']: foo} = obj;", parserOptions: { ecmaVersion: 6 } },
-        { code: "let {[foo]: bar} = obj;", parserOptions: { ecmaVersion: 6 } },
-        { code: "let {['foo']: bar} = obj;", parserOptions: { ecmaVersion: 6 } },
-        { code: "function func({foo}) {}", parserOptions: { ecmaVersion: 6 } },
-        { code: "function func({foo: bar}) {}", parserOptions: { ecmaVersion: 6 } },
-        { code: "function func({foo: bar, baz: qux}) {}", parserOptions: { ecmaVersion: 6 } },
-        { code: "({foo}) => {}", parserOptions: { ecmaVersion: 6 } },
-        { code: "({foo: bar}) => {}", parserOptions: { ecmaVersion: 6 } },
-        { code: "({foo: bar, baz: qui}) => {}", parserOptions: { ecmaVersion: 6 } },
-        { code: "import * as foo from 'foo';", parserOptions: { ecmaVersion: 6, sourceType: "module" } },
-        { code: "import foo from 'foo';", parserOptions: { ecmaVersion: 6, sourceType: "module" } },
-        { code: "import {foo} from 'foo';", parserOptions: { ecmaVersion: 6, sourceType: "module" } },
-        { code: "import {foo as bar} from 'foo';", parserOptions: { ecmaVersion: 6, sourceType: "module" } },
-        { code: "import {foo as bar, baz as qux} from 'foo';", parserOptions: { ecmaVersion: 6, sourceType: "module" } },
-        { code: "export {foo} from 'foo';", parserOptions: { ecmaVersion: 6, sourceType: "module" } },
-        { code: "export {foo as bar};", parserOptions: { ecmaVersion: 6, sourceType: "module" } },
-        { code: "export {foo as bar, baz as qux};", parserOptions: { ecmaVersion: 6, sourceType: "module" } },
-        { code: "export {foo as bar} from 'foo';", parserOptions: { ecmaVersion: 6, sourceType: "module" } },
-        { code: "export {foo as bar, baz as qux} from 'foo';", parserOptions: { ecmaVersion: 6, sourceType: "module" } },
+        "let {foo} = obj;",
+        "let {foo: bar} = obj;",
+        "let {foo: bar, baz: qux} = obj;",
+        "let {foo: {bar: baz}} = obj;",
+        "let {foo, bar: {baz: qux}} = obj;",
+        "let {'foo': bar} = obj;",
+        "let {'foo': bar, 'baz': qux} = obj;",
+        "let {'foo': {'bar': baz}} = obj;",
+        "let {foo, 'bar': {'baz': qux}} = obj;",
+        "let {['foo']: bar} = obj;",
+        "let {['foo']: bar, ['baz']: qux} = obj;",
+        "let {['foo']: {['bar']: baz}} = obj;",
+        "let {foo, ['bar']: {['baz']: qux}} = obj;",
+        "let {[foo]: foo} = obj;",
+        "let {['foo']: foo} = obj;",
+        "let {[foo]: bar} = obj;",
+        "let {['foo']: bar} = obj;",
+        "function func({foo}) {}",
+        "function func({foo: bar}) {}",
+        "function func({foo: bar, baz: qux}) {}",
+        "({foo}) => {}",
+        "({foo: bar}) => {}",
+        "({foo: bar, baz: qui}) => {}",
+        "import * as foo from 'foo';",
+        "import foo from 'foo';",
+        "import {foo} from 'foo';",
+        "import {foo as bar} from 'foo';",
+        "import {foo as bar, baz as qux} from 'foo';",
+        "export {foo} from 'foo';",
+        "export {foo as bar};",
+        "export {foo as bar, baz as qux};",
+        "export {foo as bar} from 'foo';",
+        "export {foo as bar, baz as qux} from 'foo';",
         {
             code: "const {...stuff} = myObject;",
-            parserOptions: {
-                ecmaFeatures: { experimentalObjectRestSpread: true },
-                ecmaVersion: 6
-            }
+            parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } }
         },
         {
             code: "const {foo, ...stuff} = myObject;",
-            parserOptions: {
-                ecmaFeatures: { experimentalObjectRestSpread: true },
-                ecmaVersion: 6
-            }
+            parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } }
         },
         {
             code: "const {foo: bar, ...stuff} = myObject;",
-            parserOptions: {
-                ecmaFeatures: { experimentalObjectRestSpread: true },
-                ecmaVersion: 6
-            }
+            parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } }
         },
 
         // { ignoreDestructuring: true }
         {
             code: "let {foo: foo} = obj;",
-            parserOptions: { ecmaVersion: 6, sourceType: "module" },
             options: [{ ignoreDestructuring: true}]
         },
         {
             code: "let {foo: foo, bar: baz} = obj;",
-            parserOptions: { ecmaVersion: 6, sourceType: "module" },
             options: [{ ignoreDestructuring: true}]
         },
         {
             code: "let {foo: foo, bar: bar} = obj;",
-            parserOptions: { ecmaVersion: 6, sourceType: "module" },
             options: [{ ignoreDestructuring: true}]
         },
 
         // { ignoreImport: true }
         {
             code: "import {foo as foo} from 'foo';",
-            parserOptions: { ecmaVersion: 6, sourceType: "module" },
             options: [{ ignoreImport: true}]
         },
         {
             code: "import {foo as foo, bar as baz} from 'foo';",
-            parserOptions: { ecmaVersion: 6, sourceType: "module" },
             options: [{ ignoreImport: true}]
         },
         {
             code: "import {foo as foo, bar as bar} from 'foo';",
-            parserOptions: { ecmaVersion: 6, sourceType: "module" },
             options: [{ ignoreImport: true}]
         },
 
         // { ignoreExport: true }
         {
             code: "export {foo as foo};",
-            parserOptions: { ecmaVersion: 6, sourceType: "module" },
             options: [{ ignoreExport: true}]
         },
         {
             code: "export {foo as foo, bar as baz};",
-            parserOptions: { ecmaVersion: 6, sourceType: "module" },
             options: [{ ignoreExport: true}]
         },
         {
             code: "export {foo as foo, bar as bar};",
-            parserOptions: { ecmaVersion: 6, sourceType: "module" },
             options: [{ ignoreExport: true}]
         },
         {
             code: "export {foo as foo} from 'foo';",
-            parserOptions: { ecmaVersion: 6, sourceType: "module" },
             options: [{ ignoreExport: true}]
         },
         {
             code: "export {foo as foo, bar as baz} from 'foo';",
-            parserOptions: { ecmaVersion: 6, sourceType: "module" },
             options: [{ ignoreExport: true}]
         },
         {
             code: "export {foo as foo, bar as bar} from 'foo';",
-            parserOptions: { ecmaVersion: 6, sourceType: "module" },
             options: [{ ignoreExport: true}]
         }
     ],
@@ -142,226 +121,184 @@ ruleTester.run("no-useless-rename", rule, {
         {
             code: "let {foo: foo} = obj;",
             output: "let {foo} = obj;",
-            parserOptions: { ecmaVersion: 6 },
             errors: ["Destructuring assignment foo unnecessarily renamed."]
         },
         {
             code: "let {a, foo: foo} = obj;",
             output: "let {a, foo} = obj;",
-            parserOptions: { ecmaVersion: 6 },
             errors: ["Destructuring assignment foo unnecessarily renamed."]
         },
         {
             code: "let {foo: foo, bar: baz} = obj;",
             output: "let {foo, bar: baz} = obj;",
-            parserOptions: { ecmaVersion: 6 },
             errors: ["Destructuring assignment foo unnecessarily renamed."]
         },
         {
             code: "let {foo: bar, baz: baz} = obj;",
             output: "let {foo: bar, baz} = obj;",
-            parserOptions: { ecmaVersion: 6 },
             errors: ["Destructuring assignment baz unnecessarily renamed."]
         },
         {
             code: "let {foo: foo, bar: bar} = obj;",
             output: "let {foo, bar} = obj;",
-            parserOptions: { ecmaVersion: 6 },
             errors: ["Destructuring assignment foo unnecessarily renamed.", "Destructuring assignment bar unnecessarily renamed."]
         },
         {
             code: "let {foo: {bar: bar}} = obj;",
             output: "let {foo: {bar}} = obj;",
-            parserOptions: { ecmaVersion: 6 },
             errors: ["Destructuring assignment bar unnecessarily renamed."]
         },
         {
             code: "let {foo: {bar: bar}, baz: baz} = obj;",
             output: "let {foo: {bar}, baz} = obj;",
-            parserOptions: { ecmaVersion: 6 },
             errors: ["Destructuring assignment bar unnecessarily renamed.", "Destructuring assignment baz unnecessarily renamed."]
         },
         {
             code: "let {'foo': foo} = obj;",
             output: "let {foo} = obj;",
-            parserOptions: { ecmaVersion: 6 },
             errors: ["Destructuring assignment foo unnecessarily renamed."]
         },
         {
             code: "let {'foo': foo, 'bar': baz} = obj;",
             output: "let {foo, 'bar': baz} = obj;",
-            parserOptions: { ecmaVersion: 6 },
             errors: ["Destructuring assignment foo unnecessarily renamed."]
         },
         {
             code: "let {'foo': bar, 'baz': baz} = obj;",
             output: "let {'foo': bar, baz} = obj;",
-            parserOptions: { ecmaVersion: 6 },
             errors: ["Destructuring assignment baz unnecessarily renamed."]
         },
         {
             code: "let {'foo': foo, 'bar': bar} = obj;",
             output: "let {foo, bar} = obj;",
-            parserOptions: { ecmaVersion: 6 },
             errors: ["Destructuring assignment foo unnecessarily renamed.", "Destructuring assignment bar unnecessarily renamed."]
         },
         {
             code: "let {'foo': {'bar': bar}} = obj;",
             output: "let {'foo': {bar}} = obj;",
-            parserOptions: { ecmaVersion: 6 },
             errors: ["Destructuring assignment bar unnecessarily renamed."]
         },
         {
             code: "let {'foo': {'bar': bar}, 'baz': baz} = obj;",
             output: "let {'foo': {bar}, baz} = obj;",
-            parserOptions: { ecmaVersion: 6 },
             errors: ["Destructuring assignment bar unnecessarily renamed.", "Destructuring assignment baz unnecessarily renamed."]
         },
         {
             code: "function func({foo: foo}) {}",
             output: "function func({foo}) {}",
-            parserOptions: { ecmaVersion: 6 },
             errors: ["Destructuring assignment foo unnecessarily renamed."]
         },
         {
             code: "function func({foo: foo, bar: baz}) {}",
             output: "function func({foo, bar: baz}) {}",
-            parserOptions: { ecmaVersion: 6 },
             errors: ["Destructuring assignment foo unnecessarily renamed."]
         },
         {
             code: "function func({foo: bar, baz: baz}) {}",
             output: "function func({foo: bar, baz}) {}",
-            parserOptions: { ecmaVersion: 6 },
             errors: ["Destructuring assignment baz unnecessarily renamed."]
         },
         {
             code: "function func({foo: foo, bar: bar}) {}",
             output: "function func({foo, bar}) {}",
-            parserOptions: { ecmaVersion: 6 },
             errors: ["Destructuring assignment foo unnecessarily renamed.", "Destructuring assignment bar unnecessarily renamed."]
         },
         {
             code: "({foo: foo}) => {}",
             output: "({foo}) => {}",
-            parserOptions: { ecmaVersion: 6 },
             errors: ["Destructuring assignment foo unnecessarily renamed."]
         },
         {
             code: "({foo: foo, bar: baz}) => {}",
             output: "({foo, bar: baz}) => {}",
-            parserOptions: { ecmaVersion: 6 },
             errors: ["Destructuring assignment foo unnecessarily renamed."]
         },
         {
             code: "({foo: bar, baz: baz}) => {}",
             output: "({foo: bar, baz}) => {}",
-            parserOptions: { ecmaVersion: 6 },
             errors: ["Destructuring assignment baz unnecessarily renamed."]
         },
         {
             code: "({foo: foo, bar: bar}) => {}",
             output: "({foo, bar}) => {}",
-            parserOptions: { ecmaVersion: 6 },
             errors: ["Destructuring assignment foo unnecessarily renamed.", "Destructuring assignment bar unnecessarily renamed."]
         },
         {
             code: "const {foo: foo, ...stuff} = myObject;",
             output: "const {foo, ...stuff} = myObject;",
-            parserOptions: {
-                ecmaFeatures: { experimentalObjectRestSpread: true },
-                ecmaVersion: 6
-            },
+            parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } },
             errors: ["Destructuring assignment foo unnecessarily renamed."]
         },
         {
             code: "const {foo: foo, bar: baz, ...stuff} = myObject;",
             output: "const {foo, bar: baz, ...stuff} = myObject;",
-            parserOptions: {
-                ecmaFeatures: { experimentalObjectRestSpread: true },
-                ecmaVersion: 6
-            },
+            parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } },
             errors: ["Destructuring assignment foo unnecessarily renamed."]
         },
         {
             code: "const {foo: foo, bar: bar, ...stuff} = myObject;",
             output: "const {foo, bar, ...stuff} = myObject;",
-            parserOptions: {
-                ecmaFeatures: { experimentalObjectRestSpread: true },
-                ecmaVersion: 6
-            },
+            parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } },
             errors: ["Destructuring assignment foo unnecessarily renamed.", "Destructuring assignment bar unnecessarily renamed."]
         },
         {
             code: "import {foo as foo} from 'foo';",
             output: "import {foo} from 'foo';",
-            parserOptions: { ecmaVersion: 6, sourceType: "module" },
             errors: ["Import foo unnecessarily renamed."]
         },
         {
             code: "import {foo as foo, bar as baz} from 'foo';",
             output: "import {foo, bar as baz} from 'foo';",
-            parserOptions: { ecmaVersion: 6, sourceType: "module" },
             errors: ["Import foo unnecessarily renamed."]
         },
         {
             code: "import {foo as bar, baz as baz} from 'foo';",
             output: "import {foo as bar, baz} from 'foo';",
-            parserOptions: { ecmaVersion: 6, sourceType: "module" },
             errors: ["Import baz unnecessarily renamed."]
         },
         {
             code: "import {foo as foo, bar as bar} from 'foo';",
             output: "import {foo, bar} from 'foo';",
-            parserOptions: { ecmaVersion: 6, sourceType: "module" },
             errors: ["Import foo unnecessarily renamed.", "Import bar unnecessarily renamed."]
         },
         {
             code: "export {foo as foo};",
             output: "export {foo};",
-            parserOptions: { ecmaVersion: 6, sourceType: "module" },
             errors: ["Export foo unnecessarily renamed."]
         },
         {
             code: "export {foo as foo, bar as baz};",
             output: "export {foo, bar as baz};",
-            parserOptions: { ecmaVersion: 6, sourceType: "module" },
             errors: ["Export foo unnecessarily renamed."]
         },
         {
             code: "export {foo as bar, baz as baz};",
             output: "export {foo as bar, baz};",
-            parserOptions: { ecmaVersion: 6, sourceType: "module" },
             errors: ["Export baz unnecessarily renamed."]
         },
         {
             code: "export {foo as foo, bar as bar};",
             output: "export {foo, bar};",
-            parserOptions: { ecmaVersion: 6, sourceType: "module" },
             errors: ["Export foo unnecessarily renamed.", "Export bar unnecessarily renamed."]
         },
         {
             code: "export {foo as foo} from 'foo';",
             output: "export {foo} from 'foo';",
-            parserOptions: { ecmaVersion: 6, sourceType: "module" },
             errors: ["Export foo unnecessarily renamed."]
         },
         {
             code: "export {foo as foo, bar as baz} from 'foo';",
             output: "export {foo, bar as baz} from 'foo';",
-            parserOptions: { ecmaVersion: 6, sourceType: "module" },
             errors: ["Export foo unnecessarily renamed."]
         },
         {
             code: "export {foo as bar, baz as baz} from 'foo';",
             output: "export {foo as bar, baz} from 'foo';",
-            parserOptions: { ecmaVersion: 6, sourceType: "module" },
             errors: ["Export baz unnecessarily renamed."]
         },
         {
             code: "export {foo as foo, bar as bar} from 'foo';",
             output: "export {foo, bar} from 'foo';",
-            parserOptions: { ecmaVersion: 6, sourceType: "module" },
             errors: ["Export foo unnecessarily renamed.", "Export bar unnecessarily renamed."]
         }
     ]

--- a/tests/lib/rules/no-var.js
+++ b/tests/lib/rules/no-var.js
@@ -16,25 +16,18 @@ const rule = require("../../../lib/rules/no-var"),
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
 
 ruleTester.run("no-var", rule, {
     valid: [
-        {
-            code: "const JOE = 'schmoe';",
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "let moo = 'car';",
-            parserOptions: { ecmaVersion: 6 }
-        }
+        "const JOE = 'schmoe';",
+        "let moo = 'car';"
     ],
 
     invalid: [
         {
             code: "var foo = bar;",
             output: "let foo = bar;",
-            parserOptions: { ecmaVersion: 6 },
             errors: [
                 {
                     message: "Unexpected var, use let or const instead.",
@@ -45,7 +38,6 @@ ruleTester.run("no-var", rule, {
         {
             code: "var foo = bar, toast = most;",
             output: "let foo = bar, toast = most;",
-            parserOptions: { ecmaVersion: 6 },
             errors: [
                 {
                     message: "Unexpected var, use let or const instead.",
@@ -56,7 +48,6 @@ ruleTester.run("no-var", rule, {
         {
             code: "var foo = bar; let toast = most;",
             output: "let foo = bar; let toast = most;",
-            parserOptions: { ecmaVersion: 6 },
             errors: [
                 {
                     message: "Unexpected var, use let or const instead.",
@@ -106,7 +97,6 @@ ruleTester.run("no-var", rule, {
         {
             code: "for (var a of list) {} a;",
             output: "for (var a of list) {} a;",
-            parserOptions: {ecmaVersion: 6},
             errors: [
                 "Unexpected var, use let or const instead."
             ]

--- a/tests/lib/rules/prefer-arrow-callback.js
+++ b/tests/lib/rules/prefer-arrow-callback.js
@@ -21,157 +21,136 @@ const errors = [{
     type: "FunctionExpression"
 }];
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
 
 ruleTester.run("prefer-arrow-callback", rule, {
     valid: [
-        {code: "foo(a => a);", parserOptions: { ecmaVersion: 6 }},
-        {code: "foo(function*() {});", parserOptions: { ecmaVersion: 6 }},
-        {code: "foo(function() { this; });"},
+        "foo(a => a);",
+        "foo(function*() {});",
+        "foo(function() { this; });",
         {code: "foo(function bar() {});", options: [{ allowNamedFunctions: true }]},
-        {code: "foo(function() { (() => this); });", parserOptions: { ecmaVersion: 6 }},
-        {code: "foo(function() { this; }.bind(obj));"},
-        {code: "foo(function() { this; }.call(this));"},
-        {code: "foo(a => { (function() {}); });", parserOptions: { ecmaVersion: 6 }},
-        {code: "var foo = function foo() {};"},
-        {code: "(function foo() {})();"},
-        {code: "foo(function bar() { bar; });"},
-        {code: "foo(function bar() { arguments; });"},
-        {code: "foo(function bar() { arguments; }.bind(this));"},
-        {code: "foo(function bar() { super.a; });", parserOptions: { ecmaVersion: 6 }},
-        {code: "foo(function bar() { super.a; }.bind(this));", parserOptions: { ecmaVersion: 6 }},
-        {code: "foo(function bar() { new.target; });", parserOptions: { ecmaVersion: 6 }},
-        {code: "foo(function bar() { new.target; }.bind(this));", parserOptions: { ecmaVersion: 6 }},
-        {code: "foo(function bar() { this; }.bind(this, somethingElse));"}
+        "foo(function() { (() => this); });",
+        "foo(function() { this; }.bind(obj));",
+        "foo(function() { this; }.call(this));",
+        "foo(a => { (function() {}); });",
+        "var foo = function foo() {};",
+        "(function foo() {})();",
+        "foo(function bar() { bar; });",
+        "foo(function bar() { arguments; });",
+        "foo(function bar() { arguments; }.bind(this));",
+        "foo(function bar() { super.a; });",
+        "foo(function bar() { super.a; }.bind(this));",
+        "foo(function bar() { new.target; });",
+        "foo(function bar() { new.target; }.bind(this));",
+        "foo(function bar() { this; }.bind(this, somethingElse));"
     ],
     invalid: [
         {
             code: "foo(function bar() {});",
-            parserOptions: { ecmaVersion: 6 },
             errors,
             output: "foo(() => {});"
         },
         {
             code: "foo(function() {});",
-            parserOptions: { ecmaVersion: 6 },
             options: [{ allowNamedFunctions: true }],
             errors,
             output: "foo(() => {});"
         },
         {
             code: "foo(function bar() {});",
-            parserOptions: { ecmaVersion: 6 },
             options: [{ allowNamedFunctions: false }],
             errors,
             output: "foo(() => {});"
         },
         {
             code: "foo(function() {});",
-            parserOptions: { ecmaVersion: 6 },
             errors,
             output: "foo(() => {});"
         },
         {
             code: "foo(nativeCb || function() {});",
-            parserOptions: { ecmaVersion: 6 },
             errors,
             output: "foo(nativeCb || () => {});"
         },
         {
             code: "foo(bar ? function() {} : function() {});",
-            parserOptions: { ecmaVersion: 6 },
             errors: [errors[0], errors[0]],
             output: "foo(bar ? () => {} : () => {});"
         },
         {
             code: "foo(function() { (function() { this; }); });",
-            parserOptions: { ecmaVersion: 6 },
             errors,
             output: "foo(() => { (function() { this; }); });"
         },
         {
             code: "foo(function() { this; }.bind(this));",
-            parserOptions: { ecmaVersion: 6 },
             errors,
             output: "foo(() => { this; });"
         },
         {
             code: "foo(function() { (() => this); }.bind(this));",
-            parserOptions: { ecmaVersion: 6 },
             errors,
             output: "foo(() => { (() => this); });"
         },
         {
             code: "foo(function bar(a) { a; });",
-            parserOptions: { ecmaVersion: 6 },
             errors,
             output: "foo((a) => { a; });"
         },
         {
             code: "foo(function(a) { a; });",
-            parserOptions: { ecmaVersion: 6 },
             errors,
             output: "foo((a) => { a; });"
         },
         {
             code: "foo(function(arguments) { arguments; });",
-            parserOptions: { ecmaVersion: 6 },
             errors,
             output: "foo((arguments) => { arguments; });"
         },
         {
             code: "foo(function() { this; });",
-            parserOptions: { ecmaVersion: 6 },
             options: [{ allowUnboundThis: false }],
             errors,
             output: "foo(function() { this; });" // No fix applied
         },
         {
             code: "foo(function() { (() => this); });",
-            parserOptions: { ecmaVersion: 6 },
             options: [{ allowUnboundThis: false }],
             errors,
             output: "foo(function() { (() => this); });" // No fix applied
         },
         {
             code: "qux(function(foo, bar, baz) { return foo * 2; })",
-            parserOptions: { ecmaVersion: 6 },
             errors,
             output: "qux((foo, bar, baz) => { return foo * 2; })"
         },
         {
             code: "qux(function(foo, bar, baz) { return foo * bar; }.bind(this))",
-            parserOptions: { ecmaVersion: 6 },
             errors,
             output: "qux((foo, bar, baz) => { return foo * bar; })"
         },
         {
             code: "qux(function(foo, bar, baz) { return foo * this.qux; }.bind(this))",
-            parserOptions: { ecmaVersion: 6 },
             errors,
             output: "qux((foo, bar, baz) => { return foo * this.qux; })"
         },
         {
             code: "qux(function(foo = 1, [bar = 2] = [], {qux: baz = 3} = {foo: 'bar'}) { return foo + bar; });",
-            parserOptions: { ecmaVersion: 6 },
             errors,
             output: "qux((foo = 1, [bar = 2] = [], {qux: baz = 3} = {foo: 'bar'}) => { return foo + bar; });"
         },
         {
             code: "qux(function(baz, baz) { })",
-            parserOptions: { ecmaVersion: 6 },
             errors,
             output: "qux(function(baz, baz) { })" // Duplicate parameter names are a SyntaxError in arrow functions
         },
         {
             code: "qux(function( /* no params */ ) { })",
-            parserOptions: { ecmaVersion: 6 },
             errors,
             output: "qux(( /* no params */ ) => { })"
         },
         {
             code: "qux(function( /* a */ foo /* b */ , /* c */ bar /* d */ , /* e */ baz /* f */ ) { return foo; })",
-            parserOptions: { ecmaVersion: 6 },
             errors,
             output: "qux(( /* a */ foo /* b */ , /* c */ bar /* d */ , /* e */ baz /* f */ ) => { return foo; })"
         },

--- a/tests/lib/rules/prefer-const.js
+++ b/tests/lib/rules/prefer-const.js
@@ -16,7 +16,7 @@ const rule = require("../../../lib/rules/prefer-const"),
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
 
 ruleTester.defineRule("use-x", context => ({
     VariableDeclaration() {
@@ -26,35 +26,35 @@ ruleTester.defineRule("use-x", context => ({
 
 ruleTester.run("prefer-const", rule, {
     valid: [
-        { code: "var x = 0;" },
-        { code: "let x;", parserOptions: { ecmaVersion: 6 } },
-        { code: "let x; { x = 0; } foo(x);", parserOptions: { ecmaVersion: 6 } },
-        { code: "let x = 0; x = 1;", parserOptions: { ecmaVersion: 6 } },
-        { code: "const x = 0;", parserOptions: { ecmaVersion: 6 } },
-        { code: "for (let i = 0, end = 10; i < end; ++i) {}", parserOptions: { ecmaVersion: 6 } },
-        { code: "for (let i in [1,2,3]) { i = 0; }", parserOptions: { ecmaVersion: 6 } },
-        { code: "for (let x of [1,2,3]) { x = 0; }", parserOptions: { ecmaVersion: 6 } },
-        { code: "(function() { var x = 0; })();" },
-        { code: "(function() { let x; })();", parserOptions: { ecmaVersion: 6 } },
-        { code: "(function() { let x; { x = 0; } foo(x); })();", parserOptions: { ecmaVersion: 6 } },
-        { code: "(function() { let x = 0; x = 1; })();", parserOptions: { ecmaVersion: 6 } },
-        { code: "(function() { const x = 0; })();", parserOptions: { ecmaVersion: 6 } },
-        { code: "(function() { for (let i = 0, end = 10; i < end; ++i) {} })();", parserOptions: { ecmaVersion: 6 } },
-        { code: "(function() { for (let i in [1,2,3]) { i = 0; } })();", parserOptions: { ecmaVersion: 6 } },
-        { code: "(function() { for (let x of [1,2,3]) { x = 0; } })();", parserOptions: { ecmaVersion: 6 } },
-        { code: "(function(x = 0) { })();", parserOptions: { ecmaVersion: 6 } },
-        { code: "let a; while (a = foo());", parserOptions: { ecmaVersion: 6 } },
-        { code: "let a; do {} while (a = foo());", parserOptions: { ecmaVersion: 6 } },
-        { code: "let a; for (; a = foo(); );", parserOptions: { ecmaVersion: 6 } },
-        { code: "let a; for (;; ++a);", parserOptions: { ecmaVersion: 6 } },
-        { code: "let a; for (const {b = ++a} in foo());", parserOptions: { ecmaVersion: 6 } },
-        { code: "let a; for (const {b = ++a} of foo());", parserOptions: { ecmaVersion: 6 } },
-        { code: "let a; for (const x of [1,2,3]) { if (a) {} a = foo(); }", parserOptions: { ecmaVersion: 6 } },
-        { code: "let a; for (const x of [1,2,3]) { a = a || foo(); bar(a); }", parserOptions: { ecmaVersion: 6 } },
-        { code: "let a; for (const x of [1,2,3]) { foo(++a); }", parserOptions: { ecmaVersion: 6 } },
-        { code: "let a; function foo() { if (a) {} a = bar(); }", parserOptions: { ecmaVersion: 6 } },
-        { code: "let a; function foo() { a = a || bar(); baz(a); }", parserOptions: { ecmaVersion: 6 } },
-        { code: "let a; function foo() { bar(++a); }", parserOptions: { ecmaVersion: 6 } },
+        "var x = 0;",
+        "let x;",
+        "let x; { x = 0; } foo(x);",
+        "let x = 0; x = 1;",
+        "const x = 0;",
+        "for (let i = 0, end = 10; i < end; ++i) {}",
+        "for (let i in [1,2,3]) { i = 0; }",
+        "for (let x of [1,2,3]) { x = 0; }",
+        "(function() { var x = 0; })();",
+        "(function() { let x; })();",
+        "(function() { let x; { x = 0; } foo(x); })();",
+        "(function() { let x = 0; x = 1; })();",
+        "(function() { const x = 0; })();",
+        "(function() { for (let i = 0, end = 10; i < end; ++i) {} })();",
+        "(function() { for (let i in [1,2,3]) { i = 0; } })();",
+        "(function() { for (let x of [1,2,3]) { x = 0; } })();",
+        "(function(x = 0) { })();",
+        "let a; while (a = foo());",
+        "let a; do {} while (a = foo());",
+        "let a; for (; a = foo(); );",
+        "let a; for (;; ++a);",
+        "let a; for (const {b = ++a} in foo());",
+        "let a; for (const {b = ++a} of foo());",
+        "let a; for (const x of [1,2,3]) { if (a) {} a = foo(); }",
+        "let a; for (const x of [1,2,3]) { a = a || foo(); bar(a); }",
+        "let a; for (const x of [1,2,3]) { foo(++a); }",
+        "let a; function foo() { if (a) {} a = bar(); }",
+        "let a; function foo() { a = a || bar(); baz(a); }",
+        "let a; function foo() { bar(++a); }",
         {
             code: [
                 "let id;",
@@ -65,37 +65,33 @@ ruleTester.run("prefer-const", rule, {
                 "    id = setInterval(() => {}, 250);",
                 "}",
                 "foo();"
-            ].join("\n"),
-            parserOptions: { ecmaVersion: 6 }
+            ].join("\n")
         },
-        { code: "/*exported a*/ let a; function init() { a = foo(); }", parserOptions: { ecmaVersion: 6 } },
-        { code: "/*exported a*/ let a = 1", parserOptions: { ecmaVersion: 6 } },
-        { code: "let a; if (true) a = 0; foo(a);", parserOptions: { ecmaVersion: 6 } },
+        "/*exported a*/ let a; function init() { a = foo(); }",
+        "/*exported a*/ let a = 1",
+        "let a; if (true) a = 0; foo(a);",
 
         // The assignment is located in a different scope.
         // Those are warned by prefer-smaller-scope.
-        { code: "let x; { x = 0; foo(x); }", parserOptions: { ecmaVersion: 6 } },
-        { code: "(function() { let x; { x = 0; foo(x); } })();", parserOptions: { ecmaVersion: 6 } },
-        { code: "let x; for (const a of [1,2,3]) { x = foo(); bar(x); }", parserOptions: { ecmaVersion: 6 } },
-        { code: "(function() { let x; for (const a of [1,2,3]) { x = foo(); bar(x); } })();", parserOptions: { ecmaVersion: 6 } },
-        { code: "let x; for (x of array) { x; }", parserOptions: { ecmaVersion: 6 } },
+        "let x; { x = 0; foo(x); }",
+        "(function() { let x; { x = 0; foo(x); } })();",
+        "let x; for (const a of [1,2,3]) { x = foo(); bar(x); }",
+        "(function() { let x; for (const a of [1,2,3]) { x = foo(); bar(x); } })();",
+        "let x; for (x of array) { x; }",
 
         {
             code: "let {a, b} = obj; b = 0;",
-            options: [{destructuring: "all"}],
-            parserOptions: {ecmaVersion: 6}
+            options: [{destructuring: "all"}]
         },
         {
             code: "let a, b; ({a, b} = obj); b++;",
-            options: [{destructuring: "all"}],
-            parserOptions: {ecmaVersion: 6}
+            options: [{destructuring: "all"}]
         },
 
         // ignoreReadBeforeAssign
         {
             code: "let x; function foo() { bar(x); } x = 0;",
-            options: [{ignoreReadBeforeAssign: true}],
-            parserOptions: {ecmaVersion: 6}
+            options: [{ignoreReadBeforeAssign: true}]
         },
 
 
@@ -104,85 +100,71 @@ ruleTester.run("prefer-const", rule, {
         {
             code: "let x = 1; foo(x);",
             output: "const x = 1; foo(x);",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'x' is never reassigned. Use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "for (let i in [1,2,3]) { foo(i); }",
             output: "for (const i in [1,2,3]) { foo(i); }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'i' is never reassigned. Use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "for (let x of [1,2,3]) { foo(x); }",
             output: "for (const x of [1,2,3]) { foo(x); }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'x' is never reassigned. Use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "let [x = -1, y] = [1,2]; y = 0;",
             output: "let [x = -1, y] = [1,2]; y = 0;",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'x' is never reassigned. Use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "let {a: x = -1, b: y} = {a:1,b:2}; y = 0;",
             output: "let {a: x = -1, b: y} = {a:1,b:2}; y = 0;",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'x' is never reassigned. Use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "(function() { let x = 1; foo(x); })();",
             output: "(function() { const x = 1; foo(x); })();",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'x' is never reassigned. Use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "(function() { for (let i in [1,2,3]) { foo(i); } })();",
             output: "(function() { for (const i in [1,2,3]) { foo(i); } })();",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'i' is never reassigned. Use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "(function() { for (let x of [1,2,3]) { foo(x); } })();",
             output: "(function() { for (const x of [1,2,3]) { foo(x); } })();",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'x' is never reassigned. Use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "(function() { let [x = -1, y] = [1,2]; y = 0; })();",
             output: "(function() { let [x = -1, y] = [1,2]; y = 0; })();",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'x' is never reassigned. Use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "let f = (function() { let g = x; })(); f = 1;",
             output: "let f = (function() { const g = x; })(); f = 1;",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'g' is never reassigned. Use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "(function() { let {a: x = -1, b: y} = {a:1,b:2}; y = 0; })();",
             output: "(function() { let {a: x = -1, b: y} = {a:1,b:2}; y = 0; })();",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'x' is never reassigned. Use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "let x = 0; { let x = 1; foo(x); } x = 0;",
             output: "let x = 0; { const x = 1; foo(x); } x = 0;",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'x' is never reassigned. Use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "for (let i = 0; i < 10; ++i) { let x = 1; foo(x); }",
             output: "for (let i = 0; i < 10; ++i) { const x = 1; foo(x); }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'x' is never reassigned. Use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "for (let i in [1,2,3]) { let x = 1; foo(x); }",
             output: "for (const i in [1,2,3]) { const x = 1; foo(x); }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [
                 { message: "'i' is never reassigned. Use 'const' instead.", type: "Identifier"},
                 { message: "'x' is never reassigned. Use 'const' instead.", type: "Identifier"}
@@ -205,7 +187,6 @@ ruleTester.run("prefer-const", rule, {
                 "   }",
                 "};"
             ].join("\n"),
-            parserOptions: { ecmaVersion: 6 },
             errors: [
                 { message: "'a' is never reassigned. Use 'const' instead.", type: "Identifier"}
             ]
@@ -227,7 +208,6 @@ ruleTester.run("prefer-const", rule, {
                 "   }",
                 "};"
             ].join("\n"),
-            parserOptions: { ecmaVersion: 6 },
             errors: [
                 { message: "'a' is never reassigned. Use 'const' instead.", type: "Identifier"}
             ]
@@ -236,19 +216,16 @@ ruleTester.run("prefer-const", rule, {
         {
             code: "let x; x = 0;",
             output: "let x; x = 0;",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'x' is never reassigned. Use 'const' instead.", type: "Identifier", column: 8}]
         },
         {
             code: "switch (a) { case 0: let x; x = 0; }",
             output: "switch (a) { case 0: let x; x = 0; }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'x' is never reassigned. Use 'const' instead.", type: "Identifier", column: 29}]
         },
         {
             code: "(function() { let x; x = 1; })();",
             output: "(function() { let x; x = 1; })();",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'x' is never reassigned. Use 'const' instead.", type: "Identifier", column: 22}]
         },
 
@@ -256,21 +233,18 @@ ruleTester.run("prefer-const", rule, {
             code: "let {a = 0, b} = obj; b = 0; foo(a, b);",
             output: "let {a = 0, b} = obj; b = 0; foo(a, b);",
             options: [{destructuring: "any"}],
-            parserOptions: {ecmaVersion: 6},
             errors: [{ message: "'a' is never reassigned. Use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "let {a: {b, c}} = {a: {b: 1, c: 2}}; b = 3;",
             output: "let {a: {b, c}} = {a: {b: 1, c: 2}}; b = 3;",
             options: [{destructuring: "any"}],
-            parserOptions: {ecmaVersion: 6},
             errors: [{ message: "'c' is never reassigned. Use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "let {a: {b, c}} = {a: {b: 1, c: 2}}",
             output: "const {a: {b, c}} = {a: {b: 1, c: 2}}",
             options: [{destructuring: "all"}],
-            parserOptions: {ecmaVersion: 6},
             errors: [
                 { message: "'b' is never reassigned. Use 'const' instead.", type: "Identifier"},
                 { message: "'c' is never reassigned. Use 'const' instead.", type: "Identifier"}
@@ -280,14 +254,12 @@ ruleTester.run("prefer-const", rule, {
             code: "let a, b; ({a = 0, b} = obj); b = 0; foo(a, b);",
             output: "let a, b; ({a = 0, b} = obj); b = 0; foo(a, b);",
             options: [{destructuring: "any"}],
-            parserOptions: {ecmaVersion: 6},
             errors: [{ message: "'a' is never reassigned. Use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "let {a = 0, b} = obj; foo(a, b);",
             output: "const {a = 0, b} = obj; foo(a, b);",
             options: [{destructuring: "all"}],
-            parserOptions: {ecmaVersion: 6},
             errors: [
                 { message: "'a' is never reassigned. Use 'const' instead.", type: "Identifier"},
                 { message: "'b' is never reassigned. Use 'const' instead.", type: "Identifier"}
@@ -297,7 +269,6 @@ ruleTester.run("prefer-const", rule, {
             code: "let [a] = [1]",
             output: "const [a] = [1]",
             options: [],
-            parserOptions: {ecmaVersion: 6},
             errors: [
                 { message: "'a' is never reassigned. Use 'const' instead.", type: "Identifier"}
             ]
@@ -306,7 +277,6 @@ ruleTester.run("prefer-const", rule, {
             code: "let {a} = obj",
             output: "const {a} = obj",
             options: [],
-            parserOptions: {ecmaVersion: 6},
             errors: [
                 { message: "'a' is never reassigned. Use 'const' instead.", type: "Identifier"}
             ]
@@ -315,7 +285,6 @@ ruleTester.run("prefer-const", rule, {
             code: "let a, b; ({a = 0, b} = obj); foo(a, b);",
             output: "let a, b; ({a = 0, b} = obj); foo(a, b);",
             options: [{destructuring: "all"}],
-            parserOptions: {ecmaVersion: 6},
             errors: [
                 { message: "'a' is never reassigned. Use 'const' instead.", type: "Identifier"},
                 { message: "'b' is never reassigned. Use 'const' instead.", type: "Identifier"}
@@ -325,7 +294,6 @@ ruleTester.run("prefer-const", rule, {
             code: "let {a = 0, b} = obj, c = a; b = a;",
             output: "let {a = 0, b} = obj, c = a; b = a;",
             options: [{destructuring: "any"}],
-            parserOptions: {ecmaVersion: 6},
             errors: [
                 { message: "'a' is never reassigned. Use 'const' instead.", type: "Identifier"},
                 { message: "'c' is never reassigned. Use 'const' instead.", type: "Identifier"}
@@ -335,7 +303,6 @@ ruleTester.run("prefer-const", rule, {
             code: "let {a = 0, b} = obj, c = a; b = a;",
             output: "let {a = 0, b} = obj, c = a; b = a;",
             options: [{destructuring: "all"}],
-            parserOptions: {ecmaVersion: 6},
             errors: [{ message: "'c' is never reassigned. Use 'const' instead.", type: "Identifier"}]
         },
 
@@ -343,7 +310,6 @@ ruleTester.run("prefer-const", rule, {
         {
             code: "let x; function foo() { bar(x); } x = 0;",
             output: "let x; function foo() { bar(x); } x = 0;",
-            parserOptions: {ecmaVersion: 6},
             errors: [{ message: "'x' is never reassigned. Use 'const' instead.", type: "Identifier", column: 5}]
         },
 
@@ -351,13 +317,12 @@ ruleTester.run("prefer-const", rule, {
         {
             code: "/*eslint use-x:error*/ let x = 1",
             output: "/*eslint use-x:error*/ const x = 1",
-            parserOptions: {ecmaVersion: 6, ecmaFeatures: {globalReturn: true}},
+            parserOptions: { ecmaFeatures: {globalReturn: true} },
             errors: [{ message: "'x' is never reassigned. Use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "/*eslint use-x:error*/ { let x = 1 }",
             output: "/*eslint use-x:error*/ { const x = 1 }",
-            parserOptions: {ecmaVersion: 6},
             errors: [{ message: "'x' is never reassigned. Use 'const' instead.", type: "Identifier"}]
         },
     ]

--- a/tests/lib/rules/prefer-numeric-literals.js
+++ b/tests/lib/rules/prefer-numeric-literals.js
@@ -16,14 +16,14 @@ const rule = require("../../../lib/rules/prefer-numeric-literals"),
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
 
 ruleTester.run("prefer-numeric-literals", rule, {
     valid: [
         "parseInt(1);",
         "parseInt(1, 3);",
-        { code: "0b111110111 === 503;", parserOptions: { ecmaVersion: 6 } },
-        { code: "0o767 === 503;", parserOptions: { ecmaVersion: 6 } },
+        "0b111110111 === 503;",
+        "0o767 === 503;",
         "0x1F7 === 503;",
         "a[parseInt](1,2);",
         "parseInt(foo);",
@@ -33,37 +33,30 @@ ruleTester.run("prefer-numeric-literals", rule, {
         {
             code: "parseInt(\"111110111\", 2) === 503;",
             output: "0b111110111 === 503;",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Use binary literals instead of parseInt()." }]
         }, {
             code: "parseInt(\"767\", 8) === 503;",
             output: "0o767 === 503;",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Use octal literals instead of parseInt()." }]
         }, {
             code: "parseInt(\"1F7\", 16) === 255;",
             output: "0x1F7 === 255;",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Use hexadecimal literals instead of parseInt()." }]
         }, {
             code: "parseInt('7999', 8);",
             output: "parseInt('7999', 8);", // not fixed, unexpected 9 in parseInt string
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Use octal literals instead of parseInt()." }]
         }, {
             code: "parseInt('1234', 2);",
             output: "parseInt('1234', 2);", // not fixed, invalid binary string
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Use binary literals instead of parseInt()." }]
         }, {
             code: "parseInt('1234.5', 8);",
             output: "parseInt('1234.5', 8);", // not fixed, this isn't an integer
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Use octal literals instead of parseInt()." }]
         }, {
             code: "parseInt('1️⃣3️⃣3️⃣7️⃣', 16);",
             output: "parseInt('1️⃣3️⃣3️⃣7️⃣', 16);", // not fixed, javascript doesn't support emoji literals
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Use hexadecimal literals instead of parseInt()."}]
         }
     ]

--- a/tests/lib/rules/prefer-rest-params.js
+++ b/tests/lib/rules/prefer-rest-params.js
@@ -12,15 +12,15 @@
 const rule = require("../../../lib/rules/prefer-rest-params"),
     RuleTester = require("../../../lib/testers/rule-tester");
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 }});
 
 ruleTester.run("prefer-rest-params", rule, {
     valid: [
         "arguments;",
         "function foo(arguments) { arguments; }",
         "function foo() { var arguments; arguments; }",
-        {code: "var foo = () => arguments;", parserOptions: { ecmaVersion: 6 }}, // Arrows don't have "arguments".,
-        {code: "function foo(...args) { args; }", parserOptions: { ecmaVersion: 6 }},
+        "var foo = () => arguments;", // Arrows don't have "arguments".,
+        "function foo(...args) { args; }",
         "function foo() { arguments.length; }",
         "function foo() { arguments.callee; }",
     ],

--- a/tests/lib/rules/prefer-spread.js
+++ b/tests/lib/rules/prefer-spread.js
@@ -18,31 +18,28 @@ const RuleTester = require("../../../lib/testers/rule-tester");
 
 const errors = [{message: "Use the spread operator instead of '.apply()'.", type: "CallExpression"}];
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
 
 ruleTester.run("prefer-spread", rule, {
     valid: [
-        {code: "foo.apply(obj, args);"},
-        {code: "obj.foo.apply(null, args);"},
-        {code: "obj.foo.apply(otherObj, args);"},
-        {code: "a.b(x, y).c.foo.apply(a.b(x, z).c, args);"},
-        {code: "a.b.foo.apply(a.b.c, args);"},
+        "foo.apply(obj, args);",
+        "obj.foo.apply(null, args);",
+        "obj.foo.apply(otherObj, args);",
+        "a.b(x, y).c.foo.apply(a.b(x, z).c, args);",
+        "a.b.foo.apply(a.b.c, args);",
 
         // ignores non variadic.
-        {code: "foo.apply(undefined, [1, 2]);"},
-        {code: "foo.apply(null, [1, 2]);"},
-        {code: "obj.foo.apply(obj, [1, 2]);"},
+        "foo.apply(undefined, [1, 2]);",
+        "foo.apply(null, [1, 2]);",
+        "obj.foo.apply(obj, [1, 2]);",
 
         // ignores computed property.
-        {code: "var apply; foo[apply](null, args);"},
+        "var apply; foo[apply](null, args);",
 
         // ignores incomplete things.
-        {code: "foo.apply();"},
-        {code: "obj.foo.apply();"},
-        {
-            code: "obj.foo.apply(obj, ...args)",
-            parserOptions: {ecmaVersion: 6}
-        }
+        "foo.apply();",
+        "obj.foo.apply();",
+        "obj.foo.apply(obj, ...args)"
     ],
     invalid: [
         {

--- a/tests/lib/rules/prefer-template.js
+++ b/tests/lib/rules/prefer-template.js
@@ -21,122 +21,105 @@ const errors = [{
     type: "BinaryExpression"
 }];
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
 
 ruleTester.run("prefer-template", rule, {
     valid: [
-        {code: "'use strict';"},
-        {code: "var foo = 'bar';"},
-        {code: "var foo = 'bar' + 'baz';"},
-        {code: "var foo = foo + +'100';"},
-        {code: "var foo = `bar`;", parserOptions: { ecmaVersion: 6 }},
-        {code: "var foo = `hello, ${name}!`;", parserOptions: { ecmaVersion: 6 }},
+        "'use strict';",
+        "var foo = 'bar';",
+        "var foo = 'bar' + 'baz';",
+        "var foo = foo + +'100';",
+        "var foo = `bar`;",
+        "var foo = `hello, ${name}!`;",
 
         // https://github.com/eslint/eslint/issues/3507
-        {code: "var foo = `foo` + `bar` + \"hoge\";", parserOptions: { ecmaVersion: 6 }},
-        {code: "var foo = `foo` +\n    `bar` +\n    \"hoge\";", parserOptions: { ecmaVersion: 6 }}
+        {code: "var foo = `foo` + `bar` + \"hoge\";"},
+        {code: "var foo = `foo` +\n    `bar` +\n    \"hoge\";"}
     ],
     invalid: [
         {
             code: "var foo = 'hello, ' + name + '!';",
             output: "var foo = `hello, ${  name  }!`;",
-            errors,
-            parserOptions: { ecmaVersion: 6 }
+            errors
         },
         {
             code: "var foo = bar + 'baz';",
             output: "var foo = `${bar  }baz`;",
-            errors,
-            parserOptions: { ecmaVersion: 6 }
+            errors
         },
         {
             code: "var foo = bar + `baz`;",
             output: "var foo = `${bar  }baz`;",
-            parserOptions: { ecmaVersion: 6 },
             errors
         },
         {
             code: "var foo = +100 + 'yen';",
             output: "var foo = `${+100  }yen`;",
-            parserOptions: { ecmaVersion: 6 },
             errors
         },
         {
             code: "var foo = 'bar' + baz;",
             output: "var foo = `bar${  baz}`;",
-            parserOptions: { ecmaVersion: 6 },
             errors
         },
         {
             code: "var foo = '￥' + (n * 1000) + '-'",
             output: "var foo = `￥${  n * 1000  }-`",
-            parserOptions: { ecmaVersion: 6 },
             errors
         },
         {
             code: "var foo = 'aaa' + aaa; var bar = 'bbb' + bbb;",
             output: "var foo = `aaa${  aaa}`; var bar = `bbb${  bbb}`;",
-            parserOptions: { ecmaVersion: 6 },
             errors: [errors[0], errors[0]]
         },
         {
             code: "var string = (number + 1) + 'px';",
             output: "var string = `${number + 1  }px`;",
-            parserOptions: { ecmaVersion: 6 },
             errors
         },
         {
             code: "var foo = 'bar' + baz + 'qux';",
             output: "var foo = `bar${  baz  }qux`;",
-            parserOptions: { ecmaVersion: 6 },
             errors
         },
         {
             code: "var foo = '0 backslashes: ${bar}' + baz;",
             output: "var foo = `0 backslashes: \\${bar}${  baz}`;",
-            parserOptions: { ecmaVersion: 6 },
             errors
         },
         {
             code: "var foo = '1 backslash: \\${bar}' + baz;",
             output: "var foo = `1 backslash: \\${bar}${  baz}`;",
-            parserOptions: { ecmaVersion: 6 },
             errors
         },
         {
             code: "var foo = '2 backslashes: \\\\${bar}' + baz;",
             output: "var foo = `2 backslashes: \\\\\\${bar}${  baz}`;",
-            parserOptions: { ecmaVersion: 6 },
             errors
         },
         {
             code: "var foo = '3 backslashes: \\\\\\${bar}' + baz;",
             output: "var foo = `3 backslashes: \\\\\\${bar}${  baz}`;",
-            parserOptions: { ecmaVersion: 6 },
             errors
         },
         {
             code: "var foo = bar + 'this is a backtick: `' + baz;",
             output: "var foo = `${bar  }this is a backtick: \\`${  baz}`;",
-            parserOptions: { ecmaVersion: 6 },
             errors
         },
         {
             code: "var foo = bar + 'this is a backtick preceded by a backslash: \\`' + baz;",
             output: "var foo = `${bar  }this is a backtick preceded by a backslash: \\`${  baz}`;",
-            parserOptions: { ecmaVersion: 6 },
             errors
         },
         {
             code: "var foo = bar + 'this is a backtick preceded by two backslashes: \\\\`' + baz;",
             output: "var foo = `${bar  }this is a backtick preceded by two backslashes: \\\\\\`${  baz}`;",
-            parserOptions: { ecmaVersion: 6 },
             errors
         },
         {
             code: "var foo = bar + `${baz}foo`;",
             output: "var foo = `${bar  }${baz}foo`;",
-            parserOptions: { ecmaVersion: 6 },
             errors
         },
         {
@@ -148,13 +131,11 @@ ruleTester.run("prefer-template", rule, {
             "var foo = `favorites: ${  favorites.map(f => {\n" +
             "    return f.name;\n" +
             "})  };`;",
-            parserOptions: { ecmaVersion: 6 },
             errors
         },
         {
             code: "var foo = bar + baz + 'qux';",
             output: "var foo = `${bar + baz  }qux`;",
-            parserOptions: { ecmaVersion: 6 },
             errors
         },
         {
@@ -170,49 +151,41 @@ ruleTester.run("prefer-template", rule, {
             "        return f.name;\n" +
             "    }) \n" +
             "};`;",
-            parserOptions: { ecmaVersion: 6 },
             errors
         },
         {
             code: "var foo = /* a */ 'bar' /* b */ + /* c */ baz /* d */ + 'qux' /* e */ ;",
             output: "var foo = /* a */ `bar${ /* b */  /* c */ baz /* d */  }qux` /* e */ ;",
-            parserOptions: { ecmaVersion: 6 },
             errors
         },
         {
             code: "var foo = bar + ('baz') + 'qux' + (boop);",
             output: "var foo = `${bar  }baz` + `qux${  boop}`;",
-            parserOptions: { ecmaVersion: 6 },
             errors
         },
         {
             code: "foo + 'unescapes an escaped single quote in a single-quoted string: \\''",
             output: "`${foo  }unescapes an escaped single quote in a single-quoted string: '`",
-            parserOptions: { ecmaVersion: 6 },
             errors
         },
         {
             code: "foo + \"unescapes an escaped double quote in a double-quoted string: \\\"\"",
             output: "`${foo  }unescapes an escaped double quote in a double-quoted string: \"`",
-            parserOptions: { ecmaVersion: 6 },
             errors
         },
         {
             code: "foo + 'does not unescape an escaped double quote in a single-quoted string: \\\"'",
             output: "`${foo  }does not unescape an escaped double quote in a single-quoted string: \\\"`",
-            parserOptions: { ecmaVersion: 6 },
             errors
         },
         {
             code: "foo + \"does not unescape an escaped single quote in a double-quoted string: \\'\"",
             output: "`${foo  }does not unescape an escaped single quote in a double-quoted string: \\'`",
-            parserOptions: { ecmaVersion: 6 },
             errors
         },
         {
             code: "foo + 'handles unicode escapes correctly: \\x27'", // "\x27" === "'"
             output: "`${foo  }handles unicode escapes correctly: \\x27`",
-            parserOptions: { ecmaVersion: 6 },
             errors
         }
     ]

--- a/tests/lib/rules/require-yield.js
+++ b/tests/lib/rules/require-yield.js
@@ -18,71 +18,39 @@ const RuleTester = require("../../../lib/testers/rule-tester");
 
 const errorMessage = "This generator function does not have 'yield'.";
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
 
 ruleTester.run("require-yield", rule, {
     valid: [
-        {
-            code: "function foo() { return 0; }",
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "function* foo() { yield 0; }",
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "function* foo() { }",
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "(function* foo() { yield 0; })();",
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "(function* foo() { })();",
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "var obj = { *foo() { yield 0; } };",
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "var obj = { *foo() { } };",
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "class A { *foo() { yield 0; } };",
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "class A { *foo() { } };",
-            parserOptions: { ecmaVersion: 6 }
-        }
+        "function foo() { return 0; }",
+        "function* foo() { yield 0; }",
+        "function* foo() { }",
+        "(function* foo() { yield 0; })();",
+        "(function* foo() { })();",
+        "var obj = { *foo() { yield 0; } };",
+        "var obj = { *foo() { } };",
+        "class A { *foo() { yield 0; } };",
+        "class A { *foo() { } };"
     ],
     invalid: [
         {
             code: "function* foo() { return 0; }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{message: errorMessage, type: "FunctionDeclaration"}]
         },
         {
             code: "(function* foo() { return 0; })();",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{message: errorMessage, type: "FunctionExpression"}]
         },
         {
             code: "var obj = { *foo() { return 0; } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{message: errorMessage, type: "FunctionExpression"}]
         },
         {
             code: "class A { *foo() { return 0; } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{message: errorMessage, type: "FunctionExpression"}]
         },
         {
             code: "function* foo() { function* bar() { yield 0; } }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: errorMessage,
                 type: "FunctionDeclaration",
@@ -91,7 +59,6 @@ ruleTester.run("require-yield", rule, {
         },
         {
             code: "function* foo() { function* bar() { return 0; } yield 0; }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: errorMessage,
                 type: "FunctionDeclaration",

--- a/tests/lib/rules/rest-spread-spacing.js
+++ b/tests/lib/rules/rest-spread-spacing.js
@@ -12,48 +12,47 @@
 const rule = require("../../../lib/rules/rest-spread-spacing"),
     RuleTester = require("../../../lib/testers/rule-tester");
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
 
 ruleTester.run("rest-spread-spacing", rule, {
     valid: [
-        { code: "fn(...args)", parserOptions: { ecmaVersion: 6 } },
-        { code: "fn(...(args))", parserOptions: { ecmaVersion: 6 } },
-        { code: "fn(...( args ))", parserOptions: { ecmaVersion: 6 } },
-        { code: "fn(...args)", options: ["never"], parserOptions: { ecmaVersion: 6 } },
-        { code: "fn(... args)", options: ["always"], parserOptions: { ecmaVersion: 6 } },
-        { code: "fn(...\targs)", options: ["always"], parserOptions: { ecmaVersion: 6 } },
-        { code: "fn(...\nargs)", options: ["always"], parserOptions: { ecmaVersion: 6 } },
-        { code: "[...arr, 4, 5, 6]", parserOptions: { ecmaVersion: 6 } },
-        { code: "[...(arr), 4, 5, 6]", parserOptions: { ecmaVersion: 6 } },
-        { code: "[...( arr ), 4, 5, 6]", parserOptions: { ecmaVersion: 6 } },
-        { code: "[...arr, 4, 5, 6]", options: ["never"], parserOptions: { ecmaVersion: 6 } },
-        { code: "[... arr, 4, 5, 6]", options: ["always"], parserOptions: { ecmaVersion: 6 } },
-        { code: "[...\tarr, 4, 5, 6]", options: ["always"], parserOptions: { ecmaVersion: 6 } },
-        { code: "[...\narr, 4, 5, 6]", options: ["always"], parserOptions: { ecmaVersion: 6 } },
-        { code: "let [a, b, ...arr] = [1, 2, 3, 4, 5];", parserOptions: { ecmaVersion: 6 } },
-        { code: "let [a, b, ...arr] = [1, 2, 3, 4, 5];", options: ["never"], parserOptions: { ecmaVersion: 6 } },
-        { code: "let [a, b, ... arr] = [1, 2, 3, 4, 5];", options: ["always"], parserOptions: { ecmaVersion: 6 } },
-        { code: "let [a, b, ...\tarr] = [1, 2, 3, 4, 5];", options: ["always"], parserOptions: { ecmaVersion: 6 } },
-        { code: "let [a, b, ...\narr] = [1, 2, 3, 4, 5];", options: ["always"], parserOptions: { ecmaVersion: 6 } },
-        { code: "let n = { x, y, ...z };", parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } } },
-        { code: "let n = { x, y, ...(z) };", parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } } },
-        { code: "let n = { x, y, ...( z ) };", parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } } },
-        { code: "let n = { x, y, ...z };", options: ["never"], parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } } },
-        { code: "let n = { x, y, ... z };", options: ["always"], parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } } },
-        { code: "let n = { x, y, ...\tz };", options: ["always"], parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } } },
-        { code: "let n = { x, y, ...\nz };", options: ["always"], parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } } },
-        { code: "let { x, y, ...z } = { x: 1, y: 2, a: 3, b: 4 };", parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } } },
-        { code: "let { x, y, ...z } = { x: 1, y: 2, a: 3, b: 4 };", options: ["never"], parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } } },
-        { code: "let { x, y, ... z } = { x: 1, y: 2, a: 3, b: 4 };", options: ["always"], parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } } },
-        { code: "let { x, y, ...\tz } = { x: 1, y: 2, a: 3, b: 4 };", options: ["always"], parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } } },
-        { code: "let { x, y, ...\nz } = { x: 1, y: 2, a: 3, b: 4 };", options: ["always"], parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } } }
+        "fn(...args)",
+        "fn(...(args))",
+        "fn(...( args ))",
+        { code: "fn(...args)", options: ["never"] },
+        { code: "fn(... args)", options: ["always"] },
+        { code: "fn(...\targs)", options: ["always"] },
+        { code: "fn(...\nargs)", options: ["always"] },
+        "[...arr, 4, 5, 6]",
+        "[...(arr), 4, 5, 6]",
+        "[...( arr ), 4, 5, 6]",
+        { code: "[...arr, 4, 5, 6]", options: ["never"] },
+        { code: "[... arr, 4, 5, 6]", options: ["always"] },
+        { code: "[...\tarr, 4, 5, 6]", options: ["always"] },
+        { code: "[...\narr, 4, 5, 6]", options: ["always"] },
+        "let [a, b, ...arr] = [1, 2, 3, 4, 5];",
+        { code: "let [a, b, ...arr] = [1, 2, 3, 4, 5];", options: ["never"] },
+        { code: "let [a, b, ... arr] = [1, 2, 3, 4, 5];", options: ["always"] },
+        { code: "let [a, b, ...\tarr] = [1, 2, 3, 4, 5];", options: ["always"] },
+        { code: "let [a, b, ...\narr] = [1, 2, 3, 4, 5];", options: ["always"] },
+        { code: "let n = { x, y, ...z };", parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } } },
+        { code: "let n = { x, y, ...(z) };", parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } } },
+        { code: "let n = { x, y, ...( z ) };", parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } } },
+        { code: "let n = { x, y, ...z };", options: ["never"], parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } } },
+        { code: "let n = { x, y, ... z };", options: ["always"], parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } } },
+        { code: "let n = { x, y, ...\tz };", options: ["always"], parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } } },
+        { code: "let n = { x, y, ...\nz };", options: ["always"], parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } } },
+        { code: "let { x, y, ...z } = { x: 1, y: 2, a: 3, b: 4 };", parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } } },
+        { code: "let { x, y, ...z } = { x: 1, y: 2, a: 3, b: 4 };", options: ["never"], parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } } },
+        { code: "let { x, y, ... z } = { x: 1, y: 2, a: 3, b: 4 };", options: ["always"], parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } } },
+        { code: "let { x, y, ...\tz } = { x: 1, y: 2, a: 3, b: 4 };", options: ["always"], parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } } },
+        { code: "let { x, y, ...\nz } = { x: 1, y: 2, a: 3, b: 4 };", options: ["always"], parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } } }
     ],
 
     invalid: [
         {
             code: "fn(... args)",
             output: "fn(...args)",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 line: 1,
                 column: 7,
@@ -64,7 +63,6 @@ ruleTester.run("rest-spread-spacing", rule, {
         {
             code: "fn(...\targs)",
             output: "fn(...args)",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 line: 1,
                 column: 7,
@@ -75,7 +73,6 @@ ruleTester.run("rest-spread-spacing", rule, {
         {
             code: "fn(...\nargs)",
             output: "fn(...args)",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 line: 1,
                 column: 7,
@@ -87,7 +84,6 @@ ruleTester.run("rest-spread-spacing", rule, {
             code: "fn(... args)",
             output: "fn(...args)",
             options: ["never"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 line: 1,
                 column: 7,
@@ -99,7 +95,6 @@ ruleTester.run("rest-spread-spacing", rule, {
             code: "fn(...\targs)",
             output: "fn(...args)",
             options: ["never"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 line: 1,
                 column: 7,
@@ -111,7 +106,6 @@ ruleTester.run("rest-spread-spacing", rule, {
             code: "fn(...\nargs)",
             output: "fn(...args)",
             options: ["never"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 line: 1,
                 column: 7,
@@ -123,7 +117,6 @@ ruleTester.run("rest-spread-spacing", rule, {
             code: "fn(...args)",
             output: "fn(... args)",
             options: ["always"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 line: 1,
                 column: 7,
@@ -134,7 +127,6 @@ ruleTester.run("rest-spread-spacing", rule, {
         {
             code: "fn(... (args))",
             output: "fn(...(args))",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 line: 1,
                 column: 7,
@@ -145,7 +137,6 @@ ruleTester.run("rest-spread-spacing", rule, {
         {
             code: "fn(... ( args ))",
             output: "fn(...( args ))",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 line: 1,
                 column: 7,
@@ -157,7 +148,6 @@ ruleTester.run("rest-spread-spacing", rule, {
             code: "fn(...(args))",
             output: "fn(... (args))",
             options: ["always"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 line: 1,
                 column: 7,
@@ -169,7 +159,6 @@ ruleTester.run("rest-spread-spacing", rule, {
             code: "fn(...( args ))",
             output: "fn(... ( args ))",
             options: ["always"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 line: 1,
                 column: 7,
@@ -180,7 +169,6 @@ ruleTester.run("rest-spread-spacing", rule, {
         {
             code: "[... arr, 4, 5, 6]",
             output: "[...arr, 4, 5, 6]",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 line: 1,
                 column: 5,
@@ -191,7 +179,6 @@ ruleTester.run("rest-spread-spacing", rule, {
         {
             code: "[...\tarr, 4, 5, 6]",
             output: "[...arr, 4, 5, 6]",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 line: 1,
                 column: 5,
@@ -202,7 +189,6 @@ ruleTester.run("rest-spread-spacing", rule, {
         {
             code: "[...\narr, 4, 5, 6]",
             output: "[...arr, 4, 5, 6]",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 line: 1,
                 column: 5,
@@ -214,7 +200,6 @@ ruleTester.run("rest-spread-spacing", rule, {
             code: "[... arr, 4, 5, 6]",
             output: "[...arr, 4, 5, 6]",
             options: ["never"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 line: 1,
                 column: 5,
@@ -226,7 +211,6 @@ ruleTester.run("rest-spread-spacing", rule, {
             code: "[...\tarr, 4, 5, 6]",
             output: "[...arr, 4, 5, 6]",
             options: ["never"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 line: 1,
                 column: 5,
@@ -238,7 +222,6 @@ ruleTester.run("rest-spread-spacing", rule, {
             code: "[...\narr, 4, 5, 6]",
             output: "[...arr, 4, 5, 6]",
             options: ["never"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 line: 1,
                 column: 5,
@@ -250,7 +233,6 @@ ruleTester.run("rest-spread-spacing", rule, {
             code: "[...arr, 4, 5, 6]",
             output: "[... arr, 4, 5, 6]",
             options: ["always"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 line: 1,
                 column: 5,
@@ -261,7 +243,6 @@ ruleTester.run("rest-spread-spacing", rule, {
         {
             code: "[... (arr), 4, 5, 6]",
             output: "[...(arr), 4, 5, 6]",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 line: 1,
                 column: 5,
@@ -272,7 +253,6 @@ ruleTester.run("rest-spread-spacing", rule, {
         {
             code: "[... ( arr ), 4, 5, 6]",
             output: "[...( arr ), 4, 5, 6]",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 line: 1,
                 column: 5,
@@ -284,7 +264,6 @@ ruleTester.run("rest-spread-spacing", rule, {
             code: "[...(arr), 4, 5, 6]",
             output: "[... (arr), 4, 5, 6]",
             options: ["always"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 line: 1,
                 column: 5,
@@ -296,7 +275,6 @@ ruleTester.run("rest-spread-spacing", rule, {
             code: "[...( arr ), 4, 5, 6]",
             output: "[... ( arr ), 4, 5, 6]",
             options: ["always"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 line: 1,
                 column: 5,
@@ -307,7 +285,6 @@ ruleTester.run("rest-spread-spacing", rule, {
         {
             code: "let [a, b, ... arr] = [1, 2, 3, 4, 5];",
             output: "let [a, b, ...arr] = [1, 2, 3, 4, 5];",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 line: 1,
                 column: 15,
@@ -318,7 +295,6 @@ ruleTester.run("rest-spread-spacing", rule, {
         {
             code: "let [a, b, ...\tarr] = [1, 2, 3, 4, 5];",
             output: "let [a, b, ...arr] = [1, 2, 3, 4, 5];",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 line: 1,
                 column: 15,
@@ -329,7 +305,6 @@ ruleTester.run("rest-spread-spacing", rule, {
         {
             code: "let [a, b, ...\narr] = [1, 2, 3, 4, 5];",
             output: "let [a, b, ...arr] = [1, 2, 3, 4, 5];",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 line: 1,
                 column: 15,
@@ -341,7 +316,6 @@ ruleTester.run("rest-spread-spacing", rule, {
             code: "let [a, b, ... arr] = [1, 2, 3, 4, 5];",
             output: "let [a, b, ...arr] = [1, 2, 3, 4, 5];",
             options: ["never"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 line: 1,
                 column: 15,
@@ -353,7 +327,6 @@ ruleTester.run("rest-spread-spacing", rule, {
             code: "let [a, b, ...\tarr] = [1, 2, 3, 4, 5];",
             output: "let [a, b, ...arr] = [1, 2, 3, 4, 5];",
             options: ["never"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 line: 1,
                 column: 15,
@@ -365,7 +338,6 @@ ruleTester.run("rest-spread-spacing", rule, {
             code: "let [a, b, ...\narr] = [1, 2, 3, 4, 5];",
             output: "let [a, b, ...arr] = [1, 2, 3, 4, 5];",
             options: ["never"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 line: 1,
                 column: 15,
@@ -377,7 +349,6 @@ ruleTester.run("rest-spread-spacing", rule, {
             code: "let [a, b, ...arr] = [1, 2, 3, 4, 5];",
             output: "let [a, b, ... arr] = [1, 2, 3, 4, 5];",
             options: ["always"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 line: 1,
                 column: 15,
@@ -388,7 +359,7 @@ ruleTester.run("rest-spread-spacing", rule, {
         {
             code: "let n = { x, y, ... z };",
             output: "let n = { x, y, ...z };",
-            parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },
+            parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } },
             errors: [{
                 line: 1,
                 column: 20,
@@ -399,7 +370,7 @@ ruleTester.run("rest-spread-spacing", rule, {
         {
             code: "let n = { x, y, ...\tz };",
             output: "let n = { x, y, ...z };",
-            parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },
+            parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } },
             errors: [{
                 line: 1,
                 column: 20,
@@ -410,7 +381,7 @@ ruleTester.run("rest-spread-spacing", rule, {
         {
             code: "let n = { x, y, ...\nz };",
             output: "let n = { x, y, ...z };",
-            parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },
+            parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } },
             errors: [{
                 line: 1,
                 column: 20,
@@ -422,7 +393,7 @@ ruleTester.run("rest-spread-spacing", rule, {
             code: "let n = { x, y, ... z };",
             output: "let n = { x, y, ...z };",
             options: ["never"],
-            parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },
+            parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } },
             errors: [{
                 line: 1,
                 column: 20,
@@ -434,7 +405,7 @@ ruleTester.run("rest-spread-spacing", rule, {
             code: "let n = { x, y, ...\tz };",
             output: "let n = { x, y, ...z };",
             options: ["never"],
-            parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },
+            parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } },
             errors: [{
                 line: 1,
                 column: 20,
@@ -446,7 +417,7 @@ ruleTester.run("rest-spread-spacing", rule, {
             code: "let n = { x, y, ...\nz };",
             output: "let n = { x, y, ...z };",
             options: ["never"],
-            parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },
+            parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } },
             errors: [{
                 line: 1,
                 column: 20,
@@ -458,7 +429,7 @@ ruleTester.run("rest-spread-spacing", rule, {
             code: "let n = { x, y, ...z };",
             output: "let n = { x, y, ... z };",
             options: ["always"],
-            parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },
+            parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } },
             errors: [{
                 line: 1,
                 column: 20,
@@ -470,7 +441,7 @@ ruleTester.run("rest-spread-spacing", rule, {
             code: "let n = { x, y, ... (z) };",
             output: "let n = { x, y, ...(z) };",
             options: ["never"],
-            parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },
+            parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } },
             errors: [{
                 line: 1,
                 column: 20,
@@ -482,7 +453,7 @@ ruleTester.run("rest-spread-spacing", rule, {
             code: "let n = { x, y, ... ( z ) };",
             output: "let n = { x, y, ...( z ) };",
             options: ["never"],
-            parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },
+            parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } },
             errors: [{
                 line: 1,
                 column: 20,
@@ -494,7 +465,7 @@ ruleTester.run("rest-spread-spacing", rule, {
             code: "let n = { x, y, ...(z) };",
             output: "let n = { x, y, ... (z) };",
             options: ["always"],
-            parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },
+            parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } },
             errors: [{
                 line: 1,
                 column: 20,
@@ -506,7 +477,7 @@ ruleTester.run("rest-spread-spacing", rule, {
             code: "let n = { x, y, ...( z ) };",
             output: "let n = { x, y, ... ( z ) };",
             options: ["always"],
-            parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },
+            parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } },
             errors: [{
                 line: 1,
                 column: 20,
@@ -517,7 +488,7 @@ ruleTester.run("rest-spread-spacing", rule, {
         {
             code: "let { x, y, ... z } = { x: 1, y: 2, a: 3, b: 4 };",
             output: "let { x, y, ...z } = { x: 1, y: 2, a: 3, b: 4 };",
-            parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },
+            parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } },
             errors: [{
                 line: 1,
                 column: 16,
@@ -528,7 +499,7 @@ ruleTester.run("rest-spread-spacing", rule, {
         {
             code: "let { x, y, ...\tz } = { x: 1, y: 2, a: 3, b: 4 };",
             output: "let { x, y, ...z } = { x: 1, y: 2, a: 3, b: 4 };",
-            parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },
+            parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } },
             errors: [{
                 line: 1,
                 column: 16,
@@ -539,7 +510,7 @@ ruleTester.run("rest-spread-spacing", rule, {
         {
             code: "let { x, y, ...\nz } = { x: 1, y: 2, a: 3, b: 4 };",
             output: "let { x, y, ...z } = { x: 1, y: 2, a: 3, b: 4 };",
-            parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },
+            parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } },
             errors: [{
                 line: 1,
                 column: 16,
@@ -551,7 +522,7 @@ ruleTester.run("rest-spread-spacing", rule, {
             code: "let { x, y, ... z } = { x: 1, y: 2, a: 3, b: 4 };",
             output: "let { x, y, ...z } = { x: 1, y: 2, a: 3, b: 4 };",
             options: ["never"],
-            parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },
+            parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } },
             errors: [{
                 line: 1,
                 column: 16,
@@ -563,7 +534,7 @@ ruleTester.run("rest-spread-spacing", rule, {
             code: "let { x, y, ...\tz } = { x: 1, y: 2, a: 3, b: 4 };",
             output: "let { x, y, ...z } = { x: 1, y: 2, a: 3, b: 4 };",
             options: ["never"],
-            parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },
+            parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } },
             errors: [{
                 line: 1,
                 column: 16,
@@ -575,7 +546,7 @@ ruleTester.run("rest-spread-spacing", rule, {
             code: "let { x, y, ...\nz } = { x: 1, y: 2, a: 3, b: 4 };",
             output: "let { x, y, ...z } = { x: 1, y: 2, a: 3, b: 4 };",
             options: ["never"],
-            parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },
+            parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } },
             errors: [{
                 line: 1,
                 column: 16,
@@ -587,7 +558,7 @@ ruleTester.run("rest-spread-spacing", rule, {
             code: "let { x, y, ...z } = { x: 1, y: 2, a: 3, b: 4 };",
             output: "let { x, y, ... z } = { x: 1, y: 2, a: 3, b: 4 };",
             options: ["always"],
-            parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },
+            parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } },
             errors: [{
                 line: 1,
                 column: 16,

--- a/tests/lib/rules/sort-imports.js
+++ b/tests/lib/rules/sort-imports.js
@@ -16,11 +16,7 @@ const rule = require("../../../lib/rules/sort-imports"),
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester(),
-    parserOptions = {
-        ecmaVersion: 6,
-        sourceType: "module"
-    },
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6, sourceType: "module" } }),
     expectedError = {
         message: "Imports should be sorted alphabetically.",
         type: "ImportDeclaration"
@@ -33,32 +29,27 @@ ruleTester.run("sort-imports", rule, {
             code:
                 "import a from 'foo.js';\n" +
                 "import b from 'bar.js';\n" +
-                "import c from 'baz.js';\n",
-            parserOptions
+                "import c from 'baz.js';\n"
         },
         {
             code:
                 "import * as B from 'foo.js';\n" +
-                "import A from 'bar.js';",
-            parserOptions
+                "import A from 'bar.js';"
         },
         {
             code:
                 "import * as B from 'foo.js';\n" +
-                "import {a, b} from 'bar.js';",
-            parserOptions
+                "import {a, b} from 'bar.js';"
         },
         {
             code:
                 "import {b, c} from 'bar.js';\n" +
-                "import A from 'foo.js';",
-            parserOptions
+                "import A from 'foo.js';"
         },
         {
             code:
                 "import A from 'bar.js';\n" +
                 "import {b, c} from 'foo.js';",
-            parserOptions,
             options: [{
                 memberSyntaxSortOrder: [ "single", "multiple", "none", "all" ]
             }]
@@ -66,85 +57,67 @@ ruleTester.run("sort-imports", rule, {
         {
             code:
                 "import {a, b} from 'bar.js';\n" +
-                "import {b, c} from 'foo.js';",
-            parserOptions
+                "import {b, c} from 'foo.js';"
         },
         {
             code:
                 "import A from 'foo.js';\n" +
-                "import B from 'bar.js';",
-            parserOptions
+                "import B from 'bar.js';"
         },
         {
             code:
                 "import A from 'foo.js';\n" +
-                "import a from 'bar.js';",
-            parserOptions
+                "import a from 'bar.js';"
         },
         {
             code:
                 "import a, * as b from 'foo.js';\n" +
-                "import b from 'bar.js';",
-            parserOptions
+                "import b from 'bar.js';"
         },
         {
             code:
                 "import 'foo.js';\n" +
-                " import a from 'bar.js';",
-            parserOptions
+                " import a from 'bar.js';"
         },
         {
             code:
                 "import B from 'foo.js';\n" +
-                "import a from 'bar.js';",
-            parserOptions
+                "import a from 'bar.js';"
         },
         {
             code:
                 "import a from 'foo.js';\n" +
                 "import B from 'bar.js';",
-            parserOptions,
             options: ignoreCaseArgs
         },
-        {
-            code: "import {a, b, c, d} from 'foo.js';",
-            parserOptions
-        },
+        "import {a, b, c, d} from 'foo.js';",
         {
             code: "import {b, A, C, d} from 'foo.js';",
-            parserOptions,
             options: [{
                 ignoreMemberSort: true
             }]
         },
         {
             code: "import {B, a, C, d} from 'foo.js';",
-            parserOptions,
             options: [{
                 ignoreMemberSort: true
             }]
         },
         {
             code: "import {a, B, c, D} from 'foo.js';",
-            parserOptions,
             options: ignoreCaseArgs
         },
-        {
-            code: "import a, * as b from 'foo.js';",
-            parserOptions
-        },
+        "import a, * as b from 'foo.js';",
         {
             code:
                 "import * as a from 'foo.js';\n" +
                 "\n" +
-                "import b from 'bar.js';",
-            parserOptions
+                "import b from 'bar.js';"
         },
         {
             code:
                 "import * as bar from 'bar.js';\n" +
-                "import * as foo from 'foo.js';",
-            parserOptions
+                "import * as foo from 'foo.js';"
         },
 
         // https://github.com/eslint/eslint/issues/5130
@@ -152,50 +125,41 @@ ruleTester.run("sort-imports", rule, {
             code:
                 "import 'foo';\n" +
                 "import bar from 'bar';",
-            parserOptions,
             options: ignoreCaseArgs
         },
 
         // https://github.com/eslint/eslint/issues/5305
-        {
-            code: "import React, {Component} from 'react';",
-            parserOptions
-        }
+        "import React, {Component} from 'react';"
     ],
     invalid: [
         {
             code:
                 "import a from 'foo.js';\n" +
                 "import A from 'bar.js';",
-            parserOptions,
             errors: [expectedError]
         },
         {
             code:
                 "import b from 'foo.js';\n" +
                 "import a from 'bar.js';",
-            parserOptions,
             errors: [expectedError]
         },
         {
             code:
                 "import {b, c} from 'foo.js';\n" +
                 "import {a, b} from 'bar.js';",
-            parserOptions,
             errors: [expectedError]
         },
         {
             code:
                 "import * as foo from 'foo.js';\n" +
                 "import * as bar from 'bar.js';",
-            parserOptions,
             errors: [expectedError]
         },
         {
             code:
                 "import a from 'foo.js';\n" +
                 "import {b, c} from 'bar.js';",
-            parserOptions,
             errors: [{
                 message: "Expected 'multiple' syntax before 'single' syntax.",
                 type: "ImportDeclaration"
@@ -205,7 +169,6 @@ ruleTester.run("sort-imports", rule, {
             code:
                 "import a from 'foo.js';\n" +
                 "import * as b from 'bar.js';",
-            parserOptions,
             errors: [{
                 message: "Expected 'all' syntax before 'single' syntax.",
                 type: "ImportDeclaration"
@@ -215,7 +178,6 @@ ruleTester.run("sort-imports", rule, {
             code:
                 "import a from 'foo.js';\n" +
                 "import 'bar.js';",
-            parserOptions,
             errors: [{
                 message: "Expected 'none' syntax before 'single' syntax.",
                 type: "ImportDeclaration"
@@ -225,7 +187,6 @@ ruleTester.run("sort-imports", rule, {
             code:
                 "import b from 'bar.js';\n" +
                 "import * as a from 'foo.js';",
-            parserOptions,
             options: [{
                 memberSyntaxSortOrder: [ "all", "single", "multiple", "none" ]
             }],
@@ -237,7 +198,6 @@ ruleTester.run("sort-imports", rule, {
         {
             code: "import {b, a, d, c} from 'foo.js';",
             output: "import {a, b, c, d} from 'foo.js';",
-            parserOptions,
             errors: [{
                 message: "Member 'a' of the import declaration should be sorted alphabetically.",
                 type: "ImportSpecifier"
@@ -246,7 +206,6 @@ ruleTester.run("sort-imports", rule, {
         {
             code: "import {a, B, c, D} from 'foo.js';",
             output: "import {B, D, a, c} from 'foo.js';",
-            parserOptions,
             errors: [{
                 message: "Member 'B' of the import declaration should be sorted alphabetically.",
                 type: "ImportSpecifier"
@@ -255,7 +214,6 @@ ruleTester.run("sort-imports", rule, {
         {
             code: "import {zzzzz, /* comment */ aaaaa} from 'foo.js';",
             output: "import {zzzzz, /* comment */ aaaaa} from 'foo.js';", // not fixed due to comment
-            parserOptions,
             errors: [{
                 message: "Member 'aaaaa' of the import declaration should be sorted alphabetically.",
                 type: "ImportSpecifier"
@@ -264,7 +222,6 @@ ruleTester.run("sort-imports", rule, {
         {
             code: "import {zzzzz /* comment */, aaaaa} from 'foo.js';",
             output: "import {zzzzz /* comment */, aaaaa} from 'foo.js';", // not fixed due to comment
-            parserOptions,
             errors: [{
                 message: "Member 'aaaaa' of the import declaration should be sorted alphabetically.",
                 type: "ImportSpecifier"
@@ -273,7 +230,6 @@ ruleTester.run("sort-imports", rule, {
         {
             code: "import {/* comment */ zzzzz, aaaaa} from 'foo.js';",
             output: "import {/* comment */ zzzzz, aaaaa} from 'foo.js';", // not fixed due to comment
-            parserOptions,
             errors: [{
                 message: "Member 'aaaaa' of the import declaration should be sorted alphabetically.",
                 type: "ImportSpecifier"
@@ -282,7 +238,6 @@ ruleTester.run("sort-imports", rule, {
         {
             code: "import {zzzzz, aaaaa /* comment */} from 'foo.js';",
             output: "import {zzzzz, aaaaa /* comment */} from 'foo.js';", // not fixed due to comment
-            parserOptions,
             errors: [{
                 message: "Member 'aaaaa' of the import declaration should be sorted alphabetically.",
                 type: "ImportSpecifier"
@@ -309,7 +264,6 @@ ruleTester.run("sort-imports", rule, {
                 zoo
               } from 'foo.js';
             `,
-            parserOptions,
             errors: [{
                 message: "Member 'qux' of the import declaration should be sorted alphabetically.",
                 type: "ImportSpecifier"

--- a/tests/lib/rules/symbol-description.js
+++ b/tests/lib/rules/symbol-description.js
@@ -12,39 +12,21 @@
 const rule = require("../../../lib/rules/symbol-description");
 const RuleTester = require("../../../lib/testers/rule-tester");
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({ env: { es6: true } });
 
 ruleTester.run("symbol-description", rule, {
 
     valid: [
-        {
-            code: "Symbol(\"Foo\");",
-            env: {es6: true}
-        },
-        {
-            code: "var foo = \"foo\"; Symbol(foo);",
-            env: {es6: true}
-        },
+        "Symbol(\"Foo\");",
+        "var foo = \"foo\"; Symbol(foo);",
 
         // Ignore if it's shadowed.
-        {
-            code: "var Symbol = function () {}; Symbol();",
-            env: {es6: true}
-        },
-        {
-            code: "Symbol(); var Symbol = function () {};",
-            env: {es6: true}
-        },
-        {
-            code: "function bar() { var Symbol = function () {}; Symbol(); }",
-            env: {es6: true}
-        },
+        "var Symbol = function () {}; Symbol();",
+        "Symbol(); var Symbol = function () {};",
+        "function bar() { var Symbol = function () {}; Symbol(); }",
 
         // Ignore if it's an argument.
-        {
-            code: "function bar(Symbol) { Symbol(); }",
-            env: {es6: true}
-        },
+        "function bar(Symbol) { Symbol(); }",
     ],
 
     invalid: [
@@ -53,16 +35,14 @@ ruleTester.run("symbol-description", rule, {
             errors: [{
                 message: "Expected Symbol to have a description.",
                 type: "CallExpression"
-            }],
-            env: {es6: true}
+            }]
         },
         {
             code: "Symbol(); Symbol = function () {};",
             errors: [{
                 message: "Expected Symbol to have a description.",
                 type: "CallExpression"
-            }],
-            env: {es6: true}
+            }]
         },
     ]
 });

--- a/tests/lib/rules/template-curly-spacing.js
+++ b/tests/lib/rules/template-curly-spacing.js
@@ -16,17 +16,17 @@ const rule = require("../../../lib/rules/template-curly-spacing"),
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
 
 ruleTester.run("template-curly-spacing", rule, {
     valid: [
-        {code: "{ foo }"},
-        {code: "`${foo} ${bar}`", parserOptions: {ecmaVersion: 6}},
-        {code: "`${foo} ${bar} ${\n  baz\n}`", options: ["never"], parserOptions: {ecmaVersion: 6}},
-        {code: "`${ foo } ${ bar } ${\n  baz\n}`", options: ["always"], parserOptions: {ecmaVersion: 6}},
-        {code: "tag`${foo} ${bar}`", parserOptions: {ecmaVersion: 6}},
-        {code: "tag`${foo} ${bar} ${\n  baz\n}`", options: ["never"], parserOptions: {ecmaVersion: 6}},
-        {code: "tag`${ foo } ${ bar } ${\n  baz\n}`", options: ["always"], parserOptions: {ecmaVersion: 6}}
+        "{ foo }",
+        "`${foo} ${bar}`",
+        {code: "`${foo} ${bar} ${\n  baz\n}`", options: ["never"]},
+        {code: "`${ foo } ${ bar } ${\n  baz\n}`", options: ["always"]},
+        "tag`${foo} ${bar}`",
+        {code: "tag`${foo} ${bar} ${\n  baz\n}`", options: ["never"]},
+        {code: "tag`${ foo } ${ bar } ${\n  baz\n}`", options: ["always"]}
     ],
     invalid: [
         {
@@ -37,8 +37,7 @@ ruleTester.run("template-curly-spacing", rule, {
                 {message: "Unexpected space(s) before '}'.", column: 9},
                 {message: "Unexpected space(s) after '${'.", column: 11},
                 {message: "Unexpected space(s) before '}'.", column: 18}
-            ],
-            parserOptions: {ecmaVersion: 6}
+            ]
         },
         {
             code: "`${ foo } ${ bar }`",
@@ -49,8 +48,7 @@ ruleTester.run("template-curly-spacing", rule, {
                 {message: "Unexpected space(s) after '${'.", column: 11},
                 {message: "Unexpected space(s) before '}'.", column: 18}
             ],
-            options: ["never"],
-            parserOptions: {ecmaVersion: 6}
+            options: ["never"]
         },
         {
             code: "`${foo} ${bar}`",
@@ -61,8 +59,17 @@ ruleTester.run("template-curly-spacing", rule, {
                 {message: "Expected space(s) after '${'.", column: 9},
                 {message: "Expected space(s) before '}'.", column: 14}
             ],
-            options: ["always"],
-            parserOptions: {ecmaVersion: 6}
+            options: ["always"]
+        },
+        {
+            code: "tag`${ foo } ${ bar }`",
+            output: "tag`${foo} ${bar}`",
+            errors: [
+                {message: "Unexpected space(s) after '${'.", column: 5},
+                {message: "Unexpected space(s) before '}'.", column: 12},
+                {message: "Unexpected space(s) after '${'.", column: 14},
+                {message: "Unexpected space(s) before '}'.", column: 21}
+            ]
         },
         {
             code: "tag`${ foo } ${ bar }`",
@@ -73,19 +80,7 @@ ruleTester.run("template-curly-spacing", rule, {
                 {message: "Unexpected space(s) after '${'.", column: 14},
                 {message: "Unexpected space(s) before '}'.", column: 21}
             ],
-            parserOptions: {ecmaVersion: 6}
-        },
-        {
-            code: "tag`${ foo } ${ bar }`",
-            output: "tag`${foo} ${bar}`",
-            errors: [
-                {message: "Unexpected space(s) after '${'.", column: 5},
-                {message: "Unexpected space(s) before '}'.", column: 12},
-                {message: "Unexpected space(s) after '${'.", column: 14},
-                {message: "Unexpected space(s) before '}'.", column: 21}
-            ],
-            options: ["never"],
-            parserOptions: {ecmaVersion: 6}
+            options: ["never"]
         },
         {
             code: "tag`${foo} ${bar}`",
@@ -96,8 +91,7 @@ ruleTester.run("template-curly-spacing", rule, {
                 {message: "Expected space(s) after '${'.", column: 12},
                 {message: "Expected space(s) before '}'.", column: 17}
             ],
-            options: ["always"],
-            parserOptions: {ecmaVersion: 6}
+            options: ["always"]
         }
     ]
 });

--- a/tests/lib/rules/yield-star-spacing.js
+++ b/tests/lib/rules/yield-star-spacing.js
@@ -16,153 +16,122 @@ const rule = require("../../../lib/rules/yield-star-spacing"),
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
 
 ruleTester.run("yield-star-spacing", rule, {
 
     valid: [
 
         // default (after)
-        {
-            code: "function *foo(){ yield foo; }",
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "function *foo(){ yield* foo; }",
-            parserOptions: { ecmaVersion: 6 }
-        },
+        "function *foo(){ yield foo; }",
+        "function *foo(){ yield* foo; }",
 
         // after
         {
             code: "function *foo(){ yield foo; }",
-            options: ["after"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["after"]
         },
         {
             code: "function *foo(){ yield* foo; }",
-            options: ["after"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["after"]
         },
         {
             code: "function *foo(){ yield* foo(); }",
-            options: ["after"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["after"]
         },
         {
             code: "function *foo(){ yield* 0 }",
-            options: ["after"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["after"]
         },
         {
             code: "function *foo(){ yield* []; }",
-            options: ["after"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["after"]
         },
         {
             code: "function *foo(){ var result = yield* foo(); }",
-            options: ["after"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["after"]
         },
         {
             code: "function *foo(){ var result = yield* (foo()); }",
-            options: ["after"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["after"]
         },
 
         // before
         {
             code: "function *foo(){ yield foo; }",
-            options: ["before"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["before"]
         },
         {
             code: "function *foo(){ yield *foo; }",
-            options: ["before"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["before"]
         },
         {
             code: "function *foo(){ yield *foo(); }",
-            options: ["before"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["before"]
         },
         {
             code: "function *foo(){ yield *0 }",
-            options: ["before"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["before"]
         },
         {
             code: "function *foo(){ yield *[]; }",
-            options: ["before"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["before"]
         },
         {
             code: "function *foo(){ var result = yield *foo(); }",
-            options: ["before"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["before"]
         },
 
         // both
         {
             code: "function *foo(){ yield foo; }",
-            options: ["both"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["both"]
         },
         {
             code: "function *foo(){ yield * foo; }",
-            options: ["both"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["both"]
         },
         {
             code: "function *foo(){ yield * foo(); }",
-            options: ["both"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["both"]
         },
         {
             code: "function *foo(){ yield * 0 }",
-            options: ["both"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["both"]
         },
         {
             code: "function *foo(){ yield * []; }",
-            options: ["both"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["both"]
         },
         {
             code: "function *foo(){ var result = yield * foo(); }",
-            options: ["both"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["both"]
         },
 
         // neither
         {
             code: "function *foo(){ yield foo; }",
-            options: ["neither"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["neither"]
         },
         {
             code: "function *foo(){ yield*foo; }",
-            options: ["neither"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["neither"]
         },
         {
             code: "function *foo(){ yield*foo(); }",
-            options: ["neither"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["neither"]
         },
         {
             code: "function *foo(){ yield*0 }",
-            options: ["neither"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["neither"]
         },
         {
             code: "function *foo(){ yield*[]; }",
-            options: ["neither"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["neither"]
         },
         {
             code: "function *foo(){ var result = yield*foo(); }",
-            options: ["neither"],
-            parserOptions: { ecmaVersion: 6 }
+            options: ["neither"]
         }
     ],
 
@@ -172,7 +141,6 @@ ruleTester.run("yield-star-spacing", rule, {
         {
             code: "function *foo(){ yield *foo1; }",
             output: "function *foo(){ yield* foo1; }",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Unexpected space before *.",
                 type: "Punctuator"
@@ -187,7 +155,6 @@ ruleTester.run("yield-star-spacing", rule, {
             code: "function *foo(){ yield *foo1; }",
             output: "function *foo(){ yield* foo1; }",
             options: ["after"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Unexpected space before *.",
                 type: "Punctuator"
@@ -200,7 +167,6 @@ ruleTester.run("yield-star-spacing", rule, {
             code: "function *foo(){ yield * foo; }",
             output: "function *foo(){ yield* foo; }",
             options: ["after"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Unexpected space before *.",
                 type: "Punctuator"
@@ -210,7 +176,6 @@ ruleTester.run("yield-star-spacing", rule, {
             code: "function *foo(){ yield*foo2; }",
             output: "function *foo(){ yield* foo2; }",
             options: ["after"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Missing space after *.",
                 type: "Punctuator"
@@ -222,7 +187,6 @@ ruleTester.run("yield-star-spacing", rule, {
             code: "function *foo(){ yield* foo; }",
             output: "function *foo(){ yield *foo; }",
             options: ["before"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Missing space before *.",
                 type: "Punctuator"
@@ -235,7 +199,6 @@ ruleTester.run("yield-star-spacing", rule, {
             code: "function *foo(){ yield * foo; }",
             output: "function *foo(){ yield *foo; }",
             options: ["before"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Unexpected space after *.",
                 type: "Punctuator"
@@ -245,7 +208,6 @@ ruleTester.run("yield-star-spacing", rule, {
             code: "function *foo(){ yield*foo; }",
             output: "function *foo(){ yield *foo; }",
             options: ["before"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Missing space before *.",
                 type: "Punctuator"
@@ -257,7 +219,6 @@ ruleTester.run("yield-star-spacing", rule, {
             code: "function *foo(){ yield* foo; }",
             output: "function *foo(){ yield * foo; }",
             options: ["both"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Missing space before *.",
                 type: "Punctuator"
@@ -267,7 +228,6 @@ ruleTester.run("yield-star-spacing", rule, {
             code: "function *foo(){ yield *foo3; }",
             output: "function *foo(){ yield * foo3; }",
             options: ["both"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Missing space after *.",
                 type: "Punctuator"
@@ -277,7 +237,6 @@ ruleTester.run("yield-star-spacing", rule, {
             code: "function *foo(){ yield*foo4; }",
             output: "function *foo(){ yield * foo4; }",
             options: ["both"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Missing space before *.",
                 type: "Punctuator"
@@ -292,7 +251,6 @@ ruleTester.run("yield-star-spacing", rule, {
             code: "function *foo(){ yield* foo; }",
             output: "function *foo(){ yield*foo; }",
             options: ["neither"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Unexpected space after *.",
                 type: "Punctuator"
@@ -302,7 +260,6 @@ ruleTester.run("yield-star-spacing", rule, {
             code: "function *foo(){ yield *foo; }",
             output: "function *foo(){ yield*foo; }",
             options: ["neither"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Unexpected space before *.",
                 type: "Punctuator"
@@ -312,7 +269,6 @@ ruleTester.run("yield-star-spacing", rule, {
             code: "function *foo(){ yield * foo; }",
             output: "function *foo(){ yield*foo; }",
             options: ["neither"],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Unexpected space before *.",
                 type: "Punctuator"


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

**What changes did you make? (Give an overview)**

Many of ESLint's rules are only relevant to ES6 code. The tests for some of those rules currently use "{ parserOptions: { ecmaVersion: 6 } }" for each individual test case, rather than specifying a default object as an argument to the `RuleTester` constructor. This PR updates those tests to avoid boilerplate from repeating the same parserOptions over and over.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.