### PR TITLE
Fix: Add a utility to avoid autofix conflicts (fixes #7928, fixes #8026)

### DIFF
--- a/lib/rules/no-else-return.js
+++ b/lib/rules/no-else-return.js
@@ -6,6 +6,12 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const FixTracker = require("../util/fix-tracker");
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
@@ -86,7 +92,10 @@ module.exports = {
                     } else {
                         fixedSource = source;
                     }
-                    return fixer.replaceTextRange([elseToken.start, node.end], fixedSource);
+
+                    return new FixTracker(fixer, sourceCode)
+                        .retainEnclosingFunction(node)
+                        .replaceTextRange([elseToken.start, node.end], fixedSource);
                 }
             });
         }

--- a/lib/rules/no-else-return.js
+++ b/lib/rules/no-else-return.js
@@ -93,6 +93,9 @@ module.exports = {
                         fixedSource = source;
                     }
 
+                    // Extend the replacement range to include the entire
+                    // function to avoid conflicting with no-useless-return.
+                    // https://github.com/eslint/eslint/issues/8026
                     return new FixTracker(fixer, sourceCode)
                         .retainEnclosingFunction(node)
                         .replaceTextRange([elseToken.start, node.end], fixedSource);

--- a/lib/rules/no-extra-semi.js
+++ b/lib/rules/no-extra-semi.js
@@ -6,6 +6,12 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const FixTracker = require("../util/fix-tracker");
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
@@ -34,7 +40,9 @@ module.exports = {
                 node: nodeOrToken,
                 message: "Unnecessary semicolon.",
                 fix(fixer) {
-                    return fixer.remove(nodeOrToken);
+                    return new FixTracker(fixer, context.getSourceCode())
+                        .retainSurroundingTokens(nodeOrToken)
+                        .remove(nodeOrToken);
                 }
             });
         }

