### PR TITLE
Chore: simplify and improve performance for autofix

### DIFF
--- a/lib/util/source-code-fixer.js
+++ b/lib/util/source-code-fixer.js
@@ -75,10 +75,7 @@ SourceCodeFixer.applyFixes = function(sourceCode, messages) {
         fixes = [],
         bom = (sourceCode.hasBOM ? BOM : ""),
         text = sourceCode.text;
-    let fix = null,
-        lastPos = 0,
-        start = 0,
-        end = 0,
+    let lastPos = Number.NEGATIVE_INFINITY,
         output = bom;
 
     messages.forEach(problem => {
@@ -93,29 +90,27 @@ SourceCodeFixer.applyFixes = function(sourceCode, messages) {
         debug("Found fixes to apply");
 
         for (const problem of fixes.sort(compareMessagesByFixRange)) {
-            fix = problem.fix;
-            start = fix.range[0];
-            end = fix.range[1];
+            const fix = problem.fix;
+            const start = fix.range[0];
+            const end = fix.range[1];
 
-            // Remain overwrapped fixes as problems.
-            // lastPos's initial value is 0.
-            if (lastPos > 0 && lastPos >= start) {
+            // Remain it as a problem if it's overlapped.
+            if (lastPos >= start) {
                 remainingMessages.push(problem);
                 continue;
             }
 
             // Remove BOM.
-            if (start < 0 || (start === 0 && fix.text.startsWith(BOM))) {
+            if ((start < 0 && end >= 0) || (start === 0 && fix.text.startsWith(BOM))) {
                 output = "";
-                start = 0;
             }
 
             // Make output to this fix.
-            output += text.slice(lastPos, start);
+            output += text.slice(Math.max(0, lastPos), Math.max(0, start));
             output += fix.text;
             lastPos = end;
         }
-        output += text.slice(lastPos);
+        output += text.slice(Math.max(0, lastPos));
 
         return {
             fixed: true,

--- a/lib/util/source-code-fixer.js
+++ b/lib/util/source-code-fixer.js
@@ -17,6 +17,17 @@ const debug = require("debug")("eslint:text-fixer");
 const BOM = "\uFEFF";
 
 /**
+ * Compares items in a messages array by range.
+ * @param {Message} a The first message.
+ * @param {Message} b The second message.
+ * @returns {int} -1 if a comes before b, 1 if a comes after b, 0 if equal.
+ * @private
+ */
+function compareMessagesByFixRange(a, b) {
+    return a.fix.range[0] - b.fix.range[0] || a.fix.range[1] - b.fix.range[1];
+}
+
+/**
  * Compares items in a messages array by line and column.
  * @param {Message} a The first message.
  * @param {Message} b The second message.
@@ -24,13 +35,7 @@ const BOM = "\uFEFF";
  * @private
  */
 function compareMessagesByLocation(a, b) {
-    const lineDiff = a.line - b.line;
-
-    if (lineDiff === 0) {
-        return a.column - b.column;
-    }
-    return lineDiff;
-
+    return a.line - b.line || a.column - b.column;
 }
 
 //------------------------------------------------------------------------------
@@ -68,9 +73,13 @@ SourceCodeFixer.applyFixes = function(sourceCode, messages) {
     // clone the array
     const remainingMessages = [],
         fixes = [],
+        bom = (sourceCode.hasBOM ? BOM : ""),
         text = sourceCode.text;
-    let lastFixPos = text.length + 1,
-        prefix = (sourceCode.hasBOM ? BOM : "");
+    let fix = null,
+        lastPos = 0,
+        start = 0,
+        end = 0,
+        output = bom;
 
     messages.forEach(problem => {
         if (problem.hasOwnProperty("fix")) {
@@ -83,51 +92,43 @@ SourceCodeFixer.applyFixes = function(sourceCode, messages) {
     if (fixes.length) {
         debug("Found fixes to apply");
 
-        // sort in reverse order of occurrence
-        fixes.sort((a, b) => b.fix.range[1] - a.fix.range[1] || b.fix.range[0] - a.fix.range[0]);
+        for (const problem of fixes.sort(compareMessagesByFixRange)) {
+            fix = problem.fix;
+            start = fix.range[0];
+            end = fix.range[1];
 
-        // split into array of characters for easier manipulation
-        const chars = text.split("");
-
-        fixes.forEach(problem => {
-            const fix = problem.fix;
-            let start = fix.range[0];
-            const end = fix.range[1];
-            let insertionText = fix.text;
-
-            if (end < lastFixPos) {
-                if (start < 0) {
-
-                    // Remove BOM.
-                    prefix = "";
-                    start = 0;
-                }
-
-                if (start === 0 && insertionText[0] === BOM) {
-
-                    // Set BOM.
-                    prefix = BOM;
-                    insertionText = insertionText.slice(1);
-                }
-
-                chars.splice(start, end - start, insertionText);
-                lastFixPos = start;
-            } else {
+            // Remain overwrapped fixes as problems.
+            // lastPos's initial value is 0.
+            if (lastPos > 0 && lastPos >= start) {
                 remainingMessages.push(problem);
+                continue;
             }
-        });
+
+            // Remove BOM.
+            if (start < 0 || (start === 0 && fix.text.startsWith(BOM))) {
+                output = "";
+                start = 0;
+            }
+
+            // Make output to this fix.
+            output += text.slice(lastPos, start);
+            output += fix.text;
+            lastPos = end;
+        }
+        output += text.slice(lastPos);
 
         return {
             fixed: true,
             messages: remainingMessages.sort(compareMessagesByLocation),
-            output: prefix + chars.join("")
+            output
         };
     }
+
     debug("No fixes to apply");
     return {
         fixed: false,
         messages,
-        output: prefix + text
+        output: bom + text
     };
 
 };

--- a/tests/lib/util/source-code-fixer.js
+++ b/tests/lib/util/source-code-fixer.js
@@ -272,28 +272,28 @@ describe("SourceCodeFixer", () => {
             it("should only apply one fix when ranges overlap", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [REMOVE_MIDDLE, REPLACE_ID]);
 
-                assert.equal(result.output, TEST_CODE.replace("answer", "a"));
+                assert.equal(result.output, TEST_CODE.replace("answer", "foo"));
                 assert.equal(result.messages.length, 1);
-                assert.equal(result.messages[0].message, "foo");
+                assert.equal(result.messages[0].message, "removemiddle");
                 assert.isTrue(result.fixed);
             });
 
             it("should apply one fix when the end of one range is the same as the start of a previous range overlap", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [REMOVE_START, REPLACE_ID]);
 
-                assert.equal(result.output, TEST_CODE.replace("answer", "foo"));
+                assert.equal(result.output, TEST_CODE.replace("var ", ""));
                 assert.equal(result.messages.length, 1);
-                assert.equal(result.messages[0].message, "removestart");
+                assert.equal(result.messages[0].message, "foo");
                 assert.isTrue(result.fixed);
             });
 
             it("should only apply one fix when ranges overlap and one message has no fix", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [REMOVE_MIDDLE, REPLACE_ID, NO_FIX]);
 
-                assert.equal(result.output, TEST_CODE.replace("answer", "a"));
+                assert.equal(result.output, TEST_CODE.replace("answer", "foo"));
                 assert.equal(result.messages.length, 2);
                 assert.equal(result.messages[0].message, "nofix");
-                assert.equal(result.messages[1].message, "foo");
+                assert.equal(result.messages[1].message, "removemiddle");
                 assert.isTrue(result.fixed);
             });
 
@@ -493,28 +493,28 @@ describe("SourceCodeFixer", () => {
             it("should only apply one fix when ranges overlap", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [REMOVE_MIDDLE, REPLACE_ID]);
 
-                assert.equal(result.output, `\uFEFF${TEST_CODE.replace("answer", "a")}`);
+                assert.equal(result.output, `\uFEFF${TEST_CODE.replace("answer", "foo")}`);
                 assert.equal(result.messages.length, 1);
-                assert.equal(result.messages[0].message, "foo");
+                assert.equal(result.messages[0].message, "removemiddle");
                 assert.isTrue(result.fixed);
             });
 
             it("should apply one fix when the end of one range is the same as the start of a previous range overlap", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [REMOVE_START, REPLACE_ID]);
 
-                assert.equal(result.output, `\uFEFF${TEST_CODE.replace("answer", "foo")}`);
+                assert.equal(result.output, `\uFEFF${TEST_CODE.replace("var ", "")}`);
                 assert.equal(result.messages.length, 1);
-                assert.equal(result.messages[0].message, "removestart");
+                assert.equal(result.messages[0].message, "foo");
                 assert.isTrue(result.fixed);
             });
 
             it("should only apply one fix when ranges overlap and one message has no fix", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [REMOVE_MIDDLE, REPLACE_ID, NO_FIX]);
 
-                assert.equal(result.output, `\uFEFF${TEST_CODE.replace("answer", "a")}`);
+                assert.equal(result.output, `\uFEFF${TEST_CODE.replace("answer", "foo")}`);
                 assert.equal(result.messages.length, 2);
                 assert.equal(result.messages[0].message, "nofix");
-                assert.equal(result.messages[1].message, "foo");
+                assert.equal(result.messages[1].message, "removemiddle");
                 assert.isTrue(result.fixed);
             });
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Other, please explain:

**What changes did you make? (Give an overview)**

This PR refactors the way of autofix.

The current way is:

1. Makes the array of characters.
    - This creates many string instances.
2. Applies fixes to the array with `Array#splice` in reverse.
    - `Array#splice` is a `O(n)` operation, then it's repeated as many times as the number of fixes.
3. Joins the array.

The new way of this PR is:

1. Makes the fixed string by concatenation (`+=`). It concatenates "the part followed by a fix" and "the text of the fix" by turns.

As a result, the performance of autofix improved from `O(n×m)` to `O(n+m)`. (`n` is the number of characters, `m` is the number of fixes)
I measured it by [this script](https://gist.github.com/mysticatea/fee91a313d8a201764047ee1be18f1e0) then I saw the new way gets 25% faster than the current way.

**Is there anything you'd like reviewers to focus on?**

- This PR changes the order of fixing. This is reverse of the current order. So I needed to modify tests for overlapped fixes. However, we are doing multipass fixing, so I think it's no problem.
