### PR TITLE
Fix: indent "first" option false positive on nested arrays (fixes #7727)

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -727,9 +727,19 @@ module.exports = {
                         if (parent.type === "VariableDeclarator" && parentVarNode.loc.start.line === parent.loc.start.line) {
                             nodeIndent = nodeIndent + (indentSize * options.VariableDeclarator[parentVarNode.parent.kind]);
                         } else if (parent.type === "ObjectExpression" || parent.type === "ArrayExpression") {
-                            nodeIndent += options[parent.type] * indentSize;
+                            if (typeof options[parent.type] === "number") {
+                                nodeIndent += options[parent.type] * indentSize;
+                            } else {
+                                const parentElements = node.parent.type === "ObjectExpression" ? node.parent.properties : node.parent.elements;
+
+                                nodeIndent = parentElements[0].loc.start.column;
+                            }
                         } else if (parent.type === "CallExpression" || parent.type === "NewExpression") {
-                            nodeIndent += (typeof options.CallExpression.arguments === "number" ? options.CallExpression.arguments : 1) * indentSize;
+                            if (typeof options.CallExpression.arguments === "number") {
+                                nodeIndent += options.CallExpression.arguments * indentSize;
+                            } else if (parent.arguments.indexOf(node) !== -1) {
+                                nodeIndent = parent.arguments[0].loc.start.column;
+                            }
                         } else if (parent.type === "LogicalExpression" || parent.type === "ArrowFunctionExpression") {
                             nodeIndent += indentSize;
                         }

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -1829,6 +1829,40 @@ ruleTester.run("indent", rule, {
         {
             code: "{\n}",
             options: [2, {ObjectExpression: 1}]
+        },
+        {
+            code:
+            "var foo = [\n" +
+            "  [\n" +
+            "    1\n" +
+            "  ]\n" +
+            "]",
+            options: [2, {ArrayExpression: "first"}]
+        },
+        {
+            code:
+            "var foo = [ 1,\n" +
+            "            [\n" +
+            "              2\n" +
+            "            ]\n" +
+            "];",
+            options: [2, {ArrayExpression: "first"}]
+        },
+        {
+            code:
+            "var foo = bar(1,\n" +
+            "              [ 2,\n" +
+            "                3\n" +
+            "              ]\n" +
+            ");",
+            options: [4, {ArrayExpression: "first", CallExpression: {arguments: "first"}}]
+        },
+        {
+            code:
+            "var foo =\n" +
+            "    [\n" +
+            "    ]()",
+            options: [4, {CallExpression: {arguments: "first"}, ArrayExpression: "first"}]
         }
     ],
     invalid: [


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix

See https://github.com/eslint/eslint/issues/7727

**What changes did you make? (Give an overview)**

This updates `indent` to correctly handle nested arrays and CallExpressions when the `first` option is used.

In order to determine the desired offset of an array, the rule was checking the offset of the parent node. If the parent node was an array, the offset of the array was multiplied by `options.ArrayExpression`. However, this would result in an expected indentation of `NaN` for that array.

The fix handles this by explicitly checking for an option of `first`, and computing the new node's offset accordingly.

Admittedly, this isn't the most elegant solution. If we kept track of nodes' offsets from each other rather than recomputing the desired indentation each time, we wouldn't have to calculate indentation twice in cases like this. (This is similar to the strategy that the [rewrite](https://github.com/eslint/eslint/pull/7618) uses.)

**Is there anything you'd like reviewers to focus on?**

The `ArrayExpression` and `ObjectExpression` options were just introduced in this release cycle, and have not made it into a release yet. Given that we have a release scheduled for tomorrow, I see a few options for how to handle this bug:

* Revert the commit that adds the `ArrayExpression` option, fix the issue over the next two weeks, and hopefully re-add it in the next release. (This is probably the safest option, although it would be unfortunate to delay the feature for two weeks.)
* Merge this before the release tomorrow. (This would solve the problem in theory, but at a greater risk of regressions since we wouldn't have time to review it as thoroughly as we usually do.)
* Release the feature tomorrow as-is, and add a fix in a patch release later. (This is also a viable option, but we would knowingly be releasing a buggy feature for a couple days.)