### PR TITLE
Chore: fix invalid redeclared variables in tests

### DIFF
--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -900,16 +900,16 @@ ruleTester.run("indent", rule, {
             "        a: 1,\n" +
             "        b: 2\n" +
             "      };\n" +
-            "let abc = 5,\n" +
-            "  c = 2,\n" +
-            "  xyz = \n" +
+            "let abc2 = 5,\n" +
+            "  c2 = 2,\n" +
+            "  xyz2 = \n" +
             "  {\n" +
             "    a: 1,\n" +
             "    b: 2\n" +
             "  };\n" +
-            "var abc = 5,\n" +
-            "    c = 2,\n" +
-            "    xyz = \n" +
+            "var abc3 = 5,\n" +
+            "    c3 = 2,\n" +
+            "    xyz3 = \n" +
             "    {\n" +
             "      a: 1,\n" +
             "      b: 2\n" +
@@ -2806,19 +2806,19 @@ ruleTester.run("indent", rule, {
             "      a: 1\n" +
             "    }),\n" +
             "    b = 4;\n" +
-            "const a = new Test({\n" +
+            "const c = new Test({\n" +
             "      a: 1\n" +
             "    }),\n" +
-            "    b = 4;\n",
+            "    d = 4;\n",
             output:
             "var a = new Test({\n" +
             "      a: 1\n" +
             "    }),\n" +
             "    b = 4;\n" +
-            "const a = new Test({\n" +
+            "const c = new Test({\n" +
             "    a: 1\n" +
             "  }),\n" +
-            "  b = 4;\n",
+            "  d = 4;\n",
             options: [2, { VariableDeclarator: { var: 2 } }],
             parserOptions: { ecmaVersion: 6 },
             errors: expectedErrors([

--- a/tests/lib/rules/no-redeclare.js
+++ b/tests/lib/rules/no-redeclare.js
@@ -39,7 +39,7 @@ ruleTester.run("no-redeclare", rule, {
     ],
     invalid: [
         { code: "var a = 3; var a = 10;", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' is already defined.", type: "Identifier" }] },
-        { code: "switch(foo) { case a: let b = 3;\ncase b: let b = 4}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'b' is already defined.", type: "Identifier" }] },
+        { code: "switch(foo) { case a: var b = 3;\ncase b: var b = 4}", errors: [{ message: "'b' is already defined.", type: "Identifier" }] },
         { code: "var a = 3; var a = 10;", errors: [{ message: "'a' is already defined.", type: "Identifier" }] },
         { code: "var a = {}; var a = [];", errors: [{ message: "'a' is already defined.", type: "Identifier" }] },
         { code: "var a; function a() {}", errors: [{ message: "'a' is already defined.", type: "Identifier" }] },

--- a/tests/lib/rules/no-shadow.js
+++ b/tests/lib/rules/no-shadow.js
@@ -27,7 +27,7 @@ ruleTester.run("no-shadow", rule, {
         { code: "class A {}", parserOptions: { ecmaVersion: 6 } },
         { code: "class A { constructor() { var a; } }", parserOptions: { ecmaVersion: 6 } },
         { code: "(function() { var A = class A {}; })()", parserOptions: { ecmaVersion: 6 } },
-        { code: "{ var a; } let a;", parserOptions: { ecmaVersion: 6 } }, // this case reports `no-redeclare`, not shadowing.
+        { code: "{ var a; } var a;", parserOptions: { ecmaVersion: 6 } }, // this case reports `no-redeclare`, not shadowing.
         { code: "{ let a; } let a;", options: [{ hoist: "never" }], parserOptions: { ecmaVersion: 6 } },
         { code: "{ let a; } var a;", options: [{ hoist: "never" }], parserOptions: { ecmaVersion: 6 } },
         { code: "{ let a; } function a() {}", options: [{ hoist: "never" }], parserOptions: { ecmaVersion: 6 } },

--- a/tests/lib/rules/prefer-const.js
+++ b/tests/lib/rules/prefer-const.js
@@ -92,13 +92,7 @@ ruleTester.run("prefer-const", rule, {
         {
             code: "let x; function foo() { bar(x); } x = 0;",
             options: [{ ignoreReadBeforeAssign: true }]
-        },
-
-        // https://github.com/eslint/eslint/issues/7712
-        // https://github.com/ternjs/acorn/issues/487
-        // This should be a SyntaxError, but espree parses it correctly. Don't throw an error if the variable has multiple declarations.
-        "let foo; const foo = 1;"
-
+        }
     ],
     invalid: [
         {

--- a/tests/lib/rules/sort-imports.js
+++ b/tests/lib/rules/sort-imports.js
@@ -57,7 +57,7 @@ ruleTester.run("sort-imports", rule, {
         {
             code:
                 "import {a, b} from 'bar.js';\n" +
-                "import {b, c} from 'foo.js';"
+                "import {c, d} from 'foo.js';"
         },
         {
             code:
@@ -72,7 +72,7 @@ ruleTester.run("sort-imports", rule, {
         {
             code:
                 "import a, * as b from 'foo.js';\n" +
-                "import b from 'bar.js';"
+                "import c from 'bar.js';"
         },
         {
             code:
@@ -147,7 +147,7 @@ ruleTester.run("sort-imports", rule, {
         {
             code:
                 "import {b, c} from 'foo.js';\n" +
-                "import {a, b} from 'bar.js';",
+                "import {a, d} from 'bar.js';",
             errors: [expectedError]
         },
         {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

**What changes did you make? (Give an overview)**

Several tests for rules have invalid syntax due to redeclared lexical variables. Previously, Acorn did not raise a syntax error for this, but it will probably check this in the next release now that https://github.com/ternjs/acorn/issues/487 is fixed. This commit updates the tests to remove the invalid syntax.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
