### PR TITLE
Fix: brace-style crash with lone block statements (fixes #7908)

### DIFF
--- a/lib/rules/brace-style.js
+++ b/lib/rules/brace-style.js
@@ -138,7 +138,13 @@ module.exports = {
 
         return {
             BlockStatement(node) {
-                validateCurlyPair(sourceCode.getFirstToken(node), sourceCode.getLastToken(node));
+                if (
+                    node.parent.type !== "BlockStatement" &&
+                    node.parent.type !== "SwitchCase" &&
+                    node.parent.type !== "Program"
+                ) {
+                    validateCurlyPair(sourceCode.getFirstToken(node), sourceCode.getLastToken(node));
+                }
             },
             SwitchStatement(node) {
                 const closingCurly = sourceCode.getLastToken(node);

--- a/tests/lib/rules/brace-style.js
+++ b/tests/lib/rules/brace-style.js
@@ -93,7 +93,38 @@ ruleTester.run("brace-style", rule, {
         {
             code: "switch(x) {}",
             options: ["allman", { allowSingleLine: true }]
-        }
+        },
+
+        // https://github.com/eslint/eslint/issues/7908
+        "{}",
+        `
+            if (foo) {
+
+            }
+
+            {
+
+            }
+        `,
+        `
+            switch (foo) {
+                case bar:
+                    baz();
+                    {
+                        qux();
+                    }
+            }
+        `,
+        `
+            {
+            }
+        `,
+        `
+            {
+                {
+                }
+            }
+        `
     ],
 
     invalid: [


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (see https://github.com/eslint/eslint/issues/7908)

**What changes did you make? (Give an overview)**

This updates `brace-style` to avoid crashing when it encounters a lone `BlockStatement` node.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular