### PR TITLE
Add new "consistent" option for linebreak-style

### DIFF
--- a/docs/rules/linebreak-style.md
+++ b/docs/rules/linebreak-style.md
@@ -20,6 +20,7 @@ This rule has a string option:
 
 * `"unix"` (default) enforces the usage of Unix line endings: `\n` for LF.
 * `"windows"` enforces the usage of Windows line endings: `\r\n` for CRLF.
+* `"consistent"` enforces neither CRLF nor LF, but that the file does not mix the two. This option is best for cross-platform projects, as Git will check out as CRLF by default on Windows.
 
 
 ### unix
@@ -69,9 +70,40 @@ function foo(params) { // \r\n
 } // \r\n
 ```
 
+### consistent
+
+Examples of **incorrect** code for this rule with the `"consistent"` option:
+
+```js
+/*eslint linebreak-style: ["error", "consistent"]*/
+
+var a = 'a'; // \n
+var b = 'b'; // \n
+// \r\n
+```
+
+Examples of **correct** code for this rule with the `"consistent"` option:
+
+```js
+/*eslint linebreak-style: ["error", "consistent"]*/
+
+var a = 'a', // \r\n
+    b = 'b'; // \r\n
+// \r\n
+function foo(params) { // \r\n
+    // do stuff \r\n
+} // \r\n
+```
+
+```js
+/*eslint linebreak-style: ["error", "consistent"]*/
+
+var a = 'a', // \n
+```
+
 ## When Not To Use It
 
-If you aren't concerned about having different line endings within you code, then you can safely turn this rule off.
+If you aren't concerned about having different line endings within you code, then you can safely turn this rule off. Using a  correctly-formatted [.gitattributes file](https://help.github.com/articles/dealing-with-line-endings), along with the "consistent" setting, is the best way to ensure line endings are correct on all platforms.
 
 ## Compatibility
 

--- a/lib/rules/linebreak-style.js
+++ b/lib/rules/linebreak-style.js
@@ -21,7 +21,7 @@ module.exports = {
 
         schema: [
             {
-                enum: ["unix", "windows"]
+                enum: ["unix", "windows", "consistent"]
             }
         ]
     },
@@ -58,30 +58,85 @@ module.exports = {
             Program: function checkForlinebreakStyle(node) {
                 const linebreakStyle = context.options[0] || "unix",
                     expectedLF = linebreakStyle === "unix",
-                    expectedLFChars = expectedLF ? "\n" : "\r\n",
                     source = sourceCode.getText(),
-                    pattern = /\r\n|\r|\n|\u2028|\u2029/g;
+                    pattern = /\r\n|\r|\n|\u2028|\u2029/g,
+                    checkConsistency = linebreakStyle === "consistent" ? {} : null;
+                let expectedLFChars = expectedLF ? "\n" : "\r\n";
                 let match;
 
                 let i = 0;
 
                 while ((match = pattern.exec(source)) !== null) {
                     i++;
-                    if (match[0] === expectedLFChars) {
+
+                    if (!checkConsistency && match[0] === expectedLFChars) {
                         continue;
                     }
 
                     const index = match.index;
                     const range = [index, index + match[0].length];
 
+                    if (checkConsistency) {
+                        checkConsistency[match[0]] = checkConsistency[match[0]] || [];
+                        checkConsistency[match[0]].push({
+                            line: i,
+                            index, range
+                        });
+                    } else {
+                        context.report({
+                            node,
+                            loc: {
+                                line: i,
+                                column: sourceCode.lines[i - 1].length
+                            },
+                            message: expectedLF ? EXPECTED_LF_MSG : EXPECTED_CRLF_MSG,
+                            fix: createFix(range, expectedLFChars)
+                        });
+                    }
+                }
+
+                if (!checkConsistency) {
+                    return;
+                }
+
+                if (Object.keys(checkConsistency).length < 2) {
+                    return;
+                }
+
+                let errorMessage, minorityLfValues;
+
+                if (checkConsistency["\n"].length > checkConsistency["\r\n"].length) {
+                    minorityLfValues = checkConsistency["\r\n"];
+                    errorMessage = EXPECTED_LF_MSG;
+                    expectedLFChars = "\n";
+                } else {
+                    minorityLfValues = checkConsistency["\n"];
+                    errorMessage = EXPECTED_CRLF_MSG;
+                    expectedLFChars = "\r\n";
+                }
+
+                const percent = (minorityLfValues.length / sourceCode.lines.length) * 100;
+
+                context.report({
+                    node,
+                    loc: {
+                        line: 1,
+                        column: 0
+                    },
+                    message: `Line endings are mixed, ${percent.toFixed(2)}% of lines are inconsistent`
+                });
+
+                for (i = 0; i < minorityLfValues.length; i++) {
+                    const line = minorityLfValues[i].line;
+
                     context.report({
                         node,
                         loc: {
-                            line: i,
-                            column: sourceCode.lines[i - 1].length
+                            line,
+                            column: sourceCode.lines[line - 1].length
                         },
-                        message: expectedLF ? EXPECTED_LF_MSG : EXPECTED_CRLF_MSG,
-                        fix: createFix(range, expectedLFChars)
+                        message: errorMessage,
+                        fix: createFix(minorityLfValues[i].range, expectedLFChars)
                     });
                 }
             }

--- a/tests/lib/rules/linebreak-style.js
+++ b/tests/lib/rules/linebreak-style.js
@@ -36,13 +36,25 @@ ruleTester.run("linebreak-style", rule, {
             options: ["windows"]
         },
         {
+            code: "var a = 'a',\n b = 'b';\n\n function foo(params) {\n /* do stuff */ \n }\n",
+            options: ["consistent"]
+        },
+        {
+            code: "var a = 'a',\r\n b = 'b';\r\n\r\n function foo(params) {\r\n /* do stuff */ \r\n }\r\n",
+            options: ["consistent"]
+        },
+        {
             code: "var b = 'b';",
             options: ["unix"]
         },
         {
             code: "var b = 'b';",
             options: ["windows"]
-        }
+        },
+        {
+            code: "var b = 'b';",
+            options: ["consistent"]
+        },
     ],
 
     invalid: [

--- a/tests/lib/rules/linebreak-style.js
+++ b/tests/lib/rules/linebreak-style.js
@@ -122,6 +122,42 @@ ruleTester.run("linebreak-style", rule, {
                 column: 17,
                 message: EXPECTED_CRLF_MSG
             }]
-        }
+        },
+        {
+            code: "var a = 'a',\r\n b = 'b';\r\n\r\n function foo(params) {\n /* do stuff */ \r\n }\r\n",
+            output: "var a = 'a',\r\n b = 'b';\r\n\r\n function foo(params) {\r\n /* do stuff */ \r\n }\r\n",
+            options: ["consistent"],
+            errors: [{
+                line: 1,
+                column: 1,
+                message: "Line endings are mixed, 14.29% of lines are inconsistent"
+            },
+            {
+                line: 4,
+                column: 24,
+                message: EXPECTED_CRLF_MSG
+            }]
+        },
+        {
+            code: "var a = 'a',\n b = 'b';\n\n function foo(params) {\r\n /* do stuff */ \n }\r\n",
+            output: "var a = 'a',\n b = 'b';\n\n function foo(params) {\n /* do stuff */ \n }\n",
+            options: ["consistent"],
+            errors: [{
+                line: 1,
+                column: 1,
+                message: "Line endings are mixed, 28.57% of lines are inconsistent"
+            },
+            {
+                line: 4,
+                column: 24,
+                message: EXPECTED_LF_MSG
+            },
+            {
+                line: 6,
+                column: 3,
+                message: EXPECTED_LF_MSG
+            }]
+        },
+
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))

**What rule do you want to change?**

This PR adds a new option to `linebreak-style`, "consistent". This option allows either CRLF or LF, as long as the file consistently uses one or the other. 

**Does this change cause the rule to produce more or fewer warnings?**

This will cause far less warnings when appropriately used on Windows platforms.

**How will the change be implemented? (New option, new default behavior, etc.)?**

This adds a new option to the `linebreak-style` command. 

**Please provide some example code that this change will affect:**

```js
/*eslint linebreak-style: ["error", "consistent"]*/

var a = 'a'; // \n
var b = 'b'; // \n
// \n
```

**What does the rule currently do for this code?**

It will pass if set to "unix" and fail if set to "windows", but cross-platform code has no correct answer.

**What will the rule do after it's changed?**

Pass on all platforms

**What changes did you make? (Give an overview)**

This PR adds a new option to `linebreak-style`, "consistent". This option allows either CRLF or LF, as long as the file consistently uses one or the other. The implementation calculates the line endings for all lines in the file, then compares to see if there are more than one in the file. It then determines the style in the minority (hopefully just a few lines), and cites these as errors. 

**Is there anything you'd like reviewers to focus on?**

The top-level percentage error message could be up for debate. See https://github.com/airbnb/javascript/pull/1224, https://github.com/zeit/hyper/pull/1230, and https://github.com/sindresorhus/eslint-config-xo/pull/35 for more discussion on the general purpose of this rule

The goal here is to try to come up with a solution that doesn't inhibit Windows users from contributing (i.e. by making every line of every file fail linting), while still ensuring POSIX users get LF line endings and the repo is LF.
