### PR TITLE
Chore: fix the timing to define rules for tests

### DIFF
--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -147,6 +147,12 @@ function RuleTester(testerConfig) {
         lodash.cloneDeep(defaultConfig),
         testerConfig
     );
+
+    /**
+     * Rule definitions to define before tests.
+     * @type {Object}
+     */
+    this.rules = {};
 }
 
 /**
@@ -239,7 +245,7 @@ RuleTester.prototype = {
      * @returns {void}
      */
     defineRule(name, rule) {
-        eslint.defineRule(name, rule);
+        this.rules[name] = rule;
     },
 
     /**
@@ -508,6 +514,7 @@ RuleTester.prototype = {
             RuleTester.describe("valid", () => {
                 test.valid.forEach(valid => {
                     RuleTester.it(valid.code || valid, () => {
+                        eslint.defineRules(this.rules);
                         testValidTemplate(ruleName, valid);
                     });
                 });
@@ -516,6 +523,7 @@ RuleTester.prototype = {
             RuleTester.describe("invalid", () => {
                 test.invalid.forEach(invalid => {
                     RuleTester.it(invalid.code, () => {
+                        eslint.defineRules(this.rules);
                         testInvalidTemplate(ruleName, invalid);
                     });
                 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Other, please explain:

**What changes did you make? (Give an overview)**

This PR changes the timing to define rules for tests.

Because `tests/lib/rules.js` resets rules in `beforeEach` handler, `RuleTester.define` does not work the following case.

```
$ mocha "tests/lib/rules.js" "tests/lib/rules/no-unused-vars.js" --reporter progress
```

<details><summary>Result:</summary>

```
 [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]

  207 passing (888ms)
  3 failing

  1) no-unused-vars valid /*eslint use-every-a:1*/ var a;:
     Error: undefined line 1:
        Configuration for rule "use-every-a" is invalid:
Cannot read property 'meta' of undefined
      at Object.validateRuleOptions (C:\Users\starc\Documents\GitHub\eslint\lib\config\config-validator.js:109:15)
      at Object.keys.forEach.name (C:\Users\starc\Documents\GitHub\eslint\lib\eslint.js:368:39)
      at Array.forEach (native)
      at ast.comments.forEach.comment (C:\Users\starc\Documents\GitHub\eslint\lib\eslint.js:365:44)
      at Array.forEach (native)
      at modifyConfigsFromComments (C:\Users\starc\Documents\GitHub\eslint\lib\eslint.js:331:18)
      at EventEmitter.module.exports.api.verify (C:\Users\starc\Documents\GitHub\eslint\lib\eslint.js:833:26)
      at runRuleForItem (C:\Users\starc\Documents\GitHub\eslint\lib\testers\rule-tester.js:380:38)
      at testValidTemplate (C:\Users\starc\Documents\GitHub\eslint\lib\testers\rule-tester.js:413:28)
      at Context.RuleTester.it (C:\Users\starc\Documents\GitHub\eslint\lib\testers\rule-tester.js:511:25)
      at callFn (C:\Users\starc\nodist\bin\node_modules\mocha\lib\runnable.js:326:21)
      at Test.Runnable.run (C:\Users\starc\nodist\bin\node_modules\mocha\lib\runnable.js:319:7)
      at Runner.runTest (C:\Users\starc\nodist\bin\node_modules\mocha\lib\runner.js:422:10)
      at C:\Users\starc\nodist\bin\node_modules\mocha\lib\runner.js:528:12
      at next (C:\Users\starc\nodist\bin\node_modules\mocha\lib\runner.js:342:14)
      at C:\Users\starc\nodist\bin\node_modules\mocha\lib\runner.js:352:7
      at next (C:\Users\starc\nodist\bin\node_modules\mocha\lib\runner.js:284:14)
      at Immediate._onImmediate (C:\Users\starc\nodist\bin\node_modules\mocha\lib\runner.js:320:5)

  2) no-unused-vars valid /*eslint use-every-a:1*/ !function(a) { return 1; }:
     Error: undefined line 1:
        Configuration for rule "use-every-a" is invalid:
