### PR TITLE
Fix typo in object-curly-newline.md

### DIFF
--- a/docs/rules/object-curly-newline.md
+++ b/docs/rules/object-curly-newline.md
@@ -356,32 +356,32 @@ Examples of **correct** code for this rule with the `{ "ObjectExpression": "alwa
 /*eslint object-curly-newline: ["error", { "ObjectExpression": "always", "ObjectPattern": "never" }]*/
 /*eslint-env es6*/
 
-let a = [
-];
-let b = [
-    1
-];
-let c = [
-    1, 2
-];
-let d = [
-    1,
-    2
-];
-let e = [
-    function() {
+let a = {
+};
+let b = {
+    foo: 1
+};
+let c = {
+    foo: 1, bar: 2
+};
+let d = {
+    foo: 1,
+    bar: 2
+};
+let e = {
+    foo: function() {
         dosomething();
     }
-];
+};
 
-let [] = obj;
-let [f] = obj;
-let [g, h] = obj;
-let [i,
-    j] = obj;
-let [k = function() {
+let {} = obj;
+let {f} = obj;
+let {g, h} = obj;
+let {i,
+    j} = obj;
+let {k = function() {
     dosomething();
-}] = obj;
+}} = obj;
 ```
 
 ## Compatibility


### PR DESCRIPTION
It looks like the curly braces got turned into square brackets between the incorrect and correct code examples.

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Documentation update

**What changes did you make? (Give an overview)**

See commit message.