### PR TITLE
Chore: convert remaining old-style context.report() calls to the new API

### DIFF
--- a/lib/internal-rules/internal-no-invalid-meta.js
+++ b/lib/internal-rules/internal-no-invalid-meta.js
@@ -215,7 +215,7 @@ module.exports = {
 
             "Program:exit"() {
                 if (!isCorrectExportsFormat(exportsNode)) {
-                    context.report(exportsNode, "Rule does not export an Object. Make sure the rule follows the new rule format.");
+                    context.report({node: exportsNode, message: "Rule does not export an Object. Make sure the rule follows the new rule format."});
                     return;
                 }
 

--- a/lib/rules/accessor-pairs.js
+++ b/lib/rules/accessor-pairs.js
@@ -139,9 +139,9 @@ module.exports = {
             }
 
             if (checkSetWithoutGet && isSetPresent && !isGetPresent) {
-                context.report(node, "Getter is not present.");
+                context.report({node, message: "Getter is not present."});
             } else if (checkGetWithoutSet && isGetPresent && !isSetPresent) {
-                context.report(node, "Setter is not present.");
+                context.report({node, message: "Setter is not present."});
             }
         }
 

--- a/lib/rules/block-scoped-var.js
+++ b/lib/rules/block-scoped-var.js
@@ -47,10 +47,7 @@ module.exports = {
         function report(reference) {
             const identifier = reference.identifier;
 
-            context.report(
-                identifier,
-                "'{{name}}' used outside of binding context.",
-                {name: identifier.name});
+            context.report({node: identifier, message: "'{{name}}' used outside of binding context.", data: {name: identifier.name}});
         }
 
         /**

--- a/lib/rules/callback-return.js
+++ b/lib/rules/callback-return.js
@@ -164,7 +164,7 @@ module.exports = {
 
                 // as long as you're the child of a function at this point you should be asked to return
                 if (findClosestParentOfType(node, ["FunctionDeclaration", "FunctionExpression", "ArrowFunctionExpression"])) {
-                    context.report(node, "Expected return with your callback function.");
+                    context.report({node, message: "Expected return with your callback function."});
                 }
 
             }

--- a/lib/rules/camelcase.js
+++ b/lib/rules/camelcase.js
@@ -61,7 +61,7 @@ module.exports = {
         function report(node) {
             if (reported.indexOf(node) < 0) {
                 reported.push(node);
-                context.report(node, "Identifier '{{name}}' is not in camel case.", { name: node.name });
+                context.report({node, message: "Identifier '{{name}}' is not in camel case.", data: { name: node.name }});
             }
         }
 

--- a/lib/rules/complexity.js
+++ b/lib/rules/complexity.js
@@ -91,7 +91,7 @@ module.exports = {
             }
 
             if (complexity > THRESHOLD) {
-                context.report(node, "Function '{{name}}' has a complexity of {{complexity}}.", { name, complexity });
+                context.report({node, message: "Function '{{name}}' has a complexity of {{complexity}}.", data: { name, complexity }});
             }
         }
 

--- a/lib/rules/consistent-this.js
+++ b/lib/rules/consistent-this.js
@@ -43,9 +43,7 @@ module.exports = {
          * @returns {void}
          */
         function reportBadAssignment(node, alias) {
-            context.report(node,
-                "Designated alias '{{alias}}' is not assigned to 'this'.",
-                { alias });
+            context.report({node, message: "Designated alias '{{alias}}' is not assigned to 'this'.", data: { alias }});
         }
 
         /**
@@ -64,8 +62,7 @@ module.exports = {
                     reportBadAssignment(node, name);
                 }
             } else if (isThis) {
-                context.report(node,
-                    "Unexpected alias '{{name}}' for 'this'.", { name });
+                context.report({node, message: "Unexpected alias '{{name}}' for 'this'.", data: { name }});
             }
         }
 

--- a/lib/rules/default-case.js
+++ b/lib/rules/default-case.js
@@ -81,7 +81,7 @@ module.exports = {
                     }
 
                     if (!comment || !commentPattern.test(comment.value.trim())) {
-                        context.report(node, "Expected a default case.");
+                        context.report({node, message: "Expected a default case."});
                     }
                 }
             }

--- a/lib/rules/func-names.js
+++ b/lib/rules/func-names.js
@@ -86,11 +86,11 @@ module.exports = {
 
                 if (never) {
                     if (name) {
-                        context.report(node, "Unexpected function expression name.");
+                        context.report({node, message: "Unexpected function expression name."});
                     }
                 } else {
                     if (!name && (asNeeded ? !hasInferredName(node) : !isObjectOrClassMethod(node))) {
-                        context.report(node, "Missing function expression name.");
+                        context.report({node, message: "Missing function expression name."});
                     }
                 }
             }

--- a/lib/rules/func-style.js
+++ b/lib/rules/func-style.js
@@ -44,7 +44,7 @@ module.exports = {
                 stack.push(false);
 
                 if (!enforceDeclarations && node.parent.type !== "ExportDefaultDeclaration") {
-                    context.report(node, "Expected a function expression.");
+                    context.report({node, message: "Expected a function expression."});
                 }
             },
             "FunctionDeclaration:exit"() {
@@ -55,7 +55,7 @@ module.exports = {
                 stack.push(false);
 
                 if (enforceDeclarations && node.parent.type === "VariableDeclarator") {
-                    context.report(node.parent, "Expected a function declaration.");
+                    context.report({node: node.parent, message: "Expected a function declaration."});
                 }
             },
             "FunctionExpression:exit"() {
@@ -78,7 +78,7 @@ module.exports = {
                 const hasThisExpr = stack.pop();
 
                 if (enforceDeclarations && !hasThisExpr && node.parent.type === "VariableDeclarator") {
-                    context.report(node.parent, "Expected a function declaration.");
+                    context.report({node: node.parent, message: "Expected a function declaration."});
                 }
             };
         }

--- a/lib/rules/global-require.js
+++ b/lib/rules/global-require.js
@@ -66,7 +66,7 @@ module.exports = {
                     const isGoodRequire = context.getAncestors().every(parent => ACCEPTABLE_PARENTS.indexOf(parent.type) > -1);
 
                     if (!isGoodRequire) {
-                        context.report(node, "Unexpected require().");
+                        context.report({node, message: "Unexpected require()."});
                     }
                 }
             }

--- a/lib/rules/guard-for-in.js
+++ b/lib/rules/guard-for-in.js
@@ -33,7 +33,7 @@ module.exports = {
                 const body = node.body.type === "BlockStatement" ? node.body.body[0] : node.body;
 
                 if (body && body.type !== "IfStatement") {
-                    context.report(node, "The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype.");
+                    context.report({node, message: "The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype."});
                 }
             }
         };

--- a/lib/rules/handle-callback-err.js
+++ b/lib/rules/handle-callback-err.js
@@ -74,7 +74,7 @@ module.exports = {
 
             if (firstParameter && matchesConfiguredErrorName(firstParameter.name)) {
                 if (firstParameter.references.length === 0) {
-                    context.report(node, "Expected error to be handled.");
+                    context.report({node, message: "Expected error to be handled."});
                 }
             }
         }

--- a/lib/rules/id-blacklist.js
+++ b/lib/rules/id-blacklist.js
@@ -67,9 +67,9 @@ module.exports = {
          * @private
          */
         function report(node) {
-            context.report(node, "Identifier '{{name}}' is blacklisted.", {
+            context.report({node, message: "Identifier '{{name}}' is blacklisted.", data: {
                 name: node.name
-            });
+            }});
         }
 
         return {

--- a/lib/rules/id-length.js
+++ b/lib/rules/id-length.js
@@ -102,13 +102,13 @@ module.exports = {
                 const isValidExpression = SUPPORTED_EXPRESSIONS[parent.type];
 
                 if (isValidExpression && (isValidExpression === true || isValidExpression(parent, node))) {
-                    context.report(
+                    context.report({
                         node,
-                        isShort ?
+                        message: isShort ?
                             "Identifier name '{{name}}' is too short (< {{min}})." :
                             "Identifier name '{{name}}' is too long (> {{max}}).",
-                        { name, min: minLength, max: maxLength }
-                    );
+                        data: { name, min: minLength, max: maxLength }
+                    });
                 }
             }
         };

--- a/lib/rules/id-match.js
+++ b/lib/rules/id-match.js
@@ -75,10 +75,10 @@ module.exports = {
          * @private
          */
         function report(node) {
-            context.report(node, "Identifier '{{name}}' does not match the pattern '{{pattern}}'.", {
+            context.report({node, message: "Identifier '{{name}}' does not match the pattern '{{pattern}}'.", data: {
                 name: node.name,
                 pattern
-            });
+            }});
         }
 
         return {

--- a/lib/rules/max-depth.js
+++ b/lib/rules/max-depth.js
@@ -91,8 +91,7 @@ module.exports = {
             const len = ++functionStack[functionStack.length - 1];
 
             if (len > maxDepth) {
-                context.report(node, "Blocks are nested too deeply ({{depth}}).",
-                        { depth: len });
+                context.report({node, message: "Blocks are nested too deeply ({{depth}}).", data: { depth: len }});
             }
         }
 

--- a/lib/rules/max-nested-callbacks.js
+++ b/lib/rules/max-nested-callbacks.js
@@ -83,7 +83,7 @@ module.exports = {
             if (callbackStack.length > THRESHOLD) {
                 const opts = {num: callbackStack.length, max: THRESHOLD};
 
-                context.report(node, "Too many nested callbacks ({{num}}). Maximum allowed is {{max}}.", opts);
+                context.report({node, message: "Too many nested callbacks ({{num}}). Maximum allowed is {{max}}.", data: opts});
             }
         }
 

--- a/lib/rules/max-params.js
+++ b/lib/rules/max-params.js
@@ -66,10 +66,10 @@ module.exports = {
          */
         function checkFunction(node) {
             if (node.params.length > numParams) {
-                context.report(node, "This function has too many parameters ({{count}}). Maximum allowed is {{max}}.", {
+                context.report({node, message: "This function has too many parameters ({{count}}). Maximum allowed is {{max}}.", data: {
                     count: node.params.length,
                     max: numParams
-                });
+                }});
             }
         }
 

--- a/lib/rules/max-statements.js
+++ b/lib/rules/max-statements.js
@@ -93,10 +93,11 @@ module.exports = {
                     name = `Function '${context.getSource(node.parent.key)}'`;
                 }
 
-                context.report(
+                context.report({
                     node,
-                    name + messageEnd,
-                    { count, max });
+                    message: name + messageEnd,
+                    data: { count, max }
+                });
             }
         }
 

--- a/lib/rules/new-cap.js
+++ b/lib/rules/new-cap.js
@@ -227,7 +227,7 @@ module.exports = {
                 callee = callee.property;
             }
 
-            context.report(node, callee.loc.start, message);
+            context.report({node, loc: callee.loc.start, message});
         }
 
         //--------------------------------------------------------------------------

--- a/lib/rules/no-array-constructor.js
+++ b/lib/rules/no-array-constructor.js
@@ -34,7 +34,7 @@ module.exports = {
                 node.callee.type === "Identifier" &&
                 node.callee.name === "Array"
             ) {
-                context.report(node, "The array literal notation [] is preferrable.");
+                context.report({node, message: "The array literal notation [] is preferrable."});
             }
         }
 

--- a/lib/rules/no-bitwise.js
+++ b/lib/rules/no-bitwise.js
@@ -57,7 +57,7 @@ module.exports = {
          * @returns {void}
          */
         function report(node) {
-            context.report(node, "Unexpected use of '{{operator}}'.", { operator: node.operator });
+            context.report({node, message: "Unexpected use of '{{operator}}'.", data: { operator: node.operator }});
         }
 
         /**

--- a/lib/rules/no-caller.js
+++ b/lib/rules/no-caller.js
@@ -29,7 +29,7 @@ module.exports = {
                     propertyName = node.property.name;
 
                 if (objectName === "arguments" && !node.computed && propertyName && propertyName.match(/^calle[er]$/)) {
-                    context.report(node, "Avoid arguments.{{property}}.", { property: propertyName });
+                    context.report({node, message: "Avoid arguments.{{property}}.", data: { property: propertyName }});
                 }
 
             }

--- a/lib/rules/no-catch-shadow.js
+++ b/lib/rules/no-catch-shadow.js
@@ -58,8 +58,7 @@ module.exports = {
                 }
 
                 if (paramIsShadowing(scope, node.param.name)) {
-                    context.report(node, "Value of '{{name}}' may be overwritten in IE 8 and earlier.",
-                            { name: node.param.name });
+                    context.report({node, message: "Value of '{{name}}' may be overwritten in IE 8 and earlier.", data: { name: node.param.name }});
                 }
             }
         };

--- a/lib/rules/no-class-assign.js
+++ b/lib/rules/no-class-assign.js
@@ -31,10 +31,7 @@ module.exports = {
          */
         function checkVariable(variable) {
             astUtils.getModifyingReferences(variable.references).forEach(reference => {
-                context.report(
-                    reference.identifier,
-                    "'{{name}}' is a class.",
-                    {name: reference.identifier.name});
+                context.report({node: reference.identifier, message: "'{{name}}' is a class.", data: {name: reference.identifier.name}});
 
             });
         }

--- a/lib/rules/no-cond-assign.js
+++ b/lib/rules/no-cond-assign.js
@@ -125,9 +125,9 @@ module.exports = {
             const ancestor = findConditionalAncestor(node);
 
             if (ancestor) {
-                context.report(ancestor, "Unexpected assignment within {{type}}.", {
+                context.report({node: ancestor, message: "Unexpected assignment within {{type}}.", data: {
                     type: NODE_DESCRIPTIONS[ancestor.type] || ancestor.type
-                });
+                }});
             }
         }
 

--- a/lib/rules/no-confusing-arrow.js
+++ b/lib/rules/no-confusing-arrow.js
@@ -55,7 +55,7 @@ module.exports = {
             const body = node.body;
 
             if (isConditional(body) && !(config.allowParens && astUtils.isParenthesised(sourceCode, body))) {
-                context.report(node, "Arrow function used ambiguously with a conditional expression.");
+                context.report({node, message: "Arrow function used ambiguously with a conditional expression."});
             }
         }
 

--- a/lib/rules/no-const-assign.js
+++ b/lib/rules/no-const-assign.js
@@ -31,10 +31,7 @@ module.exports = {
          */
         function checkVariable(variable) {
             astUtils.getModifyingReferences(variable.references).forEach(reference => {
-                context.report(
-                    reference.identifier,
-                    "'{{name}}' is constant.",
-                    {name: reference.identifier.name});
+                context.report({node: reference.identifier, message: "'{{name}}' is constant.", data: {name: reference.identifier.name}});
             });
         }
 

--- a/lib/rules/no-constant-condition.js
+++ b/lib/rules/no-constant-condition.js
@@ -122,7 +122,7 @@ module.exports = {
          */
         function checkConstantCondition(node) {
             if (node.test && isConstant(node.test, true)) {
-                context.report(node, "Unexpected constant condition.");
+                context.report({node, message: "Unexpected constant condition."});
             }
         }
 

--- a/lib/rules/no-continue.js
+++ b/lib/rules/no-continue.js
@@ -24,7 +24,7 @@ module.exports = {
 
         return {
             ContinueStatement(node) {
-                context.report(node, "Unexpected use of continue statement.");
+                context.report({node, message: "Unexpected use of continue statement."});
             }
         };
 

--- a/lib/rules/no-debugger.js
+++ b/lib/rules/no-debugger.js
@@ -24,7 +24,7 @@ module.exports = {
 
         return {
             DebuggerStatement(node) {
-                context.report(node, "Unexpected 'debugger' statement.");
+                context.report({node, message: "Unexpected 'debugger' statement."});
             }
         };
 

--- a/lib/rules/no-delete-var.js
+++ b/lib/rules/no-delete-var.js
@@ -26,7 +26,7 @@ module.exports = {
 
             UnaryExpression(node) {
                 if (node.operator === "delete" && node.argument.type === "Identifier") {
-                    context.report(node, "Variables should not be deleted.");
+                    context.report({node, message: "Variables should not be deleted."});
                 }
             }
         };

--- a/lib/rules/no-div-regex.js
+++ b/lib/rules/no-div-regex.js
@@ -29,7 +29,7 @@ module.exports = {
                 const token = sourceCode.getFirstToken(node);
 
                 if (token.type === "RegularExpression" && token.value[1] === "=") {
-                    context.report(node, "A regular expression literal can be confused with '/='.");
+                    context.report({node, message: "A regular expression literal can be confused with '/='."});
                 }
             }
         };

--- a/lib/rules/no-dupe-class-members.js
+++ b/lib/rules/no-dupe-class-members.js
@@ -101,7 +101,7 @@ module.exports = {
                 }
 
                 if (isDuplicate) {
-                    context.report(node, "Duplicate name '{{name}}'.", {name});
+                    context.report({node, message: "Duplicate name '{{name}}'.", data: {name}});
                 }
             }
         };

--- a/lib/rules/no-duplicate-case.js
+++ b/lib/rules/no-duplicate-case.js
@@ -32,7 +32,7 @@ module.exports = {
                     const key = sourceCode.getText(switchCase.test);
 
                     if (mapping[key]) {
-                        context.report(switchCase, "Duplicate case label.");
+                        context.report({node: switchCase, message: "Duplicate case label."});
                     } else {
                         mapping[key] = switchCase;
                     }

--- a/lib/rules/no-else-return.js
+++ b/lib/rules/no-else-return.js
@@ -33,7 +33,7 @@ module.exports = {
          * @returns {void}
          */
         function displayReport(node) {
-            context.report(node, "Unnecessary 'else' after 'return'.");
+            context.report({node, message: "Unnecessary 'else' after 'return'."});
         }
 
         /**

--- a/lib/rules/no-empty-character-class.js
+++ b/lib/rules/no-empty-character-class.js
@@ -47,7 +47,7 @@ module.exports = {
                 const token = sourceCode.getFirstToken(node);
 
                 if (token.type === "RegularExpression" && !regex.test(token.value)) {
-                    context.report(node, "Empty class.");
+                    context.report({node, message: "Empty class."});
                 }
             }
 

--- a/lib/rules/no-empty-pattern.js
+++ b/lib/rules/no-empty-pattern.js
@@ -23,12 +23,12 @@ module.exports = {
         return {
             ObjectPattern(node) {
                 if (node.properties.length === 0) {
-                    context.report(node, "Unexpected empty object pattern.");
+                    context.report({node, message: "Unexpected empty object pattern."});
                 }
             },
             ArrayPattern(node) {
                 if (node.elements.length === 0) {
-                    context.report(node, "Unexpected empty array pattern.");
+                    context.report({node, message: "Unexpected empty array pattern."});
                 }
             }
         };

--- a/lib/rules/no-empty.js
+++ b/lib/rules/no-empty.js
@@ -63,13 +63,13 @@ module.exports = {
                     return;
                 }
 
-                context.report(node, "Empty block statement.");
+                context.report({node, message: "Empty block statement."});
             },
 
             SwitchStatement(node) {
 
                 if (typeof node.cases === "undefined" || node.cases.length === 0) {
-                    context.report(node, "Empty switch statement.");
+                    context.report({node, message: "Empty switch statement."});
                 }
             }
         };

--- a/lib/rules/no-eq-null.js
+++ b/lib/rules/no-eq-null.js
@@ -30,7 +30,7 @@ module.exports = {
 
                 if (node.right.type === "Literal" && node.right.raw === "null" && badOperator ||
                         node.left.type === "Literal" && node.left.raw === "null" && badOperator) {
-                    context.report(node, "Use ‘===’ to compare with ‘null’.");
+                    context.report({node, message: "Use ‘===’ to compare with ‘null’."});
                 }
             }
         };

--- a/lib/rules/no-ex-assign.js
+++ b/lib/rules/no-ex-assign.js
@@ -31,9 +31,7 @@ module.exports = {
          */
         function checkVariable(variable) {
             astUtils.getModifyingReferences(variable.references).forEach(reference => {
-                context.report(
-                    reference.identifier,
-                    "Do not assign to the exception parameter.");
+                context.report({node: reference.identifier, message: "Do not assign to the exception parameter."});
             });
         }
 

--- a/lib/rules/no-func-assign.js
+++ b/lib/rules/no-func-assign.js
@@ -31,10 +31,7 @@ module.exports = {
          */
         function checkReference(references) {
             astUtils.getModifyingReferences(references).forEach(reference => {
-                context.report(
-                    reference.identifier,
-                    "'{{name}}' is a function.",
-                    {name: reference.identifier.name});
+                context.report({node: reference.identifier, message: "'{{name}}' is a function.", data: {name: reference.identifier.name}});
             });
         }
 

--- a/lib/rules/no-implicit-globals.js
+++ b/lib/rules/no-implicit-globals.js
@@ -32,7 +32,7 @@ module.exports = {
 
                     variable.defs.forEach(def => {
                         if (def.type === "FunctionName" || (def.type === "Variable" && def.parent.kind === "var")) {
-                            context.report(def.node, "Implicit global variable, assign as global property instead.");
+                            context.report({node: def.node, message: "Implicit global variable, assign as global property instead."});
                         }
                     });
                 });
@@ -45,7 +45,7 @@ module.exports = {
                     }
 
                     variable.defs.forEach(def => {
-                        context.report(def.node, "Implicit global variable, assign as global property instead.");
+                        context.report({node: def.node, message: "Implicit global variable, assign as global property instead."});
                     });
                 });
             }

--- a/lib/rules/no-implied-eval.js
+++ b/lib/rules/no-implied-eval.js
@@ -105,7 +105,7 @@ module.exports = {
                 // remove the entire substack, to avoid duplicate reports
                 const substack = impliedEvalAncestorsStack.pop();
 
-                context.report(substack[0], "Implied eval. Consider passing a function instead of a string.");
+                context.report({node: substack[0], message: "Implied eval. Consider passing a function instead of a string."});
             }
         }
 

--- a/lib/rules/no-inline-comments.js
+++ b/lib/rules/no-inline-comments.js
@@ -46,7 +46,7 @@ module.exports = {
 
             // Should be empty if there was only whitespace around the comment
             if (!isDirective && (preamble || postamble)) {
-                context.report(node, "Unexpected comment inline with code.");
+                context.report({node, message: "Unexpected comment inline with code."});
             }
         }
 

--- a/lib/rules/no-inner-declarations.js
+++ b/lib/rules/no-inner-declarations.js
@@ -63,14 +63,12 @@ module.exports = {
                     body.distance === 2);
 
             if (!valid) {
-                context.report(node, "Move {{type}} declaration to {{body}} root.",
-                    {
-                        type: (node.type === "FunctionDeclaration" ?
+                context.report({node, message: "Move {{type}} declaration to {{body}} root.", data: {
+                    type: (node.type === "FunctionDeclaration" ?
                             "function" : "variable"),
-                        body: (body.type === "Program" ?
+                    body: (body.type === "Program" ?
                             "program" : "function body")
-                    }
-                );
+                }});
             }
         }
 

--- a/lib/rules/no-invalid-this.js
+++ b/lib/rules/no-invalid-this.js
@@ -114,7 +114,7 @@ module.exports = {
                 const current = stack.getCurrent();
 
                 if (current && !current.valid) {
-                    context.report(node, "Unexpected 'this'.");
+                    context.report({node, message: "Unexpected 'this'."});
                 }
             }
         };

--- a/lib/rules/no-iterator.js
+++ b/lib/rules/no-iterator.js
@@ -29,7 +29,7 @@ module.exports = {
                 if (node.property &&
                         (node.property.type === "Identifier" && node.property.name === "__iterator__" && !node.computed) ||
                         (node.property.type === "Literal" && node.property.value === "__iterator__")) {
-                    context.report(node, "Reserved name '__iterator__'.");
+                    context.report({node, message: "Reserved name '__iterator__'."});
                 }
             }
         };

