### PR TITLE
New: `prefer-destructuring` rule (fixes #6053)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -204,6 +204,7 @@
         "padded-blocks": "off",
         "prefer-arrow-callback": "off",
         "prefer-const": "off",
+        "prefer-destructuring": "off",
         "prefer-numeric-literals": "off",
         "prefer-reflect": "off",
         "prefer-rest-params": "off",

--- a/docs/rules/prefer-destructuring.md
+++ b/docs/rules/prefer-destructuring.md
@@ -1,0 +1,52 @@
+# Prefer destructuring from arrays and objects (prefer-destructuring)
+
+With JavaScript ES6, a new syntax was added for creating variables from an array index of object property, called [destructuring](#further-reading).  This rule enforces usage of destructuring instead of accessing a property through a member expression.
+
+## Rule Details
+
+The following patterns are considered warnings:
+
+```javascript
+// With `array` enabled
+var foo = array[0];
+
+// With `object` enabled
+var foo = object.foo;
+var foo = object['foo'];
+```
+
+The following patterns are not warnings:
+
+```javascript
+// With `array` enabled
+var [ foo ] = array;
+
+// With `object` enabled
+var { foo } = object;
+```
+
+### Options
+
+This rule takes two properties, `array` and `object`, which can be used to turn on or off the destructuring requirement for each of those types independently.  By default, both are `true`.  If you want to change the behavior, you can configure the rule like so:
+
+```json
+{
+  "rules": {
+    "ember-suave/prefer-destructuring": ["error", {
+      "array": true,
+      "object": true
+    }]
+  }
+}
+```
+
+## When Not To Use It
+
+If you want to be able to access array indices or object properties directly, you can either configure the rule to your tastes or disable the rule entirely.
+
+## Further Reading
+
+If you want to learn more about destructuring, check out the links below:
+
+- [Destructuring Assignment (MDN)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment)
+- [Destructuring and parameter handling in ECMAScript 6 (2ality blog)](http://www.2ality.com/2015/01/es6-destructuring.html)

--- a/docs/rules/prefer-destructuring.md
+++ b/docs/rules/prefer-destructuring.md
@@ -4,7 +4,7 @@ With JavaScript ES6, a new syntax was added for creating variables from an array
 
 ## Rule Details
 
-The following patterns are considered warnings:
+Examples of **incorrect** code for this rule:
 
 ```javascript
 // With `array` enabled
@@ -15,7 +15,7 @@ var foo = object.foo;
 var foo = object['foo'];
 ```
 
-The following patterns are not warnings:
+Examples of **correct** code for this rule:
 
 ```javascript
 // With `array` enabled
@@ -32,7 +32,7 @@ This rule takes two properties, `array` and `object`, which can be used to turn 
 ```json
 {
   "rules": {
-    "ember-suave/prefer-destructuring": ["error", {
+    "prefer-destructuring": ["error", {
       "array": true,
       "object": true
     }]
@@ -43,6 +43,15 @@ This rule takes two properties, `array` and `object`, which can be used to turn 
 ## When Not To Use It
 
 If you want to be able to access array indices or object properties directly, you can either configure the rule to your tastes or disable the rule entirely.
+
+Additionally, if you intend to access large array indices directly, like:
+
+```javascript
+var foo = array[100];
+```
+
+Then the `array` part of this rule is not recommended, as destructuring does not match this use case very well.
+
 
 ## Further Reading
 

--- a/docs/rules/prefer-destructuring.md
+++ b/docs/rules/prefer-destructuring.md
@@ -1,6 +1,6 @@
 # Prefer destructuring from arrays and objects (prefer-destructuring)
 
-With JavaScript ES6, a new syntax was added for creating variables from an array index of object property, called [destructuring](#further-reading).  This rule enforces usage of destructuring instead of accessing a property through a member expression.
+With JavaScript ES6, a new syntax was added for creating variables from an array index or object property, called [destructuring](#further-reading).  This rule enforces usage of destructuring instead of accessing a property through a member expression.
 
 ## Rule Details
 
@@ -20,6 +20,7 @@ Examples of **correct** code for this rule:
 ```javascript
 // With `array` enabled
 var [ foo ] = array;
+var foo = array[someIndex];
 
 // With `object` enabled
 var { foo } = object;

--- a/docs/rules/prefer-destructuring.md
+++ b/docs/rules/prefer-destructuring.md
@@ -23,7 +23,7 @@ var [ foo ] = array;
 
 // With `object` enabled
 var { foo } = object;
-var foo = object.bar
+var foo = object.bar;
 ```
 
 ### Options

--- a/docs/rules/prefer-destructuring.md
+++ b/docs/rules/prefer-destructuring.md
@@ -23,11 +23,30 @@ var [ foo ] = array;
 
 // With `object` enabled
 var { foo } = object;
+var foo = object.bar
 ```
 
 ### Options
 
-This rule takes two properties, `array` and `object`, which can be used to turn on or off the destructuring requirement for each of those types independently.  By default, both are `true`.  If you want to change the behavior, you can configure the rule like so:
+This rule takes two sets of configuration objects; the first controls the types that the rule is applied to, and the second controls the way those objects are evaluated.
+
+The first has two properties, `array` and `object`, which can be used to turn on or off the destructuring requirement for each of those types independently.  By default, both are `true`.
+
+The second has a single property, `enforceForRenamedProperties`, that controls whether or not the `object` destructuring rules are applied in cases where the variable requires the property being access to be renamed.
+
+Examples of **incorrect** code when `enforceForRenamedProperties` is enabled:
+
+```javascript
+var foo = object.bar;
+```
+
+Examples of **correct** code when `enforceForRenamedProperties` is enabled:
+
+```javascript
+var { bar: foo } = object;
+```
+
+An example configuration, with the defaults filled in, looks like this:
 
 ```json
 {
@@ -35,6 +54,8 @@ This rule takes two properties, `array` and `object`, which can be used to turn 
     "prefer-destructuring": ["error", {
       "array": true,
       "object": true
+    }, {
+      "enforceForRenamedProperties": false
     }]
   }
 }

--- a/lib/rules/prefer-destructuring.js
+++ b/lib/rules/prefer-destructuring.js
@@ -28,6 +28,15 @@ module.exports = {
                     }
                 },
                 additionalProperties: false
+            },
+            {
+                type: "object",
+                properties: {
+                    requireRenaming: {
+                        type: "boolean"
+                    }
+                },
+                additionalProperties: false
             }
         ]
     },
@@ -35,15 +44,23 @@ module.exports = {
 
         let checkArrays = true;
         let checkObjects = true;
-        const options = context.options[0];
+        let requireRenaming = true;
+        const enabledTypes = context.options[0];
+        const additionalOptions = context.options[1];
 
-        if (options) {
-            if (typeof options.array !== "undefined") {
-                checkArrays = options.array;
+        if (enabledTypes) {
+            if (typeof enabledTypes.array !== "undefined") {
+                checkArrays = enabledTypes.array;
             }
 
-            if (typeof options.object !== "undefined") {
-                checkObjects = options.object;
+            if (typeof enabledTypes.object !== "undefined") {
+                checkObjects = enabledTypes.object;
+            }
+        }
+
+        if (additionalOptions) {
+            if (typeof additionalOptions.requireRenaming !== "undefined") {
+                requireRenaming = additionalOptions.requireRenaming;
             }
         }
 
@@ -88,6 +105,11 @@ module.exports = {
 
             if (checkObjects && !isArrayIndexAccess(rightNode)) {
                 const property = rightNode.property;
+
+                if (requireRenaming && !rightNode.computed) {
+                    context.report({ node: reportNode, message: "Use object destructuring" });
+                    return;
+                }
 
                 if (property.type === "Literal" && leftNode.name === property.value) {
                     context.report({ node: reportNode, message: "Use object destructuring" });

--- a/lib/rules/prefer-destructuring.js
+++ b/lib/rules/prefer-destructuring.js
@@ -78,20 +78,6 @@ module.exports = {
                 return;
             }
 
-            if (node.init.type === "Identifier") {
-                const objectExpression = node.id.type === "ObjectPattern" && node.id;
-
-                if (objectExpression) {
-                    const prop = objectExpression.properties[0];
-                    const key = prop.key;
-                    const value = prop.value;
-
-                    if ((key.name === value.name) && (key.start !== value.start)) {
-                        context.report({ node: prop, message: "Unnecessary duplicate variable name" });
-                    }
-                }
-            }
-
             // We only care about member expressions past this point
             if (node.init.type !== "MemberExpression") {
                 return;

--- a/lib/rules/prefer-destructuring.js
+++ b/lib/rules/prefer-destructuring.js
@@ -32,7 +32,7 @@ module.exports = {
             {
                 type: "object",
                 properties: {
-                    requireRenaming: {
+                    enforceForRenamedProperties: {
                         type: "boolean"
                     }
                 },
@@ -44,7 +44,7 @@ module.exports = {
 
         let checkArrays = true;
         let checkObjects = true;
-        let requireRenaming = true;
+        let enforceForRenamedProperties = false;
         const enabledTypes = context.options[0];
         const additionalOptions = context.options[1];
 
@@ -59,8 +59,8 @@ module.exports = {
         }
 
         if (additionalOptions) {
-            if (typeof additionalOptions.requireRenaming !== "undefined") {
-                requireRenaming = additionalOptions.requireRenaming;
+            if (typeof additionalOptions.enforceForRenamedProperties !== "undefined") {
+                enforceForRenamedProperties = additionalOptions.enforceForRenamedProperties;
             }
         }
 
@@ -82,6 +82,17 @@ module.exports = {
         }
 
         /**
+         * Report that the given node should use destructuring
+         *
+         * @param {ASTNode} reportNode the node to report
+         * @param {string} type the type of destructuring that should have been done
+         * @returns {void}
+         */
+        function report(reportNode, type) {
+            context.report({ node: reportNode, message: `Use ${type} destructuring` });
+        }
+
+        /**
          * Check that the `prefer-destructuring` rules are followed based on the
          * given left- and right-hand side of the assignment.
          *
@@ -99,24 +110,21 @@ module.exports = {
             }
 
             if (checkArrays && isArrayIndexAccess(rightNode)) {
-                context.report({ node: reportNode, message: "Use array destructuring" });
+                report(reportNode, "array");
                 return;
             }
 
-            if (checkObjects && !isArrayIndexAccess(rightNode)) {
+            if (checkObjects && enforceForRenamedProperties) {
+                report(reportNode, "object");
+                return;
+            }
+
+            if (checkObjects) {
                 const property = rightNode.property;
 
-                if (requireRenaming && !rightNode.computed) {
-                    context.report({ node: reportNode, message: "Use object destructuring" });
-                    return;
-                }
-
-                if (property.type === "Literal" && leftNode.name === property.value) {
-                    context.report({ node: reportNode, message: "Use object destructuring" });
-                }
-
-                if (property.type === "Identifier" && leftNode.name === property.name) {
-                    context.report({ node: reportNode, message: "Use object destructuring" });
+                if ((property.type === "Literal" && leftNode.name === property.value) ||
+                    (property.type === "Identifier" && leftNode.name === property.name)) {
+                    report(reportNode, "object");
                 }
             }
         }

--- a/lib/rules/prefer-destructuring.js
+++ b/lib/rules/prefer-destructuring.js
@@ -1,0 +1,128 @@
+/**
+ * @fileoverview Prefer destructuring from arrays and objects
+ * @author Alex LaFroscia
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "require destructuring from arrays and/or objects",
+            category: "ECMAScript 6",
+            recommended: false
+        },
+
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    array: {
+                        type: "boolean"
+                    },
+                    object: {
+                        type: "boolean"
+                    }
+                }
+            }
+        ]
+    },
+    create(context) {
+
+        let checkArrays = true;
+        let checkObjects = true;
+        const options = context.options[0];
+
+        if (options) {
+            if (options.hasOwnProperty("array")) {
+                checkArrays = options.array;
+            }
+
+            if (options.hasOwnProperty("object")) {
+                checkObjects = options.object;
+            }
+        }
+
+        //--------------------------------------------------------------------------
+        // Helpers
+        //--------------------------------------------------------------------------
+
+        /**
+         * Determines if the given node node is accessing an array index
+         *
+         * This is used to differentiate array index access from object property
+         * access.
+         *
+         * @param {ASTNode} node the node to evaluate
+         * @returns {boolean} whether or not the node is an integer
+         */
+        function isArrayIndexAccess(node) {
+            return Number.isInteger(node.property.value);
+        }
+
+        /**
+         * Check if a given variable declarator is coming from an property access
+         * that should be using destructuring instead
+         *
+         * @param {ASTNode} node the variable declarator to check
+         * @returns {void}
+         */
+        function checkVariableDeclarator(node) {
+
+            // Skip if variable is declared without assignment
+            if (!node.init) {
+                return;
+            }
+
+            if (node.init.type === "Identifier") {
+                const objectExpression = node.id.type === "ObjectPattern" && node.id;
+
+                if (objectExpression) {
+                    const prop = objectExpression.properties[0];
+                    const key = prop.key;
+                    const value = prop.value;
+
+                    if ((key.name === value.name) && (key.start !== value.start)) {
+                        context.report({ node: prop, message: "Unnecessary duplicate variable name" });
+                    }
+                }
+            }
+
+            // We only care about member expressions past this point
+            if (node.init.type !== "MemberExpression") {
+                return;
+            }
+
+            const memberExpression = node.init;
+
+            if (checkArrays && isArrayIndexAccess(memberExpression)) {
+                context.report({ node, message: "Use array destructuring" });
+                return;
+            }
+
+            if (checkObjects && !isArrayIndexAccess(memberExpression)) {
+                const variableIdentifier = node.id;
+                const property = node.init.property;
+
+                if (property.type === "Literal" && variableIdentifier.name === property.value) {
+                    context.report({ node, message: "Use object destructuring" });
+                }
+
+                if (property.type === "Identifier" && variableIdentifier.name === property.name) {
+                    context.report({ node, message: "Use object destructuring" });
+                }
+            }
+        }
+
+        //--------------------------------------------------------------------------
+        // Public
+        //--------------------------------------------------------------------------
+
+        return {
+            VariableDeclarator: checkVariableDeclarator
+        };
+    }
+};

--- a/lib/rules/prefer-destructuring.js
+++ b/lib/rules/prefer-destructuring.js
@@ -26,7 +26,8 @@ module.exports = {
                     object: {
                         type: "boolean"
                     }
-                }
+                },
+                additionalProperties: false
             }
         ]
     },
@@ -37,11 +38,11 @@ module.exports = {
         const options = context.options[0];
 
         if (options) {
-            if (options.hasOwnProperty("array")) {
+            if (typeof options.array !== "undefined") {
                 checkArrays = options.array;
             }
 
-            if (options.hasOwnProperty("object")) {
+            if (typeof options.object !== "undefined") {
                 checkObjects = options.object;
             }
         }

--- a/lib/rules/prefer-destructuring.js
+++ b/lib/rules/prefer-destructuring.js
@@ -65,6 +65,41 @@ module.exports = {
         }
 
         /**
+         * Check that the `prefer-destructuring` rules are followed based on the
+         * given left- and right-hand side of the assignment.
+         *
+         * Pulled out into a separate method so that VariableDeclarators and
+         * AssignmentExpressions can share the same verification logic.
+         *
+         * @param {ASTNode} leftNode the left-hand side of the assignment
+         * @param {ASTNode} rightNode the right-hand side of the assignment
+         * @param {ASTNode} reportNode the node to report the error on
+         * @returns {void}
+         */
+        function performCheck(leftNode, rightNode, reportNode) {
+            if (rightNode.type !== "MemberExpression") {
+                return;
+            }
+
+            if (checkArrays && isArrayIndexAccess(rightNode)) {
+                context.report({ node: reportNode, message: "Use array destructuring" });
+                return;
+            }
+
+            if (checkObjects && !isArrayIndexAccess(rightNode)) {
+                const property = rightNode.property;
+
+                if (property.type === "Literal" && leftNode.name === property.value) {
+                    context.report({ node: reportNode, message: "Use object destructuring" });
+                }
+
+                if (property.type === "Identifier" && leftNode.name === property.name) {
+                    context.report({ node: reportNode, message: "Use object destructuring" });
+                }
+            }
+        }
+
+        /**
          * Check if a given variable declarator is coming from an property access
          * that should be using destructuring instead
          *
@@ -83,25 +118,17 @@ module.exports = {
                 return;
             }
 
-            const memberExpression = node.init;
+            performCheck(node.id, node.init, node);
+        }
 
-            if (checkArrays && isArrayIndexAccess(memberExpression)) {
-                context.report({ node, message: "Use array destructuring" });
-                return;
-            }
-
-            if (checkObjects && !isArrayIndexAccess(memberExpression)) {
-                const variableIdentifier = node.id;
-                const property = node.init.property;
-
-                if (property.type === "Literal" && variableIdentifier.name === property.value) {
-                    context.report({ node, message: "Use object destructuring" });
-                }
-
-                if (property.type === "Identifier" && variableIdentifier.name === property.name) {
-                    context.report({ node, message: "Use object destructuring" });
-                }
-            }
+        /**
+         * Run the `prefer-destructuring` check on an AssignmentExpression
+         *
+         * @param {ASTNode} node the AssignmentExpression node
+         * @returns {void}
+         */
+        function checkAssigmentExpression(node) {
+            performCheck(node.left, node.right, node);
         }
 
         //--------------------------------------------------------------------------
@@ -109,7 +136,8 @@ module.exports = {
         //--------------------------------------------------------------------------
 
         return {
-            VariableDeclarator: checkVariableDeclarator
+            VariableDeclarator: checkVariableDeclarator,
+            AssignmentExpression: checkAssigmentExpression
         };
     }
 };

--- a/tests/lib/rules/prefer-destructuring.js
+++ b/tests/lib/rules/prefer-destructuring.js
@@ -16,17 +16,15 @@ const rule = require("../../../lib/rules/prefer-destructuring"),
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
 
 ruleTester.run("prefer-destructuring", rule, {
     valid: [
         {
-            code: "var [foo] = array;",
-            parserOptions: { ecmaVersion: 6 }
+            code: "var [foo] = array;"
         },
         {
-            code: "var { foo } = object;",
-            parserOptions: { ecmaVersion: 6 }
+            code: "var { foo } = object;"
         },
         {
 
@@ -34,39 +32,32 @@ ruleTester.run("prefer-destructuring", rule, {
             code: "var foo;"
         },
         {
-            code: "var foo = object.bar;",
-            parserOptions: { ecmaVersion: 6 }
+            code: "var foo = object.bar;"
         },
         {
-            code: "var foo = object['bar'];",
-            parserOptions: { ecmaVersion: 6 }
+            code: "var foo = object['bar'];"
         },
         {
             code: "var foo = array[0];",
-            options: [{ array: false }],
-            parserOptions: { ecmaVersion: 6 }
+            options: [{ array: false }]
         },
         {
             code: "var foo = object.foo;",
-            options: [{ object: false }],
-            parserOptions: { ecmaVersion: 6 }
+            options: [{ object: false }]
         },
         {
             code: "var foo = object['foo'];",
-            options: [{ object: false }],
-            parserOptions: { ecmaVersion: 6 }
+            options: [{ object: false }]
         },
         {
             code: "var { foo: bar } = object;",
-            options: [{ object: false }],
-            parserOptions: { ecmaVersion: 6 }
+            options: [{ object: false }]
         }
     ],
 
     invalid: [
         {
             code: "var foo = array[0];",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Use array destructuring",
                 type: "VariableDeclarator"
@@ -74,7 +65,6 @@ ruleTester.run("prefer-destructuring", rule, {
         },
         {
             code: "var foo = array.foo;",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Use object destructuring",
                 type: "VariableDeclarator"
@@ -82,7 +72,6 @@ ruleTester.run("prefer-destructuring", rule, {
         },
         {
             code: "var foo = array['foo'];",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Use object destructuring",
                 type: "VariableDeclarator"
@@ -90,7 +79,6 @@ ruleTester.run("prefer-destructuring", rule, {
         },
         {
             code: "let { foo: foo } = object;",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Unnecessary duplicate variable name",
                 type: "Property"

--- a/tests/lib/rules/prefer-destructuring.js
+++ b/tests/lib/rules/prefer-destructuring.js
@@ -48,10 +48,6 @@ ruleTester.run("prefer-destructuring", rule, {
         {
             code: "var foo = object['foo'];",
             options: [{ object: false }]
-        },
-        {
-            code: "var { foo: bar } = object;",
-            options: [{ object: false }]
         }
     ],
 
@@ -75,13 +71,6 @@ ruleTester.run("prefer-destructuring", rule, {
             errors: [{
                 message: "Use object destructuring",
                 type: "VariableDeclarator"
-            }]
-        },
-        {
-            code: "let { foo: foo } = object;",
-            errors: [{
-                message: "Unnecessary duplicate variable name",
-                type: "Property"
             }]
         }
     ]

--- a/tests/lib/rules/prefer-destructuring.js
+++ b/tests/lib/rules/prefer-destructuring.js
@@ -32,20 +32,30 @@ ruleTester.run("prefer-destructuring", rule, {
             code: "var foo;"
         },
         {
+
+            // Ensure that the default behavior does not require desturcturing when renaming
             code: "var foo = object.bar;",
-            options: [{ object: true }, { requireRenaming: false }]
+            options: [{ object: true }]
+        },
+        {
+            code: "var foo = object.bar;",
+            options: [{ object: true }, { enforceForRenamedProperties: false }]
         },
         {
             code: "var foo = object['bar'];",
-            options: [{ object: true }, { requireRenaming: false }]
-        },
-        {
-            code: "var { bar: foo } = object;",
-            options: [{ object: true }, { requireRenaming: true }]
+            options: [{ object: true }, { enforceForRenamedProperties: false }]
         },
         {
             code: "var foo = object[bar];",
-            options: [{ object: true }, { requireRenaming: true }]
+            options: [{ object: true }, { enforceForRenamedProperties: false }]
+        },
+        {
+            code: "var { bar: foo } = object;",
+            options: [{ object: true }, { enforceForRenamedProperties: true }]
+        },
+        {
+            code: "var { [bar]: foo } = object;",
+            options: [{ object: true }, { enforceForRenamedProperties: true }]
         },
         {
             code: "var foo = array[0];",
@@ -83,15 +93,23 @@ ruleTester.run("prefer-destructuring", rule, {
             }]
         },
         {
-            code: "var foo = array.foo;",
+            code: "var foo = object.foo;",
             errors: [{
                 message: "Use object destructuring",
                 type: "VariableDeclarator"
             }]
         },
         {
-            code: "var foo = array.bar;",
-            options: [{ object: true }, { requireRenaming: true }],
+            code: "var foobar = object.bar;",
+            options: [{ object: true }, { enforceForRenamedProperties: true }],
+            errors: [{
+                message: "Use object destructuring",
+                type: "VariableDeclarator"
+            }]
+        },
+        {
+            code: "var foo = object[bar];",
+            options: [{ object: true }, { enforceForRenamedProperties: true }],
             errors: [{
                 message: "Use object destructuring",
                 type: "VariableDeclarator"

--- a/tests/lib/rules/prefer-destructuring.js
+++ b/tests/lib/rules/prefer-destructuring.js
@@ -32,10 +32,20 @@ ruleTester.run("prefer-destructuring", rule, {
             code: "var foo;"
         },
         {
-            code: "var foo = object.bar;"
+            code: "var foo = object.bar;",
+            options: [{ object: true }, { requireRenaming: false }]
         },
         {
-            code: "var foo = object['bar'];"
+            code: "var foo = object['bar'];",
+            options: [{ object: true }, { requireRenaming: false }]
+        },
+        {
+            code: "var { bar: foo } = object;",
+            options: [{ object: true }, { requireRenaming: true }]
+        },
+        {
+            code: "var foo = object[bar];",
+            options: [{ object: true }, { requireRenaming: true }]
         },
         {
             code: "var foo = array[0];",
@@ -74,6 +84,14 @@ ruleTester.run("prefer-destructuring", rule, {
         },
         {
             code: "var foo = array.foo;",
+            errors: [{
+                message: "Use object destructuring",
+                type: "VariableDeclarator"
+            }]
+        },
+        {
+            code: "var foo = array.bar;",
+            options: [{ object: true }, { requireRenaming: true }],
             errors: [{
                 message: "Use object destructuring",
                 type: "VariableDeclarator"

--- a/tests/lib/rules/prefer-destructuring.js
+++ b/tests/lib/rules/prefer-destructuring.js
@@ -48,6 +48,12 @@ ruleTester.run("prefer-destructuring", rule, {
         {
             code: "var foo = object['foo'];",
             options: [{ object: false }]
+        },
+        {
+            code: "({ foo } = object);"
+        },
+        {
+            code: "[foo] = array;"
         }
     ],
 
@@ -57,6 +63,13 @@ ruleTester.run("prefer-destructuring", rule, {
             errors: [{
                 message: "Use array destructuring",
                 type: "VariableDeclarator"
+            }]
+        },
+        {
+            code: "foo = array[0];",
+            errors: [{
+                message: "Use array destructuring",
+                type: "AssignmentExpression"
             }]
         },
         {
@@ -71,6 +84,20 @@ ruleTester.run("prefer-destructuring", rule, {
             errors: [{
                 message: "Use object destructuring",
                 type: "VariableDeclarator"
+            }]
+        },
+        {
+            code: "foo = array.foo;",
+            errors: [{
+                message: "Use object destructuring",
+                type: "AssignmentExpression"
+            }]
+        },
+        {
+            code: "foo = array['foo'];",
+            errors: [{
+                message: "Use object destructuring",
+                type: "AssignmentExpression"
             }]
         }
     ]

--- a/tests/lib/rules/prefer-destructuring.js
+++ b/tests/lib/rules/prefer-destructuring.js
@@ -1,0 +1,100 @@
+/**
+ * @fileoverview Prefer destructuring from arrays and objects
+ * @author Alex LaFroscia
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../lib/rules/prefer-destructuring"),
+    RuleTester = require("../../../lib/testers/rule-tester");
+
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("prefer-destructuring", rule, {
+    valid: [
+        {
+            code: "var [foo] = array;",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var { foo } = object;",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+
+            // Ensure that this doesn't break variable declarating without assignment
+            code: "var foo;"
+        },
+        {
+            code: "var foo = object.bar;",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var foo = object['bar'];",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var foo = array[0];",
+            options: [{ array: false }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var foo = object.foo;",
+            options: [{ object: false }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var foo = object['foo'];",
+            options: [{ object: false }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var { foo: bar } = object;",
+            options: [{ object: false }],
+            parserOptions: { ecmaVersion: 6 }
+        }
+    ],
+
+    invalid: [
+        {
+            code: "var foo = array[0];",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                message: "Use array destructuring",
+                type: "VariableDeclarator"
+            }]
+        },
+        {
+            code: "var foo = array.foo;",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                message: "Use object destructuring",
+                type: "VariableDeclarator"
+            }]
+        },
+        {
+            code: "var foo = array['foo'];",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                message: "Use object destructuring",
+                type: "VariableDeclarator"
+            }]
+        },
+        {
+            code: "let { foo: foo } = object;",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                message: "Unnecessary duplicate variable name",
+                type: "Property"
+            }]
+        }
+    ]
+});


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[x] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**Please describe what the rule should do:**

This rule ensures that all object property access and array index accesses are done through [ES6 destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment).

**What category of rule is this? (place an "X" next to just one item)**

[ ] Enforces code style
[ ] Warns about a potential error
[x] Suggests an alternate way of doing something
[ ] Other (please specify:)

**Provide 2-3 code examples that this rule will warn about:**

```diff
- var foo = array[0];
+ var [ foo ] = array;

- var foo = object.foo;
+ var { foo } = object;

- var foo = object['foo'];
+ var { foo } = object;
```

**Why should this rule be included in ESLint (instead of a plugin)?**

This change supports (an encourages) a new JavaScript feature that isn't tied directly to any particular framework or library. Additionally, it _is_ part of an existing plugin, [eslint-plugin-ember-suave](https://github.com/DockYard/eslint-plugin-ember-suave/blob/master/lib/rules/prefer-destructuring.js), where I originally authored the rule.  However, someone requested that the rule be added to core in #6053 and asked if I would submit it to core.

**What changes did you make? (Give an overview)**

- Added a new rule, `prefer-destructuring`, as well as the tests and documentation that I originally authored as part of the `eslint-plugin-ember-suave`.

**Is there anything you'd like reviewers to focus on?**

Please make sure the tests and documentation are thorough enough. I just copied the implementation, tests and docs from the existing plugin (linked above), which may not have the same level of standards that the core rules have, although I did my best to follow all the best practices when I originally wrote the rule. 