### PR TITLE
Fix: Ignore inline plugin rule config in autoconfig (fixes #7860)

### DIFF
--- a/lib/config/autoconfig.js
+++ b/lib/config/autoconfig.js
@@ -296,8 +296,13 @@ class Registry {
 
                     // It is possible that the error is from a configuration comment
                     // in a linted file, in which case there may not be a config
-                    // set in this ruleSetIdx. (https://github.com/eslint/eslint/issues/5992)
-                    if (lintedRegistry.rules[result.ruleId][ruleSetIdx]) {
+                    // set in this ruleSetIdx.
+                    // (https://github.com/eslint/eslint/issues/5992)
+                    // (https://github.com/eslint/eslint/issues/7860)
+                    if (
+                        lintedRegistry.rules[result.ruleId]
+                        && lintedRegistry.rules[result.ruleId][ruleSetIdx]
+                    ) {
                         lintedRegistry.rules[result.ruleId][ruleSetIdx].errorCount += 1;
                     }
                 });

--- a/tests/fixtures/autoconfig/source-with-comments.js
+++ b/tests/fixtures/autoconfig/source-with-comments.js
@@ -1,4 +1,5 @@
 /* eslint semi: [2, "never"] */
+/* eslint import/extensions: 2 */
 
 var foo = 42;
 var baz = "baz";


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Fixes #7860 

**What changes did you make? (Give an overview)**
I added a check during auto-config to ensure that the rule name throwing an error is in the error registry.

**Is there anything you'd like reviewers to focus on?**
No, it's straight-forward.