--- a/lib/rules/no-label-var.js
+++ b/lib/rules/no-label-var.js
@@ -57,7 +57,7 @@ module.exports = {
                 // Recursively find the identifier walking up the scope, starting
                 // with the innermost scope.
                 if (findIdentifier(scope, node.label.name)) {
-                    context.report(node, "Found identifier with same name as label.");
+                    context.report({node, message: "Found identifier with same name as label."});
                 }
             }
 

--- a/lib/rules/no-lone-blocks.js
+++ b/lib/rules/no-lone-blocks.js
@@ -34,10 +34,10 @@ module.exports = {
         function report(node) {
             const parent = context.getAncestors().pop();
 
-            context.report(node, parent.type === "Program" ?
+            context.report({node, message: parent.type === "Program" ?
                 "Block is redundant." :
                 "Nested block is redundant."
-            );
+            });
         }
 
         /**

--- a/lib/rules/no-loop-func.js
+++ b/lib/rules/no-loop-func.js
@@ -185,7 +185,7 @@ module.exports = {
             if (references.length > 0 &&
                 !references.every(isSafe.bind(null, node, loopNode))
             ) {
-                context.report(node, "Don't make functions within a loop.");
+                context.report({node, message: "Don't make functions within a loop."});
             }
         }
 

--- a/lib/rules/no-mixed-requires.js
+++ b/lib/rules/no-mixed-requires.js
@@ -205,15 +205,9 @@ module.exports = {
             VariableDeclaration(node) {
 
                 if (isMixed(node.declarations)) {
-                    context.report(
-                        node,
-                        "Do not mix 'require' and other declarations."
-                    );
+                    context.report({node, message: "Do not mix 'require' and other declarations."});
                 } else if (grouping && !isGrouped(node.declarations)) {
-                    context.report(
-                        node,
-                        "Do not mix core, module, file and computed requires."
-                    );
+                    context.report({node, message: "Do not mix core, module, file and computed requires."});
                 }
             }
         };

--- a/lib/rules/no-mixed-spaces-and-tabs.js
+++ b/lib/rules/no-mixed-spaces-and-tabs.js
@@ -132,7 +132,7 @@ module.exports = {
                             return;
                         }
 
-                        context.report(node, { line: lineNumber, column }, "Mixed spaces and tabs.");
+                        context.report({node, loc: { line: lineNumber, column }, message: "Mixed spaces and tabs."});
                     }
                 });
             }

--- a/lib/rules/no-multi-str.js
+++ b/lib/rules/no-multi-str.js
@@ -42,7 +42,7 @@ module.exports = {
                 const lineBreak = /\n/;
 
                 if (lineBreak.test(node.raw) && !isJSXElement(node.parent)) {
-                    context.report(node, "Multiline support is limited to browsers supporting ES5 only.");
+                    context.report({node, message: "Multiline support is limited to browsers supporting ES5 only."});
                 }
             }
         };

--- a/lib/rules/no-negated-condition.js
+++ b/lib/rules/no-negated-condition.js
@@ -69,12 +69,12 @@ module.exports = {
                 }
 
                 if (isNegatedIf(node)) {
-                    context.report(node, "Unexpected negated condition.");
+                    context.report({node, message: "Unexpected negated condition."});
                 }
             },
             ConditionalExpression(node) {
                 if (isNegatedIf(node)) {
-                    context.report(node, "Unexpected negated condition.");
+                    context.report({node, message: "Unexpected negated condition."});
                 }
             }
         };

--- a/lib/rules/no-negated-in-lhs.js
+++ b/lib/rules/no-negated-in-lhs.js
@@ -29,7 +29,7 @@ module.exports = {
 
             BinaryExpression(node) {
                 if (node.operator === "in" && node.left.type === "UnaryExpression" && node.left.operator === "!") {
-                    context.report(node, "The 'in' expression's left operand is negated.");
+                    context.report({node, message: "The 'in' expression's left operand is negated."});
                 }
             }
         };

--- a/lib/rules/no-nested-ternary.js
+++ b/lib/rules/no-nested-ternary.js
@@ -26,7 +26,7 @@ module.exports = {
             ConditionalExpression(node) {
                 if (node.alternate.type === "ConditionalExpression" ||
                         node.consequent.type === "ConditionalExpression") {
-                    context.report(node, "Do not nest ternary expressions.");
+                    context.report({node, message: "Do not nest ternary expressions."});
                 }
             }
         };

--- a/lib/rules/no-new-func.js
+++ b/lib/rules/no-new-func.js
@@ -34,7 +34,7 @@ module.exports = {
          */
         function validateCallee(node) {
             if (node.callee.name === "Function") {
-                context.report(node, "The Function constructor is eval.");
+                context.report({node, message: "The Function constructor is eval."});
             }
         }
 

--- a/lib/rules/no-new-object.js
+++ b/lib/rules/no-new-object.js
@@ -26,7 +26,7 @@ module.exports = {
 
             NewExpression(node) {
                 if (node.callee.name === "Object") {
-                    context.report(node, "The object literal notation {} is preferrable.");
+                    context.report({node, message: "The object literal notation {} is preferrable."});
                 }
             }
         };

--- a/lib/rules/no-new-require.js
+++ b/lib/rules/no-new-require.js
@@ -26,7 +26,7 @@ module.exports = {
 
             NewExpression(node) {
                 if (node.callee.type === "Identifier" && node.callee.name === "require") {
-                    context.report(node, "Unexpected use of new with require.");
+                    context.report({node, message: "Unexpected use of new with require."});
                 }
             }
         };

--- a/lib/rules/no-new-symbol.js
+++ b/lib/rules/no-new-symbol.js
@@ -32,7 +32,7 @@ module.exports = {
                         const node = ref.identifier;
 
                         if (node.parent && node.parent.type === "NewExpression") {
-                            context.report(node, "`Symbol` cannot be called as a constructor.");
+                            context.report({node, message: "`Symbol` cannot be called as a constructor."});
                         }
                     });
                 }

--- a/lib/rules/no-new-wrappers.js
+++ b/lib/rules/no-new-wrappers.js
@@ -28,7 +28,7 @@ module.exports = {
                 const wrapperObjects = ["String", "Number", "Boolean", "Math", "JSON"];
 
                 if (wrapperObjects.indexOf(node.callee.name) > -1) {
-                    context.report(node, "Do not use {{fn}} as a constructor.", { fn: node.callee.name });
+                    context.report({node, message: "Do not use {{fn}} as a constructor.", data: { fn: node.callee.name }});
                 }
             }
         };

--- a/lib/rules/no-new.js
+++ b/lib/rules/no-new.js
@@ -28,7 +28,7 @@ module.exports = {
             ExpressionStatement(node) {
 
                 if (node.expression.type === "NewExpression") {
-                    context.report(node, "Do not use 'new' for side effects.");
+                    context.report({node, message: "Do not use 'new' for side effects."});
                 }
             }
         };

--- a/lib/rules/no-obj-calls.js
+++ b/lib/rules/no-obj-calls.js
@@ -29,7 +29,7 @@ module.exports = {
                     const name = node.callee.name;
 
                     if (name === "Math" || name === "JSON" || name === "Reflect") {
-                        context.report(node, "'{{name}}' is not a function.", { name });
+                        context.report({node, message: "'{{name}}' is not a function.", data: { name }});
                     }
                 }
             }

