### PR TITLE
Update: refactor brace-style and fix inconsistencies (fixes #7869)

### DIFF
--- a/lib/rules/brace-style.js
+++ b/lib/rules/brace-style.js
@@ -5,6 +5,8 @@
 
 "use strict";
 
+const astUtils = require("../ast-utils");
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -52,216 +54,81 @@ module.exports = {
         //--------------------------------------------------------------------------
 
         /**
-         * Determines if a given node is a block statement.
-         * @param {ASTNode} node The node to check.
-         * @returns {boolean} True if the node is a block statement, false if not.
-         * @private
-         */
-        function isBlock(node) {
-            return node && node.type === "BlockStatement";
-        }
-
-        /**
-         * Check if the token is an punctuator with a value of curly brace
-         * @param {Object} token - Token to check
-         * @returns {boolean} true if its a curly punctuator
-         * @private
-         */
-        function isCurlyPunctuator(token) {
-            return token.value === "{" || token.value === "}";
-        }
-
-        /**
-        * Reports a place where a newline unexpectedly appears
-        * @param {ASTNode} node The node to report
-        * @param {string} message The message to report
+        * Fixes a place where a newline unexpectedly appears
         * @param {Token} firstToken The token before the unexpected newline
+        * @param {Token} secondToken The token after the unexpected newline
+        * @returns {Function} A fixer function to remove the newlines between the tokens
+        */
+        function removeNewlineBetween(firstToken, secondToken) {
+            const textRange = [firstToken.range[1], secondToken.range[0]];
+            const textBetween = sourceCode.text.slice(textRange[0], textRange[1]);
+            const NEWLINE_REGEX = /\r\n|\r|\n|\u2028|\u2029/g;
+
+            // Don't do a fix if there is a comment between the tokens
+            return fixer => fixer.replaceTextRange(textRange, textBetween.trim() ? null : textBetween.replace(NEWLINE_REGEX, ""));
+        }
+
+        /**
+        * Validates a pair of curly brackets based on the user's config
+        * @param {Token} openingCurly The opening curly bracket
+        * @param {Token} closingCurly The closing curly bracket
         * @returns {void}
         */
-        function reportExtraNewline(node, message, firstToken) {
-            context.report({
-                node,
-                message,
-                fix(fixer) {
-                    const secondToken = sourceCode.getTokenAfter(firstToken);
-                    const textBetween = sourceCode.getText().slice(firstToken.range[1], secondToken.range[0]);
-                    const NEWLINE_REGEX = /\r\n|\r|\n|\u2028|\u2029/g;
+        function validateCurlyPair(openingCurly, closingCurly) {
+            const tokenBeforeOpeningCurly = sourceCode.getTokenBefore(openingCurly);
+            const tokenAfterOpeningCurly = sourceCode.getTokenAfter(openingCurly);
+            const tokenBeforeClosingCurly = sourceCode.getTokenBefore(closingCurly);
+            const tokenAfterClosingCurly = sourceCode.getTokenAfter(closingCurly);
+            const singleLineException = params.allowSingleLine && astUtils.isTokenOnSameLine(openingCurly, closingCurly);
 
-                    // Don't do a fix if there is a comment between the tokens.
-                    return textBetween.trim() ? null : fixer.replaceTextRange([firstToken.range[1], secondToken.range[0]], textBetween.replace(NEWLINE_REGEX, ""));
-                }
-            });
-        }
-
-        /**
-         * Binds a list of properties to a function that verifies that the opening
-         * curly brace is on the same line as its controlling statement of a given
-         * node.
-         * @param {...string} The properties to check on the node.
-         * @returns {Function} A function that will perform the check on a node
-         * @private
-         */
-        function checkBlock() {
-            const blockProperties = arguments;
-
-            return function(node) {
-                Array.prototype.forEach.call(blockProperties, blockProp => {
-                    const block = node[blockProp];
-
-                    if (!isBlock(block)) {
-                        return;
-                    }
-
-                    const previousToken = sourceCode.getTokenBefore(block);
-                    const curlyToken = sourceCode.getFirstToken(block);
-                    const curlyTokenEnd = sourceCode.getLastToken(block);
-                    const allOnSameLine = previousToken.loc.start.line === curlyTokenEnd.loc.start.line;
-
-                    if (allOnSameLine && params.allowSingleLine) {
-                        return;
-                    }
-
-                    if (style !== "allman" && previousToken.loc.start.line !== curlyToken.loc.start.line) {
-                        reportExtraNewline(node, OPEN_MESSAGE, previousToken);
-                    } else if (style === "allman" && previousToken.loc.start.line === curlyToken.loc.start.line) {
-                        context.report({
-                            node,
-                            message: OPEN_MESSAGE_ALLMAN,
-                            fix: fixer => fixer.insertTextBefore(curlyToken, "\n")
-                        });
-                    }
-
-                    if (!block.body.length) {
-                        return;
-                    }
-
-                    if (curlyToken.loc.start.line === block.body[0].loc.start.line) {
-                        context.report({
-                            node: block.body[0],
-                            message: BODY_MESSAGE,
-                            fix: fixer => fixer.insertTextAfter(curlyToken, "\n")
-                        });
-                    }
-
-                    if (curlyTokenEnd.loc.start.line === block.body[block.body.length - 1].loc.end.line) {
-                        context.report({
-                            node: block.body[block.body.length - 1],
-                            message: CLOSE_MESSAGE_SINGLE,
-                            fix: fixer => fixer.insertTextBefore(curlyTokenEnd, "\n")
-                        });
-                    }
-                });
-            };
-        }
-
-        /**
-         * Enforces the configured brace style on IfStatements
-         * @param {ASTNode} node An IfStatement node.
-         * @returns {void}
-         * @private
-         */
-        function checkIfStatement(node) {
-            checkBlock("consequent", "alternate")(node);
-
-            if (node.alternate) {
-
-                const tokens = sourceCode.getTokensBefore(node.alternate, 2);
-
-                if (style === "1tbs") {
-                    if (tokens[0].loc.start.line !== tokens[1].loc.start.line &&
-                        node.consequent.type === "BlockStatement" &&
-                        isCurlyPunctuator(tokens[0])) {
-                        reportExtraNewline(node.alternate, CLOSE_MESSAGE, tokens[0]);
-                    }
-                } else if (tokens[0].loc.start.line === tokens[1].loc.start.line) {
-                    context.report({
-                        node: node.alternate,
-                        message: CLOSE_MESSAGE_STROUSTRUP_ALLMAN,
-                        fix: fixer => fixer.insertTextAfter(tokens[0], "\n")
-                    });
-                }
-
-            }
-        }
-
-        /**
-         * Enforces the configured brace style on TryStatements
-         * @param {ASTNode} node A TryStatement node.
-         * @returns {void}
-         * @private
-         */
-        function checkTryStatement(node) {
-            checkBlock("block", "finalizer")(node);
-
-            if (isBlock(node.finalizer)) {
-                const tokens = sourceCode.getTokensBefore(node.finalizer, 2);
-
-                if (style === "1tbs") {
-                    if (tokens[0].loc.start.line !== tokens[1].loc.start.line) {
-                        reportExtraNewline(node.finalizer, CLOSE_MESSAGE, tokens[0]);
-                    }
-                } else if (tokens[0].loc.start.line === tokens[1].loc.start.line) {
-                    context.report({
-                        node: node.finalizer,
-                        message: CLOSE_MESSAGE_STROUSTRUP_ALLMAN,
-                        fix: fixer => fixer.insertTextAfter(tokens[0], "\n")
-                    });
-                }
-            }
-        }
-
-        /**
-         * Enforces the configured brace style on CatchClauses
-         * @param {ASTNode} node A CatchClause node.
-         * @returns {void}
-         * @private
-         */
-        function checkCatchClause(node) {
-            const previousToken = sourceCode.getTokenBefore(node),
-                firstToken = sourceCode.getFirstToken(node);
-
-            checkBlock("body")(node);
-
-            if (isBlock(node.body)) {
-                if (style === "1tbs") {
-                    if (previousToken.loc.start.line !== firstToken.loc.start.line) {
-                        reportExtraNewline(node, CLOSE_MESSAGE, previousToken);
-                    }
-                } else {
-                    if (previousToken.loc.start.line === firstToken.loc.start.line) {
-                        context.report({
-                            node,
-                            message: CLOSE_MESSAGE_STROUSTRUP_ALLMAN,
-                            fix: fixer => fixer.insertTextAfter(previousToken, "\n")
-                        });
-                    }
-                }
-            }
-        }
-
-        /**
-         * Enforces the configured brace style on SwitchStatements
-         * @param {ASTNode} node A SwitchStatement node.
-         * @returns {void}
-         * @private
-         */
-        function checkSwitchStatement(node) {
-            let tokens;
-
-            if (node.cases && node.cases.length) {
-                tokens = sourceCode.getTokensBefore(node.cases[0], 2);
-            } else {
-                tokens = sourceCode.getLastTokens(node, 3);
-            }
-
-            if (style !== "allman" && tokens[0].loc.start.line !== tokens[1].loc.start.line) {
-                reportExtraNewline(node, OPEN_MESSAGE, tokens[0]);
-            } else if (style === "allman" && tokens[0].loc.start.line === tokens[1].loc.start.line) {
+            if (style !== "allman" && !astUtils.isTokenOnSameLine(tokenBeforeOpeningCurly, openingCurly)) {
                 context.report({
-                    node,
-                    message: OPEN_MESSAGE_ALLMAN,
-                    fix: fixer => fixer.insertTextBefore(tokens[1], "\n")
+                    node: openingCurly,
+                    message: OPEN_MESSAGE,
+                    fix: removeNewlineBetween(tokenBeforeOpeningCurly, openingCurly)
                 });
+            }
+
+            if (style === "allman" && astUtils.isTokenOnSameLine(tokenBeforeOpeningCurly, openingCurly) && !singleLineException) {
+                context.report({
+                    node: openingCurly,
+                    message: OPEN_MESSAGE_ALLMAN,
+                    fix: fixer => fixer.insertTextBefore(openingCurly, "\n")
+                });
+            }
+
+            if (astUtils.isTokenOnSameLine(openingCurly, tokenAfterOpeningCurly) && tokenAfterOpeningCurly !== closingCurly && !singleLineException) {
+                context.report({
+                    node: openingCurly,
+                    message: BODY_MESSAGE,
+                    fix: fixer => fixer.insertTextAfter(openingCurly, "\n")
+                });
+            }
+
+            if (tokenBeforeClosingCurly !== openingCurly && !singleLineException && astUtils.isTokenOnSameLine(tokenBeforeClosingCurly, closingCurly)) {
+                context.report({
+                    node: closingCurly,
+                    message: CLOSE_MESSAGE_SINGLE,
+                    fix: fixer => fixer.insertTextBefore(closingCurly, "\n")
+                });
+            }
+
+            if (tokenAfterClosingCurly && tokenAfterClosingCurly.type === "Keyword" && new Set(["else", "catch", "finally"]).has(tokenAfterClosingCurly.value)) {
+                if (style === "1tbs" && !astUtils.isTokenOnSameLine(closingCurly, tokenAfterClosingCurly)) {
+                    context.report({
+                        node: closingCurly,
+                        message: CLOSE_MESSAGE,
+                        fix: removeNewlineBetween(closingCurly, tokenAfterClosingCurly)
+                    });
+                }
+
+                if (style !== "1tbs" && astUtils.isTokenOnSameLine(closingCurly, tokenAfterClosingCurly)) {
+                    context.report({
+                        node: closingCurly,
+                        message: CLOSE_MESSAGE_STROUSTRUP_ALLMAN,
+                        fix: fixer => fixer.insertTextAfter(closingCurly, "\n")
+                    });
+                }
             }
         }
 
@@ -270,20 +137,15 @@ module.exports = {
         //--------------------------------------------------------------------------
 
         return {
-            FunctionDeclaration: checkBlock("body"),
-            FunctionExpression: checkBlock("body"),
-            ArrowFunctionExpression: checkBlock("body"),
-            IfStatement: checkIfStatement,
-            TryStatement: checkTryStatement,
-            CatchClause: checkCatchClause,
-            DoWhileStatement: checkBlock("body"),
-            WhileStatement: checkBlock("body"),
-            WithStatement: checkBlock("body"),
-            ForStatement: checkBlock("body"),
-            ForInStatement: checkBlock("body"),
-            ForOfStatement: checkBlock("body"),
-            SwitchStatement: checkSwitchStatement
-        };
+            BlockStatement(node) {
+                validateCurlyPair(sourceCode.getFirstToken(node), sourceCode.getLastToken(node));
+            },
+            SwitchStatement(node) {
+                const closingCurly = sourceCode.getLastToken(node);
+                const openingCurly = sourceCode.getTokenBefore(node.cases.length ? node.cases[0] : closingCurly);
 
+                validateCurlyPair(openingCurly, closingCurly);
+            }
+        };
     }
 };

--- a/tests/lib/rules/brace-style.js
+++ b/tests/lib/rules/brace-style.js
@@ -89,6 +89,10 @@ ruleTester.run("brace-style", rule, {
         {
             code: "switch(x) \n{ \n case 1: \nbar(); \n }\n ",
             options: ["allman"]
+        },
+        {
+            code: "switch(x) {}",
+            options: ["allman", { allowSingleLine: true }]
         }
     ],
 
@@ -96,150 +100,157 @@ ruleTester.run("brace-style", rule, {
         {
             code: "if (f) {\nbar;\n}\nelse\nbaz;",
             output: "if (f) {\nbar;\n}else\nbaz;",
-            errors: [{ message: CLOSE_MESSAGE, type: "ExpressionStatement" }]
+            errors: [{ message: CLOSE_MESSAGE, type: "Punctuator" }]
         },
         {
             code: "var foo = () => { return; }",
             output: "var foo = () => {\n return; \n}",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: BODY_MESSAGE, type: "ReturnStatement" }, { message: CLOSE_MESSAGE_SINGLE, type: "ReturnStatement" }]
+            errors: [{ message: BODY_MESSAGE, type: "Punctuator" }, { message: CLOSE_MESSAGE_SINGLE, type: "Punctuator" }]
         },
         {
             code: "function foo() { return; }",
             output: "function foo() {\n return; \n}",
-            errors: [{ message: BODY_MESSAGE, type: "ReturnStatement" }, { message: CLOSE_MESSAGE_SINGLE, type: "ReturnStatement" }]
+            errors: [{ message: BODY_MESSAGE, type: "Punctuator" }, { message: CLOSE_MESSAGE_SINGLE, type: "Punctuator" }]
         },
         {
             code: "function foo() \n { \n return; }",
             output: "function foo()  { \n return; \n}",
-            errors: [{ message: OPEN_MESSAGE, type: "FunctionDeclaration" }, { message: CLOSE_MESSAGE_SINGLE, type: "ReturnStatement" }]
+            errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }, { message: CLOSE_MESSAGE_SINGLE, type: "Punctuator" }]
         },
         {
             code: "!function foo() \n { \n return; }",
             output: "!function foo()  { \n return; \n}",
-            errors: [{ message: OPEN_MESSAGE, type: "FunctionExpression" }, { message: CLOSE_MESSAGE_SINGLE, type: "ReturnStatement" }]
+            errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }, { message: CLOSE_MESSAGE_SINGLE, type: "Punctuator" }]
         },
         {
             code: "if (foo) \n { \n bar(); }",
             output: "if (foo)  { \n bar(); \n}",
-            errors: [{ message: OPEN_MESSAGE, type: "IfStatement" }, { message: CLOSE_MESSAGE_SINGLE, type: "ExpressionStatement" }]
+            errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }, { message: CLOSE_MESSAGE_SINGLE, type: "Punctuator" }]
+        },
+        {
+            code: "if (foo) \n { \n bar(); }",
+            output: "if (foo)  { \n bar(); \n}",
+            errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }, { message: CLOSE_MESSAGE_SINGLE, type: "Punctuator" }]
         },
         {
             code: "if (a) { \nb();\n } else \n { c(); }",
             output: "if (a) { \nb();\n } else  {\n c(); \n}",
-            errors: [{ message: OPEN_MESSAGE, type: "IfStatement" }, { message: BODY_MESSAGE, type: "ExpressionStatement" }, { message: CLOSE_MESSAGE_SINGLE, type: "ExpressionStatement" }]
+            errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }, { message: BODY_MESSAGE, type: "Punctuator" }, { message: CLOSE_MESSAGE_SINGLE, type: "Punctuator" }]
         },
         {
             code: "while (foo) \n { \n bar(); }",
             output: "while (foo)  { \n bar(); \n}",
-            errors: [{ message: OPEN_MESSAGE, type: "WhileStatement" }, { message: CLOSE_MESSAGE_SINGLE, type: "ExpressionStatement" }]
+            errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }, { message: CLOSE_MESSAGE_SINGLE, type: "Punctuator" }]
         },
         {
             code: "for (;;) \n { \n bar(); }",
             output: "for (;;)  { \n bar(); \n}",
-            errors: [{ message: OPEN_MESSAGE, type: "ForStatement" }, { message: CLOSE_MESSAGE_SINGLE, type: "ExpressionStatement" }]
+            errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }, { message: CLOSE_MESSAGE_SINGLE, type: "Punctuator" }]
         },
         {
             code: "with (foo) \n { \n bar(); }",
             output: "with (foo)  { \n bar(); \n}",
-            errors: [{ message: OPEN_MESSAGE, type: "WithStatement" }, { message: CLOSE_MESSAGE_SINGLE, type: "ExpressionStatement" }]
+            errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }, { message: CLOSE_MESSAGE_SINGLE, type: "Punctuator" }]
         },
         {
             code: "switch (foo) \n { \n case \"bar\": break; }",
-            output: "switch (foo)  { \n case \"bar\": break; }",
-            errors: [{ message: OPEN_MESSAGE, type: "SwitchStatement" }]
+            output: "switch (foo)  { \n case \"bar\": break; \n}",
+            errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }, { message: CLOSE_MESSAGE_SINGLE, type: "Punctuator" }]
         },
         {
             code: "switch (foo) \n { }",
             output: "switch (foo)  { }",
-            errors: [{ message: OPEN_MESSAGE, type: "SwitchStatement" }]
+            errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }]
         },
         {
             code: "try \n { \n bar(); \n } catch (e) {}",
             output: "try  { \n bar(); \n } catch (e) {}",
-            errors: [{ message: OPEN_MESSAGE, type: "TryStatement" }]
+            errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }]
         },
         {
             code: "try { \n bar(); \n } catch (e) \n {}",
             output: "try { \n bar(); \n } catch (e)  {}",
-            errors: [{ message: OPEN_MESSAGE, type: "CatchClause" }]
+            errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }]
         },
         {
             code: "do \n { \n bar(); \n} while (true)",
             output: "do  { \n bar(); \n} while (true)",
-            errors: [{ message: OPEN_MESSAGE, type: "DoWhileStatement" }]
+            errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }]
         },
         {
             code: "for (foo in bar) \n { \n baz(); \n }",
             output: "for (foo in bar)  { \n baz(); \n }",
-            errors: [{ message: OPEN_MESSAGE, type: "ForInStatement" }]
+            errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }]
         },
         {
             code: "for (foo of bar) \n { \n baz(); \n }",
             output: "for (foo of bar)  { \n baz(); \n }",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: OPEN_MESSAGE, type: "ForOfStatement" }]
