### PR TITLE
New: nonblock-statement-body-position rule (fixes #6067)

### DIFF
--- a/conf/eslint-recommended.js
+++ b/conf/eslint-recommended.js
@@ -209,6 +209,7 @@ module.exports = {
         "no-warning-comments": "off",
         "no-whitespace-before-property": "off",
         "no-with": "off",
+        "nonblock-statement-body-position": "off",
         "object-curly-newline": "off",
         "object-curly-spacing": ["off", "never"],
         "object-property-newline": "off",

--- a/docs/rules/nonblock-statement-body-position.md
+++ b/docs/rules/nonblock-statement-body-position.md
@@ -121,6 +121,12 @@ for (let i = 1; i < foo; i++)
 do
   bar();
 while (foo)
+
+if (foo) {
+  // Although the second `if` statement is on the same line as the `else`, this is a very common
+  // pattern, so it's not checked by this rule.
+} else if (bar) {
+}
 ```
 
 Examples of **incorrect** code for this rule with the `"beside", { "overrides": { "while": "below" } }` rule:

--- a/docs/rules/nonblock-statement-body-position.md
+++ b/docs/rules/nonblock-statement-body-position.md
@@ -1,0 +1,154 @@
+# enforce the location of single-line statements (nonblock-statement-body-position)
+
+(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
+When writing `if`, `else`, `while`, `do-while`, and `for` statements, the body can be a single statement instead of a block. It can be useful to enforce a consistent location for these single statements.
+
+For example, some developers avoid writing code like this:
+
+```js
+if (foo)
+  bar();
+```
+
+If another developer attempts to add `baz();` to the `if` statement, they might mistakenly change the code to
+
+```js
+if (foo)
+  bar();
+  baz(); // this line is not in the `if` statement!
+```
+
+To avoid this issue, one might require all single-line `if` statements to appear directly after the conditional, without a linebreak:
+
+```js
+if (foo) bar();
+```
+
+## Rule Details
+
+This rule aims to enforce a consistent location for single-line statements.
+
+Note that this rule does not enforce the usage of single-line statements in general. If you would like to disallow single-line statements, use the [`curly`](/docs/rules/curly.md) rule instead.
+
+### Options
+
+This rule accepts a string option:
+
+* `"beside"` (default) disallows a newline before a single-line statement.
+* `"below"` requires a newline before a single-line statement.
+* `"any"` does not enforce the position of a single-line statement.
+
+Additionally, the rule accepts an optional object option with an `"overrides"` key. This can be used to specify a location for particular statements that override the default. For example:
+
+* `"beside", { "overrides": { "while": "below" } }` requires all single-line statements to appear on the same line as their parent, unless the parent is a `while` statement, in which case the single-line statement must not be on the same line.
+* `"below", { "overrides": { "do": "any" } }` disallows all single-line statements from appearing on the same line as their parent, unless the parent is a `do-while` statement, in which case the position of the single-line statement is not enforced.
+
+Examples of **incorrect** code for this rule with the default `"beside"` option:
+
+```js
+/* eslint nonblock-statement-body-position: ["error", "beside"] */
+
+if (foo)
+  bar();
+else
+  baz();
+
+while (foo)
+  bar();
+
+for (let i = 1; i < foo; i++)
+  bar();
+
+do
+  bar();
+while (foo)
+
+```
+
+Examples of **correct** code for this rule with the default `"beside"` option:
+
+```js
+/* eslint nonblock-statement-body-position: ["error", "beside"] */
+
+if (foo) bar();
+else baz();
+
+while (foo) bar();
+
+for (let i = 1; i < foo; i++) bar();
+
+do bar(); while (foo)
+
+if (foo) { // block statements are always allowed with this rule
+  bar();
+} else {
+  baz();
+}
+```
+
+Examples of **incorrect** code for this rule with the `"below"` option:
+
+```js
+/* eslint nonblock-statement-body-position: ["error", "below"] */
+
+if (foo) bar();
+else baz();
+
+while (foo) bar();
+
+for (let i = 1; i < foo; i++) bar();
+
+do bar(); while (foo)
+```
+
+Examples of **correct** code for this rule with the `"below"` option:
+
+```js
+/* eslint nonblock-statement-body-position: ["error", "below"] */
+
+if (foo)
+  bar();
+else
+  baz();
+
+while (foo)
+  bar();
+
+for (let i = 1; i < foo; i++)
+  bar();
+
+do
+  bar();
+while (foo)
+```
+
+Examples of **incorrect** code for this rule with the `"beside", { "overrides": { "while": "below" } }` rule:
+
+```js
+/* eslint nonblock-statement-body-position: ["error", "beside", { "overrides": { "while": "below" } }] */
+
+if (foo)
+  bar();
+
+while (foo) bar();
+```
+
+Examples of **correct** code for this rule with the `"beside", { "overrides": { "while": "below" } }` rule:
+
+```js
+/* eslint nonblock-statement-body-position: ["error", "beside", { "overrides": { "while": "below" } }] */
+
+if (foo) bar();
+
+while (foo)
+  bar();
+```
+
+## When Not To Use It
+
+If you're not concerned about consistent locations of single-line statements, you should not turn on this rule. You can also disable this rule if you're using the `"all"` option for the [`curly`](/docs/rules/curly.md) rule, because this will disallow single-line statements entirely.
+
+## Further Reading
+
+* JSCS: [requireNewlineBeforeSingleStatementsInIf](http://jscs.info/rule/requireNewlineBeforeSingleStatementsInIf)

--- a/lib/rules/nonblock-statement-body-position.js
+++ b/lib/rules/nonblock-statement-body-position.js
@@ -99,7 +99,8 @@ module.exports = {
             IfStatement(node) {
                 validateStatement(node.consequent, "if");
 
-                if (node.alternate) {
+                // Check the `else` node, but don't check 'else if' statements.
+                if (node.alternate && node.alternate.type !== "IfStatement") {
                     validateStatement(node.alternate, "else");
                 }
             },

--- a/lib/rules/nonblock-statement-body-position.js
+++ b/lib/rules/nonblock-statement-body-position.js
@@ -1,0 +1,113 @@
+/**
+ * @fileoverview enforce the location of single-line statements
+ * @author Teddy Katz
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+const POSITION_SCHEMA = { enum: ["beside", "below", "any"] };
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "enforce the location of single-line statements",
+            category: "Stylistic Issues",
+            recommended: false
+        },
+        fixable: "whitespace",
+        schema: [
+            POSITION_SCHEMA,
+            {
+                properties: {
+                    overrides: {
+                        properties: {
+                            if: POSITION_SCHEMA,
+                            else: POSITION_SCHEMA,
+                            while: POSITION_SCHEMA,
+                            do: POSITION_SCHEMA,
+                            for: POSITION_SCHEMA
+                        },
+                        additionalProperties: false
+                    }
+                },
+                additionalProperties: false
+            }
+        ]
+    },
+
+    create(context) {
+        const sourceCode = context.getSourceCode();
+
+        //----------------------------------------------------------------------
+        // Helpers
+        //----------------------------------------------------------------------
+
+        /**
+         * Gets the applicable preference for a particular keyword
+         * @param {string} keywordName The name of a keyword, e.g. 'if'
+         * @returns {string} The applicable option for the keyword, e.g. 'beside'
+         */
+        function getOption(keywordName) {
+            return context.options[1] && context.options[1].overrides && context.options[1].overrides[keywordName] ||
+                context.options[0] ||
+                "beside";
+        }
+
+        /**
+         * Validates the location of a single-line statement
+         * @param {ASTNode} node The single-line statement
+         * @param {string} keywordName The applicable keyword name for the single-line statement
+         * @returns {void}
+         */
+        function validateStatement(node, keywordName) {
+            const option = getOption(keywordName);
+
+            if (node.type === "BlockStatement" || option === "any") {
+                return;
+            }
+
+            const tokenBefore = sourceCode.getTokenBefore(node);
+
+            if (tokenBefore.loc.end.line === node.loc.start.line && option === "below") {
+                context.report({
+                    node,
+                    message: "Expected a linebreak before this statement.",
+                    fix: fixer => fixer.insertTextBefore(node, "\n")
+                });
+            } else if (tokenBefore.loc.end.line !== node.loc.end.line && option === "beside") {
+                context.report({
+                    node,
+                    message: "Expected no linebreak before this statement.",
+                    fix(fixer) {
+                        if (sourceCode.getText().slice(tokenBefore.range[1], node.range[0]).trim()) {
+                            return null;
+                        }
+                        return fixer.replaceTextRange([tokenBefore.range[1], node.range[0]], " ");
+                    }
+                });
+            }
+        }
+
+        //----------------------------------------------------------------------
+        // Public
+        //----------------------------------------------------------------------
+
+        return {
+            IfStatement(node) {
+                validateStatement(node.consequent, "if");
+
+                if (node.alternate) {
+                    validateStatement(node.alternate, "else");
+                }
+            },
+            WhileStatement: node => validateStatement(node.body, "while"),
+            DoWhileStatement: node => validateStatement(node.body, "do"),
+            ForStatement: node => validateStatement(node.body, "for"),
+            ForInStatement: node => validateStatement(node.body, "for"),
+            ForOfStatement: node => validateStatement(node.body, "for")
+        };
+    }
+};

--- a/tests/lib/rules/nonblock-statement-body-position.js
+++ b/tests/lib/rules/nonblock-statement-body-position.js
@@ -1,0 +1,306 @@
+/**
+ * @fileoverview enforce the location of single-line statements
+ * @author Teddy Katz
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../lib/rules/nonblock-statement-body-position");
+const RuleTester = require("../../../lib/testers/rule-tester");
+
+const EXPECTED_LINEBREAK = { message: "Expected a linebreak before this statement." };
+const UNEXPECTED_LINEBREAK = { message: "Expected no linebreak before this statement." };
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
+
+ruleTester.run("nonblock-statement-body-position", rule, {
+
+    valid: [
+
+        // 'beside' option
+        "if (foo) bar;",
+        "while (foo) bar;",
+        "do foo; while (bar)",
+        "for (;foo;) bar;",
+        "for (foo in bar) baz;",
+        "for (foo of bar) baz;",
+        "if (foo) bar; else baz;",
+        {
+            code: "if (foo) bar();",
+            options: ["beside"]
+        },
+        {
+            code: "while (foo) bar();",
+            options: ["beside"]
+        },
+        {
+            code: "do bar(); while (foo)",
+            options: ["beside"]
+        },
+        {
+            code: "for (;foo;) bar();",
+            options: ["beside"]
+        },
+
+        // 'below' option
+        {
+            code: `
+                if (foo)
+                    bar();
+            `,
+            options: ["below"]
+        },
+        {
+            code: `
+                while (foo)
+                    bar();
+            `,
+            options: ["below"]
+        },
+        {
+            code: `
+                do
+                    bar();
+                while (foo)
+            `,
+            options: ["below"]
+        },
+        {
+            code: `
+                for (;foo;)
+                    bar();
+            `,
+            options: ["below"]
+        },
+        {
+            code: `
+                for (foo in bar)
+                    bar();
+            `,
+            options: ["below"]
+        },
+        {
+            code: `
+                for (foo of bar)
+                    bar();
+            `,
+            options: ["below"]
+        },
+        {
+            code: `
+                if (foo)
+                    bar();
+                else
+                    baz();
+            `,
+            options: ["below"]
+        },
+
+        // 'any' option
+        {
+            code: "if (foo) bar();",
+            options: ["any"]
+        },
+        {
+            code: `
+                if (foo)
+                    bar();
+            `,
+            options: ["any"]
+        },
+
+        // 'overrides' option
+        {
+            code: "if (foo) bar();",
+            options: ["beside", { overrides: { while: "below" } }]
+        },
+        {
+            code: `
+                while (foo)
+                    bar();
+            `,
+            options: ["beside", { overrides: { while: "below" } }]
+        },
+        {
+            code: `
+                while (foo)
+                    bar();
+            `,
+            options: ["beside", { overrides: { while: "any" } }]
+        },
+        {
+            code: "while (foo) bar();",
+            options: ["beside", { overrides: { while: "any" } }]
+        },
+        {
+            code: "while (foo) bar();",
+            options: ["any", { overrides: { while: "beside" } }]
+        },
+        {
+            code: " ",
+            options: ["any", { overrides: { if: "any", else: "any", for: "any", while: "any", do: "any" } }]
+        }
+    ],
+
+    invalid: [
+
+        // 'beside' option
+        {
+            code: `
+                if (foo)
+                    bar();
+            `,
+            output: `
+                if (foo) bar();
+            `,
+            errors: [UNEXPECTED_LINEBREAK]
+        },
+        {
+            code: `
+                while (foo)
+                    bar();
+            `,
+            output: `
+                while (foo) bar();
+            `,
+            errors: [UNEXPECTED_LINEBREAK]
+        },
+        {
+            code: `
+                do
+                    bar();
+                while (foo)
+            `,
+            output: `
+                do bar();
+                while (foo)
+            `,
+            errors: [UNEXPECTED_LINEBREAK]
+        },
+        {
+            code: `
+                for (;foo;)
+                    bar();
+            `,
+            output: `
+                for (;foo;) bar();
+            `,
+            errors: [UNEXPECTED_LINEBREAK]
+        },
+        {
+            code: `
+                for (foo in bar)
+                    baz();
+            `,
+            output: `
+                for (foo in bar) baz();
+            `,
+            errors: [UNEXPECTED_LINEBREAK]
+        },
+        {
+            code: `
+                for (foo of bar)
+                    baz();
+            `,
+            output: `
+                for (foo of bar) baz();
+            `,
+            errors: [UNEXPECTED_LINEBREAK]
+        },
+        {
+            code: `
+                if (foo)
+                    bar();
+                else
+                    baz();
+            `,
+            output: `
+                if (foo) bar();
+                else baz();
+            `,
+            errors: [UNEXPECTED_LINEBREAK, UNEXPECTED_LINEBREAK]
+        },
+
+        // 'below' option
+        {
+            code: "if (foo) bar();",
+            output: "if (foo) \nbar();",
+            options: ["below"],
+            errors: [EXPECTED_LINEBREAK]
+        },
+        {
+            code: "while (foo) bar();",
+            output: "while (foo) \nbar();",
+            options: ["below"],
+            errors: [EXPECTED_LINEBREAK]
+        },
+        {
+            code: "do bar(); while (foo)",
+            output: "do \nbar(); while (foo)",
+            options: ["below"],
+            errors: [EXPECTED_LINEBREAK]
+        },
+        {
+            code: "for (;foo;) bar();",
+            output: "for (;foo;) \nbar();",
+            options: ["below"],
+            errors: [EXPECTED_LINEBREAK]
+        },
+        {
+            code: "for (foo in bar) baz();",
+            output: "for (foo in bar) \nbaz();",
+            options: ["below"],
+            errors: [EXPECTED_LINEBREAK]
+        },
+        {
+            code: "for (foo of bar) baz();",
+            output: "for (foo of bar) \nbaz();",
+            options: ["below"],
+            errors: [EXPECTED_LINEBREAK]
+        },
+        {
+            code: `
+                if (foo) bar();
+                else baz();
+            `,
+            output: `
+                if (foo) \nbar();
+                else \nbaz();
+            `,
+            options: ["below"],
+            errors: [EXPECTED_LINEBREAK, EXPECTED_LINEBREAK]
+        },
+
+        // overrides
+        {
+            code: "if (foo) bar();",
+            output: "if (foo) \nbar();",
+            options: ["below", { overrides: { while: "beside" } }],
+            errors: [EXPECTED_LINEBREAK]
+        },
+        {
+            code: `
+                while (foo)
+                    bar();
+            `,
+            output: `
+                while (foo) bar();
+            `,
+            options: ["below", { overrides: { while: "beside" } }],
+            errors: [UNEXPECTED_LINEBREAK]
+        },
+        {
+            code: "do bar(); while (foo)",
+            output: "do \nbar(); while (foo)",
+            options: ["any", { overrides: { do: "below" } }],
+            errors: [EXPECTED_LINEBREAK]
+        }
+    ]
+});

--- a/tests/lib/rules/nonblock-statement-body-position.js
+++ b/tests/lib/rules/nonblock-statement-body-position.js
@@ -146,6 +146,36 @@ ruleTester.run("nonblock-statement-body-position", rule, {
         {
             code: " ",
             options: ["any", { overrides: { if: "any", else: "any", for: "any", while: "any", do: "any" } }]
+        },
+
+        // ignore 'else if'
+        `
+            if (foo) {
+            } else if (bar) {
+            }
+        `,
+        {
+            code: `
+                if (foo) {
+                } else if (bar) {
+                }
+            `,
+            options: ["below"]
+        },
+        `
+            if (foo) {
+            } else
+              if (bar) {
+              }
+        `,
+        {
+            code: `
+                if (foo) {
+                } else
+                  if (bar) {
+                  }
+            `,
+            options: ["beside"]
         }
     ],
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] New rule (see https://github.com/eslint/eslint/issues/6067)

**What changes did you make? (Give an overview)**

This implements `nonblock-body-position` as described in https://github.com/eslint/eslint/issues/6067.

I decided to make `beside` the default, because I think it's better for preventing errors like this:

```js
if (foo)
  bar();
  baz(); // <-- probably a bug
```

However, I would be fine with making `below` the default as specified in https://github.com/eslint/eslint/issues/6067 if others feel differently about this.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
