### PR TITLE
Update: add `detectDefaultValues` to `no-magic-numbers` (fixes #5672)

### DIFF
--- a/docs/rules/no-magic-numbers.md
+++ b/docs/rules/no-magic-numbers.md
@@ -124,3 +124,39 @@ var magic = {
 var dutyFreePrice = 100,
     finalPrice = dutyFreePrice + (dutyFreePrice * magic.tax);
 ```
+
+### detectDefaultValues
+
+A boolean to specify if we should detect numbers when defining default values for function parameters or object destructuring. `true` by default.
+
+Examples of **incorrect** code for the `{ "detectDefaultValues": true }` option:
+
+```js
+/*eslint no-magic-numbers: ["error", { "detectDefaultValues": true }]*/
+
+function makeRequest({ timeout = 1000 }) {};
+```
+
+```js
+/*eslint no-magic-numbers: ["error", { "detectDefaultValues": true }]*/
+
+var { timeout = 1000 } = {};
+```
+
+Examples of **correct** code for the `{ "detectDefaultValues": true }` option:
+
+```js
+/*eslint no-magic-numbers: ["error", { "detectDefaultValues": true }]*/
+
+var TIMEOUT = 1000;
+
+function makeRequest({ timeout = TIMEOUT }) {};
+```
+
+```js
+/*eslint no-magic-numbers: ["error", { "detectDefaultValues": true }]*/
+
+var TIMEOUT = 1000;
+
+var { timeout = TIMEOUT } = {};
+```

--- a/lib/rules/no-magic-numbers.js
+++ b/lib/rules/no-magic-numbers.js
@@ -23,6 +23,9 @@ module.exports = {
                 detectObjects: {
                     type: "boolean"
                 },
+                detectDefaultValues: {
+                    type: "boolean"
+                },
                 enforceConst: {
                     type: "boolean"
                 },
@@ -44,6 +47,7 @@ module.exports = {
     create(context) {
         const config = context.options[0] || {},
             detectObjects = !!config.detectObjects,
+            detectDefaultValues = config.detectDefaultValues !== false,
             enforceConst = !!config.enforceConst,
             ignore = config.ignore || [],
             ignoreArrayIndexes = !!config.ignoreArrayIndexes;
@@ -104,6 +108,10 @@ module.exports = {
                     value = node.value,
                     raw = node.raw;
                 const okTypes = detectObjects ? [] : ["ObjectExpression", "Property", "AssignmentExpression"];
+
+                if (!detectDefaultValues) {
+                    okTypes.push("AssignmentPattern");
+                }
 
                 if (!isNumber(node)) {
                     return;

--- a/tests/lib/rules/no-magic-numbers.js
+++ b/tests/lib/rules/no-magic-numbers.js
@@ -85,6 +85,20 @@ ruleTester.run("no-magic-numbers", rule, {
                     jsx: true
                 }
             }
+        },
+        {
+            code: "const { timeout = 1000 } = {};",
+            env: { es6: true },
+            options: [{
+                detectDefaultValues: false
+            }]
+        },
+        {
+            code: "function makeRequest(timeout = 1000) {}",
+            env: { es6: true },
+            options: [{
+                detectDefaultValues: false
+            }]
         }
     ],
     invalid: [
@@ -238,6 +252,22 @@ ruleTester.run("no-magic-numbers", rule, {
                 { message: "No magic number: 1.", line: 1 },
                 { message: "No magic number: 10.", line: 1 },
                 { message: "No magic number: 4.", line: 1 }
+            ]
+        },
+        {
+            code: "const { timeout = 1000 } = {};",
+            env: { es6: true },
+            options: [{}],
+            errors: [
+                { message: "No magic number: 1000.", line: 1 }
+            ]
+        },
+        {
+            code: "function makeRequest(timeout = 1000) {}",
+            env: { es6: true },
+            options: [{}],
+            errors: [
+                { message: "No magic number: 1000.", line: 1 }
             ]
         }
     ]


### PR DESCRIPTION
Add an option to detect object destructuring and function parameter default values when looking for magic numbers. Defaults to `true` for backwards compatibility with the current behavior.

This fixes #5672, which has already been closed due to inactivity. I understand @michaelficarra's objection, but I personally find it repetitive to create additional constants for values that already have an obvious use.

```js
// This is repetitive and doesn't add any value:
const DEFAULT_TIMEOUT = 1000;

function makeRequest({ timeout = DEFAULT_TIMEOUT }) {
}


// This is clear and the number has an obvious description:
function makeRequest({ timeout = 1000 }) {
}
```


**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:


**What rule do you want to change?**
[no-magic-numbers](http://eslint.org/docs/rules/no-magic-numbers)


**Does this change cause the rule to produce more or fewer warnings?**
More warnings, but only if the `detectDefaultValues` option is set to `false`.


**How will the change be implemented? (New option, new default behavior, etc.)?**
The `detectDefaultValues` option will be added, with the default value of `true`.


**Please provide some example code that this change will affect:**

```js
function makeRequest({ timeout = 1000 }) {};
```

```js
var { timeout = 1000 } = {};
```

**What does the rule currently do for this code?**
It currently raises a warning/error for default values and function parameters.


**What will the rule do after it's changed?**
The user will be able to choose whether default values and function parameters raise a warning.


**What changes did you make? (Give an overview)**
Added the `detectDefaultValues` to the `no-magic-numbers` rule with the default value of `true`.


**Is there anything you'd like reviewers to focus on?**
Nothing I can think of.

