### PR TITLE
Fix: Ensure prefer-const fixes destructuring assignments (fixes #7852)

### DIFF
--- a/lib/rules/prefer-const.js
+++ b/lib/rules/prefer-const.js
@@ -6,12 +6,6 @@
 "use strict";
 
 //------------------------------------------------------------------------------
-// Requirements
-//------------------------------------------------------------------------------
-
-const lodash = require("lodash");
-
-//------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
 
@@ -265,78 +259,10 @@ module.exports = {
 
     create(context) {
         const options = context.options[0] || {};
+        const sourceCode = context.getSourceCode();
         const checkingMixedDestructuring = options.destructuring !== "all";
         const ignoreReadBeforeAssign = options.ignoreReadBeforeAssign === true;
-        let variables = null;
-
-        /**
-         * Reports a given Identifier node.
-         *
-         * @param {ASTNode} node - An Identifier node to report.
-         * @returns {void}
-         */
-        function report(node) {
-            const reportArgs = {
-                    node,
-                    message: "'{{name}}' is never reassigned. Use 'const' instead.",
-                    data: node
-                },
-                varDeclParent = findUp(node, "VariableDeclaration", parentNode => lodash.endsWith(parentNode.type, "Statement")),
-                isNormalVarDecl = (node.parent.parent.parent.type === "ForInStatement" ||
-                        node.parent.parent.parent.type === "ForOfStatement" ||
-                        node.parent.init),
-
-                isDestructuringVarDecl =
-
-                    // {let {a} = obj} should be written as {const {a} = obj}
-                    (node.parent.parent.type === "ObjectPattern" &&
-
-                        // If options.destucturing is "all", then this warning will not occur unless
-                        // every assignment in the destructuring should be const. In that case, it's safe
-                        // to apply the fix. Otherwise, it's safe to apply the fix if there's only one
-                        // assignment occurring. If there is more than one assignment and options.destructuring
-                        // is not "all", then it's not clear how the developer would want to resolve the issue,
-                        // so we should not attempt to do it programmatically.
-                        (options.destructuring === "all" || node.parent.parent.properties.length === 1)) ||
-
-                    // {let [a] = [1]} should be written as {const [a] = [1]}
-                    (node.parent.type === "ArrayPattern" &&
-
-                        // See note above about fixing multiple warnings at once.
-                        (options.destructuring === "all" || node.parent.elements.length === 1));
-
-            if (varDeclParent &&
-                    (isNormalVarDecl || isDestructuringVarDecl) &&
-
-                    // If there are multiple variable declarations, like {let a = 1, b = 2}, then
-                    // do not attempt to fix if one of the declarations should be `const`. It's
-                    // too hard to know how the developer would want to automatically resolve the issue.
-                    varDeclParent.declarations.length === 1) {
-
-                reportArgs.fix = function(fixer) {
-                    return fixer.replaceTextRange(
-                        [varDeclParent.start, varDeclParent.start + "let".length],
-                        "const"
-                    );
-                };
-            }
-
-            context.report(reportArgs);
-        }
-
-        /**
-         * Reports a given variable if the variable should be declared as const.
-         *
-         * @param {escope.Variable} variable - A variable to report.
-         * @returns {void}
-         */
-        function checkVariable(variable) {
-            const node = getIdentifierIfShouldBeConst(variable, ignoreReadBeforeAssign);
-
-            if (node) {
-                report(node);
-            }
-        }
+        const variables = [];
 
         /**
          * Reports given identifier nodes if all of the nodes should be declared
@@ -353,25 +279,39 @@ module.exports = {
          * @returns {void}
          */
         function checkGroup(nodes) {
-            if (nodes.every(Boolean)) {
-                nodes.forEach(report);
+            const nodesToReport = nodes.filter(Boolean);
+
+            if (nodes.length && (checkingMixedDestructuring || nodesToReport.length === nodes.length)) {
+                const varDeclParent = findUp(nodes[0], "VariableDeclaration", parentNode => parentNode.type.endsWith("Statement"));
+                const shouldFix = varDeclParent &&
+
+                    // If there are multiple variable declarations, like {let a = 1, b = 2}, then
+                    // do not attempt to fix if one of the declarations should be `const`. It's
+                    // too hard to know how the developer would want to automatically resolve the issue.
+                    varDeclParent.declarations.length === 1 &&
+
+                    // Don't do a fix unless the variable is initialized (or it's in a for-in or for-of loop)
+                    (varDeclParent.parent.type === "ForInStatement" || varDeclParent.parent.type === "ForOfStatement" || varDeclParent.declarations[0].init) &&
+
+                    // If options.destucturing is "all", then this warning will not occur unless
+                    // every assignment in the destructuring should be const. In that case, it's safe
+                    // to apply the fix.
+                    nodesToReport.length === nodes.length;
+
+                nodesToReport.forEach(node => {
+                    context.report({
+                        node,
+                        message: "'{{name}}' is never reassigned. Use 'const' instead.",
+                        data: node,
+                        fix: shouldFix ? fixer => fixer.replaceText(sourceCode.getFirstToken(varDeclParent), "const") : null
+                    });
+                });
             }
         }
 
         return {
-            Program() {
-                variables = [];
-            },
-
             "Program:exit"() {
-                if (checkingMixedDestructuring) {
-                    variables.forEach(checkVariable);
-                } else {
-                    groupByDestructuring(variables, ignoreReadBeforeAssign)
-                        .forEach(checkGroup);
-                }
-
-                variables = null;
+                groupByDestructuring(variables, ignoreReadBeforeAssign).forEach(checkGroup);
             },
 
             VariableDeclaration(node) {

--- a/tests/lib/rules/prefer-const.js
+++ b/tests/lib/rules/prefer-const.js
@@ -329,5 +329,13 @@ ruleTester.run("prefer-const", rule, {
             output: "/*eslint use-x:error*/ { const x = 1 }",
             errors: [{ message: "'x' is never reassigned. Use 'const' instead.", type: "Identifier" }]
         },
+        {
+            code: "let { foo, bar } = baz;",
+            output: "const { foo, bar } = baz;",
+            errors: [
+                { message: "'foo' is never reassigned. Use 'const' instead.", type: "Identifier" },
+                { message: "'bar' is never reassigned. Use 'const' instead.", type: "Identifier" },
+            ]
+        },
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (see https://github.com/eslint/eslint/issues/7852)

**What changes did you make? (Give an overview)**

This updates `prefer-const` to autofix destructuring assignments with the `destructuring: any` option if all of the declarations in the destructuring pattern are fixable.

Previously, destructuring assignments were only fixed when the `destructuring` option was set to `all`, or when there was exactly one variable declared in the assignment. It looks like this was due to a limitation of passing `node` as a single parameter to a `report` function -- the function couldn't determine whether the other variables declared in the destructuring assignment were also fixable, so it only performed a fix if there was exactly one declaration.

This commit updates the rule to check all variables in a destructuring assignment at once, which makes it easier to determine whether a fix should be performed. In addition, this means that the same logic can be used for destructuring and non-destructuring assignments.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
