### PR TITLE
Chore: enable template-tag-spacing on ESLint codebase

### DIFF
--- a/packages/eslint-config-eslint/default.yml
+++ b/packages/eslint-config-eslint/default.yml
@@ -116,6 +116,7 @@ rules:
     spaced-comment: ["error", "always", { exceptions: ["-"]}]
     strict: ["error", "global"]
     template-curly-spacing: ["error", "never"]
+    template-tag-spacing: "error"
     valid-jsdoc: ["error", {
         prefer: { "return": "returns"},
         preferType: {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

**What changes did you make? (Give an overview)**

This enables template-tag-spacing for dogfooding. There are no existing violations with the default "never" option, and 37 existing violations with the "always" option.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
