### PR TITLE
Docs: Add details about "--fix" option for "sort-imports" rule

### DIFF
--- a/docs/rules/sort-imports.md
+++ b/docs/rules/sort-imports.md
@@ -1,5 +1,7 @@
 # Import Sorting (sort-imports)
 
+(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 The import statement is used to import members (functions, objects or primitives) that have been exported from an external module. Using a specific member syntax:
 
 ```js
@@ -26,6 +28,8 @@ When declaring multiple imports, a sorted list of import declarations make it ea
 ## Rule Details
 
 This rule checks all import declarations and verifies that all imports are first sorted by the used member syntax and then alphabetically by the first member or alias name.
+
+The `--fix` option on the command line automatically fixes some problems reported by this rule: multiple members on a single line are automatically sorted (e.g. `import { b, a } from 'foo.js'` is corrected to `import { a, b } from 'foo.js'`), but multiple lines are not reordered.
 
 ## Options
 

--- a/docs/rules/sort-imports.md
+++ b/docs/rules/sort-imports.md
@@ -1,7 +1,5 @@
 # Import Sorting (sort-imports)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 The import statement is used to import members (functions, objects or primitives) that have been exported from an external module. Using a specific member syntax:
 
 ```js


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update

**What changes did you make? (Give an overview)**
I removed the "fixable" statement from the `sort-imports` rule, as it is not actually supported (see #6866).

**Is there anything you'd like reviewers to focus on?**
Nope.


