### PR TITLE
Update: no-undefined handles properties/classes/modules (fixes #7964)

### DIFF
--- a/lib/rules/no-undefined.js
+++ b/lib/rules/no-undefined.js
@@ -21,15 +21,54 @@ module.exports = {
 
     create(context) {
 
+        /**
+         * Report an invalid "undefined" identifier node.
+         * @param {ASTNode} node The node to report.
+         * @returns {void}
+         */
+        function report(node) {
+            context.report({
+                node,
+                message: "Unexpected use of undefined."
+            });
+        }
+
+        /**
+         * Checks the given scope for references to `undefined` and reports
+         * all references found.
+         * @param {escope.Scope} scope The scope to check.
+         * @returns {void}
+         */
+        function checkScope(scope) {
+            const undefinedVar = scope.set.get("undefined");
+
+            if (!undefinedVar) {
+                return;
+            }
+
+            const references = undefinedVar.references;
+
+            const defs = undefinedVar.defs;
+
+            // Report non-initializing references (those are covered in defs below)
+            references
+                .filter(ref => !ref.init)
+                .forEach(ref => report(ref.identifier));
+
+            defs.forEach(def => report(def.name));
+        }
+
         return {
+            "Program:exit"() {
+                const globalScope = context.getScope();
 
-            Identifier(node) {
-                if (node.name === "undefined") {
-                    const parent = context.getAncestors().pop();
+                const stack = [globalScope];
 
-                    if (!parent || parent.type !== "MemberExpression" || node !== parent.property || parent.computed) {
-                        context.report({ node, message: "Unexpected use of undefined." });
-                    }
+                while (stack.length) {
+                    const scope = stack.pop();
+
+                    stack.push.apply(stack, scope.childScopes);
+                    checkScope(scope);
                 }
             }
         };

--- a/tests/lib/rules/no-undefined.js
+++ b/tests/lib/rules/no-undefined.js
@@ -13,12 +13,19 @@ const rule = require("../../../lib/rules/no-undefined"),
     RuleTester = require("../../../lib/testers/rule-tester");
 
 //------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+const ES6_SCRIPT = { ecmaVersion: 6 };
+const ES6_MODULE = { ecmaVersion: 6, sourceType: "module" };
+
+//------------------------------------------------------------------------------
 // Tests
 //------------------------------------------------------------------------------
 
 const errors = [{ message: "Unexpected use of undefined.", type: "Identifier" }];
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({ parserOptions: ES6_SCRIPT });
 
 ruleTester.run("no-undefined", rule, {
     valid: [
@@ -31,7 +38,18 @@ ruleTester.run("no-undefined", rule, {
         "ndefined",
         "a.undefined",
         "this.undefined",
-        "global['undefined']"
+        "global['undefined']",
+
+        // https://github.com/eslint/eslint/issues/7964
+        "({ undefined: bar })",
+        "({ undefined: bar } = foo)",
+        "({ undefined() {} })",
+        "class Foo { undefined() {} }",
+        "(class { undefined() {} })",
+        { code: "import { undefined as a } from 'foo'", parserOptions: ES6_MODULE },
+        { code: "export { undefined } from 'foo'", parserOptions: ES6_MODULE },
+        { code: "export { undefined as a } from 'foo'", parserOptions: ES6_MODULE },
+        { code: "export { a as undefined } from 'foo'", parserOptions: ES6_MODULE }
     ],
     invalid: [
         { code: "undefined", errors },
@@ -40,10 +58,66 @@ ruleTester.run("no-undefined", rule, {
         { code: "undefined[0]", errors },
         { code: "f(undefined)", errors },
         { code: "function f(undefined) {}", errors },
+        { code: "function f() { var undefined; }", errors },
+        { code: "function f() { undefined = true; }", errors },
         { code: "var undefined;", errors },
         { code: "try {} catch(undefined) {}", errors },
+        { code: "function undefined() {}", errors },
         { code: "(function undefined(){}())", errors },
+        { code: "var foo = function undefined() {}", errors },
+        { code: "foo = function undefined() {}", errors },
         { code: "undefined = true", errors },
-        { code: "var undefined = true", errors }
+        { code: "var undefined = true", errors },
+        { code: "({ undefined })", errors },
+        { code: "({ [undefined]: foo })", errors },
+        { code: "({ bar: undefined })", errors },
+        { code: "({ bar: undefined } = foo)", errors },
+        { code: "var { undefined } = foo", errors },
+        { code: "var { bar: undefined } = foo", errors },
+        {
+            code: "({ undefined: function undefined() {} })",
+            errors: [Object.assign({}, errors[0], { column: 24 })]
+        },
+        { code: "({ foo: function undefined() {} })", errors },
+        { code: "class Foo { [undefined]() {} }", errors },
+        { code: "(class { [undefined]() {} })", errors },
+        {
+            code: "var undefined = true; undefined = false;",
+            errors: [{
+                message: "Unexpected use of undefined.",
+                column: 5
+            }, {
+                message: "Unexpected use of undefined.",
+                column: 23
+            }]
+        },
+        {
+            code: "import undefined from 'foo'",
+            parserOptions: ES6_MODULE,
+            errors
+        },
+        {
+            code: "import * as undefined from 'foo'",
+            parserOptions: ES6_MODULE,
+            errors
+        },
+        {
+            code: "import { undefined } from 'foo'",
+            parserOptions: ES6_MODULE,
+            errors
+        },
+        {
+            code: "import { a as undefined } from 'foo'",
+            parserOptions: ES6_MODULE,
+            errors
+        },
+        {
+            code: "export { undefined }",
+            parserOptions: ES6_MODULE,
+            errors
+        },
+        { code: "let a = [b, ...undefined]", errors },
+        { code: "[a, ...undefined] = b", errors },
+        { code: "[a = undefined] = b", errors }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix

See #7964.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Fixed no-undefined to ensure that property keys (non-computed) were not incorrectly flagged. Although property keys are Identifier nodes, non-computed property keys are really strings at the end of the day.

Well, that's where we started, but then we decided to ensure that destructuring and import/export were handled correctly. In order to do that more reliably and (hopefully) ensure the rule keeps up with no syntax, I decided to refactor to use escope variables. This ended up improving performance by about 80% (at least when the rule is run on our codebase), so that's a huge win. (Identifer visitor was hit a lot, so even the performance penalty of iterating over scopes again still made this rule much faster overall.)

Labeling as "Update" in case more warnings are introduced in destructuring or import/export cases.

**Is there anything you'd like reviewers to focus on?**

Does this need a documentation update?