### PR TITLE
Use `Object.prototype` in examples

### DIFF
--- a/docs/rules/guard-for-in.md
+++ b/docs/rules/guard-for-in.md
@@ -30,6 +30,9 @@ Examples of **correct** code for this rule:
 /*eslint guard-for-in: "error"*/
 
 for (key in foo) {
+    if (Object.prototype.hasOwnProperty.call(foo, key)) {
+        doSomething(key);
+    }
     if ({}.hasOwnProperty.call(foo, key)) {
         doSomething(key);
     }

--- a/docs/rules/no-extra-parens.md
+++ b/docs/rules/no-extra-parens.md
@@ -47,6 +47,8 @@ Examples of **correct** code for this rule with the default `"all"` option:
 
 (0).toString();
 
+(Object.prototype.toString.call());
+
 ({}.toString.call());
 
 (function(){}) ? a() : b();
@@ -120,6 +122,8 @@ Examples of **correct** code for this rule with the `"functions"` option:
 /* eslint no-extra-parens: ["error", "functions"] */
 
 (0).toString();
+
+(Object.prototype.toString.call());
 
 ({}.toString.call());
 

--- a/docs/rules/no-prototype-builtins.md
+++ b/docs/rules/no-prototype-builtins.md
@@ -23,9 +23,9 @@ Examples of **correct** code for this rule:
 ```js
 /*eslint no-prototype-builtins: "error"*/
 
-var hasBarProperty = {}.hasOwnProperty.call(foo, "bar");
+var hasBarProperty = Object.prototype.hasOwnProperty.call(foo, "bar");
 
-var isPrototypeOfBar = {}.isPrototypeOf.call(foo, bar);
+var isPrototypeOfBar = Object.prototype.isPrototypeOf.call(foo, bar);
 
 var barIsEnumerable = {}.propertyIsEnumerable.call(foo, "bar");
 ```

--- a/docs/rules/prefer-rest-params.md
+++ b/docs/rules/prefer-rest-params.md
@@ -19,6 +19,11 @@ function foo() {
 }
 
 function foo(action) {
+    var args = Array.prototype.slice.call(arguments, 1);
+    action.apply(null, args);
+}
+
+function foo(action) {
     var args = [].slice.call(arguments, 1);
     action.apply(null, args);
 }


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Updating documentation for `no-prototype-builtins`

**Is there anything you'd like reviewers to focus on?**

I thought rather than encouraging people to use `{}.prototype.hasOwnProperty.call` it would be better to encourage the use of `Object.prototype.` as it does not create a new object for the purpose of using the newly created objects prototype functions, but rather just borrows the function from the `Object.prototype` directly.