--- a/lib/rules/no-octal-escape.js
+++ b/lib/rules/no-octal-escape.js
@@ -36,8 +36,7 @@ module.exports = {
 
                     // \0 is actually not considered an octal
                     if (match[2] !== "0" || typeof match[3] !== "undefined") {
-                        context.report(node, "Don't use octal: '\\{{octalDigit}}'. Use '\\u....' instead.",
-                                { octalDigit });
+                        context.report({node, message: "Don't use octal: '\\{{octalDigit}}'. Use '\\u....' instead.", data: { octalDigit }});
                     }
                 }
             }

--- a/lib/rules/no-octal.js
+++ b/lib/rules/no-octal.js
@@ -26,7 +26,7 @@ module.exports = {
 
             Literal(node) {
                 if (typeof node.value === "number" && /^0[0-7]/.test(node.raw)) {
-                    context.report(node, "Octal literals should not be used.");
+                    context.report({node, message: "Octal literals should not be used."});
                 }
             }
         };

--- a/lib/rules/no-param-reassign.js
+++ b/lib/rules/no-param-reassign.js
@@ -102,15 +102,9 @@ module.exports = {
                 (index === 0 || references[index - 1].identifier !== identifier)
             ) {
                 if (reference.isWrite()) {
-                    context.report(
-                        identifier,
-                        "Assignment to function parameter '{{name}}'.",
-                        {name: identifier.name});
+                    context.report({node: identifier, message: "Assignment to function parameter '{{name}}'.", data: {name: identifier.name}});
                 } else if (props && isModifyingProp(reference)) {
-                    context.report(
-                        identifier,
-                        "Assignment to property of function parameter '{{name}}'.",
-                        {name: identifier.name});
+                    context.report({node: identifier, message: "Assignment to property of function parameter '{{name}}'.", data: {name: identifier.name}});
                 }
             }
         }

