### PR TITLE
Fix: duplicated autofix output for inverted fix ranges (fixes #8116)

### DIFF
--- a/lib/rules/padded-blocks.js
+++ b/lib/rules/padded-blocks.js
@@ -188,6 +188,9 @@ module.exports = {
                         node,
                         loc: { line: openBrace.loc.start.line, column: openBrace.loc.start.column },
                         fix(fixer) {
+
+                            // FIXME: The start of this range is sometimes larger than the end.
+                            // https://github.com/eslint/eslint/issues/8116
                             return fixer.replaceTextRange([openBrace.end, nextToken.start - nextToken.loc.start.column], "\n");
                         },
                         message: NEVER_MESSAGE

--- a/lib/util/source-code-fixer.js
+++ b/lib/util/source-code-fixer.js
@@ -108,7 +108,13 @@ SourceCodeFixer.applyFixes = function(sourceCode, messages) {
             // Make output to this fix.
             output += text.slice(Math.max(0, lastPos), Math.max(0, start));
             output += fix.text;
-            lastPos = end;
+
+            /*
+             * If the start of the range is larger than the end for some reason, make sure
+             * the text between the end and the start doesn't get duplicated.
+             * https://github.com/eslint/eslint/issues/8116
+             */
+            lastPos = Math.max(start, end);
         }
         output += text.slice(Math.max(0, lastPos));
 

--- a/tests/lib/rules/padded-blocks.js
+++ b/tests/lib/rules/padded-blocks.js
@@ -463,6 +463,12 @@ ruleTester.run("padded-blocks", rule, {
                     line: 9
                 }
             ]
+        },
+        {
+            code: "function foo() { // a\n\n  b;\n}",
+            output: "function foo() {\n // a\n\n  b;\n}",
+            options: ["never"],
+            errors: [NEVER_MESSAGE]
         }
     ]
 });

--- a/tests/lib/util/source-code-fixer.js
+++ b/tests/lib/util/source-code-fixer.js
@@ -122,6 +122,13 @@ const INSERT_AT_END = {
         message: "nofix2",
         line: 1,
         column: 7
+    },
+    REVERSED_RANGE = {
+        message: "reversed range",
+        fix: {
+            range: [3, 0],
+            text: " "
+        }
     };
 
 //------------------------------------------------------------------------------
@@ -405,6 +412,12 @@ describe("SourceCodeFixer", () => {
 
                 assert.equal(result.output, `\uFEFF${INSERT_AT_START.fix.text}${insertInMiddle}${INSERT_AT_END.fix.text}`);
                 assert.equal(result.messages.length, 0);
+            });
+
+            it("should handle reversed ranges gracefully", () => {
+                const result = SourceCodeFixer.applyFixes(sourceCode, [REVERSED_RANGE]);
+
+                assert.equal(result.output, "\uFEFFvar  answer = 6 * 7;");
             });
 
         });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (https://github.com/eslint/eslint/issues/8116)

**What changes did you make? (Give an overview)**

The padded-blocks rule sometimes produces a fix range where the start index of the range is larger than the end index. Due to the changes in fcc38db469d987e97b668675bf7822c7c0, when source-code-fixer encountered such a range, it would output the text between the end index and the start index twice. This commit ensures that source-code-fixer behaves the same way as it previously did when it encounters an inverted fix range (it should act as if the start and end indices were equal). In the future, we should also update padded-blocks to avoid producing inverted fix ranges.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
