### PR TITLE
Fix: patch projectPath resolve when still in node_modules directory

### DIFF
--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -311,8 +311,11 @@ function write(config, filePath) {
  */
 function getBaseDir(configFilePath) {
 
+    // used to remove a trailing node_modules directory
+    const nodeModulesMatch = new RegExp(`${path.sep}node_modules$`);
+
     // calculates the path of the project including ESLint as dependency
-    const projectPath = path.resolve(__dirname, "../../../");
+    const projectPath = path.resolve(__dirname, "../../../").replace(nodeModulesMatch, "");
 
     if (configFilePath && pathIsInside(configFilePath, projectPath)) {
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Strips trailing `node_modules` from `projectPath` when the path is not "*the path of the project including eslint as a dependency*", but is actually the project’s node_modules directory.

Resolves or partially resolves #7723

**Is there anything you'd like reviewers to focus on?**

The current production code uses `path.resolve(__dirname, "../../../")` to move into project directory. This resolves incorrectly some of the time, so perhaps you should look review your existing code to see if there is a better way to land in the appropriate directory.