### PR TITLE
Chore: avoid unnecessary feature detection for Symbol

### DIFF
--- a/lib/util/glob.js
+++ b/lib/util/glob.js
@@ -15,7 +15,7 @@ const Sync = require("glob").GlobSync,
 // Private
 //------------------------------------------------------------------------------
 
-const IGNORE = typeof Symbol === "function" ? Symbol("ignore") : "_shouldIgnore";
+const IGNORE = Symbol("ignore");
 
 /**
  * Subclass of `glob.GlobSync`


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates `glob.js` to avoid doing feature detection for the `Symbol` global. According to [node.green](http://node.green/), `Symbol` has existed since Node 0.12, so it's not necessary to feature-test for it.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