--- a/lib/rules/no-extra-semi.js
+++ b/lib/rules/no-extra-semi.js
@@ -40,6 +40,10 @@ module.exports = {
                 node: nodeOrToken,
                 message: "Unnecessary semicolon.",
                 fix(fixer) {
+
+                    // Expand the replacement range to include the surrounding
+                    // tokens to avoid conflicting with semi.
+                    // https://github.com/eslint/eslint/issues/7928
                     return new FixTracker(fixer, context.getSourceCode())
                         .retainSurroundingTokens(nodeOrToken)
                         .remove(nodeOrToken);

--- a/lib/rules/no-useless-return.js
+++ b/lib/rules/no-useless-return.js
@@ -221,6 +221,11 @@ module.exports = {
                         message: "Unnecessary return statement.",
                         fix(fixer) {
                             if (isRemovable(node)) {
+
+                                // Extend the replacement range to include the
+                                // entire function to avoid conflicting with
+                                // no-else-return.
+                                // https://github.com/eslint/eslint/issues/8026
                                 return new FixTracker(fixer, context.getSourceCode())
                                     .retainEnclosingFunction(node)
                                     .remove(node);

--- a/lib/rules/no-useless-return.js
+++ b/lib/rules/no-useless-return.js
@@ -8,7 +8,8 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const astUtils = require("../ast-utils");
+const astUtils = require("../ast-utils"),
+    FixTracker = require("../util/fix-tracker");
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -219,7 +220,12 @@ module.exports = {
                         loc: node.loc,
                         message: "Unnecessary return statement.",
                         fix(fixer) {
-                            return isRemovable(node) ? fixer.remove(node) : null;
+                            if (isRemovable(node)) {
+                                return new FixTracker(fixer, context.getSourceCode())
+                                    .retainEnclosingFunction(node)
+                                    .remove(node);
+                            }
+                            return null;
                         }
                     });
                 }

--- a/lib/rules/semi.js
+++ b/lib/rules/semi.js
@@ -91,6 +91,10 @@ module.exports = {
                 message = "Extra semicolon.";
                 loc = loc.start;
                 fix = function(fixer) {
+
+                    // Expand the replacement range to include the surrounding
+                    // tokens to avoid conflicting with no-extra-semi.
+                    // https://github.com/eslint/eslint/issues/7928
                     return new FixTracker(fixer, sourceCode)
                         .retainSurroundingTokens(lastToken)
                         .remove(lastToken);

--- a/lib/rules/semi.js
+++ b/lib/rules/semi.js
@@ -5,6 +5,12 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const FixTracker = require("../util/fix-tracker");
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
@@ -85,7 +91,9 @@ module.exports = {
                 message = "Extra semicolon.";
                 loc = loc.start;
                 fix = function(fixer) {
-                    return fixer.remove(lastToken);
+                    return new FixTracker(fixer, sourceCode)
+                        .retainSurroundingTokens(lastToken)
+                        .remove(lastToken);
                 };
             }
 

--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -490,19 +490,7 @@ RuleTester.prototype = {
                 }
 
                 if (item.hasOwnProperty("output")) {
-                    let fixResult = SourceCodeFixer.applyFixes(eslint.getSourceCode(), messages);
-
-                    if (item.multipass) {
-                        for (let i = 0; i < 10; i++) {
-                            const newItem = Object.assign({}, item, { code: fixResult.output });
-                            const newResult = runRuleForItem(ruleName, newItem);
-
-                            fixResult = SourceCodeFixer.applyFixes(eslint.getSourceCode(), newResult.messages);
-                            if (newItem.code === fixResult.output) {
-                                break;
-                            }
-                        }
-                    }
+                    const fixResult = SourceCodeFixer.applyFixes(eslint.getSourceCode(), messages);
 
                     assert.equal(fixResult.output, item.output, "Output is incorrect.");
                 }

--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -490,7 +490,19 @@ RuleTester.prototype = {
                 }
 
                 if (item.hasOwnProperty("output")) {
-                    const fixResult = SourceCodeFixer.applyFixes(eslint.getSourceCode(), messages);
+                    let fixResult = SourceCodeFixer.applyFixes(eslint.getSourceCode(), messages);
+
+                    if (item.multipass) {
+                        for (let i = 0; i < 10; i++) {
+                            const newItem = Object.assign({}, item, { code: fixResult.output });
+                            const newResult = runRuleForItem(ruleName, newItem);
+
+                            fixResult = SourceCodeFixer.applyFixes(eslint.getSourceCode(), newResult.messages);
+                            if (newItem.code === fixResult.output) {
+                                break;
+                            }
+                        }
+                    }
 
                     assert.equal(fixResult.output, item.output, "Output is incorrect.");
                 }

--- a/lib/util/fix-tracker.js
+++ b/lib/util/fix-tracker.js
@@ -1,0 +1,112 @@
+/**
+ * @fileoverview Helper class to aid in constructing fix commands.
+ * @author Alan Pierce
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const astUtils = require("../ast-utils");
+
+//------------------------------------------------------------------------------
+// Public Interface
+//------------------------------------------------------------------------------
+
+/**
+ * A helper class to combine fix options into a fix command. Currently, it
+ * exposes some "retain" methods that extend the range of the text being
+ * replaced so that other fixes won't touch that region in the same pass.
+ */
+class FixTracker {
+
+    /**
+     * Create a new FixTracker.
+     *
+     * @param {ruleFixer} fixer A ruleFixer instance.
+     * @param {SourceCode} sourceCode A SourceCode object for the current code.
+     */
+    constructor(fixer, sourceCode) {
+        this.fixer = fixer;
+        this.sourceCode = sourceCode;
+        this.retainedRange = null;
+    }
+
+    /**
+     * Mark the given range as "retained", meaning that other fixes may not
+     * may not modify this region in the same pass.
+     *
+     * @param {int[]} range The range to retain.
+     * @returns {FixTracker} The same RuleFixer, for chained calls.
+     */
+    retainRange(range) {
+        this.retainedRange = range;
+        return this;
+    }
+
+    /**
+     * Given a node, find the function containing it (or the entire program) and
+     * mark it as retained, meaning that other fixes may not modify it in this
+     * pass. This is useful for avoiding conflicts in fixes that modify control
+     * flow.
+     *
+     * @param {ASTNode} node The node to use as a starting point.
+     * @returns {FixTracker} The same RuleFixer, for chained calls.
+     */
+    retainEnclosingFunction(node) {
+        const functionNode = astUtils.getUpperFunction(node);
+
+        return this.retainRange(
+            functionNode ? functionNode.range : this.sourceCode.ast.range);
+    }
+
+    /**
+     * Given a node or token, find the token before and afterward, and mark that
+     * range as retained, meaning that other fixes may not modify it in this
+     * pass. This is useful for avoiding conflicts in fixes that make a small
+     * change to the code where the AST should not be changed.
+     *
+     * @param {ASTNode|Token} nodeOrToken The node or token to use as a starting
+     *      point. The token to the left and right are use in the range.
+     * @returns {FixTracker} The same RuleFixer, for chained calls.
+     */
+    retainSurroundingTokens(nodeOrToken) {
+        const tokenBefore = this.sourceCode.getTokenBefore(nodeOrToken) || nodeOrToken;
+        const tokenAfter = this.sourceCode.getTokenAfter(nodeOrToken) || nodeOrToken;
+
+        return this.retainRange([tokenBefore.range[0], tokenAfter.range[1]]);
+    }
+
+    /**
+     * Create a fix command that replaces the given range with the given text,
+     * accounting for any retained ranges.
+     *
+     * @param {int[]} range The range to remove in the fix.
+     * @param {string} text The text to insert in place of the range.
+     * @returns {Object} The fix command.
+     */
+    replaceTextRange(range, text) {
+        const actualRetainedRange = this.retainedRange || range;
+
+        return this.fixer.replaceTextRange(
+            actualRetainedRange,
+            this.sourceCode.text.slice(actualRetainedRange[0], range[0]) +
+                text +
+                this.sourceCode.text.slice(range[1], actualRetainedRange[1])
+        );
+    }
+
+    /**
+     * Create a fix command that removes the given node or token, accounting for
+     * any retained ranges.
+     *
+     * @param {ASTNode|Token} nodeOrToken The node or token to remove.
+     * @returns {Object} The fix command.
+     */
+    remove(nodeOrToken) {
+        return this.replaceTextRange(nodeOrToken.range, "");
+    }
+}
+
+module.exports = FixTracker;

--- a/lib/util/fix-tracker.js
+++ b/lib/util/fix-tracker.js
@@ -87,13 +87,22 @@ class FixTracker {
      * @returns {Object} The fix command.
      */
     replaceTextRange(range, text) {
-        const actualRetainedRange = this.retainedRange || range;
+        let actualRange;
+
+        if (this.retainedRange) {
+            actualRange = [
+                Math.min(this.retainedRange[0], range[0]),
+                Math.max(this.retainedRange[1], range[1])
+            ];
+        } else {
+            actualRange = range;
+        }
 
         return this.fixer.replaceTextRange(
-            actualRetainedRange,
-            this.sourceCode.text.slice(actualRetainedRange[0], range[0]) +
+            actualRange,
+            this.sourceCode.text.slice(actualRange[0], range[0]) +
                 text +
-                this.sourceCode.text.slice(range[1], actualRetainedRange[1])
+                this.sourceCode.text.slice(range[1], actualRange[1])
         );
     }
 

--- a/tests/fixtures/autofix/return-conflicting-fixes.expected.js
+++ b/tests/fixtures/autofix/return-conflicting-fixes.expected.js
@@ -1,0 +1,10 @@
+/* eslint no-else-return: "error" */
+/* eslint no-useless-return: "error" */
+/* eslint no-trailing-spaces: "error" */
+function f() {
+    if (true) {
+
+    } else {
+        return 1;
+    }
+}

--- a/tests/fixtures/autofix/return-conflicting-fixes.js
+++ b/tests/fixtures/autofix/return-conflicting-fixes.js
@@ -1,0 +1,10 @@
+/* eslint no-else-return: "error" */
+/* eslint no-useless-return: "error" */
+/* eslint no-trailing-spaces: "error" */
+function f() {
+    if (true) {
+        return;
+    } else {
+        return 1;
+    }
+}

--- a/tests/fixtures/autofix/semicolon-conflicting-fixes.expected.js
+++ b/tests/fixtures/autofix/semicolon-conflicting-fixes.expected.js
@@ -1,0 +1,4 @@
+/* eslint semi: ["error", "never"] */
+/* eslint no-extra-semi: "error" */
+var foo = function(){}
+;[1].map(foo)

--- a/tests/fixtures/autofix/semicolon-conflicting-fixes.js
+++ b/tests/fixtures/autofix/semicolon-conflicting-fixes.js
@@ -1,0 +1,4 @@
+/* eslint semi: ["error", "never"] */
+/* eslint no-extra-semi: "error" */
+var foo = function(){};
+;[1].map(foo)

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -246,6 +246,34 @@ describe("CLIEngine", () => {
             });
         });
 
+        it("correctly autofixes semicolon-conflicting-fixes", () => {
+            engine = new CLIEngine({
+                cwd: path.join(fixtureDir, ".."),
+                useEslintrc: false,
+                fix: true
+            });
+            const inputPath = getFixturePath("autofix/semicolon-conflicting-fixes.js");
+            const outputPath = getFixturePath("autofix/semicolon-conflicting-fixes.expected.js");
+            const report = engine.executeOnFiles([inputPath]);
+            const expectedOutput = fs.readFileSync(outputPath, "utf8");
+
+            assert.strictEqual(report.results[0].output, expectedOutput);
+        });
+
+        it("correctly autofixes return-conflicting-fixes", () => {
+            engine = new CLIEngine({
+                cwd: path.join(fixtureDir, ".."),
+                useEslintrc: false,
+                fix: true
+            });
+            const inputPath = getFixturePath("autofix/return-conflicting-fixes.js");
+            const outputPath = getFixturePath("autofix/return-conflicting-fixes.expected.js");
+            const report = engine.executeOnFiles([inputPath]);
+            const expectedOutput = fs.readFileSync(outputPath, "utf8");
+
+            assert.strictEqual(report.results[0].output, expectedOutput);
+        });
+
         it("should return a message and omit fixed text when in fix mode and fixes aren't done", () => {
 
             engine = new CLIEngine({

--- a/tests/lib/rules/no-else-return.js
+++ b/tests/lib/rules/no-else-return.js
@@ -47,7 +47,8 @@ ruleTester.run("no-else-return", rule, {
         {
             code: "function foo4() { if (true) { if (false) return x; else return y; } else { return z; } }",
             output: "function foo4() { if (true) { if (false) return x; return y; }  return z;  }",
-            errors: [{ message: "Unnecessary 'else' after 'return'.", type: "ReturnStatement" }, { message: "Unnecessary 'else' after 'return'.", type: "BlockStatement" }]
+            errors: [{ message: "Unnecessary 'else' after 'return'.", type: "ReturnStatement" }, { message: "Unnecessary 'else' after 'return'.", type: "BlockStatement" }],
+            multipass: true
         },
         {
             code: "function foo5() { if (true) { if (false) { if (true) return x; else { w = y; } } else { w = x; } } else { return z; } }",
@@ -65,7 +66,8 @@ ruleTester.run("no-else-return", rule, {
             errors: [
                 { message: "Unnecessary 'else' after 'return'.", type: "ReturnStatement" },
                 { message: "Unnecessary 'else' after 'return'.", type: "BlockStatement" }
-            ]
+            ],
+            multipass: true
         },
         {
             code: "function foo8() { if (true) { if (false) { if (true) return x; else return y; } else { w = x; } } else { return z; } }",
@@ -73,7 +75,8 @@ ruleTester.run("no-else-return", rule, {
             errors: [
                 { message: "Unnecessary 'else' after 'return'.", type: "ReturnStatement" },
                 { message: "Unnecessary 'else' after 'return'.", type: "BlockStatement" }
-            ]
+            ],
+            multipass: true
         },
         {
             code: "function foo9() {if (x) { return true; } else if (y) { return true; } else { notAReturn(); } }",

--- a/tests/lib/rules/no-else-return.js
+++ b/tests/lib/rules/no-else-return.js
@@ -46,9 +46,8 @@ ruleTester.run("no-else-return", rule, {
             errors: [{ message: "Unnecessary 'else' after 'return'.", type: "ReturnStatement" }] },
         {
             code: "function foo4() { if (true) { if (false) return x; else return y; } else { return z; } }",
-            output: "function foo4() { if (true) { if (false) return x; return y; }  return z;  }",
-            errors: [{ message: "Unnecessary 'else' after 'return'.", type: "ReturnStatement" }, { message: "Unnecessary 'else' after 'return'.", type: "BlockStatement" }],
-            multipass: true
+            output: "function foo4() { if (true) { if (false) return x; return y; } else { return z; } }",  // Other case is fixed in the second pass.
+            errors: [{ message: "Unnecessary 'else' after 'return'.", type: "ReturnStatement" }, { message: "Unnecessary 'else' after 'return'.", type: "BlockStatement" }]
         },
         {
             code: "function foo5() { if (true) { if (false) { if (true) return x; else { w = y; } } else { w = x; } } else { return z; } }",
@@ -62,21 +61,19 @@ ruleTester.run("no-else-return", rule, {
         },
         {
             code: "function foo7() { if (true) { if (false) { if (true) return x; else return y; } return w; } else { return z; } }",
-            output: "function foo7() { if (true) { if (false) { if (true) return x; return y; } return w; }  return z;  }",
+            output: "function foo7() { if (true) { if (false) { if (true) return x; return y; } return w; } else { return z; } }",  // Other case is fixed in the second pass.
             errors: [
                 { message: "Unnecessary 'else' after 'return'.", type: "ReturnStatement" },
                 { message: "Unnecessary 'else' after 'return'.", type: "BlockStatement" }
-            ],
-            multipass: true
+            ]
         },
         {
             code: "function foo8() { if (true) { if (false) { if (true) return x; else return y; } else { w = x; } } else { return z; } }",
-            output: "function foo8() { if (true) { if (false) { if (true) return x; return y; }  w = x;  } else { return z; } }",
+            output: "function foo8() { if (true) { if (false) { if (true) return x; return y; } else { w = x; } } else { return z; } }",  // Other case is fixed in the second pass.
             errors: [
                 { message: "Unnecessary 'else' after 'return'.", type: "ReturnStatement" },
                 { message: "Unnecessary 'else' after 'return'.", type: "BlockStatement" }
-            ],
-            multipass: true
+            ]
         },
         {
             code: "function foo9() {if (x) { return true; } else if (y) { return true; } else { notAReturn(); } }",

--- a/tests/lib/rules/no-useless-return.js
+++ b/tests/lib/rules/no-useless-return.js
@@ -215,7 +215,8 @@ ruleTester.run("no-useless-return", rule, {
             errors: [
                 { message: "Unnecessary return statement.", type: "ReturnStatement" },
                 { message: "Unnecessary return statement.", type: "ReturnStatement" }
-            ]
+            ],
+            multipass: true
         },
         {
             code: `
@@ -420,7 +421,8 @@ ruleTester.run("no-useless-return", rule, {
             errors: [
                 { message: "Unnecessary return statement.", type: "ReturnStatement" },
                 { message: "Unnecessary return statement.", type: "ReturnStatement" }
-            ]
+            ],
+            multipass: true
         }
     ].map(invalidCase => Object.assign({ errors: [{ message: "Unnecessary return statement.", type: "ReturnStatement" }] }, invalidCase))
 });

--- a/tests/lib/rules/no-useless-return.js
+++ b/tests/lib/rules/no-useless-return.js
@@ -209,14 +209,13 @@ ruleTester.run("no-useless-return", rule, {
                 if (foo) {
                   
                 }
-                
+                return;
               }
-            `,
+            `,  // Other case is fixed in the second pass.
             errors: [
                 { message: "Unnecessary return statement.", type: "ReturnStatement" },
                 { message: "Unnecessary return statement.", type: "ReturnStatement" }
-            ],
-            multipass: true
+            ]
         },
         {
             code: `
@@ -417,12 +416,11 @@ ruleTester.run("no-useless-return", rule, {
         },
         {
             code: "function foo() { return; return; }",
-            output: "function foo() {   }",
+            output: "function foo() {  return; }",  // Other case is fixed in the second pass.
             errors: [
                 { message: "Unnecessary return statement.", type: "ReturnStatement" },
                 { message: "Unnecessary return statement.", type: "ReturnStatement" }
-            ],
-            multipass: true
+            ]
         }
     ].map(invalidCase => Object.assign({ errors: [{ message: "Unnecessary return statement.", type: "ReturnStatement" }] }, invalidCase))
 });

--- a/tests/lib/util/fix-tracker.js
+++ b/tests/lib/util/fix-tracker.js
@@ -1,0 +1,124 @@
+/**
+ * @fileoverview Tests for FixTracker.
+ * @author Alan Pierce
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const assert = require("chai").assert,
+    espree = require("espree"),
+    FixTracker = require("../../../lib/util/fix-tracker"),
+    ruleFixer = require("../../../lib/util/rule-fixer"),
+    SourceCode = require("../../../lib/util/source-code"),
+    Traverser = require("../../../lib/util/traverser");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+const DEFAULT_CONFIG = {
+    ecmaVersion: 6,
+    comment: true,
+    tokens: true,
+    range: true,
+    loc: true
+};
+
+/**
+ * Create a SourceCode instance from the given code. Also add parent pointers in
+ * the AST so that parent traversals will work.
+ *
+ * @param {string} text The text of the code.
+ * @returns {SourceCode} The SourceCode.
+ */
+function createSourceCode(text) {
+    const ast = espree.parse(text, DEFAULT_CONFIG);
+
+    new Traverser().traverse(ast, {
+        enter(node, parent) {
+            node.parent = parent;
+        }
+    });
+
+    return new SourceCode(text, ast);
+}
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+describe("FixTracker", () => {
+    describe("replaceTextRange", () => {
+        it("should expand to include an explicitly retained range", () => {
+            const sourceCode = createSourceCode("var foo = +bar;");
+            const result = new FixTracker(ruleFixer, sourceCode)
+                .retainRange([4, 14])
+                .replaceTextRange([10, 11], "-");
+
+            assert.deepEqual(result, {
+                range: [4, 14],
+                text: "foo = -bar"
+            });
+        });
+    });
+
+    describe("remove", () => {
+        it("should expand to include an explicitly retained range", () => {
+            const sourceCode = createSourceCode("a = b + +c");
+            const result = new FixTracker(ruleFixer, sourceCode)
+                .retainRange([4, 10])
+                .remove(sourceCode.ast.tokens[4]);
+
+            assert.deepEqual(result, {
+                range: [4, 10],
+                text: "b + c"
+            });
+        });
+    });
+
+    describe("retainEnclosingFunction", () => {
+        it("handles a normal enclosing function", () => {
+            const sourceCode = createSourceCode("f = function() { return x; }");
+            const xNode = sourceCode.ast.body[0].expression.right.body.body[0].argument;
+            const result = new FixTracker(ruleFixer, sourceCode)
+                .retainEnclosingFunction(xNode)
+                .replaceTextRange(xNode.range, "y");
+
+            assert.deepEqual(result, {
+                range: [4, 28],
+                text: "function() { return y; }"
+            });
+        });
+
+        it("handles the case when there is no enclosing function", () => {
+            const sourceCode = createSourceCode("const a = b;");
+            const bNode = sourceCode.ast.body[0].declarations[0].init;
+            const result = new FixTracker(ruleFixer, sourceCode)
+                .retainEnclosingFunction(bNode)
+                .replaceTextRange(bNode.range, "c");
+
+            assert.deepEqual(result, {
+                range: [0, 12],
+                text: "const a = c;"
+            });
+        });
+    });
+
+    describe("retainSurroungingTokens", () => {
+        it("handles a change to a binary operator", () => {
+            const sourceCode = createSourceCode("const i = j + k;");
+            const plusToken = sourceCode.ast.tokens[4];
+            const result = new FixTracker(ruleFixer, sourceCode)
+                .retainSurroundingTokens(plusToken)
+                .replaceTextRange(plusToken.range, "*");
+
+            assert.deepEqual(result, {
+                range: [10, 15],
+                text: "j * k"
+            });
+        });
+    });
+});

--- a/tests/lib/util/fix-tracker.js
+++ b/tests/lib/util/fix-tracker.js
@@ -63,6 +63,29 @@ describe("FixTracker", () => {
                 text: "foo = -bar"
             });
         });
+
+        it("ignores a retained range that's smaller than the replaced range", () => {
+            const sourceCode = createSourceCode("abcdefghij");
+            const result = new FixTracker(ruleFixer, sourceCode)
+                .retainRange([5, 7])
+                .replaceTextRange([4, 8], "123");
+
+            assert.deepEqual(result, {
+                range: [4, 8],
+                text: "123"
+            });
+        });
+
+        it("allows an unspecified retained range", () => {
+            const sourceCode = createSourceCode("abcdefghij");
+            const result = new FixTracker(ruleFixer, sourceCode)
+                .replaceTextRange([4, 8], "123");
+
+            assert.deepEqual(result, {
+                range: [4, 8],
+                text: "123"
+            });
+        });
     });
 
     describe("remove", () => {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

See #7928 and #8026 for details.

**What changes did you make? (Give an overview)**

As discussed in #7928, this commit modifies the `no-else-return`,
`no-useless-return`, `semi`, and `no-extra-semi` rules to generate fix commands
with a larger range to avoid conflicting fixes being applied in the same pass. For
the first two, the entire enclosing function is "locked", and for the semicolon rules,
just the surrounding tokens are "locked".

This works using a new internal `FixTracker` class, which is sort of a builder-style
class that allows the rule to specify the range to retain and then supply an
operation, and the class figures out the final text replacement.

In the future, `FixTracker` could also allow multiple replacement operations,
e.g. to make the `no-extra-parens` code a little simpler. It also might be
useful as a public API in the future.

**Is there anything you'd like reviewers to focus on?**

Some minor things:
* Is there another API style that would be preferred rather than the fluent class approach for `FixTracker`?
* Is there a better place for the new tests than `tests/lib/cli-engine.js`? From what I could tell, there weren't really existing tests like this (that test the interaction between different rules after multiple passes).

Also, this is my second PR, so it wouldn't surprise me if I got some style-related things wrong.