### PR TITLE
Update: ensure operator-assignment handles exponentiation operators

### DIFF
--- a/lib/rules/operator-assignment.js
+++ b/lib/rules/operator-assignment.js
@@ -27,7 +27,7 @@ function isCommutativeOperatorWithShorthand(operator) {
  *     a shorthand form.
  */
 function isNonCommutativeOperatorWithShorthand(operator) {
-    return ["+", "-", "/", "%", "<<", ">>", ">>>"].indexOf(operator) >= 0;
+    return ["+", "-", "/", "%", "<<", ">>", ">>>", "**"].indexOf(operator) >= 0;
 }
 
 //------------------------------------------------------------------------------

--- a/tests/lib/rules/operator-assignment.js
+++ b/tests/lib/rules/operator-assignment.js
@@ -16,7 +16,7 @@ const rule = require("../../../lib/rules/operator-assignment"),
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 7 } });
 
 const EXPECTED_OPERATOR_ASSIGNMENT = [{ message: "Assignment can be replaced with operator assignment.", type: "AssignmentExpression" }];
 const UNEXPECTED_OPERATOR_ASSIGNMENT = [{ message: "Unexpected operator assignment shorthand.", type: "AssignmentExpression" }];
@@ -40,6 +40,7 @@ ruleTester.run("operator-assignment", rule, {
         "x >>= x >> y",
         "x >>>= y",
         "x &= y",
+        "x **= y",
         "x ^= y ^ z",
         "x |= x | y",
         "x = x && y",
@@ -66,6 +67,11 @@ ruleTester.run("operator-assignment", rule, {
             code: "x = x + y",
             options: ["never"]
         },
+        {
+            code: "x = x ** y",
+            options: ["never"]
+        },
+        "x = y ** x",
         "x = x < y",
         "x = x > y",
         "x = x <= y",
@@ -182,6 +188,15 @@ ruleTester.run("operator-assignment", rule, {
     }, {
         code: "(foo.bar) ^= ((((((((((((((((baz))))))))))))))))",
         output: "(foo.bar) = (foo.bar) ^ ((((((((((((((((baz))))))))))))))))",
+        options: ["never"],
+        errors: UNEXPECTED_OPERATOR_ASSIGNMENT
+    }, {
+        code: "foo = foo ** bar",
+        output: "foo **= bar",
+        errors: EXPECTED_OPERATOR_ASSIGNMENT
+    }, {
+        code: "foo **= bar",
+        output: "foo = foo ** bar",
         options: ["never"],
         errors: UNEXPECTED_OPERATOR_ASSIGNMENT
     }]


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix

**Tell us about your environment**

* **ESLint Version:** master
* **Node Version:** 7.4.0
* **npm Version:** 4.0.5

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

```yml
rules:
  operator-assignment: error
parserOptions:
  ecmaVersion: 7
```

**What did you do? Please include the actual source code causing the issue.**

```js
foo = foo ** bar;
```

**What did you expect to happen?**

I expected an error to be reported, suggesting that the code use a compound operator.

**What actually happened? Please include the actual, raw output from ESLint.**

No error was reported.

**What changes did you make? (Give an overview)**

This updates `operator-assignment` to identify that the `**` operator can be replaced with a compound operator.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
