### PR TITLE
Update: ensure semi-spacing checks import/export declarations

### DIFF
--- a/lib/rules/semi-spacing.js
+++ b/lib/rules/semi-spacing.js
@@ -208,6 +208,8 @@ module.exports = {
             ThrowStatement: checkNode,
             ImportDeclaration: checkNode,
             ExportNamedDeclaration: checkNode,
+            ExportAllDeclaration: checkNode,
+            ExportDefaultDeclaration: checkNode,
             ForStatement(node) {
                 if (node.init) {
                     checkSemicolonSpacing(sourceCode.getTokenAfter(node.init), node);

--- a/lib/rules/semi-spacing.js
+++ b/lib/rules/semi-spacing.js
@@ -206,6 +206,8 @@ module.exports = {
             DebuggerStatement: checkNode,
             ReturnStatement: checkNode,
             ThrowStatement: checkNode,
+            ImportDeclaration: checkNode,
+            ExportNamedDeclaration: checkNode,
             ForStatement(node) {
                 if (node.init) {
                     checkSemicolonSpacing(sourceCode.getTokenAfter(node.init), node);

--- a/tests/lib/rules/semi-spacing.js
+++ b/tests/lib/rules/semi-spacing.js
@@ -190,6 +190,24 @@ ruleTester.run("semi-spacing", rule, {
             errors: [
                 { message: "Unexpected whitespace before semicolon.", type: "ExportNamedDeclaration", line: 1, column: 14 }
             ]
+        },
+        {
+            code: "export * from 'foo' ;",
+            output: "export * from 'foo';",
+            parserOptions: { sourceType: "module" },
+            options: [{ before: false, after: true }],
+            errors: [
+                { message: "Unexpected whitespace before semicolon.", type: "ExportAllDeclaration", line: 1, column: 21 }
+            ]
+        },
+        {
+            code: "export default foo ;",
+            output: "export default foo;",
+            parserOptions: { sourceType: "module" },
+            options: [{ before: false, after: true }],
+            errors: [
+                { message: "Unexpected whitespace before semicolon.", type: "ExportDefaultDeclaration", line: 1, column: 20 }
+            ]
         }
     ]
 });

--- a/tests/lib/rules/semi-spacing.js
+++ b/tests/lib/rules/semi-spacing.js
@@ -163,7 +163,33 @@ ruleTester.run("semi-spacing", rule, {
                 { message: "Unexpected whitespace after semicolon.", type: "ForStatement", line: 1, column: 15 },
                 { message: "Unexpected whitespace after semicolon.", type: "ForStatement", line: 1, column: 23 }
             ]
+        },
+        {
+            code: "import Foo from 'bar' ;",
+            output: "import Foo from 'bar';",
+            parserOptions: { sourceType: "module" },
+            options: [{ before: false, after: true }],
+            errors: [
+                { message: "Unexpected whitespace before semicolon.", type: "ImportDeclaration", line: 1, column: 23 }
+            ]
+        },
+        {
+            code: "import * as foo from 'bar' ;",
+            output: "import * as foo from 'bar';",
+            parserOptions: { sourceType: "module" },
+            options: [{ before: false, after: true }],
+            errors: [
+                { message: "Unexpected whitespace before semicolon.", type: "ImportDeclaration", line: 1, column: 28 }
+            ]
+        },
+        {
+            code: "export {foo} ;",
+            output: "export {foo};",
+            parserOptions: { sourceType: "module" },
+            options: [{ before: false, after: true }],
+            errors: [
+                { message: "Unexpected whitespace before semicolon.", type: "ExportNamedDeclaration", line: 1, column: 14 }
+            ]
         }
-
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix

**Tell us about your environment**

* **ESLint Version:** master
* **Node Version:** 7.5.0
* **npm Version:** 4.1.2

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

```yml
rules:
  semi-spacing: error
parserOptions:
  sourceType: module
```

**What did you do? Please include the actual source code causing the issue.**

```js
import foo from 'bar' ;
export {foo} ;
```

**What did you expect to happen?**

I expected errors to be reported because there is space before the semicolons.

**What actually happened? Please include the actual, raw output from ESLint.**

No errors were reported.

**What changes did you make? (Give an overview)**

This updates `semi-spacing` to check the semicolon spacing for `ImportDeclaration` and `ExportNamedDeclaration` nodes.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular