### PR TITLE
Chore: replace unnecessary function callbacks with arrow functions

### DIFF
--- a/lib/config/config-ops.js
+++ b/lib/config/config-ops.js
@@ -267,8 +267,6 @@ module.exports = {
      * @returns {boolean} `true` if the configuration has valid severity.
      */
     isEverySeverityValid(config) {
-        return Object.keys(config).every(function(ruleId) {
-            return this.isValidSeverity(config[ruleId]);
-        }, this);
+        return Object.keys(config).every(ruleId => this.isValidSeverity(config[ruleId]));
     }
 };

--- a/lib/config/environments.js
+++ b/lib/config/environments.js
@@ -65,9 +65,9 @@ module.exports = {
      */
     importPlugin(plugin, pluginName) {
         if (plugin.environments) {
-            Object.keys(plugin.environments).forEach(function(envName) {
+            Object.keys(plugin.environments).forEach(envName => {
                 this.define(`${pluginName}/${envName}`, plugin.environments[envName]);
-            }, this);
+            });
         }
     },
 

--- a/lib/util/source-code.js
+++ b/lib/util/source-code.js
@@ -124,9 +124,9 @@ function SourceCode(text, ast) {
     // create token store methods
     const tokenStore = createTokenStore(ast.tokens);
 
-    Object.keys(tokenStore).forEach(function(methodName) {
+    Object.keys(tokenStore).forEach(methodName => {
         this[methodName] = tokenStore[methodName];
-    }, this);
+    });
 
     const tokensAndCommentsStore = createTokenStore(this.tokensAndComments);
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

**What changes did you make? (Give an overview)**

These cases were not caught when we enabled the `prefer-arrow-callback` rule because they use `this`, but the `this`-binding is unnecessary because these functions are called with the binding of the outer scope.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular