### PR TITLE
Docs: Add TSC meeting quorum requirement

### DIFF
--- a/docs/maintainer-guide/governance.md
+++ b/docs/maintainer-guide/governance.md
@@ -122,6 +122,10 @@ members of the TSC. TSC members can add any items they like to the
 agenda at the beginning of each meeting. The moderator and the TSC
 cannot veto or remove items.
 
+No binding votes on TSC agenda items can take place without a quorum of
+TSC members present in the meeting. Quorum is achieved when more than
+half of the TSC members are present.
+
 The TSC may invite persons or representatives from certain projects to
 participate in a non-voting capacity.
 


### PR DESCRIPTION
Adding a note about TSC meetings requiring a quorum of more than half of the TSC being present at meetings in order to vote on any agenda items.

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Updated governance documentation to clarify that TSC meetings do not allow voting on issues unless a quorum of members are present.

This is not meant to be a process change: the TSC has been following this unwritten rule since it was formed. However, it was not documented on the governance page.

**Is there anything you'd like reviewers to focus on?**

Yes: I want to make sure that what I've written is actually what's being followed. My goal is not to propose a process change, but rather to document what seems to be the existing process. Let me know if this should go on the TSC Agenda to get the appropriate oversight.