### PR TITLE
Update: add fixer for object-property-newline (fixes #7740)

### DIFF
--- a/docs/rules/object-property-newline.md
+++ b/docs/rules/object-property-newline.md
@@ -1,5 +1,7 @@
 # enforce placing object properties on separate lines (object-property-newline)
 
+(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 While formatting preferences are very personal, a number of style guides require that object properties be placed on separate lines for better readability.
 
 Another argument in favor of this style is that it improves the readability of diffs when a property is changed:

--- a/lib/rules/object-property-newline.js
+++ b/lib/rules/object-property-newline.js
@@ -64,7 +64,16 @@ module.exports = {
                             node,
                             loc: firstTokenOfCurrentProperty.loc.start,
                             message: errorMessage,
-                            fix: fixer => fixer.insertTextBefore(node.properties[i], "\n")
+                            fix(fixer) {
+                                const comma = sourceCode.getTokenBefore(firstTokenOfCurrentProperty);
+                                const rangeAfterComma = [comma.range[1], firstTokenOfCurrentProperty.range[0]];
+
+                                if (sourceCode.text.slice(rangeAfterComma[0], rangeAfterComma[1]).trim()) {
+                                    return null;
+                                }
+
+                                return fixer.replaceTextRange(rangeAfterComma, "\n");
+                            }
                         });
                     }
                 }

--- a/lib/rules/object-property-newline.js
+++ b/lib/rules/object-property-newline.js
@@ -68,6 +68,7 @@ module.exports = {
                                 const comma = sourceCode.getTokenBefore(firstTokenOfCurrentProperty);
                                 const rangeAfterComma = [comma.range[1], firstTokenOfCurrentProperty.range[0]];
 
+                                // Don't perform a fix if there are any comments between the comma and the next property.
                                 if (sourceCode.text.slice(rangeAfterComma[0], rangeAfterComma[1]).trim()) {
                                     return null;
                                 }

--- a/lib/rules/object-property-newline.js
+++ b/lib/rules/object-property-newline.js
@@ -27,7 +27,9 @@ module.exports = {
                 },
                 additionalProperties: false
             }
-        ]
+        ],
+
+        fixable: "whitespace"
     },
 
     create(context) {
@@ -61,7 +63,8 @@ module.exports = {
                         context.report({
                             node,
                             loc: firstTokenOfCurrentProperty.loc.start,
-                            message: errorMessage
+                            message: errorMessage,
+                            fix: fixer => fixer.insertTextBefore(node.properties[i], "\n")
                         });
                     }
                 }

