### PR TITLE
Fix: syntax errors from object-shorthand autofix (fixes #7744)

### DIFF
--- a/lib/rules/object-shorthand.js
+++ b/lib/rules/object-shorthand.js
@@ -204,6 +204,50 @@ module.exports = {
             }
         }
 
+        /**
+        * Fixes a FunctionExpression node by making it into a shorthand property.
+        * @param {SourceCodeFixer} fixer The fixer object
+        * @param {ASTNode} node A `Property` node that has a `FunctionExpression` as its value
+        * @returns {Object} A fix for this node
+        */
+        function makeFunctionShorthand(fixer, node) {
+            const functionToken = sourceCode.getTokens(node.value).find(token => token.type === "Keyword" && token.value === "function");
+            const tokenBeforeParams = node.value.generator ? sourceCode.getTokenAfter(functionToken) : functionToken;
+            const firstKeyToken = node.computed ? sourceCode.getTokens(node).find(token => token.value === "[") : sourceCode.getFirstToken(node.key);
+            const lastKeyToken = node.computed ? sourceCode.getTokensBetween(node.key, node.value).find(token => token.value === "]") : sourceCode.getLastToken(node.key);
+            const keyText = sourceCode.text.slice(firstKeyToken.range[0], lastKeyToken.range[1]);
+            let keyPrefix = "";
+
+            if (node.value.generator) {
+                keyPrefix = "*";
+            } else if (node.value.async) {
+                keyPrefix = "async ";
+            }
+
+            return fixer.replaceTextRange([firstKeyToken.range[0], tokenBeforeParams.range[1]], keyPrefix + keyText);
+        }
+
+        /**
+        * Fixes a FunctionExpression node by making it into a longform property.
+        * @param {SourceCodeFixer} fixer The fixer object
+        * @param {ASTNode} node A `Property` node that has a `FunctionExpression` as its value
+        * @returns {Object} A fix for this node
+        */
+        function makeFunctionLongform(fixer, node) {
+            const firstKeyToken = node.computed ? sourceCode.getTokens(node).find(token => token.value === "[") : sourceCode.getFirstToken(node.key);
+            const lastKeyToken = node.computed ? sourceCode.getTokensBetween(node.key, node.value).find(token => token.value === "]") : sourceCode.getLastToken(node.key);
+            const keyText = sourceCode.text.slice(firstKeyToken.range[0], lastKeyToken.range[1]);
+            let functionHeader = "function";
+
+            if (node.value.generator) {
+                functionHeader = "function*";
+            } else if (node.value.async) {
+                functionHeader = "async function";
+            }
+
+            return fixer.replaceTextRange([node.range[0], lastKeyToken.range[1]], `${keyText}: ${functionHeader}`);
+        }
+
         //--------------------------------------------------------------------------
         // Public
         //--------------------------------------------------------------------------