+            errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }]
         },
         {
             code: "try { \n bar(); \n }\ncatch (e) {\n}",
             output: "try { \n bar(); \n }catch (e) {\n}",
-            errors: [{ message: CLOSE_MESSAGE, type: "CatchClause" }]
+            errors: [{ message: CLOSE_MESSAGE, type: "Punctuator" }]
         },
         {
             code: "try { \n bar(); \n } catch (e) {\n}\n finally {\n}",
             output: "try { \n bar(); \n } catch (e) {\n} finally {\n}",
-            errors: [{ message: CLOSE_MESSAGE, type: "BlockStatement" }]
+            errors: [{ message: CLOSE_MESSAGE, type: "Punctuator" }]
         },
         {
             code: "if (a) { \nb();\n } \n else { \nc();\n }",
             output: "if (a) { \nb();\n }  else { \nc();\n }",
-            errors: [{ message: CLOSE_MESSAGE, type: "BlockStatement" }]
+            errors: [{ message: CLOSE_MESSAGE, type: "Punctuator" }]
         },
         {
             code: "try { \n bar(); \n }\ncatch (e) {\n} finally {\n}",
             output: "try { \n bar(); \n }\ncatch (e) {\n}\n finally {\n}",
             options: ["stroustrup"],
-            errors: [{ message: CLOSE_MESSAGE_STROUSTRUP_ALLMAN, type: "BlockStatement" }]
+            errors: [{ message: CLOSE_MESSAGE_STROUSTRUP_ALLMAN, type: "Punctuator" }]
         },
         {
             code: "try { \n bar(); \n } catch (e) {\n}\n finally {\n}",
             output: "try { \n bar(); \n }\n catch (e) {\n}\n finally {\n}",
             options: ["stroustrup"],
-            errors: [{ message: CLOSE_MESSAGE_STROUSTRUP_ALLMAN, type: "CatchClause" }]
+            errors: [{ message: CLOSE_MESSAGE_STROUSTRUP_ALLMAN, type: "Punctuator" }]
         },
         {
             code: "if (a) { \nb();\n } else { \nc();\n }",
             output: "if (a) { \nb();\n }\n else { \nc();\n }",
-            options: ["stroustrup"], errors: [{ message: CLOSE_MESSAGE_STROUSTRUP_ALLMAN, type: "BlockStatement" }]
+            options: ["stroustrup"], errors: [{ message: CLOSE_MESSAGE_STROUSTRUP_ALLMAN, type: "Punctuator" }]
         },
         {
             code: "if (foo) {\nbaz();\n} else if (bar) {\nbaz();\n}\nelse {\nqux();\n}",
             output: "if (foo) {\nbaz();\n}\n else if (bar) {\nbaz();\n}\nelse {\nqux();\n}",
             options: ["stroustrup"],
-            errors: [{ message: CLOSE_MESSAGE_STROUSTRUP_ALLMAN, type: "IfStatement" }]
+            errors: [{ message: CLOSE_MESSAGE_STROUSTRUP_ALLMAN, type: "Punctuator" }]
         },
         {
             code: "if (foo) {\npoop();\n} \nelse if (bar) {\nbaz();\n} else if (thing) {\nboom();\n}\nelse {\nqux();\n}",
             output: "if (foo) {\npoop();\n} \nelse if (bar) {\nbaz();\n}\n else if (thing) {\nboom();\n}\nelse {\nqux();\n}",
             options: ["stroustrup"],
-            errors: [{ message: CLOSE_MESSAGE_STROUSTRUP_ALLMAN, type: "IfStatement" }]
+            errors: [{ message: CLOSE_MESSAGE_STROUSTRUP_ALLMAN, type: "Punctuator" }]
         },
         {
             code: "try { \n bar(); \n }\n catch (e) {\n}\n finally {\n}",
             output: "try \n{ \n bar(); \n }\n catch (e) \n{\n}\n finally \n{\n}",
             options: ["allman"],
             errors: [
-                { message: OPEN_MESSAGE_ALLMAN, type: "TryStatement", line: 1 },
-                { message: OPEN_MESSAGE_ALLMAN, type: "TryStatement", line: 1 },
-                { message: OPEN_MESSAGE_ALLMAN, type: "CatchClause", line: 4 }
+                { message: OPEN_MESSAGE_ALLMAN, type: "Punctuator", line: 1 },
+                { message: OPEN_MESSAGE_ALLMAN, type: "Punctuator", line: 4 },
+                { message: OPEN_MESSAGE_ALLMAN, type: "Punctuator", line: 6 }
             ]
         },
         {
             code: "switch(x) { case 1: \nbar(); }\n ",
-            output: "switch(x) \n{ case 1: \nbar(); }\n ",
+            output: "switch(x) \n{\n case 1: \nbar(); \n}\n ",
             options: ["allman"],
             errors: [
-                { message: OPEN_MESSAGE_ALLMAN, type: "SwitchStatement", line: 1 }
+                { message: OPEN_MESSAGE_ALLMAN, type: "Punctuator", line: 1 },
+                { message: BODY_MESSAGE, type: "Punctuator", line: 1 },
+                { message: CLOSE_MESSAGE_SINGLE, type: "Punctuator", line: 2 }
             ]
         },
         {
@@ -247,9 +258,9 @@ ruleTester.run("brace-style", rule, {
             output: "if (a) \n{ \nb();\n }\n else \n{ \nc();\n }",
             options: ["allman"],
             errors: [
-                { message: OPEN_MESSAGE_ALLMAN, type: "IfStatement" },
-                { message: OPEN_MESSAGE_ALLMAN, type: "IfStatement" },
-                { message: CLOSE_MESSAGE_STROUSTRUP_ALLMAN, type: "BlockStatement" }
+                { message: OPEN_MESSAGE_ALLMAN, type: "Punctuator" },
+                { message: CLOSE_MESSAGE_STROUSTRUP_ALLMAN, type: "Punctuator" },
+                { message: OPEN_MESSAGE_ALLMAN, type: "Punctuator" }
             ]
         },
         {
@@ -257,10 +268,10 @@ ruleTester.run("brace-style", rule, {
             output: "if (foo) \n{\nbaz();\n}\n else if (bar) \n{\nbaz();\n}\nelse \n{\nqux();\n}",
             options: ["allman"],
             errors: [
-                { message: OPEN_MESSAGE_ALLMAN, type: "IfStatement" },
-                { message: CLOSE_MESSAGE_STROUSTRUP_ALLMAN, type: "IfStatement" },
-                { message: OPEN_MESSAGE_ALLMAN, type: "IfStatement" },
-                { message: OPEN_MESSAGE_ALLMAN, type: "IfStatement" }
+                { message: OPEN_MESSAGE_ALLMAN, type: "Punctuator" },
+                { message: CLOSE_MESSAGE_STROUSTRUP_ALLMAN, type: "Punctuator" },
+                { message: OPEN_MESSAGE_ALLMAN, type: "Punctuator" },
+                { message: OPEN_MESSAGE_ALLMAN, type: "Punctuator" }
             ]
         },
         {
@@ -268,11 +279,11 @@ ruleTester.run("brace-style", rule, {
             output: "if (foo)\n{\n poop();\n} \nelse if (bar) \n{\nbaz();\n}\n else if (thing) \n{\nboom();\n}\nelse \n{\nqux();\n}",
             options: ["allman"],
             errors: [
-                { message: BODY_MESSAGE, type: "ExpressionStatement" },
-                { message: OPEN_MESSAGE_ALLMAN, type: "IfStatement" },
-                { message: CLOSE_MESSAGE_STROUSTRUP_ALLMAN, type: "IfStatement" },
-                { message: OPEN_MESSAGE_ALLMAN, type: "IfStatement" },
-                { message: OPEN_MESSAGE_ALLMAN, type: "IfStatement" }
+                { message: BODY_MESSAGE, type: "Punctuator" },
+                { message: OPEN_MESSAGE_ALLMAN, type: "Punctuator" },
+                { message: CLOSE_MESSAGE_STROUSTRUP_ALLMAN, type: "Punctuator" },
+                { message: OPEN_MESSAGE_ALLMAN, type: "Punctuator" },
+                { message: OPEN_MESSAGE_ALLMAN, type: "Punctuator" }
             ]
         },
         {
@@ -280,7 +291,7 @@ ruleTester.run("brace-style", rule, {
             output: "if (foo)\n{\n  bar(); \n}",
             options: ["allman"],
             errors: [
-                { message: CLOSE_MESSAGE_SINGLE, type: "ExpressionStatement" }
+                { message: CLOSE_MESSAGE_SINGLE, type: "Punctuator" }
             ]
         },
         {
@@ -288,7 +299,7 @@ ruleTester.run("brace-style", rule, {
             output: "try\n{\n  somethingRisky();\n}\n catch (e)\n{\n  handleError()\n}",
             options: ["allman"],
             errors: [
-                { message: CLOSE_MESSAGE_STROUSTRUP_ALLMAN, type: "CatchClause" }
+                { message: CLOSE_MESSAGE_STROUSTRUP_ALLMAN, type: "Punctuator" }
             ]
         },
 
@@ -297,159 +308,149 @@ ruleTester.run("brace-style", rule, {
             code: "function foo() { return; \n}",
             output: "function foo() {\n return; \n}",
             options: ["1tbs", { allowSingleLine: true }],
-            errors: [{ message: BODY_MESSAGE, type: "ReturnStatement" }]
+            errors: [{ message: BODY_MESSAGE, type: "Punctuator" }]
         },
         {
             code: "function foo() { a(); b(); return; \n}",
             output: "function foo() {\n a(); b(); return; \n}",
             options: ["1tbs", { allowSingleLine: true }],
-            errors: [{ message: BODY_MESSAGE, type: "ExpressionStatement" }]
+            errors: [{ message: BODY_MESSAGE, type: "Punctuator" }]
         },
         {
             code: "function foo() { \n return; }",
             output: "function foo() { \n return; \n}",
             options: ["1tbs", { allowSingleLine: true }],
-            errors: [{ message: CLOSE_MESSAGE_SINGLE, type: "ReturnStatement" }]
+            errors: [{ message: CLOSE_MESSAGE_SINGLE, type: "Punctuator" }]
         },
         {
             code: "function foo() {\na();\nb();\nreturn; }",
             output: "function foo() {\na();\nb();\nreturn; \n}",
             options: ["1tbs", { allowSingleLine: true }],
-            errors: [{ message: CLOSE_MESSAGE_SINGLE, type: "ReturnStatement" }]
+            errors: [{ message: CLOSE_MESSAGE_SINGLE, type: "Punctuator" }]
         },
         {
             code: "!function foo() { \n return; }",
             output: "!function foo() { \n return; \n}",
             options: ["1tbs", { allowSingleLine: true }],
-            errors: [{ message: CLOSE_MESSAGE_SINGLE, type: "ReturnStatement" }]
-        },
-        {
-            code: "if (foo) \n { bar(); }",
-            output: "if (foo)  {\n bar(); \n}",
-            options: ["1tbs", { allowSingleLine: true }],
-            errors: [
-                { message: OPEN_MESSAGE, type: "IfStatement" },
-                { message: BODY_MESSAGE, type: "ExpressionStatement" },
-                { message: CLOSE_MESSAGE_SINGLE, type: "ExpressionStatement" }
-            ]
+            errors: [{ message: CLOSE_MESSAGE_SINGLE, type: "Punctuator" }]
         },
         {
             code: "if (a) { b();\n } else { c(); }",
             output: "if (a) {\n b();\n } else { c(); }",
             options: ["1tbs", { allowSingleLine: true }],
-            errors: [{ message: BODY_MESSAGE, type: "ExpressionStatement" }]
+            errors: [{ message: BODY_MESSAGE, type: "Punctuator" }]
         },
         {
             code: "if (a) { b(); }\nelse { c(); }",
             output: "if (a) { b(); }else { c(); }",
             options: ["1tbs", { allowSingleLine: true }],
-            errors: [{ message: CLOSE_MESSAGE, type: "BlockStatement" }]
+            errors: [{ message: CLOSE_MESSAGE, type: "Punctuator" }]
         },
         {
             code: "while (foo) { \n bar(); }",
             output: "while (foo) { \n bar(); \n}",
             options: ["1tbs", { allowSingleLine: true }],
-            errors: [{ message: CLOSE_MESSAGE_SINGLE, type: "ExpressionStatement" }]
+            errors: [{ message: CLOSE_MESSAGE_SINGLE, type: "Punctuator" }]
         },
         {
             code: "for (;;) { bar(); \n }",
             output: "for (;;) {\n bar(); \n }",
             options: ["1tbs", { allowSingleLine: true }],
-            errors: [{ message: BODY_MESSAGE, type: "ExpressionStatement" }]
+            errors: [{ message: BODY_MESSAGE, type: "Punctuator" }]
         },
         {
             code: "with (foo) { bar(); \n }",
             output: "with (foo) {\n bar(); \n }",
             options: ["1tbs", { allowSingleLine: true }],
-            errors: [{ message: BODY_MESSAGE, type: "ExpressionStatement" }]
+            errors: [{ message: BODY_MESSAGE, type: "Punctuator" }]
         },
         {
             code: "switch (foo) \n { \n case \"bar\": break; }",
-            output: "switch (foo)  { \n case \"bar\": break; }",
+            output: "switch (foo)  { \n case \"bar\": break; \n}",
             options: ["1tbs", { allowSingleLine: true }],
-            errors: [{ message: OPEN_MESSAGE, type: "SwitchStatement" }]
+            errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }, { message: CLOSE_MESSAGE_SINGLE, type: "Punctuator" }]
         },
         {
             code: "switch (foo) \n { }",
             output: "switch (foo)  { }",
             options: ["1tbs", { allowSingleLine: true }],
-            errors: [{ message: OPEN_MESSAGE, type: "SwitchStatement" }]
+            errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }]
         },
         {
             code: "try {  bar(); }\ncatch (e) { baz();  }",
             options: ["1tbs", { allowSingleLine: true }],
-            errors: [{ message: CLOSE_MESSAGE, type: "CatchClause" }]
+            errors: [{ message: CLOSE_MESSAGE, type: "Punctuator" }]
         },
         {
             code: "try \n { \n bar(); \n } catch (e) {}",
             output: "try  { \n bar(); \n } catch (e) {}",
             options: ["1tbs", { allowSingleLine: true }],
-            errors: [{ message: OPEN_MESSAGE, type: "TryStatement" }]
+            errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }]
         },
         {
             code: "try { \n bar(); \n } catch (e) \n {}",
             output: "try { \n bar(); \n } catch (e)  {}",
             options: ["1tbs", { allowSingleLine: true }],
-            errors: [{ message: OPEN_MESSAGE, type: "CatchClause" }]
+            errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }]
         },
         {
             code: "do \n { \n bar(); \n} while (true)",
             output: "do  { \n bar(); \n} while (true)",
             options: ["1tbs", { allowSingleLine: true }],
-            errors: [{ message: OPEN_MESSAGE, type: "DoWhileStatement" }]
+            errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }]
         },
         {
             code: "for (foo in bar) \n { \n baz(); \n }",
             output: "for (foo in bar)  { \n baz(); \n }",
             options: ["1tbs", { allowSingleLine: true }],
-            errors: [{ message: OPEN_MESSAGE, type: "ForInStatement" }]
+            errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }]
         },
         {
             code: "try { \n bar(); \n }\ncatch (e) {\n}",
             output: "try { \n bar(); \n }catch (e) {\n}",
             options: ["1tbs", { allowSingleLine: true }],
-            errors: [{ message: CLOSE_MESSAGE, type: "CatchClause" }]
+            errors: [{ message: CLOSE_MESSAGE, type: "Punctuator" }]
         },
         {
             code: "try { \n bar(); \n } catch (e) {\n}\n finally {\n}",
             output: "try { \n bar(); \n } catch (e) {\n} finally {\n}",
             options: ["1tbs", { allowSingleLine: true }],
-            errors: [{ message: CLOSE_MESSAGE, type: "BlockStatement" }]
+            errors: [{ message: CLOSE_MESSAGE, type: "Punctuator" }]
         },
         {
             code: "if (a) { \nb();\n } \n else { \nc();\n }",
             output: "if (a) { \nb();\n }  else { \nc();\n }",
             options: ["1tbs", { allowSingleLine: true }],
-            errors: [{ message: CLOSE_MESSAGE, type: "BlockStatement" }]
+            errors: [{ message: CLOSE_MESSAGE, type: "Punctuator" }]
         },
         {
             code: "try { \n bar(); \n }\ncatch (e) {\n} finally {\n}",
             output: "try { \n bar(); \n }\ncatch (e) {\n}\n finally {\n}",
             options: ["stroustrup", { allowSingleLine: true }],
-            errors: [{ message: CLOSE_MESSAGE_STROUSTRUP_ALLMAN, type: "BlockStatement" }]
+            errors: [{ message: CLOSE_MESSAGE_STROUSTRUP_ALLMAN, type: "Punctuator" }]
         },
         {
             code: "try { \n bar(); \n } catch (e) {\n}\n finally {\n}",
             output: "try { \n bar(); \n }\n catch (e) {\n}\n finally {\n}",
             options: ["stroustrup", { allowSingleLine: true }],
-            errors: [{ message: CLOSE_MESSAGE_STROUSTRUP_ALLMAN, type: "CatchClause" }]
+            errors: [{ message: CLOSE_MESSAGE_STROUSTRUP_ALLMAN, type: "Punctuator" }]
         },
         {
             code: "if (a) { \nb();\n } else { \nc();\n }",
             output: "if (a) { \nb();\n }\n else { \nc();\n }",
             options: ["stroustrup", { allowSingleLine: true }],
-            errors: [{ message: CLOSE_MESSAGE_STROUSTRUP_ALLMAN, type: "BlockStatement" }]
+            errors: [{ message: CLOSE_MESSAGE_STROUSTRUP_ALLMAN, type: "Punctuator" }]
         },
         {
             code: "if (foo)\n{ poop();\n} \nelse if (bar) {\nbaz();\n} else if (thing) {\nboom();\n}\nelse {\nqux();\n}",
             output: "if (foo)\n{\n poop();\n} \nelse if (bar) \n{\nbaz();\n}\n else if (thing) \n{\nboom();\n}\nelse \n{\nqux();\n}",
             options: ["allman", { allowSingleLine: true }],
             errors: [
-                { message: BODY_MESSAGE, type: "ExpressionStatement" },
-                { message: OPEN_MESSAGE_ALLMAN, type: "IfStatement" },
-                { message: CLOSE_MESSAGE_STROUSTRUP_ALLMAN, type: "IfStatement" },
-                { message: OPEN_MESSAGE_ALLMAN, type: "IfStatement" },
-                { message: OPEN_MESSAGE_ALLMAN, type: "IfStatement" }
+                { message: BODY_MESSAGE, type: "Punctuator" },
+                { message: OPEN_MESSAGE_ALLMAN, type: "Punctuator" },
+                { message: CLOSE_MESSAGE_STROUSTRUP_ALLMAN, type: "Punctuator" },
+                { message: OPEN_MESSAGE_ALLMAN, type: "Punctuator" },
+                { message: OPEN_MESSAGE_ALLMAN, type: "Punctuator" }
             ]
         },
 
