### PR TITLE
Build: display rules’ meta data in their docs (fixes #5774)

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -635,6 +635,11 @@ target.gensite = function(prereleaseVersion) {
         };
     }
 
+    const rules = require(".").linter.getRules();
+
+    const RECOMMENDED_TEXT = "\n\n(recommended) The `\"extends\": \"eslint:recommended\"` property in a configuration file enables this rule.";
+    const FIXABLE_TEXT = "\n\n(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) can automatically fix some of the problems reported by this rule.";
+
     // 4. Loop through all files in temporary directory
     find(TEMP_DIR).forEach(filename => {
         if (test("-f", filename) && path.extname(filename) === ".md") {
@@ -650,6 +655,19 @@ target.gensite = function(prereleaseVersion) {
 
             // 5. Prepend page title and layout variables at the top of rules
             if (path.dirname(filename).indexOf("rules") >= 0) {
+
+                // Find out if the rule requires a special docs portion (e.g. if it is recommended and/or fixable)
+                const rule = rules.get(ruleName);
+                const isRecommended = rule && rule.meta.docs.recommended;
+                const isFixable = rule && rule.meta.fixable;
+
+                // Incorporate the special portion into the documentation content
+                const textSplit = text.split("\n");
+                const ruleHeading = textSplit[0];
+                const ruleDocsContent = textSplit.slice(1).join("\n");
+
+                text = `${ruleHeading}${isRecommended ? RECOMMENDED_TEXT : ""}${isFixable ? FIXABLE_TEXT : ""}\n${ruleDocsContent}`;
+
                 text = `---\ntitle: ${ruleName} - Rules\nlayout: doc\n---\n<!-- Note: No pull requests accepted for this file. See README.md in the root directory for details. -->\n\n${text}`;
             } else {
 

--- a/docs/rules/array-bracket-spacing.md
+++ b/docs/rules/array-bracket-spacing.md
@@ -1,7 +1,5 @@
 # Disallow or enforce spaces inside of brackets (array-bracket-spacing)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 A number of style guides require or disallow spaces between array brackets and other tokens. This rule
 applies to both array literals and destructuring assignments (ECMAScript 6).
 

--- a/docs/rules/arrow-body-style.md
+++ b/docs/rules/arrow-body-style.md
@@ -1,7 +1,5 @@
 # Require braces in arrow function body (arrow-body-style)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 Arrow functions have two syntactic forms for their function bodies.  They may be defined with a *block* body (denoted by curly braces) `() => { ... }` or with a single expression `() => ...`, whose value is implicitly returned.
 
 ## Rule Details

--- a/docs/rules/arrow-parens.md
+++ b/docs/rules/arrow-parens.md
@@ -1,7 +1,5 @@
 # Require parens in arrow function arguments (arrow-parens)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 Arrow functions can omit parentheses when they have exactly one parameter. In all other cases the parameter(s) must
 be wrapped in parentheses. This rule enforces the consistent use of parentheses in arrow functions.
 

--- a/docs/rules/arrow-spacing.md
+++ b/docs/rules/arrow-spacing.md
@@ -1,7 +1,5 @@
 # Require space before/after arrow function's arrow (arrow-spacing)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 This rule normalize style of spacing before/after an arrow function's arrow(`=>`).
 
 ```js

--- a/docs/rules/block-spacing.md
+++ b/docs/rules/block-spacing.md
@@ -1,7 +1,5 @@
 # Disallow or enforce spaces inside of single line blocks (block-spacing)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 ## Rule Details
 
 This rule enforces consistent spacing inside single-line blocks.

--- a/docs/rules/brace-style.md
+++ b/docs/rules/brace-style.md
@@ -1,7 +1,5 @@
 # Require Brace Style (brace-style)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 Brace style is closely related to [indent style](http://en.wikipedia.org/wiki/Indent_style) in programming and describes the placement of braces relative to their control statement and body. There are probably a dozen, if not more, brace styles in the world.
 
 The *one true brace style* is one of the most common brace styles in JavaScript, in which the opening brace of a block is placed on the same line as its corresponding statement or declaration. For example:

--- a/docs/rules/capitalized-comments.md
+++ b/docs/rules/capitalized-comments.md
@@ -1,7 +1,5 @@
 # enforce or disallow capitalization of the first letter of a comment (capitalized-comments)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 Comments are useful for leaving information for future developers. In order for that information to be useful and not distracting, it is sometimes desirable for comments to follow a particular style. One element of comment formatting styles is whether the first word of a comment should be capitalized or lowercase.
 
 In general, no comment style is any more or less valid than any others, but many developers would agree that a consistent style can improve a project's maintainability.

--- a/docs/rules/comma-dangle.md
+++ b/docs/rules/comma-dangle.md
@@ -1,7 +1,5 @@
 # require or disallow trailing commas (comma-dangle)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 Trailing commas in object literals are valid according to the ECMAScript 5 (and ECMAScript 3!) spec. However, IE8 (when not in IE8 document mode) and below will throw an error when it encounters trailing commas in JavaScript.
 
 ```js

--- a/docs/rules/comma-spacing.md
+++ b/docs/rules/comma-spacing.md
@@ -1,7 +1,5 @@
 # Enforces spacing around commas (comma-spacing)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 Spacing around commas improve readability of a list of items. Although most of the style guidelines for languages prescribe adding a space after a comma and not before it, it is subjective to the preferences of a project.
 
 ```js

--- a/docs/rules/comma-style.md
+++ b/docs/rules/comma-style.md
@@ -1,7 +1,5 @@
 # Comma style (comma-style)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 The Comma Style rule enforces styles for comma-separated lists. There are two comma styles primarily used in JavaScript:
 
 * The standard style, in which commas are placed at the end of the current line

--- a/docs/rules/computed-property-spacing.md
+++ b/docs/rules/computed-property-spacing.md
@@ -1,7 +1,5 @@
 # Disallow or enforce spaces inside of computed properties (computed-property-spacing)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 While formatting preferences are very personal, a number of style guides require
 or disallow spaces between computed properties in the following situations:
 

--- a/docs/rules/curly.md
+++ b/docs/rules/curly.md
@@ -1,7 +1,5 @@
 # Require Following Curly Brace Conventions (curly)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 JavaScript allows the omission of curly braces when a block contains only one statement. However, it is considered by many to be best practice to _never_ omit curly braces around blocks, even when they are optional, because it can lead to bugs and reduces code clarity. So the following:
 
 ```js

--- a/docs/rules/dot-location.md
+++ b/docs/rules/dot-location.md
@@ -1,7 +1,5 @@
 # Enforce newline before and after dot (dot-location)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 JavaScript allows you to place newlines before or after a dot in a member expression.
 
 Consistency in placing a newline before or after the dot can greatly increase readability.

--- a/docs/rules/dot-notation.md
+++ b/docs/rules/dot-notation.md
@@ -1,7 +1,5 @@
 # Require Dot Notation (dot-notation)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 In JavaScript, one can access properties using the dot notation (`foo.bar`) or square-bracket notation (`foo["bar"]`). However, the dot notation is often preferred because it is easier to read, less verbose, and works better with aggressive JavaScript minimizers.
 
 ```js

--- a/docs/rules/eol-last.md
+++ b/docs/rules/eol-last.md
@@ -1,7 +1,5 @@
 # require or disallow newline at the end of files (eol-last)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 Trailing newlines in non-empty files are a common UNIX idiom. Benefits of
 trailing newlines include the ability to concatenate or append to files as well
 as output files to the terminal without interfering with shell prompts.

--- a/docs/rules/eqeqeq.md
+++ b/docs/rules/eqeqeq.md
@@ -1,7 +1,5 @@
 # Require === and !== (eqeqeq)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 It is considered good practice to use the type-safe equality operators `===` and `!==` instead of their regular counterparts `==` and `!=`.
 
 The reason for this is that `==` and `!=` do type coercion which follows the rather obscure [Abstract Equality Comparison Algorithm](http://www.ecma-international.org/ecma-262/5.1/#sec-11.9.3).

--- a/docs/rules/func-call-spacing.md
+++ b/docs/rules/func-call-spacing.md
@@ -1,7 +1,5 @@
 # require or disallow spacing between function identifiers and their invocations (func-call-spacing)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 When calling a function, developers may insert optional whitespace between the function's name and the parentheses that invoke it. The following pairs of function calls are equivalent:
 
 ```js

--- a/docs/rules/generator-star-spacing.md
+++ b/docs/rules/generator-star-spacing.md
@@ -1,7 +1,5 @@
 # Enforce spacing around the * in generator functions (generator-star-spacing)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 Generators are a new type of function in ECMAScript 6 that can return multiple values over time.
 These special functions are indicated by placing an `*` after the `function` keyword.
 

--- a/docs/rules/indent.md
+++ b/docs/rules/indent.md
@@ -1,7 +1,5 @@
 # enforce consistent indentation (indent)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 There are several common guidelines which require specific indentation of nested blocks and statements, like:
 
 ```js

--- a/docs/rules/jsx-quotes.md
+++ b/docs/rules/jsx-quotes.md
@@ -1,7 +1,5 @@
 # enforce the consistent use of either double or single quotes in JSX attributes (jsx-quotes)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 JSX attribute values can contain string literals, which are delimited with single or double quotes.
 
 ```xml

--- a/docs/rules/key-spacing.md
+++ b/docs/rules/key-spacing.md
@@ -1,7 +1,5 @@
 # enforce consistent spacing between keys and values in object literal properties (key-spacing)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 This rule enforces spacing around the colon in object literal properties. It can verify each property individually, or it can ensure horizontal alignment of adjacent properties in an object literal.
 
 ## Rule Details

--- a/docs/rules/keyword-spacing.md
+++ b/docs/rules/keyword-spacing.md
@@ -1,7 +1,5 @@
 # enforce consistent spacing before and after keywords (keyword-spacing)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 Keywords are syntax elements of JavaScript, such as `function` and `if`.
 These identifiers have special meaning to the language and so often appear in a different color in code editors.
 As an important part of the language, style guides often refer to the spacing that should be used around keywords.

--- a/docs/rules/linebreak-style.md
+++ b/docs/rules/linebreak-style.md
@@ -1,7 +1,5 @@
 # enforce consistent linebreak style (linebreak-style)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 When developing with a lot of people all having different editors, VCS applications and operating systems it may occur that
 different line endings are written by either of the mentioned (might especially happen when using the windows and mac versions of SourceTree together).
 

--- a/docs/rules/lines-around-directive.md
+++ b/docs/rules/lines-around-directive.md
@@ -1,7 +1,5 @@
 # require or disallow newlines around directives (lines-around-directive)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 Directives are used in JavaScript to indicate to the execution environment that a script would like to opt into a feature such as `"strict mode"`. Directives are grouped together in a [directive prologue](http://www.ecma-international.org/ecma-262/7.0/#directive-prologue) at the top of either a file or function block and are applied to the scope in which they occur.
 
 ```js

--- a/docs/rules/new-parens.md
+++ b/docs/rules/new-parens.md
@@ -1,7 +1,5 @@
 # require parentheses when invoking a constructor with no arguments (new-parens)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 JavaScript allows the omission of parentheses when invoking a function via the `new` keyword and the constructor has no arguments. However, some coders believe that omitting the parentheses is inconsistent with the rest of the language and thus makes code less clear.
 
 ```js

--- a/docs/rules/newline-after-var.md
+++ b/docs/rules/newline-after-var.md
@@ -1,7 +1,5 @@
 # require or disallow an empty line after variable declarations (newline-after-var)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 As of today there is no consistency in separating variable declarations from the rest of the code. Some developers leave an empty line between var statements and the rest of the code like:
 
 ```js

--- a/docs/rules/newline-before-return.md
+++ b/docs/rules/newline-before-return.md
@@ -1,7 +1,5 @@
 # require an empty line before `return` statements (newline-before-return)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 There is no hard and fast rule about whether empty lines should precede `return` statements in JavaScript. However, clearly delineating where a function is returning can greatly increase the readability and clarity of the code. For example:
 
 ```js

--- a/docs/rules/no-else-return.md
+++ b/docs/rules/no-else-return.md
@@ -2,8 +2,6 @@
 
 If an `if` block contains a `return` statement, the `else` block becomes unnecessary. Its contents can be placed outside of the block.
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 ```js
 function foo() {
     if (x) {

--- a/docs/rules/no-extra-bind.md
+++ b/docs/rules/no-extra-bind.md
@@ -1,7 +1,5 @@
 # Disallow unnecessary function binding (no-extra-bind)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 The `bind()` method is used to create functions with specific `this` values and, optionally, binds arguments to specific values. When used to specify the value of `this`, it's important that the function actually use `this` in its function body. For example:
 
 ```js

--- a/docs/rules/no-extra-boolean-cast.md
+++ b/docs/rules/no-extra-boolean-cast.md
@@ -1,7 +1,5 @@
 # disallow unnecessary boolean casts (no-extra-boolean-cast)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 In contexts such as an `if` statement's test where the result of the expression will already be coerced to a Boolean, casting to a Boolean via double negation (`!!`) or a `Boolean` call is unnecessary. For example, these `if` statements are equivalent:
 
 ```js

--- a/docs/rules/no-extra-label.md
+++ b/docs/rules/no-extra-label.md
@@ -1,7 +1,5 @@
 # Disallow Unnecessary Labels (no-extra-label)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 If a loop contains no nested loops or switches, labeling the loop is unnecessary.
 
 ```js

--- a/docs/rules/no-extra-parens.md
+++ b/docs/rules/no-extra-parens.md
@@ -1,7 +1,5 @@
 # disallow unnecessary parentheses (no-extra-parens)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 This rule restricts the use of parentheses to only where they are necessary.
 
 ## Rule Details

--- a/docs/rules/no-extra-semi.md
+++ b/docs/rules/no-extra-semi.md
@@ -1,7 +1,5 @@
 # disallow unnecessary semicolons (no-extra-semi)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 Typing mistakes and misunderstandings about where semicolons are required can lead to semicolons that are unnecessary. While not technically an error, extra semicolons can cause confusion when reading code.
 
 ## Rule Details

--- a/docs/rules/no-floating-decimal.md
+++ b/docs/rules/no-floating-decimal.md
@@ -1,7 +1,5 @@
 # Disallow Floating Decimals (no-floating-decimal)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 Float values in JavaScript contain a decimal point, and there is no requirement that the decimal point be preceded or followed by a number. For example, the following are all valid JavaScript numbers:
 
 ```js

--- a/docs/rules/no-implicit-coercion.md
+++ b/docs/rules/no-implicit-coercion.md
@@ -1,7 +1,5 @@
 # Disallow the type conversion with shorter notations. (no-implicit-coercion)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 In JavaScript, there are a lot of different ways to convert value types.
 Some of them might be hard to read and understand.
 

--- a/docs/rules/no-lonely-if.md
+++ b/docs/rules/no-lonely-if.md
@@ -1,7 +1,5 @@
 # disallow `if` statements as the only statement in `else` blocks (no-lonely-if)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 If an `if` statement is the only statement in the `else` block, it is often clearer to use an `else if` form.
 
 ```js

--- a/docs/rules/no-multi-spaces.md
+++ b/docs/rules/no-multi-spaces.md
@@ -1,7 +1,5 @@
 # Disallow multiple spaces (no-multi-spaces)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 Multiple spaces in a row that are not used for indentation are typically mistakes. For example:
 
 ```js

--- a/docs/rules/no-multiple-empty-lines.md
+++ b/docs/rules/no-multiple-empty-lines.md
@@ -1,7 +1,5 @@
 # disallow multiple empty lines (no-multiple-empty-lines)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 Some developers prefer to have multiple blank lines removed, while others feel that it helps improve readability. Whitespace is useful for separating logical sections of code, but excess whitespace takes up more of the screen.
 
 ## Rule Details

--- a/docs/rules/no-regex-spaces.md
+++ b/docs/rules/no-regex-spaces.md
@@ -1,7 +1,5 @@
 # disallow multiple spaces in regular expression literals (no-regex-spaces)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 Regular expressions can be very complex and difficult to understand, which is why it's important to keep them as simple as possible in order to avoid mistakes. One of the more error-prone things you can do with a regular expression is to use more than one space, such as:
 
 ```js

--- a/docs/rules/no-spaced-func.md
+++ b/docs/rules/no-spaced-func.md
@@ -2,8 +2,6 @@
 
 This rule was **deprecated** in ESLint v3.3.0 and replaced by the [func-call-spacing](func-call-spacing.md) rule.
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 While it's possible to have whitespace between the name of a function and the parentheses that execute it, such patterns tend to look more like errors.
 
 ## Rule Details

--- a/docs/rules/no-trailing-spaces.md
+++ b/docs/rules/no-trailing-spaces.md
@@ -1,7 +1,5 @@
 # disallow trailing whitespace at the end of lines (no-trailing-spaces)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 Sometimes in the course of editing files, you can end up with extra whitespace at the end of lines. These whitespace differences can be picked up by source control systems and flagged as diffs, causing frustration for developers. While this extra whitespace causes no functional issues, many code conventions require that trailing spaces be removed before check-in.
 
 ## Rule Details

--- a/docs/rules/no-undef-init.md
+++ b/docs/rules/no-undef-init.md
@@ -1,7 +1,5 @@
 # Disallow Initializing to undefined (no-undef-init)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 In JavaScript, a variable that is declared and not initialized to any value automatically gets the value of `undefined`. For example:
 
 ```js

--- a/docs/rules/no-unneeded-ternary.md
+++ b/docs/rules/no-unneeded-ternary.md
@@ -1,7 +1,5 @@
 # disallow ternary operators when simpler alternatives exist (no-unneeded-ternary)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 It's a common mistake in JavaScript to use a conditional expression to select between two Boolean values instead of using ! to convert the test to a Boolean.
 Here are some examples:
 

--- a/docs/rules/no-unsafe-negation.md
+++ b/docs/rules/no-unsafe-negation.md
@@ -1,7 +1,5 @@
 # disallow negating the left operand of relational operators (no-unsafe-negation)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 Just as developers might type `-a + b` when they mean `-(a + b)` for the negative of a sum, they might type `!key in object` by mistake when they almost certainly mean `!(key in object)` to test that a key is not in an object. `!obj instanceof Ctor` is similar.
 
 ## Rule Details

--- a/docs/rules/no-unused-labels.md
+++ b/docs/rules/no-unused-labels.md
@@ -1,7 +1,5 @@
 # Disallow Unused Labels (no-unused-labels)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 Labels that are declared and not used anywhere in the code are most likely an error due to incomplete refactoring.
 
 ```js

--- a/docs/rules/no-useless-computed-key.md
+++ b/docs/rules/no-useless-computed-key.md
@@ -1,7 +1,5 @@
 # Disallow unnecessary computed property keys on objects (no-useless-computed-key)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 It's unnecessary to use computed properties with literals such as:
 
 ```js

--- a/docs/rules/no-useless-rename.md
+++ b/docs/rules/no-useless-rename.md
@@ -1,7 +1,5 @@
 # Disallow renaming import, export, and destructured assignments to the same name (no-useless-rename)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 ES2015 allows for the renaming of references in import and export statements as well as destructuring assignments. This gives programmers a concise syntax for performing these operations while renaming these references:
 
 ```js

--- a/docs/rules/no-useless-return.md
+++ b/docs/rules/no-useless-return.md
@@ -1,7 +1,5 @@
 # Disallow redundant return statements (no-useless-return)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 A `return;` statement with nothing after it is redundant, and has no effect on the runtime behavior of a function. This can be confusing, so it's better to disallow these redundant statements.
 
 ## Rule Details

--- a/docs/rules/no-var.md
+++ b/docs/rules/no-var.md
@@ -1,7 +1,5 @@
 # require `let` or `const` instead of `var` (no-var)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes some instances of problems reported by this rule.
-
 ECMAScript 6 allows programmers to create variables with block scope instead of function scope using the `let`
 and `const` keywords. Block scope is common in many other programming languages and helps programmers avoid mistakes
 such as:

--- a/docs/rules/no-whitespace-before-property.md
+++ b/docs/rules/no-whitespace-before-property.md
@@ -1,7 +1,5 @@
 # disallow whitespace before properties (no-whitespace-before-property)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 JavaScript allows whitespace between objects and their properties. However, inconsistent spacing can make code harder to read and can lead to errors.
 
 ```js

--- a/docs/rules/object-curly-newline.md
+++ b/docs/rules/object-curly-newline.md
@@ -1,7 +1,5 @@
 # enforce consistent line breaks inside braces (object-curly-newline)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 A number of style guides require or disallow line breaks inside of object braces and other tokens.
 
 ## Rule Details

--- a/docs/rules/object-curly-spacing.md
+++ b/docs/rules/object-curly-spacing.md
@@ -1,7 +1,5 @@
 # enforce consistent spacing inside braces (object-curly-spacing)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 While formatting preferences are very personal, a number of style guides require
 or disallow spaces between curly braces in the following situations:
 

--- a/docs/rules/object-property-newline.md
+++ b/docs/rules/object-property-newline.md
@@ -1,7 +1,5 @@
 # enforce placing object properties on separate lines (object-property-newline)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 While formatting preferences are very personal, a number of style guides require that object properties be placed on separate lines for better readability.
 
 Another argument in favor of this style is that it improves the readability of diffs when a property is changed:

--- a/docs/rules/object-shorthand.md
+++ b/docs/rules/object-shorthand.md
@@ -1,7 +1,5 @@
 # Require Object Literal Shorthand Syntax (object-shorthand)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 EcmaScript 6 provides a concise form for defining object literal methods and properties. This
 syntax can make defining complex object literals much cleaner.
 

--- a/docs/rules/one-var-declaration-per-line.md
+++ b/docs/rules/one-var-declaration-per-line.md
@@ -1,7 +1,5 @@
 # require or disallow newlines around variable declarations (one-var-declaration-per-line)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 Some developers declare multiple var statements on the same line:
 
 ```js

--- a/docs/rules/operator-assignment.md
+++ b/docs/rules/operator-assignment.md
@@ -1,7 +1,5 @@
 # require or disallow assignment operator shorthand where possible (operator-assignment)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 JavaScript provides shorthand operators that combine variable assignment and some simple mathematical operations. For example, `x = x + 4` can be shortened to `x += 4`. The supported shorthand forms are as follows:
 
 ```text

--- a/docs/rules/operator-linebreak.md
+++ b/docs/rules/operator-linebreak.md
@@ -1,7 +1,5 @@
 # enforce consistent linebreak style for operators (operator-linebreak)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 When a statement is too long to fit on a single line, line breaks are generally inserted next to the operators separating expressions. The first style coming to mind would be to place the operator at the end of the line, following the english punctuation rules.
 
 ```js

--- a/docs/rules/padded-blocks.md
+++ b/docs/rules/padded-blocks.md
@@ -1,7 +1,5 @@
 # require or disallow padding within blocks (padded-blocks)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 Some style guides require block statements to start and end with blank lines. The goal is
 to improve readability by visually separating the block content and the surrounding code.
 

--- a/docs/rules/prefer-arrow-callback.md
+++ b/docs/rules/prefer-arrow-callback.md
@@ -1,7 +1,5 @@
 # Suggest using arrow functions as callbacks. (prefer-arrow-callback)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 Arrow functions are suited to callbacks, because:
 
 - `this` keywords in arrow functions bind to the upper scope's.

--- a/docs/rules/prefer-const.md
+++ b/docs/rules/prefer-const.md
@@ -1,7 +1,5 @@
 # Suggest using `const` (prefer-const)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes some instances of problems reported by this rule.
-
 If a variable is never reassigned, using the `const` declaration is better.
 
 `const` declaration tells readers, "this variable is never reassigned," reducing cognitive load and improving maintainability.

--- a/docs/rules/prefer-numeric-literals.md
+++ b/docs/rules/prefer-numeric-literals.md
@@ -1,7 +1,5 @@
 # disallow `parseInt()` in favor of binary, octal, and hexadecimal literals (prefer-numeric-literals)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 The `parseInt()` function can be used to turn binary, octal, and hexadecimal strings into integers. As binary, octal, and hexadecimal literals are supported in ES6, this rule encourages use of those numeric literals instead of `parseInt()`.
 
 ```js

--- a/docs/rules/prefer-spread.md
+++ b/docs/rules/prefer-spread.md
@@ -1,7 +1,5 @@
 # Suggest using the spread operator instead of `.apply()`. (prefer-spread)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 Before ES2015, one must use `Function.prototype.apply()` to call variadic functions.
 
 ```js

--- a/docs/rules/prefer-template.md
+++ b/docs/rules/prefer-template.md
@@ -1,7 +1,5 @@
 # Suggest using template literals instead of string concatenation. (prefer-template)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 In ES2015 (ES6), we can use template literals instead of string concatenation.
 
 ```js

--- a/docs/rules/quote-props.md
+++ b/docs/rules/quote-props.md
@@ -1,7 +1,5 @@
 # require quotes around object literal property names (quote-props)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 Object literal property names can be defined in two ways: using literals or using strings. For example, these two objects are equivalent:
 
 ```js

--- a/docs/rules/quotes.md
+++ b/docs/rules/quotes.md
@@ -1,7 +1,5 @@
 # enforce the consistent use of either backticks, double, or single quotes (quotes)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 JavaScript allows you to define strings in one of three ways: double quotes, single quotes, and backticks (as of ECMAScript 6). For example:
 
 ```js

--- a/docs/rules/rest-spread-spacing.md
+++ b/docs/rules/rest-spread-spacing.md
@@ -1,7 +1,5 @@
 # Enforce spacing between rest and spread operators and their expressions (rest-spread-spacing)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 ES2015 introduced the rest and spread operators, which expand an iterable structure into its individual parts. Some examples of their usage are as follows:
 
 ```js

--- a/docs/rules/semi-spacing.md
+++ b/docs/rules/semi-spacing.md
@@ -1,7 +1,5 @@
 # Enforce spacing before and after semicolons (semi-spacing)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 JavaScript allows you to place unnecessary spaces before or after a semicolon.
 
 Disallowing or enforcing space around a semicolon can improve the readability of your program.

--- a/docs/rules/semi.md
+++ b/docs/rules/semi.md
@@ -1,7 +1,5 @@
 # require or disallow semicolons instead of ASI (semi)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 JavaScript is unique amongst the C-like languages in that it doesn't require semicolons at the end of each statement. In many cases, the JavaScript engine can determine that a semicolon should be in a certain spot and will automatically add it. This feature is known as **automatic semicolon insertion (ASI)** and is considered one of the more controversial features of JavaScript. For example, the following lines are both valid:
 
 ```js

--- a/docs/rules/sort-imports.md
+++ b/docs/rules/sort-imports.md
@@ -1,7 +1,5 @@
 # Import Sorting (sort-imports)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 The import statement is used to import members (functions, objects or primitives) that have been exported from an external module. Using a specific member syntax:
 
 ```js

--- a/docs/rules/space-before-blocks.md
+++ b/docs/rules/space-before-blocks.md
@@ -1,7 +1,5 @@
 # Require Or Disallow Space Before Blocks (space-before-blocks)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 Consistency is an important part of any style guide.
 While it is a personal preference where to put the opening brace of blocks,
 it should be consistent across a whole project.

--- a/docs/rules/space-before-function-paren.md
+++ b/docs/rules/space-before-function-paren.md
@@ -1,7 +1,5 @@
 # Require or disallow a space before function parenthesis (space-before-function-paren)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 When formatting a function, whitespace is allowed between the function name or `function` keyword and the opening paren. Named functions also require a space between the `function` keyword and the function name, but anonymous functions require no whitespace. For example:
 
 ```js

--- a/docs/rules/space-in-parens.md
+++ b/docs/rules/space-in-parens.md
@@ -1,7 +1,5 @@
 # Disallow or enforce spaces inside of parentheses (space-in-parens)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 Some style guides require or disallow spaces inside of parentheses:
 
 ```js

--- a/docs/rules/space-infix-ops.md
+++ b/docs/rules/space-infix-ops.md
@@ -1,7 +1,5 @@
 # require spacing around infix operators (space-infix-ops)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 While formatting preferences are very personal, a number of style guides require spaces around operators, such as:
 
 ```js

--- a/docs/rules/space-unary-ops.md
+++ b/docs/rules/space-unary-ops.md
@@ -1,7 +1,5 @@
 # Require or disallow spaces before/after unary operators (space-unary-ops)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 Some style guides require or disallow spaces before or after unary operators. This is mainly a stylistic issue, however, some JavaScript expressions can be written without spacing which makes it harder to read and maintain.
 
 ## Rule Details

--- a/docs/rules/spaced-comment.md
+++ b/docs/rules/spaced-comment.md
@@ -1,7 +1,5 @@
 # Requires or disallows a whitespace (space or tab) beginning a comment (spaced-comment)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 Some style guides require or disallow a whitespace immediately after the initial `//` or `/*` of a comment.
 Whitespace after the `//` or `/*` makes it easier to read text in comments.
 On the other hand, commenting out code is easier without having to put a whitespace right after the `//` or `/*`.

--- a/docs/rules/strict.md
+++ b/docs/rules/strict.md
@@ -1,7 +1,5 @@
 # require or disallow strict mode directives (strict)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 A strict mode directive is a `"use strict"` literal at the beginning of a script or function body. It enables strict mode semantics.
 
 When a directive occurs in global scope, strict mode applies to the entire script:

--- a/docs/rules/template-curly-spacing.md
+++ b/docs/rules/template-curly-spacing.md
@@ -1,7 +1,5 @@
 # Enforce Usage of Spacing in Template Strings (template-curly-spacing)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 We can embed expressions in template strings with using a pair of `${` and `}`.
 
 This rule can force usage of spacing _within_ the curly brace pair according to style guides.

--- a/docs/rules/template-tag-spacing.md
+++ b/docs/rules/template-tag-spacing.md
@@ -1,7 +1,5 @@
 # Require or disallow spacing between template tags and their literals (template-tag-spacing)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 With ES6, it's possible to create functions called [tagged template literals](#further-reading) where the function parameters consist of a template literal's strings and expressions.
 
 When using tagged template literals, it's possible to insert whitespace between the tag function and the template literal. Since this whitespace is optional, the following lines are equivalent:

--- a/docs/rules/unicode-bom.md
+++ b/docs/rules/unicode-bom.md
@@ -1,7 +1,5 @@
 # Require or disallow the Unicode Byte Order Mark (BOM) (unicode-bom)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 The Unicode Byte Order Mark (BOM) is used to specify whether code units are big
 endian or little endian. That is, whether the most significant or least
 significant bytes come first. UTF-8 does not require a BOM because byte ordering

--- a/docs/rules/wrap-iife.md
+++ b/docs/rules/wrap-iife.md
@@ -1,7 +1,5 @@
 # Require IIFEs to be Wrapped (wrap-iife)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 You can immediately invoke function expressions, but not function declarations. A common technique to create an immediately-invoked function expression (IIFE) is to wrap a function declaration in parentheses. The opening parentheses causes the contained function to be parsed as an expression, rather than a declaration.
 
 ```js

--- a/docs/rules/wrap-regex.md
+++ b/docs/rules/wrap-regex.md
@@ -1,7 +1,5 @@
 # Require Regex Literals to be Wrapped (wrap-regex)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 When a regular expression is used in certain situations, it can end up looking like a division operator. For example:
 
 ```js

--- a/docs/rules/yield-star-spacing.md
+++ b/docs/rules/yield-star-spacing.md
@@ -1,7 +1,5 @@
 # Enforce spacing around the `*` in `yield*` expressions (yield-star-spacing)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 ## Rule Details
 
 This rule enforces spacing around the `*` in `yield*` expressions.

--- a/docs/rules/yoda.md
+++ b/docs/rules/yoda.md
@@ -1,7 +1,5 @@
 # Require or disallow Yoda Conditions (yoda)
 
-(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
 Yoda conditions are so named because the literal value of the condition comes first while the variable comes second. For example, the following is a Yoda condition:
 
 ```js


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Modified the generation of `eslint.github.io` website so that important rule metadata such as recommended and fixable are automatically appended to the documentation of each rule.

This removes the need to hard-code the "fixable" portion on all fixable rules.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.