### PR TITLE
Docs: update outdated info in Architecture page

### DIFF
--- a/docs/developer-guide/architecture.md
+++ b/docs/developer-guide/architecture.md
@@ -8,7 +8,7 @@ At a high level, there are a few key parts to ESLint:
 
 ## The `cli` object
 
-The `cli` object is the API for the command line interface. Literally, the `bin/eslint.js` file simply passes arguments to the `cli` object and then calls `process.exit()` with the returned exit code.
+The `cli` object is the API for the command line interface. Literally, the `bin/eslint.js` file simply passes arguments to the `cli` object and then sets `process.exitCode` to the returned exit code.
 
 The main method is `cli.execute()`, which accepts an array of strings that represent the command line options (as if `process.argv` were passed without the first two arguments). If you want to run ESLint from inside of another program and have it act like the CLI, then `cli` is the object to use.
 
@@ -50,7 +50,7 @@ This object may not:
 
 The main method of the `eslint` object is `verify()` and accepts two arguments: the source text to verify and a configuration object (the baked configuration of the given configuration file plus command line options). The method first parses the given text with `espree` (or whatever the configured parser is) and retrieves the AST. The AST is produced with both line/column and range locations which are useful for reporting location of issues and retrieving the source text related to an AST node, respectively.
 
-Once the AST is available, `estraverse` is used to traverse the AST from top to bottom. At each node, the `eslint` object emits an event that has the same name as the node type (i.e., "Identifier", "WithStatement", etc.). On the way back up the subtree, an event is emitted with the AST type name and suffixed with ":after", such as "Identifier:after" - this allows rules to take action both on the way down and on the way up in the traversal. Each event is emitted with the appropriate AST node available.
+Once the AST is available, `estraverse` is used to traverse the AST from top to bottom. At each node, the `eslint` object emits an event that has the same name as the node type (i.e., "Identifier", "WithStatement", etc.). On the way back up the subtree, an event is emitted with the AST type name and suffixed with ":exit", such as "Identifier:exit" - this allows rules to take action both on the way down and on the way up in the traversal. Each event is emitted with the appropriate AST node available.
 
 This object's responsibilities include:
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

* The `cli` description stated that `bin/eslint.js` calls `process.exit()`, but this is no longer correct (this changed in 759525e1b0dffa44d8aa9f073d8f709ea4bbb794).
* The `eslint` description stated that the traverser emits events with the `:after` suffix when exiting nodes, but it actually emits events with the `:exit` suffix (this changed in f1f453d9370ca522e9765c7731e13d3c4fb75be1).

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
