### PR TITLE
Fix: no-useless-computed-key false positive with `__proto__`

### DIFF
--- a/lib/rules/no-useless-computed-key.js
+++ b/lib/rules/no-useless-computed-key.js
@@ -34,7 +34,7 @@ module.exports = {
                 const key = node.key,
                     nodeType = typeof key.value;
 
-                if (key.type === "Literal" && (nodeType === "string" || nodeType === "number")) {
+                if (key.type === "Literal" && (nodeType === "string" || nodeType === "number") && key.value !== "__proto__") {
                     context.report({
                         node,
                         message: MESSAGE_UNNECESSARY_COMPUTED,

--- a/tests/lib/rules/no-useless-computed-key.js
+++ b/tests/lib/rules/no-useless-computed-key.js
@@ -22,7 +22,8 @@ ruleTester.run("no-useless-computed-key", rule, {
     valid: [
         "({ 'a': 0, b(){} })",
         "({ [x]: 0 });",
-        "({ a: 0, [b](){} })"
+        "({ a: 0, [b](){} })",
+        "({ ['__proto__']: [] })"
     ],
     invalid: [
         {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix

**Tell us about your environment**

* **ESLint Version:** master
* **Node Version:** 7.3.0
* **npm Version:** 3.10.10

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

(none)

**What did you do? Please include the actual source code causing the issue.**

```js
/* eslint no-useless-computed-key: error */

({ ['__proto__']: [] }) instanceof Array;
```

**What did you expect to happen?**

I expected no error to be reported, because using `'__proto__'` directly as the object key would set the value of `Object.getPrototypeOf(theObject)`, and the expression's value would change from `false` to `true`.

**What actually happened? Please include the actual, raw output from ESLint.**

```
3:4  error  Unnecessarily computed property ['__proto__'] found  no-useless-computed-key
```

**What changes did you make? (Give an overview)**

This updates `no-useless-computed-key` to avoid reporting computed keys that have the literal value `__proto__`. `__proto__` is a special key that sets the internal `[[Prototype]]` property of an object when used in an object literal.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
