### PR TITLE
Chore: fix output assertion typos in rule tests

### DIFF
--- a/tests/lib/rules/comma-dangle.js
+++ b/tests/lib/rules/comma-dangle.js
@@ -760,7 +760,7 @@ ruleTester.run("comma-dangle", rule, {
         },
         {
             code: "var foo = { bar: 'baz', }",
-            ouput: "var foo = { bar: 'baz' }",
+            output: "var foo = { bar: 'baz' }",
             options: ["only-multiline"],
             errors: [
                 {
@@ -799,7 +799,7 @@ ruleTester.run("comma-dangle", rule, {
         },
         {
             code: "foo({ bar: 'baz', qux: 'quux', });",
-            ouput: "foo({ bar: 'baz', qux: 'quux' });",
+            output: "foo({ bar: 'baz', qux: 'quux' });",
             options: ["only-multiline"],
             errors: [
                 {

--- a/tests/lib/rules/computed-property-spacing.js
+++ b/tests/lib/rules/computed-property-spacing.js
@@ -156,7 +156,7 @@ ruleTester.run("computed-property-spacing", rule, {
         },
         {
             code: "obj[ foo ]",
-            outptu: "obj[foo]",
+            output: "obj[foo]",
             options: ["never"],
             errors: [
                 {

--- a/tests/lib/rules/newline-after-var.js
+++ b/tests/lib/rules/newline-after-var.js
@@ -285,7 +285,7 @@ ruleTester.run("newline-after-var", rule, {
         { code: TWO_BLANKS, output: NO_BLANK, options: ["never"], errors: [NEVER_ERROR] },
         { code: THREE_BLANKS, output: NO_BLANK, options: ["never"], errors: [NEVER_ERROR] },
         { code: ONE_BLANK_WITH_TRAILING_WS, output: NO_BLANK_WITH_TRAILING_WS, options: ["never"], errors: [NEVER_ERROR] },
-        { code: ONE_BLANK_WITH_INLINE_COMMENT, NO_BLANK_WITH_INLINE_COMMENT, options: ["never"], errors: [NEVER_ERROR] },
+        { code: ONE_BLANK_WITH_INLINE_COMMENT, output: NO_BLANK_WITH_INLINE_COMMENT, options: ["never"], errors: [NEVER_ERROR] },
         { code: MULTI_VAR_ONE_BLANK, output: MULTI_VAR_NO_BLANK, options: ["never"], errors: [NEVER_ERROR] },
         { code: MULTI_DEC_ONE_BLANK, output: MULTI_DEC_NO_BLANK, options: ["never"], errors: [NEVER_ERROR] },
         { code: MULTI_LINE_ONE_BLANK, output: MULTI_LINE_NO_BLANK, options: ["never"], errors: [NEVER_ERROR] },


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

**What changes did you make? (Give an overview)**

Several rule test files have typos preventing output from being asserted properly. This commit fixes the typos.

These typos were discovered with the [`consistent-output`](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/090091e0d36b2a739dbee736ccf732ea2c9f10ab/docs/rules/consistent-output.md) rule.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