--- a/tests/lib/rules/object-property-newline.js
+++ b/tests/lib/rules/object-property-newline.js
@@ -64,6 +64,7 @@ ruleTester.run("object-property-newline", rule, {
         // default-case
         {
             code: "var obj = { k1: 'val1', k2: 'val2', k3: 'val3' };",
+            output: "var obj = { k1: 'val1', \nk2: 'val2', \nk3: 'val3' };",
             errors: [
                 {
                     message: "Object properties must go on a new line.",
@@ -81,6 +82,7 @@ ruleTester.run("object-property-newline", rule, {
         },
         {
             code: "var obj = {\nk1: 'val1', k2: 'val2'\n};",
+            output: "var obj = {\nk1: 'val1', \nk2: 'val2'\n};",
             errors: [
                 {
                     message: "Object properties must go on a new line.",
@@ -92,6 +94,7 @@ ruleTester.run("object-property-newline", rule, {
         },
         {
             code: "var obj = {\nk1: 'val1', k2: 'val2',\nk3: 'val3', k4: 'val4'\n};",
+            output: "var obj = {\nk1: 'val1', \nk2: 'val2',\nk3: 'val3', \nk4: 'val4'\n};",
             errors: [
                 {
                     message: "Object properties must go on a new line.",
@@ -109,6 +112,7 @@ ruleTester.run("object-property-newline", rule, {
         },
         {
             code: "var obj = { k1: 'val1', [\nk2]: 'val2' };",
+            output: "var obj = { k1: 'val1', \n[\nk2]: 'val2' };",
             parserOptions: { ecmaVersion: 6 },
             errors: [
                 {
@@ -121,6 +125,7 @@ ruleTester.run("object-property-newline", rule, {
         },
         {
             code: "var obj = { k1: 'val1', ...{} };",
+            output: "var obj = { k1: 'val1', \n...{} };",
             parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },
             errors: [
                 {
@@ -133,6 +138,7 @@ ruleTester.run("object-property-newline", rule, {
         },
         {
             code: "var obj = {\nk1: 'val1', ...{}\n};",
+            output: "var obj = {\nk1: 'val1', \n...{}\n};",
             parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },
             errors: [
                 {
@@ -145,6 +151,7 @@ ruleTester.run("object-property-newline", rule, {
         },
         {
             code: "foo({ k1: 'val1', k2: 'val2' });",
+            output: "foo({ k1: 'val1', \nk2: 'val2' });",
             errors: [
                 {
                     message: "Object properties must go on a new line.",
@@ -156,6 +163,7 @@ ruleTester.run("object-property-newline", rule, {
         },
         {
             code: "foo({\nk1: 'val1', k2: 'val2'\n});",
+            output: "foo({\nk1: 'val1', \nk2: 'val2'\n});",
             errors: [
                 {
                     message: "Object properties must go on a new line.",
@@ -167,6 +175,7 @@ ruleTester.run("object-property-newline", rule, {
         },
         {
             code: "foo({ a, b });",
+            output: "foo({ a, \nb });",
             parserOptions: { ecmaVersion: 6 },
             errors: [
                 {
@@ -179,6 +188,7 @@ ruleTester.run("object-property-newline", rule, {
         },
         {
             code: "foo({\na, b\n});",
+            output: "foo({\na, \nb\n});",
             parserOptions: { ecmaVersion: 6 },
             errors: [
                 {
@@ -191,6 +201,7 @@ ruleTester.run("object-property-newline", rule, {
         },
         {
             code: "foo({\nbar() {}, baz\n});",
+            output: "foo({\nbar() {}, \nbaz\n});",
             parserOptions: { ecmaVersion: 6 },
             errors: [
                 {
@@ -203,6 +214,7 @@ ruleTester.run("object-property-newline", rule, {
         },
         {
             code: "foo({\n[bar]: 'baz', baz\n})",
+            output: "foo({\n[bar]: 'baz', \nbaz\n})",
             parserOptions: { ecmaVersion: 6 },
             errors: [
                 {
@@ -215,6 +227,7 @@ ruleTester.run("object-property-newline", rule, {
         },
         {
             code: "foo({ k1: 'val1', [\nk2]: 'val2' })",
+            output: "foo({ k1: 'val1', \n[\nk2]: 'val2' })",
             parserOptions: { ecmaVersion: 6 },
             errors: [
                 {
@@ -227,6 +240,7 @@ ruleTester.run("object-property-newline", rule, {
         },
         {
             code: "foo({ k1: 'val1', ...{} })",
+            output: "foo({ k1: 'val1', \n...{} })",
             parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },
             errors: [
                 {
@@ -239,6 +253,7 @@ ruleTester.run("object-property-newline", rule, {
         },
         {
             code: "foo({\nk1: 'val1', ...{}\n})",
+            output: "foo({\nk1: 'val1', \n...{}\n})",
             parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },
             errors: [
                 {
@@ -251,6 +266,7 @@ ruleTester.run("object-property-newline", rule, {
         },
         {
             code: "var obj = {\na: {\nb: 1,\nc: 2\n}, d: 2\n};",
+            output: "var obj = {\na: {\nb: 1,\nc: 2\n}, \nd: 2\n};",
             errors: [
                 {
                     message: "Object properties must go on a new line.",
@@ -264,6 +280,7 @@ ruleTester.run("object-property-newline", rule, {
         // allowMultiplePropertiesPerLine: true
         {
             code: "var obj = {\nk1: 'val1',\nk2: 'val2', k3: 'val3'\n};",
+            output: "var obj = {\nk1: 'val1',\nk2: 'val2', \nk3: 'val3'\n};",
             options: [{ allowMultiplePropertiesPerLine: true }],
             errors: [
                 {
@@ -276,6 +293,7 @@ ruleTester.run("object-property-newline", rule, {
         },
         {
             code: "var obj = { [\nk1]: 'val1', k2: 'val2' };",
+            output: "var obj = { [\nk1]: 'val1', \nk2: 'val2' };",
             options: [{ allowMultiplePropertiesPerLine: true }],
             parserOptions: { ecmaVersion: 6 },
             errors: [
@@ -289,6 +307,7 @@ ruleTester.run("object-property-newline", rule, {
         },
         {
             code: "var obj = {\nk1: 'val1',\nk2: 'val2', ...{}\n};",
+            output: "var obj = {\nk1: 'val1',\nk2: 'val2', \n...{}\n};",
             options: [{ allowMultiplePropertiesPerLine: true }],
             parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },
             errors: [
@@ -302,6 +321,7 @@ ruleTester.run("object-property-newline", rule, {
         },
         {
             code: "var obj = {\n...{},\nk1: 'val1', k2: 'val2'\n};",
+            output: "var obj = {\n...{},\nk1: 'val1', \nk2: 'val2'\n};",
             options: [{ allowMultiplePropertiesPerLine: true }],
             parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },
             errors: [
@@ -315,6 +335,7 @@ ruleTester.run("object-property-newline", rule, {
         },
         {
             code: "foo({ [\nk1]: 'val1', k2: 'val2' })",
+            output: "foo({ [\nk1]: 'val1', \nk2: 'val2' })",
             options: [{ allowMultiplePropertiesPerLine: true }],
             parserOptions: { ecmaVersion: 6 },
             errors: [
@@ -328,6 +349,7 @@ ruleTester.run("object-property-newline", rule, {
         },
         {
             code: "foo({\nk1: 'val1',\nk2: 'val2', ...{}\n})",
+            output: "foo({\nk1: 'val1',\nk2: 'val2', \n...{}\n})",
             options: [{ allowMultiplePropertiesPerLine: true }],
             parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },
             errors: [
@@ -341,6 +363,7 @@ ruleTester.run("object-property-newline", rule, {
         },
         {
             code: "foo({\n...{},\nk1: 'val1', k2: 'val2'\n})",
+            output: "foo({\n...{},\nk1: 'val1', \nk2: 'val2'\n})",
             options: [{ allowMultiplePropertiesPerLine: true }],
             parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },
             errors: [

--- a/tests/lib/rules/object-property-newline.js
+++ b/tests/lib/rules/object-property-newline.js
@@ -64,7 +64,7 @@ ruleTester.run("object-property-newline", rule, {
         // default-case
         {
             code: "var obj = { k1: 'val1', k2: 'val2', k3: 'val3' };",
-            output: "var obj = { k1: 'val1', \nk2: 'val2', \nk3: 'val3' };",
+            output: "var obj = { k1: 'val1',\nk2: 'val2',\nk3: 'val3' };",
             errors: [
                 {
                     message: "Object properties must go on a new line.",
@@ -82,7 +82,7 @@ ruleTester.run("object-property-newline", rule, {
         },
         {
             code: "var obj = {\nk1: 'val1', k2: 'val2'\n};",
-            output: "var obj = {\nk1: 'val1', \nk2: 'val2'\n};",
+            output: "var obj = {\nk1: 'val1',\nk2: 'val2'\n};",
             errors: [
                 {
                     message: "Object properties must go on a new line.",
@@ -94,7 +94,7 @@ ruleTester.run("object-property-newline", rule, {
         },
         {
             code: "var obj = {\nk1: 'val1', k2: 'val2',\nk3: 'val3', k4: 'val4'\n};",
-            output: "var obj = {\nk1: 'val1', \nk2: 'val2',\nk3: 'val3', \nk4: 'val4'\n};",
+            output: "var obj = {\nk1: 'val1',\nk2: 'val2',\nk3: 'val3',\nk4: 'val4'\n};",
             errors: [
                 {
                     message: "Object properties must go on a new line.",
@@ -112,7 +112,7 @@ ruleTester.run("object-property-newline", rule, {
         },
         {
             code: "var obj = { k1: 'val1', [\nk2]: 'val2' };",
-            output: "var obj = { k1: 'val1', \n[\nk2]: 'val2' };",
+            output: "var obj = { k1: 'val1',\n[\nk2]: 'val2' };",
             parserOptions: { ecmaVersion: 6 },
             errors: [
                 {
@@ -125,7 +125,7 @@ ruleTester.run("object-property-newline", rule, {
         },
         {
             code: "var obj = { k1: 'val1', ...{} };",
-            output: "var obj = { k1: 'val1', \n...{} };",
+            output: "var obj = { k1: 'val1',\n...{} };",
             parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },
             errors: [
                 {
@@ -138,7 +138,7 @@ ruleTester.run("object-property-newline", rule, {
         },
         {
             code: "var obj = {\nk1: 'val1', ...{}\n};",
-            output: "var obj = {\nk1: 'val1', \n...{}\n};",
+            output: "var obj = {\nk1: 'val1',\n...{}\n};",
             parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },
             errors: [
                 {
@@ -151,7 +151,7 @@ ruleTester.run("object-property-newline", rule, {
         },
         {
             code: "foo({ k1: 'val1', k2: 'val2' });",
-            output: "foo({ k1: 'val1', \nk2: 'val2' });",
+            output: "foo({ k1: 'val1',\nk2: 'val2' });",
             errors: [
                 {
                     message: "Object properties must go on a new line.",
@@ -163,7 +163,7 @@ ruleTester.run("object-property-newline", rule, {
         },
         {
             code: "foo({\nk1: 'val1', k2: 'val2'\n});",
-            output: "foo({\nk1: 'val1', \nk2: 'val2'\n});",
+            output: "foo({\nk1: 'val1',\nk2: 'val2'\n});",
             errors: [
                 {
                     message: "Object properties must go on a new line.",
@@ -175,7 +175,7 @@ ruleTester.run("object-property-newline", rule, {
         },
         {
             code: "foo({ a, b });",
-            output: "foo({ a, \nb });",
+            output: "foo({ a,\nb });",
             parserOptions: { ecmaVersion: 6 },
             errors: [
                 {
@@ -188,7 +188,7 @@ ruleTester.run("object-property-newline", rule, {
         },
         {
             code: "foo({\na, b\n});",
-            output: "foo({\na, \nb\n});",
+            output: "foo({\na,\nb\n});",
             parserOptions: { ecmaVersion: 6 },
             errors: [
                 {
@@ -201,7 +201,7 @@ ruleTester.run("object-property-newline", rule, {
         },
         {
             code: "foo({\nbar() {}, baz\n});",
-            output: "foo({\nbar() {}, \nbaz\n});",
+            output: "foo({\nbar() {},\nbaz\n});",
             parserOptions: { ecmaVersion: 6 },
             errors: [
                 {
@@ -214,7 +214,7 @@ ruleTester.run("object-property-newline", rule, {
         },
         {
             code: "foo({\n[bar]: 'baz', baz\n})",
-            output: "foo({\n[bar]: 'baz', \nbaz\n})",
+            output: "foo({\n[bar]: 'baz',\nbaz\n})",
             parserOptions: { ecmaVersion: 6 },
             errors: [
                 {
@@ -227,7 +227,7 @@ ruleTester.run("object-property-newline", rule, {
         },
         {
             code: "foo({ k1: 'val1', [\nk2]: 'val2' })",
-            output: "foo({ k1: 'val1', \n[\nk2]: 'val2' })",
+            output: "foo({ k1: 'val1',\n[\nk2]: 'val2' })",
             parserOptions: { ecmaVersion: 6 },
             errors: [
                 {
@@ -240,7 +240,7 @@ ruleTester.run("object-property-newline", rule, {
         },
         {
             code: "foo({ k1: 'val1', ...{} })",
-            output: "foo({ k1: 'val1', \n...{} })",
+            output: "foo({ k1: 'val1',\n...{} })",
             parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },
             errors: [
                 {
@@ -253,7 +253,7 @@ ruleTester.run("object-property-newline", rule, {
         },
         {
             code: "foo({\nk1: 'val1', ...{}\n})",
-            output: "foo({\nk1: 'val1', \n...{}\n})",
+            output: "foo({\nk1: 'val1',\n...{}\n})",
             parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },
             errors: [
                 {
@@ -266,7 +266,7 @@ ruleTester.run("object-property-newline", rule, {
         },
         {
             code: "var obj = {\na: {\nb: 1,\nc: 2\n}, d: 2\n};",
-            output: "var obj = {\na: {\nb: 1,\nc: 2\n}, \nd: 2\n};",
+            output: "var obj = {\na: {\nb: 1,\nc: 2\n},\nd: 2\n};",
             errors: [
                 {
                     message: "Object properties must go on a new line.",
@@ -280,7 +280,7 @@ ruleTester.run("object-property-newline", rule, {
         // allowMultiplePropertiesPerLine: true
         {
             code: "var obj = {\nk1: 'val1',\nk2: 'val2', k3: 'val3'\n};",
-            output: "var obj = {\nk1: 'val1',\nk2: 'val2', \nk3: 'val3'\n};",
+            output: "var obj = {\nk1: 'val1',\nk2: 'val2',\nk3: 'val3'\n};",
             options: [{ allowMultiplePropertiesPerLine: true }],
             errors: [
                 {
@@ -293,7 +293,7 @@ ruleTester.run("object-property-newline", rule, {
         },
         {
             code: "var obj = { [\nk1]: 'val1', k2: 'val2' };",
-            output: "var obj = { [\nk1]: 'val1', \nk2: 'val2' };",
+            output: "var obj = { [\nk1]: 'val1',\nk2: 'val2' };",
             options: [{ allowMultiplePropertiesPerLine: true }],
             parserOptions: { ecmaVersion: 6 },
             errors: [
@@ -307,7 +307,7 @@ ruleTester.run("object-property-newline", rule, {
         },
         {
             code: "var obj = {\nk1: 'val1',\nk2: 'val2', ...{}\n};",
-            output: "var obj = {\nk1: 'val1',\nk2: 'val2', \n...{}\n};",
+            output: "var obj = {\nk1: 'val1',\nk2: 'val2',\n...{}\n};",
             options: [{ allowMultiplePropertiesPerLine: true }],
             parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },
             errors: [
@@ -321,7 +321,7 @@ ruleTester.run("object-property-newline", rule, {
         },
         {
             code: "var obj = {\n...{},\nk1: 'val1', k2: 'val2'\n};",
-            output: "var obj = {\n...{},\nk1: 'val1', \nk2: 'val2'\n};",
+            output: "var obj = {\n...{},\nk1: 'val1',\nk2: 'val2'\n};",
             options: [{ allowMultiplePropertiesPerLine: true }],
             parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },
             errors: [
@@ -335,7 +335,7 @@ ruleTester.run("object-property-newline", rule, {
         },
         {
             code: "foo({ [\nk1]: 'val1', k2: 'val2' })",
-            output: "foo({ [\nk1]: 'val1', \nk2: 'val2' })",
+            output: "foo({ [\nk1]: 'val1',\nk2: 'val2' })",
             options: [{ allowMultiplePropertiesPerLine: true }],
             parserOptions: { ecmaVersion: 6 },
             errors: [
@@ -349,7 +349,7 @@ ruleTester.run("object-property-newline", rule, {
         },
         {
             code: "foo({\nk1: 'val1',\nk2: 'val2', ...{}\n})",
-            output: "foo({\nk1: 'val1',\nk2: 'val2', \n...{}\n})",
+            output: "foo({\nk1: 'val1',\nk2: 'val2',\n...{}\n})",
             options: [{ allowMultiplePropertiesPerLine: true }],
             parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },
             errors: [
@@ -363,7 +363,7 @@ ruleTester.run("object-property-newline", rule, {
         },
         {
             code: "foo({\n...{},\nk1: 'val1', k2: 'val2'\n})",
-            output: "foo({\n...{},\nk1: 'val1', \nk2: 'val2'\n})",
+            output: "foo({\n...{},\nk1: 'val1',\nk2: 'val2'\n})",
             options: [{ allowMultiplePropertiesPerLine: true }],
             parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },
             errors: [
@@ -372,6 +372,30 @@ ruleTester.run("object-property-newline", rule, {
                     type: "ObjectExpression",
                     line: 3,
                     column: 13
+                }
+            ]
+        },
+        {
+            code: "({ foo: 1 /* comment */, bar: 2 })",
+            output: "({ foo: 1 /* comment */,\nbar: 2 })", // not fixed due to comment
+            errors: [
+                {
+                    message: "Object properties must go on a new line.",
+                    type: "ObjectExpression",
+                    line: 1,
+                    column: 26
+                }
+            ]
+        },
+        {
+            code: "({ foo: 1, /* comment */ bar: 2 })",
+            output: "({ foo: 1, /* comment */ bar: 2 })", // not fixed due to comment
+            errors: [
+                {
+                    message: "Object properties must go on a new line.",
+                    type: "ObjectExpression",
+                    line: 1,
+                    column: 26
                 }
             ]
         }

--- a/tests/lib/rules/object-property-newline.js
+++ b/tests/lib/rules/object-property-newline.js
@@ -377,7 +377,7 @@ ruleTester.run("object-property-newline", rule, {
         },
         {
             code: "({ foo: 1 /* comment */, bar: 2 })",
-            output: "({ foo: 1 /* comment */,\nbar: 2 })", // not fixed due to comment
+            output: "({ foo: 1 /* comment */,\nbar: 2 })",
             errors: [
                 {
                     message: "Object properties must go on a new line.",


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Add autofixing to a rule

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This adds an autofixer for [`object-property-newline`](http://eslint.org/docs/rules/object-property-newline), as described in https://github.com/eslint/eslint/issues/7740.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular