### PR TITLE
Update: add fixer for no-extra-label

### DIFF
--- a/docs/rules/no-extra-label.md
+++ b/docs/rules/no-extra-label.md
@@ -1,5 +1,7 @@
 # Disallow Unnecessary Labels (no-extra-label)
 
+(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 If a loop contains no nested loops or switches, labeling the loop is unnecessary.
 
 ```js

--- a/lib/rules/no-extra-label.js
+++ b/lib/rules/no-extra-label.js
@@ -23,10 +23,13 @@ module.exports = {
             recommended: false
         },
 
-        schema: []
+        schema: [],
+
+        fixable: "code"
     },
 
     create(context) {
+        const sourceCode = context.getSourceCode();
         let scopeInfo = null;
 
         /**
@@ -37,7 +40,7 @@ module.exports = {
          */
         function enterBreakableStatement(node) {
             scopeInfo = {
-                label: astUtils.getLabel(node),
+                label: node.parent.type === "LabeledStatement" ? node.parent.label : null,
                 breakable: true,
                 upper: scopeInfo
             };
@@ -64,7 +67,7 @@ module.exports = {
         function enterLabeledStatement(node) {
             if (!astUtils.isBreakableStatement(node.body)) {
                 scopeInfo = {
-                    label: node.label.name,
+                    label: node.label,
                     breakable: false,
                     upper: scopeInfo
                 };
@@ -99,22 +102,24 @@ module.exports = {
             }
 
             const labelNode = node.label;
-            const label = labelNode.name;
-            let info = scopeInfo;
 
-            while (info) {
-                if (info.breakable || info.label === label) {
-                    if (info.breakable && info.label === label) {
+            for (let info = scopeInfo; info !== null; info = info.upper) {
+                if (info.breakable || info.label && info.label.name === labelNode.name) {
+                    if (info.breakable && info.label && info.label.name === labelNode.name) {
                         context.report({
                             node: labelNode,
                             message: "This label '{{name}}' is unnecessary.",
-                            data: labelNode
+                            data: labelNode,
+                            fix(fixer) {
+                                return fixer.replaceTextRange(
+                                    [info.label.range[0], labelNode.range[1]],
+                                    sourceCode.text.slice(info.label.parent.body.range[0], sourceCode.getFirstToken(node).range[1])
+                                );
+                            }
                         });
                     }
                     return;
                 }
-
-                info = info.upper;
             }
         }
 

--- a/tests/lib/rules/no-extra-label.js
+++ b/tests/lib/rules/no-extra-label.js
@@ -39,15 +39,56 @@ ruleTester.run("no-extra-label", rule, {
         { code: "A: for (a of ary) { switch (b) { case 0: break A; } }", parserOptions: { ecmaVersion: 6 } }
     ],
     invalid: [
-        { code: "A: while (a) break A;", errors: ["This label 'A' is unnecessary."] },
-        { code: "A: while (a) { B: { continue A; } }", errors: ["This label 'A' is unnecessary."] },
-        { code: "X: while (x) { A: while (a) { B: { break A; break B; continue X; } } }", errors: ["This label 'A' is unnecessary."] },
-        { code: "A: do { break A; } while (a);", errors: ["This label 'A' is unnecessary."] },
-        { code: "A: for (;;) { break A; }", errors: ["This label 'A' is unnecessary."] },
-        { code: "A: for (a in obj) { break A; }", errors: ["This label 'A' is unnecessary."] },
-        { code: "A: for (a of ary) { break A; }", errors: ["This label 'A' is unnecessary."], parserOptions: { ecmaVersion: 6 } },
-        { code: "A: switch (a) { case 0: break A; }", errors: ["This label 'A' is unnecessary."] },
-        { code: "X: while (x) { A: switch (a) { case 0: break A; } }", errors: ["This label 'A' is unnecessary."] },
-        { code: "X: switch (a) { case 0: A: while (b) break A; }", errors: ["This label 'A' is unnecessary."] }
+        {
+            code: "A: while (a) break A;",
+            output: "while (a) break;",
+            errors: ["This label 'A' is unnecessary."]
+        },
+        {
+            code: "A: while (a) { B: { continue A; } }",
+            output: "while (a) { B: { continue; } }",
+            errors: ["This label 'A' is unnecessary."]
+        },
+        {
+            code: "X: while (x) { A: while (a) { B: { break A; break B; continue X; } } }",
+            output: "X: while (x) { while (a) { B: { break; break B; continue X; } } }",
+            errors: ["This label 'A' is unnecessary."]
+        },
+        {
+            code: "A: do { break A; } while (a);",
+            output: "do { break; } while (a);",
+            errors: ["This label 'A' is unnecessary."]
+        },
+        {
+            code: "A: for (;;) { break A; }",
+            output: "for (;;) { break; }",
+            errors: ["This label 'A' is unnecessary."]
+        },
+        {
+            code: "A: for (a in obj) { break A; }",
+            output: "for (a in obj) { break; }",
+            errors: ["This label 'A' is unnecessary."]
+        },
+        {
+            code: "A: for (a of ary) { break A; }",
+            output: "for (a of ary) { break; }",
+            errors: ["This label 'A' is unnecessary."],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "A: switch (a) { case 0: break A; }",
+            output: "switch (a) { case 0: break; }",
+            errors: ["This label 'A' is unnecessary."]
+        },
+        {
+            code: "X: while (x) { A: switch (a) { case 0: break A; } }",
+            output: "X: while (x) { switch (a) { case 0: break; } }",
+            errors: ["This label 'A' is unnecessary."]
+        },
+        {
+            code: "X: switch (a) { case 0: A: while (b) break A; }",
+            output: "X: switch (a) { case 0: while (b) break; }",
+            errors: ["This label 'A' is unnecessary."]
+        }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Add autofixing to a rule

**What changes did you make? (Give an overview)**

This adds a fixer for [`no-extra-label`](http://eslint.org/docs/rules/no-extra-label).

```js
A: while (true) {
  break A;
}

// gets fixed to:

while (true) {
  break;
}
```

**Is there anything you'd like reviewers to focus on?**

Nothing in particular