### PR TITLE
Docs: Remove .html extensions from links in developer-guide

### DIFF
--- a/docs/developer-guide/README.md
+++ b/docs/developer-guide/README.md
@@ -14,27 +14,27 @@ In order to work with ESLint as a developer, it's recommended that:
 
 If that sounds like you, then continue reading to get started.
 
-## Section 1: Get the [Source Code](source-code.html)
+## Section 1: Get the [Source Code](source-code)
 
 Before you can get started, you'll need to get a copy of the ESLint source code. This section explains how to do that and a little about the source code structure.
 
-## Section 2: Set up a [Development Environment](development-environment.html)
+## Section 2: Set up a [Development Environment](development-environment)
 
 Developing for ESLint is a bit different than running it on the command line. This section shows you how to set up a development environment and get you ready to write code.
 
-## Section 3: Run the [Unit Tests](unit-tests.html)
+## Section 3: Run the [Unit Tests](unit-tests)
 
 There are a lot of unit tests included with ESLint to make sure that we're keeping on top of code quality. This section explains how to run the unit tests.
 
-## Section 4: [Working with Rules](working-with-rules.html)
+## Section 4: [Working with Rules](working-with-rules)
 
 You're finally ready to start working with rules. You may want to fix an existing rule or create a new one. This section explains how to do all of that.
 
-## Section 5: [Working with Plugins](working-with-plugins.html)
+## Section 5: [Working with Plugins](working-with-plugins)
 
 You've developed library-specific rules for ESLint and you want to share it with the community. You can publish an ESLint plugin on npm.
 
-## Section 6: [Node.js API](nodejs-api.html)
+## Section 6: [Node.js API](nodejs-api)
 
 If you're interested in writing a tool that uses ESLint, then you can use the Node.js API to get programmatic access to functionality.
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Removed .html extensions from links in the main developer-guide page, to conform to how we write links in other documentation pages.

**Is there anything you'd like reviewers to focus on?**

Not really.