### PR TITLE
New: allow rules to listen for AST selectors (fixes #5407)

### DIFF
--- a/docs/developer-guide/selectors.md
+++ b/docs/developer-guide/selectors.md
@@ -1,0 +1,133 @@
+# Selectors
+
+Some rules and APIs allow the use of selectors to query an AST. This page is intended to:
+
+1. Explain what selectors are
+1. Describe the syntax for creating selectors
+1. Describe what selectors can be used for
+
+## What is a selector?
+
+A selector is a string that can be used to match nodes in an Abstract Syntax Tree (AST). This is useful for describing a particular syntax pattern in your code.
+
+The syntax for AST selectors is similar to the syntax for [CSS selectors](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors). If you've used CSS selectors before, the syntax for AST selectors should be easy to understand.
+
+The simplest selector is just a node type. A node type selector will match all nodes with the given type. For example, consider the following program:
+
+```js
+var foo = 1;
+bar.baz();
+```
+
+The selector "`Identifier`" will match all `Identifier` nodes in the program. In this case, the selector will match the nodes for `foo`, `bar`, and `baz`.
+
+Selectors are not limited to matching against single node types. For example, the selector `VariableDeclarator > Identifier` will match all `Identifier` nodes that have a `VariableDeclarator` as a direct parent. In the program above, this will match the node for `foo`, but not the nodes for `bar` and `baz`.
+
+## What syntax can selectors have?
+
+The following selectors are supported:
+
+* AST node type: `ForStatement`
+* wildcard (matches all nodes): `*`
+* attribute existence: `[attr]`
+* attribute value: `[attr="foo"]` or `[attr=123]`
+* attribute regex: `[attr=/foo.*/]`
+* attribute conditons: `[attr!="foo"]`, `[attr>2]`, `[attr<3]`, `[attr>=2]`, or `[attr<=3]`
+* nested attribute: `[attr.level2="foo"]`
+* field: `FunctionDeclaration > Identifier.id`
+* First or last child: `:first-child` or `:last-child`
+* nth-child (no ax+b support): `:nth-child(2)`
+* nth-last-child (no ax+b support): `:nth-last-child(1)`
+* descendant: `ancestor descendant`
+* child: `parent > child`
+* following sibling: `node ~ sibling`
+* adjacent sibling: `node + adjacent`
+* negation: `:not(ForStatement)`
+* matches-any: `:matches([attr] > :first-child, :last-child)`
+* class of AST node: `:statement`, `:expression`, `:declaration`, `:function`, or `:pattern`
+
+This syntax is very powerful, and can be used to precisely select many syntactic patterns in your code.
+
+<sup>The examples in this section were adapted from the [esquery](https://github.com/estools/esquery) documentation.</sup>
+
+## What can selectors be used for?
+
+If you're configuring ESLint for your codebase, you might be interested in restricting particular syntax patterns with selectors. If you're writing custom ESLint rules, you might be interested in using selectors to examine specific parts of the AST.
+
+### Restricting syntax with selectors
+
+With the [no-restricted-syntax](/docs/rules/no-restricted-syntax) rule, you can restrict the usage of particular syntax in your code. For example, you can use the following configuration to disallow using `if` statements that do not have block statements as their body:
+
+```json
+{
+  "rules": {
+    "no-restricted-syntax": ["error", "IfStatement > :not(BlockStatement).body"]
+  }
+}
+```
+
+...or equivalently, you can use this configuration:
+
+```json
+{
+  "rules": {
+    "no-restricted-syntax": ["error", "IfStatement[body.type!='BlockStatement']"]
+  }
+}
+```
+
+As another example, you can disallow calls to `require()`:
+
+```json
+{
+  "rules": {
+    "no-restricted-syntax": ["error", "CallExpression[callee.name='require']"]
+  }
+}
+```
+
+Or you can enforce that calls to `setTimeout` always have two arguments:
+
+```json
+{
+  "rules": {
+    "no-restricted-syntax": ["error", "CallExpression[callee.name='setTimeout'][arguments.length!=2]"]
+  }
+}
+```
+
+Using selectors in the `no-restricted-syntax` rule can give you a lot of control over problematic patterns in your codebase, without needing to write custom rules to detect each pattern.
+
+### Listening for selectors in rules
+
+When writing a custom ESLint rule, you can listen for nodes that match a particular selector as the AST is traversed.
+
+```js
+module.exports = {
+  create(context) {
+    // ...
+
+    return {
+
+      // This listener will be called for all IfStatement nodes with blocks.
+      "IfStatement > BlockStatement": function(blockStatementNode) {
+        // ...your logic here
+      },
+
+      // This listener will be called for all function declarations with more than 3 parameters.
+      "FunctionDeclaration[params.length>3]": function(functionDeclarationNode) {
+        // ...your logic here
+      }
+    };
+  }
+};
+```
+
+Adding `:exit` to the end of a selector will cause the listener to be called when the matching nodes are exited during traversal, rather than when they are entered.
+
+If two or more selectors match the same node, their listeners will be called in order of increasing specificity. The specificity of an AST selector is similar to the specificity of a CSS selector:
+
+* When comparing two selectors, the selector that contains more class selectors, attribute selectors, and pseudo-class selectors (excluding `:not()`) has higher specificity.
+* If the class/attribute/pseudo-class count is tied, the selector that contains more node type selectors has higher specificity.
+
+If multiple selectors have equal specificity, their listeners will be called in alphabetical order for that node.

--- a/docs/developer-guide/selectors.md
+++ b/docs/developer-guide/selectors.md
@@ -52,7 +52,41 @@ This syntax is very powerful, and can be used to precisely select many syntactic
 
 ## What can selectors be used for?
 
-If you're configuring ESLint for your codebase, you might be interested in restricting particular syntax patterns with selectors. If you're writing custom ESLint rules, you might be interested in using selectors to examine specific parts of the AST.
+If you're writing custom ESLint rules, you might be interested in using selectors to examine specific parts of the AST. If you're configuring ESLint for your codebase, you might be interested in restricting particular syntax patterns with selectors.
+
+### Listening for selectors in rules
+
+When writing a custom ESLint rule, you can listen for nodes that match a particular selector as the AST is traversed.
+
+```js
+module.exports = {
+  create(context) {
+    // ...
+
+    return {
+
+      // This listener will be called for all IfStatement nodes with blocks.
+      "IfStatement > BlockStatement": function(blockStatementNode) {
+        // ...your logic here
+      },
+
+      // This listener will be called for all function declarations with more than 3 parameters.
+      "FunctionDeclaration[params.length>3]": function(functionDeclarationNode) {
+        // ...your logic here
+      }
+    };
+  }
+};
+```
+
+Adding `:exit` to the end of a selector will cause the listener to be called when the matching nodes are exited during traversal, rather than when they are entered.
+
+If two or more selectors match the same node, their listeners will be called in order of increasing specificity. The specificity of an AST selector is similar to the specificity of a CSS selector:
+
+* When comparing two selectors, the selector that contains more class selectors, attribute selectors, and pseudo-class selectors (excluding `:not()`) has higher specificity.
+* If the class/attribute/pseudo-class count is tied, the selector that contains more node type selectors has higher specificity.
+
+If multiple selectors have equal specificity, their listeners will be called in alphabetical order for that node.
 
 ### Restricting syntax with selectors
 
@@ -97,37 +131,3 @@ Or you can enforce that calls to `setTimeout` always have two arguments:
 ```
 
 Using selectors in the `no-restricted-syntax` rule can give you a lot of control over problematic patterns in your codebase, without needing to write custom rules to detect each pattern.
-
-### Listening for selectors in rules
-
-When writing a custom ESLint rule, you can listen for nodes that match a particular selector as the AST is traversed.
-
-```js
-module.exports = {
-  create(context) {
-    // ...
-
-    return {
-
-      // This listener will be called for all IfStatement nodes with blocks.
-      "IfStatement > BlockStatement": function(blockStatementNode) {
-        // ...your logic here
-      },
-
-      // This listener will be called for all function declarations with more than 3 parameters.
-      "FunctionDeclaration[params.length>3]": function(functionDeclarationNode) {
-        // ...your logic here
-      }
-    };
-  }
-};
-```
-
-Adding `:exit` to the end of a selector will cause the listener to be called when the matching nodes are exited during traversal, rather than when they are entered.
-
-If two or more selectors match the same node, their listeners will be called in order of increasing specificity. The specificity of an AST selector is similar to the specificity of a CSS selector:
-
-* When comparing two selectors, the selector that contains more class selectors, attribute selectors, and pseudo-class selectors (excluding `:not()`) has higher specificity.
-* If the class/attribute/pseudo-class count is tied, the selector that contains more node type selectors has higher specificity.
-
-If multiple selectors have equal specificity, their listeners will be called in alphabetical order for that node.

--- a/docs/developer-guide/selectors.md
+++ b/docs/developer-guide/selectors.md
@@ -38,10 +38,10 @@ The following selectors are supported:
 * First or last child: `:first-child` or `:last-child`
 * nth-child (no ax+b support): `:nth-child(2)`
 * nth-last-child (no ax+b support): `:nth-last-child(1)`
-* descendant: `ancestor descendant`
-* child: `parent > child`
-* following sibling: `node ~ sibling`
-* adjacent sibling: `node + adjacent`
+* descendant: `FunctionExpression ReturnStatement`
+* child: `UnaryExpression > Literal`
+* following sibling: `ArrayExpression > Literal + SpreadElement`
+* adjacent sibling: `VariableDeclaration ~ VariableDeclaration`
 * negation: `:not(ForStatement)`
 * matches-any: `:matches([attr] > :first-child, :last-child)`
 * class of AST node: `:statement`, `:expression`, `:declaration`, `:function`, or `:pattern`

--- a/docs/developer-guide/working-with-rules.md
+++ b/docs/developer-guide/working-with-rules.md
@@ -65,8 +65,8 @@ The source file for a rule exports an object with the following properties.
 
 `create` (function) returns an object with methods that ESLint calls to "visit" nodes while traversing the abstract syntax tree (AST as defined by [ESTree](https://github.com/estree/estree)) of JavaScript code:
 
-* if a key is a node type, ESLint calls that **visitor** function while going **down** the tree
-* if a key is a node type plus `:exit`, ESLint calls that **visitor** function while going **up** the tree
+* if a key is a node type or a [selector](./selectors), ESLint calls that **visitor** function while going **down** the tree
+* if a key is a node type or a [selector](./selectors) plus `:exit`, ESLint calls that **visitor** function while going **up** the tree
 * if a key is an event name, ESLint calls that **handler** function for [code path analysis](./code-path-analysis.md)
 
 A rule can use the current node and its surrounding tree to report or fix problems.

--- a/docs/rules/no-restricted-syntax.md
+++ b/docs/rules/no-restricted-syntax.md
@@ -1,8 +1,10 @@
 # disallow specified syntax (no-restricted-syntax)
 
-JavaScript has a lot of language features, and not everyone likes all of them. As a result, some projects choose to disallow the use of certain language features altogether. For instance, you might decide to disallow the use of `try-catch` or `class`.
+JavaScript has a lot of language features, and not everyone likes all of them. As a result, some projects choose to disallow the use of certain language features altogether. For instance, you might decide to disallow the use of `try-catch` or `class`, or you might decide to disallow the use of the `in` operator.
 
 Rather than creating separate rules for every language feature you want to turn off, this rule allows you to configure the syntax elements you want to restrict use of. These elements are represented by their [ESTree](https://github.com/estree/estree) node types. For example, a function declaration is represented by `FunctionDeclaration` and the `with` statement is represented by `WithStatement`. You may find the full list of AST node names you can use [on GitHub](https://github.com/eslint/espree/blob/master/lib/ast-node-types.js) and use the [online parser](http://eslint.org/parser/) to see what type of nodes your code consists of.
+
+You can also specify [AST selectors](../developer-guide/selectors) to restrict, allowing much more precise control over syntax patterns.
 
 ## Rule Details
 
@@ -15,12 +17,12 @@ This rule takes a list of strings:
 ```json
 {
     "rules": {
-        "no-restricted-syntax": ["error", "FunctionExpression", "WithStatement"]
+        "no-restricted-syntax": ["error", "FunctionExpression", "WithStatement", "CallExpression[name='require']"]
     }
 }
 ```
 
-Examples of **incorrect** code for this rule with the `"FunctionExpression", "WithStatement"` options:
+Examples of **incorrect** code for this rule with the `"FunctionExpression", "WithStatement", CallExpression[name='require']` options:
 
 ```js
 /* eslint no-restricted-syntax: ["error", "FunctionExpression", "WithStatement"] */
@@ -30,9 +32,11 @@ with (me) {
 }
 
 var doSomething = function () {};
+
+require('foo');
 ```
 
-Examples of **correct** code for this rule with the `"FunctionExpression", "WithStatement"` options:
+Examples of **correct** code for this rule with the `"FunctionExpression", "WithStatement", CallExpression[name='require']` options:
 
 ```js
 /* eslint no-restricted-syntax: ["error", "FunctionExpression", "WithStatement"] */
@@ -40,6 +44,8 @@ Examples of **correct** code for this rule with the `"FunctionExpression", "With
 me.dontMess();
 
 function doSomething() {};
+
+foo();
 ```
 
 ## When Not To Use It

--- a/docs/rules/no-restricted-syntax.md
+++ b/docs/rules/no-restricted-syntax.md
@@ -17,15 +17,15 @@ This rule takes a list of strings:
 ```json
 {
     "rules": {
-        "no-restricted-syntax": ["error", "FunctionExpression", "WithStatement", "CallExpression[name='require']"]
+        "no-restricted-syntax": ["error", "FunctionExpression", "WithStatement", "BinaryExpression[operator='in']"]
     }
 }
 ```
 
-Examples of **incorrect** code for this rule with the `"FunctionExpression", "WithStatement", CallExpression[name='require']` options:
+Examples of **incorrect** code for this rule with the `"FunctionExpression", "WithStatement", BinaryExpression[operator='in']` options:
 
 ```js
-/* eslint no-restricted-syntax: ["error", "FunctionExpression", "WithStatement"] */
+/* eslint no-restricted-syntax: ["error", "FunctionExpression", "WithStatement", "BinaryExpression[operator='in']"] */
 
 with (me) {
     dontMess();
@@ -33,19 +33,19 @@ with (me) {
 
 var doSomething = function () {};
 
-require('foo');
+foo in bar;
 ```
 
-Examples of **correct** code for this rule with the `"FunctionExpression", "WithStatement", CallExpression[name='require']` options:
+Examples of **correct** code for this rule with the `"FunctionExpression", "WithStatement", BinaryExpression[operator='in']` options:
 
 ```js
-/* eslint no-restricted-syntax: ["error", "FunctionExpression", "WithStatement"] */
+/* eslint no-restricted-syntax: ["error", "FunctionExpression", "WithStatement", "BinaryExpression[operator='in']"] */
 
 me.dontMess();
 
 function doSomething() {};
 
-foo();
+foo instanceof bar;
 ```
 
 ## When Not To Use It

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -914,7 +914,7 @@ module.exports = (function() {
                 }
             }
 
-            let eventGenerator = new NodeEventGenerator(api, Array.from(selectors));
+            let eventGenerator = new NodeEventGenerator(api, selectors);
 
             eventGenerator = new CodePathAnalyzer(eventGenerator);
             eventGenerator = new CommentEventGenerator(eventGenerator, sourceCode);

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -757,6 +757,8 @@ module.exports = (function() {
      */
     api.verify = function(textOrSourceCode, config, filenameOrOptions, saveState) {
         const text = (typeof textOrSourceCode === "string") ? textOrSourceCode : null;
+        const selectors = new Set();
+
         let ast,
             parseResult,
             shebang,
@@ -868,10 +870,11 @@ module.exports = (function() {
                         : ruleCreator(ruleContext);
 
                     // add all the node types as listeners
-                    Object.keys(rule).forEach(nodeType => {
-                        api.on(nodeType, timing.enabled
-                            ? timing.time(key, rule[nodeType])
-                            : rule[nodeType]
+                    Object.keys(rule).forEach(selector => {
+                        selectors.add(selector);
+                        api.on(selector, timing.enabled
+                            ? timing.time(key, rule[selector])
+                            : rule[selector]
                         );
                     });
                 } catch (ex) {
@@ -911,7 +914,7 @@ module.exports = (function() {
                 }
             }
 
-            let eventGenerator = new NodeEventGenerator(api);
+            let eventGenerator = new NodeEventGenerator(api, Array.from(selectors));
 
             eventGenerator = new CodePathAnalyzer(eventGenerator);
             eventGenerator = new CommentEventGenerator(eventGenerator, sourceCode);

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -757,8 +757,6 @@ module.exports = (function() {
      */
     api.verify = function(textOrSourceCode, config, filenameOrOptions, saveState) {
         const text = (typeof textOrSourceCode === "string") ? textOrSourceCode : null;
-        const selectors = new Set();
-
         let ast,
             parseResult,
             shebang,
@@ -869,9 +867,8 @@ module.exports = (function() {
                     const rule = ruleCreator.create ? ruleCreator.create(ruleContext)
                         : ruleCreator(ruleContext);
 
-                    // add all the node types as listeners
+                    // add all the selectors from the rule as listeners
                     Object.keys(rule).forEach(selector => {
-                        selectors.add(selector);
                         api.on(selector, timing.enabled
                             ? timing.time(key, rule[selector])
                             : rule[selector]
@@ -914,7 +911,7 @@ module.exports = (function() {
                 }
             }
 
-            let eventGenerator = new NodeEventGenerator(api, selectors);
+            let eventGenerator = new NodeEventGenerator(api);
 
             eventGenerator = new CodePathAnalyzer(eventGenerator);
             eventGenerator = new CommentEventGenerator(eventGenerator, sourceCode);

--- a/lib/rules/no-new-func.js
+++ b/lib/rules/no-new-func.js
@@ -27,20 +27,18 @@ module.exports = {
         //--------------------------------------------------------------------------
 
         /**
-         * Checks if the callee is the Function constructor, and if so, reports an issue.
-         * @param {ASTNode} node The node to check and report on
+         * Reports a node.
+         * @param {ASTNode} node The node to report
          * @returns {void}
          * @private
          */
-        function validateCallee(node) {
-            if (node.callee.name === "Function") {
-                context.report({ node, message: "The Function constructor is eval." });
-            }
+        function report(node) {
+            context.report({ node, message: "The Function constructor is eval." });
         }
 
         return {
-            NewExpression: validateCallee,
-            CallExpression: validateCallee
+            "NewExpression[callee.name = 'Function']": report,
+            "CallExpression[callee.name = 'Function']": report
         };
 
     }

--- a/lib/rules/no-new.js
+++ b/lib/rules/no-new.js
@@ -24,12 +24,8 @@ module.exports = {
     create(context) {
 
         return {
-
-            ExpressionStatement(node) {
-
-                if (node.expression.type === "NewExpression") {
-                    context.report({ node, message: "Do not use 'new' for side effects." });
-                }
+            "ExpressionStatement > NewExpression"(node) {
+                context.report({ node: node.parent, message: "Do not use 'new' for side effects." });
             }
         };
 

--- a/lib/rules/no-process-exit.js
+++ b/lib/rules/no-process-exit.js
@@ -26,17 +26,9 @@ module.exports = {
         //--------------------------------------------------------------------------
 
         return {
-
-            CallExpression(node) {
-                const callee = node.callee;
-
-                if (callee.type === "MemberExpression" && callee.object.name === "process" &&
-                    callee.property.name === "exit"
-                ) {
-                    context.report({ node, message: "Don't use process.exit(); throw an error instead." });
-                }
+            "CallExpression > MemberExpression.callee[object.name = 'process'][property.name = 'exit']"(node) {
+                context.report({ node: node.parent, message: "Don't use process.exit(); throw an error instead." });
             }
-
         };
 
     }

--- a/lib/rules/no-restricted-syntax.js
+++ b/lib/rules/no-restricted-syntax.js
@@ -8,8 +8,6 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
-const nodeTypes = require("espree").Syntax;
-
 module.exports = {
     meta: {
         docs: {
@@ -20,32 +18,18 @@ module.exports = {
 
         schema: {
             type: "array",
-            items: [
-                {
-                    enum: Object.keys(nodeTypes).map(k => nodeTypes[k])
-                }
-            ],
+            items: [{ type: "string" }],
             uniqueItems: true,
             minItems: 0
         }
     },
 
     create(context) {
-
-        /**
-         * Generates a warning from the provided node, saying that node type is not allowed.
-         * @param {ASTNode} node The node to warn on
-         * @returns {void}
-         */
-        function warn(node) {
-            context.report({ node, message: "Using '{{type}}' is not allowed.", data: node });
-        }
-
-        return context.options.reduce((result, nodeType) => {
-            result[nodeType] = warn;
-
-            return result;
-        }, {});
+        return context.options.reduce((result, selector) => Object.assign(result, {
+            [selector](node) {
+                context.report({ node, message: "Using '{{selector}}' is not allowed.", data: { selector } });
+            }
+        }), {});
 
     }
 };

--- a/lib/rules/no-sync.js
+++ b/lib/rules/no-sync.js
@@ -26,19 +26,14 @@ module.exports = {
 
         return {
 
-            MemberExpression(node) {
-                const propertyName = node.property.name,
-                    syncRegex = /.*Sync$/;
-
-                if (syncRegex.exec(propertyName) !== null) {
-                    context.report({
-                        node,
-                        message: "Unexpected sync method: '{{propertyName}}'.",
-                        data: {
-                            propertyName
-                        }
-                    });
-                }
+            "MemberExpression[property.name=/.*Sync$/]"(node) {
+                context.report({
+                    node,
+                    message: "Unexpected sync method: '{{propertyName}}'.",
+                    data: {
+                        propertyName: node.property.name
+                    }
+                });
             }
         };
 

--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -343,12 +343,13 @@ RuleTester.prototype = {
              * running the rule under test.
              */
             eslint.reset();
+
             eslint.on("Program", node => {
                 beforeAST = cloneDeeplyExcludesParent(node);
+            });
 
-                eslint.on("Program:exit", node => {
-                    afterAST = cloneDeeplyExcludesParent(node);
-                });
+            eslint.on("Program:exit", node => {
+                afterAST = node;
             });
 
             // Freezes rule-context properties.
@@ -385,7 +386,7 @@ RuleTester.prototype = {
                 return {
                     messages: eslint.verify(code, config, filename, true),
                     beforeAST,
-                    afterAST
+                    afterAST: cloneDeeplyExcludesParent(afterAST)
                 };
             } finally {
                 rules.get = originalGet;

--- a/lib/util/node-event-generator.js
+++ b/lib/util/node-event-generator.js
@@ -6,6 +6,42 @@
 "use strict";
 
 const esquery = require("esquery");
+const lodash = require("lodash");
+const scheduledExitMatches = new WeakMap();
+
+/**
+* Gets the possible types of a selector
+* @param {Object} selector parsed selector
+* @returns {string[]|null} return value (TODO)
+*/
+function getPossibleTypes(selector) {
+    switch (selector.type) {
+        case "identifier":
+            return [selector.value];
+
+        case "matches": {
+            const typesPerCase = selector.selectors.map(getPossibleTypes);
+
+            if (typesPerCase.every(typeList => typeList)) {
+                return lodash.union.apply(null, typesPerCase);
+            }
+            return null;
+        }
+
+        case "compound":
+            return lodash.intersection.apply(null, selector.selectors.map(getPossibleTypes).filter(Boolean));
+
+        case "child":
+        case "descendant":
+        case "sibling":
+        case "adjacent":
+            return getPossibleTypes(selector.right);
+
+        default:
+            return null;
+
+    }
+}
 
 //------------------------------------------------------------------------------
 // Public Interface
@@ -27,19 +63,36 @@ class NodeEventGenerator {
 
     /**
     * @param {EventEmitter} emitter - An event emitter which is the destination of events.
-    * @param {string[]} selectors A list of query selector strings to detect and emit
+    * @param {string[]} rawSelectors A list of query selector strings to detect and emit
     * @returns {NodeEventGenerator} new instance
     */
-    constructor(emitter, selectors) {
+    constructor(emitter, rawSelectors) {
         this.emitter = emitter;
         this.currentAncestry = [];
-        this.parsedQueryMap = (selectors || [])
+        this.parsedQueryMap = (rawSelectors || [])
 
             // Filter out selectors that only contain a node name, and treat them as a special case.
             // Although these selectors are valid, it's not necessary to check all of them on every node, because it's
             // always safe to just emit a node's type while entering it.
             .filter(query => !/^\w+(:exit)?$/.test(query))
-            .reduce((parsedQueryMap, selector) => parsedQueryMap.set(selector, esquery.parse(selector)), new Map());
+            .reduce((parsedQueryMap, rawSelector) => parsedQueryMap.set(esquery.parse(rawSelector.replace(/:exit$/, "")), rawSelector), new Map());
+
+        this.selectorsByNodeType = new Map();
+        this.anyTypeSelectors = [];
+        this.parsedQueryMap.forEach((_, parsedSelector) => {
+            const possibleTypes = getPossibleTypes(parsedSelector);
+
+            if (possibleTypes) {
+                possibleTypes.forEach(nodeType => {
+                    if (!this.selectorsByNodeType.has(nodeType)) {
+                        this.selectorsByNodeType.set(nodeType, []);
+                    }
+                    this.selectorsByNodeType.get(nodeType).push(parsedSelector);
+                });
+            } else {
+                this.anyTypeSelectors.push(parsedSelector);
+            }
+        });
     }
 
     /**
@@ -54,11 +107,20 @@ class NodeEventGenerator {
             this.currentAncestry.unshift(node.parent);
         }
 
-        this.parsedQueryMap.forEach((parsedQuery, rawQuery) => {
-            if (esquery.matches(node, parsedQuery, this.currentAncestry)) {
-                this.emitter.emit(rawQuery, node);
-            }
-        });
+        const selectorsToAttempt = this.anyTypeSelectors.concat(this.selectorsByNodeType.get(node.type) || []);
+
+        selectorsToAttempt
+            .filter(selector => esquery.matches(node, selector, this.currentAncestry))
+            .forEach(selector => {
+                if (this.parsedQueryMap.get(selector).endsWith(":exit")) {
+                    if (!scheduledExitMatches.has(node)) {
+                        scheduledExitMatches.set(node, []);
+                    }
+                    scheduledExitMatches.get(node).push(selector);
+                } else {
+                    this.emitter.emit(this.parsedQueryMap.get(selector), node);
+                }
+            });
     }
 
     /**
@@ -69,6 +131,10 @@ class NodeEventGenerator {
     leaveNode(node) {
         this.currentAncestry.shift();
         this.emitter.emit(`${node.type}:exit`, node);
+
+        if (scheduledExitMatches.has(node)) {
+            scheduledExitMatches.get(node).forEach(selector => this.emitter.emit(selector, node));
+        }
     }
 }
 

--- a/lib/util/node-event-generator.js
+++ b/lib/util/node-event-generator.js
@@ -5,6 +5,8 @@
 
 "use strict";
 
+const esquery = require("esquery");
+
 //------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
@@ -24,10 +26,20 @@
 class NodeEventGenerator {
 
     /**
-     * @param {EventEmitter} emitter - An event emitter which is the destination of events.
-     */
-    constructor(emitter) {
+    * @param {EventEmitter} emitter - An event emitter which is the destination of events.
+    * @param {string[]} selectors A list of query selector strings to detect and emit
+    * @returns {NodeEventGenerator} new instance
+    */
+    constructor(emitter, selectors) {
         this.emitter = emitter;
+        this.currentAncestry = [];
+        this.parsedQueryMap = (selectors || [])
+
+            // Filter out selectors that only contain a node name, and treat them as a special case.
+            // Although these selectors are valid, it's not necessary to check all of them on every node, because it's
+            // always safe to just emit a node's type while entering it.
+            .filter(query => !/^\w+(:exit)?$/.test(query))
+            .reduce((parsedQueryMap, selector) => parsedQueryMap.set(selector, esquery.parse(selector)), new Map());
     }
 
     /**
@@ -37,6 +49,16 @@ class NodeEventGenerator {
      */
     enterNode(node) {
         this.emitter.emit(node.type, node);
+
+        if (node.parent) {
+            this.currentAncestry.unshift(node.parent);
+        }
+
+        this.parsedQueryMap.forEach((parsedQuery, rawQuery) => {
+            if (esquery.matches(node, parsedQuery, this.currentAncestry)) {
+                this.emitter.emit(rawQuery, node);
+            }
+        });
     }
 
     /**
@@ -45,6 +67,7 @@ class NodeEventGenerator {
      * @returns {void}
      */
     leaveNode(node) {
+        this.currentAncestry.shift();
         this.emitter.emit(`${node.type}:exit`, node);
     }
 }

--- a/lib/util/node-event-generator.js
+++ b/lib/util/node-event-generator.js
@@ -5,21 +5,45 @@
 
 "use strict";
 
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
 const esquery = require("esquery");
 const lodash = require("lodash");
 
+//------------------------------------------------------------------------------
+// Typedefs
+//------------------------------------------------------------------------------
+
+/**
+ * An object describing an AST selector
+ * @typedef {Object} ASTSelector
+ * @property {string} rawSelector The string that was parsed into this selector
+ * @property {boolean} isExit `true` if this should be emitted when exiting the node rather than when entering
+ * @property {Object} parsedSelector An object (from esquery) describing the matching behavior of the selector
+ * @property {string[]|null} listenerTypes A list of node types that could possibly cause the selector to match,
+ * or `null` if all node types could cause a match
+ * @property {number} attributeCount The total number of classes, pseudo-classes, and attribute queries in this selector
+ * @property {number} identifierCount The total number of identifier queries in this selector
+ */
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
 /**
 * Gets the possible types of a selector
-* @param {Object} selector parsed selector
+* @param {Object} parsedSelector An object (from esquery) describing the matching behavior of the selector
 * @returns {string[]|null} The node types that could possibly trigger this selector, or `null` if all node types could trigger it
 */
-function getPossibleTypes(selector) {
-    switch (selector.type) {
+function getPossibleTypes(parsedSelector) {
+    switch (parsedSelector.type) {
         case "identifier":
-            return [selector.value];
+            return [parsedSelector.value];
 
         case "matches": {
-            const typesForComponents = selector.selectors.map(getPossibleTypes);
+            const typesForComponents = parsedSelector.selectors.map(getPossibleTypes);
 
             if (typesForComponents.every(typesForComponent => typesForComponent)) {
                 return lodash.union.apply(null, typesForComponents);
@@ -28,7 +52,7 @@ function getPossibleTypes(selector) {
         }
 
         case "compound": {
-            const typesForComponents = selector.selectors.map(getPossibleTypes).filter(typesForComponent => typesForComponent);
+            const typesForComponents = parsedSelector.selectors.map(getPossibleTypes).filter(typesForComponent => typesForComponent);
 
             // If all of the components could match any type, then the compound could also match any type.
             if (!typesForComponents.length) {
@@ -46,7 +70,7 @@ function getPossibleTypes(selector) {
         case "descendant":
         case "sibling":
         case "adjacent":
-            return getPossibleTypes(selector.right);
+            return getPossibleTypes(parsedSelector.right);
 
         default:
             return null;
@@ -56,21 +80,21 @@ function getPossibleTypes(selector) {
 
 /**
  * Counts the number of class, pseudo-class, and attribute queries in this selector
- * @param {Object} selector A parsed selector object
+ * @param {Object} parsedSelector An object (from esquery) describing the selector's matching behavior
  * @returns {number} The number of class, pseudo-class, and attribute queries in this selector
  */
-function countClassAttributes(selector) {
-    switch (selector.type) {
+function countClassAttributes(parsedSelector) {
+    switch (parsedSelector.type) {
         case "child":
         case "descendant":
         case "sibling":
         case "adjacent":
-            return countClassAttributes(selector.left) + countClassAttributes(selector.right);
+            return countClassAttributes(parsedSelector.left) + countClassAttributes(parsedSelector.right);
 
         case "compound":
         case "not":
         case "matches":
-            return selector.selectors.reduce((sum, childSelector) => sum + countClassAttributes(childSelector), 0);
+            return parsedSelector.selectors.reduce((sum, childSelector) => sum + countClassAttributes(childSelector), 0);
 
         case "attribute":
         case "field":
@@ -85,21 +109,21 @@ function countClassAttributes(selector) {
 
 /**
  * Counts the number of identifier queries in this selector
- * @param {Object} selector A parsed selector object
- * @returns {number} The number of type queries
+ * @param {Object} parsedSelector An object (from esquery) describing the selector's matching behavior
+ * @returns {number} The number of identifier queries
  */
-function countIdentifiers(selector) {
-    switch (selector.type) {
+function countIdentifiers(parsedSelector) {
+    switch (parsedSelector.type) {
         case "child":
         case "descendant":
         case "sibling":
         case "adjacent":
-            return countIdentifiers(selector.left) + countIdentifiers(selector.right);
+            return countIdentifiers(parsedSelector.left) + countIdentifiers(parsedSelector.right);
 
         case "compound":
         case "not":
         case "matches":
-            return selector.selectors.reduce((sum, childSelector) => sum + countIdentifiers(childSelector), 0);
+            return parsedSelector.selectors.reduce((sum, childSelector) => sum + countIdentifiers(childSelector), 0);
 
         case "identifier":
             return 1;
@@ -111,8 +135,8 @@ function countIdentifiers(selector) {
 
 /**
  * Compares the specificity of two selector objects, with CSS-like rules.
- * @param {Object} selectorA An object describing a selector (like the return value of parseSelector)
- * @param {Object} selectorB An object describing a selector (like the return value of parseSelector)
+ * @param {ASTSelector} selectorA An AST selector descriptor
+ * @param {ASTSelector} selectorB Another AST selector descriptor
  * @returns {number}
  * a value less than 0 if selectorA is less specific than selectorB
  * a value greater than 0 if selectorA is more specific than selectorB
@@ -128,7 +152,7 @@ function compareSpecificity(selectorA, selectorB) {
 /**
  * Parses a raw selector string, and throws a useful error if parsing fails.
  * @param {string} rawSelector A raw AST selector
- * @returns {Object} A parsed AST selector object
+ * @returns {Object} An object (from esquery) describing the matching behavior of this selector
  * @throws {Error} An error if the selector is invalid
  */
 function tryParseSelector(rawSelector) {
@@ -145,13 +169,7 @@ function tryParseSelector(rawSelector) {
 /**
  * Parses a raw selector string, and returns the parsed selector along with specificity and type information.
  * @param {string} rawSelector A raw AST selector
- * @returns {Object} Information about the selector with the following properties:
- * rawSelector (string): The original raw selector that was passed in
- * isExit (boolean): true if the selector should be called when exiting the given node, rather than entering
- * parsedSelector (object): A parsed AST selector object
- * listenerTypes (string[]|null): The types of nodes that this selector could possibly fire on, or null if it could fire on any type
- * attributeCount (number): The total number of classe, pseudo-classe, and attribute queries in this selector
- * identifierCount (number): The total number of identifier queries in this selector
+ * @returns {ASTSelector} A selector descriptor
  */
 const parseSelector = lodash.memoize(rawSelector => {
     const parsedSelector = tryParseSelector(rawSelector);
@@ -239,7 +257,7 @@ class NodeEventGenerator {
     /**
      * Checks a selector against a node, and emits it if it matches
      * @param {ASTNode} node The node to check
-     * @param {Object} selector An object with selector info (from `parseSelector`)
+     * @param {ASTSelector} selector An AST selector descriptor
      * @returns {void}
      */
     applySelector(node, selector) {

--- a/lib/util/node-event-generator.js
+++ b/lib/util/node-event-generator.js
@@ -7,12 +7,11 @@
 
 const esquery = require("esquery");
 const lodash = require("lodash");
-const scheduledExitMatches = new WeakMap();
 
 /**
 * Gets the possible types of a selector
 * @param {Object} selector parsed selector
-* @returns {string[]|null} return value (TODO)
+* @returns {string[]|null} The node types that could possibly trigger this selector, or `null` if all node types could trigger it
 */
 function getPossibleTypes(selector) {
     switch (selector.type) {
@@ -43,6 +42,15 @@ function getPossibleTypes(selector) {
     }
 }
 
+class Selector {
+    constructor(query) {
+        this.query = query;
+        this.parsedSelector = esquery.parse(query.replace(/:exit$/, ""));
+        this.isExit = query.endsWith(":exit");
+        this.listenerTypes = getPossibleTypes(this.parsedSelector);
+    }
+}
+
 //------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
@@ -69,30 +77,42 @@ class NodeEventGenerator {
     constructor(emitter, rawSelectors) {
         this.emitter = emitter;
         this.currentAncestry = [];
-        this.parsedQueryMap = (rawSelectors || [])
+        this.scheduledExitMatches = new WeakMap();
+        this.selectors = (rawSelectors || [])
 
             // Filter out selectors that only contain a node name, and treat them as a special case.
             // Although these selectors are valid, it's not necessary to check all of them on every node, because it's
             // always safe to just emit a node's type while entering it.
-            .filter(query => !/^\w+(:exit)?$/.test(query))
-            .reduce((parsedQueryMap, rawSelector) => parsedQueryMap.set(esquery.parse(rawSelector.replace(/:exit$/, "")), rawSelector), new Map());
+            .filter(query => !/(^\w+|\*)(:exit)?$/.test(query))
+            .map(query => new Selector(query));
 
         this.selectorsByNodeType = new Map();
         this.anyTypeSelectors = [];
-        this.parsedQueryMap.forEach((_, parsedSelector) => {
-            const possibleTypes = getPossibleTypes(parsedSelector);
-
-            if (possibleTypes) {
-                possibleTypes.forEach(nodeType => {
+        this.selectors.forEach(selector => {
+            if (selector.listenerTypes) {
+                selector.listenerTypes.forEach(nodeType => {
                     if (!this.selectorsByNodeType.has(nodeType)) {
                         this.selectorsByNodeType.set(nodeType, []);
                     }
-                    this.selectorsByNodeType.get(nodeType).push(parsedSelector);
+                    this.selectorsByNodeType.get(nodeType).push(selector);
                 });
             } else {
-                this.anyTypeSelectors.push(parsedSelector);
+                this.anyTypeSelectors.push(selector);
             }
         });
+    }
+
+    applySelector(node, selector) {
+        if (esquery.matches(node, selector.parsedSelector, this.currentAncestry)) {
+            if (selector.isExit) {
+                if (!this.scheduledExitMatches.has(node)) {
+                    this.scheduledExitMatches.set(node, []);
+                }
+                this.scheduledExitMatches.get(node).push(selector);
+            } else {
+                this.emitter.emit(selector.query, node);
+            }
+        }
     }
 
     /**
@@ -102,25 +122,17 @@ class NodeEventGenerator {
      */
     enterNode(node) {
         this.emitter.emit(node.type, node);
+        this.emitter.emit("*", node);
 
         if (node.parent) {
             this.currentAncestry.unshift(node.parent);
         }
 
-        const selectorsToAttempt = this.anyTypeSelectors.concat(this.selectorsByNodeType.get(node.type) || []);
+        this.anyTypeSelectors.forEach(selector => this.applySelector(node, selector));
 
-        selectorsToAttempt
-            .filter(selector => esquery.matches(node, selector, this.currentAncestry))
-            .forEach(selector => {
-                if (this.parsedQueryMap.get(selector).endsWith(":exit")) {
-                    if (!scheduledExitMatches.has(node)) {
-                        scheduledExitMatches.set(node, []);
-                    }
-                    scheduledExitMatches.get(node).push(selector);
-                } else {
-                    this.emitter.emit(this.parsedQueryMap.get(selector), node);
-                }
-            });
+        if (this.selectorsByNodeType.has(node.type)) {
+            this.selectorsByNodeType.get(node.type).forEach(selector => this.applySelector(node, selector));
+        }
     }
 
     /**
@@ -131,9 +143,10 @@ class NodeEventGenerator {
     leaveNode(node) {
         this.currentAncestry.shift();
         this.emitter.emit(`${node.type}:exit`, node);
+        this.emitter.emit("*:exit", node);
 
-        if (scheduledExitMatches.has(node)) {
-            scheduledExitMatches.get(node).forEach(selector => this.emitter.emit(selector, node));
+        if (this.scheduledExitMatches.has(node)) {
+            this.scheduledExitMatches.get(node).forEach(selector => this.emitter.emit(selector.parsedSelector, node));
         }
     }
 }

--- a/lib/util/node-event-generator.js
+++ b/lib/util/node-event-generator.js
@@ -54,14 +54,98 @@ function getPossibleTypes(selector) {
     }
 }
 
-const parseSelector = lodash.memoize(query => {
-    const parsedSelector = esquery.parse(query.replace(/:exit$/, ""));
+/**
+ * Counts the number of class, pseudo-class, and attribute queries in this selector
+ * @param {Object} selector A parsed selector object
+ * @returns {number} The number of class, pseudo-class, and attribute queries in this selector
+ */
+function countClassAttributes(selector) {
+    switch (selector.type) {
+        case "child":
+        case "descendant":
+        case "sibling":
+        case "adjacent":
+            return countClassAttributes(selector.left) + countClassAttributes(selector.right);
+
+        case "compound":
+        case "not":
+        case "matches":
+            return selector.selectors.reduce((sum, childSelector) => sum + countClassAttributes(childSelector), 0);
+
+        case "attribute":
+        case "field":
+        case "nth-child":
+        case "nth-last-child":
+            return 1;
+
+        default:
+            return 0;
+    }
+}
+
+/**
+ * Counts the number of identifier queries in this selector
+ * @param {Object} selector A parsed selector object
+ * @returns {number} The number of type queries
+ */
+function countIdentifiers(selector) {
+    switch (selector.type) {
+        case "child":
+        case "descendant":
+        case "sibling":
+        case "adjacent":
+            return countIdentifiers(selector.left) + countIdentifiers(selector.right);
+
+        case "compound":
+        case "not":
+        case "matches":
+            return selector.selectors.reduce((sum, childSelector) => sum + countIdentifiers(childSelector), 0);
+
+        case "identifier":
+            return 1;
+
+        default:
+            return 0;
+    }
+}
+
+/**
+ * Compares the specificity of two selector objects, with CSS-like rules.
+ * @param {Object} selectorA An object describing a selector (like the return value of parseSelector)
+ * @param {Object} selectorB An object describing a selector (like the return value of parseSelector)
+ * @returns {number}
+ * a value less than 0 if selectorA is less specific than selectorB
+ * a value greater than 0 if selectorA is more specific than selectorB
+ * a value less than 0 if selectorA and selectorB have the same specificity, and selectorA <= selectorB alphabetically
+ * a value greater than 0 if selectorA and selectorB have the same specificity, and selectorA > selectorB alphabetically
+ */
+function compareSpecificity(selectorA, selectorB) {
+    return selectorA.attributeCount - selectorB.attributeCount ||
+        selectorA.identifierCount - selectorB.identifierCount ||
+        (selectorA.rawSelector <= selectorB.rawSelector ? -1 : 1);
+}
+
+/**
+ * Parses a raw selector string, and returns the parsed selector along with specificity and type information.
+ * @param {string} rawSelector A raw AST selector
+ * @returns {Object} Information about the selector with the following properties:
+ * rawSelector (string): The original raw selector that was passed in
+ * isExit (boolean): true if the selector should be called when exiting the given node, rather than entering
+ * parsedSelector (object): A parsed AST selector object
+ * listenerTypes (string[]|null): The types of nodes that this selector could possibly fire on, or null if it could fire on any type
+ * attributeCount (number): The total number of classe, pseudo-classe, and attribute queries in this selector
+ * identifierCount (number): The total number of identifier queries in this selector
+ */
+const parseSelector = lodash.memoize(rawSelector => {
+    const parsedSelector = esquery.parse(rawSelector.replace(/:exit$/, ""));
 
     return {
-        query,
-        isExit: query.endsWith(":exit"),
+        rawSelector,
+        isExit: rawSelector.endsWith(":exit"),
         parsedSelector,
-        listenerTypes: getPossibleTypes(parsedSelector)
+        listenerTypes: getPossibleTypes(parsedSelector),
+        attributeCount: countClassAttributes(parsedSelector),
+        identifierCount: countIdentifiers(parsedSelector)
     };
 });
 
@@ -91,44 +175,72 @@ class NodeEventGenerator {
     constructor(emitter, queries) {
         this.emitter = emitter;
         this.currentAncestry = [];
-        this.scheduledExitMatches = new WeakMap();
-        this.selectors = [];
-        this.selectorsByNodeType = new Map();
-        this.anyTypeSelectors = [];
+        this.enterSelectorsByNodeType = new Map();
+        this.exitSelectorsByNodeType = new Map();
+        this.anyTypeEnterSelectors = [];
+        this.anyTypeExitSelectors = [];
 
-        queries.forEach(query => {
+        queries.forEach(rawSelector => {
+            const selector = parseSelector(rawSelector);
 
-            // Filter out selectors that only contain a node name, and treat them as a special case.
-            // Although these selectors are valid, it's not necessary to check all of them on every node, because it's
-            // always safe to just emit a node's type while entering it.
-            if (!/^\w+(:exit)?$/.test(query)) {
-                this.selectors.push(parseSelector(query));
-            }
-        });
-
-        this.selectors.forEach(selector => {
             if (selector.listenerTypes) {
                 selector.listenerTypes.forEach(nodeType => {
-                    if (!this.selectorsByNodeType.has(nodeType)) {
-                        this.selectorsByNodeType.set(nodeType, []);
+                    const typeMap = selector.isExit ? this.exitSelectorsByNodeType : this.enterSelectorsByNodeType;
+
+                    if (!typeMap.has(nodeType)) {
+                        typeMap.set(nodeType, []);
                     }
-                    this.selectorsByNodeType.get(nodeType).push(selector);
+                    typeMap.get(nodeType).push(selector);
                 });
             } else {
-                this.anyTypeSelectors.push(selector);
+                (selector.isExit ? this.anyTypeExitSelectors : this.anyTypeEnterSelectors).push(selector);
             }
         });
+
+        this.anyTypeEnterSelectors.sort(compareSpecificity);
+        this.anyTypeExitSelectors.sort(compareSpecificity);
+        this.enterSelectorsByNodeType.forEach(selectorList => selectorList.sort(compareSpecificity));
+        this.exitSelectorsByNodeType.forEach(selectorList => selectorList.sort(compareSpecificity));
     }
 
+    /**
+     * Checks a selector against a node, and emits it if it matches
+     * @param {ASTNode} node The node to check
+     * @param {Object} selector An object with selector info (from `parseSelector`)
+     * @returns {void}
+     */
     applySelector(node, selector) {
         if (esquery.matches(node, selector.parsedSelector, this.currentAncestry)) {
-            if (selector.isExit) {
-                if (!this.scheduledExitMatches.has(node)) {
-                    this.scheduledExitMatches.set(node, []);
-                }
-                this.scheduledExitMatches.get(node).push(selector);
+            this.emitter.emit(selector.rawSelector, node);
+        }
+    }
+
+    /**
+     * Applies all appropriate selectors to a node, in specificity order
+     * @param {ASTNode} node The node to check
+     * @param {boolean} isExit `false` if the node is currently being entered, `true` if it's currently being exited
+     * @returns {void}
+     */
+    applySelectors(node, isExit) {
+        const selectorsByNodeType = (isExit ? this.exitSelectorsByNodeType : this.enterSelectorsByNodeType).get(node.type) || [];
+        const anyTypeSelectors = isExit ? this.anyTypeExitSelectors : this.anyTypeEnterSelectors;
+
+        /*
+         * selectorsByNodeType and anyTypeSelectors were already sorted by specificity in the constructor.
+         * Iterate through each of them, applying selectors in the right order.
+         */
+        let selectorsByTypeIndex = 0;
+        let anyTypeSelectorsIndex = 0;
+
+        while (selectorsByTypeIndex < selectorsByNodeType.length || anyTypeSelectorsIndex < anyTypeSelectors.length) {
+            if (
+                selectorsByTypeIndex >= selectorsByNodeType.length ||
+                anyTypeSelectorsIndex < anyTypeSelectors.length &&
+                compareSpecificity(anyTypeSelectors[anyTypeSelectorsIndex], selectorsByNodeType[selectorsByTypeIndex]) < 0
+            ) {
+                this.applySelector(node, anyTypeSelectors[anyTypeSelectorsIndex++]);
             } else {
-                this.emitter.emit(selector.query, node);
+                this.applySelector(node, selectorsByNodeType[selectorsByTypeIndex++]);
             }
         }
     }
@@ -139,17 +251,10 @@ class NodeEventGenerator {
      * @returns {void}
      */
     enterNode(node) {
-        this.emitter.emit(node.type, node);
-
         if (node.parent) {
             this.currentAncestry.unshift(node.parent);
         }
-
-        this.anyTypeSelectors.forEach(selector => this.applySelector(node, selector));
-
-        if (this.selectorsByNodeType.has(node.type)) {
-            this.selectorsByNodeType.get(node.type).forEach(selector => this.applySelector(node, selector));
-        }
+        this.applySelectors(node, false);
     }
 
     /**
@@ -158,12 +263,8 @@ class NodeEventGenerator {
      * @returns {void}
      */
     leaveNode(node) {
+        this.applySelectors(node, true);
         this.currentAncestry.shift();
-        this.emitter.emit(`${node.type}:exit`, node);
-
-        if (this.scheduledExitMatches.has(node)) {
-            this.scheduledExitMatches.get(node).forEach(selector => this.emitter.emit(selector.query, node));
-        }
     }
 }
 

--- a/lib/util/node-event-generator.js
+++ b/lib/util/node-event-generator.js
@@ -90,7 +90,7 @@ class NodeEventGenerator {
                 // Filter out selectors that only contain a node name, and treat them as a special case.
                 // Although these selectors are valid, it's not necessary to check all of them on every node, because it's
                 // always safe to just emit a node's type while entering it.
-                if (!/(^\w+|\*)(:exit)?$/.test(query)) {
+                if (!/^\w+(:exit)?$/.test(query)) {
                     this.selectors.push(parseSelector(query));
                 }
             });
@@ -130,7 +130,6 @@ class NodeEventGenerator {
      */
     enterNode(node) {
         this.emitter.emit(node.type, node);
-        this.emitter.emit("*", node);
 
         if (node.parent) {
             this.currentAncestry.unshift(node.parent);
@@ -151,7 +150,6 @@ class NodeEventGenerator {
     leaveNode(node) {
         this.currentAncestry.shift();
         this.emitter.emit(`${node.type}:exit`, node);
-        this.emitter.emit("*:exit", node);
 
         if (this.scheduledExitMatches.has(node)) {
             this.scheduledExitMatches.get(node).forEach(selector => this.emitter.emit(selector.parsedSelector, node));

--- a/lib/util/node-event-generator.js
+++ b/lib/util/node-event-generator.js
@@ -168,11 +168,11 @@ const parseSelector = lodash.memoize(rawSelector => {
 class NodeEventGenerator {
 
     /**
-    * @param {EventEmitter} emitter - An event emitter which is the destination of events.
-    * @param {Set<string>} queries A list of query selector strings to detect and emit
+    * @param {EventEmitter} emitter - An event emitter which is the destination of events. This emitter must already
+    * have registered listeners for all of the events that it needs to listen for.
     * @returns {NodeEventGenerator} new instance
     */
-    constructor(emitter, queries) {
+    constructor(emitter) {
         this.emitter = emitter;
         this.currentAncestry = [];
         this.enterSelectorsByNodeType = new Map();
@@ -180,7 +180,23 @@ class NodeEventGenerator {
         this.anyTypeEnterSelectors = [];
         this.anyTypeExitSelectors = [];
 
-        queries.forEach(rawSelector => {
+        const eventNames = typeof emitter.eventNames === "function"
+
+            // Use the built-in eventNames() function if available (Node 6+)
+            ? emitter.eventNames()
+
+            /*
+             * Otherwise, use the private _events property.
+             * Using a private property isn't ideal here, but this seems to
+             * be the best way to get a list of event names without overriding
+             * addEventListener, which would hurt performance. This property
+             * is widely used and unlikely to be removed in a future version
+             * (see https://github.com/nodejs/node/issues/1817). Also, future
+             * node versions will have eventNames() anyway.
+             */
+            : Object.keys(emitter._events); // eslint-disable-line no-underscore-dangle
+
+        eventNames.forEach(rawSelector => {
             const selector = parseSelector(rawSelector);
 
             if (selector.listenerTypes) {

--- a/lib/util/node-event-generator.js
+++ b/lib/util/node-event-generator.js
@@ -126,6 +126,23 @@ function compareSpecificity(selectorA, selectorB) {
 }
 
 /**
+ * Parses a raw selector string, and throws a useful error if parsing fails.
+ * @param {string} rawSelector A raw AST selector
+ * @returns {Object} A parsed AST selector object
+ * @throws {Error} An error if the selector is invalid
+ */
+function tryParseSelector(rawSelector) {
+    try {
+        return esquery.parse(rawSelector.replace(/:exit$/, ""));
+    } catch (err) {
+        if (typeof err.offset === "number") {
+            throw new Error(`Syntax error in selector "${rawSelector}" at position ${err.offset}: ${err.message}`);
+        }
+        throw err;
+    }
+}
+
+/**
  * Parses a raw selector string, and returns the parsed selector along with specificity and type information.
  * @param {string} rawSelector A raw AST selector
  * @returns {Object} Information about the selector with the following properties:
@@ -137,7 +154,7 @@ function compareSpecificity(selectorA, selectorB) {
  * identifierCount (number): The total number of identifier queries in this selector
  */
 const parseSelector = lodash.memoize(rawSelector => {
-    const parsedSelector = esquery.parse(rawSelector.replace(/:exit$/, ""));
+    const parsedSelector = tryParseSelector(rawSelector);
 
     return {
         rawSelector,

--- a/lib/util/node-event-generator.js
+++ b/lib/util/node-event-generator.js
@@ -73,23 +73,29 @@ class NodeEventGenerator {
 
     /**
     * @param {EventEmitter} emitter - An event emitter which is the destination of events.
-    * @param {string[]} rawSelectors A list of query selector strings to detect and emit
+    * @param {Set<string>} queries A list of query selector strings to detect and emit
     * @returns {NodeEventGenerator} new instance
     */
-    constructor(emitter, rawSelectors) {
+    constructor(emitter, queries) {
         this.emitter = emitter;
         this.currentAncestry = [];
         this.scheduledExitMatches = new WeakMap();
-        this.selectors = (rawSelectors || [])
-
-            // Filter out selectors that only contain a node name, and treat them as a special case.
-            // Although these selectors are valid, it's not necessary to check all of them on every node, because it's
-            // always safe to just emit a node's type while entering it.
-            .filter(query => !/(^\w+|\*)(:exit)?$/.test(query))
-            .map(parseSelector);
-
+        this.selectors = [];
         this.selectorsByNodeType = new Map();
         this.anyTypeSelectors = [];
+
+        if (queries) {
+            queries.forEach(query => {
+
+                // Filter out selectors that only contain a node name, and treat them as a special case.
+                // Although these selectors are valid, it's not necessary to check all of them on every node, because it's
+                // always safe to just emit a node's type while entering it.
+                if (!/(^\w+|\*)(:exit)?$/.test(query)) {
+                    this.selectors.push(parseSelector(query));
+                }
+            });
+        }
+
         this.selectors.forEach(selector => {
             if (selector.listenerTypes) {
                 selector.listenerTypes.forEach(nodeType => {

--- a/lib/util/node-event-generator.js
+++ b/lib/util/node-event-generator.js
@@ -84,17 +84,15 @@ class NodeEventGenerator {
         this.selectorsByNodeType = new Map();
         this.anyTypeSelectors = [];
 
-        if (queries) {
-            queries.forEach(query => {
+        queries.forEach(query => {
 
-                // Filter out selectors that only contain a node name, and treat them as a special case.
-                // Although these selectors are valid, it's not necessary to check all of them on every node, because it's
-                // always safe to just emit a node's type while entering it.
-                if (!/^\w+(:exit)?$/.test(query)) {
-                    this.selectors.push(parseSelector(query));
-                }
-            });
-        }
+            // Filter out selectors that only contain a node name, and treat them as a special case.
+            // Although these selectors are valid, it's not necessary to check all of them on every node, because it's
+            // always safe to just emit a node's type while entering it.
+            if (!/^\w+(:exit)?$/.test(query)) {
+                this.selectors.push(parseSelector(query));
+            }
+        });
 
         this.selectors.forEach(selector => {
             if (selector.listenerTypes) {

--- a/lib/util/node-event-generator.js
+++ b/lib/util/node-event-generator.js
@@ -19,16 +19,28 @@ function getPossibleTypes(selector) {
             return [selector.value];
 
         case "matches": {
-            const typesPerCase = selector.selectors.map(getPossibleTypes);
+            const typesForComponents = selector.selectors.map(getPossibleTypes);
 
-            if (typesPerCase.every(typeList => typeList)) {
-                return lodash.union.apply(null, typesPerCase);
+            if (typesForComponents.every(typesForComponent => typesForComponent)) {
+                return lodash.union.apply(null, typesForComponents);
             }
             return null;
         }
 
-        case "compound":
-            return lodash.intersection.apply(null, selector.selectors.map(getPossibleTypes).filter(Boolean));
+        case "compound": {
+            const typesForComponents = selector.selectors.map(getPossibleTypes).filter(typesForComponent => typesForComponent);
+
+            // If all of the components could match any type, then the compound could also match any type.
+            if (!typesForComponents.length) {
+                return null;
+            }
+
+            /*
+             * If at least one of the components could only match a particular type, the compound could only match
+             * the intersection of those types.
+             */
+            return lodash.intersection.apply(null, typesForComponents);
+        }
 
         case "child":
         case "descendant":
@@ -150,7 +162,7 @@ class NodeEventGenerator {
         this.emitter.emit(`${node.type}:exit`, node);
 
         if (this.scheduledExitMatches.has(node)) {
-            this.scheduledExitMatches.get(node).forEach(selector => this.emitter.emit(selector.parsedSelector, node));
+            this.scheduledExitMatches.get(node).forEach(selector => this.emitter.emit(selector.query, node));
         }
     }
 }

--- a/lib/util/node-event-generator.js
+++ b/lib/util/node-event-generator.js
@@ -42,14 +42,16 @@ function getPossibleTypes(selector) {
     }
 }
 
-class Selector {
-    constructor(query) {
-        this.query = query;
-        this.parsedSelector = esquery.parse(query.replace(/:exit$/, ""));
-        this.isExit = query.endsWith(":exit");
-        this.listenerTypes = getPossibleTypes(this.parsedSelector);
-    }
-}
+const parseSelector = lodash.memoize(query => {
+    const parsedSelector = esquery.parse(query.replace(/:exit$/, ""));
+
+    return {
+        query,
+        isExit: query.endsWith(":exit"),
+        parsedSelector,
+        listenerTypes: getPossibleTypes(parsedSelector)
+    };
+});
 
 //------------------------------------------------------------------------------
 // Public Interface
@@ -84,7 +86,7 @@ class NodeEventGenerator {
             // Although these selectors are valid, it's not necessary to check all of them on every node, because it's
             // always safe to just emit a node's type while entering it.
             .filter(query => !/(^\w+|\*)(:exit)?$/.test(query))
-            .map(query => new Selector(query));
+            .map(parseSelector);
 
         this.selectorsByNodeType = new Map();
         this.anyTypeSelectors = [];

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "doctrine": "^1.2.2",
     "escope": "^3.6.0",
     "espree": "^3.4.0",
-    "esquery": "^0.4.0",
+    "esquery": "^1.0.0",
     "estraverse": "^4.2.0",
     "esutils": "^2.0.2",
     "file-entry-cache": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "doctrine": "^1.2.2",
     "escope": "^3.6.0",
     "espree": "^3.4.0",
+    "esquery": "^0.4.0",
     "estraverse": "^4.2.0",
     "esutils": "^2.0.2",
     "file-entry-cache": "^2.0.0",

--- a/tests/lib/code-path-analysis/code-path-analyzer.js
+++ b/tests/lib/code-path-analysis/code-path-analyzer.js
@@ -59,7 +59,7 @@ describe("CodePathAnalyzer", () => {
     });
 
     EventGeneratorTester.testEventGeneratorInterface(
-        new CodePathAnalyzer(new NodeEventGenerator(new EventEmitter(), new Set()))
+        new CodePathAnalyzer(new NodeEventGenerator(new EventEmitter()))
     );
 
     describe("interface of code paths", () => {

--- a/tests/lib/code-path-analysis/code-path-analyzer.js
+++ b/tests/lib/code-path-analysis/code-path-analyzer.js
@@ -59,7 +59,7 @@ describe("CodePathAnalyzer", () => {
     });
 
     EventGeneratorTester.testEventGeneratorInterface(
-        new CodePathAnalyzer(new NodeEventGenerator(new EventEmitter()))
+        new CodePathAnalyzer(new NodeEventGenerator(new EventEmitter(), new Set()))
     );
 
     describe("interface of code paths", () => {

--- a/tests/lib/rules/no-restricted-syntax.js
+++ b/tests/lib/rules/no-restricted-syntax.js
@@ -21,7 +21,12 @@ ruleTester.run("no-restricted-syntax", rule, {
     valid: [
         { code: "doSomething();" },
         { code: "var foo = 42;", options: ["ConditionalExpression"] },
-        { code: "foo += 42;", options: ["VariableDeclaration", "FunctionExpression"] }
+        { code: "foo += 42;", options: ["VariableDeclaration", "FunctionExpression"] },
+        { code: "foo;", options: ["Identifier[name=\"bar\"]"] },
+        { code: "() => 5", options: ["ArrowFunctionExpression > BlockStatement"], parserOptions: { ecmaVersion: 6 } },
+        { code: "({ foo: 1, bar: 2 })", options: ["Property > Literal.key"] },
+        { code: "A: for (;;) break;", options: ["BreakStatement[label]"] },
+        { code: "function foo(bar, baz) {}", options: ["FunctionDeclaration[params.length>2]"] }
     ],
     invalid: [
         {
@@ -43,6 +48,40 @@ ruleTester.run("no-restricted-syntax", rule, {
                 { message: "Using 'CatchClause' is not allowed.", type: "CatchClause" },
                 { message: "Using 'CallExpression' is not allowed.", type: "CallExpression" }
             ]
-        }
+        },
+        {
+            code: "bar;",
+            options: ["Identifier[name=\"bar\"]"],
+            errors: [{ message: "Using 'Identifier[name=\"bar\"]' is not allowed.", type: "Identifier" }]
+        },
+        {
+            code: "bar;",
+            options: ["Identifier", "Identifier[name=\"bar\"]"],
+            errors: [
+                { message: "Using 'Identifier' is not allowed.", type: "Identifier" },
+                { message: "Using 'Identifier[name=\"bar\"]' is not allowed.", type: "Identifier" }
+            ]
+        },
+        {
+            code: "() => {}",
+            parserOptions: { ecmaVersion: 6 },
+            options: ["ArrowFunctionExpression > BlockStatement"],
+            errors: [{ message: "Using 'ArrowFunctionExpression > BlockStatement' is not allowed.", type: "BlockStatement" }]
+        },
+        {
+            code: "({ foo: 1, 'bar': 2 })",
+            options: ["Property > Literal.key"],
+            errors: [{ message: "Using 'Property > Literal.key' is not allowed.", type: "Literal" }]
+        },
+        {
+            code: "A: for (;;) break A;",
+            options: ["BreakStatement[label]"],
+            errors: [{ message: "Using 'BreakStatement[label]' is not allowed.", type: "BreakStatement" }]
+        },
+        {
+            code: "function foo(bar, baz, qux) {}",
+            options: ["FunctionDeclaration[params.length>2]"],
+            errors: [{ message: "Using 'FunctionDeclaration[params.length>2]' is not allowed.", type: "FunctionDeclaration" }]
+        },
     ]
 });

--- a/tests/lib/rules/no-restricted-syntax.js
+++ b/tests/lib/rules/no-restricted-syntax.js
@@ -82,6 +82,6 @@ ruleTester.run("no-restricted-syntax", rule, {
             code: "function foo(bar, baz, qux) {}",
             options: ["FunctionDeclaration[params.length>2]"],
             errors: [{ message: "Using 'FunctionDeclaration[params.length>2]' is not allowed.", type: "FunctionDeclaration" }]
-        },
+        }
     ]
 });

--- a/tests/lib/util/comment-event-generator.js
+++ b/tests/lib/util/comment-event-generator.js
@@ -24,12 +24,12 @@ const assert = require("assert"),
 
 describe("NodeEventGenerator", () => {
     EventGeneratorTester.testEventGeneratorInterface(
-        new CommentEventGenerator(new NodeEventGenerator(new EventEmitter()))
+        new CommentEventGenerator(new NodeEventGenerator(new EventEmitter(), new Set()))
     );
 
     it("should generate comment events without duplicate.", () => {
         const emitter = new EventEmitter();
-        let generator = new NodeEventGenerator(emitter);
+        let generator = new NodeEventGenerator(emitter, new Set());
         const code = "//foo\nvar zzz /*aaa*/ = 777;\n//bar";
         const ast = espree.parse(code, {
             range: true,

--- a/tests/lib/util/comment-event-generator.js
+++ b/tests/lib/util/comment-event-generator.js
@@ -24,12 +24,11 @@ const assert = require("assert"),
 
 describe("NodeEventGenerator", () => {
     EventGeneratorTester.testEventGeneratorInterface(
-        new CommentEventGenerator(new NodeEventGenerator(new EventEmitter(), new Set()))
+        new CommentEventGenerator(new NodeEventGenerator(new EventEmitter()))
     );
 
     it("should generate comment events without duplicate.", () => {
         const emitter = new EventEmitter();
-        let generator = new NodeEventGenerator(emitter, new Set());
         const code = "//foo\nvar zzz /*aaa*/ = 777;\n//bar";
         const ast = espree.parse(code, {
             range: true,
@@ -58,6 +57,10 @@ describe("NodeEventGenerator", () => {
             ["LineComment:exit", ast.comments[0]], // foo
             ["Program:exit", ast]
         ];
+
+        expected.forEach(expectedValues => emitter.on(expectedValues[0], () => {}));
+
+        let generator = new NodeEventGenerator(emitter);
 
         emitter.emit = sinon.spy(emitter.emit);
         generator = new CommentEventGenerator(generator, sourceCode);

--- a/tests/lib/util/node-event-generator.js
+++ b/tests/lib/util/node-event-generator.js
@@ -28,7 +28,7 @@ describe("NodeEventGenerator", () => {
     beforeEach(() => {
         emitter = new EventEmitter();
         emitter.emit = sinon.spy(emitter.emit);
-        generator = new NodeEventGenerator(emitter);
+        generator = new NodeEventGenerator(emitter, ["Foo", "Foo > Bar"]);
     });
 
     it("should generate events for entering AST node.", () => {
@@ -47,5 +47,14 @@ describe("NodeEventGenerator", () => {
 
         assert(emitter.emit.calledOnce);
         assert(emitter.emit.calledWith("Foo:exit", dummyNode));
+    });
+
+    it("should generate events for AST queries", () => {
+        const dummyNode = { type: "Bar", parent: { type: "Foo" } };
+
+        generator.enterNode(dummyNode);
+
+        assert(emitter.emit.calledTwice);
+        assert(emitter.emit.calledWith("Foo > Bar", dummyNode));
     });
 });

--- a/tests/lib/util/node-event-generator.js
+++ b/tests/lib/util/node-event-generator.js
@@ -20,7 +20,7 @@ const assert = require("assert"),
 
 describe("NodeEventGenerator", () => {
     EventGeneratorTester.testEventGeneratorInterface(
-        new NodeEventGenerator(new EventEmitter())
+        new NodeEventGenerator(new EventEmitter(), new Set())
     );
 
     let emitter, generator;

--- a/tests/lib/util/node-event-generator.js
+++ b/tests/lib/util/node-event-generator.js
@@ -269,4 +269,15 @@ describe("NodeEventGenerator", () => {
             ]
         );
     });
+
+    describe("parsing an invalid selector", () => {
+        it("throws a useful error", () => {
+            assert.throws(() => {
+                const emitter = new EventEmitter();
+
+                emitter.on("Foo >", () => {});
+                return new NodeEventGenerator(emitter);
+            }, /Syntax error in selector "Foo >" at position 5: Expected " ", "!", .*/);
+        });
+    });
 });

--- a/tests/lib/util/node-event-generator.js
+++ b/tests/lib/util/node-event-generator.js
@@ -108,7 +108,6 @@ describe("NodeEventGenerator", () => {
          * @param {Array<string>} possibleQueries A collection of selectors that rules are listening for
          * @param {Array<string>} expectedEmissions The emissions that the generator is expected to produce, in order.
          * This should only include emissions that appear in possibleQueries.
-         * that appear in possibleQueries.
          * @returns {void}
          */
         function assertEmissions(sourceText, possibleQueries, expectedEmissions) {
@@ -251,7 +250,7 @@ describe("NodeEventGenerator", () => {
                 ":not(Program, ExpressionStatement)", // 0 pseudoclasses, 2 identifiers
                 "ExpressionStatement > Identifier", // 0 pseudoclasses, 2 identifiers
                 "Identifier, ReturnStatement", // 0 pseudoclasses, 2 identifiers
-                "[name = 'foo']", // 0 pseudoclass, 0 identifiers
+                "[name = 'foo']", // 1 pseudoclass, 0 identifiers
                 "[name='foo']", // 1 pseudoclass, 0 identifiers
                 "ExpressionStatement > [name='foo']", // 1 attribute, 1 identifier
                 "Identifier[name='foo']", // 1 attribute, 1 identifier

--- a/tests/lib/util/node-event-generator.js
+++ b/tests/lib/util/node-event-generator.js
@@ -30,7 +30,7 @@ const ESPREE_CONFIG = {
 
 describe("NodeEventGenerator", () => {
     EventGeneratorTester.testEventGeneratorInterface(
-        new NodeEventGenerator(new EventEmitter(), new Set())
+        new NodeEventGenerator(new EventEmitter())
     );
 
     describe("entering a single AST node", () => {
@@ -38,8 +38,9 @@ describe("NodeEventGenerator", () => {
 
         beforeEach(() => {
             emitter = new EventEmitter();
+            ["Foo", "Bar", "Foo > Bar", "Foo:exit"].forEach(selector => emitter.on(selector, () => {}));
             emitter.emit = sinon.spy(emitter.emit);
-            generator = new NodeEventGenerator(emitter, ["Foo", "Bar", "Foo > Bar", "Foo:exit"]);
+            generator = new NodeEventGenerator(emitter);
         });
 
         it("should generate events for entering AST node.", () => {
@@ -81,7 +82,9 @@ describe("NodeEventGenerator", () => {
         function getEmissions(sourceText, possibleQueries) {
             const emissions = [];
             const emitter = new EventEmitter();
-            const generator = new NodeEventGenerator(emitter, possibleQueries);
+
+            possibleQueries.forEach(query => emitter.on(query, () => {}));
+            const generator = new NodeEventGenerator(emitter);
             const ast = espree.parse(sourceText, ESPREE_CONFIG);
 
             emitter.emit = type => emissions.push(type);

--- a/tests/lib/util/node-event-generator.js
+++ b/tests/lib/util/node-event-generator.js
@@ -232,6 +232,22 @@ describe("NodeEventGenerator", () => {
         );
 
         assertEmissions(
+            "foo; bar + baz; qux()",
+            [":expression", ":statement"],
+            ast => [
+                [":statement", ast.body[0]],
+                [":expression", ast.body[0].expression],
+                [":statement", ast.body[1]],
+                [":expression", ast.body[1].expression],
+                [":expression", ast.body[1].expression.left],
+                [":expression", ast.body[1].expression.right],
+                [":statement", ast.body[2]],
+                [":expression", ast.body[2].expression],
+                [":expression", ast.body[2].expression.callee]
+            ]
+        );
+
+        assertEmissions(
             "foo;",
             [
                 "*",

--- a/tests/lib/util/node-event-generator.js
+++ b/tests/lib/util/node-event-generator.js
@@ -272,12 +272,13 @@ describe("NodeEventGenerator", () => {
 
     describe("parsing an invalid selector", () => {
         it("throws a useful error", () => {
-            assert.throws(() => {
-                const emitter = new EventEmitter();
+            const emitter = new EventEmitter();
 
-                emitter.on("Foo >", () => {});
-                return new NodeEventGenerator(emitter);
-            }, /Syntax error in selector "Foo >" at position 5: Expected " ", "!", .*/);
+            emitter.on("Foo >", () => {});
+            assert.throws(
+                () => new NodeEventGenerator(emitter),
+                /Syntax error in selector "Foo >" at position 5: Expected " ", "!", .*/
+            );
         });
     });
 });

--- a/tests/lib/util/node-event-generator.js
+++ b/tests/lib/util/node-event-generator.js
@@ -11,6 +11,8 @@
 const assert = require("assert"),
     EventEmitter = require("events").EventEmitter,
     sinon = require("sinon"),
+    espree = require("espree"),
+    estraverse = require("estraverse"),
     EventGeneratorTester = require("../../../lib/testers/event-generator-tester"),
     NodeEventGenerator = require("../../../lib/util/node-event-generator");
 
@@ -18,43 +20,193 @@ const assert = require("assert"),
 // Tests
 //------------------------------------------------------------------------------
 
+const ESPREE_CONFIG = {
+    ecmaVersion: 6,
+    comment: true,
+    tokens: true,
+    range: true,
+    loc: true
+};
+
 describe("NodeEventGenerator", () => {
     EventGeneratorTester.testEventGeneratorInterface(
         new NodeEventGenerator(new EventEmitter(), new Set())
     );
 
-    let emitter, generator;
+    describe("entering a single AST node", () => {
+        let emitter, generator;
 
-    beforeEach(() => {
-        emitter = new EventEmitter();
-        emitter.emit = sinon.spy(emitter.emit);
-        generator = new NodeEventGenerator(emitter, ["Foo", "Foo > Bar"]);
+        beforeEach(() => {
+            emitter = new EventEmitter();
+            emitter.emit = sinon.spy(emitter.emit);
+            generator = new NodeEventGenerator(emitter, ["Foo", "Foo > Bar"]);
+        });
+
+        it("should generate events for entering AST node.", () => {
+            const dummyNode = { type: "Foo", value: 1 };
+
+            generator.enterNode(dummyNode);
+
+            assert(emitter.emit.calledOnce);
+            assert(emitter.emit.calledWith("Foo", dummyNode));
+        });
+
+        it("should generate events for exitting AST node.", () => {
+            const dummyNode = { type: "Foo", value: 1 };
+
+            generator.leaveNode(dummyNode);
+
+            assert(emitter.emit.calledOnce);
+            assert(emitter.emit.calledWith("Foo:exit", dummyNode));
+        });
+
+        it("should generate events for AST queries", () => {
+            const dummyNode = { type: "Bar", parent: { type: "Foo" } };
+
+            generator.enterNode(dummyNode);
+
+            assert(emitter.emit.calledTwice);
+            assert(emitter.emit.calledWith("Foo > Bar", dummyNode));
+        });
     });
 
-    it("should generate events for entering AST node.", () => {
-        const dummyNode = { type: "Foo", value: 1 };
+    describe("traversing the entire AST", () => {
 
-        generator.enterNode(dummyNode);
+        /**
+         * Gets a list of emitted types/selectors from the generator, in emission order
+         * @param {string} sourceText Source code to parse and traverse
+         * @param {Array<string>|Set<string>} possibleQueries Selectors to detect
+         * @returns {string[]} A list of strings that were emitted, in the order that they were emitted in
+         */
+        function getEmissions(sourceText, possibleQueries) {
+            const emissions = [];
+            const emitter = new EventEmitter();
+            const generator = new NodeEventGenerator(emitter, possibleQueries);
+            const ast = espree.parse(sourceText, ESPREE_CONFIG);
 
-        assert(emitter.emit.calledOnce);
-        assert(emitter.emit.calledWith("Foo", dummyNode));
-    });
+            emitter.emit = type => emissions.push(type);
 
-    it("should generate events for exitting AST node.", () => {
-        const dummyNode = { type: "Foo", value: 1 };
+            estraverse.traverse(ast, {
+                enter(node, parent) {
+                    node.parent = parent;
+                    generator.enterNode(node);
+                },
+                leave(node) {
+                    generator.leaveNode(node);
+                }
+            });
 
-        generator.leaveNode(dummyNode);
+            return emissions;
+        }
 
-        assert(emitter.emit.calledOnce);
-        assert(emitter.emit.calledWith("Foo:exit", dummyNode));
-    });
+        /**
+         * Creates a test case that asserts a particular sequence of generator emissions
+         * @param {string} sourceText The source text that should be parsed and traversed
+         * @param {Array<string>} possibleQueries A collection of selectors that rules are listening for
+         * @param {Array<string>} expectedEmissions The emissions that the generator is expected to produce, in order
+         * @param {Function} emissionFilter A filter for the emission list. Defaults to only containing selectors
+         * that appear in possibleQueries.
+         * @returns {void}
+         */
+        function assertEmissions(sourceText, possibleQueries, expectedEmissions, emissionFilter) {
+            it(possibleQueries.join("; "), () => {
+                const emissions = getEmissions(sourceText, possibleQueries)
+                    .filter(emissionFilter || (emission => possibleQueries.indexOf(emission) !== -1));
 
-    it("should generate events for AST queries", () => {
-        const dummyNode = { type: "Bar", parent: { type: "Foo" } };
+                assert.deepEqual(emissions, expectedEmissions);
+            });
+        }
 
-        generator.enterNode(dummyNode);
+        assertEmissions(
+            "foo + bar",
+            [],
+            ["Program", "ExpressionStatement", "BinaryExpression", "Identifier", "Identifier:exit", "Identifier", "Identifier:exit", "BinaryExpression:exit", "ExpressionStatement:exit", "Program:exit"],
+            () => true
+        );
 
-        assert(emitter.emit.calledTwice);
-        assert(emitter.emit.calledWith("Foo > Bar", dummyNode));
+        assertEmissions(
+            "foo + 5",
+            [
+                "BinaryExpression > Identifier",
+                "BinaryExpression",
+                "BinaryExpression Literal:exit",
+                "BinaryExpression > Identifier:exit",
+                "BinaryExpression:exit"
+            ],
+            [
+                "BinaryExpression", // foo + 5
+                "BinaryExpression > Identifier", // foo
+                "BinaryExpression > Identifier:exit", // exiting foo
+                "BinaryExpression Literal:exit", // exiting 5
+                "BinaryExpression:exit" // exiting foo + 5
+            ]
+        );
+
+        assertEmissions(
+            "foo + 5",
+            ["BinaryExpression > *[name='foo']"],
+            ["BinaryExpression > *[name='foo']"] // entering foo
+        );
+
+        assertEmissions(
+            "foo",
+            ["*"],
+            ["*", "*", "*"] // Program, ExpressionStatement, Identifier
+        );
+
+        assertEmissions(
+            "foo",
+            ["*:not(ExpressionStatement)"],
+            ["*:not(ExpressionStatement)", "*:not(ExpressionStatement)"] // Program, Identifier
+        );
+
+        assertEmissions(
+            "foo()",
+            ["CallExpression[callee.name='foo']"],
+            ["CallExpression[callee.name='foo']"] // foo()
+        );
+
+        assertEmissions(
+            "foo()",
+            ["CallExpression[callee.name='bar']"],
+            [] // (nothing emitted)
+        );
+
+        assertEmissions(
+            "foo + bar + baz",
+            [":not(*)"],
+            [] // (nothing emitted)
+        );
+
+        assertEmissions(
+            "foo + bar + baz",
+            [":matches(Identifier[name='foo'], Identifier[name='bar'], Identifier[name='baz'])"],
+            [
+                ":matches(Identifier[name='foo'], Identifier[name='bar'], Identifier[name='baz'])", // foo
+                ":matches(Identifier[name='foo'], Identifier[name='bar'], Identifier[name='baz'])", // bar
+                ":matches(Identifier[name='foo'], Identifier[name='bar'], Identifier[name='baz'])" // baz
+            ]
+        );
+
+        assertEmissions(
+            "foo + 5 + 6",
+            [":matches(Identifier, Literal[value=5])"],
+            [
+                ":matches(Identifier, Literal[value=5])", // foo
+                ":matches(Identifier, Literal[value=5])" // 5
+            ]
+        );
+
+        assertEmissions(
+            "[foo, 5, foo]",
+            ["Identifier + Literal"],
+            ["Identifier + Literal"]  // 5
+        );
+
+        assertEmissions(
+            "[foo, {}, 5]",
+            ["Identifier + Literal", "Identifier ~ Literal"],
+            ["Identifier ~ Literal"]  // 5
+        );
     });
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Add something to the core

**What changes did you make? (Give an overview)**

This updates node-event-generator to allow rules to listen for selectors. It also updates the implementation of a few simple rules to use this feature.

Before traversal begins, all the selectors needed by the active rules are gathered and passed to `node-event-generator`. When a node is entered, `node-event-generator` checks whether the node matches each selector using esquery, and emits the selector if so. Since this implementation detects shallow matches for a given node rather than getting all matches in the AST for a selector, it only needs to do one AST traversal.

~~This PR is not yet complete. Remaining things to do:~~

* ~~Decide whether we want to go forward with this approach~~
* ~~Call selector listeners in a consistent order. Currently, if a rule is listening for multiple selectors that match the same node, they fire in a different order depending on whether other rules also listen for those selectors. This is undesirable -- we should guarantee that listeners always fire in the same order.~~
* ~~Determine how to support `:exit` with selectors. (Currently, `Foo:exit` is valid like it was before, but something like `Foo > Bar:exit` is not.)~~
* ~~Add documentation~~
* ~~Add more tests~~
* ~~Make sure selector specificity definition is consistent with CSS~~
* ~~Fail gracefully if a rule specifies an invalid selector~~

Also see: https://github.com/eslint/eslint/pull/5441, https://github.com/eslint/eslint/pull/7822

**Is there anything you'd like reviewers to focus on?**

I'm interested in feedback on this approach to detecting selector matches.