### PR TITLE
New: Allow regexes in RuleTester (fixes #7837)

### DIFF
--- a/docs/developer-guide/working-with-plugins.md
+++ b/docs/developer-guide/working-with-plugins.md
@@ -139,10 +139,16 @@ ruleTester.run("custom-plugin-rule", rule, {
         {
             code: "var invalidVariable = true",
             errors: [ { message: "Unexpected invalid variable." } ]
+        },
+        {
+            code: "var invalidVariable = true",
+            errors: [ { message: /^Unexpected.+variable/ } ]
         }
     ]
 });
 ```
+
+As shown above, the message passed to `RuleTester` can be either a string or a regular expression.
 
 The `RuleTester` constructor optionally accepts an object argument, which can be used to specify defaults for your test cases. For example, if all of your test cases use ES2015, you can set it as a default:
 

--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -426,6 +426,28 @@ RuleTester.prototype = {
         }
 
         /**
+         * Asserts that the message matches its expected value. If the expected
+         * value is a regular expression, it is checked against the actual
+         * value.
+         * @param {string} actual Actual value
+         * @param {string|RegExp} expected Expected value
+         * @returns {void}
+         * @private
+         */
+        function assertMessageMatches(actual, expected) {
+            if (expected instanceof RegExp) {
+
+                // assert.js doesn't have a built-in RegExp match function
+                assert.ok(
+                    expected.test(actual),
+                    `Expected '${actual}' to match ${expected}`
+                );
+            } else {
+                assert.equal(actual, expected);
+            }
+        }
+
+        /**
          * Check if the template is invalid or not
          * all invalid cases go through this.
          * @param {string} ruleName name of the rule
@@ -454,10 +476,10 @@ RuleTester.prototype = {
                     assert.ok(!("fatal" in messages[i]), `A fatal parsing error occurred: ${messages[i].message}`);
                     assert.equal(messages[i].ruleId, ruleName, "Error rule name should be the same as the name of the rule being tested");
 
-                    if (typeof item.errors[i] === "string") {
+                    if (typeof item.errors[i] === "string" || item.errors[i] instanceof RegExp) {
 
                         // Just an error message.
-                        assert.equal(messages[i].message, item.errors[i]);
+                        assertMessageMatches(messages[i].message, item.errors[i]);
                     } else if (typeof item.errors[i] === "object") {
 
                         /*
@@ -466,7 +488,7 @@ RuleTester.prototype = {
                          * column.
                          */
                         if (item.errors[i].message) {
-                            assert.equal(messages[i].message, item.errors[i].message);
+                            assertMessageMatches(messages[i].message, item.errors[i].message);
                         }
 
                         if (item.errors[i].type) {
@@ -490,8 +512,8 @@ RuleTester.prototype = {
                         }
                     } else {
 
-                        // Only string or object errors are valid.
-                        assert.fail(messages[i], null, "Error should be a string or object.");
+                        // Message was an unexpected type
+                        assert.fail(messages[i], null, "Error should be a string, object, or RegExp.");
                     }
                 }
             }

--- a/tests/lib/testers/rule-tester.js
+++ b/tests/lib/testers/rule-tester.js
@@ -122,6 +122,17 @@ describe("RuleTester", () => {
         }, /Bad var\..*==.*Bad error message/);
     });
 
+    it("should throw an error when the error message regex does not match", () => {
+        assert.throws(() => {
+            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+                valid: [],
+                invalid: [
+                    { code: "var foo = bar;", errors: [{ message: /Bad error message/ }] }
+                ]
+            });
+        }, /Expected 'Bad var.' to match \/Bad error message\//);
+    });
+
     it("should throw an error when the error is neither an object nor a string", () => {
         assert.throws(() => {
             ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
@@ -134,7 +145,7 @@ describe("RuleTester", () => {
                     { code: "var foo = bar;", errors: [42] }
                 ]
             });
-        }, /Error should be a string or object/);
+        }, /Error should be a string, object, or RegExp/);
     });
 
     it("should throw an error when the error is a string and it does not match error message", () => {
@@ -152,6 +163,19 @@ describe("RuleTester", () => {
         }, /Bad var\..*==.*Bad error message/);
     });
 
+    it("should throw an error when the error is a string and it does not match error message", () => {
+        assert.throws(() => {
+            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+
+                valid: [
+                ],
+                invalid: [
+                    { code: "var foo = bar;", errors: [/Bad error message/] }
+                ]
+            });
+        }, /Expected 'Bad var.' to match \/Bad error message\//);
+    });
+
     it("should not throw an error when the error is a string and it matches error message", () => {
         assert.doesNotThrow(() => {
             ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
@@ -162,6 +186,28 @@ describe("RuleTester", () => {
                 ],
                 invalid: [
                     { code: "var foo = bar;", errors: ["Bad var."] }
+                ]
+            });
+        });
+    });
+
+    it("should not throw an error when the error is a regex and it matches error message", () => {
+        assert.doesNotThrow(() => {
+            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+                valid: [],
+                invalid: [
+                    { code: "var foo = bar;", errors: [/^Bad var/] }
+                ]
+            });
+        });
+    });
+
+    it("should not throw an error when the error is a regex in an object and it matches error message", () => {
+        assert.doesNotThrow(() => {
+            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+                valid: [],
+                invalid: [
+                    { code: "var foo = bar;", errors: [{ message: /^Bad var/ }] }
                 ]
             });
         });

--- a/tests/lib/testers/rule-tester.js
+++ b/tests/lib/testers/rule-tester.js
@@ -133,7 +133,7 @@ describe("RuleTester", () => {
         }, /Expected 'Bad var.' to match \/Bad error message\//);
     });
 
-    it("should throw an error when the error is neither an object nor a string", () => {
+    it("should throw an error when the error is not a supported type", () => {
         assert.throws(() => {
             ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Add something to the core

**What changes did you make? (Give an overview)**
Updated RuleTester to allow the use of regular expressions for matching rule messages, instead of just plain strings

Fixes #7837