### PR TITLE
Update: Add `ignoreComments` option to `no-trailing-spaces`

### DIFF
--- a/lib/rules/no-trailing-spaces.js
+++ b/lib/rules/no-trailing-spaces.js
@@ -43,9 +43,8 @@ module.exports = {
 
         const options = context.options[0] || {},
             skipBlankLines = options.skipBlankLines || false,
-            ignoreComments = options.ignoreComments || true;
+            ignoreComments = typeof options.ignoreComments !== "undefined" ? options.ignoreComments : true;
 
-        const commentNodes = [];
 
         /**
          * Report the error message
@@ -75,13 +74,13 @@ module.exports = {
         /**
          * Given a list of comment nodes, return the line numbers for those comments.
          * @param {Array} comments An array of comment nodes.
-         * @return {number[]} A array of line numbers containing comments.
+         * @returns {number[]} A array of line numbers containing comments.
          */
         function getCommentLineNumbers(comments) {
             const lines = [];
 
             comments.forEach(comment => {
-                for(let i = comment.loc.start.line; i <= comment.loc.end.line; i++) {
+                for (let i = comment.loc.start.line; i <= comment.loc.end.line; i++) {
                     lines.push(i);
                 }
             });
@@ -146,7 +145,7 @@ module.exports = {
 
                         fixRange = [rangeStart, rangeEnd];
 
-                        if(!ignoreComments || !commentLineNumbers.includes(location.line)) {
+                        if (!ignoreComments || !commentLineNumbers.includes(location.line)) {
                             report(node, location, fixRange);
                         }
                     }

--- a/lib/rules/no-trailing-spaces.js
+++ b/lib/rules/no-trailing-spaces.js
@@ -24,6 +24,9 @@ module.exports = {
                 properties: {
                     skipBlankLines: {
                         type: "boolean"
+                    },
+                    ignoreComments: {
+                        type: "boolean"
                     }
                 },
                 additionalProperties: false
@@ -39,7 +42,10 @@ module.exports = {
             NONBLANK = `${BLANK_CLASS}+$`;
 
         const options = context.options[0] || {},
-            skipBlankLines = options.skipBlankLines || false;
+            skipBlankLines = options.skipBlankLines || false,
+            ignoreComments = options.ignoreComments || true;
+
+        const commentNodes = [];
 
         /**
          * Report the error message
@@ -66,6 +72,22 @@ module.exports = {
             });
         }
 
+        /**
+         * Given a list of comment nodes, return the line numbers for those comments.
+         * @param {Array} comments An array of comment nodes.
+         * @return {number[]} A array of line numbers containing comments.
+         */
+        function getCommentLineNumbers(comments) {
+            const lines = [];
+
+            comments.forEach(comment => {
+                for(let i = comment.loc.start.line; i <= comment.loc.end.line; i++) {
+                    lines.push(i);
+                }
+            });
+
+            return lines;
+        }
 
         //--------------------------------------------------------------------------
         // Public
@@ -81,9 +103,13 @@ module.exports = {
                 const re = new RegExp(NONBLANK),
                     skipMatch = new RegExp(SKIP_BLANK),
                     lines = sourceCode.lines,
-                    linebreaks = sourceCode.getText().match(/\r\n|\r|\n|\u2028|\u2029/g);
+                    linebreaks = sourceCode.getText().match(/\r\n|\r|\n|\u2028|\u2029/g),
+                    comments = sourceCode.getAllComments(),
+                    commentLineNumbers = getCommentLineNumbers(comments);
+
                 let totalLength = 0,
                     fixRange = [];
+
 
                 for (let i = 0, ii = lines.length; i < ii; i++) {
                     const matches = re.exec(lines[i]);
@@ -119,7 +145,10 @@ module.exports = {
                         }
 
                         fixRange = [rangeStart, rangeEnd];
-                        report(node, location, fixRange);
+
+                        if(!ignoreComments || !commentLineNumbers.includes(location.line)) {
+                            report(node, location, fixRange);
+                        }
                     }
 
                     totalLength += lineLength;

--- a/lib/rules/no-trailing-spaces.js
+++ b/lib/rules/no-trailing-spaces.js
@@ -145,7 +145,7 @@ module.exports = {
 
                         fixRange = [rangeStart, rangeEnd];
 
-                        if (!ignoreComments || !commentLineNumbers.includes(location.line)) {
+                        if (!ignoreComments || commentLineNumbers.indexOf(location.line) === -1) {
                             report(node, location, fixRange);
                         }
                     }

--- a/tests/lib/rules/no-trailing-spaces.js
+++ b/tests/lib/rules/no-trailing-spaces.js
@@ -456,7 +456,6 @@ ruleTester.run("no-trailing-spaces", rule, {
                     column: 24
                 }
             ]
-        },
-    
+        }
     ]
 });

--- a/tests/lib/rules/no-trailing-spaces.js
+++ b/tests/lib/rules/no-trailing-spaces.js
@@ -70,6 +70,14 @@ ruleTester.run("no-trailing-spaces", rule, {
             code: "let str = `${a}\n   \n${b}`;\n   \n   ",
             parserOptions: { ecmaVersion: 6 },
             options: [{ skipBlankLines: true }]
+        },
+        {
+            code: "// Trailing comment test. ",
+            options: [{ ignoreComments: true }]
+        },
+        {
+            code: "/* \nTrailing comments test. \n*/",
+            options: [{ ignoreComments: true }]
         }
     ],
 
@@ -416,6 +424,39 @@ ruleTester.run("no-trailing-spaces", rule, {
                     column: 8
                 }
             ]
-        }
+        },
+        {
+            code: "// Trailing comment test. ",
+            output: "// Trailing comment test.",
+            options: [{ ignoreComments: false }],
+            errors: [
+                {
+                    message: "Trailing spaces not allowed.",
+                    type: "Program",
+                    line: 1,
+                    column: 26
+                }
+            ]
+        },
+        {
+            code: "/* \nTrailing comments test. \n*/",
+            output: "/*\nTrailing comments test.\n*/",
+            options: [{ ignoreComments: false }],
+            errors: [
+                {
+                    message: "Trailing spaces not allowed.",
+                    type: "Program",
+                    line: 1,
+                    column: 3
+                },
+                {
+                    message: "Trailing spaces not allowed.",
+                    type: "Program",
+                    line: 2,
+                    column: 24
+                }
+            ]
+        },
+    
     ]
 });


### PR DESCRIPTION
Adds the option `ignoreComments` to the `no-trailing-spaces` rule. In many IDEs, spaces are automatically added after the * character in multi-line comment blocks. When trying to add a blank line to your comment, you currently have to delete the trailing spaces yourself, even though they're in a comment block and don't affect anything.

```js
/* I'm leaving a comment here.
 * 
 * Please don't remove it! */
```
The second line has a trailing space, but in many ways that's expected; each other line begins with *[space], so it makes sense for the blank line to do so as well.

This change doesn't just modify `skipBlankLines` on an empty comment line, as theoretically you could use any symbol at the start of your comment lines. I'm not sure why you _would_, but you could.

```js
/*- Some comment here
 *-  
 */
```
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:


**What rule do you want to change?**
[no-trailing-spaces](http://eslint.org/docs/rules/no-trailing-spaces)

**Does this change cause the rule to produce more or fewer warnings?**
More warnings, but only if the `ignoreComments` option is set to `false`.

**How will the change be implemented? (New option, new default behavior, etc.)?**
The `ignoreComments` option is added, with a default value of `false`.

**Please provide some example code that this change will affect:**

```js
/**
 * Description for my method
 *
 * @returns {number} A number.
 */
```
There is a trailing space at the end of the third line.

```js
// Some comment here. 
```
There is a trailing space at the end of this line.

**What does the rule currently do for this code?**
It'll raise a warning/error if you have a trailing space in a comment block.

**What will the rule do after it's changed?**
If `ignoreComments` is true, no warning/error will be raised if you have a trailing space in a comment block.

**What changes did you make? (Give an overview)**
Added the option `ignoreComments` to `no-trailing-spaces` with a default value of `true`.

**Is there anything you'd like reviewers to focus on?**
I don't think so.

