### PR TITLE
Fix: no-multiple-empty-lines perf issue on large files (fixes #7803)

### DIFF
--- a/lib/rules/no-multiple-empty-lines.js
+++ b/lib/rules/no-multiple-empty-lines.js
@@ -81,7 +81,12 @@ module.exports = {
                 return allLines
 
                     // Given a list of lines, first get a list of line numbers that are non-empty.
-                    .reduce((nonEmptyLineNumbers, line, index) => nonEmptyLineNumbers.concat(line.trim() || templateLiteralLines.has(index + 1) ? [index + 1] : []), [])
+                    .reduce((nonEmptyLineNumbers, line, index) => {
+                        if (line.trim() || templateLiteralLines.has(index + 1)) {
+                            nonEmptyLineNumbers.push(index + 1);
+                        }
+                        return nonEmptyLineNumbers;
+                    }, [])
 
                     // Add a value at the end to allow trailing empty lines to be checked.
                     .concat(allLines.length + 1)


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (see https://github.com/eslint/eslint/issues/7803)

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates the `.reduce` function in `no-multiple-empty-lines` to avoid creating a new large array for every line in a file. 

Before:

```bash
(master)$ TIMING=1 bin/eslint.js --no-eslintrc --rule 'no-multiple-empty-lines: error' test-data.js

Rule                    | Time (ms) | Relative
:-----------------------|----------:|--------:
no-multiple-empty-lines |  1364.584 |   100.0%
```

After:

```bash
(no-multiple-empty-lines-perf)$ TIMING=1 bin/eslint.js --no-eslintrc --rule 'no-multiple-empty-lines: error' test-data.js
Rule                    | Time (ms) | Relative
:-----------------------|----------:|--------:
no-multiple-empty-lines |     9.742 |   100.0%
```

`test-data.js` is [this file](https://gist.github.com/mysticatea/2fca6bc8c2194f75e4808a884a1e351a) (originally from [this comment](https://github.com/eslint/eslint/pull/7618#issuecomment-264705477))

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.

I saw that this issue was assigned to @mysticatea, but I happened to find this fix while working on https://github.com/eslint/eslint/pull/7842, so I decided I might as well submit it.
