### PR TITLE
Fix: `no-extra-semi` should not remove necessary semicolon (fixes #79…

### DIFF
--- a/lib/rules/no-extra-semi.js
+++ b/lib/rules/no-extra-semi.js
@@ -77,7 +77,10 @@ module.exports = {
                         "WithStatement"
                     ];
 
-                if (allowedParentTypes.indexOf(parent.type) === -1) {
+                const prevToken = sourceCode.getTokenBefore(node);
+
+                if (prevToken.range[1] === node.range[0] &&
+                    allowedParentTypes.indexOf(parent.type) === -1) {
                     report(node);
                 }
             },

--- a/tests/lib/rules/no-extra-semi.js
+++ b/tests/lib/rules/no-extra-semi.js
@@ -10,6 +10,7 @@
 //------------------------------------------------------------------------------
 
 const rule = require("../../../lib/rules/no-extra-semi"),
+    assert = require("chai").assert,
     RuleTester = require("../../../lib/testers/rule-tester");
 
 //------------------------------------------------------------------------------
@@ -159,4 +160,37 @@ ruleTester.run("no-extra-semi", rule, {
             output: "class A { a() {} get b() {} }"
         }
     ]
+});
+
+// Deal with edge cases.
+describe("no-extra-semi", () => {
+
+    const CLIEngine = require("../../../lib/cli-engine");
+
+    it("should not remove necessary semicolon", () => {
+        const engine = new CLIEngine({
+            fix: true,
+            useEslintrc: false,
+            rules: {
+                semi: [2, "never"],
+                "no-extra-semi": 2
+            }
+        });
+
+        const report = engine.executeOnText("var foo = function(){};\n;[1].map(foo)");
+
+        assert.deepEqual(report, {
+            results: [
+                {
+                    filePath: "<text>",
+                    messages: [],
+                    errorCount: 0,
+                    warningCount: 0,
+                    output: "var foo = function(){}\n;[1].map(foo)"
+                }
+            ],
+            errorCount: 0,
+            warningCount: 0
+        });
+    });
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
Fix #7928 
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

`semi(never)` will remove current semicolon if the following token is also a semicolon. `no-extra-semi`  will also remove current semicolon if the previous token is a semicolon.

If there is no whitespace between two semicolons, it is safe because `SourceCodeFixer` don't fix two contacted problem. I add verification of whether the previous semi contacts with the current one in `no-extra-semi`.

**Is there anything you'd like reviewers to focus on?**

How to test two rules at the same time and where to put the test file.
