### PR TITLE
Fix: func-call-spacing does not recognize all line terminators (fixes #7923)

### DIFF
--- a/lib/rules/func-call-spacing.js
+++ b/lib/rules/func-call-spacing.js
@@ -86,9 +86,9 @@ module.exports = {
                 return;
             }
 
-            const hasWhitespace = sourceCode.isSpaceBetweenTokens(prevToken, parenToken);
-            const hasNewline = hasWhitespace &&
-                /\n/.test(text.slice(prevToken.range[1], parenToken.range[0]).replace(/\/\*.*?\*\//g, ""));
+            const textBetweenTokens = text.slice(prevToken.range[1], parenToken.range[0]).replace(/\/\*.*?\*\//g, "");
+            const hasWhitespace = /\s/.test(textBetweenTokens);
+            const hasNewline = hasWhitespace && /[\n\r\u2028\u2029]/.test(textBetweenTokens);
 
             /*
              * never allowNewlines hasWhitespace hasNewline message

--- a/tests/lib/rules/func-call-spacing.js
+++ b/tests/lib/rules/func-call-spacing.js
@@ -187,6 +187,22 @@ ruleTester.run("func-call-spacing", rule, {
         {
             code: "f\n/*\n*/\n()",
             options: ["always", { allowNewlines: true }]
+        },
+        {
+            code: "f\r();",
+            options: ["always", { allowNewlines: true }]
+        },
+        {
+            code: "f\u2028();",
+            options: ["always", { allowNewlines: true }]
+        },
+        {
+            code: "f\u2029();",
+            options: ["always", { allowNewlines: true }]
+        },
+        {
+            code: "f\r\n();",
+            options: ["always", { allowNewlines: true }]
         }
     ],
     invalid: [
@@ -249,6 +265,33 @@ ruleTester.run("func-call-spacing", rule, {
                 { message: "Unexpected space between function name and paren.", type: "CallExpression" }
             ],
             output: "f();\n t();"
+        },
+
+        // https://github.com/eslint/eslint/issues/7787
+        {
+            code: "f\n();",
+            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression" }],
+            output: "f\n();" // no change
+        },
+        {
+            code: "f\r();",
+            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression" }],
+            output: "f\r();" // no change
+        },
+        {
+            code: "f\u2028();",
+            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression" }],
+            output: "f\u2028();" // no change
+        },
+        {
+            code: "f\u2029();",
+            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression" }],
+            output: "f\u2029();" // no change
+        },
+        {
+            code: "f\r\n();",
+            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression" }],
+            output: "f\r\n();" // no change
         },
 
         // "never"
@@ -393,6 +436,50 @@ ruleTester.run("func-call-spacing", rule, {
                 "(0, baz())"
             ].join("\n") // no change
         },
+        {
+            code: "f\r();",
+            options: ["never"],
+            errors: [
+                {
+                    message: "Unexpected space between function name and paren.",
+                    type: "CallExpression"
+                }
+            ],
+            output: "f\r();" // no change
+        },
+        {
+            code: "f\u2028();",
+            options: ["never"],
+            errors: [
+                {
+                    message: "Unexpected space between function name and paren.",
+                    type: "CallExpression"
+                }
+            ],
+            output: "f\u2028();" // no change
+        },
+        {
+            code: "f\u2029();",
+            options: ["never"],
+            errors: [
+                {
+                    message: "Unexpected space between function name and paren.",
+                    type: "CallExpression"
+                }
+            ],
+            output: "f\u2029();" // no change
+        },
+        {
+            code: "f\r\n();",
+            options: ["never"],
+            errors: [
+                {
+                    message: "Unexpected space between function name and paren.",
+                    type: "CallExpression"
+                }
+            ],
+            output: "f\r\n();" // no change
+        },
 
         // "always"
         {
@@ -502,6 +589,30 @@ ruleTester.run("func-call-spacing", rule, {
                 { message: "Missing space between function name and paren.", type: "CallExpression" }
             ],
             output: "f ();\n t ();"
+        },
+        {
+            code: "f\r();",
+            options: ["always"],
+            errors: [{ message: "Unexpected newline between function name and paren.", type: "CallExpression" }],
+            output: "f ();"
+        },
+        {
+            code: "f\u2028();",
+            options: ["always"],
+            errors: [{ message: "Unexpected newline between function name and paren.", type: "CallExpression" }],
+            output: "f ();"
+        },
+        {
+            code: "f\u2029();",
+            options: ["always"],
+            errors: [{ message: "Unexpected newline between function name and paren.", type: "CallExpression" }],
+            output: "f ();"
+        },
+        {
+            code: "f\r\n();",
+            options: ["always"],
+            errors: [{ message: "Unexpected newline between function name and paren.", type: "CallExpression" }],
+            output: "f ();"
         },
 
         // "always", "allowNewlines": true


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (see #7923)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Updated a regular expression in the `func-call-spacing` rule source to match the line terminator characters `"\r"`, `"\u2028"` and `"\u2029"` along with `"\n"`. This has the effect of disallowing those characters as separators when the option `"always"` is used without `"allowNewlines"`.

**Is there anything you'd like reviewers to focus on?**

Nothing that shouldn't be clear.
