### PR TITLE
Update: add object-shorthand option for arrow functions (fixes #7564)

### DIFF
--- a/docs/rules/object-shorthand.md
+++ b/docs/rules/object-shorthand.md
@@ -103,7 +103,13 @@ You can set the option in configuration like this:
 }
 ```
 
-While set to `"always"`, `"methods"`, or `"properties"`, shorthand syntax using string literal keys can be ignored using the optional parameter `"avoidQuotes"`. This will make it so longform syntax is preferred whenever the object key is a string literal. Note: The first parameter must be specified when using this optional parameter.
+Additionally, the rule takes an optional object configuration:
+
+* `"avoidQuotes": true` indicates that longform syntax is preferred whenever the object key is a string literal (default: `false`). Note that this option can only be enabled when the string option is set to `"always"`, `"methods"`, or `"properties"`.
+* `"ignoreConstructors": true` can be used to prevent the rule from reporting errors for constructor functions. (By default, the rule treats constructors the same way as other functions.) Note that this option can only be enabled when the string option is set to `"always"` or `"methods"`.
+* `"avoidExplicitReturnArrows": true` indicates that methods are preferred over explicit-return arrow functions for function properties. (By default, the rule allows either of these.) Note that this option can only be enabled when the string option is set to `"always"` or `"methods"`.
+
+### `avoidQuotes`
 
 ```json
 {
@@ -134,7 +140,7 @@ var foo = {
 };
 ```
 
-While set to `"always"` or `"methods"`, constructor functions can be ignored with the optional parameter `"ignoreConstructors"` enabled. Note: The first parameter must be specified when using this optional parameter.
+### `ignoreConstructors`
 
 ```json
 {
@@ -150,6 +156,46 @@ Example of **correct** code for this rule with the `"always", { "ignoreConstruct
 
 var foo = {
     ConstructorFunction: function() {}
+};
+```
+
+### `avoidExplicitReturnArrows`
+
+```json
+{
+    "object-shorthand": ["error", "always", { "avoidExplicitReturnArrows": true }]
+}
+```
+
+Example of **incorrect** code for this rule with the `"always", { "avoidExplicitReturnArrows": true }` option:
+
+```js
+/*eslint object-shorthand: ["error", "always", { "avoidExplicitReturnArrows": true }]*/
+/*eslint-env es6*/
+
+var foo = {
+  foo: (bar, baz) => {
+    return bar + baz;
+  },
+
+  qux: (foobar) => {
+    return foobar * 2;
+  }
+};
+```
+
+Example of **correct** code for this rule with the `"always", { "avoidExplicitReturnArrows": true }` option:
+
+```js
+/*eslint object-shorthand: ["error", "always", { "avoidExplicitReturnArrows": true }]*/
+/*eslint-env es6*/
+
+var foo = {
+  foo(bar, baz) {
+    return bar + baz;
+  },
+
+  qux: foobar => foobar * 2
 };
 ```
 

--- a/lib/rules/object-shorthand.js
+++ b/lib/rules/object-shorthand.js
@@ -77,6 +77,9 @@ module.exports = {
                                 },
                                 avoidQuotes: {
                                     type: "boolean"
+                                },
+                                allowExplicitReturnArrows: {
+                                    type: "boolean"
                                 }
                             },
                             additionalProperties: false
@@ -100,6 +103,7 @@ module.exports = {
         const PARAMS = context.options[1] || {};
         const IGNORE_CONSTRUCTORS = PARAMS.ignoreConstructors;
         const AVOID_QUOTES = PARAMS.avoidQuotes;
+        const ALLOW_EXPLICIT_RETURN_ARROWS = typeof PARAMS.allowExplicitReturnArrows === "undefined" || PARAMS.allowExplicitReturnArrows;
         const sourceCode = context.getSourceCode();
 
         //--------------------------------------------------------------------------
@@ -207,12 +211,10 @@ module.exports = {
         /**
         * Fixes a FunctionExpression node by making it into a shorthand property.
         * @param {SourceCodeFixer} fixer The fixer object
-        * @param {ASTNode} node A `Property` node that has a `FunctionExpression` as its value
+        * @param {ASTNode} node A `Property` node that has a `FunctionExpression` or `ArrowFunctionExpression` as its value
         * @returns {Object} A fix for this node
         */
         function makeFunctionShorthand(fixer, node) {
-            const functionToken = sourceCode.getTokens(node.value).find(token => token.type === "Keyword" && token.value === "function");
-            const tokenBeforeParams = node.value.generator ? sourceCode.getTokenAfter(functionToken) : functionToken;
             const firstKeyToken = node.computed ? sourceCode.getTokens(node).find(token => token.value === "[") : sourceCode.getFirstToken(node.key);
             const lastKeyToken = node.computed ? sourceCode.getTokensBetween(node.key, node.value).find(token => token.value === "]") : sourceCode.getLastToken(node.key);
             const keyText = sourceCode.text.slice(firstKeyToken.range[0], lastKeyToken.range[1]);
@@ -224,7 +226,20 @@ module.exports = {
                 keyPrefix = "async ";
             }
 
-            return fixer.replaceTextRange([firstKeyToken.range[0], tokenBeforeParams.range[1]], keyPrefix + keyText);
+            if (node.value.type === "FunctionExpression") {
+                const functionToken = sourceCode.getTokens(node.value).find(token => token.type === "Keyword" && token.value === "function");
+                const tokenBeforeParams = node.value.generator ? sourceCode.getTokenAfter(functionToken) : functionToken;
+
+                return fixer.replaceTextRange([firstKeyToken.range[0], tokenBeforeParams.range[1]], keyPrefix + keyText);
+            } else {
+                const arrowToken = sourceCode.getTokens(node.value).find(token => token.value === "=>");
+                const tokenBeforeArrow = sourceCode.getTokenBefore(arrowToken);
+                const hasParensAroundParameters = tokenBeforeArrow.type === "Punctuator" && tokenBeforeArrow.value === ")";
+                const oldParamText = sourceCode.text.slice(sourceCode.getFirstToken(node.value, node.value.async ? 1 : 0).range[0], tokenBeforeArrow.range[1]);
+                const newParamText = hasParensAroundParameters ? oldParamText : `(${oldParamText})`;
+
+                return fixer.replaceTextRange([firstKeyToken.range[0], arrowToken.range[1]], keyPrefix + keyText + newParamText);
+            }
         }
 
         /**
@@ -248,11 +263,81 @@ module.exports = {
             return fixer.replaceTextRange([node.range[0], lastKeyToken.range[1]], `${keyText}: ${functionHeader}`);
         }
 
+        /*
+         * To determine whether a given arrow function has a lexical identifier (`this`, `arguments`, `super`, or `new.target`),
+         * create a stack of functions that define these identifiers (i.e. all functions except arrow functions) as the AST is
+         * traversed. Whenever a new function is encountered, create a new entry on the stack (corresponding to a different lexical
+         * scope of `this`, and whenever a function is exited, pop that entry off the stack. When an arrow function is entered,
+         * keep a reference to it on the current stack entry, and remove that reference when the arrow function is exited.
+         * When a lexical identifier is encountered, mark all the arrow functions on the current stack entry by adding them
+         * to an `arrowsWithLexicalIdentifiers` set. Any arrow function in that set will not be reported by this rule,
+         * because converting it into a method would change the value of one of the lexical identifiers.
+         */
+        const lexicalScopeStack = [];
+        const arrowsWithLexicalIdentifiers = new WeakSet();
+        const argumentsIdentifiers = new WeakSet();
+
+        /**
+        * Enters a function. This creates a new lexical identifier scope, so a new Set of arrow functions is pushed onto the stack.
+        * Also, this marks all `arguments` identifiers so that they can be detected later.
+        * @returns {void}
+        */
+        function enterFunction() {
+            lexicalScopeStack.unshift(new Set());
+            context.getScope().variables.filter(variable => variable.name === "arguments").forEach(variable => {
+                variable.references.map(ref => ref.identifier).forEach(identifier => argumentsIdentifiers.add(identifier));
+            });
+        }
+
+        /**
+        * Exits a function. This pops the current set of arrow functions off the lexical scope stack.
+        * @returns {void}
+        */
+        function exitFunction() {
+            lexicalScopeStack.shift();
+        }
+
+        /**
+        * Marks the current function as having a lexical keyword. This implies that all arrow functions
+        * in the current lexical scope contain a reference to this lexical keyword.
+        * @returns {void}
+        */
+        function reportLexicalIdentifier() {
+            lexicalScopeStack[0].forEach(arrowFunction => arrowsWithLexicalIdentifiers.add(arrowFunction));
+        }
+
         //--------------------------------------------------------------------------
         // Public
         //--------------------------------------------------------------------------
 
         return {
+            Program: enterFunction,
+            FunctionDeclaration: enterFunction,
+            FunctionExpression: enterFunction,
+            "Program:exit": exitFunction,
+            "FunctionDeclaration:exit": exitFunction,
+            "FunctionExpression:exit": exitFunction,
+
+            ArrowFunctionExpression(node) {
+                lexicalScopeStack[0].add(node);
+            },
+            "ArrowFunctionExpression:exit"(node) {
+                lexicalScopeStack[0].delete(node);
+            },
+
+            ThisExpression: reportLexicalIdentifier,
+            Super: reportLexicalIdentifier,
+            MetaProperty(node) {
+                if (node.meta.name === "new" && node.property.name === "target") {
+                    reportLexicalIdentifier();
+                }
+            },
+            Identifier(node) {
+                if (argumentsIdentifiers.has(node)) {
+                    reportLexicalIdentifier();
+                }
+            },
+
             ObjectExpression(node) {
                 if (APPLY_CONSISTENT) {
                     checkConsistency(node, false);
@@ -261,7 +346,7 @@ module.exports = {
                 }
             },
 
-            Property(node) {
+            "Property:exit"(node) {
                 const isConciseProperty = node.method || node.shorthand;
 
                 // Ignore destructuring assignment
@@ -275,7 +360,7 @@ module.exports = {
                 }
 
                 // only computed methods can fail the following checks
-                if (node.computed && node.value.type !== "FunctionExpression") {
+                if (node.computed && node.value.type !== "FunctionExpression" && node.value.type !== "ArrowFunctionExpression") {
                     return;
                 }
 
@@ -299,7 +384,7 @@ module.exports = {
                             fix: fixer => fixer.insertTextAfter(node.key, `: ${node.key.name}`)
                         });
                     }
-                } else if (node.value.type === "FunctionExpression" && !node.value.id && APPLY_TO_METHODS) {
+                } else if (APPLY_TO_METHODS && !node.value.id && (node.value.type === "FunctionExpression" || node.value.type === "ArrowFunctionExpression")) {
                     if (IGNORE_CONSTRUCTORS && isConstructor(node.key.name)) {
                         return;
                     }
@@ -307,11 +392,19 @@ module.exports = {
                         return;
                     }
 
-                    context.report({
-                        node,
-                        message: "Expected method shorthand.",
-                        fix: fixer => makeFunctionShorthand(fixer, node)
-                    });
+                    // {[x]: function(){}} should be written as {[x]() {}}
+                    if (node.value.type === "FunctionExpression" ||
+                        node.value.type === "ArrowFunctionExpression" &&
+                        node.value.body.type === "BlockStatement" &&
+                        !ALLOW_EXPLICIT_RETURN_ARROWS &&
+                        !arrowsWithLexicalIdentifiers.has(node.value)
+                    ) {
+                        context.report({
+                            node,
+                            message: "Expected method shorthand.",
+                            fix: fixer => makeFunctionShorthand(fixer, node)
+                        });
+                    }
                 } else if (node.value.type === "Identifier" && node.key.name === node.value.name && APPLY_TO_PROPS) {
 
                     // {x: x} should be written as {x}

--- a/lib/rules/object-shorthand.js
+++ b/lib/rules/object-shorthand.js
@@ -267,7 +267,7 @@ module.exports = {
          * To determine whether a given arrow function has a lexical identifier (`this`, `arguments`, `super`, or `new.target`),
          * create a stack of functions that define these identifiers (i.e. all functions except arrow functions) as the AST is
          * traversed. Whenever a new function is encountered, create a new entry on the stack (corresponding to a different lexical
-         * scope of `this`, and whenever a function is exited, pop that entry off the stack. When an arrow function is entered,
+         * scope of `this`), and whenever a function is exited, pop that entry off the stack. When an arrow function is entered,
          * keep a reference to it on the current stack entry, and remove that reference when the arrow function is exited.
          * When a lexical identifier is encountered, mark all the arrow functions on the current stack entry by adding them
          * to an `arrowsWithLexicalIdentifiers` set. Any arrow function in that set will not be reported by this rule,

--- a/lib/rules/object-shorthand.js
+++ b/lib/rules/object-shorthand.js
@@ -78,7 +78,7 @@ module.exports = {
                                 avoidQuotes: {
                                     type: "boolean"
                                 },
-                                allowExplicitReturnArrows: {
+                                avoidExplicitReturnArrows: {
                                     type: "boolean"
                                 }
                             },
@@ -103,7 +103,7 @@ module.exports = {
         const PARAMS = context.options[1] || {};
         const IGNORE_CONSTRUCTORS = PARAMS.ignoreConstructors;
         const AVOID_QUOTES = PARAMS.avoidQuotes;
-        const ALLOW_EXPLICIT_RETURN_ARROWS = typeof PARAMS.allowExplicitReturnArrows === "undefined" || PARAMS.allowExplicitReturnArrows;
+        const AVOID_EXPLICIT_RETURN_ARROWS = !!PARAMS.avoidExplicitReturnArrows;
         const sourceCode = context.getSourceCode();
 
         //--------------------------------------------------------------------------
@@ -396,7 +396,7 @@ module.exports = {
                     if (node.value.type === "FunctionExpression" ||
                         node.value.type === "ArrowFunctionExpression" &&
                         node.value.body.type === "BlockStatement" &&
-                        !ALLOW_EXPLICIT_RETURN_ARROWS &&
+                        AVOID_EXPLICIT_RETURN_ARROWS &&
                         !arrowsWithLexicalIdentifiers.has(node.value)
                     ) {
                         context.report({

--- a/tests/lib/rules/object-shorthand.js
+++ b/tests/lib/rules/object-shorthand.js
@@ -269,7 +269,7 @@ ruleTester.run("object-shorthand", rule, {
             options: ["consistent-as-needed"]
         },
 
-        // avoidLongformArrows
+        // avoidExplicitReturnArrows
         {
             code: "({ x: () => foo })",
             options: ["always", { avoidExplicitReturnArrows: false }]
@@ -783,7 +783,7 @@ ruleTester.run("object-shorthand", rule, {
             errors: [MIXED_SHORTHAND_ERROR]
         },
 
-        // avoidLongformArrows
+        // avoidExplicitReturnArrows
         {
             code: "({ x: () => { return; } })",
             output: "({ x() { return; } })",

--- a/tests/lib/rules/object-shorthand.js
+++ b/tests/lib/rules/object-shorthand.js
@@ -272,43 +272,43 @@ ruleTester.run("object-shorthand", rule, {
         // avoidLongformArrows
         {
             code: "({ x: () => foo })",
-            options: ["always", { allowExplicitReturnArrows: true }]
+            options: ["always", { avoidExplicitReturnArrows: false }]
         },
         {
             code: "({ x: () => { return; } })",
-            options: ["always", { allowExplicitReturnArrows: true }]
+            options: ["always", { avoidExplicitReturnArrows: false }]
         },
         {
             code: "({ x: () => foo })",
-            options: ["always", { allowExplicitReturnArrows: false }]
+            options: ["always", { avoidExplicitReturnArrows: true }]
         },
         {
             code: "({ x() { return; } })",
-            options: ["always", { allowExplicitReturnArrows: false }]
+            options: ["always", { avoidExplicitReturnArrows: true }]
         },
         {
             code: "({ x() { return; }, y() { return; } })",
-            options: ["always", { allowExplicitReturnArrows: false }]
+            options: ["always", { avoidExplicitReturnArrows: true }]
         },
         {
             code: "({ x() { return; }, y: () => foo })",
-            options: ["always", { allowExplicitReturnArrows: false }]
+            options: ["always", { avoidExplicitReturnArrows: true }]
         },
         {
             code: "({ x: () => foo, y() { return; } })",
-            options: ["always", { allowExplicitReturnArrows: false }]
+            options: ["always", { avoidExplicitReturnArrows: true }]
         },
         {
             code: "({ x: () => { this; } })",
-            options: ["always", { allowExplicitReturnArrows: false }]
+            options: ["always", { avoidExplicitReturnArrows: true }]
         },
         {
             code: "function foo() { ({ x: () => { arguments; } }) }",
-            options: ["always", { allowExplicitReturnArrows: false }]
+            options: ["always", { avoidExplicitReturnArrows: true }]
         },
         {
             code: "function foo() { ({ x: () => { arguments; } }) }",
-            options: ["always", { allowExplicitReturnArrows: false }]
+            options: ["always", { avoidExplicitReturnArrows: true }]
         },
         {
             code: `
@@ -318,7 +318,7 @@ ruleTester.run("object-shorthand", rule, {
                   }
               }
             `,
-            options: ["always", { allowExplicitReturnArrows: false }]
+            options: ["always", { avoidExplicitReturnArrows: true }]
         },
         {
             code: `
@@ -328,7 +328,7 @@ ruleTester.run("object-shorthand", rule, {
                     }
                 }
             `,
-            options: ["always", { allowExplicitReturnArrows: false }]
+            options: ["always", { avoidExplicitReturnArrows: true }]
         },
         {
             code: `
@@ -336,7 +336,7 @@ ruleTester.run("object-shorthand", rule, {
                     var x = { x: () => { new.target; } };
                 }
             `,
-            options: ["always", { allowExplicitReturnArrows: false }]
+            options: ["always", { avoidExplicitReturnArrows: true }]
         },
         {
             code: `
@@ -348,7 +348,7 @@ ruleTester.run("object-shorthand", rule, {
                     };
                 }
             `,
-            options: ["always", { allowExplicitReturnArrows: false }]
+            options: ["always", { avoidExplicitReturnArrows: true }]
         },
         {
             code: `
@@ -361,7 +361,7 @@ ruleTester.run("object-shorthand", rule, {
                     };
                 }
             `,
-            options: ["always", { allowExplicitReturnArrows: false }]
+            options: ["always", { avoidExplicitReturnArrows: true }]
         },
         {
             code: `
@@ -373,7 +373,7 @@ ruleTester.run("object-shorthand", rule, {
                     };
                 }
             `,
-            options: ["always", { allowExplicitReturnArrows: false }]
+            options: ["always", { avoidExplicitReturnArrows: true }]
         }
     ],
     invalid: [
@@ -787,61 +787,61 @@ ruleTester.run("object-shorthand", rule, {
         {
             code: "({ x: () => { return; } })",
             output: "({ x() { return; } })",
-            options: ["always", { allowExplicitReturnArrows: false }],
+            options: ["always", { avoidExplicitReturnArrows: true }],
             errors: [METHOD_ERROR]
         },
         {
             code: "({ x() { return; }, y: () => { return; } })",
             output: "({ x() { return; }, y() { return; } })",
-            options: ["always", { allowExplicitReturnArrows: false }],
+            options: ["always", { avoidExplicitReturnArrows: true }],
             errors: [METHOD_ERROR]
         },
         {
             code: "({ x: () => { return; }, y: () => foo })",
             output: "({ x() { return; }, y: () => foo })",
-            options: ["always", { allowExplicitReturnArrows: false }],
+            options: ["always", { avoidExplicitReturnArrows: true }],
             errors: [METHOD_ERROR]
         },
         {
             code: "({ x: () => { return; }, y: () => { return; } })",
             output: "({ x() { return; }, y() { return; } })",
-            options: ["always", { allowExplicitReturnArrows: false }],
+            options: ["always", { avoidExplicitReturnArrows: true }],
             errors: [METHOD_ERROR, METHOD_ERROR]
         },
         {
             code: "({ x: foo => { return; } })",
             output: "({ x(foo) { return; } })",
-            options: ["always", { allowExplicitReturnArrows: false }],
+            options: ["always", { avoidExplicitReturnArrows: true }],
             errors: [METHOD_ERROR]
         },
         {
             code: "({ x: (foo = 1) => { return; } })",
             output: "({ x(foo = 1) { return; } })",
-            options: ["always", { allowExplicitReturnArrows: false }],
+            options: ["always", { avoidExplicitReturnArrows: true }],
             errors: [METHOD_ERROR]
         },
         {
             code: "({ x: ({ foo: bar = 1 } = {}) => { return; } })",
             output: "({ x({ foo: bar = 1 } = {}) { return; } })",
-            options: ["always", { allowExplicitReturnArrows: false }],
+            options: ["always", { avoidExplicitReturnArrows: true }],
             errors: [METHOD_ERROR]
         },
         {
             code: "({ x: () => { function foo() { this; } } })",
             output: "({ x() { function foo() { this; } } })",
-            options: ["always", { allowExplicitReturnArrows: false }],
+            options: ["always", { avoidExplicitReturnArrows: true }],
             errors: [METHOD_ERROR]
         },
         {
             code: "({ x: () => { var foo = function() { arguments; } } })",
             output: "({ x() { var foo = function() { arguments; } } })",
-            options: ["always", { allowExplicitReturnArrows: false }],
+            options: ["always", { avoidExplicitReturnArrows: true }],
             errors: [METHOD_ERROR]
         },
         {
             code: "({ x: () => { function foo() { arguments; } } })",
             output: "({ x() { function foo() { arguments; } } })",
-            options: ["always", { allowExplicitReturnArrows: false }],
+            options: ["always", { avoidExplicitReturnArrows: true }],
             errors: [METHOD_ERROR]
         },
         {
@@ -867,7 +867,7 @@ ruleTester.run("object-shorthand", rule, {
                     }
                 })
             `,
-            options: ["always", { allowExplicitReturnArrows: false }],
+            options: ["always", { avoidExplicitReturnArrows: true }],
             errors: [METHOD_ERROR]
         },
         {
@@ -889,32 +889,32 @@ ruleTester.run("object-shorthand", rule, {
                     }
                 })
             `,
-            options: ["always", { allowExplicitReturnArrows: false }],
+            options: ["always", { avoidExplicitReturnArrows: true }],
             errors: [METHOD_ERROR]
         },
         {
             code: "({ 'foo bar': () => { return; } })",
             output: "({ 'foo bar'() { return; } })",
-            options: ["always", { allowExplicitReturnArrows: false }],
+            options: ["always", { avoidExplicitReturnArrows: true }],
             errors: [METHOD_ERROR]
         },
         {
             code: "({ [foo]: () => { return; } })",
             output: "({ [foo]() { return; } })",
-            options: ["always", { allowExplicitReturnArrows: false }],
+            options: ["always", { avoidExplicitReturnArrows: true }],
             errors: [METHOD_ERROR]
         },
         {
             code: "({ a: 1, foo: async (bar = 1) => { return; } })",
             output: "({ a: 1, async foo(bar = 1) { return; } })",
-            options: ["always", { allowExplicitReturnArrows: false }],
+            options: ["always", { avoidExplicitReturnArrows: true }],
             parserOptions: { ecmaVersion: 8 },
             errors: [METHOD_ERROR]
         },
         {
             code: "({ [ foo ]: async bar => { return; } })",
             output: "({ async [ foo ](bar) { return; } })",
-            options: ["always", { allowExplicitReturnArrows: false }],
+            options: ["always", { avoidExplicitReturnArrows: true }],
             parserOptions: { ecmaVersion: 8 },
             errors: [METHOD_ERROR]
         },
@@ -939,7 +939,7 @@ ruleTester.run("object-shorthand", rule, {
                     };
                 }
             `,
-            options: ["always", { allowExplicitReturnArrows: false }],
+            options: ["always", { avoidExplicitReturnArrows: true }],
             errors: [METHOD_ERROR]
         },
         {
@@ -963,7 +963,7 @@ ruleTester.run("object-shorthand", rule, {
                     };
                 }
             `,
-            options: ["always", { allowExplicitReturnArrows: false }],
+            options: ["always", { avoidExplicitReturnArrows: true }],
             errors: [METHOD_ERROR]
         }
     ]


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Changes an existing rule

See https://github.com/eslint/eslint/issues/7564

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This adds an `avoidExplicitReturnArrows` option to `object-shorthand`, as discussed in https://github.com/eslint/eslint/issues/7564.

**Is there anything you'd like reviewers to focus on?**

~~Don't merge yet. There are still a few things left to do:~~

* Bikeshed about the option name?
* ~~Add documentation for the option~~
* ~~Wait for https://github.com/eslint/eslint/pull/7745 to get merged (this PR builds off of that commit)~~
