### PR TITLE
Fix: brace-style false positive for keyword method names (fixes #7974)

### DIFF
--- a/lib/rules/brace-style.js
+++ b/lib/rules/brace-style.js
@@ -78,7 +78,6 @@ module.exports = {
             const tokenBeforeOpeningCurly = sourceCode.getTokenBefore(openingCurly);
             const tokenAfterOpeningCurly = sourceCode.getTokenAfter(openingCurly);
             const tokenBeforeClosingCurly = sourceCode.getTokenBefore(closingCurly);
-            const tokenAfterClosingCurly = sourceCode.getTokenAfter(closingCurly);
             const singleLineException = params.allowSingleLine && astUtils.isTokenOnSameLine(openingCurly, closingCurly);
 
             if (style !== "allman" && !astUtils.isTokenOnSameLine(tokenBeforeOpeningCurly, openingCurly)) {
@@ -112,23 +111,30 @@ module.exports = {
                     fix: fixer => fixer.insertTextBefore(closingCurly, "\n")
                 });
             }
+        }
 
-            if (tokenAfterClosingCurly && tokenAfterClosingCurly.type === "Keyword" && new Set(["else", "catch", "finally"]).has(tokenAfterClosingCurly.value)) {
-                if (style === "1tbs" && !astUtils.isTokenOnSameLine(closingCurly, tokenAfterClosingCurly)) {
-                    context.report({
-                        node: closingCurly,
-                        message: CLOSE_MESSAGE,
-                        fix: removeNewlineBetween(closingCurly, tokenAfterClosingCurly)
-                    });
-                }
+        /**
+        * Validates the location of a token that appears before a keyword (e.g. a newline before `else`)
+        * @param {Token} curlyToken The closing curly token. This is assumed to precede a keyword token (such as `else` or `finally`).
+        * @returns {void}
+        */
+        function validateCurlyBeforeKeyword(curlyToken) {
+            const keywordToken = sourceCode.getTokenAfter(curlyToken);
 
-                if (style !== "1tbs" && astUtils.isTokenOnSameLine(closingCurly, tokenAfterClosingCurly)) {
-                    context.report({
-                        node: closingCurly,
-                        message: CLOSE_MESSAGE_STROUSTRUP_ALLMAN,
-                        fix: fixer => fixer.insertTextAfter(closingCurly, "\n")
-                    });
-                }
+            if (style === "1tbs" && !astUtils.isTokenOnSameLine(curlyToken, keywordToken)) {
+                context.report({
+                    node: curlyToken,
+                    message: CLOSE_MESSAGE,
+                    fix: removeNewlineBetween(curlyToken, keywordToken)
+                });
+            }
+
+            if (style !== "1tbs" && astUtils.isTokenOnSameLine(curlyToken, keywordToken)) {
+                context.report({
+                    node: curlyToken,
+                    message: CLOSE_MESSAGE_STROUSTRUP_ALLMAN,
+                    fix: fixer => fixer.insertTextAfter(curlyToken, "\n")
+                });
             }
         }
 
@@ -154,6 +160,24 @@ module.exports = {
                 const openingCurly = sourceCode.getTokenBefore(node.cases.length ? node.cases[0] : closingCurly);
 
                 validateCurlyPair(openingCurly, closingCurly);
+            },
+            IfStatement(node) {
+                if (node.consequent.type === "BlockStatement" && node.alternate) {
+
+                    // Handle the keyword after the `if` block (before `else`)
+                    validateCurlyBeforeKeyword(sourceCode.getLastToken(node.consequent));
+                }
+            },
+            TryStatement(node) {
+
+                // Handle the keyword after the `try` block (before `catch` or `finally`)
+                validateCurlyBeforeKeyword(sourceCode.getLastToken(node.block));
+
+                if (node.handler && node.finalizer) {
+
+                    // Handle the keyword after the `catch` block (before `finally`)
+                    validateCurlyBeforeKeyword(sourceCode.getLastToken(node.handler.body));
+                }
             }
         };
     }

--- a/tests/lib/rules/brace-style.js
+++ b/tests/lib/rules/brace-style.js
@@ -170,6 +170,30 @@ ruleTester.run("brace-style", rule, {
                 {
                 }
             }
+        `,
+
+        // https://github.com/eslint/eslint/issues/7974
+        `
+          class Ball {
+            throw() {}
+            catch() {}
+          }
+        `,
+        `
+          ({
+            and() {},
+            finally() {}
+          })
+        `,
+        `
+          (class {
+            or() {}
+            else() {}
+          })
+        `,
+        `
+          if (foo) bar = function() {}
+          else baz()
         `
     ],
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (see https://github.com/eslint/eslint/issues/7974)

**What changes did you make? (Give an overview)**

This updates `brace-style` to use node-specific checks for braces next to `catch`, `finally`, and `else` keywords. Previously, the rule would simply detect any `catch`, `finally`, or `else` keyword that followed a closing curly brace, but that had a false positive if these keywords were used as class method names.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular