### PR TITLE
Fix: no-useless-return stack overflow on loops after throw (fixes #7855)

### DIFF
--- a/lib/rules/no-useless-return.js
+++ b/lib/rules/no-useless-return.js
@@ -120,15 +120,23 @@ module.exports = {
          *
          * @param {ASTNode[]} uselessReturns - The collected return statements.
          * @param {CodePathSegment[]} prevSegments - The previous segments to traverse.
+         * @param {WeakSet<CodePathSegment>} [traversedSegments] A set of segments that have already been traversed in this call
          * @returns {ASTNode[]} `uselessReturns`.
          */
-        function getUselessReturns(uselessReturns, prevSegments) {
+        function getUselessReturns(uselessReturns, prevSegments, traversedSegments) {
+            if (!traversedSegments) {
+                traversedSegments = new WeakSet();
+            }
             for (const segment of prevSegments) {
                 if (!segment.reachable) {
-                    getUselessReturns(
-                        uselessReturns,
-                        segment.allPrevSegments.filter(isReturned)
-                    );
+                    if (!traversedSegments.has(segment)) {
+                        traversedSegments.add(segment);
+                        getUselessReturns(
+                            uselessReturns,
+                            segment.allPrevSegments.filter(isReturned),
+                            traversedSegments
+                        );
+                    }
                     continue;
                 }
 

--- a/tests/lib/rules/no-useless-return.js
+++ b/tests/lib/rules/no-useless-return.js
@@ -157,6 +157,14 @@ ruleTester.run("no-useless-return", rule, {
             while (foo) return;
             foo;
           }
+        `,
+
+        // https://github.com/eslint/eslint/issues/7855
+        `
+          try {
+            throw new Error('foo');
+            while (false);
+          } catch (err) {}
         `
     ],
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (see https://github.com/eslint/eslint/issues/7855)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates `no-useless-return` to avoid circular backtracking through unreachable loops.

This is similar to https://github.com/eslint/eslint/issues/7583, but it's a different issue. (There are two places in `no-useless-return` where unreachable segments are traversed, and the fix for https://github.com/eslint/eslint/issues/7583 only addressed one of the places.)

**Is there anything you'd like reviewers to focus on?**

Nothing in particular