--- a/lib/rules/no-path-concat.js
+++ b/lib/rules/no-path-concat.js
@@ -39,7 +39,7 @@ module.exports = {
                         (right.type === "Identifier" && MATCHER.test(right.name)))
                 ) {
 
-                    context.report(node, "Use path.join() or path.resolve() instead of + to create paths.");
+                    context.report({node, message: "Use path.join() or path.resolve() instead of + to create paths."});
                 }
             }
 

--- a/lib/rules/no-process-env.js
+++ b/lib/rules/no-process-env.js
@@ -28,7 +28,7 @@ module.exports = {
                     propertyName = node.property.name;
 
                 if (objectName === "process" && !node.computed && propertyName && propertyName === "env") {
-                    context.report(node, "Unexpected use of process.env.");
+                    context.report({node, message: "Unexpected use of process.env."});
                 }
 
             }

--- a/lib/rules/no-process-exit.js
+++ b/lib/rules/no-process-exit.js
@@ -33,7 +33,7 @@ module.exports = {
                 if (callee.type === "MemberExpression" && callee.object.name === "process" &&
                     callee.property.name === "exit"
                 ) {
-                    context.report(node, "Don't use process.exit(); throw an error instead.");
+                    context.report({node, message: "Don't use process.exit(); throw an error instead."});
                 }
             }
 

--- a/lib/rules/no-proto.js
+++ b/lib/rules/no-proto.js
@@ -29,7 +29,7 @@ module.exports = {
                 if (node.property &&
                         (node.property.type === "Identifier" && node.property.name === "__proto__" && !node.computed) ||
                         (node.property.type === "Literal" && node.property.value === "__proto__")) {
-                    context.report(node, "The '__proto__' property is deprecated.");
+                    context.report({node, message: "The '__proto__' property is deprecated."});
                 }
             }
         };

--- a/lib/rules/no-redeclare.js
+++ b/lib/rules/no-redeclare.js
@@ -48,10 +48,7 @@ module.exports = {
                     variable.identifiers.sort((a, b) => a.range[1] - b.range[1]);
 
                     for (let i = (hasBuiltin ? 0 : 1), l = variable.identifiers.length; i < l; i++) {
-                        context.report(
-                            variable.identifiers[i],
-                            "'{{a}}' is already defined.",
-                            {a: variable.name});
+                        context.report({node: variable.identifiers[i], message: "'{{a}}' is already defined.", data: {a: variable.name}});
                     }
                 }
             });

--- a/lib/rules/no-restricted-globals.js
+++ b/lib/rules/no-restricted-globals.js
@@ -40,9 +40,9 @@ module.exports = {
          * @private
          */
         function reportReference(reference) {
-            context.report(reference.identifier, "Unexpected use of '{{name}}'.", {
+            context.report({node: reference.identifier, message: "Unexpected use of '{{name}}'.", data: {
                 name: reference.identifier.name
-            });
+            }});
         }
 
         /**

--- a/lib/rules/no-restricted-properties.js
+++ b/lib/rules/no-restricted-properties.js
@@ -109,18 +109,18 @@ module.exports = {
             if (matchedObjectProperty) {
                 const message = matchedObjectProperty.message ? ` ${matchedObjectProperty.message}` : "";
 
-                context.report(node, "'{{objectName}}.{{propertyName}}' is restricted from being used.{{message}}", {
+                context.report({node, message: "'{{objectName}}.{{propertyName}}' is restricted from being used.{{message}}", data: {
                     objectName,
                     propertyName,
                     message
-                });
+                }});
             } else if (globalMatchedProperty) {
                 const message = globalMatchedProperty.message ? ` ${globalMatchedProperty.message}` : "";
 
-                context.report(node, "'{{propertyName}}' is restricted from being used.{{message}}", {
+                context.report({node, message: "'{{propertyName}}' is restricted from being used.{{message}}", data: {
                     propertyName,
                     message
-                });
+                }});
             }
         }
 

--- a/lib/rules/no-restricted-syntax.js
+++ b/lib/rules/no-restricted-syntax.js
@@ -38,7 +38,7 @@ module.exports = {
          * @returns {void}
          */
         function warn(node) {
-            context.report(node, "Using '{{type}}' is not allowed.", node);
+            context.report({node, message: "Using '{{type}}' is not allowed.", data: node});
         }
 
         return context.options.reduce((result, nodeType) => {

--- a/lib/rules/no-script-url.js
+++ b/lib/rules/no-script-url.js
@@ -31,7 +31,7 @@ module.exports = {
                     const value = node.value.toLowerCase();
 
                     if (value.indexOf("javascript:") === 0) {
-                        context.report(node, "Script URL is a form of eval.");
+                        context.report({node, message: "Script URL is a form of eval."});
                     }
                 }
             }

--- a/lib/rules/no-self-compare.js
+++ b/lib/rules/no-self-compare.js
@@ -31,7 +31,7 @@ module.exports = {
                 if (operators.indexOf(node.operator) > -1 &&
                     (node.left.type === "Identifier" && node.right.type === "Identifier" && node.left.name === node.right.name ||
                     node.left.type === "Literal" && node.right.type === "Literal" && node.left.value === node.right.value)) {
-                    context.report(node, "Comparing to itself is potentially pointless.");
+                    context.report({node, message: "Comparing to itself is potentially pointless."});
                 }
             }
         };

--- a/lib/rules/no-sequences.js
+++ b/lib/rules/no-sequences.js
@@ -101,7 +101,7 @@ module.exports = {
 
                 const child = sourceCode.getTokenAfter(node.expressions[0]);
 
-                context.report(node, child.loc.start, "Unexpected use of comma operator.");
+                context.report({node, loc: child.loc.start, message: "Unexpected use of comma operator."});
             }
         };
 

--- a/lib/rules/no-sparse-arrays.js
+++ b/lib/rules/no-sparse-arrays.js
@@ -33,7 +33,7 @@ module.exports = {
                 const emptySpot = node.elements.indexOf(null) > -1;
 
                 if (emptySpot) {
-                    context.report(node, "Unexpected comma in middle of array.");
+                    context.report({node, message: "Unexpected comma in middle of array."});
                 }
             }
 

--- a/lib/rules/no-tabs.js
+++ b/lib/rules/no-tabs.js
@@ -31,14 +31,10 @@ module.exports = {
                     const match = regex.exec(line);
 
                     if (match) {
-                        context.report(
-                            node,
-                            {
-                                line: index + 1,
-                                column: match.index + 1
-                            },
-                            "Unexpected tab character."
-                        );
+                        context.report({node, loc: {
+                            line: index + 1,
+                            column: match.index + 1
+                        }, message: "Unexpected tab character."});
                     }
                 });
             }

--- a/lib/rules/no-ternary.js
+++ b/lib/rules/no-ternary.js
@@ -25,7 +25,7 @@ module.exports = {
         return {
 
             ConditionalExpression(node) {
-                context.report(node, "Ternary operator used.");
+                context.report({node, message: "Ternary operator used."});
             }
 
         };

--- a/lib/rules/no-throw-literal.js
+++ b/lib/rules/no-throw-literal.js
@@ -65,10 +65,10 @@ module.exports = {
 
             ThrowStatement(node) {
                 if (!couldBeError(node.argument)) {
-                    context.report(node, "Expected an object to be thrown.");
+                    context.report({node, message: "Expected an object to be thrown."});
                 } else if (node.argument.type === "Identifier") {
                     if (node.argument.name === "undefined") {
-                        context.report(node, "Do not throw undefined.");
+                        context.report({node, message: "Do not throw undefined."});
                     }
                 }
 

--- a/lib/rules/no-undefined.js
+++ b/lib/rules/no-undefined.js
@@ -28,7 +28,7 @@ module.exports = {
                     const parent = context.getAncestors().pop();
 
                     if (!parent || parent.type !== "MemberExpression" || node !== parent.property || parent.computed) {
-                        context.report(node, "Unexpected use of undefined.");
+                        context.report({node, message: "Unexpected use of undefined."});
                     }
                 }
             }

--- a/lib/rules/no-unexpected-multiline.js
+++ b/lib/rules/no-unexpected-multiline.js
@@ -45,7 +45,7 @@ module.exports = {
             }
 
             if (openParen.loc.start.line !== nodeExpressionEnd.loc.end.line) {
-                context.report(node, openParen.loc.start, msg, { char: openParen.value });
+                context.report({node, loc: openParen.loc.start, message: msg, data: { char: openParen.value }});
             }
         }
 
@@ -66,7 +66,7 @@ module.exports = {
                 if (node.tag.loc.end.line === node.quasi.loc.start.line) {
                     return;
                 }
-                context.report(node, node.loc.start, TAGGED_TEMPLATE_MESSAGE);
+                context.report({node, loc: node.loc.start, message: TAGGED_TEMPLATE_MESSAGE});
             },
 
             CallExpression(node) {

--- a/lib/rules/no-unneeded-ternary.js
+++ b/lib/rules/no-unneeded-ternary.js
@@ -60,9 +60,9 @@ module.exports = {
 
             ConditionalExpression(node) {
                 if (isBooleanLiteral(node.alternate) && isBooleanLiteral(node.consequent)) {
-                    context.report(node, node.consequent.loc.start, "Unnecessary use of boolean literals in conditional expression.");
+                    context.report({node, loc: node.consequent.loc.start, message: "Unnecessary use of boolean literals in conditional expression."});
                 } else if (!defaultAssignment && matchesDefaultAssignment(node)) {
-                    context.report(node, node.consequent.loc.start, "Unnecessary use of conditional expression for default assignment.");
+                    context.report({node, loc: node.consequent.loc.start, message: "Unnecessary use of conditional expression for default assignment."});
                 }
             }
         };

--- a/lib/rules/no-unused-expressions.js
+++ b/lib/rules/no-unused-expressions.js
@@ -108,7 +108,7 @@ module.exports = {
         return {
             ExpressionStatement(node) {
                 if (!isValidExpression(node.expression) && !isDirective(node, context.getAncestors())) {
-                    context.report(node, "Expected an assignment or function call and instead saw an expression.");
+                    context.report({node, message: "Expected an assignment or function call and instead saw an expression."});
                 }
             }
         };

--- a/lib/rules/no-useless-call.js
+++ b/lib/rules/no-useless-call.js
@@ -96,10 +96,7 @@ module.exports = {
                 const thisArg = node.arguments[0];
 
                 if (isValidThisArg(expectedThis, thisArg, sourceCode)) {
-                    context.report(
-                        node,
-                        "unnecessary '.{{name}}()'.",
-                        {name: node.callee.property.name});
+                    context.report({node, message: "unnecessary '.{{name}}()'.", data: {name: node.callee.property.name}});
                 }
             }
         };

--- a/lib/rules/no-useless-concat.js
+++ b/lib/rules/no-useless-concat.js
@@ -93,10 +93,11 @@ module.exports = {
                         operatorToken = sourceCode.getTokenAfter(operatorToken);
                     }
 
-                    context.report(
+                    context.report({
                         node,
-                        operatorToken.loc.start,
-                        "Unexpected string concatenation of literals.");
+                        loc: operatorToken.loc.start,
+                        message: "Unexpected string concatenation of literals."
+                    });
                 }
             }
         };

--- a/lib/rules/no-void.js
+++ b/lib/rules/no-void.js
@@ -28,7 +28,7 @@ module.exports = {
         return {
             UnaryExpression(node) {
                 if (node.operator === "void") {
-                    context.report(node, "Expected 'undefined' and instead saw 'void'.");
+                    context.report({node, message: "Expected 'undefined' and instead saw 'void'."});
                 }
             }
         };

--- a/lib/rules/no-with.js
+++ b/lib/rules/no-with.js
@@ -24,7 +24,7 @@ module.exports = {
 
         return {
             WithStatement(node) {
-                context.report(node, "Unexpected use of 'with' statement.");
+                context.report({node, message: "Unexpected use of 'with' statement."});
             }
         };
 

--- a/lib/rules/object-shorthand.js
+++ b/lib/rules/object-shorthand.js
@@ -189,7 +189,7 @@ module.exports = {
 
                     // We have at least 1 shorthand property
                     if (shorthandProperties.length > 0) {
-                        context.report(node, "Unexpected mix of shorthand and non-shorthand properties.");
+                        context.report({node, message: "Unexpected mix of shorthand and non-shorthand properties."});
                     } else if (checkRedundancy) {
 
                         // If all properties of the object contain a method or value with a name matching it's key,
@@ -197,7 +197,7 @@ module.exports = {
                         const canAlwaysUseShorthand = properties.every(isRedundant);
 
                         if (canAlwaysUseShorthand) {
-                            context.report(node, "Expected shorthand for all properties.");
+                            context.report({node, message: "Expected shorthand for all properties."});
                         }
                     }
                 }

--- a/lib/rules/prefer-reflect.js
+++ b/lib/rules/prefer-reflect.js
@@ -83,10 +83,10 @@ module.exports = {
          * @returns {void}
          */
         function report(node, existing, substitute) {
-            context.report(node, "Avoid using {{existing}}, instead use {{substitute}}.", {
+            context.report({node, message: "Avoid using {{existing}}, instead use {{substitute}}.", data: {
                 existing,
                 substitute
-            });
+            }});
         }
 
         return {

--- a/lib/rules/require-jsdoc.js
+++ b/lib/rules/require-jsdoc.js
@@ -55,7 +55,7 @@ module.exports = {
          * @returns {void}
          */
         function report(node) {
-            context.report(node, "Missing JSDoc comment.");
+            context.report({node, message: "Missing JSDoc comment."});
         }
 
         /**

--- a/lib/rules/require-yield.js
+++ b/lib/rules/require-yield.js
@@ -48,9 +48,7 @@ module.exports = {
             const countYield = stack.pop();
 
             if (countYield === 0 && node.body.body.length > 0) {
-                context.report(
-                    node,
-                    "This generator function does not have 'yield'.");
+                context.report({node, message: "This generator function does not have 'yield'."});
             }
         }
 

--- a/lib/rules/sort-vars.js
+++ b/lib/rules/sort-vars.js
@@ -51,7 +51,7 @@ module.exports = {
                     }
 
                     if (currenVariableName < lastVariableName) {
-                        context.report(decl, "Variables within the same declaration block should be sorted alphabetically.");
+                        context.report({node: decl, message: "Variables within the same declaration block should be sorted alphabetically."});
                         return memo;
                     } else {
                         return decl;

--- a/lib/rules/strict.js
+++ b/lib/rules/strict.js
@@ -176,7 +176,7 @@ module.exports = {
 
             if (isStrict) {
                 if (!isSimpleParameterList(node.params)) {
-                    context.report(useStrictDirectives[0], messages.nonSimpleParameterList);
+                    context.report({node: useStrictDirectives[0], message: messages.nonSimpleParameterList});
                 } else if (isParentStrict) {
                     context.report({node: useStrictDirectives[0], message: messages.unnecessary, fix: getFixFunction(useStrictDirectives[0])});
                 } else if (isInClass) {
@@ -186,9 +186,9 @@ module.exports = {
                 reportAllExceptFirst(useStrictDirectives, messages.multiple, true);
             } else if (isParentGlobal) {
                 if (isSimpleParameterList(node.params)) {
-                    context.report(node, messages.function);
+                    context.report({node, message: messages.function});
                 } else {
-                    context.report(node, messages.wrap);
+                    context.report({node, message: messages.wrap});
                 }
             }
 
@@ -221,7 +221,7 @@ module.exports = {
                 if (isSimpleParameterList(node.params)) {
                     reportAll(useStrictDirectives, messages[mode], shouldFix(mode));
                 } else {
-                    context.report(useStrictDirectives[0], messages.nonSimpleParameterList);
+                    context.report({node: useStrictDirectives[0], message: messages.nonSimpleParameterList});
                     reportAllExceptFirst(useStrictDirectives, messages.multiple, true);
                 }
             }
@@ -237,7 +237,7 @@ module.exports = {
 
                 if (mode === "global") {
                     if (node.body.length > 0 && useStrictDirectives.length === 0) {
-                        context.report(node, messages.global);
+                        context.report({node, message: messages.global});
                     }
                     reportAllExceptFirst(useStrictDirectives, messages.multiple, true);
                 } else {

--- a/lib/rules/use-isnan.js
+++ b/lib/rules/use-isnan.js
@@ -25,7 +25,7 @@ module.exports = {
         return {
             BinaryExpression(node) {
                 if (/^(?:[<>]|[!=]=)=?$/.test(node.operator) && (node.left.name === "NaN" || node.right.name === "NaN")) {
-                    context.report(node, "Use the isNaN function to compare with NaN.");
+                    context.report({node, message: "Use the isNaN function to compare with NaN."});
                 }
             }
         };

--- a/lib/rules/valid-jsdoc.js
+++ b/lib/rules/valid-jsdoc.js
@@ -246,9 +246,9 @@ module.exports = {
                 } catch (ex) {
 
                     if (/braces/i.test(ex.message)) {
-                        context.report(jsdocNode, "JSDoc type missing brace.");
+                        context.report({node: jsdocNode, message: "JSDoc type missing brace."});
                     } else {
-                        context.report(jsdocNode, "JSDoc syntax error.");
+                        context.report({node: jsdocNode, message: "JSDoc syntax error."});
                     }
 
                     return;
@@ -262,15 +262,15 @@ module.exports = {
                         case "arg":
                         case "argument":
                             if (!tag.type) {
-                                context.report(jsdocNode, "Missing JSDoc parameter type for '{{name}}'.", { name: tag.name });
+                                context.report({node: jsdocNode, message: "Missing JSDoc parameter type for '{{name}}'.", data: { name: tag.name }});
                             }
 
                             if (!tag.description && requireParamDescription) {
-                                context.report(jsdocNode, "Missing JSDoc parameter description for '{{name}}'.", { name: tag.name });
+                                context.report({node: jsdocNode, message: "Missing JSDoc parameter description for '{{name}}'.", data: { name: tag.name }});
                             }
 
                             if (params[tag.name]) {
-                                context.report(jsdocNode, "Duplicate JSDoc parameter '{{name}}'.", { name: tag.name });
+                                context.report({node: jsdocNode, message: "Duplicate JSDoc parameter '{{name}}'.", data: { name: tag.name }});
                             } else if (tag.name.indexOf(".") === -1) {
                                 params[tag.name] = 1;
                             }
@@ -290,11 +290,11 @@ module.exports = {
                                 });
                             } else {
                                 if (requireReturnType && !tag.type) {
-                                    context.report(jsdocNode, "Missing JSDoc return type.");
+                                    context.report({node: jsdocNode, message: "Missing JSDoc return type."});
                                 }
 
                                 if (!isValidReturnType(tag) && !tag.description && requireReturnDescription) {
-                                    context.report(jsdocNode, "Missing JSDoc return description.");
+                                    context.report({node: jsdocNode, message: "Missing JSDoc return description."});
                                 }
                             }
 
@@ -324,7 +324,7 @@ module.exports = {
 
                     // check tag preferences
                     if (prefer.hasOwnProperty(tag.title) && tag.title !== prefer[tag.title]) {
-                        context.report(jsdocNode, "Use @{{name}} instead.", { name: prefer[tag.title] });
+                        context.report({node: jsdocNode, message: "Use @{{name}} instead.", data: { name: prefer[tag.title] }});
                     }
 
                     // validate the types
@@ -362,14 +362,14 @@ module.exports = {
                         // TODO(nzakas): Figure out logical things to do with destructured, default, rest params
                         if (param.type === "Identifier") {
                             if (jsdocParams[i] && (name !== jsdocParams[i])) {
-                                context.report(jsdocNode, "Expected JSDoc for '{{name}}' but found '{{jsdocName}}'.", {
+                                context.report({node: jsdocNode, message: "Expected JSDoc for '{{name}}' but found '{{jsdocName}}'.", data: {
                                     name,
                                     jsdocName: jsdocParams[i]
-                                });
+                                }});
                             } else if (!params[name] && !isOverride) {
-                                context.report(jsdocNode, "Missing JSDoc for parameter '{{name}}'.", {
+                                context.report({node: jsdocNode, message: "Missing JSDoc for parameter '{{name}}'.", data: {
                                     name
-                                });
+                                }});
                             }
                         }
                     });
@@ -379,7 +379,7 @@ module.exports = {
                     const regex = new RegExp(options.matchDescription);
 
                     if (!regex.test(jsdoc.description)) {
-                        context.report(jsdocNode, "JSDoc description does not satisfy the regex pattern.");
+                        context.report({node: jsdocNode, message: "JSDoc description does not satisfy the regex pattern."});
                     }
                 }
 

--- a/lib/rules/valid-typeof.js
+++ b/lib/rules/valid-typeof.js
@@ -62,10 +62,10 @@ module.exports = {
                             const value = sibling.type === "Literal" ? sibling.value : sibling.quasis[0].value.cooked;
 
                             if (VALID_TYPES.indexOf(value) === -1) {
-                                context.report(sibling, "Invalid typeof comparison value.");
+                                context.report({node: sibling, message: "Invalid typeof comparison value."});
                             }
                         } else if (requireStringLiterals && !isTypeofExpression(sibling)) {
-                            context.report(sibling, "Typeof comparisons should be to string literals.");
+                            context.report({node: sibling, message: "Typeof comparisons should be to string literals."});
                         }
                     }
                 }

--- a/lib/rules/vars-on-top.js
+++ b/lib/rules/vars-on-top.js
@@ -100,7 +100,7 @@ module.exports = {
          */
         function globalVarCheck(node, parent) {
             if (!isVarOnTop(node, parent.body)) {
-                context.report(node, errorMessage);
+                context.report({node, message: errorMessage});
             }
         }
 
@@ -115,7 +115,7 @@ module.exports = {
             if (!(/Function/.test(grandParent.type) &&
                     parent.type === "BlockStatement" &&
                     isVarOnTop(node, parent.body))) {
-                context.report(node, errorMessage);
+                context.report({node, message: errorMessage});
             }
         }
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This fixes the remaining instances of the old-style `context.report` API to the new style.

I made a [rule](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/master/docs/rules/no-deprecated-report-api.md) that checks for these calls and converts them automatically. We might want to add that plugin at some point, but not for at least a little while (that plugin isn't very stable yet). 

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
