### PR TITLE
Update: add fixer for no-unused-labels

### DIFF
--- a/docs/rules/no-unused-labels.md
+++ b/docs/rules/no-unused-labels.md
@@ -1,5 +1,7 @@
 # Disallow Unused Labels (no-unused-labels)
 
+(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 Labels that are declared and not used anywhere in the code are most likely an error due to incomplete refactoring.
 
 ```js

--- a/lib/rules/no-unused-labels.js
+++ b/lib/rules/no-unused-labels.js
@@ -17,7 +17,9 @@ module.exports = {
             recommended: true
         },
 
-        schema: []
+        schema: [],
+
+        fixable: "code"
     },
 
     create(context) {
@@ -49,7 +51,8 @@ module.exports = {
                 context.report({
                     node: node.label,
                     message: "'{{name}}:' is defined but never used.",
-                    data: node.label
+                    data: node.label,
+                    fix: fixer => fixer.removeRange([node.range[0], node.body.range[0]])
                 });
             }
 

--- a/lib/rules/no-unused-labels.js
+++ b/lib/rules/no-unused-labels.js
@@ -23,6 +23,7 @@ module.exports = {
     },
 
     create(context) {
+        const sourceCode = context.getSourceCode();
         let scopeInfo = null;
 
         /**
@@ -52,7 +53,18 @@ module.exports = {
                     node: node.label,
                     message: "'{{name}}:' is defined but never used.",
                     data: node.label,
-                    fix: fixer => fixer.removeRange([node.range[0], node.body.range[0]])
+                    fix(fixer) {
+
+                        /*
+                         * Only perform a fix if there are no comments between the label and the body. This will be the case
+                         * when there is exactly one token/comment (the ":") between the label and the body.
+                         */
+                        if (sourceCode.getTokenOrCommentAfter(node.label) === sourceCode.getTokenOrCommentBefore(node.body)) {
+                            return fixer.removeRange([node.range[0], node.body.range[0]]);
+                        }
+
+                        return null;
+                    }
                 });
             }
 

--- a/tests/lib/rules/no-unused-labels.js
+++ b/tests/lib/rules/no-unused-labels.js
@@ -29,13 +29,41 @@ ruleTester.run("no-unused-labels", rule, {
         "A: { var A = 0; console.log(A); break A; console.log(A); }"
     ],
     invalid: [
-        { code: "A: var foo = 0;", errors: ["'A:' is defined but never used."] },
-        { code: "A: { foo(); bar(); }", errors: ["'A:' is defined but never used."] },
-        { code: "A: if (a) { foo(); bar(); }", errors: ["'A:' is defined but never used."] },
-        { code: "A: for (var i = 0; i < 10; ++i) { foo(); if (a) break; bar(); }", errors: ["'A:' is defined but never used."] },
-        { code: "A: for (var i = 0; i < 10; ++i) { foo(); if (a) continue; bar(); }", errors: ["'A:' is defined but never used."] },
-        { code: "A: for (var i = 0; i < 10; ++i) { B: break A; }", errors: ["'B:' is defined but never used."] },
-        { code: "A: { var A = 0; console.log(A); }", errors: ["'A:' is defined but never used."] }
+        {
+            code: "A: var foo = 0;",
+            output: "var foo = 0;",
+            errors: ["'A:' is defined but never used."]
+        },
+        {
+            code: "A: { foo(); bar(); }",
+            output: "{ foo(); bar(); }",
+            errors: ["'A:' is defined but never used."]
+        },
+        {
+            code: "A: if (a) { foo(); bar(); }",
+            output: "if (a) { foo(); bar(); }",
+            errors: ["'A:' is defined but never used."]
+        },
+        {
+            code: "A: for (var i = 0; i < 10; ++i) { foo(); if (a) break; bar(); }",
+            output: "for (var i = 0; i < 10; ++i) { foo(); if (a) break; bar(); }",
+            errors: ["'A:' is defined but never used."]
+        },
+        {
+            code: "A: for (var i = 0; i < 10; ++i) { foo(); if (a) continue; bar(); }",
+            output: "for (var i = 0; i < 10; ++i) { foo(); if (a) continue; bar(); }",
+            errors: ["'A:' is defined but never used."]
+        },
+        {
+            code: "A: for (var i = 0; i < 10; ++i) { B: break A; }",
+            output: "A: for (var i = 0; i < 10; ++i) { break A; }",
+            errors: ["'B:' is defined but never used."]
+        },
+        {
+            code: "A: { var A = 0; console.log(A); }",
+            output: "{ var A = 0; console.log(A); }",
+            errors: ["'A:' is defined but never used."]
+        }
 
         // Below is fatal errors.
         // "A: break B",

--- a/tests/lib/rules/no-unused-labels.js
+++ b/tests/lib/rules/no-unused-labels.js
@@ -63,6 +63,16 @@ ruleTester.run("no-unused-labels", rule, {
             code: "A: { var A = 0; console.log(A); }",
             output: "{ var A = 0; console.log(A); }",
             errors: ["'A:' is defined but never used."]
+        },
+        {
+            code: "A: /* comment */ foo",
+            output: "A: /* comment */ foo",
+            errors: ["'A:' is defined but never used."]
+        },
+        {
+            code: "A /* comment */: foo",
+            output: "A /* comment */: foo",
+            errors: ["'A:' is defined but never used."]
         }
 
         // Below is fatal errors.


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Add autofixing to a rule

**What changes did you make? (Give an overview)**

This adds a fixer for [`no-unused-labels`](http://eslint.org/docs/rules/no-unused-labels).

```js
foo: while (true) {}

// gets fixed to:

while (true) {}
```

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.
