### PR TITLE
Update: Add semi-spacing fixer for semicolon only line 

### DIFF
--- a/lib/rules/semi-spacing.js
+++ b/lib/rules/semi-spacing.js
@@ -98,6 +98,15 @@ module.exports = {
         }
 
         /**
+         * Checks if the given token is a semicolon only line.
+         * @param {Token} token The token to check.
+         * @returns {boolean} Whether or not the token is a semicolon only line.
+         */
+        function isSemicolonOnlyLine(token) {
+            return isFirstTokenInCurrentLine(token) && isLastTokenInCurrentLine(token);
+        }
+
+        /**
          * Checks if the next token of a given token is a closing parenthesis.
          * @param {Token} token The token to check.
          * @returns {boolean} Whether or not the next token of a given token is a closing parenthesis.
@@ -131,8 +140,8 @@ module.exports = {
             if (isSemicolon(token)) {
                 const location = token.loc.start;
 
-                if (hasLeadingSpace(token)) {
-                    if (!requireSpaceBefore) {
+                if (!requireSpaceBefore) {
+                    if (hasLeadingSpace(token) || isSemicolonOnlyLine(token)) {
                         context.report({
                             node,
                             loc: location,
@@ -145,13 +154,15 @@ module.exports = {
                         });
                     }
                 } else {
-                    if (requireSpaceBefore) {
+                    if (!hasLeadingSpace(token) || isSemicolonOnlyLine(token)) {
                         context.report({
                             node,
                             loc: location,
                             message: "Missing whitespace before semicolon.",
                             fix(fixer) {
-                                return fixer.insertTextBefore(token, " ");
+                                const tokenBefore = context.getTokenBefore(token);
+
+                                return fixer.replaceTextRange([tokenBefore.range[1], token.range[0]], " ");
                             }
                         });
                     }

--- a/tests/lib/rules/semi-spacing.js
+++ b/tests/lib/rules/semi-spacing.js
@@ -127,6 +127,19 @@ ruleTester.run("semi-spacing", rule, {
             errors: [{ message: "Missing whitespace after semicolon.", type: "VariableDeclaration", line: 1, column: 12 }]
         },
         {
+            code: "var a = 'b'\n;\nc = 'd';",
+            output: "var a = 'b';\nc = 'd';",
+            errors: [
+                { message: "Unexpected whitespace before semicolon.", type: "VariableDeclaration", line: 2, column: 1 }
+            ]
+        },
+        {
+            code: "var a = 'b'\n;\nc = 'd' ;",
+            output: "var a = 'b' ;\nc = 'd' ;",
+            options: [{ before: true, after: true }],
+            errors: [{ message: "Missing whitespace before semicolon.", type: "VariableDeclaration", line: 2, column: 1 }]
+        },
+        {
             code: "var a = 'b';",
             output: "var a = 'b' ;",
             options: [{ before: true, after: true }],


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[x] Add autofixing to a rule

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->


**What rule do you want to change?**

* semi-spacing

**Does this change cause the rule to produce more or fewer warnings?**

Yes, warning when code has semicolon only line.

**How will the change be implemented? (New option, new default behavior, etc.)?**

New default behavior.

**Please provide some example code that this change will affect:**

```js
var a = b
;
var c = d;
```

and `--fix` to

```js
var a = b;
var c = d;
```

**What does the rule currently do for this code?**

Not warning and fixing.

**What will the rule do after it's changed?**

Warn semicolon only line.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Currently, semi-spacing is ignore isolated semicolon only line and I want fix this (like [comma-style](http://eslint.org/docs/rules/comma-style) )

**Is there anything you'd like reviewers to focus on?**

My purpose(want) is fix isolated semicolon line, and I try add this fixing to `semi-spacing`. 
But this may more appropriate rule or may create new rule.

