### PR TITLE
Update: make no-lone-blocks report blocks in switch cases (fixes #8047)

### DIFF
--- a/lib/rules/no-lone-blocks.js
+++ b/lib/rules/no-lone-blocks.js
@@ -32,26 +32,22 @@ module.exports = {
          * @returns {void}
         */
         function report(node) {
-            const parent = context.getAncestors().pop();
+            const message = node.parent.type === "BlockStatement" ? "Nested block is redundant." : "Block is redundant.";
 
-            context.report({ node, message: parent.type === "Program"
-                ? "Block is redundant."
-                : "Nested block is redundant."
-            });
+            context.report({ node, message });
         }
 
         /**
-         * Checks for any ocurrence of BlockStatement > BlockStatement or Program > BlockStatement
-         * @returns {boolean} True if the current node is a lone block.
+         * Checks for any ocurrence of a BlockStatement in a place where lists of statements can appear
+         * @param {ASTNode} node The node to check
+         * @returns {boolean} True if the node is a lone block.
         */
-        function isLoneBlock() {
-            const parent = context.getAncestors().pop();
+        function isLoneBlock(node) {
+            return node.parent.type === "BlockStatement" ||
+                node.parent.type === "Program" ||
 
-            /*
-             * Note: astUtils.STATEMENT_LIST_PARENTS is not used here because blocks in SwitchCases are not checked.
-             * https://github.com/eslint/eslint/issues/8047
-             */
-            return parent.type === "BlockStatement" || parent.type === "Program";
+                // Don't report blocks in switch cases if the block is the only statement of the case.
+                node.parent.type === "SwitchCase" && !(node.parent.consequent[0] === node && node.parent.consequent.length === 1);
         }
 
         /**

--- a/tests/lib/rules/no-lone-blocks.js
+++ b/tests/lib/rules/no-lone-blocks.js
@@ -31,7 +31,32 @@ ruleTester.run("no-lone-blocks", rule, {
         { code: "{ function bar() {} }", parserOptions: { ecmaVersion: 6, ecmaFeatures: { impliedStrict: true } } },
         { code: "{ class Bar {} }", parserOptions: { ecmaVersion: 6 } },
 
-        { code: "{ {let y = 1;} let x = 1; }", parserOptions: { ecmaVersion: 6 } }
+        { code: "{ {let y = 1;} let x = 1; }", parserOptions: { ecmaVersion: 6 } },
+        `
+          switch (foo) {
+            case bar: {
+              baz;
+            }
+          }
+        `,
+        `
+          switch (foo) {
+            case bar: {
+              baz;
+            }
+            case qux: {
+              boop;
+            }
+          }
+        `,
+        `
+          switch (foo) {
+            case bar:
+            {
+              baz;
+            }
+          }
+        `
     ],
     invalid: [
         { code: "{}", errors: [{ message: "Block is redundant.", type: "BlockStatement" }] },
@@ -69,6 +94,30 @@ ruleTester.run("no-lone-blocks", rule, {
                 { message: "Nested block is redundant.", type: "BlockStatement", line: 2 },
                 { message: "Block is redundant.", type: "BlockStatement", line: 4 }
             ]
+        },
+        {
+            code: `
+              switch (foo) {
+                case 1:
+                    foo();
+                    {
+                        bar;
+                    }
+              }
+            `,
+            errors: [{ message: "Block is redundant.", type: "BlockStatement", line: 5 }]
+        },
+        {
+            code: `
+              switch (foo) {
+                case 1:
+                {
+                    bar;
+                }
+                foo();
+              }
+            `,
+            errors: [{ message: "Block is redundant.", type: "BlockStatement", line: 4 }]
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (https://github.com/eslint/eslint/issues/8047)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates `no-lone-blocks` to report block statements in SwitchCase nodes. As described in https://github.com/eslint/eslint/issues/8047, it does not report blocks if they are the *only* statement in SwitchCase nodes.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular