### PR TITLE
Fix: indent bug with AssignmentExpressions (fixes #7747)

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -722,16 +722,28 @@ module.exports = {
                 const parent = node.parent;
 
                 nodeIndent = getNodeIndent(parent).goodChar;
-                if (parentVarNode && parentVarNode.loc.start.line !== node.loc.start.line) {
+                if (!parentVarNode || parentVarNode.loc.start.line !== node.loc.start.line) {
                     if (parent.type !== "VariableDeclarator" || parentVarNode === parentVarNode.parent.declarations[0]) {
                         if (parent.type === "VariableDeclarator" && parentVarNode.loc.start.line === parent.loc.start.line) {
                             nodeIndent = nodeIndent + (indentSize * options.VariableDeclarator[parentVarNode.parent.kind]);
                         } else if (parent.type === "ObjectExpression" || parent.type === "ArrayExpression") {
-                            if (typeof options[parent.type] === "number") {
+                            const parentElements = node.parent.type === "ObjectExpression" ? node.parent.properties : node.parent.elements;
+
+                            if (parentElements[0].loc.start.line === parent.loc.start.line && parentElements[0].loc.end.line !== parent.loc.start.line) {
+
+                                /*
+                                 * If the first element of the array spans multiple lines, don't increase the expected indentation of the rest.
+                                 * e.g. [{
+                                 *        foo: 1
+                                 *      },
+                                 *      {
+                                 *        bar: 1
+                                 *      }]
+                                 * the second object is not indented.
+                                 */
+                            } else if (typeof options[parent.type] === "number") {
                                 nodeIndent += options[parent.type] * indentSize;
                             } else {
-                                const parentElements = node.parent.type === "ObjectExpression" ? node.parent.properties : node.parent.elements;
-
                                 nodeIndent = parentElements[0].loc.start.column;
                             }
                         } else if (parent.type === "CallExpression" || parent.type === "NewExpression") {

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -1907,6 +1907,13 @@ ruleTester.run("indent", rule, {
             "\t);\n" +
             "}",
             options: ["tab"]
+        },
+        {
+            code:
+            "echo = spawn('cmd.exe',\n" +
+            "             ['foo', 'bar',\n" +
+            "              'baz']);",
+            options: [2, {ArrayExpression: "first", CallExpression: {arguments: "first"}}]
         }
     ],
     invalid: [
@@ -3849,6 +3856,18 @@ ruleTester.run("indent", rule, {
             "}",
             options: [2, {ArrayExpression: 4}],
             errors: expectedErrors([2, 2, 4, "ExpressionStatement"])
+        },
+        {
+            code:
+            "echo = spawn('cmd.exe',\n" +
+            "            ['foo', 'bar',\n" +
+            "             'baz']);",
+            output:
+            "echo = spawn('cmd.exe',\n" +
+            "             ['foo', 'bar',\n" +
+            "             'baz']);",
+            options: [2, {ArrayExpression: "first", CallExpression: {arguments: "first"}}],
+            errors: expectedErrors([2, 13, 12, "ArrayExpression"])
         },
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix

**What changes did you make? (Give an overview)**

This updates `indent` to apply array/object offsets even when they don't have a VariableDeclarator parent.

**Is there anything you'd like reviewers to focus on?**

This builds off of https://github.com/eslint/eslint/pull/7734, so it should not be merged until that PR is merged. Since this bug is not a regression, it might be better to do a patch release with only https://github.com/eslint/eslint/pull/7734 rather than rushing this PR.
