### PR TITLE
Fix: no-var should fix ForStatement.init

### DIFF
--- a/lib/rules/no-var.js
+++ b/lib/rules/no-var.js
@@ -273,6 +273,7 @@ module.exports = {
 
             if (
                 !isLoopAssignee(node) &&
+                !(node.parent.type === "ForStatement" && node.parent.init === node) &&
                 node.parent.type !== "BlockStatement" &&
                 node.parent.type !== "Program" &&
                 node.parent.type !== "SwitchCase"

--- a/tests/lib/rules/no-var.js
+++ b/tests/lib/rules/no-var.js
@@ -92,7 +92,21 @@ ruleTester.run("no-var", rule, {
                 { message: "Unexpected var, use let or const instead.", type: "VariableDeclaration" }
             ]
         },
-
+        {
+            code: "for (var i = 0, i = 0; false;);",
+            output: "for (var i = 0, i = 0; false;);",
+            errors: [
+                { message: "Unexpected var, use let or const instead.", type: "VariableDeclaration" }
+            ]
+        },
+        {
+            code: "var i = 0; for (var i = 1; false;); console.log(i);",
+            output: "var i = 0; for (var i = 1; false;); console.log(i);",
+            errors: [
+                { message: "Unexpected var, use let or const instead.", type: "VariableDeclaration" },
+                { message: "Unexpected var, use let or const instead.", type: "VariableDeclaration" }
+            ]
+        },
 
         // Not fix if it's redeclared or it's used from outside of the scope or it's declared on a case chunk.
         {

--- a/tests/lib/rules/no-var.js
+++ b/tests/lib/rules/no-var.js
@@ -85,6 +85,13 @@ ruleTester.run("no-var", rule, {
                 }
             ]
         },
+        {
+            code: "for (var i = 0; i < list.length; ++i) { foo(i) }",
+            output: "for (let i = 0; i < list.length; ++i) { foo(i) }",
+            errors: [
+                { message: "Unexpected var, use let or const instead.", type: "VariableDeclaration" }
+            ]
+        },
 
 
         // Not fix if it's redeclared or it's used from outside of the scope or it's declared on a case chunk.


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

**Tell us about your environment**

* **ESLint Version:** 3.14.1
* **Node Version:** 6.9.4
* **npm Version:** 3.8.8

**What parser (default, Babel-ESLint, etc.) are you using?**

- default

**Please show your full configuration:**

- nothing

**What did you do? Please include the actual source code causing the issue.**

```js
for (var i = 0; i < 10; ++i) {
    foo(i)
}
```

```bash
$ eslint test.js --env es6 --rule no-var:error --fix --no-eslintrc --no-ignore
```

**What did you expect to happen?**

The `var` declaration is fixed then no errors.

**What actually happened? Please include the actual, raw output from ESLint.**

```
path/to/test.js
  1:6  error  Unexpected var, use let or const instead  no-var

✖ 1 problem (1 error, 0 warnings)
```

**What changes did you make? (Give an overview)**

I changed `no-var` rule to fix `var` declarations at `ForStatement.init`.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.
