### PR TITLE
Fix: prefer-destructuring reporting compound assignments (fixes #7881)

### DIFF
--- a/lib/rules/prefer-destructuring.js
+++ b/lib/rules/prefer-destructuring.js
@@ -158,7 +158,9 @@ module.exports = {
          * @returns {void}
          */
         function checkAssigmentExpression(node) {
-            performCheck(node.left, node.right, node);
+            if (node.operator === "=") {
+                performCheck(node.left, node.right, node);
+            }
         }
 
         //--------------------------------------------------------------------------

--- a/tests/lib/rules/prefer-destructuring.js
+++ b/tests/lib/rules/prefer-destructuring.js
@@ -72,9 +72,9 @@ ruleTester.run("prefer-destructuring", rule, {
         {
             code: "({ foo } = object);"
         },
-        {
-            code: "[foo] = array;"
-        }
+        "[foo] = array;",
+        "foo += array[0]",
+        "foo += bar.foo"
     ],
 
     invalid: [


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**
[x] Bug fix (see https://github.com/eslint/eslint/issues/7881)

**What changes did you make? (Give an overview)**

This updates `prefer-destructuring` to avoid reporting compound assignments such as `foo += bar.foo`, since these assignments can't be replaced with destructuring assignments.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
