### PR TITLE
Update: fix quotes false negative for string literals as template tags

### DIFF
--- a/lib/rules/quotes.js
+++ b/lib/rules/quotes.js
@@ -257,7 +257,11 @@ module.exports = {
             TemplateLiteral(node) {
 
                 // If backticks are expected or it's a tagged template, then this shouldn't throw an errors
-                if (allowTemplateLiterals || quoteOption === "backtick" || node.parent.type === "TaggedTemplateExpression") {
+                if (
+                    allowTemplateLiterals ||
+                    quoteOption === "backtick" ||
+                    node.parent.type === "TaggedTemplateExpression" && node === node.parent.quasi
+                ) {
                     return;
                 }
 

--- a/tests/lib/rules/quotes.js
+++ b/tests/lib/rules/quotes.js
@@ -302,6 +302,12 @@ ruleTester.run("quotes", rule, {
             output: "var foo = \"foo\\\\\\\nbar\";",
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Strings must use doublequote.", type: "TemplateLiteral" }]
+        },
+        {
+            code: "````",
+            output: "\"\"``",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Strings must use doublequote.", type: "TemplateLiteral", line: 1, column: 1 }]
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix

**Tell us about your environment**

* **ESLint Version:** master
* **Node Version:** 7.5.0
* **npm Version:** 4.1.2

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

```yml
rules:
  quotes: error
parserOptions:
  ecmaVersion: 6
```

**What did you do? Please include the actual source code causing the issue.**

I absentmindedly spammed `` ` `` while working on something else, and I ended up with something like this:

`````js
````
`````

This is a tagged template literal, where the tag is the first ``` `` ``` and the quasi is the second ``` `` ```.

**What did you expect to happen?**

I expected the first ``` `` ``` to be reported, since it can be in double quotes. Only the second ``` `` ``` needs to be a template literal.

**What actually happened? Please include the actual, raw output from ESLint.**

No errors were reported.

**What changes did you make? (Give an overview)**

This fixes a tagged template check in `quotes`. Since the "literal" of a tagged template literal can't be converted to single/double quotes (e.g. `` foo`bar` ``), the rule currently ignores template literals that have a `TaggedTemplateLiteral` parent. However, it should only ignore these if the template literal is actually the `quasi` if the parent -- an error should still be reported if the template literal is the `tag` of the parent.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular