### PR TITLE
Docs: Fix misleading section in brace-style documentation

### DIFF
--- a/docs/rules/brace-style.md
+++ b/docs/rules/brace-style.md
@@ -299,7 +299,7 @@ catch(e) { handleError(); }
 
 ## When Not To Use It
 
-If your project will not be using the one true brace style, turn this rule off.
+If you don't want to enforce a particular brace style, don't enable this rule.
 
 ## Further Reading
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update

**What changes did you make? (Give an overview)**

This updates a misleading section in the `brace-style` documentation. It looks like this section was added when the brace-style rule only supported the 1tbs option, and the section hasn't been updated since then.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular