### PR TITLE
Chore: enable no-unneeded-ternary on ESLint codebase

### DIFF
--- a/lib/rules/func-name-matching.js
+++ b/lib/rules/func-name-matching.js
@@ -155,7 +155,7 @@ module.exports = {
                     return;
                 }
 
-                const isProp = node.left.type === "MemberExpression" ? true : false;
+                const isProp = node.left.type === "MemberExpression";
                 const name = isProp ? astUtils.getStaticPropertyName(node.left) : node.left.name;
 
                 if (node.right.id && isIdentifier(name) && shouldWarn(name, node.right.id.name)) {

--- a/packages/eslint-config-eslint/default.yml
+++ b/packages/eslint-config-eslint/default.yml
@@ -84,6 +84,7 @@ rules:
     no-undefined: "error"
     no-underscore-dangle: ["error", {allowAfterThis: true}]
     no-unmodified-loop-condition: "error"
+    no-unneeded-ternary: "error"
     no-unused-expressions: "error"
     no-unused-vars: ["error", {vars: "all", args: "after-used"}]
     no-use-before-define: "error"


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

**What changes did you make? (Give an overview)**

This enables [`no-unneeded-ternary`](http://eslint.org/docs/rules/no-unneeded-ternary) on the ESLint codebase for dogfooding.

The (one) change in this PR was made with ESLint's autofixer.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular