### PR TITLE
Chore: unify checks for statement list parents

### DIFF
--- a/lib/ast-utils.js
+++ b/lib/ast-utils.js
@@ -24,6 +24,9 @@ const bindOrCallOrApplyPattern = /^(?:bind|call|apply)$/;
 const breakableTypePattern = /^(?:(?:Do)?While|For(?:In|Of)?|Switch)Statement$/;
 const thisTagPattern = /^[\s*]*@this/m;
 
+// A set of node types that can contain a list of statements
+const STATEMENT_LIST_PARENTS = new Set(["Program", "BlockStatement", "SwitchCase"]);
+
 /**
  * Checks reference if is non initializer and writable.
  * @param {Reference} reference - A reference to check.
@@ -319,6 +322,7 @@ function getLineIndices(sourceCode) {
 //------------------------------------------------------------------------------
 
 module.exports = {
+    STATEMENT_LIST_PARENTS,
 
     /**
      * Determines whether two adjacent tokens are on the same line.

--- a/lib/rules/brace-style.js
+++ b/lib/rules/brace-style.js
@@ -144,11 +144,7 @@ module.exports = {
 
         return {
             BlockStatement(node) {
-                if (
-                    node.parent.type !== "BlockStatement" &&
-                    node.parent.type !== "SwitchCase" &&
-                    node.parent.type !== "Program"
-                ) {
+                if (!astUtils.STATEMENT_LIST_PARENTS.has(node.parent.type)) {
                     validateCurlyPair(sourceCode.getFirstToken(node), sourceCode.getLastToken(node));
                 }
             },

--- a/lib/rules/no-lone-blocks.js
+++ b/lib/rules/no-lone-blocks.js
@@ -47,6 +47,10 @@ module.exports = {
         function isLoneBlock() {
             const parent = context.getAncestors().pop();
 
+            /*
+             * Note: astUtils.STATEMENT_LIST_PARENTS is not used here because blocks in SwitchCases are not checked.
+             * https://github.com/eslint/eslint/issues/8047
+             */
             return parent.type === "BlockStatement" || parent.type === "Program";
         }
 

--- a/lib/rules/no-useless-return.js
+++ b/lib/rules/no-useless-return.js
@@ -45,13 +45,7 @@ function remove(array, element) {
  * @returns {boolean} `true` if the node is removeable.
  */
 function isRemovable(node) {
-    const parent = node.parent;
-
-    return (
-        parent.type === "Program" ||
-        parent.type === "BlockStatement" ||
-        parent.type === "SwitchCase"
-    );
+    return astUtils.STATEMENT_LIST_PARENTS.has(node.parent.type);
 }
 
 /**

--- a/lib/rules/no-var.js
+++ b/lib/rules/no-var.js
@@ -274,9 +274,7 @@ module.exports = {
             if (
                 !isLoopAssignee(node) &&
                 !(node.parent.type === "ForStatement" && node.parent.init === node) &&
-                node.parent.type !== "BlockStatement" &&
-                node.parent.type !== "Program" &&
-                node.parent.type !== "SwitchCase"
+                !astUtils.STATEMENT_LIST_PARENTS.has(node.parent.type)
             ) {
 
                 // If the declaration is not in a block, e.g. `if (foo) var bar = 1;`, then it can't be fixed.


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

**What changes did you make? (Give an overview)**

There are currently three types of nodes that can contain a list of statements:

* `Program`
* `BlockStatement`
* `SwitchCase`

Several rules have to check for these node types, and sometimes they do it incorrectly (see https://github.com/eslint/eslint/issues/8047). This commit puts the node types in a constant in `ast-utils`.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
