### PR TITLE
Adapt new-paren rule so that it can handle TypeScript

### DIFF
--- a/tests/fixtures/fixture-parser.js
+++ b/tests/fixtures/fixture-parser.js
@@ -1,0 +1,16 @@
+"use strict";
+
+const path = require("path");
+
+/**
+ * Gets the path to the specified parser.
+ *
+ * @param {string[]} arguments - The path containing the parser.
+ * @returns {string} The path to the specified parser.
+ */
+module.exports = function parser() {
+    const parts = Array.from(arguments);
+    const name = parts.pop();
+
+    return path.resolve(__dirname, "parsers", parts.join(path.sep), `${name}.js`);
+};

--- a/tests/fixtures/parsers/typescript-parsers/new-parens.js
+++ b/tests/fixtures/parsers/typescript-parsers/new-parens.js
@@ -1,0 +1,136 @@
+"use strict";
+
+// new Storage<RootState>('state');
+
+exports.parse = () => ({
+    type: "Program",
+    range: [0, 32],
+    loc: {
+        start: { line: 1, column: 0 },
+        end: { line: 1, column: 32 }
+    },
+    body: [
+        {
+            type: "ExpressionStatement",
+            range: [0, 32],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 32 }
+            },
+            expression: {
+                type: "NewExpression",
+                range: [0, 31],
+                loc: {
+                    start: { line: 1, column: 0 },
+                    end: { line: 1, column: 31 }
+                },
+                callee: {
+                    type: "Identifier",
+                    range: [4, 11],
+                    loc: {
+                        start: { line: 1, column: 4 },
+                        end: { line: 1, column: 11 }
+                    },
+                    name: "Storage"
+                },
+                arguments: [
+                    {
+                        type: "Literal",
+                        range: [23, 30],
+                        loc: {
+                            start: { line: 1, column: 23 },
+                            end: { line: 1, column: 30 }
+                        },
+                        value: "state",
+                        raw: "'state'"
+                    }
+                ]
+            }
+        }
+    ],
+    sourceType: "script",
+    tokens: [
+        {
+            type: "Keyword",
+            value: "new",
+            range: [0, 3],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 3 }
+            }
+        },
+        {
+            type: "Identifier",
+            value: "Storage",
+            range: [4, 11],
+            loc: {
+                start: { line: 1, column: 4 },
+                end: { line: 1, column: 11 }
+            }
+        },
+        {
+            type: "Punctuator",
+            value: "<",
+            range: [11, 12],
+            loc: {
+                start: { line: 1, column: 11 },
+                end: { line: 1, column: 12 }
+            }
+        },
+        {
+            type: "Identifier",
+            value: "RootState",
+            range: [12, 21],
+            loc: {
+                start: { line: 1, column: 12 },
+                end: { line: 1, column: 21 }
+            }
+        },
+        {
+            type: "Punctuator",
+            value: ">",
+            range: [21, 22],
+            loc: {
+                start: { line: 1, column: 21 },
+                end: { line: 1, column: 22 }
+            }
+        },
+        {
+            type: "Punctuator",
+            value: "(",
+            range: [22, 23],
+            loc: {
+                start: { line: 1, column: 22 },
+                end: { line: 1, column: 23 }
+            }
+        },
+        {
+            type: "String",
+            value: "'state'",
+            range: [23, 30],
+            loc: {
+                start: { line: 1, column: 23 },
+                end: { line: 1, column: 30 }
+            }
+        },
+        {
+            type: "Punctuator",
+            value: ")",
+            range: [30, 31],
+            loc: {
+                start: { line: 1, column: 30 },
+                end: { line: 1, column: 31 }
+            }
+        },
+        {
+            type: "Punctuator",
+            value: ";",
+            range: [31, 32],
+            loc: {
+                start: { line: 1, column: 31 },
+                end: { line: 1, column: 32 }
+            }
+        }
+    ],
+    comments: []
+});

--- a/tests/lib/rules/arrow-parens.js
+++ b/tests/lib/rules/arrow-parens.js
@@ -9,23 +9,11 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const path = require("path"),
+const baseParser = require("../../fixtures/fixture-parser"),
     rule = require("../../../lib/rules/arrow-parens"),
     RuleTester = require("../../../lib/testers/rule-tester");
 
-//------------------------------------------------------------------------------
-// Helpers
-//------------------------------------------------------------------------------
-
-/**
- * Gets the path to the specified parser.
- *
- * @param {string} name - The parser name to get.
- * @returns {string} The path to the specified parser.
- */
-function parser(name) {
-    return path.resolve(__dirname, `../../fixtures/parsers/arrow-parens/${name}.js`);
-}
+const parser = baseParser.bind(null, "arrow-parens");
 
 //------------------------------------------------------------------------------
 // Tests

--- a/tests/lib/rules/new-parens.js
+++ b/tests/lib/rules/new-parens.js
@@ -9,7 +9,8 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const rule = require("../../../lib/rules/new-parens"),
+const parser = require("../../fixtures/fixture-parser"),
+    rule = require("../../../lib/rules/new-parens"),
     RuleTester = require("../../../lib/testers/rule-tester");
 
 //------------------------------------------------------------------------------
@@ -27,6 +28,7 @@ ruleTester.run("new-parens", rule, {
         "var a = (new Date());",
         "var a = new foo.Bar();",
         "var a = (new Foo()).bar;",
+        { code: "new Storage<RootState>('state');", parser: parser("typescript-parsers/new-parens") },
     ],
     invalid: [
         {


### PR DESCRIPTION
This is a bug fix that changes the way the new-paren rule works.

It exploits the invariant that parentheses can only be omitted if there are no arguments, and in this case, the last two tokens have to be `(` and `)`