### PR TITLE
Fix: `indent` regression with function calls (fixes #7732, fixes #7733)

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -737,8 +737,12 @@ module.exports = {
                         } else if (parent.type === "CallExpression" || parent.type === "NewExpression") {
                             if (typeof options.CallExpression.arguments === "number") {
                                 nodeIndent += options.CallExpression.arguments * indentSize;
-                            } else if (parent.arguments.indexOf(node) !== -1) {
-                                nodeIndent = parent.arguments[0].loc.start.column;
+                            } else if (options.CallExpression.arguments === "first") {
+                                if (parent.arguments.indexOf(node) !== -1) {
+                                    nodeIndent = parent.arguments[0].loc.start.column;
+                                }
+                            } else {
+                                nodeIndent += indentSize;
                             }
                         } else if (parent.type === "LogicalExpression" || parent.type === "ArrowFunctionExpression") {
                             nodeIndent += indentSize;

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -1863,6 +1863,50 @@ ruleTester.run("indent", rule, {
             "    [\n" +
             "    ]()",
             options: [4, {CallExpression: {arguments: "first"}, ArrayExpression: "first"}]
+        },
+
+        // https://github.com/eslint/eslint/issues/7732
+        {
+            code:
+            "const lambda = foo => {\n" +
+            "  Object.assign({},\n" +
+            "    filterName,\n" +
+            "    {\n" +
+            "      display\n" +
+            "    }\n" +
+            "  );" +
+            "}",
+            options: [2, {ObjectExpression: 1}],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code:
+            "const lambda = foo => {\n" +
+            "  Object.assign({},\n" +
+            "    filterName,\n" +
+            "    {\n" +
+            "      display\n" +
+            "    }\n" +
+            "  );" +
+            "}",
+            options: [2, {ObjectExpression: "first"}],
+            parserOptions: { ecmaVersion: 6 }
+        },
+
+        // https://github.com/eslint/eslint/issues/7733
+        {
+            code:
+            "var foo = function() {\n" +
+            "\twindow.foo('foo',\n" +
+            "\t\t{\n" +
+            "\t\t\tfoo: 'bar'," +
+            "\t\t\tbar: {\n" +
+            "\t\t\t\tfoo: 'bar'\n" +
+            "\t\t\t}\n" +
+            "\t\t}\n" +
+            "\t);\n" +
+            "}",
+            options: ["tab"]
         }
     ],
     invalid: [


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix

See https://github.com/eslint/eslint/issues/7732 and https://github.com/eslint/eslint/issues/7733

**What changes did you make? (Give an overview)**

This fixes a regression in`indent` in which if a configuration did not specify a value for the `CallExpression` option, it would get interpreted as `CallExpression: first` for object and array arguments.

**Is there anything you'd like reviewers to focus on?**

I think we should add some additional fixtures or smoketests to the indent rule, even if the fixture contains a large codebase in itself. The rule has several hundred tests, but it seems like we're still missing cases. If we add more fixtures, we can be more confident that a particular change isn't going to break anything.

Also, I'm wondering if it would be possible to separate out the breaking parts of https://github.com/eslint/eslint/pull/7618 and land the indent rewrite without waiting for a major update. It looks like the indent rule is getting difficult to effectively maintain -- we've broken things the last few times we've tried to change it.