### PR TITLE
Update: Add ignoreComments option to no-trailing-spaces

### DIFF
--- a/docs/rules/no-trailing-spaces.md
+++ b/docs/rules/no-trailing-spaces.md
@@ -31,6 +31,8 @@ This rule has an object option:
 
 * `"skipBlankLines": false` (default) disallows trailing whitespace on empty lines
 * `"skipBlankLines": true` allows trailing whitespace on empty lines
+* `"ignoreComments": false` (default) disallows trailing whitespace in comment blocks
+* `"ignoreComments": true` allows trailing whitespace in comment blocks
 
 ### skipBlankLines
 
@@ -42,4 +44,20 @@ Examples of **correct** code for this rule with the `{ "skipBlankLines": true }`
 var foo = 0;
 var baz = 5;
 //•••••
+```
+
+### ignoreComments
+
+Examples of **correct** code for this rule with the `{ "ignoreComments": true }` option:
+
+```js
+/*eslint no-trailing-spaces: ["error", { "ignoreComments": true }]*/
+
+//foo•
+//•••••
+/**
+ *•baz
+ *••
+ *•bar
+ */
 ```

--- a/tests/lib/rules/no-trailing-spaces.js
+++ b/tests/lib/rules/no-trailing-spaces.js
@@ -70,6 +70,18 @@ ruleTester.run("no-trailing-spaces", rule, {
             code: "let str = `${a}\n   \n${b}`;\n   \n   ",
             parserOptions: { ecmaVersion: 6 },
             options: [{ skipBlankLines: true }]
+        },
+        {
+            code: "// Trailing comment test. ",
+            options: [{ ignoreComments: true }]
+        },
+        {
+            code: "/* \nTrailing comments test. \n*/",
+            options: [{ ignoreComments: true }]
+        },
+        {
+            code: "#!/usr/bin/env node ",
+            options: [{ ignoreComments: true }]
         }
     ],
 
@@ -414,6 +426,66 @@ ruleTester.run("no-trailing-spaces", rule, {
                     type: "Program",
                     line: 2,
                     column: 8
+                }
+            ]
+        },
+
+        // Tests for ignoreComments flag.
+        {
+            code: "var foo = 'bar'; ",
+            output: "var foo = 'bar';",
+            options: [{ ignoreComments: true }],
+            errors: [
+                {
+                    message: "Trailing spaces not allowed.",
+                    type: "Program",
+                    line: 1,
+                    column: 17
+                }
+            ]
+        },
+        {
+            code: "// Trailing comment test. ",
+            output: "// Trailing comment test.",
+            options: [{ ignoreComments: false }],
+            errors: [
+                {
+                    message: "Trailing spaces not allowed.",
+                    type: "Program",
+                    line: 1,
+                    column: 26
+                }
+            ]
+        },
+        {
+            code: "/* \nTrailing comments test. \n*/",
+            output: "/*\nTrailing comments test.\n*/",
+            options: [{ ignoreComments: false }],
+            errors: [
+                {
+                    message: "Trailing spaces not allowed.",
+                    type: "Program",
+                    line: 1,
+                    column: 3
+                },
+                {
+                    message: "Trailing spaces not allowed.",
+                    type: "Program",
+                    line: 2,
+                    column: 24
+                }
+            ]
+        },
+        {
+            code: "#!/usr/bin/env node ",
+            output: "#!/usr/bin/env node",
+            options: [{ ignoreComments: false }],
+            errors: [
+                {
+                    message: "Trailing spaces not allowed.",
+                    type: "Program",
+                    line: 1,
+                    column: 20
                 }
             ]
         }


### PR DESCRIPTION
Adds the option `ignoreComments` to the `no-trailing-spaces` rule. In many IDEs, spaces are automatically added after the * character in multi-line comment blocks. When trying to add a blank line to your comment, you currently have to delete the trailing spaces yourself, even though they're in a comment block and don't affect anything.

```js
/* I'm leaving a comment here.
 * 
 * Please don't remove it! */
```
The second line has a trailing space, but in many ways that's expected; each other line begins with *[space], so it makes sense for the blank line to do so as well.

This change doesn't just modify `skipBlankLines` on an empty comment line, as theoretically you could use any symbol at the start of your comment lines. I'm not sure why you _would_, but you could.

```js
/*- Some comment here
 *-  
 */
```
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:


**What rule do you want to change?**
[no-trailing-spaces](http://eslint.org/docs/rules/no-trailing-spaces)

**Does this change cause the rule to produce more or fewer warnings?**
Fewer warnings if the `ignoreComments` option is set to `true`.

**How will the change be implemented? (New option, new default behavior, etc.)?**
The `ignoreComments` option is added, with a default value of `false`.

**Please provide some example code that this change will affect:**

```js
/**
 * Description for my method
 *
 * @returns {number} A number.
 */
```
There is a trailing space at the end of the third line.

```js
// Some comment here. 
```
There is a trailing space at the end of this line.

**What does the rule currently do for this code?**
It'll raise a warning/error if you have a trailing space in a comment block.

**What will the rule do after it's changed?**
If `ignoreComments` is true, no warning/error will be raised if you have a trailing space in a comment block.

**What changes did you make? (Give an overview)**
Added the option `ignoreComments` to `no-trailing-spaces` with a default value of `false`.

**Is there anything you'd like reviewers to focus on?**
I don't think so.

