### PR TITLE
New: Add "exceptions" option to space-infix-ops

### DIFF
--- a/docs/rules/space-infix-ops.md
+++ b/docs/rules/space-infix-ops.md
@@ -26,6 +26,8 @@ This rule accepts a single options argument with the following defaults:
 "space-infix-ops": ["error", {"int32Hint": false}]
 ```
 
+To avoid contradictions if other rules or conventions require different spacing, this rule has an `exceptions` option to ignore certain node types in the abstract syntax tree (AST) of JavaScript code.
+
 ### `int32Hint`
 
 Set the `int32Hint` option to `true` (default is `false`) to allow write `a|0` without space.
@@ -72,4 +74,96 @@ const a = {b:1};
 var {a = 0} = bar;
 
 function foo(a = 0) { }
+```
+
+### exceptions
+
+The `exceptions` object expects property names to be AST node types as defined by [ESTree](https://github.com/estree/estree). The easiest way to determine the node types for `exceptions` is to use the [online demo](http://eslint.org/parser).
+
+Possible node types are AssignmentPattern, AssignmentExpression, BinaryExpression, LogicalExpression, ConditionalExpression, VariableDeclarator.
+
+The `exceptions` object expects property values to be one of "always", "never", "ignore":
+"always" - enforce spaces around infix operators of the given node type
+"never" - enforce lack of spaces around infix operators of the given node type
+"ignore" - do not enforce spacing around infix operators of the given node type
+
+Examples of **correct** code for the `"exceptions": { "AssignmentPattern": "never" }` option:
+
+```js
+/*eslint space-infix-ops: ["error", { exceptions: { "AssignmentPattern": "never" } }]*/
+/*eslint-env es6*/
+
+var foo = (a=0) => a / 2;
+```
+
+Examples of **correct** code for the `"exceptions": { "BinaryExpression": "never" }` option:
+
+```js
+/*eslint space-infix-ops: ["error", { exceptions: { "BinaryExpression": "never" } }]*/
+/*eslint-env es6*/
+
+var foo = (a = 0) => a/2;
+```
+
+Examples of **correct** code for the `"exceptions": { "VariableDeclarator": "never" }` option:
+
+```js
+/*eslint space-infix-ops: ["error", { exceptions: { "VariableDeclarator": "never" } }]*/
+/*eslint-env es6*/
+
+var foo=(a = 0) => a / 2;
+```
+
+Examples of **correct** code for the `"exceptions": { "AssignmentPattern": "always" }` option:
+
+```js
+/*eslint space-infix-ops: ["error", { exceptions: { "AssignmentPattern": "always" } }]*/
+/*eslint-env es6*/
+
+var foo = (a = 0) => a / 2;
+```
+
+Examples of **correct** code for the `"exceptions": { "BinaryExpression": "always" }` option:
+
+```js
+/*eslint space-infix-ops: ["error", { exceptions: { "BinaryExpression": "always" } }]*/
+/*eslint-env es6*/
+
+var foo = (a = 0) => a / 2;
+```
+
+Examples of **correct** code for the `"exceptions": { "VariableDeclarator": "always" }` option:
+
+```js
+/*eslint space-infix-ops: ["error", { exceptions: { "VariableDeclarator": "always" } }]*/
+/*eslint-env es6*/
+
+var foo = (a = 0) => a / 2;
+```
+
+Examples of **correct** code for the `"exceptions": { "AssignmentPattern": "ignore" }` option:
+
+```js
+/*eslint space-infix-ops: ["error", { exceptions: { "AssignmentPattern": "ignore" } }]*/
+/*eslint-env es6*/
+
+var foo = (a= 0) => a / 2;
+```
+
+Examples of **correct** code for the `"exceptions": { "BinaryExpression": "ignore" }` option:
+
+```js
+/*eslint space-infix-ops: ["error", { exceptions: { "BinaryExpression": "ignore" } }]*/
+/*eslint-env es6*/
+
+var foo = (a = 0) => a /2;
+```
+
+Examples of **correct** code for the `"exceptions": { "VariableDeclarator": "ignore" }` option:
+
+```js
+/*eslint space-infix-ops: ["error", { exceptions: { "VariableDeclarator": "ignore" } }]*/
+/*eslint-env es6*/
+
+var foo= (a = 0) => a / 2;
 ```

--- a/lib/rules/space-infix-ops.js
+++ b/lib/rules/space-infix-ops.js
@@ -24,6 +24,15 @@ module.exports = {
                 properties: {
                     int32Hint: {
                         type: "boolean"
+                    },
+                    exceptions: {
+                        type: "object",
+                        patternProperties: {
+                            "^([A-Z][a-z]*)+$": {
+                                enum: ["always", "never", "ignore"]
+                            }
+                        },
+                        additionalProperties: false
                     }
                 },
                 additionalProperties: false
@@ -32,7 +41,21 @@ module.exports = {
     },
 
     create(context) {
-        const int32Hint = context.options[0] ? context.options[0].int32Hint === true : false;
+        const options = context.options[0];
+        const int32Hint = options ? options.int32Hint === true : false;
+        const exceptions = options && options.exceptions;
+        const neverExceptions = new Set();
+        const ignoreExceptions = new Set();
+
+        if (exceptions) {
+            Object.keys(exceptions).forEach(nodeType => {
+                if (exceptions[nodeType] === "never") {
+                    neverExceptions.add(nodeType);
+                } else if (exceptions[nodeType] === "ignore") {
+                    ignoreExceptions.add(nodeType);
+                }
+            });
+        }
 
         const OPERATORS = [
             "*", "/", "%", "+", "-", "<<", ">>", ">>>", "<", "<=", ">", ">=", "in",
@@ -47,19 +70,25 @@ module.exports = {
          * Returns the first token which violates the rule
          * @param {ASTNode} left - The left node of the main node
          * @param {ASTNode} right - The right node of the main node
+         * @param {boolean} never - How to apply the rule - "always", "never", or "ignore"
          * @returns {Object} The violator token or null
          * @private
          */
-        function getFirstNonSpacedToken(left, right) {
+        function getFirstNonSpacedToken(left, right, never) {
+            const comparator = never ? (a, b) => a < b : (a, b) => a >= b;
             const tokens = sourceCode.getTokensBetween(left, right, 1);
 
             for (let i = 1, l = tokens.length - 1; i < l; ++i) {
                 const op = tokens[i];
+                const opStart = op.range[0];
+                const opEnd = op.range[1];
+                const prevEnd = tokens[i - 1].range[1];
+                const nextStart = tokens[i + 1].range[0];
 
                 if (
                     (op.type === "Punctuator" || op.type === "Keyword") &&
                     OPERATORS.indexOf(op.value) >= 0 &&
-                    (tokens[i - 1].range[1] >= op.range[0] || op.range[1] >= tokens[i + 1].range[0])
+                    (comparator(prevEnd, opStart) || comparator(opEnd, nextStart))
                 ) {
                     return op;
                 }
@@ -71,26 +100,35 @@ module.exports = {
          * Reports an AST node as a rule violation
          * @param {ASTNode} mainNode - The node to report
          * @param {Object} culpritToken - The token which has a problem
+         * @param {boolean} never - Should lack of spaces be enforced?
          * @returns {void}
          * @private
          */
-        function report(mainNode, culpritToken) {
+        function report(mainNode, culpritToken, never) {
             context.report({
                 node: mainNode,
                 loc: culpritToken.loc.start,
                 message: "Infix operators must be spaced.",
                 fix(fixer) {
-                    const previousToken = sourceCode.getTokenBefore(culpritToken);
-                    const afterToken = sourceCode.getTokenAfter(culpritToken);
+                    const prevToken = sourceCode.getTokenBefore(culpritToken);
+                    const nextToken = sourceCode.getTokenAfter(culpritToken);
+                    const prevEnd = prevToken.range[1];
+                    const nextStart = nextToken.range[0];
+                    const culpritStart = culpritToken.range[0];
+                    const culpritEnd = culpritToken.range[1];
                     let fixString = "";
 
-                    if (culpritToken.range[0] - previousToken.range[1] === 0) {
-                        fixString = " ";
+                    if (never) {
+                        return fixer.replaceTextRange([prevEnd, nextStart], culpritToken.value);
+                    }
+
+                    if (culpritStart - prevEnd === 0) {
+                        fixString += " ";
                     }
 
                     fixString += culpritToken.value;
 
-                    if (afterToken.range[0] - culpritToken.range[1] === 0) {
+                    if (nextStart - culpritEnd === 0) {
                         fixString += " ";
                     }
 
@@ -101,58 +139,61 @@ module.exports = {
 
         /**
          * Check if the node is binary then report
-         * @param {ASTNode} node node to evaluate
+         * @param {ASTNode} node - The node to evaluate
+         * @param {boolean} never - Should lack of spaces be enforced?
          * @returns {void}
          * @private
          */
-        function checkBinary(node) {
+        function checkBinary(node, never) {
             if (node.left.typeAnnotation) {
                 return;
             }
 
-            const nonSpacedNode = getFirstNonSpacedToken(node.left, node.right);
+            const nonSpacedNode = getFirstNonSpacedToken(node.left, node.right, never);
 
             if (nonSpacedNode) {
                 if (!(int32Hint && sourceCode.getText(node).substr(-2) === "|0")) {
-                    report(node, nonSpacedNode);
+                    report(node, nonSpacedNode, never);
                 }
             }
         }
 
         /**
          * Check if the node is conditional
-         * @param {ASTNode} node node to evaluate
+         * @param {ASTNode} node - The node to evaluate
+         * @param {boolean} never - Should lack of spaces be enforced?
          * @returns {void}
          * @private
          */
-        function checkConditional(node) {
-            const nonSpacedConsequesntNode = getFirstNonSpacedToken(node.test, node.consequent);
-            const nonSpacedAlternateNode = getFirstNonSpacedToken(node.consequent, node.alternate);
+        function checkConditional(node, never) {
+            const nonSpacedConsequesntNode = getFirstNonSpacedToken(node.test, node.consequent, never);
+            const nonSpacedAlternateNode = getFirstNonSpacedToken(node.consequent, node.alternate, never);
 
             if (nonSpacedConsequesntNode) {
-                report(node, nonSpacedConsequesntNode);
+                report(node, nonSpacedConsequesntNode, never);
             } else if (nonSpacedAlternateNode) {
-                report(node, nonSpacedAlternateNode);
+                report(node, nonSpacedAlternateNode, never);
             }
         }
 
         /**
          * Check if the node is a variable
-         * @param {ASTNode} node node to evaluate
+         * @param {ASTNode} node - The node to evaluate
+         * @param {boolean} never - Should lack of spaces be enforced?
          * @returns {void}
          * @private
          */
-        function checkVar(node) {
+        function checkVar(node, never) {
             if (node.init) {
-                const nonSpacedNode = getFirstNonSpacedToken(node.id, node.init);
+                const nonSpacedNode = getFirstNonSpacedToken(node.id, node.init, never);
 
                 if (nonSpacedNode) {
-                    report(node, nonSpacedNode);
+                    report(node, nonSpacedNode, never);
                 }
             }
         }
 
-        return {
+        const checks = {
             AssignmentExpression: checkBinary,
             AssignmentPattern: checkBinary,
             BinaryExpression: checkBinary,
@@ -161,5 +202,18 @@ module.exports = {
             VariableDeclarator: checkVar
         };
 
+        if (exceptions) {
+            Object.keys(checks).forEach(nodeType => {
+                const check = checks[nodeType];
+
+                if (ignoreExceptions.has(nodeType)) {
+                    delete checks[nodeType];
+                } else {
+                    checks[nodeType] = node => check(node, neverExceptions.has(nodeType));
+                }
+            });
+        }
+
+        return checks;
     }
 };

--- a/tests/lib/rules/space-infix-ops.js
+++ b/tests/lib/rules/space-infix-ops.js
@@ -33,7 +33,348 @@ ruleTester.run("space-infix-ops", rule, {
         { code: "function foo(a: number = 0) { }", parser: path.resolve(__dirname, "../../fixtures/parsers/flow-stub-parser.js"), parserOptions: { ecmaVersion: 6 } },
         { code: "a ** b", parserOptions: { ecmaVersion: 7 } },
         { code: "a|0", options: [{ int32Hint: true }] },
-        { code: "a |0", options: [{ int32Hint: true }] }
+        { code: "a |0", options: [{ int32Hint: true }] },
+        {
+            code: "a + b",
+            options: [{ exceptions: { BinaryExpression: "always" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "a+b",
+            options: [{ exceptions: { BinaryExpression: "never" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "a + b",
+            options: [{ exceptions: { BinaryExpression: "ignore" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "a+b",
+            options: [{ exceptions: { BinaryExpression: "ignore" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "a+ b",
+            options: [{ exceptions: { BinaryExpression: "ignore" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "a +b",
+            options: [{ exceptions: { BinaryExpression: "ignore" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "a || b",
+            options: [{ exceptions: { LogicalExpression: "always" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "a||b",
+            options: [{ exceptions: { LogicalExpression: "never" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "a || b",
+            options: [{ exceptions: { LogicalExpression: "ignore" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "a||b",
+            options: [{ exceptions: { LogicalExpression: "ignore" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "a|| b",
+            options: [{ exceptions: { LogicalExpression: "ignore" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "a ||b",
+            options: [{ exceptions: { LogicalExpression: "ignore" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "a = b",
+            options: [{ exceptions: { AssignmentExpression: "always" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "a=b",
+            options: [{ exceptions: { AssignmentExpression: "never" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "a = b",
+            options: [{ exceptions: { AssignmentExpression: "ignore" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "a=b",
+            options: [{ exceptions: { AssignmentExpression: "ignore" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "a= b",
+            options: [{ exceptions: { AssignmentExpression: "ignore" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "a =b",
+            options: [{ exceptions: { AssignmentExpression: "ignore" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "a ? b : c",
+            options: [{ exceptions: { ConditionalExpression: "always" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "a?b:c",
+            options: [{ exceptions: { ConditionalExpression: "never" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "a ? b : c",
+            options: [{ exceptions: { ConditionalExpression: "ignore" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "a?b:c",
+            options: [{ exceptions: { ConditionalExpression: "ignore" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "a? b: c",
+            options: [{ exceptions: { ConditionalExpression: "ignore" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "a ?b :c",
+            options: [{ exceptions: { ConditionalExpression: "ignore" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var a = b",
+            options: [{ exceptions: { VariableDeclarator: "always" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var a=b",
+            options: [{ exceptions: { VariableDeclarator: "never" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var a = b",
+            options: [{ exceptions: { VariableDeclarator: "ignore" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var a=b",
+            options: [{ exceptions: { VariableDeclarator: "ignore" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var a= b",
+            options: [{ exceptions: { VariableDeclarator: "ignore" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var a =b",
+            options: [{ exceptions: { VariableDeclarator: "ignore" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+
+        {
+            code: "var a = b, c = d",
+            options: [{ exceptions: { VariableDeclarator: "always" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var a = b,c = d",
+            options: [{ exceptions: { VariableDeclarator: "always" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var a=b, c=d",
+            options: [{ exceptions: { VariableDeclarator: "never" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var a=b,c=d",
+            options: [{ exceptions: { VariableDeclarator: "never" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var a = b, c = d",
+            options: [{ exceptions: { VariableDeclarator: "ignore" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var a=b, c=d",
+            options: [{ exceptions: { VariableDeclarator: "ignore" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var a= b, c= d",
+            options: [{ exceptions: { VariableDeclarator: "ignore" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var a =b, c =d",
+            options: [{ exceptions: { VariableDeclarator: "ignore" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var {a = 0} = bar;",
+            options: [{ exceptions: { AssignmentPattern: "always" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var {a=0} = bar;",
+            options: [{ exceptions: { AssignmentPattern: "never" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var {a = 0} = bar;",
+            options: [{ exceptions: { AssignmentPattern: "ignore" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var {a=0} = bar;",
+            options: [{ exceptions: { AssignmentPattern: "ignore" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var {a= 0} = bar;",
+            options: [{ exceptions: { AssignmentPattern: "ignore" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var {a =0} = bar;",
+            options: [{ exceptions: { AssignmentPattern: "ignore" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "function foo(a = 0) { }",
+            options: [{ exceptions: { AssignmentPattern: "always" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "function foo(a=0) { }",
+            options: [{ exceptions: { AssignmentPattern: "never" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "function foo(a = 0) { }",
+            options: [{ exceptions: { AssignmentPattern: "ignore" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "function foo(a=0) { }",
+            options: [{ exceptions: { AssignmentPattern: "ignore" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "function foo(a= 0) { }",
+            options: [{ exceptions: { AssignmentPattern: "ignore" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "function foo(a =0) { }",
+            options: [{ exceptions: { AssignmentPattern: "ignore" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "a ** b",
+            options: [{ exceptions: { BinaryExpression: "always" } }],
+            parserOptions: { ecmaVersion: 7 }
+        },
+        {
+            code: "a**b",
+            options: [{ exceptions: { BinaryExpression: "never" } }],
+            parserOptions: { ecmaVersion: 7 }
+        },
+        {
+            code: "a ** b",
+            options: [{ exceptions: { BinaryExpression: "ignore" } }],
+            parserOptions: { ecmaVersion: 7 }
+        },
+        {
+            code: "a**b",
+            options: [{ exceptions: { BinaryExpression: "ignore" } }],
+            parserOptions: { ecmaVersion: 7 }
+        },
+        {
+            code: "a** b",
+            options: [{ exceptions: { BinaryExpression: "ignore" } }],
+            parserOptions: { ecmaVersion: 7 }
+        },
+        {
+            code: "a **b",
+            options: [{ exceptions: { BinaryExpression: "ignore" } }],
+            parserOptions: { ecmaVersion: 7 }
+        },
+        {
+            code: "'foo' in {}",
+            options: [{ exceptions: { BinaryExpression: "always" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "'foo'in{}",
+            options: [{ exceptions: { BinaryExpression: "never" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "'foo' in {}",
+            options: [{ exceptions: { BinaryExpression: "ignore" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "'foo'in{}",
+            options: [{ exceptions: { BinaryExpression: "ignore" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "'foo'in {}",
+            options: [{ exceptions: { BinaryExpression: "ignore" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "'foo' in{}",
+            options: [{ exceptions: { BinaryExpression: "ignore" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "'foo' instanceof {}",
+            options: [{ exceptions: { BinaryExpression: "always" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "'foo'instanceof{}",
+            options: [{ exceptions: { BinaryExpression: "never" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "'foo' instanceof {}",
+            options: [{ exceptions: { BinaryExpression: "ignore" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "'foo'instanceof{}",
+            options: [{ exceptions: { BinaryExpression: "ignore" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "'foo'instanceof {}",
+            options: [{ exceptions: { BinaryExpression: "ignore" } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "'foo' instanceof{}",
+            options: [{ exceptions: { BinaryExpression: "ignore" } }],
+            parserOptions: { ecmaVersion: 6 }
+        }
     ],
     invalid: [
         {
@@ -307,6 +648,112 @@ ruleTester.run("space-infix-ops", rule, {
             }]
         },
         {
+            code: "var {a = 0}=bar;",
+            output: "var {a = 0} = bar;",
+            options: [{ exceptions: { AssignmentPattern: "always" } }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                message: "Infix operators must be spaced.",
+                line: 1,
+                column: 12,
+                nodeType: "VariableDeclarator"
+            }]
+        },
+        {
+            code: "var {a=0} = bar;",
+            output: "var {a = 0} = bar;",
+            options: [{ exceptions: { AssignmentPattern: "always" } }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                message: "Infix operators must be spaced.",
+                line: 1,
+                column: 7,
+                nodeType: "AssignmentPattern"
+            }]
+        },
+        {
+            code: "var {a=0}=bar;",
+            output: "var {a = 0} = bar;",
+            options: [{ exceptions: { AssignmentPattern: "always" } }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                message: "Infix operators must be spaced.",
+                line: 1,
+                column: 7,
+                nodeType: "AssignmentPattern"
+            }, {
+                message: "Infix operators must be spaced.",
+                line: 1,
+                column: 10,
+                nodeType: "VariableDeclarator"
+            }]
+        },
+        {
+            code: "var {a=0}=bar;",
+            output: "var {a=0} = bar;",
+            options: [{ exceptions: { AssignmentPattern: "never" } }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                message: "Infix operators must be spaced.",
+                line: 1,
+                column: 10,
+                nodeType: "VariableDeclarator"
+            }]
+        },
+        {
+            code: "var {a = 0} = bar;",
+            output: "var {a=0} = bar;",
+            options: [{ exceptions: { AssignmentPattern: "never" } }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                message: "Infix operators must be spaced.",
+                line: 1,
+                column: 8,
+                nodeType: "AssignmentPattern"
+            }]
+        },
+        {
+            code: "var {a = 0}=bar;",
+            output: "var {a=0} = bar;",
+            options: [{ exceptions: { AssignmentPattern: "never" } }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                message: "Infix operators must be spaced.",
+                line: 1,
+                column: 8,
+                nodeType: "AssignmentPattern"
+            }, {
+                message: "Infix operators must be spaced.",
+                line: 1,
+                column: 12,
+                nodeType: "VariableDeclarator"
+            }]
+        },
+        {
+            code: "var {a = 0}=bar;",
+            output: "var {a = 0} = bar;",
+            options: [{ exceptions: { AssignmentPattern: "ignore" } }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                message: "Infix operators must be spaced.",
+                line: 1,
+                column: 12,
+                nodeType: "VariableDeclarator"
+            }]
+        },
+        {
+            code: "var {a=0}=bar;",
+            output: "var {a=0} = bar;",
+            options: [{ exceptions: { AssignmentPattern: "ignore" } }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                message: "Infix operators must be spaced.",
+                line: 1,
+                column: 10,
+                nodeType: "VariableDeclarator"
+            }]
+        },
+        {
             code: "function foo(a=0) { }",
             output: "function foo(a = 0) { }",
             parserOptions: { ecmaVersion: 6 },
@@ -315,6 +762,112 @@ ruleTester.run("space-infix-ops", rule, {
                 line: 1,
                 column: 15,
                 nodeType: "AssignmentPattern"
+            }]
+        },
+        {
+            code: "function foo(a = 0) { return a/2; }",
+            output: "function foo(a = 0) { return a / 2; }",
+            options: [{ exceptions: { AssignmentPattern: "always" } }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                message: "Infix operators must be spaced.",
+                line: 1,
+                column: 31,
+                nodeType: "BinaryExpression"
+            }]
+        },
+        {
+            code: "function foo(a=0) { return a / 2; }",
+            output: "function foo(a = 0) { return a / 2; }",
+            options: [{ exceptions: { AssignmentPattern: "always" } }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                message: "Infix operators must be spaced.",
+                line: 1,
+                column: 15,
+                nodeType: "AssignmentPattern"
+            }]
+        },
+        {
+            code: "function foo(a=0) { return a/2; }",
+            output: "function foo(a = 0) { return a / 2; }",
+            options: [{ exceptions: { AssignmentPattern: "always" } }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                message: "Infix operators must be spaced.",
+                line: 1,
+                column: 15,
+                nodeType: "AssignmentPattern"
+            }, {
+                message: "Infix operators must be spaced.",
+                line: 1,
+                column: 29,
+                nodeType: "BinaryExpression"
+            }]
+        },
+        {
+            code: "function foo(a=0) { return a/2; }",
+            output: "function foo(a=0) { return a / 2; }",
+            options: [{ exceptions: { AssignmentPattern: "never" } }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                message: "Infix operators must be spaced.",
+                line: 1,
+                column: 29,
+                nodeType: "BinaryExpression"
+            }]
+        },
+        {
+            code: "function foo(a = 0) { return a / 2; }",
+            output: "function foo(a=0) { return a / 2; }",
+            options: [{ exceptions: { AssignmentPattern: "never" } }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                message: "Infix operators must be spaced.",
+                line: 1,
+                column: 16,
+                nodeType: "AssignmentPattern"
+            }]
+        },
+        {
+            code: "function foo(a = 0) { return a/2; }",
+            output: "function foo(a=0) { return a / 2; }",
+            options: [{ exceptions: { AssignmentPattern: "never" } }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                message: "Infix operators must be spaced.",
+                line: 1,
+                column: 16,
+                nodeType: "AssignmentPattern"
+            }, {
+                message: "Infix operators must be spaced.",
+                line: 1,
+                column: 31,
+                nodeType: "BinaryExpression"
+            }]
+        },
+        {
+            code: "function foo(a = 0) { return a/2; }",
+            output: "function foo(a = 0) { return a / 2; }",
+            options: [{ exceptions: { AssignmentPattern: "ignore" } }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                message: "Infix operators must be spaced.",
+                line: 1,
+                column: 31,
+                nodeType: "BinaryExpression"
+            }]
+        },
+        {
+            code: "function foo(a=0) { return a/2; }",
+            output: "function foo(a=0) { return a / 2; }",
+            options: [{ exceptions: { AssignmentPattern: "ignore" } }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                message: "Infix operators must be spaced.",
+                line: 1,
+                column: 29,
+                nodeType: "BinaryExpression"
             }]
         },
         {
@@ -346,6 +899,84 @@ ruleTester.run("space-infix-ops", rule, {
                 line: 1,
                 column: 6,
                 nodeType: "BinaryExpression"
+            }]
+        },
+        {
+            code: "var foo=function(a=0) { return a/2; }",
+            output: "var foo = function(a = 0) { return a / 2; }",
+            options: [{ exceptions: {
+                VariableDeclarator: "always",
+                AssignmentPattern: "always",
+                BinaryExpression: "always"
+            } }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                message: "Infix operators must be spaced.",
+                line: 1,
+                column: 8,
+                nodetype: "VariableDeclarator"
+            },
+            {
+                message: "Infix operators must be spaced.",
+                line: 1,
+                column: 19,
+                nodetype: "AssignmentPattern"
+            },
+            {
+                message: "Infix operators must be spaced.",
+                line: 1,
+                column: 33,
+                nodetype: "BinaryExpression"
+            }]
+        },
+        {
+            code: "var foo = function(a = 0) { return a / 2; }",
+            output: "var foo=function(a=0) { return a/2; }",
+            options: [{ exceptions: {
+                VariableDeclarator: "never",
+                AssignmentPattern: "never",
+                BinaryExpression: "never"
+            } }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                message: "Infix operators must be spaced.",
+                line: 1,
+                column: 9,
+                nodetype: "VariableDeclarator"
+            },
+            {
+                message: "Infix operators must be spaced.",
+                line: 1,
+                column: 22,
+                nodetype: "AssignmentPattern"
+            },
+            {
+                message: "Infix operators must be spaced.",
+                line: 1,
+                column: 38,
+                nodetype: "BinaryExpression"
+            }]
+        },
+        {
+            code: "var foo=function(a = 0) { return a/ 2; }",
+            output: "var foo = function(a=0) { return a/ 2; }",
+            options: [{ exceptions: {
+                VariableDeclarator: "always",
+                AssignmentPattern: "never",
+                BinaryExpression: "ignore"
+            } }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                message: "Infix operators must be spaced.",
+                line: 1,
+                column: 8,
+                nodetype: "VariableDeclarator"
+            },
+            {
+                message: "Infix operators must be spaced.",
+                line: 1,
+                column: 20,
+                nodetype: "AssignmentPattern"
             }]
         }
     ]


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

AST node types to be excluded from space-infix-ops can now be
defined via "exceptions". Follows precedent and conventions set by
no-multi-spaces. Use case: es6 default args a la "(a=0) => {}"

**Is there anything you'd like reviewers to focus on?**

Nope
