### PR TITLE
Chore: Enable comma-dangle on ESLint codebase (fixes #7725)

### DIFF
--- a/lib/ast-utils.js
+++ b/lib/ast-utils.js
@@ -1037,7 +1037,7 @@ module.exports = {
 
         return {
             start: Object.assign({}, start),
-            end: Object.assign({}, end),
+            end: Object.assign({}, end)
         };
     },
 

--- a/lib/config/config-initializer.js
+++ b/lib/config/config-initializer.js
@@ -317,7 +317,7 @@ function promptUser(callback) {
             default: false,
             when(answers) {
                 return answers.styleguide === "airbnb";
-            },
+            }
         },
         {
             type: "input",

--- a/lib/formatters/codeframe.js
+++ b/lib/formatters/codeframe.js
@@ -56,7 +56,7 @@ function formatMessage(message, parentResult) {
         `${type}:`,
         `${msg}`,
         ruleId ? `${ruleId}` : "",
-        sourceCode ? `at ${filePath}:` : `at ${filePath}`,
+        sourceCode ? `at ${filePath}:` : `at ${filePath}`
     ].filter(String).join(" ");
 
     const result = [firstLine];

--- a/lib/internal-rules/internal-consistent-docs-description.js
+++ b/lib/internal-rules/internal-consistent-docs-description.js
@@ -71,7 +71,7 @@ function checkMetaDocsDescription(context, exportsNode) {
     if (description === "") {
         context.report({
             node: metaDocsDescription.value,
-            message: "`meta.docs.description` should not be empty.",
+            message: "`meta.docs.description` should not be empty."
         });
         return;
     }

--- a/lib/rules/comma-dangle.js
+++ b/lib/rules/comma-dangle.js
@@ -20,7 +20,7 @@ const DEFAULT_OPTIONS = Object.freeze({
     objects: "never",
     imports: "never",
     exports: "never",
-    functions: "ignore",
+    functions: "ignore"
 });
 
 /**
@@ -53,7 +53,7 @@ function normalizeOptions(optionValue) {
             exports: optionValue,
 
             // For backward compatibility, always ignore functions.
-            functions: "ignore",
+            functions: "ignore"
         };
     }
     if (typeof optionValue === "object" && optionValue !== null) {
@@ -62,7 +62,7 @@ function normalizeOptions(optionValue) {
             objects: optionValue.objects || DEFAULT_OPTIONS.objects,
             imports: optionValue.imports || DEFAULT_OPTIONS.imports,
             exports: optionValue.exports || DEFAULT_OPTIONS.exports,
-            functions: optionValue.functions || DEFAULT_OPTIONS.functions,
+            functions: optionValue.functions || DEFAULT_OPTIONS.functions
         };
     }
 
@@ -121,7 +121,7 @@ module.exports = {
                         additionalProperties: false
                     }
                 ]
-            },
+            }
         ]
     },
 
@@ -312,7 +312,7 @@ module.exports = {
             "always-multiline": forceTrailingCommaIfMultiline,
             "only-multiline": allowTrailingCommaIfMultiline,
             never: forbidTrailingComma,
-            ignore: lodash.noop,
+            ignore: lodash.noop
         };
 
         return {
@@ -330,7 +330,7 @@ module.exports = {
             FunctionExpression: predicate[options.functions],
             ArrowFunctionExpression: predicate[options.functions],
             CallExpression: predicate[options.functions],
-            NewExpression: predicate[options.functions],
+            NewExpression: predicate[options.functions]
         };
     }
 };

--- a/lib/rules/comma-style.js
+++ b/lib/rules/comma-style.js
@@ -48,7 +48,7 @@ module.exports = {
             FunctionDeclaration: true,
             FunctionExpression: true,
             ImportDeclaration: true,
-            ObjectPattern: true,
+            ObjectPattern: true
         };
 
         if (context.options.length === 2 && context.options[1].hasOwnProperty("exceptions")) {

--- a/lib/rules/lines-around-directive.js
+++ b/lib/rules/lines-around-directive.js
@@ -31,7 +31,7 @@ module.exports = {
                         },
                         after: {
                             enum: ["always", "never"]
-                        },
+                        }
                     },
                     additionalProperties: false,
                     minProperties: 2

--- a/lib/rules/max-lines.js
+++ b/lib/rules/max-lines.js
@@ -134,7 +134,7 @@ module.exports = {
                         message: "File must be at most {{max}} lines long. It's {{actual}} lines long.",
                         data: {
                             max,
-                            actual: lines.length,
+                            actual: lines.length
                         }
                     });
                 }

--- a/lib/rules/max-statements-per-line.js
+++ b/lib/rules/max-statements-per-line.js
@@ -60,7 +60,7 @@ module.exports = {
                     data: {
                         numberOfStatementsOnThisLine,
                         maxStatementsPerLine,
-                        statements: numberOfStatementsOnThisLine === 1 ? "statement" : "statements",
+                        statements: numberOfStatementsOnThisLine === 1 ? "statement" : "statements"
                     }
                 });
             }

--- a/lib/rules/no-await-in-loop.js
+++ b/lib/rules/no-await-in-loop.js
@@ -10,7 +10,7 @@ const loopTypes = new Set([
     "ForOfStatement",
     "ForInStatement",
     "WhileStatement",
-    "DoWhileStatement",
+    "DoWhileStatement"
 ]);
 
 // Node types at which we should stop looking for loops. For example, it is fine to declare an async
@@ -18,7 +18,7 @@ const loopTypes = new Set([
 const boundaryTypes = new Set([
     "FunctionDeclaration",
     "FunctionExpression",
-    "ArrowFunctionExpression",
+    "ArrowFunctionExpression"
 ]);
 
 module.exports = {
@@ -26,9 +26,9 @@ module.exports = {
         docs: {
             description: "disallow `await` inside of loops",
             category: "Possible Errors",
-            recommended: false,
+            recommended: false
         },
-        schema: [],
+        schema: []
     },
     create(context) {
         return {
@@ -69,7 +69,7 @@ module.exports = {
                         }
                     }
                 }
-            },
+            }
         };
     }
 };

--- a/lib/rules/no-dupe-keys.js
+++ b/lib/rules/no-dupe-keys.js
@@ -123,7 +123,7 @@ module.exports = {
                         node: info.node,
                         loc: node.key.loc,
                         message: "Duplicate key '{{name}}'.",
-                        data: { name },
+                        data: { name }
                     });
                 }
 

--- a/lib/rules/no-return-await.js
+++ b/lib/rules/no-return-await.js
@@ -35,7 +35,7 @@ module.exports = {
             context.report({
                 node: context.getSourceCode().getFirstToken(node),
                 loc: node.loc,
-                message,
+                message
             });
         }
 
@@ -88,7 +88,7 @@ module.exports = {
                 if (isInTailCallPosition(node) && !hasErrorHandler(node)) {
                     reportUnnecessaryAwait(node);
                 }
-            },
+            }
         };
     }
 };

--- a/lib/rules/no-useless-return.js
+++ b/lib/rules/no-useless-return.js
@@ -213,7 +213,7 @@ module.exports = {
                 scopeInfo = {
                     upper: scopeInfo,
                     uselessReturns: [],
-                    codePath,
+                    codePath
                 };
             },
 
@@ -226,7 +226,7 @@ module.exports = {
                         message: "Unnecessary return statement.",
                         fix(fixer) {
                             return isRemovable(node) ? fixer.remove(node) : null;
-                        },
+                        }
                     });
                 }
 
@@ -238,7 +238,7 @@ module.exports = {
             onCodePathSegmentStart(segment) {
                 const info = {
                     uselessReturns: getUselessReturns([], segment.allPrevSegments),
-                    returned: false,
+                    returned: false
                 };
 
                 // Stores the info.
@@ -287,7 +287,7 @@ module.exports = {
             WithStatement: markReturnStatementsOnCurrentSegmentsAsUsed,
             ExportNamedDeclaration: markReturnStatementsOnCurrentSegmentsAsUsed,
             ExportDefaultDeclaration: markReturnStatementsOnCurrentSegmentsAsUsed,
-            ExportAllDeclaration: markReturnStatementsOnCurrentSegmentsAsUsed,
+            ExportAllDeclaration: markReturnStatementsOnCurrentSegmentsAsUsed
         };
     }
 };

--- a/lib/rules/quotes.js
+++ b/lib/rules/quotes.js
@@ -269,7 +269,7 @@ module.exports = {
                         node,
                         message: "Strings must use {{description}}.",
                         data: {
-                            description: settings.description,
+                            description: settings.description
                         },
                         fix(fixer) {
                             if (isPartOfDirectivePrologue(node)) {

--- a/lib/rules/require-await.js
+++ b/lib/rules/require-await.js
@@ -51,7 +51,7 @@ module.exports = {
         function enterFunction() {
             scopeInfo = {
                 upper: scopeInfo,
-                hasAwait: false,
+                hasAwait: false
             };
         }
 

--- a/lib/rules/sort-keys.js
+++ b/lib/rules/sort-keys.js
@@ -64,7 +64,7 @@ const isValidOrders = {
     },
     descIN(a, b) {
         return isValidOrders.ascIN(b, a);
-    },
+    }
 };
 
 //------------------------------------------------------------------------------
@@ -147,7 +147,7 @@ module.exports = {
                             prevName,
                             order,
                             insensitive: insensitive ? "insensitive " : "",
-                            natual: natual ? "natural " : "",
+                            natual: natual ? "natural " : ""
                         }
                     });
                 }

--- a/lib/rules/space-before-function-paren.js
+++ b/lib/rules/space-before-function-paren.js
@@ -159,7 +159,7 @@ module.exports = {
         return {
             FunctionDeclaration: validateSpacingBeforeParentheses,
             FunctionExpression: validateSpacingBeforeParentheses,
-            ArrowFunctionExpression: validateSpacingBeforeParentheses,
+            ArrowFunctionExpression: validateSpacingBeforeParentheses
         };
     }
 };

--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -213,7 +213,7 @@ Object.defineProperties(RuleTester, {
             RuleTester[DESCRIBE] = value;
         },
         configurable: true,
-        enumerable: true,
+        enumerable: true
     },
     it: {
         get() {
@@ -226,8 +226,8 @@ Object.defineProperties(RuleTester, {
             RuleTester[IT] = value;
         },
         configurable: true,
-        enumerable: true,
-    },
+        enumerable: true
+    }
 });
 
 RuleTester.prototype = {

--- a/lib/util/glob-util.js
+++ b/lib/util/glob-util.js
@@ -165,7 +165,7 @@ function listFilesToProcess(globPatterns, options) {
             const globOptions = {
                 nodir: true,
                 dot: true,
-                cwd,
+                cwd
             };
 
             new GlobSync(pattern, globOptions, shouldIgnore).found.forEach(globMatch => {

--- a/packages/eslint-config-eslint/default.yml
+++ b/packages/eslint-config-eslint/default.yml
@@ -13,6 +13,7 @@ rules:
     camelcase: ["error", { properties: "never" }]
     callback-return: ["error", ["cb", "callback", "next"]]
     class-methods-use-this: "error"
+    comma-dangle: "error"
     comma-spacing: "error"
     comma-style: ["error", "last"]
     consistent-return: "error"

--- a/tests/lib/ast-utils.js
+++ b/tests/lib/ast-utils.js
@@ -759,7 +759,7 @@ describe("ast-utils", () => {
             "class A { static *foo() {} }": "static generator method 'foo'",
             "class A { static async foo() {} }": "static async method 'foo'",
             "class A { static get foo() {} }": "static getter 'foo'",
-            "class A { static set foo(a) {} }": "static setter 'foo'",
+            "class A { static set foo(a) {} }": "static setter 'foo'"
         };
 
         Object.keys(expectedResults).forEach(key => {
@@ -832,7 +832,7 @@ describe("ast-utils", () => {
             "class A { static *foo() {} }": [10, 21],
             "class A { static async foo() {} }": [10, 26],
             "class A { static get foo() {} }": [10, 24],
-            "class A { static set foo(a) {} }": [10, 24],
+            "class A { static set foo(a) {} }": [10, 24]
         };
 
         Object.keys(expectedResults).forEach(key => {
@@ -877,7 +877,7 @@ describe("ast-utils", () => {
         const expectedResults = {
             "{}": true,
             "{ a }": false,
-            a: false,
+            a: false
         };
 
         Object.keys(expectedResults).forEach(key => {
@@ -895,7 +895,7 @@ describe("ast-utils", () => {
             "(function foo() { a })": false,
             "(a) => {}": true,
             "(a) => { a }": false,
-            "(a) => a": false,
+            "(a) => a": false
         };
 
         Object.keys(expectedResults).forEach(key => {

--- a/tests/lib/formatters/codeframe.js
+++ b/tests/lib/formatters/codeframe.js
@@ -146,7 +146,7 @@ describe("formatter:codeframe", () => {
                 line: 1,
                 column: 7,
                 ruleId: "no-unused-vars"
-            }],
+            }]
         }];
 
         it("should return a string with multiple entries", () => {

--- a/tests/lib/rules/array-bracket-spacing.js
+++ b/tests/lib/rules/array-bracket-spacing.js
@@ -178,7 +178,7 @@ ruleTester.run("array-bracket-spacing", rule, {
 
         // destructuring with type annotation
         { code: "([ a, b ]: Array<any>) => {}", options: ["always"], parserOptions: { ecmaVersion: 6 }, parser: parser("flow-destructuring-1") },
-        { code: "([a, b]: Array< any >) => {}", options: ["never"], parserOptions: { ecmaVersion: 6 }, parser: parser("flow-destructuring-2") },
+        { code: "([a, b]: Array< any >) => {}", options: ["never"], parserOptions: { ecmaVersion: 6 }, parser: parser("flow-destructuring-2") }
     ],
 
     invalid: [
@@ -696,46 +696,46 @@ ruleTester.run("array-bracket-spacing", rule, {
             output: "([a, b]: Array<any>) => {}",
             options: ["never"],
             ecmaFeatures: {
-                ecmaVersion: 6,
+                ecmaVersion: 6
             },
             errors: [
                 {
                     message: "There should be no space after '['.",
                     type: "ArrayPattern",
                     line: 1,
-                    column: 2,
+                    column: 2
                 },
                 {
                     message: "There should be no space before ']'.",
                     type: "ArrayPattern",
                     line: 1,
                     column: 9
-                },
+                }
             ],
-            parser: parser("flow-destructuring-1"),
+            parser: parser("flow-destructuring-1")
         },
         {
             code: "([a, b]: Array< any >) => {}",
             output: "([ a, b ]: Array< any >) => {}",
             options: ["always"],
             ecmaFeatures: {
-                ecmaVersion: 6,
+                ecmaVersion: 6
             },
             errors: [
                 {
                     message: "A space is required after '['.",
                     type: "ArrayPattern",
                     line: 1,
-                    column: 2,
+                    column: 2
                 },
                 {
                     message: "A space is required before ']'.",
                     type: "ArrayPattern",
                     line: 1,
-                    column: 7,
-                },
+                    column: 7
+                }
             ],
-            parser: parser("flow-destructuring-2"),
-        },
-    ],
+            parser: parser("flow-destructuring-2")
+        }
+    ]
 });

--- a/tests/lib/rules/arrow-body-style.js
+++ b/tests/lib/rules/arrow-body-style.js
@@ -294,6 +294,6 @@ ruleTester.run("arrow-body-style", rule, {
             errors: [
                 { line: 2, column: 31, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
             ]
-        },
+        }
     ]
 });

--- a/tests/lib/rules/arrow-parens.js
+++ b/tests/lib/rules/arrow-parens.js
@@ -68,7 +68,7 @@ const valid = [
     { code: "async a => ({})", options: ["as-needed", { requireForBlockBody: true }], parserOptions: { ecmaVersion: 8 } },
     { code: "async a => a", options: ["as-needed", { requireForBlockBody: true }], parserOptions: { ecmaVersion: 8 } },
     { code: "(a: T) => a", options: ["as-needed", { requireForBlockBody: true }], parser: parser("identifer-type") },
-    { code: "(a): T => a", options: ["as-needed", { requireForBlockBody: true }], parser: parser("return-type") },
+    { code: "(a): T => a", options: ["as-needed", { requireForBlockBody: true }], parser: parser("return-type") }
 ];
 
 const message = "Expected parentheses around arrow function argument.";

--- a/tests/lib/rules/arrow-spacing.js
+++ b/tests/lib/rules/arrow-spacing.js
@@ -292,8 +292,8 @@ const invalid = [
             { column: 7, line: 1, message: "Missing space before =>." },
             { column: 10, line: 1, message: "Missing space after =>." },
             { column: 11, line: 1, message: "Missing space before =>." },
-            { column: 14, line: 1, message: "Missing space after =>." },
-        ],
+            { column: 14, line: 1, message: "Missing space after =>." }
+        ]
     },
     {
         code: "(a = ()=>0)=>(1)",
@@ -302,9 +302,9 @@ const invalid = [
             { column: 7, line: 1, message: "Missing space before =>." },
             { column: 10, line: 1, message: "Missing space after =>." },
             { column: 11, line: 1, message: "Missing space before =>." },
-            { column: 14, line: 1, message: "Missing space after =>." },
-        ],
-    },
+            { column: 14, line: 1, message: "Missing space after =>." }
+        ]
+    }
 ];
 
 ruleTester.run("arrow-spacing", rule, {

--- a/tests/lib/rules/capitalized-comments.js
+++ b/tests/lib/rules/capitalized-comments.js
@@ -836,11 +836,11 @@ ruleTester.run("capitalized-comments", rule, {
         {
             code: [
                 "// this comment is invalid since it is not capitalized,",
-                "// but this one is ignored since it is consecutive.",
+                "// but this one is ignored since it is consecutive."
             ].join("\n"),
             output: [
                 "// This comment is invalid since it is not capitalized,",
-                "// but this one is ignored since it is consecutive.",
+                "// but this one is ignored since it is consecutive."
             ].join("\n"),
             options: ["always", { ignoreConsecutiveComments: true }],
             errors: [{
@@ -852,11 +852,11 @@ ruleTester.run("capitalized-comments", rule, {
         {
             code: [
                 "// This comment is invalid since it is not capitalized,",
-                "// But this one is ignored since it is consecutive.",
+                "// But this one is ignored since it is consecutive."
             ].join("\n"),
             output: [
                 "// this comment is invalid since it is not capitalized,",
-                "// But this one is ignored since it is consecutive.",
+                "// But this one is ignored since it is consecutive."
             ].join("\n"),
             options: ["never", { ignoreConsecutiveComments: true }],
             errors: [{
@@ -870,11 +870,11 @@ ruleTester.run("capitalized-comments", rule, {
         {
             code: [
                 "// This comment is valid since it is capitalized,",
-                "// but this one is invalid even if it follows a valid one.",
+                "// but this one is invalid even if it follows a valid one."
             ].join("\n"),
             output: [
                 "// This comment is valid since it is capitalized,",
-                "// But this one is invalid even if it follows a valid one.",
+                "// But this one is invalid even if it follows a valid one."
             ].join("\n"),
             options: ["always", { ignoreConsecutiveComments: false }],
             errors: [{

--- a/tests/lib/rules/class-methods-use-this.js
+++ b/tests/lib/rules/class-methods-use-this.js
@@ -87,7 +87,7 @@ ruleTester.run("class-methods-use-this", rule, {
             parserOptions: { ecmaVersion: 6 },
             options: [{ exceptMethods: ["bar"] }],
             errors: [
-                { type: "FunctionExpression", line: 1, column: 14, message: "Expected 'this' to be used by class method 'foo'." },
+                { type: "FunctionExpression", line: 1, column: 14, message: "Expected 'this' to be used by class method 'foo'." }
             ]
         },
         {

--- a/tests/lib/rules/comma-dangle.js
+++ b/tests/lib/rules/comma-dangle.js
@@ -248,167 +248,167 @@ ruleTester.run("comma-dangle", rule, {
         {
             code: "function foo(a,) {}",
             parserOptions: { ecmaVersion: 8 },
-            options: ["never"],
+            options: ["never"]
         },
         {
             code: "foo(a,)",
             parserOptions: { ecmaVersion: 8 },
-            options: ["never"],
+            options: ["never"]
         },
         {
             code: "function foo(a) {}",
             parserOptions: { ecmaVersion: 8 },
-            options: ["always"],
+            options: ["always"]
         },
         {
             code: "foo(a)",
             parserOptions: { ecmaVersion: 8 },
-            options: ["always"],
+            options: ["always"]
         },
         {
             code: "function foo(\na,\nb\n) {}",
             parserOptions: { ecmaVersion: 8 },
-            options: ["always-multiline"],
+            options: ["always-multiline"]
         },
         {
             code: "foo(\na,b)",
             parserOptions: { ecmaVersion: 8 },
-            options: ["always-multiline"],
+            options: ["always-multiline"]
         },
         {
             code: "function foo(a,b,) {}",
             parserOptions: { ecmaVersion: 8 },
-            options: ["always-multiline"],
+            options: ["always-multiline"]
         },
         {
             code: "foo(a,b,)",
             parserOptions: { ecmaVersion: 8 },
-            options: ["always-multiline"],
+            options: ["always-multiline"]
         },
         {
             code: "function foo(a,b,) {}",
             parserOptions: { ecmaVersion: 8 },
-            options: ["only-multiline"],
+            options: ["only-multiline"]
         },
         {
             code: "foo(a,b,)",
             parserOptions: { ecmaVersion: 8 },
-            options: ["only-multiline"],
+            options: ["only-multiline"]
         },
 
         // trailing comma in functions
         {
             code: "function foo(a) {} ",
             parserOptions: { ecmaVersion: 8 },
-            options: [{ functions: "never" }],
+            options: [{ functions: "never" }]
         },
         {
             code: "foo(a)",
             parserOptions: { ecmaVersion: 8 },
-            options: [{ functions: "never" }],
+            options: [{ functions: "never" }]
         },
         {
             code: "function foo(a,) {}",
             parserOptions: { ecmaVersion: 8 },
-            options: [{ functions: "always" }],
+            options: [{ functions: "always" }]
         },
         {
             code: "function bar(a, ...b) {}",
             parserOptions: { ecmaVersion: 8 },
-            options: [{ functions: "always" }],
+            options: [{ functions: "always" }]
         },
         {
             code: "foo(a,)",
             parserOptions: { ecmaVersion: 8 },
-            options: [{ functions: "always" }],
+            options: [{ functions: "always" }]
         },
         {
             code: "bar(...a,)",
             parserOptions: { ecmaVersion: 8 },
-            options: [{ functions: "always" }],
+            options: [{ functions: "always" }]
         },
         {
             code: "function foo(a) {} ",
             parserOptions: { ecmaVersion: 8 },
-            options: [{ functions: "always-multiline" }],
+            options: [{ functions: "always-multiline" }]
         },
         {
             code: "foo(a)",
             parserOptions: { ecmaVersion: 8 },
-            options: [{ functions: "always-multiline" }],
+            options: [{ functions: "always-multiline" }]
         },
         {
             code: "function foo(\na,\nb,\n) {} ",
             parserOptions: { ecmaVersion: 8 },
-            options: [{ functions: "always-multiline" }],
+            options: [{ functions: "always-multiline" }]
         },
         {
             code: "function foo(\na,\n...b\n) {} ",
             parserOptions: { ecmaVersion: 8 },
-            options: [{ functions: "always-multiline" }],
+            options: [{ functions: "always-multiline" }]
         },
         {
             code: "foo(\na,\nb,\n)",
             parserOptions: { ecmaVersion: 8 },
-            options: [{ functions: "always-multiline" }],
+            options: [{ functions: "always-multiline" }]
         },
         {
             code: "foo(\na,\n...b,\n)",
             parserOptions: { ecmaVersion: 8 },
-            options: [{ functions: "always-multiline" }],
+            options: [{ functions: "always-multiline" }]
         },
         {
             code: "function foo(a) {} ",
             parserOptions: { ecmaVersion: 8 },
-            options: [{ functions: "only-multiline" }],
+            options: [{ functions: "only-multiline" }]
         },
         {
             code: "foo(a)",
             parserOptions: { ecmaVersion: 8 },
-            options: [{ functions: "only-multiline" }],
+            options: [{ functions: "only-multiline" }]
         },
         {
             code: "function foo(\na,\nb,\n) {} ",
             parserOptions: { ecmaVersion: 8 },
-            options: [{ functions: "only-multiline" }],
+            options: [{ functions: "only-multiline" }]
         },
         {
             code: "foo(\na,\nb,\n)",
             parserOptions: { ecmaVersion: 8 },
-            options: [{ functions: "only-multiline" }],
+            options: [{ functions: "only-multiline" }]
         },
         {
             code: "function foo(\na,\nb\n) {} ",
             parserOptions: { ecmaVersion: 8 },
-            options: [{ functions: "only-multiline" }],
+            options: [{ functions: "only-multiline" }]
         },
         {
             code: "foo(\na,\nb\n)",
             parserOptions: { ecmaVersion: 8 },
-            options: [{ functions: "only-multiline" }],
+            options: [{ functions: "only-multiline" }]
         },
 
         // https://github.com/eslint/eslint/issues/7370
         {
             code: "function foo({a}: {a: string,}) {}",
             parser: parser("object-pattern-1"),
-            options: ["never"],
+            options: ["never"]
         },
         {
             code: "function foo({a,}: {a: string}) {}",
             parser: parser("object-pattern-2"),
-            options: ["always"],
+            options: ["always"]
         },
         {
             code: "function foo(a): {b: boolean,} {}",
             parser: parser("return-type-1"),
-            options: [{ functions: "never" }],
+            options: [{ functions: "never" }]
         },
         {
             code: "function foo(a,): {b: boolean} {}",
             parser: parser("return-type-2"),
-            options: [{ functions: "always" }],
-        },
+            options: [{ functions: "always" }]
+        }
     ],
     invalid: [
         {
@@ -1457,28 +1457,28 @@ export {d,};
             output: "function foo({a,}: {a: string,}) {}",
             parser: parser("object-pattern-1"),
             options: ["always"],
-            errors: [{ message: "Missing trailing comma." }],
+            errors: [{ message: "Missing trailing comma." }]
         },
         {
             code: "function foo({a,}: {a: string}) {}",
             output: "function foo({a}: {a: string}) {}",
             parser: parser("object-pattern-2"),
             options: ["never"],
-            errors: [{ message: "Unexpected trailing comma." }],
+            errors: [{ message: "Unexpected trailing comma." }]
         },
         {
             code: "function foo(a): {b: boolean,} {}",
             output: "function foo(a,): {b: boolean,} {}",
             parser: parser("return-type-1"),
             options: [{ functions: "always" }],
-            errors: [{ message: "Missing trailing comma." }],
+            errors: [{ message: "Missing trailing comma." }]
         },
         {
             code: "function foo(a,): {b: boolean} {}",
             output: "function foo(a): {b: boolean} {}",
             parser: parser("return-type-2"),
             options: [{ functions: "never" }],
-            errors: [{ message: "Unexpected trailing comma." }],
-        },
+            errors: [{ message: "Unexpected trailing comma." }]
+        }
     ]
 });

--- a/tests/lib/rules/comma-style.js
+++ b/tests/lib/rules/comma-style.js
@@ -182,7 +182,7 @@ ruleTester.run("comma-style", rule, {
             options: ["last", {
                 exceptions: {
                     ArrowFunctionExpression: true
-                },
+                }
             }],
             parserOptions: {
                 ecmaVersion: 6
@@ -385,7 +385,7 @@ ruleTester.run("comma-style", rule, {
             options: ["last", {
                 exceptions: {
                     ArrowFunctionExpression: false
-                },
+                }
             }],
             output: "const foo = (a,\n b) => { return a + b; }",
             parserOptions: {

--- a/tests/lib/rules/consistent-return.js
+++ b/tests/lib/rules/consistent-return.js
@@ -42,7 +42,7 @@ ruleTester.run("consistent-return", rule, {
 
         // https://github.com/eslint/eslint/issues/7790
         { code: "class Foo { constructor() { if (true) return foo; } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "var Foo = class { constructor() { if (true) return foo; } }", parserOptions: { ecmaVersion: 6 } },
+        { code: "var Foo = class { constructor() { if (true) return foo; } }", parserOptions: { ecmaVersion: 6 } }
     ],
 
     invalid: [

--- a/tests/lib/rules/generator-star-spacing.js
+++ b/tests/lib/rules/generator-star-spacing.js
@@ -428,7 +428,7 @@ ruleTester.run("generator-star-spacing", rule, {
         {
             code: "(class {async foo() { }})",
             parserOptions: { ecmaVersion: 8 }
-        },
+        }
     ],
 
     invalid: [

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -3868,6 +3868,6 @@ ruleTester.run("indent", rule, {
             "             'baz']);",
             options: [2, { ArrayExpression: "first", CallExpression: { arguments: "first" } }],
             errors: expectedErrors([2, 13, 12, "ArrayExpression"])
-        },
+        }
     ]
 });

--- a/tests/lib/rules/key-spacing.js
+++ b/tests/lib/rules/key-spacing.js
@@ -1691,7 +1691,7 @@ ruleTester.run("key-spacing", rule, {
                 align: {
                     beforeColon: false,
                     afterColon: true,
-                    on: "colon",
+                    on: "colon"
                 }
             }
         }],
@@ -1720,7 +1720,7 @@ ruleTester.run("key-spacing", rule, {
             align: {
                 beforeColon: false,
                 afterColon: true,
-                on: "colon",
+                on: "colon"
             }
         }],
         parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },

--- a/tests/lib/rules/new-parens.js
+++ b/tests/lib/rules/new-parens.js
@@ -28,7 +28,7 @@ ruleTester.run("new-parens", rule, {
         "var a = (new Date());",
         "var a = new foo.Bar();",
         "var a = (new Foo()).bar;",
-        { code: "new Storage<RootState>('state');", parser: parser("typescript-parsers/new-parens") },
+        { code: "new Storage<RootState>('state');", parser: parser("typescript-parsers/new-parens") }
     ],
     invalid: [
         {

--- a/tests/lib/rules/no-await-in-loop.js
+++ b/tests/lib/rules/no-await-in-loop.js
@@ -35,7 +35,7 @@ ruleTester.run("no-await-in-loop", rule, {
         "async function foo() { while (true) { var y = async () => { await foo; } } }",
 
         // Blocked by a class method
-        "async function foo() { while (true) { class Foo { async foo() { await bar; } } } }",
+        "async function foo() { while (true) { class Foo { async foo() { await bar; } } } }"
 
     ],
     invalid: [
@@ -64,6 +64,6 @@ ruleTester.run("no-await-in-loop", rule, {
         { code: "async function foo() { while (true) { if (bar) { foo(await bar); } } }", errors: [message] },
 
         // Deep in a loop condition
-        { code: "async function foo() { while (xyz || 5 > await x) {  } }", errors: [message] },
-    ],
+        { code: "async function foo() { while (xyz || 5 > await x) {  } }", errors: [message] }
+    ]
 });

--- a/tests/lib/rules/no-console.js
+++ b/tests/lib/rules/no-console.js
@@ -35,7 +35,7 @@ ruleTester.run("no-console", rule, {
         { code: "console.log(foo)", options: [{ allow: ["info", "log", "warn"] }] },
 
         // https://github.com/eslint/eslint/issues/7010
-        "var console = require('myconsole'); console.log(foo)",
+        "var console = require('myconsole'); console.log(foo)"
     ],
     invalid: [
 
@@ -58,6 +58,6 @@ ruleTester.run("no-console", rule, {
         { code: "console.warn(foo)", options: [{ allow: ["info", "log"] }], errors: [{ message: "Unexpected console statement.", type: "MemberExpression" }] },
 
         // In case that implicit global variable of 'console' exists
-        { code: "console.log(foo)", env: { node: true }, errors: [{ message: "Unexpected console statement.", type: "MemberExpression" }] },
+        { code: "console.log(foo)", env: { node: true }, errors: [{ message: "Unexpected console statement.", type: "MemberExpression" }] }
     ]
 });

--- a/tests/lib/rules/no-dupe-keys.js
+++ b/tests/lib/rules/no-dupe-keys.js
@@ -27,7 +27,7 @@ ruleTester.run("no-dupe-keys", rule, {
         { code: "var x = { a: b, ...c }", parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } } },
         { code: "var x = { get a() {}, set a (value) {} };", parserOptions: { ecmaVersion: 6 } },
         { code: "var x = { a: 1, b: { a: 2 } };", parserOptions: { ecmaVersion: 6 } },
-        { code: "var {a, a} = obj", parserOptions: { ecmaVersion: 6 } },
+        { code: "var {a, a} = obj", parserOptions: { ecmaVersion: 6 } }
     ],
     invalid: [
         { code: "var x = { a: b, ['a']: b };", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Duplicate key 'a'.", type: "ObjectExpression" }] },
@@ -37,6 +37,6 @@ ruleTester.run("no-dupe-keys", rule, {
         { code: "var foo = {\n  bar: 1,\n  bar: 1,\n}", errors: [{ message: "Duplicate key 'bar'.", line: 3, column: 3 }] },
         { code: "var x = { a: 1, get a() {} };", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Duplicate key 'a'.", type: "ObjectExpression" }] },
         { code: "var x = { a: 1, set a(value) {} };", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Duplicate key 'a'.", type: "ObjectExpression" }] },
-        { code: "var x = { a: 1, b: { a: 2 }, get b() {} };", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Duplicate key 'b'.", type: "ObjectExpression" }] },
+        { code: "var x = { a: 1, b: { a: 2 }, get b() {} };", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Duplicate key 'b'.", type: "ObjectExpression" }] }
     ]
 });

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -291,7 +291,7 @@ ruleTester.run("no-extra-parens", rule, {
         { code: "foo instanceof (bar instanceof baz)", options: ["all", { nestedBinaryExpressions: false }] },
         { code: "foo in (bar in baz)", options: ["all", { nestedBinaryExpressions: false }] },
         { code: "foo + (bar + baz)", options: ["all", { nestedBinaryExpressions: false }] },
-        { code: "foo && (bar && baz)", options: ["all", { nestedBinaryExpressions: false }] },
+        { code: "foo && (bar && baz)", options: ["all", { nestedBinaryExpressions: false }] }
     ],
 
     invalid: [
@@ -590,7 +590,7 @@ ruleTester.run("no-extra-parens", rule, {
                     type: "LogicalExpression"
                 }
             ],
-            output: "b => b || c;",
+            output: "b => b || c;"
         },
         {
             code: "b => ((b = c) || (d = e));",
@@ -691,7 +691,7 @@ ruleTester.run("no-extra-parens", rule, {
                 {
                     message: "Gratuitous parentheses around expression.",
                     type: "AwaitExpression"
-                },
+                }
             ],
             output: "async function a() { await a + await b; }"
         },

--- a/tests/lib/rules/no-invalid-this.js
+++ b/tests/lib/rules/no-invalid-this.js
@@ -581,7 +581,7 @@ const patterns = [
         errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
-    },
+    }
 ];
 
 const ruleTester = new RuleTester();

--- a/tests/lib/rules/no-new-symbol.js
+++ b/tests/lib/rules/no-new-symbol.js
@@ -22,7 +22,7 @@ ruleTester.run("no-new-symbol", rule, {
     valid: [
         "var foo = Symbol('foo');",
         "function bar(Symbol) { var baz = new Symbol('baz');}",
-        "function Symbol() {} new Symbol();",
+        "function Symbol() {} new Symbol();"
     ],
     invalid: [
         {

--- a/tests/lib/rules/no-restricted-properties.js
+++ b/tests/lib/rules/no-restricted-properties.js
@@ -98,7 +98,7 @@ ruleTester.run("no-restricted-properties", rule, {
         }, {
             code: "let bar = foo;",
             options: [{ object: "foo", property: "bar" }],
-            parserOptions: { ecmaVersion: 6 },
+            parserOptions: { ecmaVersion: 6 }
         }, {
             code: "let {baz: bar} = foo;",
             options: [{ object: "foo", property: "bar" }],

--- a/tests/lib/rules/no-return-await.js
+++ b/tests/lib/rules/no-return-await.js
@@ -132,105 +132,105 @@ ruleTester.run("no-return-await", rule, {
               baz();
             }
           }
-        `,
+        `
     ],
 
     invalid: [
         {
             code: "\nasync function foo() {\n\treturn await bar();\n}\n",
-            errors,
+            errors
         },
         {
             code: "\nasync function foo() {\n\treturn (a, await bar());\n}\n",
-            errors,
+            errors
         },
         {
             code: "\nasync function foo() {\n\treturn (a, b, await bar());\n}\n",
-            errors,
+            errors
         },
         {
             code: "\nasync function foo() {\n\treturn (a && await bar());\n}\n",
-            errors,
+            errors
         },
         {
             code: "\nasync function foo() {\n\treturn (a && b && await bar());\n}\n",
-            errors,
+            errors
         },
         {
             code: "\nasync function foo() {\n\treturn (a || await bar());\n}\n",
-            errors,
+            errors
         },
         {
             code: "\nasync function foo() {\n\treturn (a, b, (c, d, await bar()));\n}\n",
-            errors,
+            errors
         },
         {
             code: "\nasync function foo() {\n\treturn (a, b, (c && await bar()));\n}\n",
-            errors,
+            errors
         },
         {
             code: "\nasync function foo() {\n\treturn (await baz(), b, await bar());\n}\n",
-            errors,
+            errors
         },
         {
             code: "\nasync function foo() {\n\treturn (baz() ? await bar() : b);\n}\n",
-            errors,
+            errors
         },
         {
             code: "\nasync function foo() {\n\treturn (baz() ? a : await bar());\n}\n",
-            errors,
+            errors
         },
         {
             code: "\nasync function foo() {\n\treturn (baz() ? (a, await bar()) : b);\n}\n",
-            errors,
+            errors
         },
         {
             code: "\nasync function foo() {\n\treturn (baz() ? a : (b, await bar()));\n}\n",
-            errors,
+            errors
         },
         {
             code: "\nasync function foo() {\n\treturn (baz() ? (a && await bar()) : b);\n}\n",
-            errors,
+            errors
         },
         {
             code: "\nasync function foo() {\n\treturn (baz() ? a : (b && await bar()));\n}\n",
-            errors,
+            errors
         },
         {
             code: "\nasync () => { return await bar(); }\n",
-            errors,
+            errors
         },
         {
             code: "\nasync () => await bar()\n",
-            errors,
+            errors
         },
         {
             code: "\nasync () => (a, b, await bar())\n",
-            errors,
+            errors
         },
         {
             code: "\nasync () => (a && await bar())\n",
-            errors,
+            errors
         },
         {
             code: "\nasync () => (baz() ? await bar() : b)\n",
-            errors,
+            errors
         },
         {
             code: "\nasync () => (baz() ? a : (b, await bar()))\n",
-            errors,
+            errors
         },
         {
             code: "\nasync () => (baz() ? a : (b && await bar()))\n",
-            errors,
+            errors
         },
         {
             code: "\nasync function foo() {\nif (a) {\n\t\tif (b) {\n\t\t\treturn await bar();\n\t\t}\n\t}\n}\n",
-            errors,
+            errors
         },
         {
             code: "\nasync () => {\nif (a) {\n\t\tif (b) {\n\t\t\treturn await bar();\n\t\t}\n\t}\n}\n",
-            errors,
+            errors
         },
         {
             code: `

--- a/tests/lib/rules/no-self-assign.js
+++ b/tests/lib/rules/no-self-assign.js
@@ -51,7 +51,7 @@ ruleTester.run("no-self-assign", rule, {
         { code: "a.b.c = a.b.c" },
         { code: "a[b] = a[b]" },
         { code: "a['b'] = a['b']" },
-        { code: "a[\n    'b'\n] = a[\n    'b'\n]" },
+        { code: "a[\n    'b'\n] = a[\n    'b'\n]" }
     ],
     invalid: [
         { code: "a = a", errors: ["'a' is assigned to itself."] },
@@ -72,6 +72,6 @@ ruleTester.run("no-self-assign", rule, {
         { code: "a.b.c = a.b.c", options: [{ props: true }], errors: ["'a.b.c' is assigned to itself."] },
         { code: "a[b] = a[b]", options: [{ props: true }], errors: ["'a[b]' is assigned to itself."] },
         { code: "a['b'] = a['b']", options: [{ props: true }], errors: ["'a['b']' is assigned to itself."] },
-        { code: "a[\n    'b'\n] = a[\n    'b'\n]", options: [{ props: true }], errors: ["'a['b']' is assigned to itself."] },
+        { code: "a[\n    'b'\n] = a[\n    'b'\n]", options: [{ props: true }], errors: ["'a['b']' is assigned to itself."] }
     ]
 });

--- a/tests/lib/rules/no-tabs.js
+++ b/tests/lib/rules/no-tabs.js
@@ -23,7 +23,7 @@ ruleTester.run("no-tabs", rule, {
         "function test(){\n}",
         "function test(){\n" +
         "  //   sdfdsf \n" +
-        "}",
+        "}"
     ],
     invalid: [
         {

--- a/tests/lib/rules/no-unsafe-negation.js
+++ b/tests/lib/rules/no-unsafe-negation.js
@@ -27,7 +27,7 @@ ruleTester.run("no-unsafe-negation", rule, {
         "a instanceof b",
         "a instanceof b === false",
         "!(a instanceof b)",
-        "(!a) instanceof b",
+        "(!a) instanceof b"
     ],
     invalid: [
         {
@@ -59,6 +59,6 @@ ruleTester.run("no-unsafe-negation", rule, {
             code: "!(a) instanceof b",
             output: "!((a) instanceof b)",
             errors: ["Unexpected negating the left operand of 'instanceof' operator."]
-        },
+        }
     ]
 });

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -204,7 +204,7 @@ ruleTester.run("no-unused-vars", rule, {
                 "ref = setInterval(",
                 "    function(){",
                 "        clearInterval(ref);",
-                "    }, 10);",
+                "    }, 10);"
             ].join("\n")
         },
         {
@@ -213,7 +213,7 @@ ruleTester.run("no-unused-vars", rule, {
                 "function f() {",
                 "    _timer = setTimeout(function () {}, _timer ? 100 : 0);",
                 "}",
-                "f();",
+                "f();"
             ].join("\n")
         },
         { code: "function foo(cb) { cb = function() { function something(a) { cb(1 + a); } register(something); }(); } foo();" },
@@ -249,12 +249,12 @@ ruleTester.run("no-unused-vars", rule, {
         // https://github.com/eslint/eslint/issues/7250
         {
             code: "(function(a, b, c) { c })",
-            options: [{ argsIgnorePattern: "c" }],
+            options: [{ argsIgnorePattern: "c" }]
         },
         {
             code: "(function(a, b, {c, d}) { c })",
             options: [{ argsIgnorePattern: "[cd]" }],
-            parserOptions: { ecmaVersion: 6 },
+            parserOptions: { ecmaVersion: 6 }
         },
 
         // https://github.com/eslint/eslint/issues/7351
@@ -529,6 +529,6 @@ ruleTester.run("no-unused-vars", rule, {
             options: [{ argsIgnorePattern: "d" }],
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'c' is defined but never used." }]
-        },
+        }
     ]
 });

--- a/tests/lib/rules/no-use-before-define.js
+++ b/tests/lib/rules/no-use-before-define.js
@@ -91,6 +91,6 @@ ruleTester.run("no-use-before-define", rule, {
         { code: "var {a = 0} = a;", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
         { code: "var [a = 0] = a;", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
         { code: "for (var a in a) {}", errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
-        { code: "for (var a of a) {}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] },
+        { code: "for (var a of a) {}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' was used before it was defined.", type: "Identifier" }] }
     ]
 });

--- a/tests/lib/rules/no-useless-escape.js
+++ b/tests/lib/rules/no-useless-escape.js
@@ -150,7 +150,7 @@ ruleTester.run("no-useless-escape", rule, {
             code: "var foo = '\\`foo\\`';",
             errors: [
                 { line: 1, column: 12, message: "Unnecessary escape character: \\`.", type: "Literal" },
-                { line: 1, column: 17, message: "Unnecessary escape character: \\`.", type: "Literal" },
+                { line: 1, column: 17, message: "Unnecessary escape character: \\`.", type: "Literal" }
             ]
         },
         {
@@ -158,7 +158,7 @@ ruleTester.run("no-useless-escape", rule, {
             parserOptions: { ecmaVersion: 6 },
             errors: [
                 { line: 1, column: 12, message: "Unnecessary escape character: \\\".", type: "TemplateElement" },
-                { line: 1, column: 20, message: "Unnecessary escape character: \\\".", type: "TemplateElement" },
+                { line: 1, column: 20, message: "Unnecessary escape character: \\\".", type: "TemplateElement" }
             ]
         },
         {
@@ -188,21 +188,21 @@ ruleTester.run("no-useless-escape", rule, {
             code: "var foo = `\\$\\{{${foo}`;",
             parserOptions: { ecmaVersion: 6 },
             errors: [
-                { line: 1, column: 12, message: "Unnecessary escape character: \\$.", type: "TemplateElement" },
+                { line: 1, column: 12, message: "Unnecessary escape character: \\$.", type: "TemplateElement" }
             ]
         },
         {
             code: "var foo = `\\$a${foo}`;",
             parserOptions: { ecmaVersion: 6 },
             errors: [
-                { line: 1, column: 12, message: "Unnecessary escape character: \\$.", type: "TemplateElement" },
+                { line: 1, column: 12, message: "Unnecessary escape character: \\$.", type: "TemplateElement" }
             ]
         },
         {
             code: "var foo = `a\\{{${foo}`;",
             parserOptions: { ecmaVersion: 6 },
             errors: [
-                { line: 1, column: 13, message: "Unnecessary escape character: \\{.", type: "TemplateElement" },
+                { line: 1, column: 13, message: "Unnecessary escape character: \\{.", type: "TemplateElement" }
             ]
         },
         {

--- a/tests/lib/rules/no-useless-return.js
+++ b/tests/lib/rules/no-useless-return.js
@@ -214,7 +214,7 @@ ruleTester.run("no-useless-return", rule, {
             `,
             errors: [
                 { message: "Unnecessary return statement.", type: "ReturnStatement" },
-                { message: "Unnecessary return statement.", type: "ReturnStatement" },
+                { message: "Unnecessary return statement.", type: "ReturnStatement" }
             ]
         },
         {
@@ -419,7 +419,7 @@ ruleTester.run("no-useless-return", rule, {
             output: "function foo() {   }",
             errors: [
                 { message: "Unnecessary return statement.", type: "ReturnStatement" },
-                { message: "Unnecessary return statement.", type: "ReturnStatement" },
+                { message: "Unnecessary return statement.", type: "ReturnStatement" }
             ]
         }
     ].map(invalidCase => Object.assign({ errors: [{ message: "Unnecessary return statement.", type: "ReturnStatement" }] }, invalidCase))

--- a/tests/lib/rules/no-var.js
+++ b/tests/lib/rules/no-var.js
@@ -154,6 +154,6 @@ ruleTester.run("no-var", rule, {
             errors: [
                 "Unexpected var, use let or const instead."
             ]
-        },
+        }
     ]
 });

--- a/tests/lib/rules/prefer-arrow-callback.js
+++ b/tests/lib/rules/prefer-arrow-callback.js
@@ -164,7 +164,7 @@ ruleTester.run("prefer-arrow-callback", rule, {
             code: "qux(async function (foo = 1, bar = 2, baz = 3) { return this; }.bind(this))",
             output: "qux(async (foo = 1, bar = 2, baz = 3) => { return this; })",
             parserOptions: { ecmaVersion: 8 },
-            errors,
+            errors
         }
     ]
 });

--- a/tests/lib/rules/prefer-const.js
+++ b/tests/lib/rules/prefer-const.js
@@ -334,8 +334,8 @@ ruleTester.run("prefer-const", rule, {
             output: "const { foo, bar } = baz;",
             errors: [
                 { message: "'foo' is never reassigned. Use 'const' instead.", type: "Identifier" },
-                { message: "'bar' is never reassigned. Use 'const' instead.", type: "Identifier" },
+                { message: "'bar' is never reassigned. Use 'const' instead.", type: "Identifier" }
             ]
-        },
+        }
     ]
 });

--- a/tests/lib/rules/prefer-rest-params.js
+++ b/tests/lib/rules/prefer-rest-params.js
@@ -22,12 +22,12 @@ ruleTester.run("prefer-rest-params", rule, {
         "var foo = () => arguments;", // Arrows don't have "arguments".,
         "function foo(...args) { args; }",
         "function foo() { arguments.length; }",
-        "function foo() { arguments.callee; }",
+        "function foo() { arguments.callee; }"
     ],
     invalid: [
         { code: "function foo() { arguments; }", errors: [{ type: "Identifier", message: "Use the rest parameters instead of 'arguments'." }] },
         { code: "function foo() { arguments[0]; }", errors: [{ type: "Identifier", message: "Use the rest parameters instead of 'arguments'." }] },
         { code: "function foo() { arguments[1]; }", errors: [{ type: "Identifier", message: "Use the rest parameters instead of 'arguments'." }] },
-        { code: "function foo() { arguments[Symbol.iterator]; }", errors: [{ type: "Identifier", message: "Use the rest parameters instead of 'arguments'." }] },
+        { code: "function foo() { arguments[Symbol.iterator]; }", errors: [{ type: "Identifier", message: "Use the rest parameters instead of 'arguments'." }] }
     ]
 });

--- a/tests/lib/rules/quote-props.js
+++ b/tests/lib/rules/quote-props.js
@@ -174,7 +174,7 @@ ruleTester.run("quote-props", rule, {
         output: "({ \"true\": 0, 'null': 0 })",
         options: ["consistent"],
         errors: [{
-            message: "Inconsistently quoted property 'true' found.", type: "Property",
+            message: "Inconsistently quoted property 'true' found.", type: "Property"
         }]
     }, {
         code: "({ 'a': 0, 'b': 0 })",

--- a/tests/lib/rules/quotes.js
+++ b/tests/lib/rules/quotes.js
@@ -224,8 +224,8 @@ ruleTester.run("quotes", rule, {
             options: ["single"],
             parserOptions: { ecmaFeatures: { jsx: true } },
             errors: [
-                { message: "Strings must use singlequote.", type: "Literal" },
-            ],
+                { message: "Strings must use singlequote.", type: "Literal" }
+            ]
         },
         {
             code: "<div blah={'blah'} />",
@@ -233,8 +233,8 @@ ruleTester.run("quotes", rule, {
             options: ["double"],
             parserOptions: { ecmaFeatures: { jsx: true } },
             errors: [
-                { message: "Strings must use doublequote.", type: "Literal" },
-            ],
+                { message: "Strings must use doublequote.", type: "Literal" }
+            ]
         },
         {
             code: "<div blah={'blah'} />",
@@ -242,8 +242,8 @@ ruleTester.run("quotes", rule, {
             options: ["backtick"],
             parserOptions: { ecmaFeatures: { jsx: true } },
             errors: [
-                { message: "Strings must use backtick.", type: "Literal" },
-            ],
+                { message: "Strings must use backtick.", type: "Literal" }
+            ]
         },
 
         // https://github.com/eslint/eslint/issues/7610

--- a/tests/lib/rules/require-await.js
+++ b/tests/lib/rules/require-await.js
@@ -38,44 +38,44 @@ ruleTester.run("require-await", rule, {
         "async () => {}",
 
         // normal functions are ok.
-        "function foo() { doSomething() }",
+        "function foo() { doSomething() }"
     ],
     invalid: [
         {
             code: "async function foo() { doSomething() }",
-            errors: ["Async function 'foo' has no 'await' expression."],
+            errors: ["Async function 'foo' has no 'await' expression."]
         },
         {
             code: "(async function() { doSomething() })",
-            errors: ["Async function has no 'await' expression."],
+            errors: ["Async function has no 'await' expression."]
         },
         {
             code: "async () => { doSomething() }",
-            errors: ["Async arrow function has no 'await' expression."],
+            errors: ["Async arrow function has no 'await' expression."]
         },
         {
             code: "async () => doSomething()",
-            errors: ["Async arrow function has no 'await' expression."],
+            errors: ["Async arrow function has no 'await' expression."]
         },
         {
             code: "({ async foo() { doSomething() } })",
-            errors: ["Async method 'foo' has no 'await' expression."],
+            errors: ["Async method 'foo' has no 'await' expression."]
         },
         {
             code: "class A { async foo() { doSomething() } }",
-            errors: ["Async method 'foo' has no 'await' expression."],
+            errors: ["Async method 'foo' has no 'await' expression."]
         },
         {
             code: "(class { async foo() { doSomething() } })",
-            errors: ["Async method 'foo' has no 'await' expression."],
+            errors: ["Async method 'foo' has no 'await' expression."]
         },
         {
             code: "async function foo() { async () => { await doSomething() } }",
-            errors: ["Async function 'foo' has no 'await' expression."],
+            errors: ["Async function 'foo' has no 'await' expression."]
         },
         {
             code: "async function foo() { await async () => { doSomething() } }",
-            errors: ["Async arrow function has no 'await' expression."],
-        },
+            errors: ["Async arrow function has no 'await' expression."]
+        }
     ]
 });

--- a/tests/lib/rules/require-jsdoc.js
+++ b/tests/lib/rules/require-jsdoc.js
@@ -342,6 +342,6 @@ ruleTester.run("require-jsdoc", rule, {
                 message: "Missing JSDoc comment.",
                 type: "ArrowFunctionExpression"
             }]
-        },
+        }
     ]
 });

--- a/tests/lib/rules/sort-keys.js
+++ b/tests/lib/rules/sort-keys.js
@@ -116,7 +116,7 @@ ruleTester.run("sort-keys", rule, {
         { code: "var obj = {C:2, c:3, b_:1}", options: ["desc", { natural: true, caseSensitive: false }] },
         { code: "var obj = {a:4, A:3, _:2, $:1}", options: ["desc", { natural: true, caseSensitive: false }] },
         { code: "var obj = {A:3, '11':2, 2:4, 1:1}", options: ["desc", { natural: true, caseSensitive: false }] },
-        { code: "var obj = {è:4, À:3, 'Z':2, '#':1}", options: ["desc", { natural: true, caseSensitive: false }] },
+        { code: "var obj = {è:4, À:3, 'Z':2, '#':1}", options: ["desc", { natural: true, caseSensitive: false }] }
     ],
     invalid: [
 
@@ -165,7 +165,7 @@ ruleTester.run("sort-keys", rule, {
                 ecmaFeatures: { experimentalObjectRestSpread: true }
             },
             errors: [
-                "Expected object keys to be in ascending order. 'a' should be before 'b'.",
+                "Expected object keys to be in ascending order. 'a' should be before 'b'."
             ]
         },
 
@@ -174,7 +174,7 @@ ruleTester.run("sort-keys", rule, {
             code: "var obj = {a:1, c:{y:1, x:1}, b:1}",
             errors: [
                 "Expected object keys to be in ascending order. 'x' should be before 'y'.",
-                "Expected object keys to be in ascending order. 'b' should be before 'c'.",
+                "Expected object keys to be in ascending order. 'b' should be before 'c'."
             ]
         },
 
@@ -183,49 +183,49 @@ ruleTester.run("sort-keys", rule, {
             code: "var obj = {a:1, _:2, b:3} // asc",
             options: ["asc"],
             errors: [
-                "Expected object keys to be in ascending order. '_' should be before 'a'.",
+                "Expected object keys to be in ascending order. '_' should be before 'a'."
             ]
         },
         {
             code: "var obj = {a:1, c:2, b:3}",
             options: ["asc"],
             errors: [
-                "Expected object keys to be in ascending order. 'b' should be before 'c'.",
+                "Expected object keys to be in ascending order. 'b' should be before 'c'."
             ]
         },
         {
             code: "var obj = {b_:1, a:2, b:3}",
             options: ["asc"],
             errors: [
-                "Expected object keys to be in ascending order. 'a' should be before 'b_'.",
+                "Expected object keys to be in ascending order. 'a' should be before 'b_'."
             ]
         },
         {
             code: "var obj = {b_:1, c:2, C:3}",
             options: ["asc"],
             errors: [
-                "Expected object keys to be in ascending order. 'C' should be before 'c'.",
+                "Expected object keys to be in ascending order. 'C' should be before 'c'."
             ]
         },
         {
             code: "var obj = {$:1, _:2, A:3, a:4}",
             options: ["asc"],
             errors: [
-                "Expected object keys to be in ascending order. 'A' should be before '_'.",
+                "Expected object keys to be in ascending order. 'A' should be before '_'."
             ]
         },
         {
             code: "var obj = {1:1, 2:4, A:3, '11':2}",
             options: ["asc"],
             errors: [
-                "Expected object keys to be in ascending order. '11' should be before 'A'.",
+                "Expected object keys to be in ascending order. '11' should be before 'A'."
             ]
         },
         {
             code: "var obj = {'#':1, À:3, 'Z':2, è:4}",
             options: ["asc"],
             errors: [
-                "Expected object keys to be in ascending order. 'Z' should be before 'À'.",
+                "Expected object keys to be in ascending order. 'Z' should be before 'À'."
             ]
         },
 
@@ -234,42 +234,42 @@ ruleTester.run("sort-keys", rule, {
             code: "var obj = {a:1, _:2, b:3} // asc, insensitive",
             options: ["asc", { caseSensitive: false }],
             errors: [
-                "Expected object keys to be in insensitive ascending order. '_' should be before 'a'.",
+                "Expected object keys to be in insensitive ascending order. '_' should be before 'a'."
             ]
         },
         {
             code: "var obj = {a:1, c:2, b:3}",
             options: ["asc", { caseSensitive: false }],
             errors: [
-                "Expected object keys to be in insensitive ascending order. 'b' should be before 'c'.",
+                "Expected object keys to be in insensitive ascending order. 'b' should be before 'c'."
             ]
         },
         {
             code: "var obj = {b_:1, a:2, b:3}",
             options: ["asc", { caseSensitive: false }],
             errors: [
-                "Expected object keys to be in insensitive ascending order. 'a' should be before 'b_'.",
+                "Expected object keys to be in insensitive ascending order. 'a' should be before 'b_'."
             ]
         },
         {
             code: "var obj = {$:1, A:3, _:2, a:4}",
             options: ["asc", { caseSensitive: false }],
             errors: [
-                "Expected object keys to be in insensitive ascending order. '_' should be before 'A'.",
+                "Expected object keys to be in insensitive ascending order. '_' should be before 'A'."
             ]
         },
         {
             code: "var obj = {1:1, 2:4, A:3, '11':2}",
             options: ["asc", { caseSensitive: false }],
             errors: [
-                "Expected object keys to be in insensitive ascending order. '11' should be before 'A'.",
+                "Expected object keys to be in insensitive ascending order. '11' should be before 'A'."
             ]
         },
         {
             code: "var obj = {'#':1, À:3, 'Z':2, è:4}",
             options: ["asc", { caseSensitive: false }],
             errors: [
-                "Expected object keys to be in insensitive ascending order. 'Z' should be before 'À'.",
+                "Expected object keys to be in insensitive ascending order. 'Z' should be before 'À'."
             ]
         },
 
@@ -278,49 +278,49 @@ ruleTester.run("sort-keys", rule, {
             code: "var obj = {a:1, _:2, b:3} // asc, natural",
             options: ["asc", { natural: true }],
             errors: [
-                "Expected object keys to be in natural ascending order. '_' should be before 'a'.",
+                "Expected object keys to be in natural ascending order. '_' should be before 'a'."
             ]
         },
         {
             code: "var obj = {a:1, c:2, b:3}",
             options: ["asc", { natural: true }],
             errors: [
-                "Expected object keys to be in natural ascending order. 'b' should be before 'c'.",
+                "Expected object keys to be in natural ascending order. 'b' should be before 'c'."
             ]
         },
         {
             code: "var obj = {b_:1, a:2, b:3}",
             options: ["asc", { natural: true }],
             errors: [
-                "Expected object keys to be in natural ascending order. 'a' should be before 'b_'.",
+                "Expected object keys to be in natural ascending order. 'a' should be before 'b_'."
             ]
         },
         {
             code: "var obj = {b_:1, c:2, C:3}",
             options: ["asc", { natural: true }],
             errors: [
-                "Expected object keys to be in natural ascending order. 'C' should be before 'c'.",
+                "Expected object keys to be in natural ascending order. 'C' should be before 'c'."
             ]
         },
         {
             code: "var obj = {$:1, A:3, _:2, a:4}",
             options: ["asc", { natural: true }],
             errors: [
-                "Expected object keys to be in natural ascending order. '_' should be before 'A'.",
+                "Expected object keys to be in natural ascending order. '_' should be before 'A'."
             ]
         },
         {
             code: "var obj = {1:1, 2:4, A:3, '11':2}",
             options: ["asc", { natural: true }],
             errors: [
-                "Expected object keys to be in natural ascending order. '11' should be before 'A'.",
+                "Expected object keys to be in natural ascending order. '11' should be before 'A'."
             ]
         },
         {
             code: "var obj = {'#':1, À:3, 'Z':2, è:4}",
             options: ["asc", { natural: true }],
             errors: [
-                "Expected object keys to be in natural ascending order. 'Z' should be before 'À'.",
+                "Expected object keys to be in natural ascending order. 'Z' should be before 'À'."
             ]
         },
 
@@ -329,42 +329,42 @@ ruleTester.run("sort-keys", rule, {
             code: "var obj = {a:1, _:2, b:3} // asc, natural, insensitive",
             options: ["asc", { natural: true, caseSensitive: false }],
             errors: [
-                "Expected object keys to be in natural insensitive ascending order. '_' should be before 'a'.",
+                "Expected object keys to be in natural insensitive ascending order. '_' should be before 'a'."
             ]
         },
         {
             code: "var obj = {a:1, c:2, b:3}",
             options: ["asc", { natural: true, caseSensitive: false }],
             errors: [
-                "Expected object keys to be in natural insensitive ascending order. 'b' should be before 'c'.",
+                "Expected object keys to be in natural insensitive ascending order. 'b' should be before 'c'."
             ]
         },
         {
             code: "var obj = {b_:1, a:2, b:3}",
             options: ["asc", { natural: true, caseSensitive: false }],
             errors: [
-                "Expected object keys to be in natural insensitive ascending order. 'a' should be before 'b_'.",
+                "Expected object keys to be in natural insensitive ascending order. 'a' should be before 'b_'."
             ]
         },
         {
             code: "var obj = {$:1, A:3, _:2, a:4}",
             options: ["asc", { natural: true, caseSensitive: false }],
             errors: [
-                "Expected object keys to be in natural insensitive ascending order. '_' should be before 'A'.",
+                "Expected object keys to be in natural insensitive ascending order. '_' should be before 'A'."
             ]
         },
         {
             code: "var obj = {1:1, '11':2, 2:4, A:3}",
             options: ["asc", { natural: true, caseSensitive: false }],
             errors: [
-                "Expected object keys to be in natural insensitive ascending order. '2' should be before '11'.",
+                "Expected object keys to be in natural insensitive ascending order. '2' should be before '11'."
             ]
         },
         {
             code: "var obj = {'#':1, À:3, 'Z':2, è:4}",
             options: ["asc", { natural: true, caseSensitive: false }],
             errors: [
-                "Expected object keys to be in natural insensitive ascending order. 'Z' should be before 'À'.",
+                "Expected object keys to be in natural insensitive ascending order. 'Z' should be before 'À'."
             ]
         },
 
@@ -373,28 +373,28 @@ ruleTester.run("sort-keys", rule, {
             code: "var obj = {a:1, _:2, b:3} // desc",
             options: ["desc"],
             errors: [
-                "Expected object keys to be in descending order. 'b' should be before '_'.",
+                "Expected object keys to be in descending order. 'b' should be before '_'."
             ]
         },
         {
             code: "var obj = {a:1, c:2, b:3}",
             options: ["desc"],
             errors: [
-                "Expected object keys to be in descending order. 'c' should be before 'a'.",
+                "Expected object keys to be in descending order. 'c' should be before 'a'."
             ]
         },
         {
             code: "var obj = {b_:1, a:2, b:3}",
             options: ["desc"],
             errors: [
-                "Expected object keys to be in descending order. 'b' should be before 'a'.",
+                "Expected object keys to be in descending order. 'b' should be before 'a'."
             ]
         },
         {
             code: "var obj = {b_:1, c:2, C:3}",
             options: ["desc"],
             errors: [
-                "Expected object keys to be in descending order. 'c' should be before 'b_'.",
+                "Expected object keys to be in descending order. 'c' should be before 'b_'."
             ]
         },
         {
@@ -402,7 +402,7 @@ ruleTester.run("sort-keys", rule, {
             options: ["desc"],
             errors: [
                 "Expected object keys to be in descending order. '_' should be before '$'.",
-                "Expected object keys to be in descending order. 'a' should be before 'A'.",
+                "Expected object keys to be in descending order. 'a' should be before 'A'."
             ]
         },
         {
@@ -410,7 +410,7 @@ ruleTester.run("sort-keys", rule, {
             options: ["desc"],
             errors: [
                 "Expected object keys to be in descending order. '2' should be before '1'.",
-                "Expected object keys to be in descending order. 'A' should be before '2'.",
+                "Expected object keys to be in descending order. 'A' should be before '2'."
             ]
         },
         {
@@ -418,7 +418,7 @@ ruleTester.run("sort-keys", rule, {
             options: ["desc"],
             errors: [
                 "Expected object keys to be in descending order. 'À' should be before '#'.",
-                "Expected object keys to be in descending order. 'è' should be before 'Z'.",
+                "Expected object keys to be in descending order. 'è' should be before 'Z'."
             ]
         },
 
@@ -427,28 +427,28 @@ ruleTester.run("sort-keys", rule, {
             code: "var obj = {a:1, _:2, b:3} // desc, insensitive",
             options: ["desc", { caseSensitive: false }],
             errors: [
-                "Expected object keys to be in insensitive descending order. 'b' should be before '_'.",
+                "Expected object keys to be in insensitive descending order. 'b' should be before '_'."
             ]
         },
         {
             code: "var obj = {a:1, c:2, b:3}",
             options: ["desc", { caseSensitive: false }],
             errors: [
-                "Expected object keys to be in insensitive descending order. 'c' should be before 'a'.",
+                "Expected object keys to be in insensitive descending order. 'c' should be before 'a'."
             ]
         },
         {
             code: "var obj = {b_:1, a:2, b:3}",
             options: ["desc", { caseSensitive: false }],
             errors: [
-                "Expected object keys to be in insensitive descending order. 'b' should be before 'a'.",
+                "Expected object keys to be in insensitive descending order. 'b' should be before 'a'."
             ]
         },
         {
             code: "var obj = {b_:1, c:2, C:3}",
             options: ["desc", { caseSensitive: false }],
             errors: [
-                "Expected object keys to be in insensitive descending order. 'c' should be before 'b_'.",
+                "Expected object keys to be in insensitive descending order. 'c' should be before 'b_'."
             ]
         },
         {
@@ -456,7 +456,7 @@ ruleTester.run("sort-keys", rule, {
             options: ["desc", { caseSensitive: false }],
             errors: [
                 "Expected object keys to be in insensitive descending order. '_' should be before '$'.",
-                "Expected object keys to be in insensitive descending order. 'A' should be before '_'.",
+                "Expected object keys to be in insensitive descending order. 'A' should be before '_'."
             ]
         },
         {
@@ -464,7 +464,7 @@ ruleTester.run("sort-keys", rule, {
             options: ["desc", { caseSensitive: false }],
             errors: [
                 "Expected object keys to be in insensitive descending order. '2' should be before '1'.",
-                "Expected object keys to be in insensitive descending order. 'A' should be before '2'.",
+                "Expected object keys to be in insensitive descending order. 'A' should be before '2'."
             ]
         },
         {
@@ -472,7 +472,7 @@ ruleTester.run("sort-keys", rule, {
             options: ["desc", { caseSensitive: false }],
             errors: [
                 "Expected object keys to be in insensitive descending order. 'À' should be before '#'.",
-                "Expected object keys to be in insensitive descending order. 'è' should be before 'Z'.",
+                "Expected object keys to be in insensitive descending order. 'è' should be before 'Z'."
             ]
         },
 
@@ -481,28 +481,28 @@ ruleTester.run("sort-keys", rule, {
             code: "var obj = {a:1, _:2, b:3} // desc, natural",
             options: ["desc", { natural: true }],
             errors: [
-                "Expected object keys to be in natural descending order. 'b' should be before '_'.",
+                "Expected object keys to be in natural descending order. 'b' should be before '_'."
             ]
         },
         {
             code: "var obj = {a:1, c:2, b:3}",
             options: ["desc", { natural: true }],
             errors: [
-                "Expected object keys to be in natural descending order. 'c' should be before 'a'.",
+                "Expected object keys to be in natural descending order. 'c' should be before 'a'."
             ]
         },
         {
             code: "var obj = {b_:1, a:2, b:3}",
             options: ["desc", { natural: true }],
             errors: [
-                "Expected object keys to be in natural descending order. 'b' should be before 'a'.",
+                "Expected object keys to be in natural descending order. 'b' should be before 'a'."
             ]
         },
         {
             code: "var obj = {b_:1, c:2, C:3}",
             options: ["desc", { natural: true }],
             errors: [
-                "Expected object keys to be in natural descending order. 'c' should be before 'b_'.",
+                "Expected object keys to be in natural descending order. 'c' should be before 'b_'."
             ]
         },
         {
@@ -511,7 +511,7 @@ ruleTester.run("sort-keys", rule, {
             errors: [
                 "Expected object keys to be in natural descending order. '_' should be before '$'.",
                 "Expected object keys to be in natural descending order. 'A' should be before '_'.",
-                "Expected object keys to be in natural descending order. 'a' should be before 'A'.",
+                "Expected object keys to be in natural descending order. 'a' should be before 'A'."
             ]
         },
         {
@@ -519,7 +519,7 @@ ruleTester.run("sort-keys", rule, {
             options: ["desc", { natural: true }],
             errors: [
                 "Expected object keys to be in natural descending order. '2' should be before '1'.",
-                "Expected object keys to be in natural descending order. 'A' should be before '2'.",
+                "Expected object keys to be in natural descending order. 'A' should be before '2'."
             ]
         },
         {
@@ -527,7 +527,7 @@ ruleTester.run("sort-keys", rule, {
             options: ["desc", { natural: true }],
             errors: [
                 "Expected object keys to be in natural descending order. 'À' should be before '#'.",
-                "Expected object keys to be in natural descending order. 'è' should be before 'Z'.",
+                "Expected object keys to be in natural descending order. 'è' should be before 'Z'."
             ]
         },
 
@@ -536,28 +536,28 @@ ruleTester.run("sort-keys", rule, {
             code: "var obj = {a:1, _:2, b:3} // desc, natural, insensitive",
             options: ["desc", { natural: true, caseSensitive: false }],
             errors: [
-                "Expected object keys to be in natural insensitive descending order. 'b' should be before '_'.",
+                "Expected object keys to be in natural insensitive descending order. 'b' should be before '_'."
             ]
         },
         {
             code: "var obj = {a:1, c:2, b:3}",
             options: ["desc", { natural: true, caseSensitive: false }],
             errors: [
-                "Expected object keys to be in natural insensitive descending order. 'c' should be before 'a'.",
+                "Expected object keys to be in natural insensitive descending order. 'c' should be before 'a'."
             ]
         },
         {
             code: "var obj = {b_:1, a:2, b:3}",
             options: ["desc", { natural: true, caseSensitive: false }],
             errors: [
-                "Expected object keys to be in natural insensitive descending order. 'b' should be before 'a'.",
+                "Expected object keys to be in natural insensitive descending order. 'b' should be before 'a'."
             ]
         },
         {
             code: "var obj = {b_:1, c:2, C:3}",
             options: ["desc", { natural: true, caseSensitive: false }],
             errors: [
-                "Expected object keys to be in natural insensitive descending order. 'c' should be before 'b_'.",
+                "Expected object keys to be in natural insensitive descending order. 'c' should be before 'b_'."
             ]
         },
         {
@@ -565,7 +565,7 @@ ruleTester.run("sort-keys", rule, {
             options: ["desc", { natural: true, caseSensitive: false }],
             errors: [
                 "Expected object keys to be in natural insensitive descending order. '_' should be before '$'.",
-                "Expected object keys to be in natural insensitive descending order. 'A' should be before '_'.",
+                "Expected object keys to be in natural insensitive descending order. 'A' should be before '_'."
             ]
         },
         {
@@ -574,7 +574,7 @@ ruleTester.run("sort-keys", rule, {
             errors: [
                 "Expected object keys to be in natural insensitive descending order. '2' should be before '1'.",
                 "Expected object keys to be in natural insensitive descending order. '11' should be before '2'.",
-                "Expected object keys to be in natural insensitive descending order. 'A' should be before '11'.",
+                "Expected object keys to be in natural insensitive descending order. 'A' should be before '11'."
             ]
         },
         {
@@ -582,8 +582,8 @@ ruleTester.run("sort-keys", rule, {
             options: ["desc", { natural: true, caseSensitive: false }],
             errors: [
                 "Expected object keys to be in natural insensitive descending order. 'À' should be before '#'.",
-                "Expected object keys to be in natural insensitive descending order. 'è' should be before 'Z'.",
+                "Expected object keys to be in natural insensitive descending order. 'è' should be before 'Z'."
             ]
-        },
+        }
     ]
 });

--- a/tests/lib/rules/space-before-function-paren.js
+++ b/tests/lib/rules/space-before-function-paren.js
@@ -112,7 +112,7 @@ ruleTester.run("space-before-function-paren", rule, {
         { code: "async () => 1", options: ["always"], parserOptions: { ecmaVersion: 8 } },
         { code: "async() => 1", options: ["always"], parserOptions: { ecmaVersion: 8 } },
         { code: "async () => 1", options: ["never"], parserOptions: { ecmaVersion: 8 } },
-        { code: "async() => 1", options: ["never"], parserOptions: { ecmaVersion: 8 } },
+        { code: "async() => 1", options: ["never"], parserOptions: { ecmaVersion: 8 } }
     ],
 
     invalid: [
@@ -489,6 +489,6 @@ ruleTester.run("space-before-function-paren", rule, {
             options: [{ asyncArrow: "never" }],
             parserOptions: { ecmaVersion: 8 },
             errors: ["Unexpected space before function parentheses."]
-        },
+        }
     ]
 });

--- a/tests/lib/rules/space-infix-ops.js
+++ b/tests/lib/rules/space-infix-ops.js
@@ -347,6 +347,6 @@ ruleTester.run("space-infix-ops", rule, {
                 column: 6,
                 nodeType: "BinaryExpression"
             }]
-        },
+        }
     ]
 });

--- a/tests/lib/rules/symbol-description.js
+++ b/tests/lib/rules/symbol-description.js
@@ -26,7 +26,7 @@ ruleTester.run("symbol-description", rule, {
         "function bar() { var Symbol = function () {}; Symbol(); }",
 
         // Ignore if it's an argument.
-        "function bar(Symbol) { Symbol(); }",
+        "function bar(Symbol) { Symbol(); }"
     ],
 
     invalid: [
@@ -43,6 +43,6 @@ ruleTester.run("symbol-description", rule, {
                 message: "Expected Symbol to have a description.",
                 type: "CallExpression"
             }]
-        },
+        }
     ]
 });

--- a/tests/lib/rules/valid-typeof.js
+++ b/tests/lib/rules/valid-typeof.js
@@ -46,7 +46,7 @@ ruleTester.run("valid-typeof", rule, {
         "var oddUse = typeof foo + 'thing'",
         {
             code: "typeof foo === 'number'",
-            options: [{ requireStringLiterals: true }],
+            options: [{ requireStringLiterals: true }]
         },
         {
             code: "typeof foo === \"number\"",
@@ -128,7 +128,7 @@ ruleTester.run("valid-typeof", rule, {
         {
             code: "if (typeof bar === `umdefined`) {}",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "Invalid typeof comparison value.", type: "TemplateLiteral" }],
+            errors: [{ message: "Invalid typeof comparison value.", type: "TemplateLiteral" }]
         },
         {
             code: "typeof foo == 'invalid string'",


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This enables `comma-dangle: never` on the ESLint codebase, as discussed in https://github.com/eslint/eslint/issues/7725.

All of the changes were made with ESLint's autofixer.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular