### PR TITLE
Fix: no-var autofix syntax error in single-line statements (fixes #7961)

### DIFF
--- a/lib/rules/no-var.js
+++ b/lib/rules/no-var.js
@@ -209,6 +209,7 @@ module.exports = {
          * - A variable is used from a closure within a loop.
          * - A variable might be used before it is assigned within a loop.
          * - A variable might be used in TDZ.
+         * - A variable is declared in statement position (e.g. a single-line `IfStatement`)
          *
          * ## A variable is declared on a SwitchCase node.
          *
@@ -268,6 +269,17 @@ module.exports = {
                 if (!isLoopAssignee(node) && !isDeclarationInitialized(node)) {
                     return false;
                 }
+            }
+
+            if (
+                !isLoopAssignee(node) &&
+                node.parent.type !== "BlockStatement" &&
+                node.parent.type !== "Program" &&
+                node.parent.type !== "SwitchCase"
+            ) {
+
+                // If the declaration is not in a block, e.g. `if (foo) var bar = 1;`, then it can't be fixed.
+                return false;
             }
 
             return true;

--- a/tests/lib/rules/no-var.js
+++ b/tests/lib/rules/no-var.js
@@ -215,6 +215,15 @@ ruleTester.run("no-var", rule, {
             errors: [
                 "Unexpected var, use let or const instead."
             ]
+        },
+
+        // https://github.com/eslint/eslint/issues/7961
+        {
+            code: "if (foo) var bar = 1;",
+            output: "if (foo) var bar = 1;",
+            errors: [
+                { message: "Unexpected var, use let or const instead.", type: "VariableDeclaration" }
+            ]
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (https://github.com/eslint/eslint/issues/7961)

**What changes did you make? (Give an overview)**

This updates the `no-var` autofixer to avoid fixing variable declarations in single-line if/while/etc. statements, because `let` declarations are not allowed there.

**Is there anything you'd like reviewers to focus on?**

This is not a particularly urgent fix -- the bug has existed since `no-var` became autofixable in July. If we do a patch release this week then we might as well include this fix, but I don't think this bug warrants a patch release on its own.