### PR TITLE
Add ESLint tutorial embed & links to `Getting started` docs page

### DIFF
--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -6,6 +6,11 @@ ESLint is a tool for identifying and reporting on patterns found in ECMAScript/J
 * ESLint uses an AST to evaluate patterns in code.
 * ESLint is completely pluggable, every single rule is a plugin and you can add more at runtime.
 
+## Getting Started Tutorial
+
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/hppJw2REb8g?rel=0" frameborder="0" allowfullscreen></iframe>
+*Why ESLint* @0:00, *Installing and using ESLint* @2:20.  <a href="https://www.pluralsight.com/courses/eslint-better-code-quality?utm_source=eslint-dot-org&utm_medium=video&utm_campaign=authordemo" target="_blank">Full ESLint Course at Pluralsight</a>
+
 ## Installation and Usage
 
 There are two ways to install ESLint: globally and locally.


### PR DESCRIPTION

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Prior context here:
https://github.com/eslint/eslint.github.io/issues/324

This PR adds a youtube embed of an ESLint Tutorial Video to the `Getting started` docs page.

@ilyavolodin I don't have strong feelings about any of the wording or placement. We don't even have to include the `Pluralsight` verbiage.

**Is there anything you'd like reviewers to focus on?**
Content and placement.

**Special Notes & Testing steps**
I added the embed and tested it in the `eslint.github.io` repo locally, and by publishing it as github pages. In both cases the youtube embed seemed to work fine. Screenshot:

<img width="922" alt="screen shot 2017-01-23 at 9 50 21 pm" src="https://cloud.githubusercontent.com/assets/606014/22236702/3120113a-e1bc-11e6-9113-b3dc8c724b26.png">

