### PR TITLE
Fix: Improve keyword-spacing typescript support (fixes #8110)

### DIFF
--- a/lib/rules/keyword-spacing.js
+++ b/lib/rules/keyword-spacing.js
@@ -359,7 +359,8 @@ module.exports = {
             const firstToken = node && sourceCode.getFirstToken(node);
 
             if (firstToken &&
-                (firstToken.type === "Keyword" || firstToken.value === "async")
+                ((firstToken.type === "Keyword" && firstToken.value === "function") ||
+                firstToken.value === "async")
             ) {
                 checkSpacingBefore(firstToken);
             }
@@ -495,10 +496,24 @@ module.exports = {
                     node.value.async
                 )
             ) {
-                const token = sourceCode.getFirstToken(
-                    node,
-                    node.static ? 1 : 0
+                const token = sourceCode.getTokenBefore(
+                    node.key,
+                    tok => {
+                        switch (tok.value) {
+                            case "get":
+                            case "set":
+                            case "async":
+                                return true;
+                            default:
+                                return false;
+                        }
+                    }
                 );
+
+                if (!token) {
+                    throw new Error("Failed to find token get, set, or async beside method name");
+                }
+
 
                 checkSpacingAround(token);
             }

--- a/tests/fixtures/parsers/typescript-parsers/decorator-with-class-methods.js
+++ b/tests/fixtures/parsers/typescript-parsers/decorator-with-class-methods.js
@@ -1,0 +1,890 @@
+"use strict";
+
+/**
+ * Parser: typescript-eslint-parser v1.0.3 (TS 2.0.6)
+ * Source code:
+ * class Foo { @dec get bar() { } @dec set baz() { } @dec async baw() { } }
+ */
+
+exports.parse = () => ({
+    "type": "Program",
+    "range": [
+        0,
+        72
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 1,
+            "column": 72
+        }
+    },
+    "body": [
+        {
+            "type": "ClassDeclaration",
+            "range": [
+                0,
+                72
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 72
+                }
+            },
+            "id": {
+                "type": "Identifier",
+                "range": [
+                    6,
+                    9
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 6
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 9
+                    }
+                },
+                "name": "Foo"
+            },
+            "body": {
+                "type": "ClassBody",
+                "body": [
+                    {
+                        "type": "MethodDefinition",
+                        "range": [
+                            12,
+                            30
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 12
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 30
+                            }
+                        },
+                        "key": {
+                            "type": "Identifier",
+                            "range": [
+                                21,
+                                24
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 21
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 24
+                                }
+                            },
+                            "name": "bar"
+                        },
+                        "value": {
+                            "type": "FunctionExpression",
+                            "id": null,
+                            "generator": false,
+                            "expression": false,
+                            "async": false,
+                            "body": {
+                                "type": "BlockStatement",
+                                "range": [
+                                    27,
+                                    30
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 27
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 30
+                                    }
+                                },
+                                "body": []
+                            },
+                            "range": [
+                                24,
+                                30
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 24
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 30
+                                }
+                            },
+                            "params": []
+                        },
+                        "computed": false,
+                        "static": false,
+                        "kind": "get",
+                        "accessibility": null,
+                        "decorators": [
+                            {
+                                "type": "Identifier",
+                                "range": [
+                                    13,
+                                    16
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 13
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 16
+                                    }
+                                },
+                                "name": "dec"
+                            }
+                        ]
+                    },
+                    {
+                        "type": "MethodDefinition",
+                        "range": [
+                            31,
+                            49
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 31
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 49
+                            }
+                        },
+                        "key": {
+                            "type": "Identifier",
+                            "range": [
+                                40,
+                                43
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 40
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 43
+                                }
+                            },
+                            "name": "baz"
+                        },
+                        "value": {
+                            "type": "FunctionExpression",
+                            "id": null,
+                            "generator": false,
+                            "expression": false,
+                            "async": false,
+                            "body": {
+                                "type": "BlockStatement",
+                                "range": [
+                                    46,
+                                    49
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 46
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 49
+                                    }
+                                },
+                                "body": []
+                            },
+                            "range": [
+                                43,
+                                49
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 43
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 49
+                                }
+                            },
+                            "params": []
+                        },
+                        "computed": false,
+                        "static": false,
+                        "kind": "set",
+                        "accessibility": null,
+                        "decorators": [
+                            {
+                                "type": "Identifier",
+                                "range": [
+                                    32,
+                                    35
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 32
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 35
+                                    }
+                                },
+                                "name": "dec"
+                            }
+                        ]
+                    },
+                    {
+                        "type": "MethodDefinition",
+                        "range": [
+                            50,
+                            70
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 50
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 70
+                            }
+                        },
+                        "key": {
+                            "type": "Identifier",
+                            "range": [
+                                61,
+                                64
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 61
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 64
+                                }
+                            },
+                            "name": "baw"
+                        },
+                        "value": {
+                            "type": "FunctionExpression",
+                            "id": null,
+                            "generator": false,
+                            "expression": false,
+                            "async": true,
+                            "body": {
+                                "type": "BlockStatement",
+                                "range": [
+                                    67,
+                                    70
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 67
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 70
+                                    }
+                                },
+                                "body": []
+                            },
+                            "range": [
+                                64,
+                                70
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 64
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 70
+                                }
+                            },
+                            "params": []
+                        },
+                        "computed": false,
+                        "static": false,
+                        "kind": "method",
+                        "accessibility": null,
+                        "decorators": [
+                            {
+                                "type": "Identifier",
+                                "range": [
+                                    51,
+                                    54
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 51
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 54
+                                    }
+                                },
+                                "name": "dec"
+                            }
+                        ]
+                    }
+                ],
+                "range": [
+                    10,
+                    72
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 10
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 72
+                    }
+                }
+            },
+            "superClass": null,
+            "implements": [],
+            "decorators": []
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "class",
+            "range": [
+                0,
+                5
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 5
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "Foo",
+            "range": [
+                6,
+                9
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 6
+                },
+                "end": {
+                    "line": 1,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "range": [
+                10,
+                11
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 10
+                },
+                "end": {
+                    "line": 1,
+                    "column": 11
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "@",
+            "range": [
+                12,
+                13
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 12
+                },
+                "end": {
+                    "line": 1,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "dec",
+            "range": [
+                13,
+                16
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 13
+                },
+                "end": {
+                    "line": 1,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "get",
+            "range": [
+                17,
+                20
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 17
+                },
+                "end": {
+                    "line": 1,
+                    "column": 20
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "bar",
+            "range": [
+                21,
+                24
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 21
+                },
+                "end": {
+                    "line": 1,
+                    "column": 24
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "range": [
+                24,
+                25
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 24
+                },
+                "end": {
+                    "line": 1,
+                    "column": 25
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "range": [
+                25,
+                26
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 25
+                },
+                "end": {
+                    "line": 1,
+                    "column": 26
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "range": [
+                27,
+                28
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 27
+                },
+                "end": {
+                    "line": 1,
+                    "column": 28
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "range": [
+                29,
+                30
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 29
+                },
+                "end": {
+                    "line": 1,
+                    "column": 30
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "@",
+            "range": [
+                31,
+                32
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 31
+                },
+                "end": {
+                    "line": 1,
+                    "column": 32
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "dec",
+            "range": [
+                32,
+                35
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 32
+                },
+                "end": {
+                    "line": 1,
+                    "column": 35
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "set",
+            "range": [
+                36,
+                39
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 36
+                },
+                "end": {
+                    "line": 1,
+                    "column": 39
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "baz",
+            "range": [
+                40,
+                43
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 40
+                },
+                "end": {
+                    "line": 1,
+                    "column": 43
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "range": [
+                43,
+                44
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 43
+                },
+                "end": {
+                    "line": 1,
+                    "column": 44
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "range": [
+                44,
+                45
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 44
+                },
+                "end": {
+                    "line": 1,
+                    "column": 45
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "range": [
+                46,
+                47
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 46
+                },
+                "end": {
+                    "line": 1,
+                    "column": 47
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "range": [
+                48,
+                49
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 48
+                },
+                "end": {
+                    "line": 1,
+                    "column": 49
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "@",
+            "range": [
+                50,
+                51
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 50
+                },
+                "end": {
+                    "line": 1,
+                    "column": 51
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "dec",
+            "range": [
+                51,
+                54
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 51
+                },
+                "end": {
+                    "line": 1,
+                    "column": 54
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "async",
+            "range": [
+                55,
+                60
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 55
+                },
+                "end": {
+                    "line": 1,
+                    "column": 60
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "baw",
+            "range": [
+                61,
+                64
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 61
+                },
+                "end": {
+                    "line": 1,
+                    "column": 64
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "range": [
+                64,
+                65
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 64
+                },
+                "end": {
+                    "line": 1,
+                    "column": 65
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "range": [
+                65,
+                66
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 65
+                },
+                "end": {
+                    "line": 1,
+                    "column": 66
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "range": [
+                67,
+                68
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 67
+                },
+                "end": {
+                    "line": 1,
+                    "column": 68
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "range": [
+                69,
+                70
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 69
+                },
+                "end": {
+                    "line": 1,
+                    "column": 70
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "range": [
+                71,
+                72
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 71
+                },
+                "end": {
+                    "line": 1,
+                    "column": 72
+                }
+            }
+        }
+    ],
+    "comments": []
+});
+

--- a/tests/fixtures/parsers/typescript-parsers/decorator-with-class.js
+++ b/tests/fixtures/parsers/typescript-parsers/decorator-with-class.js
@@ -1,0 +1,214 @@
+"use strict";
+
+/**
+ * Parser: typescript-eslint-parser v1.0.3 (TS 2.0.6)
+ * Source code:
+ * @dec class Foo { }
+ */
+
+exports.parse = () => ({
+    "type": "Program",
+    "range": [
+        0,
+        18
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 1,
+            "column": 18
+        }
+    },
+    "body": [
+        {
+            "type": "ClassDeclaration",
+            "range": [
+                0,
+                18
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 18
+                }
+            },
+            "id": {
+                "type": "Identifier",
+                "range": [
+                    11,
+                    14
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 11
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 14
+                    }
+                },
+                "name": "Foo"
+            },
+            "body": {
+                "type": "ClassBody",
+                "body": [],
+                "range": [
+                    15,
+                    18
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 15
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 18
+                    }
+                }
+            },
+            "superClass": null,
+            "implements": [],
+            "decorators": [
+                {
+                    "type": "Identifier",
+                    "range": [
+                        1,
+                        4
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 1
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 4
+                        }
+                    },
+                    "name": "dec"
+                }
+            ]
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Punctuator",
+            "value": "@",
+            "range": [
+                0,
+                1
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 1
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "dec",
+            "range": [
+                1,
+                4
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 1
+                },
+                "end": {
+                    "line": 1,
+                    "column": 4
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "class",
+            "range": [
+                5,
+                10
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 5
+                },
+                "end": {
+                    "line": 1,
+                    "column": 10
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "Foo",
+            "range": [
+                11,
+                14
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 11
+                },
+                "end": {
+                    "line": 1,
+                    "column": 14
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "range": [
+                15,
+                16
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 15
+                },
+                "end": {
+                    "line": 1,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "range": [
+                17,
+                18
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 17
+                },
+                "end": {
+                    "line": 1,
+                    "column": 18
+                }
+            }
+        }
+    ],
+    "comments": []
+});

--- a/tests/fixtures/parsers/typescript-parsers/decorator-with-keywords-class-method.js
+++ b/tests/fixtures/parsers/typescript-parsers/decorator-with-keywords-class-method.js
@@ -1,0 +1,1183 @@
+"use strict";
+
+/**
+ * Parser: typescript-eslint-parser v1.0.3 (TS 2.0.6)
+ * Source code:
+ * class Foo { @desc({set a(value) {}, get a() {}, async c() {}}) async[foo]() {} }
+ */
+
+exports.parse = () => ({
+    "type": "Program",
+    "range": [
+        0,
+        80
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 1,
+            "column": 80
+        }
+    },
+    "body": [
+        {
+            "type": "ClassDeclaration",
+            "range": [
+                0,
+                80
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 80
+                }
+            },
+            "id": {
+                "type": "Identifier",
+                "range": [
+                    6,
+                    9
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 6
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 9
+                    }
+                },
+                "name": "Foo"
+            },
+            "body": {
+                "type": "ClassBody",
+                "body": [
+                    {
+                        "type": "MethodDefinition",
+                        "range": [
+                            12,
+                            78
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 12
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 78
+                            }
+                        },
+                        "key": {
+                            "type": "Identifier",
+                            "range": [
+                                69,
+                                72
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 69
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 72
+                                }
+                            },
+                            "name": "foo"
+                        },
+                        "value": {
+                            "type": "FunctionExpression",
+                            "id": null,
+                            "generator": false,
+                            "expression": false,
+                            "async": true,
+                            "body": {
+                                "type": "BlockStatement",
+                                "range": [
+                                    76,
+                                    78
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 76
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 78
+                                    }
+                                },
+                                "body": []
+                            },
+                            "range": [
+                                73,
+                                78
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 73
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 78
+                                }
+                            },
+                            "params": []
+                        },
+                        "computed": true,
+                        "static": false,
+                        "kind": "method",
+                        "accessibility": null,
+                        "decorators": [
+                            {
+                                "type": "CallExpression",
+                                "range": [
+                                    13,
+                                    62
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 13
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 62
+                                    }
+                                },
+                                "callee": {
+                                    "type": "Identifier",
+                                    "range": [
+                                        13,
+                                        17
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 1,
+                                            "column": 13
+                                        },
+                                        "end": {
+                                            "line": 1,
+                                            "column": 17
+                                        }
+                                    },
+                                    "name": "desc"
+                                },
+                                "arguments": [
+                                    {
+                                        "type": "ObjectExpression",
+                                        "range": [
+                                            18,
+                                            61
+                                        ],
+                                        "loc": {
+                                            "start": {
+                                                "line": 1,
+                                                "column": 18
+                                            },
+                                            "end": {
+                                                "line": 1,
+                                                "column": 61
+                                            }
+                                        },
+                                        "properties": [
+                                            {
+                                                "type": "Property",
+                                                "range": [
+                                                    19,
+                                                    34
+                                                ],
+                                                "loc": {
+                                                    "start": {
+                                                        "line": 1,
+                                                        "column": 19
+                                                    },
+                                                    "end": {
+                                                        "line": 1,
+                                                        "column": 34
+                                                    }
+                                                },
+                                                "key": {
+                                                    "type": "Identifier",
+                                                    "range": [
+                                                        23,
+                                                        24
+                                                    ],
+                                                    "loc": {
+                                                        "start": {
+                                                            "line": 1,
+                                                            "column": 23
+                                                        },
+                                                        "end": {
+                                                            "line": 1,
+                                                            "column": 24
+                                                        }
+                                                    },
+                                                    "name": "a"
+                                                },
+                                                "value": {
+                                                    "type": "FunctionExpression",
+                                                    "id": null,
+                                                    "generator": false,
+                                                    "expression": false,
+                                                    "async": false,
+                                                    "body": {
+                                                        "type": "BlockStatement",
+                                                        "range": [
+                                                            32,
+                                                            34
+                                                        ],
+                                                        "loc": {
+                                                            "start": {
+                                                                "line": 1,
+                                                                "column": 32
+                                                            },
+                                                            "end": {
+                                                                "line": 1,
+                                                                "column": 34
+                                                            }
+                                                        },
+                                                        "body": []
+                                                    },
+                                                    "range": [
+                                                        24,
+                                                        34
+                                                    ],
+                                                    "loc": {
+                                                        "start": {
+                                                            "line": 1,
+                                                            "column": 24
+                                                        },
+                                                        "end": {
+                                                            "line": 1,
+                                                            "column": 34
+                                                        }
+                                                    },
+                                                    "params": [
+                                                        {
+                                                            "type": "Identifier",
+                                                            "range": [
+                                                                25,
+                                                                30
+                                                            ],
+                                                            "loc": {
+                                                                "start": {
+                                                                    "line": 1,
+                                                                    "column": 25
+                                                                },
+                                                                "end": {
+                                                                    "line": 1,
+                                                                    "column": 30
+                                                                }
+                                                            },
+                                                            "name": "value"
+                                                        }
+                                                    ]
+                                                },
+                                                "computed": false,
+                                                "method": false,
+                                                "shorthand": false,
+                                                "kind": "set"
+                                            },
+                                            {
+                                                "type": "Property",
+                                                "range": [
+                                                    36,
+                                                    46
+                                                ],
+                                                "loc": {
+                                                    "start": {
+                                                        "line": 1,
+                                                        "column": 36
+                                                    },
+                                                    "end": {
+                                                        "line": 1,
+                                                        "column": 46
+                                                    }
+                                                },
+                                                "key": {
+                                                    "type": "Identifier",
+                                                    "range": [
+                                                        40,
+                                                        41
+                                                    ],
+                                                    "loc": {
+                                                        "start": {
+                                                            "line": 1,
+                                                            "column": 40
+                                                        },
+                                                        "end": {
+                                                            "line": 1,
+                                                            "column": 41
+                                                        }
+                                                    },
+                                                    "name": "a"
+                                                },
+                                                "value": {
+                                                    "type": "FunctionExpression",
+                                                    "id": null,
+                                                    "generator": false,
+                                                    "expression": false,
+                                                    "async": false,
+                                                    "body": {
+                                                        "type": "BlockStatement",
+                                                        "range": [
+                                                            44,
+                                                            46
+                                                        ],
+                                                        "loc": {
+                                                            "start": {
+                                                                "line": 1,
+                                                                "column": 44
+                                                            },
+                                                            "end": {
+                                                                "line": 1,
+                                                                "column": 46
+                                                            }
+                                                        },
+                                                        "body": []
+                                                    },
+                                                    "range": [
+                                                        41,
+                                                        46
+                                                    ],
+                                                    "loc": {
+                                                        "start": {
+                                                            "line": 1,
+                                                            "column": 41
+                                                        },
+                                                        "end": {
+                                                            "line": 1,
+                                                            "column": 46
+                                                        }
+                                                    },
+                                                    "params": []
+                                                },
+                                                "computed": false,
+                                                "method": false,
+                                                "shorthand": false,
+                                                "kind": "get"
+                                            },
+                                            {
+                                                "type": "Property",
+                                                "range": [
+                                                    48,
+                                                    60
+                                                ],
+                                                "loc": {
+                                                    "start": {
+                                                        "line": 1,
+                                                        "column": 48
+                                                    },
+                                                    "end": {
+                                                        "line": 1,
+                                                        "column": 60
+                                                    }
+                                                },
+                                                "key": {
+                                                    "type": "Identifier",
+                                                    "range": [
+                                                        54,
+                                                        55
+                                                    ],
+                                                    "loc": {
+                                                        "start": {
+                                                            "line": 1,
+                                                            "column": 54
+                                                        },
+                                                        "end": {
+                                                            "line": 1,
+                                                            "column": 55
+                                                        }
+                                                    },
+                                                    "name": "c"
+                                                },
+                                                "value": {
+                                                    "type": "FunctionExpression",
+                                                    "id": null,
+                                                    "generator": false,
+                                                    "expression": false,
+                                                    "async": true,
+                                                    "body": {
+                                                        "type": "BlockStatement",
+                                                        "range": [
+                                                            58,
+                                                            60
+                                                        ],
+                                                        "loc": {
+                                                            "start": {
+                                                                "line": 1,
+                                                                "column": 58
+                                                            },
+                                                            "end": {
+                                                                "line": 1,
+                                                                "column": 60
+                                                            }
+                                                        },
+                                                        "body": []
+                                                    },
+                                                    "range": [
+                                                        55,
+                                                        60
+                                                    ],
+                                                    "loc": {
+                                                        "start": {
+                                                            "line": 1,
+                                                            "column": 55
+                                                        },
+                                                        "end": {
+                                                            "line": 1,
+                                                            "column": 60
+                                                        }
+                                                    },
+                                                    "params": []
+                                                },
+                                                "computed": false,
+                                                "method": true,
+                                                "shorthand": false,
+                                                "kind": "init"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "range": [
+                    10,
+                    80
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 10
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 80
+                    }
+                }
+            },
+            "superClass": null,
+            "implements": [],
+            "decorators": []
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "class",
+            "range": [
+                0,
+                5
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 5
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "Foo",
+            "range": [
+                6,
+                9
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 6
+                },
+                "end": {
+                    "line": 1,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "range": [
+                10,
+                11
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 10
+                },
+                "end": {
+                    "line": 1,
+                    "column": 11
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "@",
+            "range": [
+                12,
+                13
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 12
+                },
+                "end": {
+                    "line": 1,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "desc",
+            "range": [
+                13,
+                17
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 13
+                },
+                "end": {
+                    "line": 1,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "range": [
+                17,
+                18
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 17
+                },
+                "end": {
+                    "line": 1,
+                    "column": 18
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "range": [
+                18,
+                19
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 18
+                },
+                "end": {
+                    "line": 1,
+                    "column": 19
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "set",
+            "range": [
+                19,
+                22
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 19
+                },
+                "end": {
+                    "line": 1,
+                    "column": 22
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "a",
+            "range": [
+                23,
+                24
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 23
+                },
+                "end": {
+                    "line": 1,
+                    "column": 24
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "range": [
+                24,
+                25
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 24
+                },
+                "end": {
+                    "line": 1,
+                    "column": 25
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "value",
+            "range": [
+                25,
+                30
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 25
+                },
+                "end": {
+                    "line": 1,
+                    "column": 30
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "range": [
+                30,
+                31
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 30
+                },
+                "end": {
+                    "line": 1,
+                    "column": 31
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "range": [
+                32,
+                33
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 32
+                },
+                "end": {
+                    "line": 1,
+                    "column": 33
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "range": [
+                33,
+                34
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 33
+                },
+                "end": {
+                    "line": 1,
+                    "column": 34
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ",",
+            "range": [
+                34,
+                35
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 34
+                },
+                "end": {
+                    "line": 1,
+                    "column": 35
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "get",
+            "range": [
+                36,
+                39
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 36
+                },
+                "end": {
+                    "line": 1,
+                    "column": 39
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "a",
+            "range": [
+                40,
+                41
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 40
+                },
+                "end": {
+                    "line": 1,
+                    "column": 41
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "range": [
+                41,
+                42
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 41
+                },
+                "end": {
+                    "line": 1,
+                    "column": 42
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "range": [
+                42,
+                43
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 42
+                },
+                "end": {
+                    "line": 1,
+                    "column": 43
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "range": [
+                44,
+                45
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 44
+                },
+                "end": {
+                    "line": 1,
+                    "column": 45
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "range": [
+                45,
+                46
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 45
+                },
+                "end": {
+                    "line": 1,
+                    "column": 46
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ",",
+            "range": [
+                46,
+                47
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 46
+                },
+                "end": {
+                    "line": 1,
+                    "column": 47
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "async",
+            "range": [
+                48,
+                53
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 48
+                },
+                "end": {
+                    "line": 1,
+                    "column": 53
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "c",
+            "range": [
+                54,
+                55
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 54
+                },
+                "end": {
+                    "line": 1,
+                    "column": 55
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "range": [
+                55,
+                56
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 55
+                },
+                "end": {
+                    "line": 1,
+                    "column": 56
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "range": [
+                56,
+                57
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 56
+                },
+                "end": {
+                    "line": 1,
+                    "column": 57
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "range": [
+                58,
+                59
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 58
+                },
+                "end": {
+                    "line": 1,
+                    "column": 59
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "range": [
+                59,
+                60
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 59
+                },
+                "end": {
+                    "line": 1,
+                    "column": 60
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "range": [
+                60,
+                61
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 60
+                },
+                "end": {
+                    "line": 1,
+                    "column": 61
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "range": [
+                61,
+                62
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 61
+                },
+                "end": {
+                    "line": 1,
+                    "column": 62
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "async",
+            "range": [
+                63,
+                68
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 63
+                },
+                "end": {
+                    "line": 1,
+                    "column": 68
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "[",
+            "range": [
+                68,
+                69
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 68
+                },
+                "end": {
+                    "line": 1,
+                    "column": 69
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "foo",
+            "range": [
+                69,
+                72
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 69
+                },
+                "end": {
+                    "line": 1,
+                    "column": 72
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "]",
+            "range": [
+                72,
+                73
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 72
+                },
+                "end": {
+                    "line": 1,
+                    "column": 73
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "range": [
+                73,
+                74
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 73
+                },
+                "end": {
+                    "line": 1,
+                    "column": 74
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "range": [
+                74,
+                75
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 74
+                },
+                "end": {
+                    "line": 1,
+                    "column": 75
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "range": [
+                76,
+                77
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 76
+                },
+                "end": {
+                    "line": 1,
+                    "column": 77
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "range": [
+                77,
+                78
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 77
+                },
+                "end": {
+                    "line": 1,
+                    "column": 78
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "range": [
+                79,
+                80
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 79
+                },
+                "end": {
+                    "line": 1,
+                    "column": 80
+                }
+            }
+        }
+    ],
+    "comments": []
+});

--- a/tests/fixtures/parsers/typescript-parsers/decorator-with-static-class-methods.js
+++ b/tests/fixtures/parsers/typescript-parsers/decorator-with-static-class-methods.js
@@ -1,0 +1,1187 @@
+"use strict";
+
+/**
+ * Parser: typescript-eslint-parser v1.0.3 (TS 2.0.6)
+ * Source code:
+ * class Foo { @dec static qux() { } @dec static get bar() { } @dec static set baz() { } @dec static async baw() { } }
+ */
+
+exports.parse = () => ({
+    "type": "Program",
+    "range": [
+        0,
+        111
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 1,
+            "column": 111
+        }
+    },
+    "body": [
+        {
+            "type": "ClassDeclaration",
+            "range": [
+                0,
+                111
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 111
+                }
+            },
+            "id": {
+                "type": "Identifier",
+                "range": [
+                    6,
+                    9
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 6
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 9
+                    }
+                },
+                "name": "Foo"
+            },
+            "body": {
+                "type": "ClassBody",
+                "body": [
+                    {
+                        "type": "MethodDefinition",
+                        "range": [
+                            12,
+                            32
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 12
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 32
+                            }
+                        },
+                        "key": {
+                            "type": "Identifier",
+                            "range": [
+                                24,
+                                27
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 24
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 27
+                                }
+                            },
+                            "name": "qux"
+                        },
+                        "value": {
+                            "type": "FunctionExpression",
+                            "id": null,
+                            "generator": false,
+                            "expression": false,
+                            "async": false,
+                            "body": {
+                                "type": "BlockStatement",
+                                "range": [
+                                    30,
+                                    32
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 30
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 32
+                                    }
+                                },
+                                "body": []
+                            },
+                            "range": [
+                                27,
+                                32
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 27
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 32
+                                }
+                            },
+                            "params": []
+                        },
+                        "computed": false,
+                        "static": true,
+                        "kind": "method",
+                        "accessibility": null,
+                        "decorators": [
+                            {
+                                "type": "Identifier",
+                                "range": [
+                                    13,
+                                    16
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 13
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 16
+                                    }
+                                },
+                                "name": "dec"
+                            }
+                        ]
+                    },
+                    {
+                        "type": "MethodDefinition",
+                        "range": [
+                            33,
+                            57
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 33
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 57
+                            }
+                        },
+                        "key": {
+                            "type": "Identifier",
+                            "range": [
+                                49,
+                                52
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 49
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 52
+                                }
+                            },
+                            "name": "bar"
+                        },
+                        "value": {
+                            "type": "FunctionExpression",
+                            "id": null,
+                            "generator": false,
+                            "expression": false,
+                            "async": false,
+                            "body": {
+                                "type": "BlockStatement",
+                                "range": [
+                                    55,
+                                    57
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 55
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 57
+                                    }
+                                },
+                                "body": []
+                            },
+                            "range": [
+                                52,
+                                57
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 52
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 57
+                                }
+                            },
+                            "params": []
+                        },
+                        "computed": false,
+                        "static": true,
+                        "kind": "get",
+                        "accessibility": null,
+                        "decorators": [
+                            {
+                                "type": "Identifier",
+                                "range": [
+                                    34,
+                                    37
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 34
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 37
+                                    }
+                                },
+                                "name": "dec"
+                            }
+                        ]
+                    },
+                    {
+                        "type": "MethodDefinition",
+                        "range": [
+                            58,
+                            82
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 58
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 82
+                            }
+                        },
+                        "key": {
+                            "type": "Identifier",
+                            "range": [
+                                74,
+                                77
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 74
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 77
+                                }
+                            },
+                            "name": "baz"
+                        },
+                        "value": {
+                            "type": "FunctionExpression",
+                            "id": null,
+                            "generator": false,
+                            "expression": false,
+                            "async": false,
+                            "body": {
+                                "type": "BlockStatement",
+                                "range": [
+                                    80,
+                                    82
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 80
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 82
+                                    }
+                                },
+                                "body": []
+                            },
+                            "range": [
+                                77,
+                                82
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 77
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 82
+                                }
+                            },
+                            "params": []
+                        },
+                        "computed": false,
+                        "static": true,
+                        "kind": "set",
+                        "accessibility": null,
+                        "decorators": [
+                            {
+                                "type": "Identifier",
+                                "range": [
+                                    59,
+                                    62
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 59
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 62
+                                    }
+                                },
+                                "name": "dec"
+                            }
+                        ]
+                    },
+                    {
+                        "type": "MethodDefinition",
+                        "range": [
+                            83,
+                            109
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 83
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 109
+                            }
+                        },
+                        "key": {
+                            "type": "Identifier",
+                            "range": [
+                                101,
+                                104
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 101
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 104
+                                }
+                            },
+                            "name": "baw"
+                        },
+                        "value": {
+                            "type": "FunctionExpression",
+                            "id": null,
+                            "generator": false,
+                            "expression": false,
+                            "async": true,
+                            "body": {
+                                "type": "BlockStatement",
+                                "range": [
+                                    107,
+                                    109
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 107
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 109
+                                    }
+                                },
+                                "body": []
+                            },
+                            "range": [
+                                104,
+                                109
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 104
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 109
+                                }
+                            },
+                            "params": []
+                        },
+                        "computed": false,
+                        "static": true,
+                        "kind": "method",
+                        "accessibility": null,
+                        "decorators": [
+                            {
+                                "type": "Identifier",
+                                "range": [
+                                    84,
+                                    87
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 84
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 87
+                                    }
+                                },
+                                "name": "dec"
+                            }
+                        ]
+                    }
+                ],
+                "range": [
+                    10,
+                    111
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 10
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 111
+                    }
+                }
+            },
+            "superClass": null,
+            "implements": [],
+            "decorators": []
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "class",
+            "range": [
+                0,
+                5
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 5
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "Foo",
+            "range": [
+                6,
+                9
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 6
+                },
+                "end": {
+                    "line": 1,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "range": [
+                10,
+                11
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 10
+                },
+                "end": {
+                    "line": 1,
+                    "column": 11
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "@",
+            "range": [
+                12,
+                13
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 12
+                },
+                "end": {
+                    "line": 1,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "dec",
+            "range": [
+                13,
+                16
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 13
+                },
+                "end": {
+                    "line": 1,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "static",
+            "range": [
+                17,
+                23
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 17
+                },
+                "end": {
+                    "line": 1,
+                    "column": 23
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "qux",
+            "range": [
+                24,
+                27
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 24
+                },
+                "end": {
+                    "line": 1,
+                    "column": 27
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "range": [
+                27,
+                28
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 27
+                },
+                "end": {
+                    "line": 1,
+                    "column": 28
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "range": [
+                28,
+                29
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 28
+                },
+                "end": {
+                    "line": 1,
+                    "column": 29
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "range": [
+                30,
+                31
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 30
+                },
+                "end": {
+                    "line": 1,
+                    "column": 31
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "range": [
+                31,
+                32
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 31
+                },
+                "end": {
+                    "line": 1,
+                    "column": 32
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "@",
+            "range": [
+                33,
+                34
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 33
+                },
+                "end": {
+                    "line": 1,
+                    "column": 34
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "dec",
+            "range": [
+                34,
+                37
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 34
+                },
+                "end": {
+                    "line": 1,
+                    "column": 37
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "static",
+            "range": [
+                38,
+                44
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 38
+                },
+                "end": {
+                    "line": 1,
+                    "column": 44
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "get",
+            "range": [
+                45,
+                48
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 45
+                },
+                "end": {
+                    "line": 1,
+                    "column": 48
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "bar",
+            "range": [
+                49,
+                52
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 49
+                },
+                "end": {
+                    "line": 1,
+                    "column": 52
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "range": [
+                52,
+                53
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 52
+                },
+                "end": {
+                    "line": 1,
+                    "column": 53
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "range": [
+                53,
+                54
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 53
+                },
+                "end": {
+                    "line": 1,
+                    "column": 54
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "range": [
+                55,
+                56
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 55
+                },
+                "end": {
+                    "line": 1,
+                    "column": 56
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "range": [
+                56,
+                57
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 56
+                },
+                "end": {
+                    "line": 1,
+                    "column": 57
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "@",
+            "range": [
+                58,
+                59
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 58
+                },
+                "end": {
+                    "line": 1,
+                    "column": 59
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "dec",
+            "range": [
+                59,
+                62
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 59
+                },
+                "end": {
+                    "line": 1,
+                    "column": 62
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "static",
+            "range": [
+                63,
+                69
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 63
+                },
+                "end": {
+                    "line": 1,
+                    "column": 69
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "set",
+            "range": [
+                70,
+                73
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 70
+                },
+                "end": {
+                    "line": 1,
+                    "column": 73
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "baz",
+            "range": [
+                74,
+                77
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 74
+                },
+                "end": {
+                    "line": 1,
+                    "column": 77
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "range": [
+                77,
+                78
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 77
+                },
+                "end": {
+                    "line": 1,
+                    "column": 78
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "range": [
+                78,
+                79
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 78
+                },
+                "end": {
+                    "line": 1,
+                    "column": 79
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "range": [
+                80,
+                81
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 80
+                },
+                "end": {
+                    "line": 1,
+                    "column": 81
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "range": [
+                81,
+                82
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 81
+                },
+                "end": {
+                    "line": 1,
+                    "column": 82
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "@",
+            "range": [
+                83,
+                84
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 83
+                },
+                "end": {
+                    "line": 1,
+                    "column": 84
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "dec",
+            "range": [
+                84,
+                87
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 84
+                },
+                "end": {
+                    "line": 1,
+                    "column": 87
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "static",
+            "range": [
+                88,
+                94
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 88
+                },
+                "end": {
+                    "line": 1,
+                    "column": 94
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "async",
+            "range": [
+                95,
+                100
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 95
+                },
+                "end": {
+                    "line": 1,
+                    "column": 100
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "baw",
+            "range": [
+                101,
+                104
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 101
+                },
+                "end": {
+                    "line": 1,
+                    "column": 104
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "range": [
+                104,
+                105
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 104
+                },
+                "end": {
+                    "line": 1,
+                    "column": 105
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "range": [
+                105,
+                106
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 105
+                },
+                "end": {
+                    "line": 1,
+                    "column": 106
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "range": [
+                107,
+                108
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 107
+                },
+                "end": {
+                    "line": 1,
+                    "column": 108
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "range": [
+                108,
+                109
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 108
+                },
+                "end": {
+                    "line": 1,
+                    "column": 109
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "range": [
+                110,
+                111
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 110
+                },
+                "end": {
+                    "line": 1,
+                    "column": 111
+                }
+            }
+        }
+    ],
+    "comments": []
+});
+

--- a/tests/fixtures/parsers/typescript-parsers/keyword-with-arrow-function.js
+++ b/tests/fixtures/parsers/typescript-parsers/keyword-with-arrow-function.js
@@ -1,0 +1,180 @@
+"use strict";
+
+/**
+ * Parser: typescript-eslint-parser v1.0.3 (TS 2.0.6)
+ * Source code:
+ * symbol => 4;
+ */
+
+exports.parse = () => ({
+    "type": "Program",
+    "range": [
+        0,
+        12
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 1,
+            "column": 12
+        }
+    },
+    "body": [
+        {
+            "type": "ExpressionStatement",
+            "range": [
+                0,
+                12
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 12
+                }
+            },
+            "expression": {
+                "type": "ArrowFunctionExpression",
+                "range": [
+                    0,
+                    11
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 11
+                    }
+                },
+                "generator": false,
+                "id": null,
+                "params": [
+                    {
+                        "type": "Identifier",
+                        "range": [
+                            0,
+                            6
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 0
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 6
+                            }
+                        },
+                        "name": "symbol"
+                    }
+                ],
+                "body": {
+                    "type": "Literal",
+                    "range": [
+                        10,
+                        11
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 10
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 11
+                        }
+                    },
+                    "value": 4,
+                    "raw": "4"
+                },
+                "async": false,
+                "expression": true
+            }
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "symbol",
+            "range": [
+                0,
+                6
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 6
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "=>",
+            "range": [
+                7,
+                9
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 7
+                },
+                "end": {
+                    "line": 1,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Numeric",
+            "value": "4",
+            "range": [
+                10,
+                11
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 10
+                },
+                "end": {
+                    "line": 1,
+                    "column": 11
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "range": [
+                11,
+                12
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 11
+                },
+                "end": {
+                    "line": 1,
+                    "column": 12
+                }
+            }
+        }
+    ],
+    "comments": []
+});

--- a/tests/lib/rules/keyword-spacing.js
+++ b/tests/lib/rules/keyword-spacing.js
@@ -9,7 +9,8 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const rule = require("../../../lib/rules/keyword-spacing"),
+const parser = require("../../fixtures/fixture-parser"),
+    rule = require("../../../lib/rules/keyword-spacing"),
     RuleTester = require("../../../lib/testers/rule-tester");
 
 //------------------------------------------------------------------------------
@@ -1331,7 +1332,21 @@ ruleTester.run("keyword-spacing", rule, {
 
         // not conflict with `jsx-curly-spacing`
         { code: "function* foo() { <Foo onClick={yield} /> }", parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
-        { code: "function* foo() { <Foo onClick={ yield } /> }", options: [NEITHER], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } }
+        { code: "function* foo() { <Foo onClick={ yield } /> }", options: [NEITHER], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
+
+        //----------------------------------------------------------------------
+        // typescript parser
+        //----------------------------------------------------------------------
+
+        // class declaration don't error with decorator
+        { code: "@dec class Foo {}", parser: parser("typescript-parsers/decorator-with-class") },
+
+        // get, set, async methods don't error with decorator
+        { code: "class Foo { @dec get bar() {} @dec set baz() {} @dec async baw() {} }", parser: parser("typescript-parsers/decorator-with-class-methods") },
+        { code: "class Foo { @dec static qux() {} @dec static get bar() {} @dec static set baz() {} @dec static async baw() {} }", parser: parser("typescript-parsers/decorator-with-static-class-methods") },
+
+        // type keywords can be used as parameters in arrow functions
+        { code: "symbol => 4;", parser: parser("typescript-parsers/keyword-with-arrow-function") }
     ],
 
     invalid: [
@@ -3070,6 +3085,18 @@ ruleTester.run("keyword-spacing", rule, {
             errors: unexpectedBefore("yield"),
             options: [override("yield", NEITHER)],
             parserOptions: { ecmaVersion: 6 }
+        },
+
+        //----------------------------------------------------------------------
+        // typescript parser
+        //----------------------------------------------------------------------
+
+        // get, set, async decorator keywords shouldn't be detected
+        {
+            code: "class Foo { @desc({set a(value) {}, get a() {}, async c() {}}) async[foo]() {} }",
+            output: "class Foo { @desc({set a(value) {}, get a() {}, async c() {}}) async [foo]() {} }",
+            errors: expectedAfter("async"),
+            parser: parser("typescript-parsers/decorator-with-keywords-class-method")
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ X] Other, please explain:
https://github.com/eslint/eslint/issues/8110
<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Allow keyword-spacing rule to find the first token better by skipping over decorators, generated by typescript, and not including symbol keyword when parsing arrow functions.

**Is there anything you'd like reviewers to focus on?**
Is this the best solution to allow the typescript parser to work correctly with the keyword-spacing rule?

