### PR TITLE
Fix: consistent-return shouldn't report class constructors (fixes #7790)

### DIFF
--- a/lib/rules/consistent-return.js
+++ b/lib/rules/consistent-return.js
@@ -33,6 +33,18 @@ function isUnreachable(segment) {
     return !segment.reachable;
 }
 
+/**
+* Checks whether a given node is a `constructor` method in an ES6 class
+* @param {ASTNode} node A node to check
+* @returns {boolean} `true` if the node is a `constructor` method
+*/
+function isClassConstructor(node) {
+    return node.type === "FunctionExpression" &&
+        node.parent &&
+        node.parent.type === "MethodDefinition" &&
+        node.parent.kind === "constructor";
+}
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -77,7 +89,8 @@ module.exports = {
              */
             if (!funcInfo.hasReturnValue ||
                 funcInfo.codePath.currentSegments.every(isUnreachable) ||
-                astUtils.isES5Constructor(node)
+                astUtils.isES5Constructor(node) ||
+                isClassConstructor(node)
             ) {
                 return;
             }

--- a/tests/lib/rules/consistent-return.js
+++ b/tests/lib/rules/consistent-return.js
@@ -38,7 +38,11 @@ ruleTester.run("consistent-return", rule, {
         { code: "function foo() { if (true) return void 0; else return; }", options: [{ treatUndefinedAsUnspecified: true }] },
         { code: "function foo() { if (true) return void 0; else return undefined; }", options: [{ treatUndefinedAsUnspecified: true }] },
         { code: "var x = () => {  return {}; };", parserOptions: { ecmaVersion: 6 } },
-        { code: "if (true) { return 1; } return 0;", parserOptions: { ecmaVersion: 6, ecmaFeatures: { globalReturn: true } } }
+        { code: "if (true) { return 1; } return 0;", parserOptions: { ecmaVersion: 6, ecmaFeatures: { globalReturn: true } } },
+
+        // https://github.com/eslint/eslint/issues/7790
+        { code: "class Foo { constructor() { if (true) return foo; } }", parserOptions: { ecmaVersion: 6 } },
+        { code: "var Foo = class { constructor() { if (true) return foo; } }", parserOptions: { ecmaVersion: 6 } },
     ],
 
     invalid: [
@@ -233,6 +237,28 @@ ruleTester.run("consistent-return", rule, {
                     message: "Expected to return a value at the end of this program.",
                     type: "Program",
                     column: 1
+                }
+            ]
+        },
+        {
+            code: "class A { CapitalizedFunction() { if (a) return true; } }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    message: "Expected to return a value at the end of this method.",
+                    type: "FunctionExpression",
+                    column: 11
+                }
+            ]
+        },
+        {
+            code: "({ constructor() { if (a) return true; } });",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    message: "Expected to return a value at the end of this method.",
+                    type: "FunctionExpression",
+                    column: 4
                 }
             ]
         }


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (see https://github.com/eslint/eslint/issues/7790)

**What changes did you make? (Give an overview)**

This updates `consistent-return` to avoid reporting inconsistent returns in the `constructor` function of a `ClassExpression` or `ClassDeclaration`. The rule already ignores ES5 constructor functions, but it hadn't been updated to account for ES6 constructors yet.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular