### PR TITLE
Build: avoid creating broken rule links in the blogpost

### DIFF
--- a/templates/blogpost.md.ejs
+++ b/templates/blogpost.md.ejs
@@ -10,13 +10,13 @@ tags:
 We just pushed ESLint v<%- version %>, which is a <%- type %> release upgrade of ESLint. This release <% if (type !== "patch") { %>adds some new features and<% } %> fixes several bugs found in the previous release. <% if (type === "major") { %>This release also has some breaking changes, so please read the following closely. <% } %>
 
 <%
-const RULE_REGEX = new RegExp(ruleList.map(ruleName => `\`?${ruleName}\`?`).join("|"), "g");
+const RULE_REGEX = new RegExp(`\`?(${ruleList.join("|")})\`?`, "g");
 
 function linkify(line) {
     return line
         .replace(/#(\d+)/g, "[#$1](https://github.com/eslint/eslint/issues/$1)")
         .replace(/([a-z0-9]+)/, "[$1](https://github.com/eslint/eslint/commit/$1)")
-        .replace(RULE_REGEX, "[$&](/docs/rules/$&)");
+        .replace(RULE_REGEX, "[$&](/docs/rules/$1)");
 }
 
 function outputList(items) {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Previously, if a rule name in a commit message was surrounded by backticks, the generated URL in the blogpost would also contain backticks around the rule name, resulting in a 404. This updates the blogpost generator to avoid outputting the backticks in URLs.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.