### PR TITLE
Fix: Fix broken links in documentation

### DIFF
--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -2,7 +2,7 @@
 
 This guide is intended for those who wish to use ESLint as an end-user. If you're looking for how to extend ESLint or work with the ESLint source code, please see the [Developer Guide](../developer-guide).
 
-## [Getting Started](getting-started)
+## [Getting Started](getting-started.md)
 
 Want to skip ahead and just start using ESLint? This section gives a high-level overview of installation, setup, and configuration options.
 
@@ -10,22 +10,22 @@ Want to skip ahead and just start using ESLint? This section gives a high-level 
 
 ESLint has a lot of rules that you can configure to fine-tune it to your project. This section is an exhaustive list of every rule and link to each rule's documentation.
 
-## [Configuring](configuring)
+## [Configuring](configuring.md)
 
 Once you've got ESLint running, you'll probably want to adjust the configuration to better suit your project. This section explains all the different ways you can configure ESLint.
 
-## [Command Line Interface](command-line-interface)
+## [Command Line Interface](command-line-interface.md)
 
 There are a lot of command line flags for ESLint and this section explains what they do.
 
-## [Integrations](integrations)
+## [Integrations](integrations.md)
 
 Wondering if ESLint will work with your favorite editor or build system? This section has a list of all known integrations (submitted by their authors).
 
-## [Rule Deprecation](rule-deprecation)
+## [Rule Deprecation](rule-deprecation.md)
 
 The ESLint team is committed to making upgrading as easy and painless as possible. This section outlines the guidelines the team has set in place for the deprecation of rules in future releases.
 
-## [Migrating to 1.0.0](migrating-to-1.0.0)
+## [Migrating to 1.0.0](migrating-to-1.0.0.md)
 
 If you were using a version of ESLint prior to v1.0.0, this section helps you with the transition.


### PR DESCRIPTION
Documentation update/fix
This is small update fixing broken links in Markdown documentation.



