### PR TITLE
Docs: Rules restricting globals/properties/syntax are linked together

### DIFF
--- a/docs/rules/no-restricted-globals.md
+++ b/docs/rules/no-restricted-globals.md
@@ -44,3 +44,8 @@ import event from "event-module";
 
 var event = 1;
 ```
+
+## Related Rules
+
+* [no-restricted-properties](no-restricted-properties.md)
+* [no-restricted-syntax](no-restricted-syntax.md)

--- a/docs/rules/no-restricted-properties.md
+++ b/docs/rules/no-restricted-properties.md
@@ -121,4 +121,5 @@ If you don't have any object/property combinations to restrict, you should not u
 
 ## Related Rules
 
+* [no-restricted-globals](no-restricted-globals.md)
 * [no-restricted-syntax](no-restricted-syntax.md)

--- a/docs/rules/no-restricted-syntax.md
+++ b/docs/rules/no-restricted-syntax.md
@@ -51,3 +51,5 @@ If you don't want to restrict your code from using any JavaScript features or sy
 * [no-alert](no-alert.md)
 * [no-console](no-console.md)
 * [no-debugger](no-debugger.md)
+* [no-restricted-properties](no-restricted-properties.md)
+* [no-restricted-syntax](no-restricted-syntax.md)


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Ensured that `no-restricted-globals`, `no-restricted-properties`, and `no-restricted-syntax` all linked to each other in their documentation.

**Is there anything you'd like reviewers to focus on?**

I'm not sure `no-restricted-syntax` really fits with `no-restricted-globals` and `no-restricted-properties`, but there was already a link between `no-restricted-properties` and `no-restricted-syntax`. Should I instead remove `no-restricted-syntax` from the other two rules? `no-restricted-syntax` points to rules like `no-debugger` which it supersedes.