### PR TITLE
Fix: no-extra-label autofix should not remove labels used elsewhere

### DIFF
--- a/lib/rules/no-extra-label.js
+++ b/lib/rules/no-extra-label.js
@@ -110,12 +110,7 @@ module.exports = {
                             node: labelNode,
                             message: "This label '{{name}}' is unnecessary.",
                             data: labelNode,
-                            fix(fixer) {
-                                return fixer.replaceTextRange(
-                                    [info.label.range[0], labelNode.range[1]],
-                                    sourceCode.text.slice(info.label.parent.body.range[0], sourceCode.getFirstToken(node).range[1])
-                                );
-                            }
+                            fix: fixer => fixer.removeRange([sourceCode.getFirstToken(node).range[1], labelNode.range[1]])
                         });
                     }
                     return;

--- a/tests/lib/rules/no-extra-label.js
+++ b/tests/lib/rules/no-extra-label.js
@@ -41,54 +41,73 @@ ruleTester.run("no-extra-label", rule, {
     invalid: [
         {
             code: "A: while (a) break A;",
-            output: "while (a) break;",
+            output: "A: while (a) break;",
             errors: ["This label 'A' is unnecessary."]
         },
         {
             code: "A: while (a) { B: { continue A; } }",
-            output: "while (a) { B: { continue; } }",
+            output: "A: while (a) { B: { continue; } }",
             errors: ["This label 'A' is unnecessary."]
         },
         {
             code: "X: while (x) { A: while (a) { B: { break A; break B; continue X; } } }",
-            output: "X: while (x) { while (a) { B: { break; break B; continue X; } } }",
+            output: "X: while (x) { A: while (a) { B: { break; break B; continue X; } } }",
             errors: ["This label 'A' is unnecessary."]
         },
         {
             code: "A: do { break A; } while (a);",
-            output: "do { break; } while (a);",
+            output: "A: do { break; } while (a);",
             errors: ["This label 'A' is unnecessary."]
         },
         {
             code: "A: for (;;) { break A; }",
-            output: "for (;;) { break; }",
+            output: "A: for (;;) { break; }",
             errors: ["This label 'A' is unnecessary."]
         },
         {
             code: "A: for (a in obj) { break A; }",
-            output: "for (a in obj) { break; }",
+            output: "A: for (a in obj) { break; }",
             errors: ["This label 'A' is unnecessary."]
         },
         {
             code: "A: for (a of ary) { break A; }",
-            output: "for (a of ary) { break; }",
+            output: "A: for (a of ary) { break; }",
             errors: ["This label 'A' is unnecessary."],
             parserOptions: { ecmaVersion: 6 }
         },
         {
             code: "A: switch (a) { case 0: break A; }",
-            output: "switch (a) { case 0: break; }",
+            output: "A: switch (a) { case 0: break; }",
             errors: ["This label 'A' is unnecessary."]
         },
         {
             code: "X: while (x) { A: switch (a) { case 0: break A; } }",
-            output: "X: while (x) { switch (a) { case 0: break; } }",
+            output: "X: while (x) { A: switch (a) { case 0: break; } }",
             errors: ["This label 'A' is unnecessary."]
         },
         {
             code: "X: switch (a) { case 0: A: while (b) break A; }",
-            output: "X: switch (a) { case 0: while (b) break; }",
+            output: "X: switch (a) { case 0: A: while (b) break; }",
             errors: ["This label 'A' is unnecessary."]
+        },
+        {
+            code: `\
+                A: while (true) {
+                    break A;
+                    while (true) {
+                        break A;
+                    }
+                }
+            `,
+            output: `\
+                A: while (true) {
+                    break;
+                    while (true) {
+                        break A;
+                    }
+                }
+            `,
+            errors: [{ message: "This label 'A' is unnecessary.", type: "Identifier", line: 2 }]
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix

**Tell us about your environment**

* **ESLint Version:** 3.13.0
* **Node Version:** 7.3.0
* **npm Version:** 3.10.10

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

(none)

**What did you do? Please include the actual source code causing the issue.**

```js
/* eslint no-extra-label: error */

A: while (true) {
  break A;
  while (true) {
    break A;
  }
}
```

**What did you expect to happen?**

I expected an error to be reported on line 2, and the code to be fixed to

```js
/* eslint no-extra-label: error */

A: while (true) {
  break;
  while (true) {
    break A;
  }
}
```

**What actually happened? Please include the actual, raw output from ESLint.**

An error was reported on line 2 as expected, but the code was fixed to

```js
/* eslint no-extra-label: error */

while (true) {
  break;
  while (true) {
    break A;
  }
}
```

...which is a syntax error, because the `A` label no longer exists even though it's used elsewhere.

**What changes did you make? (Give an overview)**

This changes the behavior of the `no-extra-label` autofixer. Previously, the autofixer would behave like this:

```js
A: while (true) {
  break A;
}

// gets fixed to

while (true) {
  break;
}
```

However, it now behaves like this:

```js
A: while (true) {
  break A;
}

// gets fixed to

A: while (true) {
  break;
}
```

In other words, it now only fixes the break/continue statement that got reported, but doesn't touch the loop. In my opinion, this is a better fix, because the `no-extra-label` rule is only concerned about extra `break`/`continue` labels, not unused labels on loops. (The `no-unused-labels` rule can be used to enforce no missing loop labels, and it will be able to do this automatically when/if https://github.com/eslint/eslint/pull/7841 is merged.)

**Is there anything you'd like reviewers to focus on?**

It would be good to verify that this change is a good idea. My only concern is that there was some opposition to adding a fixer for `no-unused-labels` in https://github.com/eslint/eslint/pull/7841, so if that PR stalls or is rejected, people might have more unused labels in their code after autofixing.
