### PR TITLE
Fix: padded-blocks autofix problems with comments

### DIFF
--- a/lib/rules/padded-blocks.js
+++ b/lib/rules/padded-blocks.js
@@ -91,22 +91,30 @@ module.exports = {
         }
 
         /**
+         * Checks if there is padding between two tokens
+         * @param {Token} first The first token
+         * @param {Token} second The second token
+         * @returns {boolean} True if there is at least a line between the tokens
+         */
+        function isPaddingBetweenTokens(first, second) {
+            return second.loc.start.line - first.loc.end.line >= 2;
+        }
+
+
+        /**
          * Checks if the given token has a blank line after it.
          * @param {Token} token The token to check.
          * @returns {boolean} Whether or not the token is followed by a blank line.
          */
-        function isTokenTopPadded(token) {
-            const tokenStartLine = token.loc.start.line,
-                expectedFirstLine = tokenStartLine + 2;
+        function getFirstBlockToken(token) {
+            const tokenStartLine = token.loc.start.line;
             let first = token;
 
             do {
                 first = sourceCode.getTokenAfter(first, { includeComments: true });
             } while (isComment(first) && first.loc.start.line === tokenStartLine);
 
-            const firstLine = first.loc.start.line;
-
-            return expectedFirstLine <= firstLine;
+            return first;
         }
 
         /**
@@ -114,18 +122,15 @@ module.exports = {
          * @param {Token} token The token to check
          * @returns {boolean} Whether or not the token is preceeded by a blank line
          */
-        function isTokenBottomPadded(token) {
-            const blockEnd = token.loc.end.line,
-                expectedLastLine = blockEnd - 2;
+        function getLastBlockToken(token) {
+            const blockEnd = token.loc.end.line;
             let last = token;
 
             do {
                 last = sourceCode.getTokenBefore(last, { includeComments: true });
             } while (isComment(last) && last.loc.end.line === blockEnd);
 
-            const lastLine = last.loc.end.line;
-
-            return lastLine <= expectedLastLine;
+            return last;
         }
 
         /**
@@ -155,17 +160,21 @@ module.exports = {
          */
         function checkPadding(node) {
             const openBrace = getOpenBrace(node),
+                firstBlockToken = getFirstBlockToken(openBrace),
+                tokenBeforeFirst = sourceCode.getTokenBefore(firstBlockToken, { includeComments: true }),
                 closeBrace = sourceCode.getLastToken(node),
-                blockHasTopPadding = isTokenTopPadded(openBrace),
-                blockHasBottomPadding = isTokenBottomPadded(closeBrace);
+                lastBlockToken = getLastBlockToken(closeBrace),
+                tokenAfterLast = sourceCode.getTokenAfter(lastBlockToken, { includeComments: true }),
+                blockHasTopPadding = isPaddingBetweenTokens(tokenBeforeFirst, firstBlockToken),
+                blockHasBottomPadding = isPaddingBetweenTokens(lastBlockToken, tokenAfterLast);
 
             if (requirePaddingFor(node)) {
                 if (!blockHasTopPadding) {
                     context.report({
                         node,
-                        loc: { line: openBrace.loc.start.line, column: openBrace.loc.start.column },
+                        loc: { line: tokenBeforeFirst.loc.start.line, column: tokenBeforeFirst.loc.start.column },
                         fix(fixer) {
-                            return fixer.insertTextAfter(openBrace, "\n");
+                            return fixer.insertTextAfter(tokenBeforeFirst, "\n");
                         },
                         message: ALWAYS_MESSAGE
                     });
@@ -175,37 +184,32 @@ module.exports = {
                         node,
                         loc: { line: closeBrace.loc.end.line, column: closeBrace.loc.end.column - 1 },
                         fix(fixer) {
-                            return fixer.insertTextBefore(closeBrace, "\n");
+                            return fixer.insertTextBefore(tokenAfterLast, "\n");
                         },
                         message: ALWAYS_MESSAGE
                     });
                 }
             } else {
                 if (blockHasTopPadding) {
-                    const nextToken = sourceCode.getTokenAfter(openBrace, { includeComments: true });
 
                     context.report({
                         node,
-                        loc: { line: openBrace.loc.start.line, column: openBrace.loc.start.column },
+                        loc: { line: tokenBeforeFirst.loc.start.line, column: tokenBeforeFirst.loc.start.column },
                         fix(fixer) {
-
-                            // FIXME: The start of this range is sometimes larger than the end.
-                            // https://github.com/eslint/eslint/issues/8116
-                            return fixer.replaceTextRange([openBrace.end, nextToken.start - nextToken.loc.start.column], "\n");
+                            return fixer.replaceTextRange([tokenBeforeFirst.end, firstBlockToken.start - firstBlockToken.loc.start.column], "\n");
                         },
                         message: NEVER_MESSAGE
                     });
                 }
 
                 if (blockHasBottomPadding) {
-                    const previousToken = sourceCode.getTokenBefore(closeBrace, { includeComments: true });
 
                     context.report({
                         node,
                         loc: { line: closeBrace.loc.end.line, column: closeBrace.loc.end.column - 1 },
                         message: NEVER_MESSAGE,
                         fix(fixer) {
-                            return fixer.replaceTextRange([previousToken.end, closeBrace.start - closeBrace.loc.start.column], "\n");
+                            return fixer.replaceTextRange([lastBlockToken.end, tokenAfterLast.start - tokenAfterLast.loc.start.column], "\n");
                         }
                     });
                 }

--- a/lib/rules/padded-blocks.js
+++ b/lib/rules/padded-blocks.js
@@ -107,12 +107,13 @@ module.exports = {
          * @returns {boolean} Whether or not the token is followed by a blank line.
          */
         function getFirstBlockToken(token) {
-            const tokenStartLine = token.loc.start.line;
-            let first = token;
+            let prev = token,
+                first = token;
 
             do {
+                prev = first;
                 first = sourceCode.getTokenAfter(first, { includeComments: true });
-            } while (isComment(first) && first.loc.start.line === tokenStartLine);
+            } while (isComment(first) && first.loc.start.line === prev.loc.end.line);
 
             return first;
         }
@@ -123,12 +124,13 @@ module.exports = {
          * @returns {boolean} Whether or not the token is preceeded by a blank line
          */
         function getLastBlockToken(token) {
-            const blockEnd = token.loc.end.line;
-            let last = token;
+            let last = token,
+                next = token;
 
             do {
+                next = last;
                 last = sourceCode.getTokenBefore(last, { includeComments: true });
-            } while (isComment(last) && last.loc.end.line === blockEnd);
+            } while (isComment(last) && last.loc.end.line === next.loc.start.line);
 
             return last;
         }
@@ -182,7 +184,7 @@ module.exports = {
                 if (!blockHasBottomPadding) {
                     context.report({
                         node,
-                        loc: { line: closeBrace.loc.end.line, column: closeBrace.loc.end.column - 1 },
+                        loc: { line: tokenAfterLast.loc.end.line, column: tokenAfterLast.loc.end.column - 1 },
                         fix(fixer) {
                             return fixer.insertTextBefore(tokenAfterLast, "\n");
                         },
@@ -206,7 +208,7 @@ module.exports = {
 
                     context.report({
                         node,
-                        loc: { line: closeBrace.loc.end.line, column: closeBrace.loc.end.column - 1 },
+                        loc: { line: tokenAfterLast.loc.end.line, column: tokenAfterLast.loc.end.column - 1 },
                         message: NEVER_MESSAGE,
                         fix(fixer) {
                             return fixer.replaceTextRange([lastBlockToken.end, tokenAfterLast.start - tokenAfterLast.loc.start.column], "\n");

--- a/tests/lib/rules/padded-blocks.js
+++ b/tests/lib/rules/padded-blocks.js
@@ -30,6 +30,11 @@ ruleTester.run("padded-blocks", rule, {
         { code: "{\n\na()\n//comment\n\n}" },
         { code: "{\n\na = 1\n\n}" },
         { code: "{//comment\n\na();\n\n}" },
+        { code: "{ /* comment */\n\na();\n\n}" },
+        { code: "{ /* comment \n */\n\na();\n\n}" },
+        { code: "{ /* comment \n */ /* another comment \n */\n\na();\n\n}" },
+        { code: "{ /* comment \n */ /* another comment \n */\n\na();\n\n/* comment \n */ /* another comment \n */}" },
+
         { code: "{\n\na();\n\n/* comment */ }" },
         { code: "{\n\na();\n\n/* comment */ }", options: ["always"] },
         { code: "{\n\na();\n\n/* comment */ }", options: [{ blocks: "always" }] },
@@ -482,20 +487,32 @@ ruleTester.run("padded-blocks", rule, {
             errors: [NEVER_MESSAGE]
         },
         {
-            code: "function foo() { /* a\n */\n\n  b;\n}",
-            output: "function foo() { /* a\n */\n  b;\n}",
+            code: "function foo() { /* a\n */\n\n  bar;\n}",
+            output: "function foo() { /* a\n */\n  bar;\n}",
             options: ["never"],
             errors: [NEVER_MESSAGE]
         },
         {
-            code: "function foo() {\n\n  b;\n/* a\n */}",
-            output: "function foo() {\n\n  b;\n\n/* a\n */}",
+            code: "function foo() {\n\n  bar;\n/* a\n */}",
+            output: "function foo() {\n\n  bar;\n\n/* a\n */}",
             options: ["always"],
             errors: [ALWAYS_MESSAGE]
         },
         {
-            code: "function foo() { /* a\n */\n/* b\n */\n  b;\n}",
-            output: "function foo() { /* a\n */\n\n/* b\n */\n  b;\n\n}",
+            code: "function foo() { /* a\n */\n/* b\n */\n  bar;\n}",
+            output: "function foo() { /* a\n */\n\n/* b\n */\n  bar;\n\n}",
+            options: ["always"],
+            errors: [ALWAYS_MESSAGE, ALWAYS_MESSAGE]
+        },
+        {
+            code: "function foo() { /* a\n */ /* b\n */\n  bar;\n}",
+            output: "function foo() { /* a\n */ /* b\n */\n\n  bar;\n\n}",
+            options: ["always"],
+            errors: [ALWAYS_MESSAGE, ALWAYS_MESSAGE]
+        },
+        {
+            code: "function foo() { /* a\n */ /* b\n */\n  bar;\n/* c\n *//* d\n */}",
+            output: "function foo() { /* a\n */ /* b\n */\n\n  bar;\n\n/* c\n *//* d\n */}",
             options: ["always"],
             errors: [ALWAYS_MESSAGE, ALWAYS_MESSAGE]
         }

--- a/tests/lib/rules/padded-blocks.js
+++ b/tests/lib/rules/padded-blocks.js
@@ -86,6 +86,17 @@ ruleTester.run("padded-blocks", rule, {
             ]
         },
         {
+            code: "{ //comment\na();\n\n}",
+            output: "{ //comment\n\na();\n\n}",
+            errors: [
+                {
+                    message: ALWAYS_MESSAGE,
+                    line: 1,
+                    column: 3
+                }
+            ]
+        },
+        {
             code: "{\n\na();\n//comment\n}",
             output: "{\n\na();\n//comment\n\n}",
             errors: [
@@ -466,9 +477,27 @@ ruleTester.run("padded-blocks", rule, {
         },
         {
             code: "function foo() { // a\n\n  b;\n}",
-            output: "function foo() { // a\n\n  b;\n}",
+            output: "function foo() { // a\n  b;\n}",
             options: ["never"],
             errors: [NEVER_MESSAGE]
+        },
+        {
+            code: "function foo() { /* a\n */\n\n  b;\n}",
+            output: "function foo() { /* a\n */\n  b;\n}",
+            options: ["never"],
+            errors: [NEVER_MESSAGE]
+        },
+        {
+            code: "function foo() {\n\n  b;\n/* a\n */}",
+            output: "function foo() {\n\n  b;\n\n/* a\n */}",
+            options: ["always"],
+            errors: [ALWAYS_MESSAGE]
+        },
+        {
+            code: "function foo() { /* a\n */\n/* b\n */\n  b;\n}",
+            output: "function foo() { /* a\n */\n\n/* b\n */\n  b;\n\n}",
+            options: ["always"],
+            errors: [ALWAYS_MESSAGE, ALWAYS_MESSAGE]
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->
Thi is an alternative to https://github.com/eslint/eslint/pull/8145 covering some edge cases.

**What changes did you make? (Give an overview)**
Ignore the tokens and comments starting on the same line as the brace, and repeat until there is a token or comment on a different line.

**Is there anything you'd like reviewers to focus on?**
Review the edge cases with comments spanning multiple lines and where a comment follows (or precedes) another one.

