### PR TITLE
Docs: fix unclear example for no-useless-escape

### DIFF
--- a/docs/rules/no-useless-escape.md
+++ b/docs/rules/no-useless-escape.md
@@ -45,7 +45,7 @@ Examples of **correct** code for this rule:
 `$\{${foo}\}`;
 /\\/g;
 /\t/g;
-/\\w\\$\\*\\^\\./;
+/\w\$\*\^\./;
 
 ```
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update

**What changes did you make? (Give an overview)**

This updates a `no-useless-escape` docs example to remove (what I think is) accidental escaping.

Technically both versions would be correct, but I think the updated version more clearly indicates what the rule is doing.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular

