### PR TITLE
Fix: `semi` false positive before regex/template literals (fixes #7782)

### DIFF
--- a/lib/rules/semi.js
+++ b/lib/rules/semi.js
@@ -53,7 +53,7 @@ module.exports = {
 
     create(context) {
 
-        const OPT_OUT_PATTERN = /^[-[(/+]$/; // One of [(/+-, but not ++ or --
+        const OPT_OUT_PATTERN = /^[-[(/+`]/; // One of [(/+-`
         const options = context.options[1];
         const never = context.options[0] === "never",
             exceptOneLine = options && options.omitLastInOneLineBlock === true,
@@ -127,7 +127,7 @@ module.exports = {
 
             const lastTokenLine = lastToken.loc.end.line;
             const nextTokenLine = nextToken.loc.start.line;
-            const isOptOutToken = OPT_OUT_PATTERN.test(nextToken.value);
+            const isOptOutToken = OPT_OUT_PATTERN.test(nextToken.value) && nextToken.value !== "++" && nextToken.value !== "--";
             const isDivider = (nextToken.value === "}" || nextToken.value === ";");
 
             return (lastTokenLine !== nextTokenLine && !isOptOutToken) || isDivider;

--- a/tests/lib/rules/semi.js
+++ b/tests/lib/rules/semi.js
@@ -92,8 +92,11 @@ ruleTester.run("semi", rule, {
         { code: "export default foo = 42", options: ["never"], parserOptions: { sourceType: "module" } },
         { code: "export default foo += 42", options: ["never"], parserOptions: { sourceType: "module" } },
         { code: "++\nfoo;", options: ["always"] },
-        { code: "var a = b;\n+ c", options: ["never"] }
+        { code: "var a = b;\n+ c", options: ["never"] },
 
+        // https://github.com/eslint/eslint/issues/7782
+        { code: "var a = b;\n/foo/.test(c)", options: ["never"] },
+        { code: "var a = b;\n`foo`", options: ["never"], parserOptions: { ecmaVersion: 6 } }
     ],
     invalid: [
         { code: "import * as utils from './utils'", output: "import * as utils from './utils';", parserOptions: { sourceType: "module" }, errors: [{ message: "Missing semicolon.", type: "ImportDeclaration", column: 33 }] },


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (see https://github.com/eslint/eslint/issues/7782)

**What changes did you make? (Give an overview)**

This updates `semi` to detect template literals and regular expressions correctly.

This should not get reported as an error:

```js
/* eslint semi: [error, "never"] */

var foo = 1; // semicolon is required here, otherwise this would be a tagged template.
`bar`

var baz = 1; // semicolon is required here, otherwise this would be parsed as division.
/qux/
```

Previously, the rule was detecting `/` characters, but it was only looking for a single-character token with the value `'/'`, due to a bug in the logic that handles `++` and `--` tokens. The rule was not detecting `` ` `` characters at all.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular