### PR TITLE
Fix: invalid autofix of padded-blocks (refs #8117)

### DIFF
--- a/lib/rules/padded-blocks.js
+++ b/lib/rules/padded-blocks.js
@@ -6,6 +6,12 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const astUtils = require("../ast-utils");
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
@@ -82,12 +88,37 @@ module.exports = {
         }
 
         /**
-         * Checks if the given parameter is a comment node
-         * @param {ASTNode|Token} node An AST node or token
-         * @returns {boolean} True if node is a comment
+         * Gets the next token of the given opening brace token.
+         * But it ignores comments on the same line.
+         * @param {Token} openBraceToken The opening brace token to get.
+         * @returns {Token} The found next token.
          */
-        function isComment(node) {
-            return node.type === "Line" || node.type === "Block";
+        function getFirstLineToken(openBraceToken) {
+            const braceLine = openBraceToken.loc.end.line;
+
+            return sourceCode.getTokenAfter(openBraceToken, {
+                includeComments: true,
+                filter: token =>
+                    !astUtils.isCommentToken(token) ||
+                    token.loc.start.line !== braceLine
+            });
+        }
+
+        /**
+         * Gets the previous token of the given closing brace token.
+         * But it ignores comments on the same line.
+         * @param {Token} closeBraceToken The closing brace token to get.
+         * @returns {Token} The found previous token.
+         */
+        function getLastLineToken(closeBraceToken) {
+            const braceLine = closeBraceToken.loc.end.line;
+
+            return sourceCode.getTokenBefore(closeBraceToken, {
+                includeComments: true,
+                filter: token =>
+                    !astUtils.isCommentToken(token) ||
+                    token.loc.start.line !== braceLine
+            });
         }
 
         /**
@@ -96,15 +127,10 @@ module.exports = {
          * @returns {boolean} Whether or not the token is followed by a blank line.
          */
         function isTokenTopPadded(token) {
-            const tokenStartLine = token.loc.start.line,
-                expectedFirstLine = tokenStartLine + 2;
-            let first = token;
-
-            do {
-                first = sourceCode.getTokenAfter(first, { includeComments: true });
-            } while (isComment(first) && first.loc.start.line === tokenStartLine);
-
-            const firstLine = first.loc.start.line;
+            const tokenStartLine = token.loc.start.line;
+            const expectedFirstLine = tokenStartLine + 2;
+            const firstLineToken = getFirstLineToken(token);
+            const firstLine = firstLineToken.loc.start.line;
 
             return expectedFirstLine <= firstLine;
         }
@@ -115,15 +141,10 @@ module.exports = {
          * @returns {boolean} Whether or not the token is preceeded by a blank line
          */
         function isTokenBottomPadded(token) {
-            const blockEnd = token.loc.end.line,
-                expectedLastLine = blockEnd - 2;
-            let last = token;
-
-            do {
-                last = sourceCode.getTokenBefore(last, { includeComments: true });
-            } while (isComment(last) && last.loc.end.line === blockEnd);
-
-            const lastLine = last.loc.end.line;
+            const blockEnd = token.loc.end.line;
+            const expectedLastLine = blockEnd - 2;
+            const lastLineToken = getLastLineToken(token);
+            const lastLine = lastLineToken.loc.end.line;
 
             return lastLine <= expectedLastLine;
         }
@@ -182,30 +203,29 @@ module.exports = {
                 }
             } else {
                 if (blockHasTopPadding) {
-                    const nextToken = sourceCode.getTokenAfter(openBrace, { includeComments: true });
+                    const nextToken = getFirstLineToken(openBrace);
+                    const prevToken = sourceCode.getTokenBefore(nextToken, { includeComments: true });
 
                     context.report({
                         node,
-                        loc: { line: openBrace.loc.start.line, column: openBrace.loc.start.column },
+                        loc: openBrace.loc,
                         fix(fixer) {
-
-                            // FIXME: The start of this range is sometimes larger than the end.
-                            // https://github.com/eslint/eslint/issues/8116
-                            return fixer.replaceTextRange([openBrace.end, nextToken.start - nextToken.loc.start.column], "\n");
+                            return fixer.replaceTextRange([prevToken.end, nextToken.start - nextToken.loc.start.column], "\n");
                         },
                         message: NEVER_MESSAGE
                     });
                 }
 
                 if (blockHasBottomPadding) {
-                    const previousToken = sourceCode.getTokenBefore(closeBrace, { includeComments: true });
+                    const prevToken = getLastLineToken(closeBrace);
+                    const nextToken = sourceCode.getTokenAfter(prevToken, { includeComments: true });
 
                     context.report({
                         node,
-                        loc: { line: closeBrace.loc.end.line, column: closeBrace.loc.end.column - 1 },
+                        loc: closeBrace.loc,
                         message: NEVER_MESSAGE,
                         fix(fixer) {
-                            return fixer.replaceTextRange([previousToken.end, closeBrace.start - closeBrace.loc.start.column], "\n");
+                            return fixer.replaceTextRange([prevToken.end, nextToken.start - nextToken.loc.start.column], "\n");
                         }
                     });
                 }

--- a/tests/lib/rules/padded-blocks.js
+++ b/tests/lib/rules/padded-blocks.js
@@ -466,7 +466,13 @@ ruleTester.run("padded-blocks", rule, {
         },
         {
             code: "function foo() { // a\n\n  b;\n}",
-            output: "function foo() {\n // a\n\n  b;\n}",
+            output: "function foo() { // a\n  b;\n}",
+            options: ["never"],
+            errors: [NEVER_MESSAGE]
+        },
+        {
+            code: "function foo() {\n  b;\n\n/*a*/}",
+            output: "function foo() {\n  b;\n/*a*/}",
             options: ["never"],
             errors: [NEVER_MESSAGE]
         }


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

**Tell us about your environment**

* **ESLint Version:** 3.16.1
* **Node Version:** 7.6.0
* **npm Version:** 4.2.0

**What parser (default, Babel-ESLint, etc.) are you using?**

- default

**Please show your full configuration:**

- nothing

**What did you do? Please include the actual source code causing the issue.**

I did `eslint --fix` to the following code:

```js
/* eslint padded-blocks: [error, never] */

function foo() { /*a*/
    
    bar()
    
/*b*/ }
```

```bash
$ eslint test.js --fix --no-ignore --no-eslintrc
```

**What did you expect to happen?**

The padding lines are removed.

```js
/* eslint padded-blocks: [error, never] */

function foo() { /*a*/
    bar()
/*b*/ }
```

**What actually happened? Please include the actual, raw output from ESLint.**

The padding lines remained as is.

```js
/* eslint padded-blocks: [error, never] */

function foo() {
 /*a*/
    
    bar()
    
/*b*/
 }
```

**What changes did you make? (Give an overview)**

This PR fixes a bug of `padded-blocks` rule.

This is related to #8117 and #8133.
The current `padded-blocks` rule sometimes makes inverted range's autofix. This is a bug.

The root cause is:

- The rule ignores comments on the same line as braces when it counts padding lines.
- But the rule does not ignore the comments when autofix.

As a result, it fixes the code wrongly. The wrong fix's range is inverted.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.
