### PR TITLE
Fix: add parentheses in no-extra-boolean-cast autofixer (fixes #7912)

### DIFF
--- a/lib/rules/no-extra-boolean-cast.js
+++ b/lib/rules/no-extra-boolean-cast.js
@@ -6,6 +6,12 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const astUtils = require("../ast-utils");
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
@@ -91,7 +97,14 @@ module.exports = {
                     context.report({
                         node,
                         message: "Redundant Boolean call.",
-                        fix: fixer => fixer.replaceText(node, sourceCode.getText(node.arguments[0]))
+                        fix: fixer => {
+                            const argument = node.arguments[0];
+
+                            if (astUtils.getPrecedence(argument) < astUtils.getPrecedence(node.parent)) {
+                                return fixer.replaceText(node, `(${sourceCode.getText(argument)})`);
+                            }
+                            return fixer.replaceText(node, sourceCode.getText(argument));
+                        }
                     });
                 }
             }

--- a/tests/lib/rules/no-extra-boolean-cast.js
+++ b/tests/lib/rules/no-extra-boolean-cast.js
@@ -146,6 +146,46 @@ ruleTester.run("no-extra-boolean-cast", rule, {
                 message: "Redundant Boolean call.",
                 type: "CallExpression"
             }]
+        },
+        {
+            code: "!Boolean(foo && bar)",
+            output: "!(foo && bar)",
+            errors: [{
+                message: "Redundant Boolean call.",
+                type: "CallExpression"
+            }]
+        },
+        {
+            code: "!Boolean(foo + bar)",
+            output: "!(foo + bar)",
+            errors: [{
+                message: "Redundant Boolean call.",
+                type: "CallExpression"
+            }]
+        },
+        {
+            code: "!Boolean(+foo)",
+            output: "!+foo",
+            errors: [{
+                message: "Redundant Boolean call.",
+                type: "CallExpression"
+            }]
+        },
+        {
+            code: "!Boolean(foo())",
+            output: "!foo()",
+            errors: [{
+                message: "Redundant Boolean call.",
+                type: "CallExpression"
+            }]
+        },
+        {
+            code: "!Boolean(foo = bar)",
+            output: "!(foo = bar)",
+            errors: [{
+                message: "Redundant Boolean call.",
+                type: "CallExpression"
+            }]
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**
[X] Bug fix for #7912 

**What changes did you make? (Give an overview)**
I've change autofixer in no-extra-boolean-cast rule for "Redundant Boolean call" to include brackets if the inner part is an expression.

