### PR TITLE
Fix: unicode-bom fixer insert BOM in appropriate location (fixes #8083)

### DIFF
--- a/lib/rules/unicode-bom.js
+++ b/lib/rules/unicode-bom.js
@@ -45,7 +45,7 @@ module.exports = {
                         loc: location,
                         message: "Expected Unicode BOM (Byte Order Mark).",
                         fix(fixer) {
-                            return fixer.insertTextBefore(node, "\uFEFF");
+                            return fixer.insertTextBeforeRange([0, 1], "\uFEFF");
                         }
                     });
                 } else if (sourceCode.hasBOM && (requireBOM === "never")) {

--- a/tests/lib/rules/unicode-bom.js
+++ b/tests/lib/rules/unicode-bom.js
@@ -42,6 +42,12 @@ ruleTester.run("unicode-bom", rule, {
             output: "\uFEFFvar a = 123;"
         },
         {
+            code: " // here's a comment \nvar a = 123;",
+            errors: [{ message: "Expected Unicode BOM (Byte Order Mark).", type: "Program" }],
+            options: ["always"],
+            output: "\uFEFF // here's a comment \nvar a = 123;"
+        },
+        {
             code: "\uFEFF var a = 123;",
             errors: [{ message: "Unexpected Unicode BOM (Byte Order Mark).", type: "Program" }],
             output: " var a = 123;"


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
See issue [#8083](https://github.com/eslint/eslint/issues/8083)
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Insert BOM at specific location using `fixer.insertTextBeforeRange()` instead before node. Because node range doesn't include comments.

**Is there anything you'd like reviewers to focus on?**
nothing