### PR TITLE
Docs: Wrap placeholder sample in {% raw %}

### DIFF
--- a/docs/developer-guide/working-with-rules.md
+++ b/docs/developer-guide/working-with-rules.md
@@ -154,6 +154,7 @@ The node contains all of the information necessary to figure out the line and co
 You can also use placeholders in the message and provide `data`:
 
 ```js
+{% raw %}
 context.report({
     node: node,
     message: "Unexpected identifier: {{ identifier }}",
@@ -161,6 +162,7 @@ context.report({
         identifier: node.name
     }
 });
+{% endraw %}
 ```
 
 Note that leading and trailing whitespace is optional in message parameters.


### PR DESCRIPTION
**What is the purpose of this pull request?**
Documentation update

**What changes did you make? (Give an overview)**
The placeholder sample on http://eslint.org/docs/developer-guide/working-with-rules is actually missing the placeholder, as it's being interpreted as a variable by the site builder:

![](http://ss.dan.cx/2016/12/chrome_20-16.35.19.png)

This code snippet was correctly marked as "raw" for `working-with-rules-deprecated.md` (in #6551) but the same change wasn't applied to the non-deprecated version.