### PR TITLE
Update: add `backtick` to `--init` (fixes #7997)

### DIFF
--- a/lib/config/config-initializer.js
+++ b/lib/config/config-initializer.js
@@ -443,7 +443,14 @@ function promptUser(callback) {
                     name: "quotes",
                     message: "What quotes do you use for strings?",
                     default: "double",
-                    choices: [{ name: "Double", value: "double" }, { name: "Single", value: "single" }]
+                    choices() {
+                        const options = [{ name: "Double", value: "double" }, { name: "Single", value: "single" }];
+
+                        if (secondAnswers.es6) {
+                            options.push({ name: "Backtick", value: "backtick" });
+                        }
+                        return options;
+                    }
                 },
                 {
                     type: "list",

--- a/tests/lib/config/config-initializer.js
+++ b/tests/lib/config/config-initializer.js
@@ -173,6 +173,13 @@ describe("configInitializer", () => {
 
                 assert.isTrue(config.env.commonjs);
             });
+
+            it("should backtick quotes when set", () => {
+                answers.quotes = "backtick";
+                const config = init.processAnswers(answers);
+
+                assert.deepEqual(config.rules.quotes, ["error", "backtick"]);
+            });
         });
 
         describe("guide", () => {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[X] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Add an option to `eslint --init` to set `quotes` rule to `backtick`.

**Is there anything you'd like reviewers to focus on?**
No

