### PR TITLE
Fix: `ignoreRestSiblings` option didn't cover arguments (fixes #8119)

### DIFF
--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -66,6 +66,7 @@ module.exports = {
 
         const DEFINED_MESSAGE = "'{{name}}' is defined but never used.";
         const ASSIGNED_MESSAGE = "'{{name}}' is assigned a value but never used.";
+        const REST_PROPERTY_TYPE = /^(?:Experimental)?RestProperty$/;
 
         const config = {
             vars: "all",
@@ -139,17 +140,16 @@ module.exports = {
          */
         function hasRestSpreadSibling(variable) {
             if (config.ignoreRestSiblings) {
-                const restProperties = new Set(["ExperimentalRestProperty", "RestProperty"]);
+                return variable.defs.some(def => {
+                    const propertyNode = def.name.parent;
+                    const patternNode = propertyNode.parent;
 
-                return variable.defs
-                    .filter(def => def.name.type === "Identifier")
-                    .some(def => (
-                        def.node.id &&
-                        def.node.id.type === "ObjectPattern" &&
-                        def.node.id.properties.length &&
-                        restProperties.has(def.node.id.properties[def.node.id.properties.length - 1].type) &&  // last property is a rest property
-                        !restProperties.has(def.name.parent.type)  // variable is sibling of the rest property
-                    ));
+                    return (
+                        propertyNode.type === "Property" &&
+                        patternNode.type === "ObjectPattern" &&
+                        REST_PROPERTY_TYPE.test(patternNode.properties[patternNode.properties.length - 1].type)
+                    );
+                });
             }
 
             return false;

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -287,7 +287,13 @@ ruleTester.run("no-unused-vars", rule, {
         {
             code: "class Foo { set bar(UNUSED) {} } console.log(Foo)",
             parserOptions: { ecmaVersion: 6 }
-        }
+        },
+
+        // https://github.com/eslint/eslint/issues/8119
+        includeRestPropertyParser({
+            code: "(({a, ...rest}) => rest)",
+            options: [{ args: "all", ignoreRestSiblings: true }]
+        })
     ],
     invalid: [
         { code: "function foox() { return foox(); }", errors: [definedError("foox")] },
@@ -394,6 +400,13 @@ ruleTester.run("no-unused-vars", rule, {
             errors: [
                 { line: 2, column: 21, message: "'x' is assigned a value but never used." }
             ]
+        }),
+
+        // https://github.com/eslint/eslint/issues/8119
+        includeRestPropertyParser({
+            code: "(({a, ...rest}) => {})",
+            options: [{ args: "all", ignoreRestSiblings: true }],
+            errors: ["'rest' is defined but never used."]
         }),
 
         // https://github.com/eslint/eslint/issues/3714


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

Fixes #8119 .

**What changes did you make? (Give an overview)**

This PR makes `ignoreRestSiblings` option of `no-unused-vars` rule covering arguments.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.
