### PR TITLE
Chore: use ast-utils helper functions in no-multiple-empty-lines

### DIFF
--- a/lib/rules/no-multiple-empty-lines.js
+++ b/lib/rules/no-multiple-empty-lines.js
@@ -5,6 +5,8 @@
  */
 "use strict";
 
+const astUtils = require("../ast-utils");
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -56,8 +58,6 @@ module.exports = {
         }
 
         const sourceCode = context.getSourceCode();
-        const fullLines = sourceCode.text.match(/.*(\r\n|\r|\n|\u2028|\u2029)/g) || [];
-        const lineStartLocations = fullLines.reduce((startIndices, nextLine) => startIndices.concat(startIndices[startIndices.length - 1] + nextLine.length), [0]);
 
         // Swallow the final newline, as some editors add it automatically and we don't want it to cause an issue
         const allLines = sourceCode.lines[sourceCode.lines.length - 1] === "" ? sourceCode.lines.slice(0, -1) : sourceCode.lines;
@@ -107,7 +107,12 @@ module.exports = {
                                 loc: { start: { line: lastLineNumber + 1, column: 0 }, end: { line: lineNumber, column: 0 } },
                                 message,
                                 data: { max: maxAllowed, pluralizedLines: maxAllowed === 1 ? "line" : "lines" },
-                                fix: fixer => fixer.removeRange([lineStartLocations[lastLineNumber], lineStartLocations[lineNumber - maxAllowed - 1]])
+                                fix(fixer) {
+                                    return fixer.removeRange([
+                                        astUtils.getRangeIndexFromLocation(sourceCode, { line: lastLineNumber + 1, column: 0 }),
+                                        astUtils.getRangeIndexFromLocation(sourceCode, { line: lineNumber - maxAllowed, column: 0 })
+                                    ]);
+                                }
                             });
                         }
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

**What changes did you make? (Give an overview)**

This updates `no-multiple-empty-lines` to use the `astUtils.getRangeIndexFromLocation` function to convert a line number to a range index instead of reimplementing the functionality. The current logic in the rule was implemented before `getRangeIndexFromLocation` was added.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.