### PR TITLE
Add support for DOTFILES_PATH environment variable

### DIFF
--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -57,6 +57,7 @@ const CONFIG_FILES = [
     ".eslintrc",
     "package.json"
 ];
+const DOTFILES_PATH = process.env.DOTFILES_PATH || "";
 
 const resolver = new ModuleResolver();
 
@@ -564,7 +565,7 @@ module.exports = {
      */
     getFilenameForDirectory(directory) {
         for (let i = 0, len = CONFIG_FILES.length; i < len; i++) {
-            const filename = path.join(directory, CONFIG_FILES[i]);
+            const filename = path.join(directory, DOTFILES_PATH, CONFIG_FILES[i]);
 
             if (shell.test("-f", filename)) {
                 return filename;


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

**What changes did you make? (Give an overview)**

The purpose of this edit is to provide a commonly accepted environment variable used by the JavaScript/npm scripts where to look for their dotfiles (config files).

This is an attempt to resolve the problem with the high number of "dotfiles" stored in the root directory of the projects.

**Is there anything you'd like reviewers to focus on?**

I don't expect this PR to be merged, but I wanted to raise attention to the problem and see if you have feedbacks.

There's a related PR in the Babel repository:
https://github.com/babel/babel/pull/5039