### PR TITLE
Build: Don't create blogpost links from rule names within other words

### DIFF
--- a/templates/blogpost.md.ejs
+++ b/templates/blogpost.md.ejs
@@ -10,7 +10,7 @@ tags:
 We just pushed ESLint v<%- version %>, which is a <%- type %> release upgrade of ESLint. This release <% if (type !== "patch") { %>adds some new features and<% } %> fixes several bugs found in the previous release. <% if (type === "major") { %>This release also has some breaking changes, so please read the following closely. <% } %>
 
 <%
-const RULE_REGEX = new RegExp(`\`?(${ruleList.join("|")})\`?`, "g");
+const RULE_REGEX = new RegExp(`\`?\\b(${ruleList.join("|")})\\b\`?`, "g");
 
 function linkify(line) {
     return line


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

**What changes did you make? (Give an overview)**

In the latest blogpost (see [here](https://github.com/eslint/eslint.github.io/blob/0709ac422ed42219219887e9468ca867ed18f4f4/_posts/2016-12-12-eslint-v3.12.1-released.md#documentation)), the word "restricting" in a commit message caused a link to be created to the [`strict`](http://eslint.org/docs/rules/strict) rule documentation.

This commit fixes the issue by requiring a word boundary to be present around the rule name for a URL to be inserted.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.