### PR TITLE
Update: add ignoreJSX option to no-extra-parens (Fixes #7444)

### DIFF
--- a/docs/rules/no-extra-parens.md
+++ b/docs/rules/no-extra-parens.md
@@ -23,6 +23,7 @@ This rule has an object option for exceptions to the `"all"` option:
 * `"conditionalAssign": false` allows extra parentheses around assignments in conditional test expressions
 * `"returnAssign": false` allows extra parentheses around assignments in `return` statements
 * `"nestedBinaryExpressions": false` allows extra parentheses in nested binary expressions
+* `"ignoreJSX": "none|all|multi-line|single-line"` allows extra parentheses around no/all/multi-line/single-line JSX components. Defaults to `none`.
 
 ### all
 
@@ -102,6 +103,68 @@ Examples of **correct** code for this rule with the `"all"` and `{ "nestedBinary
 x = a || (b && c);
 x = a + (b * c);
 x = (a * b) / c;
+```
+
+### ignoreJSX
+
+Examples of **correct** code for this rule with the `all` and `{ "ignoreJSX": "all" }` options:
+
+```js
+/* eslint no-extra-parens: ["error", "all", { ignoreJSX: "all" }] */
+const Component = (<div />)
+const Component = (
+    <div
+        prop={true}
+    />
+)
+```
+
+Examples of **incorrect** code for this rule with the `all` and `{ "ignoreJSX": "multi-line" }` options:
+
+```js
+/* eslint no-extra-parens: ["error", "all", { ignoreJSX: "multi-line" }] */
+const Component = (<div />)
+const Component = (<div><p /></div>)
+```
+
+Examples of **correct** code for this rule with the `all` and `{ "ignoreJSX": "multi-line" }` options:
+
+```js
+/* eslint no-extra-parens: ["error", "all", { ignoreJSX: "multi-line" }] */
+const Component = (
+    <div>
+        <p />
+    </div>
+)
+const Component = (
+    <div
+        prop={true}
+    />
+)
+```
+
+Examples of **incorrect** code for this rule with the `all` and `{ "ignoreJSX": "single-line" }` options:
+
+```js
+/* eslint no-extra-parens: ["error", "all", { ignoreJSX: "single-line" }] */
+const Component = (
+    <div>
+        <p />
+    </div>
+)
+const Component = (
+    <div
+        prop={true}
+    />
+)
+```
+
+Examples of **correct** code for this rule with the `all` and `{ "ignoreJSX": "single-line" }` options:
+
+```js
+/* eslint no-extra-parens: ["error", "all", { ignoreJSX: "single-line" }] */
+const Component = (<div />)
+const Component = (<div><p /></div>)
 ```
 
 ### functions

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -44,7 +44,8 @@ module.exports = {
                             properties: {
                                 conditionalAssign: { type: "boolean" },
                                 nestedBinaryExpressions: { type: "boolean" },
-                                returnAssign: { type: "boolean" }
+                                returnAssign: { type: "boolean" },
+                                ignoreJSX: { enum: ["none", "all", "single-line", "multi-line"] }
                             },
                             additionalProperties: false
                         }
@@ -65,6 +66,7 @@ module.exports = {
         const EXCEPT_COND_ASSIGN = ALL_NODES && context.options[1] && context.options[1].conditionalAssign === false;
         const NESTED_BINARY = ALL_NODES && context.options[1] && context.options[1].nestedBinaryExpressions === false;
         const EXCEPT_RETURN_ASSIGN = ALL_NODES && context.options[1] && context.options[1].returnAssign === false;
+        const IGNORE_JSX = ALL_NODES && context.options[1] && context.options[1].ignoreJSX;
 
         /**
          * Determines if this rule should be enforced for a node given the current configuration.
@@ -73,6 +75,31 @@ module.exports = {
          * @private
          */
         function ruleApplies(node) {
+            if (node.type === "JSXElement") {
+                const isSingleLine = node.loc.start.line === node.loc.end.line;
+
+                switch (IGNORE_JSX) {
+
+                    // Exclude this JSX element from linting
+                    case "all":
+                        return false;
+
+                    // Exclude this JSX element if it is multi-line element
+                    case "multi-line":
+                        return isSingleLine;
+
+                    // Exclude this JSX element if it is single-line element
+                    case "single-line":
+                        return !isSingleLine;
+
+                    // Nothing special to be done for JSX elements
+                    case "none":
+                        break;
+
+                    // no default
+                }
+            }
+
             return ALL_NODES || node.type === "FunctionExpression" || node.type === "ArrowFunctionExpression";
         }
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

- [ ] Documentation update
- [ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
- [ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
- [x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

- New option added to `no-extra-parens` rule: `ignoreJSX`, with options available:
  - `"all"`: All JSX components are ignored
  - `"multiline"`: Multiline JSX components are ignored
  - `"single-line"`: Single line JSX components are ignored


**Is there anything you'd like reviewers to focus on?**

Please review everything thoroughly, the rule was already quite complex and I am new to working with rules in ESLint.