### PR TITLE
Fix: check output in RuleTester when errors is a number (fixes #7640)

### DIFF
--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -494,13 +494,12 @@ RuleTester.prototype = {
                         assert.fail(messages[i], null, "Error should be a string or object.");
                     }
                 }
+            }
 
-                if (item.hasOwnProperty("output")) {
-                    const fixResult = SourceCodeFixer.applyFixes(eslint.getSourceCode(), messages);
+            if (item.hasOwnProperty("output")) {
+                const fixResult = SourceCodeFixer.applyFixes(eslint.getSourceCode(), messages);
 
-                    assert.equal(fixResult.output, item.output, "Output is incorrect.");
-                }
-
+                assert.equal(fixResult.output, item.output, "Output is incorrect.");
             }
 
             assertASTDidntChange(result.beforeAST, result.afterAST);

--- a/tests/lib/rules/spaced-comment.js
+++ b/tests/lib/rules/spaced-comment.js
@@ -386,18 +386,6 @@ ruleTester.run("spaced-comment", rule, {
             }]
         },
         {
-            code: invalidShebangProgram,
-            output: "#!/path/to/node\n#!/second/shebang\nvar a = 3;",
-            errors: 1,
-            options: ["always"]
-        },
-        {
-            code: invalidShebangProgram,
-            output: "#!/path/to/node\n#!/second/shebang\nvar a = 3;",
-            errors: 1,
-            options: ["never"]
-        },
-        {
             code: "var a = 1; /* A valid comment starting with space */",
             output: "var a = 1; /*A valid comment starting with space */",
             options: ["never"],
@@ -584,6 +572,18 @@ ruleTester.run("spaced-comment", rule, {
                 message: "Unexpected space or tab before '*/' in comment.",
                 type: "Block"
             }]
+        },
+
+        // Parser errors
+        {
+            code: invalidShebangProgram,
+            errors: 1,
+            options: ["always"]
+        },
+        {
+            code: invalidShebangProgram,
+            errors: 1,
+            options: ["never"]
         }
     ]
 

--- a/tests/lib/testers/rule-tester.js
+++ b/tests/lib/testers/rule-tester.js
@@ -181,6 +181,20 @@ describe("RuleTester", () => {
         }, /Output is incorrect/);
     });
 
+    it("should throw an error when the expected output doesn't match and errors is just a number", () => {
+
+        assert.throws(() => {
+            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+                valid: [
+                    "bar = baz;"
+                ],
+                invalid: [
+                    { code: "var foo = bar;", output: "foo = bar", errors: 1 }
+                ]
+            });
+        }, /Output is incorrect/);
+    });
+
     it("should throw an error if invalid code specifies wrong type", () => {
 
         assert.throws(() => {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Ensure `output` is checked when `errors` is a number in `RuleTester`.

The change revealed a couple of tests in `spaced-comments` where the output was wrong (there is no output because there is a parsing error) so I fixed those, too.

**Is there anything you'd like reviewers to focus on?**
No.

