### PR TITLE
New: `template-tag-spacing` rule (fixes #7631)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -233,6 +233,7 @@
         "strict": "off",
         "symbol-description": "off",
         "template-curly-spacing": "off",
+        "template-tag-spacing": "off",
         "unicode-bom": "off",
         "use-isnan": "error",
         "valid-jsdoc": "off",

--- a/docs/rules/template-tag-spacing.md
+++ b/docs/rules/template-tag-spacing.md
@@ -4,10 +4,11 @@
 
 With ES6, it's possible to create functions called [tagged template literals](#further-reading) where the function parameters consist of a template literal's strings and expressions.
 
-This rule can force usage of spacing _between_ the tag function and the template literal.
+When using tagged template literals, it's possible to insert whitespace between the tag function and the template literal. Since this whitespace is optional, the following lines are equivalent:
 
 ```js
 let hello = func`Hello world`;
+let hello = func `Hello world`;
 ```
 
 ## Rule Details

--- a/docs/rules/template-tag-spacing.md
+++ b/docs/rules/template-tag-spacing.md
@@ -1,0 +1,70 @@
+# Enforce Usage of Spacing in Tagged Template Literals (template-tag-spacing)
+
+(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
+We can create functions whose parameters consist of template literals.
+
+This rule can force usage of spacing _between_ the tag function and the template literal.
+
+```js
+let hello = func`Hello world`;
+```
+
+## Rule Details
+
+This rule aims to maintain consistency around the spacing between template tag functions and their template literals.
+
+## Options
+
+```json
+{
+    "template-tag-spacing": ["error", "never"]
+}
+```
+
+This rule has one option which has either `"never"` or `"always"` as value.
+
+* `"never"` (default) - Disallows spaces between a tag function and its template literal.
+* `"always"` - Requires one or more spaces between a tag function and its template literal.
+
+## Examples
+
+### never
+
+Examples of **incorrect** code for this rule with the default `"never"` option:
+
+```js
+/*eslint template-tag-spacing: "error"*/
+
+func `Hello world`;
+```
+
+Examples of **correct** code for this rule with the default `"never"` option:
+
+```js
+/*eslint template-tag-spacing: "error"*/
+
+func`Hello world`;
+```
+
+### always
+
+Examples of **incorrect** code for this rule with the `"always"` option:
+
+```js
+/*eslint template-tag-spacing: ["error", "always"]*/
+
+func`Hello world`;
+```
+
+Examples of **correct** code for this rule with the `"always"` option:
+
+```js
+/*eslint template-tag-spacing: ["error", "always"]*/
+
+func `Hello world`;
+```
+
+## When Not To Use It
+
+If you don't want to be notified about usage of spacing between tag functions and their template literals, then it's safe to disable this rule.

--- a/docs/rules/template-tag-spacing.md
+++ b/docs/rules/template-tag-spacing.md
@@ -1,4 +1,4 @@
-# Enforce Usage of Spacing in Tagged Template Literals (template-tag-spacing)
+# Require or disallow spacing between template tags and their literals (template-tag-spacing)
 
 (fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
 
@@ -23,7 +23,7 @@ This rule aims to maintain consistency around the spacing between template tag f
 }
 ```
 
-This rule has one option which has either `"never"` or `"always"` as value.
+This rule has one option whose value can be set to "never" or "always"
 
 * `"never"` (default) - Disallows spaces between a tag function and its template literal.
 * `"always"` - Requires one or more spaces between a tag function and its template literal.

--- a/docs/rules/template-tag-spacing.md
+++ b/docs/rules/template-tag-spacing.md
@@ -2,7 +2,7 @@
 
 (fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
 
-We can create functions whose parameters consist of template literals.
+With ES6, it's possible to create functions called [tagged template literals](#further-reading) where the function parameters consist of a template literal's strings and expressions.
 
 This rule can force usage of spacing _between_ the tag function and the template literal.
 
@@ -68,3 +68,10 @@ func `Hello world`;
 ## When Not To Use It
 
 If you don't want to be notified about usage of spacing between tag functions and their template literals, then it's safe to disable this rule.
+
+## Further Reading
+
+If you want to learn more about tagged template literals, check out the links below:
+
+* [Template literals (MDN)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Tagged_template_literals)
+* [Examples of using tagged template literals (Exploring ES6)](http://exploringjs.com/es6/ch_template-literals.html#_examples-of-using-tagged-template-literals)

--- a/lib/rules/template-tag-spacing.js
+++ b/lib/rules/template-tag-spacing.js
@@ -13,7 +13,7 @@ module.exports = {
     meta: {
         docs: {
             description: "require or disallow spacing between template tags and their literals",
-            category: "ECMAScript 6",
+            category: "Stylistic Issues",
             recommended: false
         },
 

--- a/lib/rules/template-tag-spacing.js
+++ b/lib/rules/template-tag-spacing.js
@@ -35,8 +35,8 @@ module.exports = {
          * @private
          */
         function checkSpacing(node) {
-            const tagToken = sourceCode.getLastToken(node.tag);
-            const literalToken = sourceCode.getTokenAfter(tagToken);
+            const tagToken = sourceCode.getTokenBefore(node.quasi);
+            const literalToken = sourceCode.getFirstToken(node.quasi);
             const hasWhitespace = sourceCode.isSpaceBetweenTokens(tagToken, literalToken);
 
             if (never && hasWhitespace) {

--- a/lib/rules/template-tag-spacing.js
+++ b/lib/rules/template-tag-spacing.js
@@ -1,0 +1,67 @@
+/**
+ * @fileoverview Rule to check spacing between template tags and their literals
+ * @author Jonathan Wilsson
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "require or disallow spacing between template tags and their literals",
+            category: "ECMAScript 6",
+            recommended: false
+        },
+
+        fixable: "whitespace",
+
+        schema: [
+            { enum: ["always", "never"] }
+        ]
+    },
+
+    create(context) {
+        const never = context.options[0] !== "always";
+        const sourceCode = context.getSourceCode();
+
+        /**
+         * Check if a space is present between a template tag and its literal
+         * @param {ASTNode} node node to evaluate
+         * @returns {void}
+         * @private
+         */
+        function checkSpacing(node) {
+            const tagToken = sourceCode.getLastToken(node.tag);
+            const literalToken = sourceCode.getTokenAfter(tagToken);
+            const hasWhitespace = sourceCode.isSpaceBetweenTokens(tagToken, literalToken);
+
+            if (never && hasWhitespace) {
+                context.report({
+                    node,
+                    loc: tagToken.loc.start,
+                    message: "Unexpected space between template tag and template literal.",
+                    fix(fixer) {
+                        return fixer.removeRange([tagToken.range[1], literalToken.range[0]]);
+                    }
+                });
+            } else if (!never && !hasWhitespace) {
+                context.report({
+                    node,
+                    loc: tagToken.loc.start,
+                    message: "Missing space between template tag and template literal.",
+                    fix(fixer) {
+                        return fixer.insertTextBefore(literalToken, " ");
+                    }
+                });
+            }
+        }
+
+        return {
+            TaggedTemplateExpression: checkSpacing
+        };
+    }
+};

--- a/lib/rules/template-tag-spacing.js
+++ b/lib/rules/template-tag-spacing.js
@@ -45,7 +45,17 @@ module.exports = {
                     loc: tagToken.loc.start,
                     message: "Unexpected space between template tag and template literal.",
                     fix(fixer) {
-                        return fixer.removeRange([tagToken.range[1], literalToken.range[0]]);
+                        const comments = sourceCode.getComments(node.quasi).leading;
+
+                        // Don't fix anything if there's a single line comment after the template tag
+                        if (comments.some(comment => comment.type === "Line")) {
+                            return null;
+                        }
+
+                        return fixer.replaceTextRange(
+                            [tagToken.range[1], literalToken.range[0]],
+                            comments.reduce((text, comment) => text + sourceCode.getText(comment), "")
+                        );
                     }
                 });
             } else if (!never && !hasWhitespace) {
@@ -54,7 +64,7 @@ module.exports = {
                     loc: tagToken.loc.start,
                     message: "Missing space between template tag and template literal.",
                     fix(fixer) {
-                        return fixer.insertTextBefore(literalToken, " ");
+                        return fixer.insertTextAfter(tagToken, " ");
                     }
                 });
             }

--- a/tests/lib/rules/template-tag-spacing.js
+++ b/tests/lib/rules/template-tag-spacing.js
@@ -31,7 +31,19 @@ ruleTester.run("template-tag-spacing", rule, {
         { code: "new tag `name`", options: ["always"] },
         "new tag`hello ${name}`",
         { code: "new tag`hello ${name}`", options: ["never"] },
-        { code: "new tag `hello ${name}`", options: ["always"] }
+        { code: "new tag `hello ${name}`", options: ["always"] },
+        "(tag)`name`",
+        { code: "(tag)`name`", options: ["never"] },
+        { code: "(tag) `name`", options: ["always"] },
+        "(tag)`hello ${name}`",
+        { code: "(tag)`hello ${name}`", options: ["never"] },
+        { code: "(tag) `hello ${name}`", options: ["always"] },
+        "new (tag)`name`",
+        { code: "new (tag)`name`", options: ["never"] },
+        { code: "new (tag) `name`", options: ["always"] },
+        "new (tag)`hello ${name}`",
+        { code: "new (tag)`hello ${name}`", options: ["never"] },
+        { code: "new (tag) `hello ${name}`", options: ["always"] }
     ],
     invalid: [
         {
@@ -121,6 +133,98 @@ ruleTester.run("template-tag-spacing", rule, {
         {
             code: "new tag`hello ${name}`",
             output: "new tag `hello ${name}`",
+            errors: [
+                { message: "Missing space between template tag and template literal." }
+            ],
+            options: ["always"]
+        },
+        {
+            code: "(tag) `name`",
+            output: "(tag)`name`",
+            errors: [
+                { message: "Unexpected space between template tag and template literal." }
+            ]
+        },
+        {
+            code: "(tag) `name`",
+            output: "(tag)`name`",
+            errors: [
+                { message: "Unexpected space between template tag and template literal." }
+            ],
+            options: ["never"]
+        },
+        {
+            code: "(tag)`name`",
+            output: "(tag) `name`",
+            errors: [
+                { message: "Missing space between template tag and template literal." }
+            ],
+            options: ["always"]
+        },
+        {
+            code: "(tag) `hello ${name}`",
+            output: "(tag)`hello ${name}`",
+            errors: [
+                { message: "Unexpected space between template tag and template literal." }
+            ]
+        },
+        {
+            code: "(tag) `hello ${name}`",
+            output: "(tag)`hello ${name}`",
+            errors: [
+                { message: "Unexpected space between template tag and template literal." }
+            ],
+            options: ["never"]
+        },
+        {
+            code: "(tag)`hello ${name}`",
+            output: "(tag) `hello ${name}`",
+            errors: [
+                { message: "Missing space between template tag and template literal." }
+            ],
+            options: ["always"]
+        },
+        {
+            code: "new (tag) `name`",
+            output: "new (tag)`name`",
+            errors: [
+                { message: "Unexpected space between template tag and template literal." }
+            ]
+        },
+        {
+            code: "new (tag) `name`",
+            output: "new (tag)`name`",
+            errors: [
+                { message: "Unexpected space between template tag and template literal." }
+            ],
+            options: ["never"]
+        },
+        {
+            code: "new (tag)`name`",
+            output: "new (tag) `name`",
+            errors: [
+                { message: "Missing space between template tag and template literal." }
+            ],
+            options: ["always"]
+        },
+        {
+            code: "new (tag) `hello ${name}`",
+            output: "new (tag)`hello ${name}`",
+            errors: [
+                { message: "Unexpected space between template tag and template literal." }
+            ]
+        },
+        {
+            code: "new (tag) `hello ${name}`",
+            output: "new (tag)`hello ${name}`",
+            errors: [
+                { message: "Unexpected space between template tag and template literal." }
+            ],
+            options: ["never"]
+        },
+        {
+            code: "new (tag)`hello ${name}`",
+            output: "new (tag) `hello ${name}`",
             errors: [
                 { message: "Missing space between template tag and template literal." }
             ],

--- a/tests/lib/rules/template-tag-spacing.js
+++ b/tests/lib/rules/template-tag-spacing.js
@@ -75,6 +75,7 @@ ruleTester.run("template-tag-spacing", rule, {
         },
         {
             code: "tag /*here's a comment*/`Hello world`",
+            output: "tag/*here's a comment*/`Hello world`",
             errors: [
                 { message: "Unexpected space between template tag and template literal." }
             ],
@@ -82,6 +83,7 @@ ruleTester.run("template-tag-spacing", rule, {
         },
         {
             code: "tag/*here's a comment*/ `Hello world`",
+            output: "tag/*here's a comment*/`Hello world`",
             errors: [
                 { message: "Unexpected space between template tag and template literal." }
             ],
@@ -89,10 +91,26 @@ ruleTester.run("template-tag-spacing", rule, {
         },
         {
             code: "tag/*here's a comment*/`Hello world`",
+            output: "tag /*here's a comment*/`Hello world`",
             errors: [
                 { message: "Missing space between template tag and template literal." }
             ],
             options: ["always"]
+        },
+        {
+            code: "tag // here's a comment \n`bar`",
+            output: "tag // here's a comment \n`bar`",
+            errors: [
+                { message: "Unexpected space between template tag and template literal." }
+            ]
+        },
+        {
+            code: "tag // here's a comment \n`bar`",
+            output: "tag // here's a comment \n`bar`",
+            errors: [
+                { message: "Unexpected space between template tag and template literal." }
+            ],
+            options: ["never"]
         },
         {
             code: "tag `hello ${name}`",

--- a/tests/lib/rules/template-tag-spacing.js
+++ b/tests/lib/rules/template-tag-spacing.js
@@ -1,0 +1,130 @@
+/**
+ * @fileoverview Tests for template-tag-spacing rule.
+ * @author Jonathan Wilsson
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../lib/rules/template-tag-spacing"),
+    RuleTester = require("../../../lib/testers/rule-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
+
+ruleTester.run("template-tag-spacing", rule, {
+    valid: [
+        "tag`name`",
+        { code: "tag`name`", options: ["never"] },
+        { code: "tag `name`", options: ["always"] },
+        "tag`hello ${name}`",
+        { code: "tag`hello ${name}`", options: ["never"] },
+        { code: "tag `hello ${name}`", options: ["always"] },
+        "new tag`name`",
+        { code: "new tag`name`", options: ["never"] },
+        { code: "new tag `name`", options: ["always"] },
+        "new tag`hello ${name}`",
+        { code: "new tag`hello ${name}`", options: ["never"] },
+        { code: "new tag `hello ${name}`", options: ["always"] }
+    ],
+    invalid: [
+        {
+            code: "tag `name`",
+            output: "tag`name`",
+            errors: [
+                { message: "Unexpected space between template tag and template literal." }
+            ]
+        },
+        {
+            code: "tag `name`",
+            output: "tag`name`",
+            errors: [
+                { message: "Unexpected space between template tag and template literal." }
+            ],
+            options: ["never"]
+        },
+        {
+            code: "tag`name`",
+            output: "tag `name`",
+            errors: [
+                { message: "Missing space between template tag and template literal." }
+            ],
+            options: ["always"]
+        },
+        {
+            code: "tag `hello ${name}`",
+            output: "tag`hello ${name}`",
+            errors: [
+                { message: "Unexpected space between template tag and template literal." }
+            ]
+        },
+        {
+            code: "tag `hello ${name}`",
+            output: "tag`hello ${name}`",
+            errors: [
+                { message: "Unexpected space between template tag and template literal." }
+            ],
+            options: ["never"]
+        },
+        {
+            code: "tag`hello ${name}`",
+            output: "tag `hello ${name}`",
+            errors: [
+                { message: "Missing space between template tag and template literal." }
+            ],
+            options: ["always"]
+        },
+        {
+            code: "new tag `name`",
+            output: "new tag`name`",
+            errors: [
+                { message: "Unexpected space between template tag and template literal." }
+            ]
+        },
+        {
+            code: "new tag `name`",
+            output: "new tag`name`",
+            errors: [
+                { message: "Unexpected space between template tag and template literal." }
+            ],
+            options: ["never"]
+        },
+        {
+            code: "new tag`name`",
+            output: "new tag `name`",
+            errors: [
+                { message: "Missing space between template tag and template literal." }
+            ],
+            options: ["always"]
+        },
+        {
+            code: "new tag `hello ${name}`",
+            output: "new tag`hello ${name}`",
+            errors: [
+                { message: "Unexpected space between template tag and template literal." }
+            ]
+        },
+        {
+            code: "new tag `hello ${name}`",
+            output: "new tag`hello ${name}`",
+            errors: [
+                { message: "Unexpected space between template tag and template literal." }
+            ],
+            options: ["never"]
+        },
+        {
+            code: "new tag`hello ${name}`",
+            output: "new tag `hello ${name}`",
+            errors: [
+                { message: "Missing space between template tag and template literal." }
+            ],
+            options: ["always"]
+        }
+    ]
+});

--- a/tests/lib/rules/template-tag-spacing.js
+++ b/tests/lib/rules/template-tag-spacing.js
@@ -26,6 +26,10 @@ ruleTester.run("template-tag-spacing", rule, {
         "tag`hello ${name}`",
         { code: "tag`hello ${name}`", options: ["never"] },
         { code: "tag `hello ${name}`", options: ["always"] },
+        "tag/*here's a comment*/`Hello world`",
+        { code: "tag/*here's a comment*/`Hello world`", options: ["never"] },
+        { code: "tag /*here's a comment*/`Hello world`", options: ["always"] },
+        { code: "tag/*here's a comment*/ `Hello world`", options: ["always"] },
         "new tag`name`",
         { code: "new tag`name`", options: ["never"] },
         { code: "new tag `name`", options: ["always"] },
@@ -64,6 +68,27 @@ ruleTester.run("template-tag-spacing", rule, {
         {
             code: "tag`name`",
             output: "tag `name`",
+            errors: [
+                { message: "Missing space between template tag and template literal." }
+            ],
+            options: ["always"]
+        },
+        {
+            code: "tag /*here's a comment*/`Hello world`",
+            errors: [
+                { message: "Unexpected space between template tag and template literal." }
+            ],
+            options: ["never"]
+        },
+        {
+            code: "tag/*here's a comment*/ `Hello world`",
+            errors: [
+                { message: "Unexpected space between template tag and template literal." }
+            ],
+            options: ["never"]
+        },
+        {
+            code: "tag/*here's a comment*/`Hello world`",
             errors: [
                 { message: "Missing space between template tag and template literal." }
             ],


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ X ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**Please describe what the rule should do:**
This rule is very similiar to `func-call-spacing` in the way it will enforce spacing between [template tags](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Tagged_template_literals) and their corresponding template literal.

**What category of rule is this? (place an "X" next to just one item)**

[ X ] Enforces code style
[ ] Warns about a potential error
[ ] Suggests an alternate way of doing something
[ ] Other (please specify:)

**Provide 2-3 code examples that this rule will warn about:**

```js
/* eslint template-tag-spacing: ["error", "never"] */
func `foo`
```

```js
/* eslint template-tag-spacing: ["error", "always"] */
func`foo`
```

**Why should this rule be included in ESLint (instead of a plugin)?**
Since it's really similar to `func-call-spacing` which is already included in ESLint it makes sense to enforce this styling too, especially since tagged template literals will become more and more common.