@@ -457,36 +458,42 @@ ruleTester.run("brace-style", rule, {
         {
             code: "if (foo) // comment \n{\nbar();\n}",
             output: "if (foo) // comment \n{\nbar();\n}",
-            errors: [{ message: OPEN_MESSAGE, type: "IfStatement" }]
+            errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }]
         },
 
         // https://github.com/eslint/eslint/issues/7493
         {
             code: "if (foo) {\n bar\n.baz }",
             output: "if (foo) {\n bar\n.baz \n}",
-            errors: [{ message: CLOSE_MESSAGE_SINGLE, type: "ExpressionStatement" }]
+            errors: [{ message: CLOSE_MESSAGE_SINGLE, type: "Punctuator" }]
         },
         {
             code: "if (foo)\n{\n bar\n.baz }",
             output: "if (foo)\n{\n bar\n.baz \n}",
             options: ["allman"],
-            errors: [{ message: CLOSE_MESSAGE_SINGLE, type: "ExpressionStatement" }]
+            errors: [{ message: CLOSE_MESSAGE_SINGLE, type: "Punctuator" }]
         },
         {
             code: "if (foo) { bar\n.baz }",
             output: "if (foo) {\n bar\n.baz \n}",
             options: ["1tbs", { allowSingleLine: true }],
-            errors: [{ message: BODY_MESSAGE, type: "ExpressionStatement" }, { message: CLOSE_MESSAGE_SINGLE, type: "ExpressionStatement" }]
+            errors: [{ message: BODY_MESSAGE, type: "Punctuator" }, { message: CLOSE_MESSAGE_SINGLE, type: "Punctuator" }]
         },
         {
             code: "if (foo) { bar\n.baz }",
             output: "if (foo) \n{\n bar\n.baz \n}",
             options: ["allman", { allowSingleLine: true }],
             errors: [
-                { message: OPEN_MESSAGE_ALLMAN, type: "IfStatement" },
-                { message: BODY_MESSAGE, type: "ExpressionStatement" },
-                { message: CLOSE_MESSAGE_SINGLE, type: "ExpressionStatement" }
+                { message: OPEN_MESSAGE_ALLMAN, type: "Punctuator" },
+                { message: BODY_MESSAGE, type: "Punctuator" },
+                { message: CLOSE_MESSAGE_SINGLE, type: "Punctuator" }
             ]
         },
+        {
+            code: "switch (x) {\n case 1: foo() }",
+            output: "switch (x) {\n case 1: foo() \n}",
+            options: ["1tbs", { allowSingleLine: true }],
+            errors: [{ message: CLOSE_MESSAGE_SINGLE, type: "Punctuator" }]
+        }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (see https://github.com/eslint/eslint/issues/7869)

**What changes did you make? (Give an overview)**

This makes a few changes to `brace-style`:

* It unifies the logic for all types of braced statements into a single function. Previously, there was a lot of code duplication, which led to inconsistencies like https://github.com/eslint/eslint/issues/7869 and https://github.com/eslint/eslint/issues/7869#issuecomment-270802875.
* It changes the report type to report the curly brace token itself, rather than a node in the general vicinity. For example, the previous version of the rule would report the `IfStatement` node here:

```js
/* eslint brace-style: error */
if (foo) {

  // ...lots of code

  bar(); } // <-- there is an issue with this brace, but the `IfStatement` is the node that gets reported
```

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
