### PR TITLE
Fix #7967: Handle globals config usage

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -174,6 +174,37 @@ function getLocalConfig(thisConfig, directory) {
     return config;
 }
 
+/**
+ * Parse global config
+ * @param {Object | Array} globalOpts Globals configuration
+ * @returns {Object} globals config object
+ */
+function parseGlobals(globalOpts) {
+
+    let output;
+
+    if (isObject(globalOpts)) {
+        output = globalOpts;
+
+    } else {
+        /*
+         * Handle declared globals.
+         * For global variable foo, handle "foo:false" and "foo:true" to set
+         * whether global is writable.
+         * If user declares "foo", convert to "foo:false".
+         */
+        output = (globalOpts || []).reduce((globals, def) => {
+            const parts = def.split(":");
+
+            globals[parts[0]] = (parts.length > 1 && parts[1] === "true");
+
+            return globals;
+        }, {});
+    }
+
+    return output;
+}
+
 //------------------------------------------------------------------------------
 // API
 //------------------------------------------------------------------------------
@@ -205,19 +236,7 @@ class Config {
             return envs;
         }, {});
 
-        /*
-         * Handle declared globals.
-         * For global variable foo, handle "foo:false" and "foo:true" to set
-         * whether global is writable.
-         * If user declares "foo", convert to "foo:false".
-         */
-        this.globals = (options.globals || []).reduce((globals, def) => {
-            const parts = def.split(":");
-
-            globals[parts[0]] = (parts.length > 1 && parts[1] === "true");
-
-            return globals;
-        }, {});
+        this.globals = parseGlobals(options.globals);
 
         const useConfig = options.configFile;
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -187,6 +187,7 @@ function parseGlobals(globalOpts) {
         output = globalOpts;
 
     } else {
+
         /*
          * Handle declared globals.
          * For global variable foo, handle "foo:false" and "foo:true" to set

--- a/tests/lib/config.js
+++ b/tests/lib/config.js
@@ -144,6 +144,35 @@ describe("Config", () => {
             assert.deepEqual(customBaseConfig, { foo: "bar" });
             assert.equal(configHelper.options.format, "foo");
         });
+
+        it("should return an empty object when the globals property is undefined", () => {
+            const customConfig = { globals: undefined },
+                configHelper = new Config(customConfig);
+
+            assert.deepEqual(configHelper.globals, {});
+        });
+
+        // https://github.com/eslint/eslint/issues/7967
+        it("should return an empty object when the globals property is an empty object", () => {
+            const customConfig = { globals: {} },
+                configHelper = new Config(customConfig);
+
+            assert.deepEqual(configHelper.globals, {});
+        });
+
+        it("should return an empty object when the globals property is an empty array", () => {
+            const customConfig = { globals: [] },
+                configHelper = new Config(customConfig);
+
+            assert.deepEqual(configHelper.globals, {});
+        });
+
+        it("should return an object when the globals property has a variable property", () => {
+            const customConfig = { globals: { foo: true } },
+                configHelper = new Config(customConfig);
+
+            assert.deepEqual(configHelper.globals, { foo: true });
+        });
     });
 
     describe("findLocalConfigFiles()", () => {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
**Associated Issue:**
#7967 
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
 - Add tests to cover the various possibilities for the `options.globals` property
 - Add a private function to parse the `options.globals` property to return a formatted object regardless of means of input (CLI vs. config object)

**Is there anything you'd like reviewers to focus on?**
There are more tests than necessary in hopes of ensuring that other use cases are handled properly. Please validate these use cases when reviewing. 

