### PR TITLE
Fix: Make RuleTester handle empty-string cases gracefully (fixes #8142)

### DIFF
--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -512,7 +512,7 @@ RuleTester.prototype = {
         RuleTester.describe(ruleName, () => {
             RuleTester.describe("valid", () => {
                 test.valid.forEach(valid => {
-                    RuleTester.it(valid.code || valid, () => {
+                    RuleTester.it(typeof valid === "object" ? valid.code : valid, () => {
                         eslint.defineRules(this.rules);
                         testValidTemplate(ruleName, valid);
                     });

--- a/tests/lib/testers/rule-tester.js
+++ b/tests/lib/testers/rule-tester.js
@@ -11,6 +11,7 @@
 //------------------------------------------------------------------------------
 
 const sinon = require("sinon"),
+    EventEmitter = require("events"),
     eslint = require("../../../lib/eslint"),
     RuleTester = require("../../../lib/testers/rule-tester"),
     assert = require("chai").assert;
@@ -28,13 +29,20 @@ const sinon = require("sinon"),
  * RuleTester to do nothing but run code. Effectively, it() and describe()
  * just become regular functions inside of index.js, not at all related to Mocha.
  * That allows the results of this file to be untainted and therefore accurate.
+ *
+ * To assert that the right arguments are passed to RuleTester.describe/it, an
+ * event emitter is used which emits the arguments.
  */
 
+const ruleTesterTestEmitter = new EventEmitter();
+
 RuleTester.describe = function(text, method) {
+    ruleTesterTestEmitter.emit("describe", text, method);
     return method.apply(this);
 };
 
 RuleTester.it = function(text, method) {
+    ruleTesterTestEmitter.emit("it", text, method);
     return method.apply(this);
 };
 
@@ -680,5 +688,99 @@ describe("RuleTester", () => {
                 invalid: []
             });
         }, "Test Scenarios for rule foo is invalid:\nCould not find any valid test scenarios");
+    });
+
+    describe("naming test cases", () => {
+
+        /**
+         * Asserts that a particular value will be emitted from an EventEmitter.
+         * @param {EventEmitter} emitter The emitter that should emit a value
+         * @param {string} emitType The type of emission to listen for
+         * @param {*} expectedValue The value that should be emitted
+         * @returns {Promise} A Promise that fulfills if the value is emitted, and rejects if something else is emitted.
+         * The Promise will be indefinitely pending if no value is emitted.
+         */
+        function assertEmitted(emitter, emitType, expectedValue) {
+            return new Promise((resolve, reject) => {
+                emitter.once(emitType, emittedValue => {
+                    if (emittedValue === expectedValue) {
+                        resolve();
+                    } else {
+                        reject(new Error(`Expected ${expectedValue} to be emitted but ${emittedValue} was emitted instead.`));
+                    }
+                });
+            });
+        }
+
+        it("should use the first argument as the name of the test suite", () => {
+            const assertion = assertEmitted(ruleTesterTestEmitter, "describe", "this-is-a-rule-name");
+
+            ruleTester.run("this-is-a-rule-name", require("../../fixtures/testers/rule-tester/no-var"), {
+                valid: [],
+                invalid: []
+            });
+
+            return assertion;
+        });
+
+        it("should use the test code as the name of the tests for valid code (string form)", () => {
+            const assertion = assertEmitted(ruleTesterTestEmitter, "it", "valid(code);");
+
+            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
+                valid: [
+                    "valid(code);"
+                ],
+                invalid: []
+            });
+
+            return assertion;
+        });
+
+        it("should use the test code as the name of the tests for valid code (object form)", () => {
+            const assertion = assertEmitted(ruleTesterTestEmitter, "it", "valid(code);");
+
+            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
+                valid: [
+                    {
+                        code: "valid(code);"
+                    }
+                ],
+                invalid: []
+            });
+
+            return assertion;
+        });
+
+        it("should use the test code as the name of the tests for invalid code", () => {
+            const assertion = assertEmitted(ruleTesterTestEmitter, "it", "var x = invalid(code);");
+
+            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
+                valid: [],
+                invalid: [
+                    {
+                        code: "var x = invalid(code);",
+                        errors: 1
+                    }
+                ]
+            });
+
+            return assertion;
+        });
+
+        // https://github.com/eslint/eslint/issues/8142
+        it("should use the empty string as the name of the test if the test case is an empty string", () => {
+            const assertion = assertEmitted(ruleTesterTestEmitter, "it", "");
+
+            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/no-var"), {
+                valid: [
+                    {
+                        code: ""
+                    }
+                ],
+                invalid: []
+            });
+
+            return assertion;
+        });
     });
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (#8142)

**What changes did you make? (Give an overview)**

This updates `RuleTester` to correctly handle test cases where `code` is an empty string. Previously, this would either result in a test called `[object Object]` or throw an error, depending on the version of Mocha.

This also adds tests to assert the suite/testcase names when using RuleTester.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
