### PR TITLE
Fix: `getTokenAfter` was wrong

### DIFF
--- a/lib/token-store/index.js
+++ b/lib/token-store/index.js
@@ -45,7 +45,7 @@ const PUBLIC_METHODS = Object.freeze([
  * Creates the map from locations to indices in `tokens`.
  *
  * The first/last location of tokens is mapped to the index of the token.
- * The first/last location of comments is mapped to the index of the previous token of each comment.
+ * The first/last location of comments is mapped to the index of the next token of each comment.
  *
  * @param {Token[]} tokens - The array of tokens.
  * @param {Comment[]} comments - The array of comments.

--- a/lib/token-store/utils.js
+++ b/lib/token-store/utils.js
@@ -61,7 +61,15 @@ exports.getFirstIndex = function getFirstIndex(tokens, indexMap, startLoc) {
         return indexMap[startLoc];
     }
     if ((startLoc - 1) in indexMap) {
-        return indexMap[startLoc - 1] + 1;
+        const index = indexMap[startLoc - 1];
+        const token = (index >= 0 && index < tokens.length) ? tokens[index] : null;
+
+        // For the map of "comment's location -> token's index", it points the next token of a comment.
+        // In that case, +1 is unnecessary.
+        if (token && token.range[0] >= startLoc) {
+            return index;
+        }
+        return index + 1;
     }
     return 0;
 };
@@ -81,7 +89,15 @@ exports.getLastIndex = function getLastIndex(tokens, indexMap, endLoc) {
         return indexMap[endLoc] - 1;
     }
     if ((endLoc - 1) in indexMap) {
-        return indexMap[endLoc - 1];
+        const index = indexMap[endLoc - 1];
+        const token = (index >= 0 && index < tokens.length) ? tokens[index] : null;
+
+        // For the map of "comment's location -> token's index", it points the next token of a comment.
+        // In that case, -1 is necessary.
+        if (token && token.range[1] > endLoc) {
+            return index - 1;
+        }
+        return index;
     }
     return tokens.length - 1;
 };


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

**Tell us about your environment**

* **ESLint Version:** master
* **Node Version:** 7.3.0
* **npm Version:** 3.8.9

**What parser (default, Babel-ESLint, etc.) are you using?**

- default

**Please show your full configuration:**

- nothing

**What did you do? Please include the actual source code causing the issue.**

I traversed tokens and comments by `token = sourceCode.getTokenAfter(token, { includeComments: true })`.

```js
(function(a, /*b,*/ c){})
```

**What did you expect to happen?**

- It traverses 11 tokens.

**What actually happened? Please include the actual, raw output from ESLint.**

- It traverses 10 tokens (`c` is lost).

**What changes did you make? (Give an overview)**

This PR makes correct usage of indexMap (the map from locations to indices).

The map includes 2 kind of mapping; "token's locations to token's indices" and "comment's locations to token's indices". In the former case, it points itself index of each token. In the latter case, it points the next token's index of each comment. So it required additional checks in `utils.getFirstIndex` and `utils.getLastIndex`.

This PR fixes those, and adds tests for some edge cases.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.
