### PR TITLE
Update: Allow query selectors as options for no-restricted-syntax

### DIFF
--- a/docs/rules/no-restricted-syntax.md
+++ b/docs/rules/no-restricted-syntax.md
@@ -10,36 +10,45 @@ This rule disallows specified (that is, user-defined) syntax.
 
 ## Options
 
-This rule takes a list of strings:
+This rule takes a list of AST selectors with syntax similar to CSS:
 
 ```json
 {
     "rules": {
-        "no-restricted-syntax": ["error", "FunctionExpression", "WithStatement"]
+        "no-restricted-syntax": ["error", "FunctionExpression", "WithStatement", "IfStatement > BlockStatement"]
     }
 }
 ```
 
-Examples of **incorrect** code for this rule with the `"FunctionExpression", "WithStatement"` options:
+For more details on the syntax that can be used in selectors, see the [ESQuery](https://github.com/estools/esquery) documentation.
+
+Examples of **incorrect** code for this rule with the `"FunctionExpression", "WithStatement", "IfStatement > BlockStatement"` options:
 
 ```js
-/* eslint no-restricted-syntax: ["error", "FunctionExpression", "WithStatement"] */
+/* eslint no-restricted-syntax: ["error", "FunctionExpression", "WithStatement", "IfStatement > BlockStatement"] */
 
 with (me) {
     dontMess();
 }
 
 var doSomething = function () {};
+
+if (foo) {
+    bar();
+}
 ```
 
-Examples of **correct** code for this rule with the `"FunctionExpression", "WithStatement"` options:
+Examples of **correct** code for this rule with the `"FunctionExpression", "WithStatement", "IfStatement > BlockStatement"` options:
 
 ```js
-/* eslint no-restricted-syntax: ["error", "FunctionExpression", "WithStatement"] */
+/* eslint no-restricted-syntax: ["error", "FunctionExpression", "WithStatement", "IfStatement > BlockStatement"] */
 
 me.dontMess();
 
 function doSomething() {};
+
+if (foo)
+    bar();
 ```
 
 ## When Not To Use It

--- a/lib/rules/no-restricted-syntax.js
+++ b/lib/rules/no-restricted-syntax.js
@@ -8,7 +8,7 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
-const nodeTypes = require("espree").Syntax;
+const esquery = require("esquery");
 
 module.exports = {
     meta: {
@@ -20,32 +20,25 @@ module.exports = {
 
         schema: {
             type: "array",
-            items: [
-                {
-                    enum: Object.keys(nodeTypes).map(k => nodeTypes[k])
-                }
-            ],
+            items: [{ type: "string" }],
             uniqueItems: true,
             minItems: 0
         }
     },
 
     create(context) {
-
-        /**
-         * Generates a warning from the provided node, saying that node type is not allowed.
-         * @param {ASTNode} node The node to warn on
-         * @returns {void}
-         */
-        function warn(node) {
-            context.report({ node, message: "Using '{{type}}' is not allowed.", data: node });
-        }
-
-        return context.options.reduce((result, nodeType) => {
-            result[nodeType] = warn;
-
-            return result;
-        }, {});
-
+        return {
+            Program(ast) {
+                context.options.forEach(selector => {
+                    esquery(ast, selector).forEach(matchedNode => {
+                        context.report({
+                            node: matchedNode,
+                            message: "Using '{{selector}}' is not allowed.",
+                            data: { selector }
+                        });
+                    });
+                });
+            }
+        };
     }
 };

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "doctrine": "^1.2.2",
     "escope": "^3.6.0",
     "espree": "^3.3.1",
+    "esquery": "^0.4.0",
     "estraverse": "^4.2.0",
     "esutils": "^2.0.2",
     "file-entry-cache": "^2.0.0",

--- a/tests/lib/rules/no-restricted-syntax.js
+++ b/tests/lib/rules/no-restricted-syntax.js
@@ -21,7 +21,12 @@ ruleTester.run("no-restricted-syntax", rule, {
     valid: [
         { code: "doSomething();" },
         { code: "var foo = 42;", options: ["ConditionalExpression"] },
-        { code: "foo += 42;", options: ["VariableDeclaration", "FunctionExpression"] }
+        { code: "foo += 42;", options: ["VariableDeclaration", "FunctionExpression"] },
+        { code: "foo;", options: ["Identifier[name=\"bar\"]"] },
+        { code: "() => 5", options: ["ArrowFunctionExpression > BlockStatement"], parserOptions: { ecmaVersion: 6 } },
+        { code: "({ foo: 1, bar: 2 })", options: ["Property > Literal.key"] },
+        { code: "A: for (;;) break;", options: ["BreakStatement[label]"] },
+        { code: "function foo(bar, baz) {}", options: ["FunctionDeclaration[params.length>2]"] }
     ],
     invalid: [
         {
@@ -43,6 +48,40 @@ ruleTester.run("no-restricted-syntax", rule, {
                 { message: "Using 'CatchClause' is not allowed.", type: "CatchClause" },
                 { message: "Using 'CallExpression' is not allowed.", type: "CallExpression" }
             ]
-        }
+        },
+        {
+            code: "bar;",
+            options: ["Identifier[name=\"bar\"]"],
+            errors: [{ message: "Using 'Identifier[name=\"bar\"]' is not allowed.", type: "Identifier" }]
+        },
+        {
+            code: "bar;",
+            options: ["Identifier", "Identifier[name=\"bar\"]"],
+            errors: [
+                { message: "Using 'Identifier' is not allowed.", type: "Identifier" },
+                { message: "Using 'Identifier[name=\"bar\"]' is not allowed.", type: "Identifier" }
+            ]
+        },
+        {
+            code: "() => {}",
+            parserOptions: { ecmaVersion: 6 },
+            options: ["ArrowFunctionExpression > BlockStatement"],
+            errors: [{ message: "Using 'ArrowFunctionExpression > BlockStatement' is not allowed.", type: "BlockStatement" }]
+        },
+        {
+            code: "({ foo: 1, 'bar': 2 })",
+            options: ["Property > Literal.key"],
+            errors: [{ message: "Using 'Property > Literal.key' is not allowed.", type: "Literal" }]
+        },
+        {
+            code: "A: for (;;) break A;",
+            options: ["BreakStatement[label]"],
+            errors: [{ message: "Using 'BreakStatement[label]' is not allowed.", type: "BreakStatement" }]
+        },
+        {
+            code: "function foo(bar, baz, qux) {}",
+            options: ["FunctionDeclaration[params.length>2]"],
+            errors: [{ message: "Using 'FunctionDeclaration[params.length>2]' is not allowed.", type: "FunctionDeclaration" }]
+        },
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Changes an existing rule

**What rule do you want to change?**

[`no-restricted-syntax`](http://eslint.org/docs/rules/no-restricted-syntax)

**Does this change cause the rule to produce more or fewer warnings?**

The change is backwards-compatible, so the same number of warnings will be produced for existing configurations.

**How will the change be implemented? (New option, new default behavior, etc.)?**

The rule will accept certain strings as options for which it previously would have raised a schema error.

**Please provide some example code that this change will affect:**

```js
/* eslint no-restricted-syntax: [error, "ForStatement > BlockStatement"] */
```

**What does the rule currently do for this code?**

It raises a schema error.

**What will the rule do after it's changed?**

It will report `BlockStatement` nodes that have a `ForStatement` as a direct parent.

**What changes did you make? (Give an overview)**

The [`no-restricted-syntax`](http://eslint.org/docs/rules/no-restricted-syntax) rule currently accepts a list of node types to disallow. While this is useful in some cases, it's not ideal. For example, a user might want to forbid a node only when it appears in a particular location, or when has a particular attribute. Currently, if there are no other core rules that meet a user's particular requirements, the user has to make a custom rule. Additionally, since the rule schema is defined by the node types in Espree, it's currently not possible for a user to restrict the usage of a nonstandard node type.

This commit updates `no-restricted-syntax` to accept query selectors on the AST. These selectors have a syntax similar to CSS, and are handled by the [esquery](https://github.com/estools/esquery) module. Allowing query selectors makes the rule much more powerful -- it can be configured to report arbitrary user-defined syntax patterns. Additionally, since a string containing a node type is itself a valid query selector that matches all nodes of the given type, this change is fully backwards-compatible.

Examples:

* Suppose in user wants to only allow single-line `if` statements, and disallow `if` statements that have a `BlockStatement`. There is currently no way to enforce this with ESLint's core rules. With this change, the user could impose that restriction with selectors:

  ```yml
  rules:
    # Disallow `BlockStatement` nodes that have an `IfStatement` parent
    no-restricted-syntax: [error, 'IfStatement > BlockStatement']
  ```

* https://github.com/eslint/eslint/issues/7542 proposed a new rule that warns `setTimeout` calls with less than two arguments. With this change, the user could impose that restriction with selectors rather than needing a new rule:

  ```yml
  rules:
    no-restricted-properties: [error, 'CallExpression[callee.name="setTimeout"][arguments.length<2]']
  ```

I think this change would be a very useful improvement. It would allow users to be much more precise in restricting syntax, and it would avoid the need to create new rules that only apply to a specific syntax preference.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular