### PR TITLE
Fix: `sourceCode.getJSDocComment` should work with decorated classes/methods

### DIFF
--- a/lib/util/source-code.js
+++ b/lib/util/source-code.js
@@ -79,6 +79,16 @@ function looksLikeExport(astNode) {
 }
 
 /**
+ * Check to see if its a ES-proposal decorator wrapped
+ * @param {ASTNode} astNode - any node
+ * @returns {boolean} whether the given node have decorator wrapping
+ * @private
+ */
+function looksLikeDecorated(astNode) {
+    return astNode.decorators && astNode.decorators[0];
+}
+
+/**
  * Merges two sorted lists into a larger sorted list in O(n) time
  * @param {Token[]} tokens The list of tokens
  * @param {Token[]} comments The list of comments
@@ -245,6 +255,10 @@ SourceCode.prototype = {
                 if (looksLikeExport(parent)) {
                     return findJSDocComment(parent.leadingComments, parent.loc.start.line);
                 }
+                if (node.type === "ClassDeclaration" && looksLikeDecorated(node)) {
+                    return findJSDocComment(node.decorators[0].leadingComments, node.decorators[0].loc.start.line) ||
+                        findJSDocComment(node.leadingComments, node.loc.start.line);
+                }
                 return findJSDocComment(node.leadingComments, node.loc.start.line);
 
             case "ClassExpression":
@@ -257,7 +271,10 @@ SourceCode.prototype = {
                     while (parent && !parent.leadingComments && !/Function/.test(parent.type) && parent.type !== "MethodDefinition" && parent.type !== "Property") {
                         parent = parent.parent;
                     }
-
+                    if (parent && parent.type === "MethodDefinition" && looksLikeDecorated(parent)) {
+                        return findJSDocComment(parent.decorators[0].leadingComments, parent.decorators[0].loc.start.line) ||
+                            findJSDocComment(parent.leadingComments, parent.loc.start.line);
+                    }
                     return parent && (parent.type !== "FunctionDeclaration") ? findJSDocComment(parent.leadingComments, parent.loc.start.line) : null;
                 } else if (node.leadingComments) {
                     return findJSDocComment(node.leadingComments, node.loc.start.line);

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "user-home": "^2.0.0"
   },
   "devDependencies": {
+    "babel-eslint": "^7.1.1",
     "babel-polyfill": "^6.9.1",
     "babel-preset-es2015": "^6.9.0",
     "babelify": "^7.3.0",

--- a/tests/fixtures/parsers/babel-parser.js
+++ b/tests/fixtures/parsers/babel-parser.js
@@ -1,0 +1,9 @@
+var babel = require("babel-eslint");
+
+exports.parseForESLint = function(code, options) {
+    return babel.parseNoPatch(code, options);
+};
+
+exports.parse = function() {
+    throw new Error("Use parseForESLint() instead.");
+};

--- a/tests/lib/util/source-code.js
+++ b/tests/lib/util/source-code.js
@@ -867,6 +867,132 @@ describe("SourceCode", () => {
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
         });
 
+        it("should get JSDoc comment for class declaration when the class has decorator before comment", () => {
+            const alternateParser = path.resolve(__dirname, "../../fixtures/parsers/babel-parser.js");
+
+            const code = [
+                "@decorator",
+                "/** Documentation. */",
+                "class A {",
+                "}"
+            ].join("\n");
+
+            /**
+             * Check jsdoc presence
+             * @param {ASTNode} node not to check
+             * @returns {void}
+             * @private
+             */
+            function assertJSDoc(node) {
+                const sourceCode = eslint.getSourceCode();
+                const jsdoc = sourceCode.getJSDocComment(node);
+
+                assert.equal(jsdoc.type, "Block");
+                assert.equal(jsdoc.value, "* Documentation. ");
+            }
+
+            const spy = sandbox.spy(assertJSDoc);
+
+            eslint.on("ClassDeclaration", spy);
+            eslint.verify(code, { rules: {}, parser: alternateParser }, filename, true);
+            assert.isTrue(spy.calledOnce, "Event handler should be called.");
+        });
+
+        it("should get JSDoc comment for class declaration when the class has decorator after comment", () => {
+            const alternateParser = path.resolve(__dirname, "../../fixtures/parsers/babel-parser.js");
+
+            const code = [
+                "/** Documentation. */",
+                "@decorator",
+                "class A {",
+                "}"
+            ].join("\n");
+
+            /**
+             * Check jsdoc presence
+             * @param {ASTNode} node not to check
+             * @returns {void}
+             * @private
+             */
+            function assertJSDoc(node) {
+                const sourceCode = eslint.getSourceCode();
+                const jsdoc = sourceCode.getJSDocComment(node);
+
+                assert.equal(jsdoc.type, "Block");
+                assert.equal(jsdoc.value, "* Documentation. ");
+            }
+
+            const spy = sandbox.spy(assertJSDoc);
+
+            eslint.on("ClassDeclaration", spy);
+            eslint.verify(code, { rules: {}, parser: alternateParser }, filename, true);
+            assert.isTrue(spy.calledOnce, "Event handler should be called.");
+        });
+
+        it("should get JSDoc comment for class method when the method has decorator before comment", () => {
+            const alternateParser = path.resolve(__dirname, "../../fixtures/parsers/babel-parser.js");
+
+            const code = [
+                "class A {",
+                "  @decorator",
+                "  /** Documentation. */",
+                "  method() {}",
+                "};"
+            ].join("\n");
+
+            /**
+             * Check jsdoc presence
+             * @param {ASTNode} node not to check
+             * @returns {void}
+             * @private
+             */
+            function assertJSDoc(node) {
+                const sourceCode = eslint.getSourceCode();
+                const jsdoc = sourceCode.getJSDocComment(node);
+
+                assert.equal(jsdoc.type, "Block");
+                assert.equal(jsdoc.value, "* Documentation. ");
+            }
+
+            const spy = sandbox.spy(assertJSDoc);
+
+            eslint.on("FunctionExpression", spy);
+            eslint.verify(code, { rules: {}, parser: alternateParser }, filename, true);
+            assert.isTrue(spy.calledOnce, "Event handler should be called.");
+        });
+
+        it("should get JSDoc comment for class method when the method has decorator after comment", () => {
+            const alternateParser = path.resolve(__dirname, "../../fixtures/parsers/babel-parser.js");
+
+            const code = [
+                "class A {",
+                "  /** Documentation. */",
+                "  @decorator",
+                "  method() {}",
+                "};"
+            ].join("\n");
+
+            /**
+             * Check jsdoc presence
+             * @param {ASTNode} node not to check
+             * @returns {void}
+             * @private
+             */
+            function assertJSDoc(node) {
+                const sourceCode = eslint.getSourceCode();
+                const jsdoc = sourceCode.getJSDocComment(node);
+
+                assert.equal(jsdoc.type, "Block");
+                assert.equal(jsdoc.value, "* Documentation. ");
+            }
+
+            const spy = sandbox.spy(assertJSDoc);
+
+            eslint.on("FunctionExpression", spy);
+            eslint.verify(code, { rules: {}, parser: alternateParser }, filename, true);
+            assert.isTrue(spy.calledOnce, "Event handler should be called.");
+        });
+
     });
 
     describe("getComments()", () => {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
**This fix for work with `babel-eslint` parser & `babel-plugin-syntax-decorators`**
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Please see https://github.com/babel/eslint-plugin-babel/issues/48
This PR allow use JSDoc before @decorators, like this case
```js
/**
 * Class description
 */
@Bar
class Foo {

}
```
This need for `require-jsdoc` & `valid-jsdoc` rules

**Is there anything you'd like reviewers to focus on?**


