### PR TITLE
Add option to ignore property in no-param-reassign

### DIFF
--- a/docs/rules/no-param-reassign.md
+++ b/docs/rules/no-param-reassign.md
@@ -34,7 +34,7 @@ function foo(bar) {
 
 ## Options
 
-This rule takes one option, an object, with a boolean property `"props"`. It is `false` by default. If it is set to `true`, this rule warns against the modification of parameter properties.
+This rule takes one option, an object, with a boolean property `"props"` and an array `"ignorePropertyAssignmentsFor"`. `"props"` is `false` by default. If `"props"` is set to `true`, this rule warns against the modification of parameter properties unless they're included in `"ignorePropertyAssignmentsFor"`, which is an empty object by default.
 
 ### props
 

--- a/docs/rules/no-param-reassign.md
+++ b/docs/rules/no-param-reassign.md
@@ -34,7 +34,7 @@ function foo(bar) {
 
 ## Options
 
-This rule takes one option, an object, with a boolean property `"props"` and an array `"ignorePropertyAssignmentsFor"`. `"props"` is `false` by default. If `"props"` is set to `true`, this rule warns against the modification of parameter properties unless they're included in `"ignorePropertyAssignmentsFor"`, which is an empty array by default.
+This rule takes one option, an object, with a boolean property `"props"` and an array `"ignorePropertyModificationsFor"`. `"props"` is `false` by default. If `"props"` is set to `true`, this rule warns against the modification of parameter properties unless they're included in `"ignorePropertyModificationsFor"`, which is an empty array by default.
 
 ### props
 
@@ -74,10 +74,10 @@ function foo(bar) {
 }
 ```
 
-Examples of **correct** code for the `{ "props": true }` option with `"ignorePropertyAssignmentsFor"` set:
+Examples of **correct** code for the `{ "props": true }` option with `"ignorePropertyModificationsFor"` set:
 
 ```js
-/*eslint no-param-reassign: ["error", { "props": true, "ignorePropertyAssignmentsFor": ["bar"] }]*/
+/*eslint no-param-reassign: ["error", { "props": true, "ignorePropertyModificationsFor": ["bar"] }]*/
 
 function foo(bar) {
     bar.prop = "value";

--- a/docs/rules/no-param-reassign.md
+++ b/docs/rules/no-param-reassign.md
@@ -34,7 +34,7 @@ function foo(bar) {
 
 ## Options
 
-This rule takes one option, an object, with a boolean property `"props"` and an array `"ignorePropertyAssignmentsFor"`. `"props"` is `false` by default. If `"props"` is set to `true`, this rule warns against the modification of parameter properties unless they're included in `"ignorePropertyAssignmentsFor"`, which is an empty object by default.
+This rule takes one option, an object, with a boolean property `"props"` and an array `"ignorePropertyAssignmentsFor"`. `"props"` is `false` by default. If `"props"` is set to `true`, this rule warns against the modification of parameter properties unless they're included in `"ignorePropertyAssignmentsFor"`, which is an empty array by default.
 
 ### props
 
@@ -73,6 +73,25 @@ function foo(bar) {
     bar.aaa++;
 }
 ```
+
+Examples of **correct** code for the `{ "props": true }` option with `"ignorePropertyAssignmentsFor" set:
+
+```js
+/*eslint no-param-reassign: ["error", { "props": true, "ignorePropertyAssignmentsFor": ["bar"] }]*/
+
+function foo(bar) {
+    bar.prop = "value";
+}
+
+function foo(bar) {
+    delete bar.aaa;
+}
+
+function foo(bar) {
+    bar.aaa++;
+}
+```
+
 
 ## When Not To Use It
 

--- a/docs/rules/no-param-reassign.md
+++ b/docs/rules/no-param-reassign.md
@@ -74,7 +74,7 @@ function foo(bar) {
 }
 ```
 
-Examples of **correct** code for the `{ "props": true }` option with `"ignorePropertyAssignmentsFor" set:
+Examples of **correct** code for the `{ "props": true }` option with `"ignorePropertyAssignmentsFor"` set:
 
 ```js
 /*eslint no-param-reassign: ["error", { "props": true, "ignorePropertyAssignmentsFor": ["bar"] }]*/

--- a/lib/rules/no-param-reassign.js
+++ b/lib/rules/no-param-reassign.js
@@ -40,7 +40,8 @@ module.exports = {
                                 type: "array",
                                 items: {
                                     type: "string"
-                                }
+                                },
+                                uniqueItems: true
                             }
                         },
                         additionalProperties: false

--- a/lib/rules/no-param-reassign.js
+++ b/lib/rules/no-param-reassign.js
@@ -20,17 +20,32 @@ module.exports = {
 
         schema: [
             {
-                type: "object",
-                properties: {
-                    props: { type: "boolean" },
-                    ignorePropertyAssignmentsFor: {
-                        type: "array",
-                        items: {
-                            type: "string"
-                        }
+                oneOf: [
+                    {
+                        type: "object",
+                        properties: {
+                            props: {
+                                enum: [false]
+                            }
+                        },
+                        additionalProperties: false
+                    },
+                    {
+                        type: "object",
+                        properties: {
+                            props: {
+                                enum: [true]
+                            },
+                            ignorePropertyAssignmentsFor: {
+                                type: "array",
+                                items: {
+                                    type: "string"
+                                }
+                            }
+                        },
+                        additionalProperties: false
                     }
-                },
-                additionalProperties: false
+                ]
             }
         ]
     },

--- a/lib/rules/no-param-reassign.js
+++ b/lib/rules/no-param-reassign.js
@@ -22,7 +22,13 @@ module.exports = {
             {
                 type: "object",
                 properties: {
-                    props: { type: "boolean" }
+                    props: { type: "boolean" },
+                    ignorePropertyAssignmentsFor: {
+                        type: "array",
+                        items: {
+                            type: "string"
+                        }
+                    }
                 },
                 additionalProperties: false
             }
@@ -31,6 +37,7 @@ module.exports = {
 
     create(context) {
         const props = context.options[0] && Boolean(context.options[0].props);
+        const ignoredPropertyAssignmentsFor = context.options[0] && context.options[0].ignorePropertyAssignmentsFor || [];
 
         /**
          * Checks whether or not the reference modifies properties of its variable.
@@ -103,7 +110,7 @@ module.exports = {
             ) {
                 if (reference.isWrite()) {
                     context.report({ node: identifier, message: "Assignment to function parameter '{{name}}'.", data: { name: identifier.name } });
-                } else if (props && isModifyingProp(reference)) {
+                } else if (props && isModifyingProp(reference) && ignoredPropertyAssignmentsFor.indexOf(identifier.name) === -1) {
                     context.report({ node: identifier, message: "Assignment to property of function parameter '{{name}}'.", data: { name: identifier.name } });
                 }
             }

--- a/lib/rules/no-param-reassign.js
+++ b/lib/rules/no-param-reassign.js
@@ -36,7 +36,7 @@ module.exports = {
                             props: {
                                 enum: [true]
                             },
-                            ignorePropertyAssignmentsFor: {
+                            ignorePropertyModificationsFor: {
                                 type: "array",
                                 items: {
                                     type: "string"
@@ -53,7 +53,7 @@ module.exports = {
 
     create(context) {
         const props = context.options[0] && Boolean(context.options[0].props);
-        const ignoredPropertyAssignmentsFor = context.options[0] && context.options[0].ignorePropertyAssignmentsFor || [];
+        const ignoredPropertyAssignmentsFor = context.options[0] && context.options[0].ignorePropertyModificationsFor || [];
 
         /**
          * Checks whether or not the reference modifies properties of its variable.

--- a/tests/lib/rules/no-param-reassign.js
+++ b/tests/lib/rules/no-param-reassign.js
@@ -30,7 +30,8 @@ ruleTester.run("no-param-reassign", rule, {
         { code: "function foo(a) { [a.b] = []; }", parserOptions: { ecmaVersion: 6 } },
         { code: "function foo(a) { bar(a.b).c = 0; }", options: [{ props: true }] },
         { code: "function foo(a) { data[a.b] = 0; }", options: [{ props: true }] },
-        { code: "function foo(a) { +a.b; }", options: [{ props: true }] }
+        { code: "function foo(a) { +a.b; }", options: [{ props: true }] },
+        { code: "function foo(a) { a.b = 0; }", options: [{ props: true, ignorePropertyAssignmentsFor: ["a"] }] }
     ],
 
     invalid: [

--- a/tests/lib/rules/no-param-reassign.js
+++ b/tests/lib/rules/no-param-reassign.js
@@ -34,7 +34,8 @@ ruleTester.run("no-param-reassign", rule, {
         { code: "function foo(a) { a.b = 0; }", options: [{ props: true, ignorePropertyModificationsFor: ["a"] }] },
         { code: "function foo(a) { ++a.b; }", options: [{ props: true, ignorePropertyModificationsFor: ["a"] }] },
         { code: "function foo(a) { delete a.b; }", options: [{ props: true, ignorePropertyModificationsFor: ["a"] }] },
-        { code: "function foo(a, z) { a.b = 0; x.y = 0; }", options: [{ props: true, ignorePropertyModificationsFor: ["a", "x"] }] }
+        { code: "function foo(a, z) { a.b = 0; x.y = 0; }", options: [{ props: true, ignorePropertyModificationsFor: ["a", "x"] }] },
+        { code: "function foo(a) { a.b.c = 0;}", options: [{ props: true, ignorePropertyModificationsFor: ["a"] }] }
     ],
 
     invalid: [

--- a/tests/lib/rules/no-param-reassign.js
+++ b/tests/lib/rules/no-param-reassign.js
@@ -31,7 +31,8 @@ ruleTester.run("no-param-reassign", rule, {
         { code: "function foo(a) { bar(a.b).c = 0; }", options: [{ props: true }] },
         { code: "function foo(a) { data[a.b] = 0; }", options: [{ props: true }] },
         { code: "function foo(a) { +a.b; }", options: [{ props: true }] },
-        { code: "function foo(a) { a.b = 0; }", options: [{ props: true, ignorePropertyAssignmentsFor: ["a"] }] }
+        { code: "function foo(a) { a.b = 0; }", options: [{ props: true, ignorePropertyAssignmentsFor: ["a"] }] },
+        { code: "function foo(a, z) { a.b = 0; x.y = 0; }", options: [{ props: true, ignorePropertyAssignmentsFor: ["a", "x"] }] }
     ],
 
     invalid: [
@@ -71,6 +72,12 @@ ruleTester.run("no-param-reassign", rule, {
             code: "function foo(bar) { [bar.a] = []; }",
             parserOptions: { ecmaVersion: 6 },
             options: [{ props: true }],
+            errors: [{ message: "Assignment to property of function parameter 'bar'." }]
+        },
+        {
+            code: "function foo(bar) { [bar.a] = []; }",
+            parserOptions: { ecmaVersion: 6 },
+            options: [{ props: true, ignorePropertyAssignmentsFor: ["a"] }],
             errors: [{ message: "Assignment to property of function parameter 'bar'." }]
         }
     ]

--- a/tests/lib/rules/no-param-reassign.js
+++ b/tests/lib/rules/no-param-reassign.js
@@ -31,8 +31,8 @@ ruleTester.run("no-param-reassign", rule, {
         { code: "function foo(a) { bar(a.b).c = 0; }", options: [{ props: true }] },
         { code: "function foo(a) { data[a.b] = 0; }", options: [{ props: true }] },
         { code: "function foo(a) { +a.b; }", options: [{ props: true }] },
-        { code: "function foo(a) { a.b = 0; }", options: [{ props: true, ignorePropertyAssignmentsFor: ["a"] }] },
-        { code: "function foo(a, z) { a.b = 0; x.y = 0; }", options: [{ props: true, ignorePropertyAssignmentsFor: ["a", "x"] }] }
+        { code: "function foo(a) { a.b = 0; }", options: [{ props: true, ignorePropertyModificationsFor: ["a"] }] },
+        { code: "function foo(a, z) { a.b = 0; x.y = 0; }", options: [{ props: true, ignorePropertyModificationsFor: ["a", "x"] }] }
     ],
 
     invalid: [
@@ -77,7 +77,7 @@ ruleTester.run("no-param-reassign", rule, {
         {
             code: "function foo(bar) { [bar.a] = []; }",
             parserOptions: { ecmaVersion: 6 },
-            options: [{ props: true, ignorePropertyAssignmentsFor: ["a"] }],
+            options: [{ props: true, ignorePropertyModificationsFor: ["a"] }],
             errors: [{ message: "Assignment to property of function parameter 'bar'." }]
         }
     ]

--- a/tests/lib/rules/no-param-reassign.js
+++ b/tests/lib/rules/no-param-reassign.js
@@ -32,6 +32,8 @@ ruleTester.run("no-param-reassign", rule, {
         { code: "function foo(a) { data[a.b] = 0; }", options: [{ props: true }] },
         { code: "function foo(a) { +a.b; }", options: [{ props: true }] },
         { code: "function foo(a) { a.b = 0; }", options: [{ props: true, ignorePropertyModificationsFor: ["a"] }] },
+        { code: "function foo(a) { ++a.b; }", options: [{ props: true, ignorePropertyModificationsFor: ["a"] }] },
+        { code: "function foo(a) { delete a.b; }", options: [{ props: true, ignorePropertyModificationsFor: ["a"] }] },
         { code: "function foo(a, z) { a.b = 0; x.y = 0; }", options: [{ props: true, ignorePropertyModificationsFor: ["a", "x"] }] }
     ],
 


### PR DESCRIPTION
This adds code, tests, and documentation to the `no-param-reassign` rule to implement the `ignoredPropertyAssignmentsFor` option exactly as proposed by @platinumazure in [this comment](https://github.com/eslint/eslint/issues/6505#issuecomment-269525748)).

Obviously this is very similar to #6504, but was written independently so as not to merge non-CLA'd code into the ESLint codebase. Please let me know if you have any questions or change requests, thanks!

Fix #6505