### PR TITLE
Fix: Relax no-useless-escape's handling of ']' in regexes (fixes #7789)

### DIFF
--- a/lib/rules/no-useless-escape.js
+++ b/lib/rules/no-useless-escape.js
@@ -25,8 +25,7 @@ function union(setA, setB) {
 }
 
 const VALID_STRING_ESCAPES = new Set("\\nrvtbfux\n\r\u2028\u2029");
-const REGEX_GENERAL_ESCAPES = new Set("\\bcdDfnrsStvwWxu0123456789");
-const REGEX_CHARCLASS_ESCAPES = union(REGEX_GENERAL_ESCAPES, new Set("]"));
+const REGEX_GENERAL_ESCAPES = new Set("\\bcdDfnrsStvwWxu0123456789]");
 const REGEX_NON_CHARCLASS_ESCAPES = union(REGEX_GENERAL_ESCAPES, new Set("^/.$*+?[{}|()B"));
 
 /**
@@ -194,7 +193,7 @@ module.exports = {
                     .filter(charInfo => charInfo.escaped)
 
                     // Filter out characters that are valid to escape, based on their position in the regular expression.
-                    .filter(charInfo => !(charInfo.inCharClass ? REGEX_CHARCLASS_ESCAPES : REGEX_NON_CHARCLASS_ESCAPES).has(charInfo.text))
+                    .filter(charInfo => !(charInfo.inCharClass ? REGEX_GENERAL_ESCAPES : REGEX_NON_CHARCLASS_ESCAPES).has(charInfo.text))
 
                     // Report all the remaining characters.
                     .forEach(charInfo => report(node, charInfo.index, charInfo.text));

--- a/tests/lib/rules/no-useless-escape.js
+++ b/tests/lib/rules/no-useless-escape.js
@@ -105,7 +105,15 @@ ruleTester.run("no-useless-escape", rule, {
         "var foo = /[\\0]/", // null character in character class
 
         "var foo = 'foo \\\u2028 bar'",
-        "var foo = 'foo \\\u2029 bar'"
+        "var foo = 'foo \\\u2029 bar'",
+
+        // https://github.com/eslint/eslint/issues/7789
+        String.raw`/]/`,
+        String.raw`/\]/`,
+        { code: String.raw`/\]/u`, parserOptions: { ecmaVersion: 6 } },
+        String.raw`var foo = /foo\]/`,
+        String.raw`var foo = /[[]\]/`, // A character class containing '[', followed by a ']' character
+        String.raw`var foo = /\[foo\.bar\]/`
     ],
 
     invalid: [
@@ -236,18 +244,6 @@ ruleTester.run("no-useless-escape", rule, {
         {
             code: String.raw`var foo = /[\[]/`,
             errors: [{ line: 1, column: 13, message: "Unnecessary escape character: \\[.", type: "Literal" }]
-        },
-        {
-            code: String.raw`var foo = /foo\]/`,
-            errors: [{ line: 1, column: 15, message: "Unnecessary escape character: \\].", type: "Literal" }]
-        },
-        {
-            code: String.raw`var foo = /[[]\]/`, // A character class containing '[', followed by a ']' character
-            errors: [{ line: 1, column: 15, message: "Unnecessary escape character: \\].", type: "Literal" }]
-        },
-        {
-            code: String.raw`var foo = /\[foo\.bar\]/`, // Matches the literal string '[foo.bar]'
-            errors: [{ line: 1, column: 22, message: "Unnecessary escape character: \\].", type: "Literal" }]
         },
         {
             code: String.raw`var foo = /[\/]/`, // A character class containing '/'


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (see https://github.com/eslint/eslint/issues/7789)

**What changes did you make? (Give an overview)**

']' is only allowed to be unescaped in regular expressions when the engine implements Annex B, a legacy part of the ECMA262 spec which is only normative for browsers. In engines that do not implement Annex B, regular expressions like /]/ are a syntax error. Since ESLint can't tell what engine the code will run on, it shouldn't consider escaping ] to be "useless" since it's only useless on engines that implement Annex B, and only in regular expressions that don't contain the unicode flag. (For example, the regular expression /]/u is a syntax error even on engines that implement Annex B.)

This updates `no-useless-escape` to avoid reporting escaped `]` in regular expressions.

Also see: https://github.com/eslint/eslint/issues/7656#issuecomment-267878150, https://github.com/eslint/eslint/issues/7789

**Is there anything you'd like reviewers to focus on?**

I'd appreciate if someone could verify that this is the right solution. I was also against relaxing this before I realized that the `]` behavior was only specified in Annex B. I've requested a review from @mysticatea and @platinumazure since we've discussed this behavior in the past.