### PR TITLE
Update: improve null detection in eqeqeq for ES6 regexes (fixes #8020)

### DIFF
--- a/lib/ast-utils.js
+++ b/lib/ast-utils.js
@@ -1298,8 +1298,8 @@ module.exports = {
          * When parsing values that cannot be represented in the current environment (e.g. unicode
          * regexes in Node 4), `node.value` is set to `null` because it wouldn't be possible to
          * set `node.value` to a unicode regex. To make sure a literal is actually `null`, check
-         * `node.raw` instead. Also see: https://github.com/eslint/eslint/issues/8020
+         * `node.regex` instead. Also see: https://github.com/eslint/eslint/issues/8020
          */
-        return node.type === "Literal" && node.value === null && node.raw === "null";
+        return node.type === "Literal" && node.value === null && !node.regex;
     }
 };

--- a/lib/ast-utils.js
+++ b/lib/ast-utils.js
@@ -1284,5 +1284,22 @@ module.exports = {
             default:
                 return false;
         }
+    },
+
+    /**
+     * Determines whether the given node is a `null` literal.
+     * @param {ASTNode} node The node to check
+     * @returns {boolean} `true` if the node is a `null` literal
+     */
+    isNullLiteral(node) {
+
+        /*
+         * Checking `node.value === null` does not guarantee that a literal is a null literal.
+         * When parsing values that cannot be represented in the current environment (e.g. unicode
+         * regexes in Node 4), `node.value` is set to `null` because it wouldn't be possible to
+         * set `node.value` to a unicode regex. To make sure a literal is actually `null`, check
+         * `node.raw` instead. Also see: https://github.com/eslint/eslint/issues/8020
+         */
+        return node.type === "Literal" && node.value === null && node.raw === "null";
     }
 };

--- a/lib/ast-utils.js
+++ b/lib/ast-utils.js
@@ -145,7 +145,7 @@ function isInLoop(node) {
  */
 function isNullOrUndefined(node) {
     return (
-        (node.type === "Literal" && node.value === null) ||
+        module.exports.isNullLiteral(node) ||
         (node.type === "Identifier" && node.name === "undefined") ||
         (node.type === "UnaryExpression" && node.operator === "void")
     );

--- a/lib/rules/eqeqeq.js
+++ b/lib/rules/eqeqeq.js
@@ -6,6 +6,12 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const astUtils = require("../ast-utils");
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
@@ -100,8 +106,7 @@ module.exports = {
          * @private
          */
         function isNullCheck(node) {
-            return (node.right.type === "Literal" && node.right.value === null) ||
-                    (node.left.type === "Literal" && node.left.value === null);
+            return astUtils.isNullLiteral(node.right) || astUtils.isNullLiteral(node.left);
         }
 
         /**

--- a/tests/lib/ast-utils.js
+++ b/tests/lib/ast-utils.js
@@ -171,6 +171,10 @@ describe("ast-utils", () => {
             eslint.on("CallExpression", checker);
             eslint.verify("foo.apply({}, a, b);", {}, filename, true);
         });
+
+        it("should return false if it's a unicode regex", () => {
+            assert.isFalse(astUtils.isNullOrUndefined(espree.parse("/abc/u", { ecmaVersion: 6 }).body[0].expression));
+        });
     });
 
     describe("checkReference", () => {

--- a/tests/lib/ast-utils.js
+++ b/tests/lib/ast-utils.js
@@ -1245,4 +1245,22 @@ describe("ast-utils", () => {
         });
     }
 
+    describe("isNullLiteral", () => {
+        const EXPECTED_RESULTS = {
+            null: true,
+            "/abc/u": false,
+            5: false,
+            true: false,
+            "'null'": false,
+            foo: false
+        };
+
+        Object.keys(EXPECTED_RESULTS).forEach(key => {
+            it(`returns ${EXPECTED_RESULTS[key]} for ${key}`, () => {
+                const ast = espree.parse(key, { ecmaVersion: 6 });
+
+                assert.strictEqual(astUtils.isNullLiteral(ast.body[0].expression), EXPECTED_RESULTS[key]);
+            });
+        });
+    });
 });

--- a/tests/lib/rules/eqeqeq.js
+++ b/tests/lib/rules/eqeqeq.js
@@ -42,7 +42,10 @@ ruleTester.run("eqeqeq", rule, {
         { code: "a == null", options: ["always", { null: "never" }] },
         { code: "a != null", options: ["always", { null: "never" }] },
         { code: "null == null", options: ["always", { null: "never" }] },
-        { code: "null != null", options: ["always", { null: "never" }] }
+        { code: "null != null", options: ["always", { null: "never" }] },
+
+        // https://github.com/eslint/eslint/issues/8020
+        { code: "foo === /abc/u", options: ["always", { null: "never" }], parserOptions: { ecmaVersion: 6 } }
     ],
     invalid: [
         { code: "a == b", errors: [{ message: "Expected '===' and instead saw '=='.", type: "BinaryExpression" }] },


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (see https://github.com/eslint/eslint/issues/8020)

**What changes did you make? (Give an overview)**

This fixes the detection of `null` literals in `eqeqeq`, to prevent it from treating unicode/sticky regexes like `null` in Node 4. When parsing values that cannot be represented in the current environment (e.g. unicode regexes in Node 4), the result is a `Literal` node with `node.value === null`. The `eqeqeq` rule assumed that any literal node with `node.value === null` is a `null` literal.

This also adds a `isNullLiteral` function to `ast-utils.js` to prevent other rules from making the same mistake.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular