### PR TITLE
Fix: no-implied-eval false positive on 'setTimeoutFoo' (fixes #7821)

### DIFF
--- a/lib/rules/no-implied-eval.js
+++ b/lib/rules/no-implied-eval.js
@@ -21,7 +21,7 @@ module.exports = {
     },
 
     create(context) {
-        const CALLEE_RE = /set(?:Timeout|Interval)|execScript/;
+        const CALLEE_RE = /^(setTimeout|setInterval|execScript)$/;
 
         /*
          * Figures out if we should inspect a given binary expression. Is a stack

--- a/tests/lib/rules/no-implied-eval.js
+++ b/tests/lib/rules/no-implied-eval.js
@@ -53,7 +53,10 @@ ruleTester.run("no-implied-eval", rule, {
         "setTimeout(foobar, foo + 'bar')",
 
         // only checks immediate subtrees of the argument
-        "setTimeout(function() { return 'foobar'; }, 10)"
+        "setTimeout(function() { return 'foobar'; }, 10)",
+
+        // https://github.com/eslint/eslint/issues/7821
+        "setTimeoutFooBar('Foo Bar')"
     ],
 
     invalid: [


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (see https://github.com/eslint/eslint/issues/7821)

**What changes did you make? (Give an overview)**

This updates the function name matcher in `no-implied-eval` to ensure that a match like `setTimeout` matches the entire name of the function rather than a substring. This prevents the rule from reporting functions like `setTimeoutFooBar`.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.
