### PR TITLE
fix(indent): --fix will not fix indentation with tabs of JSX.

### DIFF
--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -3878,6 +3878,28 @@ ruleTester.run("indent", rule, {
             "             'baz']);",
             options: [2, { ArrayExpression: "first", CallExpression: { arguments: "first" } }],
             errors: expectedErrors([2, 13, 12, "ArrayExpression"])
+        },
+        {
+            code:
+            "<foo\n" +
+            "  prop1={true}\n" +
+            "  prop2={false}\n" +
+            "  prop3={32}\n" +
+            ">\n" +
+            "  bar" +
+            "</foo>",
+            parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } },
+            options: ["tab"],
+            errors: [
+            ],
+            output:
+            "<foo\n" +
+            "	prop1={true}\n" + // eslint-disable-line no-tabs
+            "	prop2={false}\n" + // eslint-disable-line no-tabs
+            "	prop3={32}\n" + // eslint-disable-line no-tabs
+            ">\n" +
+            "	bar" + // eslint-disable-line no-tabs
+            "</foo>"
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix

Indenting with Tabs will not fix JSX

**Tell us about your environment**

This bug applies to the latest of everything AFAIK

* **ESLint Version:** 3.14.1
* **Node Version:** any
* **npm Version:** any

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

See the test

**What did you do? Please include the actual source code causing the issue.**

See the test

**What did you expect to happen?**

See the test `output`

**What actually happened? Please include the actual, raw output from ESLint.**

Here's an example use case:

Input:

```javascript
import React from 'react'

function MyComponent() {
  return (
    <foo
      prop1={true}
      prop2={false}
      prop3={32}
    >
    bar</foo>
  )
}
```

Output:

```javascript
import React from 'react'

function MyComponent() {
	return (
    <foo
      prop1={true}
      prop2={false}
      prop3={32}
    >
    bar</foo>
	)
}
```

If you look closely, you'll notice that there's a tab character on line 4 (`return`) and line 11 (`)`), but not on the lines with JSX.

**What changes did you make? (Give an overview)**

So far this just adds a test to reproduce the behavior.

**Is there anything you'd like reviewers to focus on?**

Any direction on how to make the test pass is appreciated!