### PR TITLE
Update: no-unused-vars to account for rest property omissions

### DIFF
--- a/docs/rules/no-unused-vars.md
+++ b/docs/rules/no-unused-vars.md
@@ -99,7 +99,7 @@ By default this rule is enabled with `all` option for variables and `after-used`
 ```json
 {
     "rules": {
-        "no-unused-vars": ["error", { "vars": "all", "args": "after-used" }]
+        "no-unused-vars": ["error", { "vars": "all", "args": "after-used", "ignoreRestSiblings": false }]
     }
 }
 ```
@@ -193,6 +193,18 @@ Examples of **correct** code for the `{ "args": "none" }` option:
 (function(foo, bar, baz) {
     return bar;
 })();
+```
+
+### ignoreRestSiblings
+
+The `ignoreRestSiblings` option is a boolean (default: `false`). Using a [Rest Property](https://github.com/sebmarkbage/ecmascript-rest-spread) it is possible to "omit" properties from an object, but by default the sibling properties are marked as "unused". With this option enabled the rest property's siblings are ignored.
+
+Examples of **correct** code for the `{ "ignoreRestSiblings": true }` option:
+
+```js
+/*eslint no-unused-vars: ["error", { "ignoreRestSiblings": true }]*/
+// 'type' is ignored because it has a rest property sibling.
+var { type, ...coords } = data;
 ```
 
 ### argsIgnorePattern

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -42,6 +42,9 @@ module.exports = {
                             args: {
                                 enum: ["all", "after-used", "none"]
                             },
+                            ignoreRestSiblings: {
+                                type: "boolean"
+                            },
                             argsIgnorePattern: {
                                 type: "string"
                             },
@@ -66,6 +69,7 @@ module.exports = {
         const config = {
             vars: "all",
             args: "after-used",
+            ignoreRestSiblings: false,
             caughtErrors: "none"
         };
 
@@ -77,6 +81,7 @@ module.exports = {
             } else {
                 config.vars = firstOption.vars || config.vars;
                 config.args = firstOption.args || config.args;
+                config.ignoreRestSiblings = firstOption.ignoreRestSiblings || config.ignoreRestSiblings;
                 config.caughtErrors = firstOption.caughtErrors || config.caughtErrors;
 
                 if (firstOption.varsIgnorePattern) {
@@ -120,6 +125,30 @@ module.exports = {
                 }
 
                 return node.parent.type.indexOf("Export") === 0;
+            } else {
+                return false;
+            }
+        }
+
+        /**
+         * Determines if a variable has a sibling rest property
+         * @param {Variable} variable - EScope variable object.
+         * @returns {boolean} True if the variable is exported, false if not.
+         * @private
+         */
+        function hasRestSpreadSibling(variable) {
+            if (config.ignoreRestSiblings) {
+                const restProperties = new Set(["ExperimentalRestProperty", "RestProperty"]);
+
+                return variable.defs
+                    .filter(def => def.name.type === "Identifier")
+                    .some(def => (
+                        def.node.id &&
+                        def.node.id.type === "ObjectPattern" &&
+                        def.node.id.properties.length &&
+                        restProperties.has(def.node.id.properties[def.node.id.properties.length - 1].type) &&  // last property is a rest property
+                        !restProperties.has(def.name.parent.type)  // variable is sibling of the rest property
+                    ));
             } else {
                 return false;
             }
@@ -495,7 +524,7 @@ module.exports = {
                         }
                     }
 
-                    if (!isUsedVariable(variable) && !isExported(variable)) {
+                    if (!isUsedVariable(variable) && !isExported(variable) && !hasRestSpreadSibling(variable)) {
                         unusedVars.push(variable);
                     }
                 }


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**
[X] Changes an existing rule ([template]

**What rule do you want to change?**
no-unused-vars

**Does this change cause the rule to produce more or fewer warnings?**
fewer

**How will the change be implemented? (New option, new default behavior, etc.)?**
new default behavior

**Please provide some example code that this change will affect:**
```js
var data = { type: 'coordinates', x: 0, y: 0 };
var { type, ...coordinates } = data;
console.log(coordinates);
```

**What does the rule currently do for this code?**
Errors that `type` is unused.

**What will the rule do after it's changed?**
`type` will be considered to be passively used. Meaning that although it is not used afterwards, it's existence effects the declaration of `coordinates`. Much like `_.omit(data, ['type']);`

**What changes did you make? (Give an overview)**
The change is pretty simple. If the variable is unused, but has a sibling rest parameter, we now consider it to be used. The logic is found in the `hasRestSpreadSibling` function. 

**Is there anything you'd like reviewers to focus on?**
Although the rest property is still considered experimental, it is [stage-3](https://github.com/sebmarkbage/ecmascript-rest-spread) and widely adopted in the community. The ability to use it as a means of property omission is also becoming increasingly popular.

