### PR TITLE
Docs: clarify the default behavior of `operator-linebreak` (fixes #7459)

### DIFF
--- a/docs/rules/operator-linebreak.md
+++ b/docs/rules/operator-linebreak.md
@@ -26,13 +26,15 @@ This rule has one option, which can be a string option or an object option.
 
 String option:
 
-* `"after"` (default) requires linebreaks to be placed after the operator (except for the ternary operator characters `?` and `:`)
+* `"after"` requires linebreaks to be placed after the operator
 * `"before"` requires linebreaks to be placed before the operator
 * `"none"` disallows linebreaks on either side of the operator
 
 Object option:
 
 * `"overrides"` overrides the global setting for specified operators
+
+The default configuration is `"after", { "overrides": { "?": "before", ":": "before" } }`
 
 ### after
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update

**What changes did you make? (Give an overview)**

The default behavior for `operator-linebreak` is to use the `"after"` option with overrides for the `?` and `:` operators. However, the documentation incorrectly implied that the overrides were always present when using the `"after"` option, which is not the case. The overrides are part of the default configuration, but they aren't related to the `"after"` option.

(fixes https://github.com/eslint/eslint/issues/7459)

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.

