### PR TITLE
Fix: check require-jsdoc for FunctionExpression by let and const

### DIFF
--- a/lib/rules/require-jsdoc.js
+++ b/lib/rules/require-jsdoc.js
@@ -93,7 +93,9 @@ module.exports = {
                 }
             },
             FunctionExpression(node) {
-                if (options.MethodDefinition) {
+                if (options.FunctionDeclaration && node.parent.type === "VariableDeclarator") {
+                    checkJsDoc(node);
+                } else if (options.MethodDefinition) {
                     checkClassMethodJsDoc(node);
                 }
             },

--- a/tests/lib/rules/require-jsdoc.js
+++ b/tests/lib/rules/require-jsdoc.js
@@ -192,7 +192,37 @@ ruleTester.run("require-jsdoc", rule, {
                     ArrowFunctionExpression: true
                 }
             }]
-        }
+        },
+        {
+            code:
+            "/**\n" +
+            " * Foo description\n" +
+            " */\n" +
+            "const foo = function bar(fooParam) {\n" +
+            "    return fooParam;\n" +
+            "};\n",
+            parserOptions: { ecmaVersion: 6 },
+            options: [{
+                require: {
+                    FunctionDeclaration: true
+                }
+            }]
+        },
+        {
+            code:
+            "/**\n" +
+            " * Foo description\n" +
+            " */\n" +
+            "let foo = function bar(fooParam) {\n" +
+            "    return fooParam;\n" +
+            "};\n",
+            parserOptions: { ecmaVersion: 6 },
+            options: [{
+                require: {
+                    FunctionDeclaration: true
+                }
+            }]
+        },
     ],
 
     invalid: [
@@ -341,6 +371,38 @@ ruleTester.run("require-jsdoc", rule, {
             errors: [{
                 message: "Missing JSDoc comment.",
                 type: "ArrowFunctionExpression"
+            }]
+        },
+        {
+            code:
+            "const foo = function bar(fooParam) {\n" +
+            "    return fooParam;\n" +
+            "};\n",
+            parserOptions: { ecmaVersion: 6 },
+            options: [{
+                require: {
+                    FunctionDeclaration: true
+                }
+            }],
+            errors: [{
+                message: "Missing JSDoc comment.",
+                type: "FunctionExpression"
+            }]
+        },
+        {
+            code:
+            "let foo = function bar(fooParam) {\n" +
+            "    return fooParam;\n" +
+            "};\n",
+            parserOptions: { ecmaVersion: 6 },
+            options: [{
+                require: {
+                    FunctionDeclaration: true
+                }
+            }],
+            errors: [{
+                message: "Missing JSDoc comment.",
+                type: "FunctionExpression"
             }]
         },
     ]


### PR DESCRIPTION
Signed-off-by: Octavian Ionescu <itavyg@gmail.com>

**What is the purpose of this pull request? (put an "X" next to item)**

[ x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

**What changes did you make? (Give an overview)**

fixed the check for rule 'require-jsdoc'  when const/let are used for FunctionExpression declaration

**Is there anything you'd like reviewers to focus on?**
if there is needed to duplicate for const/let the tests that are defined for 'var'
