### PR TITLE
Fix: capitalized-comments: Ignore consec. comments if first is invalid

### DIFF
--- a/docs/rules/capitalized-comments.md
+++ b/docs/rules/capitalized-comments.md
@@ -56,7 +56,7 @@ Here are the supported object options:
 * `ignorePattern`: A string representing a regular expression pattern of words that should be ignored by this rule. If the first word of a comment matches the pattern, this rule will not report that comment.
     * Note that the following words are always ignored by this rule: `["jscs", "jshint", "eslint", "istanbul", "global", "globals", "exported"]`.
 * `ignoreInlineComments`: If this is `true`, the rule will not report on comments in the middle of code. By default, this is `false`.
-* `ignoreConsecutiveComments`: If this is `true`, the rule will not report on a comment which violates the rule, as long as the comment immediately follows a comment which is also not reported. By default, this is `false`.
+* `ignoreConsecutiveComments`: If this is `true`, the rule will not report on a comment which violates the rule, as long as the comment immediately follows another comment. By default, this is `false`.
 
 Here is an example configuration:
 
@@ -172,7 +172,7 @@ function foo(/* ignored */ a) {
 
 #### `ignoreConsecutiveComments`
 
-If the `ignoreConsecutiveComments` option is set to `true`, then comments which otherwise violate the rule will not be reported as long as they immediately follow a comment which did not violate the rule. This can be applied more than once.
+If the `ignoreConsecutiveComments` option is set to `true`, then comments which otherwise violate the rule will not be reported as long as they immediately follow another comment. This can be applied more than once.
 
 Examples of **correct** code with `ignoreConsecutiveComments` set to `true`:
 
@@ -188,6 +188,15 @@ Examples of **correct** code with `ignoreConsecutiveComments` set to `true`:
 /*
  * in fact, even if any of these are multi-line, that is fine too.
  */
+```
+
+Examples of **incorrect** code with `ignoreConsecutiveComments` set to `true`:
+
+```js
+/* eslint capitalize-comments: ["error", "always", { "ignoreConsecutiveComments": true }] */
+
+// this comment is invalid, but only on this line.
+// this comment does NOT get reported, since it is a consecutive comment.
 ```
 
 ### Using Different Options for Line and Block Comments

--- a/docs/rules/capitalized-comments.md
+++ b/docs/rules/capitalized-comments.md
@@ -179,12 +179,12 @@ Examples of **correct** code with `ignoreConsecutiveComments` set to `true`:
 ```js
 /* eslint capitalize-comments: ["error", "always", { "ignoreConsecutiveComments": true }] */
 
-// This comment is valid since it has the correct capitalization,
-// and so is this one because it immediately follows a valid comment,
-// and this one as well because it follows the previous valid comment.
+// This comment is valid since it has the correct capitalization.
+// this comment is ignored since it follows another comment,
+// and this one as well because it follows yet another comment.
 
 /* Here is a block comment which has the correct capitalization, */
-/* and this one is valid as well; */
+/* but this one is ignored due to being consecutive; */
 /*
  * in fact, even if any of these are multi-line, that is fine too.
  */

--- a/lib/rules/capitalized-comments.js
+++ b/lib/rules/capitalized-comments.js
@@ -137,8 +137,7 @@ module.exports = {
 
         const capitalize = context.options[0] || "always",
             normalizedOptions = getAllNormalizedOptions(context.options[1]),
-            sourceCode = context.getSourceCode(),
-            validCommentMap = new Map();
+            sourceCode = context.getSourceCode();
 
         createRegExpForIgnorePatterns(normalizedOptions);
 
@@ -186,8 +185,7 @@ module.exports = {
 
             return Boolean(
                 previousTokenOrComment &&
-                ["Block", "Line"].indexOf(previousTokenOrComment.type) !== -1 &&
-                validCommentMap.get(previousTokenOrComment)
+                ["Block", "Line"].indexOf(previousTokenOrComment.type) !== -1
             );
         }
 
@@ -286,8 +284,6 @@ module.exports = {
                     }
                 });
             }
-
-            validCommentMap.set(comment, commentValid);
         }
 
         //----------------------------------------------------------------------

--- a/lib/rules/capitalized-comments.js
+++ b/lib/rules/capitalized-comments.js
@@ -175,12 +175,12 @@ module.exports = {
         }
 
         /**
-         * Determine if a comment follows another valid comment.
+         * Determine if a comment follows another comment.
          *
          * @param {ASTNode} comment The comment to check.
          * @returns {boolean} True if the comment follows a valid comment.
          */
-        function isConsecutiveValidComment(comment) {
+        function isConsecutiveComment(comment) {
             const previousTokenOrComment = sourceCode.getTokenOrCommentBefore(comment);
 
             return Boolean(
@@ -217,7 +217,7 @@ module.exports = {
             }
 
             // 4. Is this a consecutive comment (and are we tolerating those)?
-            if (options.ignoreConsecutiveComments && isConsecutiveValidComment(comment)) {
+            if (options.ignoreConsecutiveComments && isConsecutiveComment(comment)) {
                 return true;
             }
 

--- a/tests/lib/rules/capitalized-comments.js
+++ b/tests/lib/rules/capitalized-comments.js
@@ -849,6 +849,22 @@ ruleTester.run("capitalized-comments", rule, {
                 column: 1
             }]
         },
+        {
+            code: [
+                "// This comment is invalid since it is not capitalized,",
+                "// But this one is ignored since it is consecutive.",
+            ].join("\n"),
+            output: [
+                "// this comment is invalid since it is not capitalized,",
+                "// But this one is ignored since it is consecutive.",
+            ].join("\n"),
+            options: ["never", { ignoreConsecutiveComments: true }],
+            errors: [{
+                message: NEVER_MESSAGE,
+                line: 1,
+                column: 1
+            }]
+        },
 
         // Consecutive comments should warn if ignoreConsecutiveComments:false
         {

--- a/tests/lib/rules/capitalized-comments.js
+++ b/tests/lib/rules/capitalized-comments.js
@@ -832,6 +832,24 @@ ruleTester.run("capitalized-comments", rule, {
             }]
         },
 
+        // Only the initial comment should warn if ignoreConsecutiveComments:true
+        {
+            code: [
+                "// this comment is invalid since it is not capitalized,",
+                "// but this one is ignored since it is consecutive.",
+            ].join("\n"),
+            output: [
+                "// This comment is invalid since it is not capitalized,",
+                "// but this one is ignored since it is consecutive.",
+            ].join("\n"),
+            options: ["always", { ignoreConsecutiveComments: true }],
+            errors: [{
+                message: ALWAYS_MESSAGE,
+                line: 1,
+                column: 1
+            }]
+        },
+
         // Consecutive comments should warn if ignoreConsecutiveComments:false
         {
             code: [


### PR DESCRIPTION
Only applies when `ignoreConsecutiveComments` option is enabled.

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

See issue #7831.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Ensure that all consecutive comments are ignored (with `ignoreConsecutiveComments: true` option), even if first comment in the "text block" is invalid. This ensures that the autofixer does not incorrectly fix consecutive comments.

**Is there anything you'd like reviewers to focus on?**

It seemed simpler to remove the data structure I was using to track consecutive comments since it no longer matters if the previous comment was valid. Do you agree with that change? And am I missing any test cases?