Cannot read property 'meta' of undefined
      at Object.validateRuleOptions (C:\Users\starc\Documents\GitHub\eslint\lib\config\config-validator.js:109:15)
      at Object.keys.forEach.name (C:\Users\starc\Documents\GitHub\eslint\lib\eslint.js:368:39)
      at Array.forEach (native)
      at ast.comments.forEach.comment (C:\Users\starc\Documents\GitHub\eslint\lib\eslint.js:365:44)
      at Array.forEach (native)
      at modifyConfigsFromComments (C:\Users\starc\Documents\GitHub\eslint\lib\eslint.js:331:18)
      at EventEmitter.module.exports.api.verify (C:\Users\starc\Documents\GitHub\eslint\lib\eslint.js:833:26)
      at runRuleForItem (C:\Users\starc\Documents\GitHub\eslint\lib\testers\rule-tester.js:380:38)
      at testValidTemplate (C:\Users\starc\Documents\GitHub\eslint\lib\testers\rule-tester.js:413:28)
      at Context.RuleTester.it (C:\Users\starc\Documents\GitHub\eslint\lib\testers\rule-tester.js:511:25)
      at callFn (C:\Users\starc\nodist\bin\node_modules\mocha\lib\runnable.js:326:21)
      at Test.Runnable.run (C:\Users\starc\nodist\bin\node_modules\mocha\lib\runnable.js:319:7)
      at Runner.runTest (C:\Users\starc\nodist\bin\node_modules\mocha\lib\runner.js:422:10)
      at C:\Users\starc\nodist\bin\node_modules\mocha\lib\runner.js:528:12
      at next (C:\Users\starc\nodist\bin\node_modules\mocha\lib\runner.js:342:14)
      at C:\Users\starc\nodist\bin\node_modules\mocha\lib\runner.js:352:7
      at next (C:\Users\starc\nodist\bin\node_modules\mocha\lib\runner.js:284:14)
      at Immediate._onImmediate (C:\Users\starc\nodist\bin\node_modules\mocha\lib\runner.js:320:5)

  3) no-unused-vars valid /*eslint use-every-a:1*/ !function() { var a; return 1 }:
     Error: undefined line 1:
        Configuration for rule "use-every-a" is invalid:
Cannot read property 'meta' of undefined
      at Object.validateRuleOptions (C:\Users\starc\Documents\GitHub\eslint\lib\config\config-validator.js:109:15)
      at Object.keys.forEach.name (C:\Users\starc\Documents\GitHub\eslint\lib\eslint.js:368:39)
      at Array.forEach (native)
      at ast.comments.forEach.comment (C:\Users\starc\Documents\GitHub\eslint\lib\eslint.js:365:44)
      at Array.forEach (native)
      at modifyConfigsFromComments (C:\Users\starc\Documents\GitHub\eslint\lib\eslint.js:331:18)
      at EventEmitter.module.exports.api.verify (C:\Users\starc\Documents\GitHub\eslint\lib\eslint.js:833:26)
      at runRuleForItem (C:\Users\starc\Documents\GitHub\eslint\lib\testers\rule-tester.js:380:38)
      at testValidTemplate (C:\Users\starc\Documents\GitHub\eslint\lib\testers\rule-tester.js:413:28)
      at Context.RuleTester.it (C:\Users\starc\Documents\GitHub\eslint\lib\testers\rule-tester.js:511:25)
      at callFn (C:\Users\starc\nodist\bin\node_modules\mocha\lib\runnable.js:326:21)
      at Test.Runnable.run (C:\Users\starc\nodist\bin\node_modules\mocha\lib\runnable.js:319:7)
      at Runner.runTest (C:\Users\starc\nodist\bin\node_modules\mocha\lib\runner.js:422:10)
      at C:\Users\starc\nodist\bin\node_modules\mocha\lib\runner.js:528:12
      at next (C:\Users\starc\nodist\bin\node_modules\mocha\lib\runner.js:342:14)
      at C:\Users\starc\nodist\bin\node_modules\mocha\lib\runner.js:352:7
      at next (C:\Users\starc\nodist\bin\node_modules\mocha\lib\runner.js:284:14)
      at Immediate._onImmediate (C:\Users\starc\nodist\bin\node_modules\mocha\lib\runner.js:320:5)
```

</details>

.

1. `tests/lib/rules/no-unused-vars.js` defines `use-every-a` rule on the top.
2. `tests/lib/rules.js` set the `beforeEach` handler to reset rules.
3. It runs the `beforeEach` handler, then it removes `use-every-a` rule.
4. The testcases of `tests/lib/rules/no-unused-vars.js` use `use-every-a` rule, but it's not defined.

So this PR moves the timing which defines rules to "before each test".

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.
