### PR TITLE
Update: fix no-useless-escape false negative with braces (fixes #7772)

### DIFF
--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -987,7 +987,7 @@ module.exports = (function() {
         }
 
         if (opts) {
-            message = message.replace(/\{\{\s*([^{}]+?)\s*\}\}/g, (fullMatch, term) => {
+            message = message.replace(/{{\s*([^{}]+?)\s*}}/g, (fullMatch, term) => {
                 if (term in opts) {
                     return opts[term];
                 }

--- a/lib/rules/keyword-spacing.js
+++ b/lib/rules/keyword-spacing.js
@@ -20,8 +20,8 @@ const PREV_TOKEN = /^[)\]}>]$/;
 const NEXT_TOKEN = /^(?:[([{<~!]|\+\+?|--?)$/;
 const PREV_TOKEN_M = /^[)\]}>*]$/;
 const NEXT_TOKEN_M = /^[{*]$/;
-const TEMPLATE_OPEN_PAREN = /\$\{$/;
-const TEMPLATE_CLOSE_PAREN = /^\}/;
+const TEMPLATE_OPEN_PAREN = /\${$/;
+const TEMPLATE_CLOSE_PAREN = /^}/;
 const CHECK_TYPE = /^(?:JSXElement|RegularExpression|String|Template)$/;
 const KEYS = keywords.concat(["as", "async", "await", "from", "get", "let", "of", "set", "yield"]);
 

--- a/lib/rules/no-template-curly-in-string.js
+++ b/lib/rules/no-template-curly-in-string.js
@@ -20,7 +20,7 @@ module.exports = {
     },
 
     create(context) {
-        const regex = /\$\{[^}]+\}/;
+        const regex = /\${[^}]+}/;
 
         return {
             Literal(node) {

--- a/lib/rules/no-useless-escape.js
+++ b/lib/rules/no-useless-escape.js
@@ -27,7 +27,7 @@ function union(setA, setB) {
 const VALID_STRING_ESCAPES = new Set("\\nrvtbfux\n\r\u2028\u2029");
 const REGEX_GENERAL_ESCAPES = new Set("\\bcdDfnrsStvwWxu0123456789");
 const REGEX_CHARCLASS_ESCAPES = union(REGEX_GENERAL_ESCAPES, new Set("]"));
-const REGEX_NON_CHARCLASS_ESCAPES = union(REGEX_GENERAL_ESCAPES, new Set("^/.$*+?[{}|()B"));
+const REGEX_NON_CHARCLASS_ESCAPES = union(REGEX_GENERAL_ESCAPES, new Set("^/.$*+?[|()B"));
 
 /**
 * Parses a regular expression into a list of characters with character class info.
@@ -39,36 +39,77 @@ const REGEX_NON_CHARCLASS_ESCAPES = union(REGEX_GENERAL_ESCAPES, new Set("^/.$*+
 *
 * returns:
 * [
-*   {text: 'a', index: 0, escaped: false, inCharClass: false, startsCharClass: false, endsCharClass: false},
-*   {text: 'b', index: 2, escaped: true, inCharClass: false, startsCharClass: false, endsCharClass: false},
-*   {text: 'c', index: 4, escaped: false, inCharClass: true, startsCharClass: true, endsCharClass: false},
-*   {text: 'd', index: 5, escaped: false, inCharClass: true, startsCharClass: false, endsCharClass: false},
-*   {text: '-', index: 6, escaped: false, inCharClass: true, startsCharClass: false, endsCharClass: false}
+*   {text: 'a', index: 0, escaped: false, inCharClass: false},
+*   {text: 'b', index: 2, escaped: true, inCharClass: false},
+*   {text: '[', index: 3, escaped: false, inCharClass: false},
+*   {text: 'c', index: 4, escaped: false, inCharClass: true},
+*   {text: 'd', index: 5, escaped: false, inCharClass: true},
+*   {text: '-', index: 6, escaped: false, inCharClass: true},
+*   {text: ']', index: 7, escaped: false, inCharClass: true}
 * ]
 */
 function parseRegExp(regExpText) {
     const charList = [];
 
     regExpText.split("").reduce((state, char, index) => {
-        if (!state.escapeNextChar) {
-            if (char === "\\") {
-                return Object.assign(state, { escapeNextChar: true });
-            }
-            if (char === "[" && !state.inCharClass) {
-                return Object.assign(state, { inCharClass: true, startingCharClass: true });
-            }
-            if (char === "]" && state.inCharClass) {
-                if (charList.length && charList[charList.length - 1].inCharClass) {
-                    charList[charList.length - 1].endsCharClass = true;
-                }
-                return Object.assign(state, { inCharClass: false, startingCharClass: false });
-            }
+        if (!state.escapeNextChar && char === "\\") {
+
+            // Backslashes used in escapes should not be included in the output list.
+            return Object.assign(state, { escapeNextChar: true });
         }
-        charList.push({ text: char, index, escaped: state.escapeNextChar, inCharClass: state.inCharClass, startsCharClass: state.startingCharClass, endsCharClass: false });
-        return Object.assign(state, { escapeNextChar: false, startingCharClass: false });
-    }, { escapeNextChar: false, inCharClass: false, startingCharClass: false });
+        charList.push({ text: char, index, escaped: state.escapeNextChar, inCharClass: state.inCharClass });
+        if (!state.escapeNextChar && char === "[") {
+            state.inCharClass = true;
+        }
+        if (!state.escapeNextChar && char === "]") {
+            state.inCharClass = false;
+        }
+        return Object.assign(state, { escapeNextChar: false });
+    }, { escapeNextChar: false, inCharClass: false });
 
     return charList;
+}
+
+/**
+* Determines whether the character at a given index is the first element in a character class
+* @param {Object[]} parsedRegExp A parsed regular expression, in the same format returned by parseRegExp
+* @param {number} charIndex The index of the character in the list
+* @returns {boolean} `true` if the character is the first element in a character class
+*/
+function startsCharClass(parsedRegExp, charIndex) {
+    return parsedRegExp[charIndex].inCharClass &&
+        !parsedRegExp[charIndex - 1].inCharClass &&
+        (parsedRegExp[charIndex].escaped || parsedRegExp[charIndex].text !== "]");
+}
+
+/**
+* Determines whether the character at a given index is the last element in a character class
+* @param {Object[]} parsedRegExp A parsed regular expression, in the same format returned by parseRegExp
+* @param {number} charIndex The index of the character in the list
+* @returns {boolean} `true` if the character is the last element in a character class
+*/
+function endsCharClass(parsedRegExp, charIndex) {
+    return parsedRegExp[charIndex].inCharClass &&
+        parsedRegExp[charIndex + 1].inCharClass &&
+        parsedRegExp[charIndex + 1].text === "]" &&
+        !parsedRegExp[charIndex + 1].escaped;
+}
+
+/**
+* Gets all matches of a regex on a string
+* @param {string} string The string
+* @param {RegExp} pattern A global regular expression
+* @returns {Array[]} A list of matches of the regex
+*/
+function matchAll(string, pattern) {
+    const matches = [];
+    let match;
+
+    while ((match = pattern.exec(string))) {
+        matches.push(match);
+    }
+
+    return matches;
 }
 
 module.exports = {
@@ -164,34 +205,43 @@ module.exports = {
                     return;
                 }
 
-                const value = isTemplateElement ? node.value.raw : node.raw.slice(1, -1);
-                const pattern = /\\[^\d]/g;
-                let match;
-
-                while ((match = pattern.exec(value))) {
-                    validateString(node, match);
-                }
+                matchAll(isTemplateElement ? node.value.raw : node.raw.slice(1, -1), /\\[^\d]/g)
+                    .forEach(match => validateString(node, match));
             } else if (node.regex) {
-                parseRegExp(node.regex.pattern)
+                const parsedRegExp = parseRegExp(node.regex.pattern);
+                const specialAllowedEscapes = new WeakSet();
 
-                    /*
-                     * The '-' character is a special case, because it's only valid to escape it if it's in a character
-                     * class, and is not at either edge of the character class. To account for this, don't consider '-'
-                     * characters to be valid in general, and filter out '-' characters that appear in the middle of a
-                     * character class.
-                     */
-                    .filter(charInfo => !(charInfo.text === "-" && charInfo.inCharClass && !charInfo.startsCharClass && !charInfo.endsCharClass))
+                parsedRegExp
 
-                    /*
-                     * The '^' character is also a special case; it must always be escaped outside of character classes, but
-                     * it only needs to be escaped in character classes if it's at the beginning of the character class. To
-                     * account for this, consider it to be a valid escape character outside of character classes, and filter
-                     * out '^' characters that appear at the start of a character class.
-                     */
-                    .filter(charInfo => !(charInfo.text === "^" && charInfo.startsCharClass))
+                    // Don't report '-' if it's in the middle of a character class.
+                    .filter((charInfo, index) => charInfo.text === "-" && charInfo.inCharClass && !startsCharClass(parsedRegExp, index) && !endsCharClass(parsedRegExp, index))
+                    .forEach(charInfo => specialAllowedEscapes.add(charInfo));
+
+                parsedRegExp
+
+                    // Don't report '^' if it's at the start of a character class. (It is already considered legal outside of a character class.)
+                    .filter((charInfo, index) => charInfo.text === "^" && startsCharClass(parsedRegExp, index))
+                    .forEach(charInfo => specialAllowedEscapes.add(charInfo));
+
+                // Detect quantifier groups such as `a{1,2}`
+                matchAll(parsedRegExp.map(charInfo => charInfo.text).join(""), /{\d+(,\d*)?}/g)
+                    .filter(match => !parsedRegExp[match.index].inCharClass)
+                    .forEach(match => {
+
+                        // Always allow the { to be escaped. If the { is not escaped, allow the } to be escaped.
+                        specialAllowedEscapes.add(parsedRegExp[match.index]);
+                        if (!parsedRegExp[match.index].escaped) {
+                            specialAllowedEscapes.add(parsedRegExp[match.index + match[0].length - 1]);
+                        }
+                    });
+
+                parsedRegExp
 
                     // Filter out characters that aren't escaped.
                     .filter(charInfo => charInfo.escaped)
+
+                    // Filter out characters that are determined to be allowed in special cases
+                    .filter(charInfo => !specialAllowedEscapes.has(charInfo))
 
                     // Filter out characters that are valid to escape, based on their position in the regular expression.
                     .filter(charInfo => !(charInfo.inCharClass ? REGEX_CHARCLASS_ESCAPES : REGEX_NON_CHARCLASS_ESCAPES).has(charInfo.text))

--- a/lib/rules/template-curly-spacing.js
+++ b/lib/rules/template-curly-spacing.js
@@ -15,8 +15,8 @@ const astUtils = require("../ast-utils");
 // Helpers
 //------------------------------------------------------------------------------
 
-const OPEN_PAREN = /\$\{$/;
-const CLOSE_PAREN = /^\}/;
+const OPEN_PAREN = /\${$/;
+const CLOSE_PAREN = /^}/;
 
 //------------------------------------------------------------------------------
 // Rule Definition

--- a/tests/lib/rules/no-useless-escape.js
+++ b/tests/lib/rules/no-useless-escape.js
@@ -30,7 +30,6 @@ ruleTester.run("no-useless-escape", rule, {
         "var foo = /\\\\/g",
         "var foo = /\\w\\$\\*\\./",
         "var foo = /\\^\\+\\./",
-        "var foo = /\\|\\}\\{\\./",
         "var foo = /]\\[\\(\\)\\//",
         "var foo = \"\\x123\"",
         "var foo = \"\\u00a9\"",
@@ -105,7 +104,25 @@ ruleTester.run("no-useless-escape", rule, {
         "var foo = /[\\0]/", // null character in character class
 
         "var foo = 'foo \\\u2028 bar'",
-        "var foo = 'foo \\\u2029 bar'"
+        "var foo = 'foo \\\u2029 bar'",
+
+        String.raw`/\{1}/`,
+        String.raw`/{1\}/`,
+        String.raw`/a\{1}/`,
+        String.raw`/a{1\}/`,
+        String.raw`/a\{1}/`,
+        String.raw`/a{1\}/`,
+        String.raw`/a\{1234}/`,
+        String.raw`/a{1234\}/`,
+        String.raw`/a\{1,}/`,
+        String.raw`/a{1,\}/`,
+        String.raw`/a\{1234,}/`,
+        String.raw`/a{1234,\}/`,
+        String.raw`/a\{1,2}/`,
+        String.raw`/a{1,2\}/`,
+        String.raw`/a{1234,2\}/`,
+        String.raw`/a{1,1234\}/`,
+        String.raw`/\\{a}/`,
     ],
 
     invalid: [
@@ -273,6 +290,143 @@ ruleTester.run("no-useless-escape", rule, {
             code: "`multiline template\nliteral with useless \\escape`",
             parserOptions: { ecmaVersion: 6 },
             errors: [{ line: 2, column: 22, message: "Unnecessary escape character: \\e.", type: "TemplateElement" }]
+        },
+        {
+            code: String.raw`/\{/`,
+            errors: [{ line: 1, column: 2, message: "Unnecessary escape character: \\{.", type: "Literal" }]
+        },
+        {
+            code: String.raw`/\{a}/`,
+            errors: [{ line: 1, column: 2, message: "Unnecessary escape character: \\{.", type: "Literal" }]
+        },
+        {
+            code: String.raw`/{a\}/`,
+            errors: [{ line: 1, column: 4, message: "Unnecessary escape character: \\}.", type: "Literal" }]
+        },
+        {
+            code: String.raw`/a\{1 }/`,
+            errors: [{ line: 1, column: 3, message: "Unnecessary escape character: \\{.", type: "Literal" }]
+        },
+        {
+            code: String.raw`/a\{ 1}/`,
+            errors: [{ line: 1, column: 3, message: "Unnecessary escape character: \\{.", type: "Literal" }]
+        },
+        {
+            code: String.raw`/a\{1, }/`,
+            errors: [{ line: 1, column: 3, message: "Unnecessary escape character: \\{.", type: "Literal" }]
+        },
+        {
+            code: String.raw`/a\{1, 2}/`,
+            errors: [{ line: 1, column: 3, message: "Unnecessary escape character: \\{.", type: "Literal" }]
+        },
+        {
+            code: String.raw`/a\{a}/`,
+            errors: [{ line: 1, column: 3, message: "Unnecessary escape character: \\{.", type: "Literal" }]
+        },
+        {
+            code: String.raw`/a{a\}/`,
+            errors: [{ line: 1, column: 5, message: "Unnecessary escape character: \\}.", type: "Literal" }]
+        },
+        {
+            code: String.raw`/[a\{1}]/`,
+            errors: [{ line: 1, column: 4, message: "Unnecessary escape character: \\{.", type: "Literal" }]
+        },
+        {
+            code: String.raw`/[a{1\}]/`,
+            errors: [{ line: 1, column: 6, message: "Unnecessary escape character: \\}.", type: "Literal" }]
+        },
+        {
+            code: String.raw`/a\{1,a}/`,
+            errors: [{ line: 1, column: 3, message: "Unnecessary escape character: \\{.", type: "Literal" }]
+        },
+        {
+            code: String.raw`/a{1,a\}/`,
+            errors: [{ line: 1, column: 7, message: "Unnecessary escape character: \\}.", type: "Literal" }]
+        },
+        {
+            code: String.raw`/a\{1a,}/`,
+            errors: [{ line: 1, column: 3, message: "Unnecessary escape character: \\{.", type: "Literal" }]
+        },
+        {
+            code: String.raw`/a{1a,\}/`,
+            errors: [{ line: 1, column: 7, message: "Unnecessary escape character: \\}.", type: "Literal" }]
+        },
+        {
+            code: String.raw`/a\{1a,1}/`,
+            errors: [{ line: 1, column: 3, message: "Unnecessary escape character: \\{.", type: "Literal" }]
+        },
+        {
+            code: String.raw`/a\{1,2,}/`,
+            errors: [{ line: 1, column: 3, message: "Unnecessary escape character: \\{.", type: "Literal" }]
+        },
+        {
+            code: String.raw`/a\{1,2,}/`,
+            errors: [{ line: 1, column: 3, message: "Unnecessary escape character: \\{.", type: "Literal" }]
+        },
+        {
+            code: String.raw`/a{1,2,\}/`,
+            errors: [{ line: 1, column: 8, message: "Unnecessary escape character: \\}.", type: "Literal" }]
+        },
+        {
+            code: String.raw`/[a\{1]}/`,
+            errors: [{ line: 1, column: 4, message: "Unnecessary escape character: \\{.", type: "Literal" }]
+        },
+        {
+            code: String.raw`/[a{1]\}/`,
+            errors: [{ line: 1, column: 7, message: "Unnecessary escape character: \\}.", type: "Literal" }]
+        },
+        {
+            code: String.raw`/a[\{1]}/`,
+            errors: [{ line: 1, column: 4, message: "Unnecessary escape character: \\{.", type: "Literal" }]
+        },
+        {
+            code: String.raw`/a{1[\}]/`,
+            errors: [{ line: 1, column: 6, message: "Unnecessary escape character: \\}.", type: "Literal" }]
+        },
+        {
+            code: String.raw`/a{1[]\}/`,
+            errors: [{ line: 1, column: 7, message: "Unnecessary escape character: \\}.", type: "Literal" }]
+        },
+        {
+            code: String.raw`/a\{[1]}/`,
+            errors: [{ line: 1, column: 3, message: "Unnecessary escape character: \\{.", type: "Literal" }]
+        },
+        {
+            code: String.raw`/a{[1]\}/`,
+            errors: [{ line: 1, column: 7, message: "Unnecessary escape character: \\}.", type: "Literal" }]
+        },
+        {
+            code: String.raw`/a\{1[],}/`,
+            errors: [{ line: 1, column: 3, message: "Unnecessary escape character: \\{.", type: "Literal" }]
+        },
+        {
+            code: String.raw`/a\{1[],}/`,
+            errors: [{ line: 1, column: 3, message: "Unnecessary escape character: \\{.", type: "Literal" }]
+        },
+
+        // If a regex has two violations, but their fixes would be mutually exclusive, only report the second violation.
+        {
+            code: String.raw`/a\{1\}/`,
+            errors: [{ line: 1, column: 6, message: "Unnecessary escape character: \\}.", type: "Literal" }]
+        },
+        {
+            code: String.raw`/a\{1,\}/`,
+            errors: [{ line: 1, column: 7, message: "Unnecessary escape character: \\}.", type: "Literal" }]
+        },
+        {
+            code: String.raw`/a\{1,2\}/`,
+            errors: [{ line: 1, column: 8, message: "Unnecessary escape character: \\}.", type: "Literal" }]
+        },
+        {
+            code: String.raw`/a\\\{1,2\}/`,
+            errors: [{ line: 1, column: 10, message: "Unnecessary escape character: \\}.", type: "Literal" }]
+        },
+        {
+            code: String.raw`/\|\}\{\./`,
+            errors: [
+                { line: 1, column: 4, message: "Unnecessary escape character: \\}.", type: "Literal" },
+                { line: 1, column: 6, message: "Unnecessary escape character: \\{.", type: "Literal" }
+            ]
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (see https://github.com/eslint/eslint/issues/7772)

**What changes did you make? (Give an overview)**

This updates `no-useless-escape` to detect when escaped `{` and `}` are used in the position of regex quantifiers, and report them if they appear anywhere else in a regular expression. Previously, the rule just allowed `{` and `}` anywhere in regular expressions (outside of character classes).

This required updating the return value of the internal `parseRegExp` function to include square brackets that mark the boundary of character classes. Otherwise, there would be no way to detect empty character classes to distinguish between cases like `/foo\{1[]}/` and `/foo\{1}/` based on the return value of that function.

In cases like the line below, where both the `{` and the `}` are escaped, the rule only reports the `}` and not the `{`. Even though the two escapes are both independently useless, I think it would be unexpected for the rule to report two errors here, because only one of them can be removed without changing the meaning of the expression.

```js
/a\{1\}/;
```

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.