@@ -238,52 +282,24 @@ module.exports = {
                 //--------------------------------------------------------------
                 // Checks for property/method shorthand.
                 if (isConciseProperty) {
+                    if (node.method && (APPLY_NEVER || AVOID_QUOTES && isStringLiteral(node.key))) {
 
-                    // if we're "never" and concise we should warn now
-                    if (APPLY_NEVER) {
-                        const type = node.method ? "method" : "property";
-
+                        // { x() {} } should be written as { x: function() {} }
                         context.report({
                             node,
-                            message: "Expected longform {{type}} syntax.",
-                            data: {
-                                type
-                            },
-                            fix(fixer) {
-                                if (node.method) {
-                                    if (node.value.generator) {
-                                        return fixer.replaceTextRange([node.range[0], node.key.range[1]], `${node.key.name}: function*`);
-                                    }
-
-                                    return fixer.insertTextAfter(node.key, ": function");
-                                }
-
-                                return fixer.insertTextAfter(node.key, `: ${node.key.name}`);
-                            }
+                            message: `Expected longform method syntax${APPLY_NEVER ? "" : " for string literal keys"}.`,
+                            fix: fixer => makeFunctionLongform(fixer, node)
                         });
-                    }
+                    } else if (APPLY_NEVER) {
 
-                    // {'xyz'() {}} should be written as {'xyz': function() {}}
-                    if (AVOID_QUOTES && isStringLiteral(node.key)) {
+                        // { x } should be written as { x: x }
                         context.report({
                             node,
-                            message: "Expected longform method syntax for string literal keys.",
-                            fix(fixer) {
-                                if (node.computed) {
-                                    return fixer.insertTextAfterRange([node.key.range[0], node.key.range[1] + 1], ": function");
-                                }
-
-                                return fixer.insertTextAfter(node.key, ": function");
-                            }
+                            message: "Expected longform property syntax.",
+                            fix: fixer => fixer.insertTextAfter(node.key, `: ${node.key.name}`)
                         });
                     }
-
-                    return;
-                }
-
-                //--------------------------------------------------------------
-                // Checks for longform properties.
-                if (node.value.type === "FunctionExpression" && !node.value.id && APPLY_TO_METHODS) {
+                } else if (node.value.type === "FunctionExpression" && !node.value.id && APPLY_TO_METHODS) {
                     if (IGNORE_CONSTRUCTORS && isConstructor(node.key.name)) {
                         return;
                     }
@@ -291,49 +307,10 @@ module.exports = {
                         return;
                     }
 
-                    // {[x]: function(){}} should be written as {[x]() {}}
-                    if (node.computed) {
-                        context.report({
-                            node,
-                            message: "Expected method shorthand.",
-                            fix(fixer) {
-
-                                // NOTE: If this rule is enhanced to handle arrow functions as well, this logic needs to be updated.
-                                const functionToken = sourceCode.getTokens(node).find(token => token.type === "Keyword" && token.value === "function");
-
-                                if (node.value.generator) {
-                                    return fixer.replaceTextRange([sourceCode.getTokenBefore(node.key).range[0], sourceCode.getTokenAfter(functionToken).range[1]], `*[${sourceCode.getText(node.key)}]`);
-                                }
-
-                                if (node.value.async) {
-                                    return fixer.replaceTextRange([sourceCode.getTokenBefore(node.key).range[0], functionToken.range[1]], `async [${sourceCode.getText(node.key)}]`);
-                                }
-
-                                return fixer.removeRange([sourceCode.getTokenAfter(node.key).range[1], functionToken.range[1]]);
-                            }
-                        });
-                        return;
-                    }
-
-                    // {x: function(){}} should be written as {x() {}}
                     context.report({
                         node,
                         message: "Expected method shorthand.",
-                        fix(fixer) {
-
-                            // NOTE: If this rule is enhanced to handle arrow functions as well, this logic needs to be updated.
-                            const functionToken = sourceCode.getTokens(node).find(token => token.type === "Keyword" && token.value === "function");
-
-                            if (node.value.generator) {
-                                return fixer.replaceTextRange([node.key.range[0], sourceCode.getTokenAfter(functionToken).range[1]], `*${sourceCode.getText(node.key)}`);
-                            }
-
-                            if (node.value.async) {
-                                return fixer.replaceTextRange([node.key.range[0], functionToken.range[1]], `async ${sourceCode.getText(node.key)}`);
-                            }
-
-                            return fixer.removeRange([node.key.range[1], functionToken.range[1]]);
-                        }
+                        fix: fixer => makeFunctionShorthand(fixer, node)
                     });
                 } else if (node.value.type === "Identifier" && node.key.name === node.value.name && APPLY_TO_PROPS) {
 

--- a/tests/lib/rules/object-shorthand.js
+++ b/tests/lib/rules/object-shorthand.js
@@ -412,7 +412,7 @@ ruleTester.run("object-shorthand", rule, {
         },
         {
             code: "({ [ foo ]: async function() {} })",
-            output: "({ async [foo]() {} })",
+            output: "({ async [ foo ]() {} })",
             parserOptions: { ecmaVersion: 8 },
             errors: [METHOD_ERROR]
         },
@@ -456,6 +456,73 @@ ruleTester.run("object-shorthand", rule, {
             output: "var x = {[y]() {}}",
             options: ["methods"],
             errors: [METHOD_ERROR]
+        },
+        {
+            code: "({ [(foo)]: function() { return; } })",
+            output: "({ [(foo)]() { return; } })",
+            errors: [METHOD_ERROR]
+        },
+        {
+            code: "({ [(foo)]: async function() { return; } })",
+            output: "({ async [(foo)]() { return; } })",
+            parserOptions: { ecmaVersion: 8 },
+            errors: [METHOD_ERROR]
+        },
+        {
+            code: "({ [(((((((foo)))))))]: function() { return; } })",
+            output: "({ [(((((((foo)))))))]() { return; } })",
+            errors: [METHOD_ERROR]
+        },
+        {
+            code: "({ [(foo)]() { return; } })",
+            output: "({ [(foo)]: function() { return; } })",
+            options: ["never"],
+            errors: [LONGFORM_METHOD_ERROR]
+        },
+        {
+            code: "({ async [(foo)]() { return; } })",
+            output: "({ [(foo)]: async function() { return; } })",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 8 },
+            errors: [LONGFORM_METHOD_ERROR]
+        },
+        {
+            code: "({ *[((foo))]() { return; } })",
+            output: "({ [((foo))]: function*() { return; } })",
+            options: ["never"],
+            errors: [LONGFORM_METHOD_ERROR]
+        },
+        {
+            code: "({ [(((((((foo)))))))]() { return; } })",
+            output: "({ [(((((((foo)))))))]: function() { return; } })",
+            options: ["never"],
+            errors: [LONGFORM_METHOD_ERROR]
+        },
+        {
+            code: "({ 'foo bar'() { return; } })",
+            output: "({ 'foo bar': function() { return; } })",
+            options: ["never"],
+            errors: [LONGFORM_METHOD_ERROR]
+        },
+        {
+            code: "({ *foo() { return; } })",
+            output: "({ foo: function*() { return; } })",
+            options: ["never"],
+            errors: [LONGFORM_METHOD_ERROR]
+        },
+        {
+            code: "({ async foo() { return; } })",
+            output: "({ foo: async function() { return; } })",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 8 },
+            errors: [LONGFORM_METHOD_ERROR]
+        },
+        {
+            code: "({ *['foo bar']() { return; } })",
+            output: "({ ['foo bar']: function*() { return; } })",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 8 },
+            errors: [LONGFORM_METHOD_ERROR]
         },
         {
             code: "var x = {x: x}",


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix

See https://github.com/eslint/eslint/issues/7744

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This refactors object-shorthand's autofixing logic to avoid code duplication, and fixes the following issues:

* Shorthand async methods would cause a syntax error when fixed to longform properties
* Longform properties with parenthesized computed keys would cause a syntax error when fixed to shorthand properties

**Is there anything you'd like reviewers to focus on?**

Nothing in particular