### PR TITLE
Incorrect source code test text

### DIFF
--- a/tests/lib/util/source-code.js
+++ b/tests/lib/util/source-code.js
@@ -77,7 +77,7 @@ describe("SourceCode", () => {
 
         });
 
-        it("should throw an error when called with an AST that's missing comments", () => {
+        it("should throw an error when called with an AST that's missing location", () => {
 
             assert.throws(() => {
                 new SourceCode("foo;", { comments: [], tokens: [], range: [] });
@@ -85,7 +85,7 @@ describe("SourceCode", () => {
 
         });
 
-        it("should throw an error when called with an AST that's missing comments", () => {
+        it("should throw an error when called with an AST that's missing range", () => {
 
             assert.throws(() => {
                 new SourceCode("foo;", { comments: [], tokens: [], loc: {} });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

I changed the description for two tests covering `source-code.js`

**Is there anything you'd like reviewers to focus on?**

Not really. In trying to figure out how to write a fixer for `prefer-destructuring`, I discovered this small issue
