### PR TITLE
Fix: no-extra-boolean-cast incorrect Boolean() autofixing (fixes #7977)

### DIFF
--- a/lib/rules/no-extra-boolean-cast.js
+++ b/lib/rules/no-extra-boolean-cast.js
@@ -98,6 +98,14 @@ module.exports = {
                         node,
                         message: "Redundant Boolean call.",
                         fix: fixer => {
+                            if (!node.arguments.length) {
+                                return fixer.replaceText(parent, "true");
+                            }
+
+                            if (node.arguments.length > 1 || node.arguments[0].type === "SpreadElement") {
+                                return null;
+                            }
+
                             const argument = node.arguments[0];
 
                             if (astUtils.getPrecedence(argument) < astUtils.getPrecedence(node.parent)) {

--- a/tests/lib/rules/no-extra-boolean-cast.js
+++ b/tests/lib/rules/no-extra-boolean-cast.js
@@ -186,6 +186,47 @@ ruleTester.run("no-extra-boolean-cast", rule, {
                 message: "Redundant Boolean call.",
                 type: "CallExpression"
             }]
+        },
+        {
+            code: "!Boolean(...foo);",
+            output: "!Boolean(...foo);",
+            parserOptions: { ecmaVersion: 2015 },
+            errors: [{
+                message: "Redundant Boolean call.",
+                type: "CallExpression"
+            }]
+        },
+        {
+            code: "!Boolean(foo, bar());",
+            output: "!Boolean(foo, bar());",
+            errors: [{
+                message: "Redundant Boolean call.",
+                type: "CallExpression"
+            }]
+        },
+        {
+            code: "!Boolean((foo, bar()));",
+            output: "!(foo, bar());",
+            errors: [{
+                message: "Redundant Boolean call.",
+                type: "CallExpression"
+            }]
+        },
+        {
+            code: "!Boolean();",
+            output: "true;",
+            errors: [{
+                message: "Redundant Boolean call.",
+                type: "CallExpression"
+            }]
+        },
+        {
+            code: "!(Boolean());",
+            output: "true;",
+            errors: [{
+                message: "Redundant Boolean call.",
+                type: "CallExpression"
+            }]
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
As outlined in #7977, autofixing is not performed when:
* `Boolean` is called with more than one argument.
* `Boolean` is called with a spread element as the first argument.

And `!Boolean()` now autofixed to `true`.

**Is there anything you'd like reviewers to focus on?**
I'm a bit unsure if the autofixing logic for `!Boolean()` is solid enough, an extra set of eyes is appreciated!

