### PR TITLE
Update: ignore eslint comments in lines-arount-comment (fixes #4345)

### DIFF
--- a/docs/rules/lines-around-comment.md
+++ b/docs/rules/lines-around-comment.md
@@ -340,7 +340,7 @@ const [
 
 ### ignorePattern
 
-By default this rule ignores comments starting with the following words: `eslint`, `jshint`, `jslint`, `istanbul`, `global`, `exported`, `jscs`, `falls through`. An alternative regular expression can be provided.
+By default this rule ignores comments starting with the following words: `eslint`, `jshint`, `jslint`, `istanbul`, `global`, `exported`, `jscs`. An alternative regular expression can be provided.
 
 Examples of **correct** code for the `ignorePattern` option:
 

--- a/docs/rules/lines-around-comment.md
+++ b/docs/rules/lines-around-comment.md
@@ -21,6 +21,9 @@ This rule has an object option:
 * `"allowObjectEnd": true` allows comments to appear at the end of object literals
 * `"allowArrayStart": true` allows comments to appear at the start of array literals
 * `"allowArrayEnd": true` allows comments to appear at the end of array literals
+* `"applyDefaultPatterns"` enables or disables the default comment patterns to be ignored by the rule
+* `"ignorePattern"` custom patterns to be ignored by the rule
+
 
 ### beforeBlockComment
 
@@ -333,6 +336,60 @@ const [
     /* what a great and wonderful day */
 ] = ["great", "not great"];
 ```
+
+
+### ignorePattern
+
+By default this rule ignores comments starting with the following words: `eslint`, `jshint`, `jslint`, `istanbul`, `global`, `exported`, `jscs`, `falls through`. An alternative regular expression can be provided.
+
+Examples of **correct** code for the `ignorePattern` option:
+
+```js
+/*eslint lines-around-comment: ["error"]*/
+
+foo();
+/* eslint mentioned in this comment */,
+bar();
+
+
+/*eslint lines-around-comment: ["error", { "ignorePattern": "pragma" }] */
+
+foo();
+/* a valid comment using pragma in it */
+```
+
+Examples of **incorrect** code for the `ignorePattern` option:
+
+```js
+/*eslint lines-around-comment: ["error", { "ignorePattern": "pragma" }] */
+
+1 + 1;
+/* something else */
+```
+
+### applyDefaultPatterns
+
+Default ignore patterns are applied even when `ignorePattern` is provided. If you want to omit default patterns, set this option to `false`.
+
+Examples of **correct** code for the `{ "applyDefaultPatterns": false }` option:
+
+```js
+/*eslint lines-around-comment: ["error", { "ignorePattern": "pragma", applyDefaultPatterns: false }] */
+
+foo();
+/* a valid comment using pragma in it */
+```
+
+Examples of **incorrect** code for the `{ "applyDefaultPatterns": false }` option:
+
+```js
+/*eslint lines-around-comment: ["error", { "applyDefaultPatterns": false }] */
+
+foo();
+/* eslint mentioned in comment */
+
+```
+
 
 ## When Not To Use It
 

--- a/docs/rules/lines-around-comment.md
+++ b/docs/rules/lines-around-comment.md
@@ -21,7 +21,7 @@ This rule has an object option:
 * `"allowObjectEnd": true` allows comments to appear at the end of object literals
 * `"allowArrayStart": true` allows comments to appear at the start of array literals
 * `"allowArrayEnd": true` allows comments to appear at the end of array literals
-* `"applyDefaultPatterns"` enables or disables the default comment patterns to be ignored by the rule
+* `"applyDefaultIgnorePatterns"` enables or disables the default comment patterns to be ignored by the rule
 * `"ignorePattern"` custom patterns to be ignored by the rule
 
 
@@ -367,23 +367,23 @@ Examples of **incorrect** code for the `ignorePattern` option:
 /* something else */
 ```
 
-### applyDefaultPatterns
+### applyDefaultIgnorePatterns
 
 Default ignore patterns are applied even when `ignorePattern` is provided. If you want to omit default patterns, set this option to `false`.
 
-Examples of **correct** code for the `{ "applyDefaultPatterns": false }` option:
+Examples of **correct** code for the `{ "applyDefaultIgnorePatterns": false }` option:
 
 ```js
-/*eslint lines-around-comment: ["error", { "ignorePattern": "pragma", applyDefaultPatterns: false }] */
+/*eslint lines-around-comment: ["error", { "ignorePattern": "pragma", applyDefaultIgnorePatterns: false }] */
 
 foo();
 /* a valid comment using pragma in it */
 ```
 
-Examples of **incorrect** code for the `{ "applyDefaultPatterns": false }` option:
+Examples of **incorrect** code for the `{ "applyDefaultIgnorePatterns": false }` option:
 
 ```js
-/*eslint lines-around-comment: ["error", { "applyDefaultPatterns": false }] */
+/*eslint lines-around-comment: ["error", { "applyDefaultIgnorePatterns": false }] */
 
 foo();
 /* eslint mentioned in comment */

--- a/lib/ast-utils.js
+++ b/lib/ast-utils.js
@@ -24,7 +24,7 @@ const breakableTypePattern = /^(?:(?:Do)?While|For(?:In|Of)?|Switch)Statement$/;
 const thisTagPattern = /^[\s*]*@this/m;
 
 
-const COMMENTS_IGNORE_PATTERN = "^\\s*(?:eslint|jshint\\s+|jslint\\s+|istanbul\\s+|globals?\\s+|exported\\s+|jscs|falls?\\s?through)";
+const COMMENTS_IGNORE_PATTERN = /^\s*(?:eslint|jshint\s+|jslint\s+|istanbul\s+|globals?\s+|exported\s+|jscs|falls?\s?through)/;
 const LINEBREAKS = new Set(["\r\n", "\r", "\n", "\u2028", "\u2029"]);
 const LINEBREAK_MATCHER = /\r\n|[\r\n\u2028\u2029]/;
 

--- a/lib/ast-utils.js
+++ b/lib/ast-utils.js
@@ -23,6 +23,8 @@ const bindOrCallOrApplyPattern = /^(?:bind|call|apply)$/;
 const breakableTypePattern = /^(?:(?:Do)?While|For(?:In|Of)?|Switch)Statement$/;
 const thisTagPattern = /^[\s*]*@this/m;
 
+
+const COMMENTS_IGNORE_PATTERN = "^\\s*(?:eslint|jshint\\s+|jslint\\s+|istanbul\\s+|globals?\\s+|exported\\s+|jscs|falls?\\s?through)";
 const LINEBREAKS = new Set(["\r\n", "\r", "\n", "\u2028", "\u2029"]);
 const LINEBREAK_MATCHER = /\r\n|[\r\n\u2028\u2029]/;
 
@@ -407,6 +409,7 @@ function createGlobalLinebreakMatcher() {
 //------------------------------------------------------------------------------
 
 module.exports = {
+    COMMENTS_IGNORE_PATTERN,
     LINEBREAKS,
     LINEBREAK_MATCHER,
     STATEMENT_LIST_PARENTS,

--- a/lib/ast-utils.js
+++ b/lib/ast-utils.js
@@ -24,7 +24,7 @@ const breakableTypePattern = /^(?:(?:Do)?While|For(?:In|Of)?|Switch)Statement$/;
 const thisTagPattern = /^[\s*]*@this/m;
 
 
-const COMMENTS_IGNORE_PATTERN = /^\s*(?:eslint|jshint\s+|jslint\s+|istanbul\s+|globals?\s+|exported\s+|jscs|falls?\s?through)/;
+const COMMENTS_IGNORE_PATTERN = /^\s*(?:eslint|jshint\s+|jslint\s+|istanbul\s+|globals?\s+|exported\s+|jscs)/;
 const LINEBREAKS = new Set(["\r\n", "\r", "\n", "\u2028", "\u2029"]);
 const LINEBREAK_MATCHER = /\r\n|[\r\n\u2028\u2029]/;
 

--- a/lib/rules/capitalized-comments.js
+++ b/lib/rules/capitalized-comments.js
@@ -9,6 +9,7 @@
 //------------------------------------------------------------------------------
 
 const LETTER_PATTERN = require("../util/patterns/letters");
+const astUtils = require("../ast-utils");
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -16,7 +17,7 @@ const LETTER_PATTERN = require("../util/patterns/letters");
 
 const ALWAYS_MESSAGE = "Comments should not begin with a lowercase character",
     NEVER_MESSAGE = "Comments should not begin with an uppercase character",
-    DEFAULT_IGNORE_PATTERN = /^\s*(?:eslint|istanbul|jscs|jshint|globals?|exported)\b/,
+    DEFAULT_IGNORE_PATTERN = new RegExp(astUtils.COMMENTS_IGNORE_PATTERN),
     WHITESPACE = /\s/g,
     MAYBE_URL = /^\s*[^:/?#\s]+:\/\/[^?#]/,    // TODO: Combine w/ max-len pattern?
     DEFAULTS = {

--- a/lib/rules/capitalized-comments.js
+++ b/lib/rules/capitalized-comments.js
@@ -17,7 +17,7 @@ const astUtils = require("../ast-utils");
 
 const ALWAYS_MESSAGE = "Comments should not begin with a lowercase character",
     NEVER_MESSAGE = "Comments should not begin with an uppercase character",
-    DEFAULT_IGNORE_PATTERN = new RegExp(astUtils.COMMENTS_IGNORE_PATTERN),
+    DEFAULT_IGNORE_PATTERN = astUtils.COMMENTS_IGNORE_PATTERN,
     WHITESPACE = /\s/g,
     MAYBE_URL = /^\s*[^:/?#\s]+:\/\/[^?#]/,    // TODO: Combine w/ max-len pattern?
     DEFAULTS = {

--- a/lib/rules/line-comment-position.js
+++ b/lib/rules/line-comment-position.js
@@ -4,6 +4,8 @@
  */
 "use strict";
 
+const astUtils = require("../ast-utils");
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -43,7 +45,6 @@ module.exports = {
     },
 
     create(context) {
-        const DEFAULT_IGNORE_PATTERN = "^\\s*(?:eslint|jshint\\s+|jslint\\s+|istanbul\\s+|globals?\\s+|exported\\s+|jscs|falls?\\s?through)";
         const options = context.options[0];
 
         let above,
@@ -59,7 +60,7 @@ module.exports = {
             applyDefaultPatterns = options.applyDefaultPatterns !== false;
         }
 
-        const defaultIgnoreRegExp = new RegExp(DEFAULT_IGNORE_PATTERN);
+        const defaultIgnoreRegExp = new RegExp(astUtils.COMMENTS_IGNORE_PATTERN);
         const customIgnoreRegExp = new RegExp(ignorePattern);
         const sourceCode = context.getSourceCode();
 

--- a/lib/rules/line-comment-position.js
+++ b/lib/rules/line-comment-position.js
@@ -60,7 +60,7 @@ module.exports = {
             applyDefaultPatterns = options.applyDefaultPatterns !== false;
         }
 
-        const defaultIgnoreRegExp = new RegExp(astUtils.COMMENTS_IGNORE_PATTERN);
+        const defaultIgnoreRegExp = astUtils.COMMENTS_IGNORE_PATTERN;
         const customIgnoreRegExp = new RegExp(ignorePattern);
         const sourceCode = context.getSourceCode();
 

--- a/lib/rules/line-comment-position.js
+++ b/lib/rules/line-comment-position.js
@@ -61,6 +61,7 @@ module.exports = {
         }
 
         const defaultIgnoreRegExp = astUtils.COMMENTS_IGNORE_PATTERN;
+        const fallThroughRegExp = /^\s*falls?\s?through/;
         const customIgnoreRegExp = new RegExp(ignorePattern);
         const sourceCode = context.getSourceCode();
 
@@ -70,7 +71,7 @@ module.exports = {
 
         return {
             LineComment(node) {
-                if (applyDefaultPatterns && defaultIgnoreRegExp.test(node.value)) {
+                if (applyDefaultPatterns && (defaultIgnoreRegExp.test(node.value) || fallThroughRegExp.test(node.value))) {
                     return;
                 }
 

--- a/lib/rules/lines-around-comment.js
+++ b/lib/rules/lines-around-comment.js
@@ -93,6 +93,12 @@ module.exports = {
                     },
                     allowArrayEnd: {
                         type: "boolean"
+                    },
+                    ignorePattern: {
+                        type: "string"
+                    },
+                    applyDefaultPatterns: {
+                        type: "boolean"
                     }
                 },
                 additionalProperties: false
@@ -103,6 +109,12 @@ module.exports = {
     create(context) {
 
         const options = context.options[0] ? Object.assign({}, context.options[0]) : {};
+        const DEFAULT_IGNORE_PATTERN = "^\\s*(?:eslint|jshint\\s+|jslint\\s+|istanbul\\s+|globals?\\s+|exported\\s+|jscs|falls?\\s?through)";
+        const ignorePattern = options.ignorePattern;
+        const defaultIgnoreRegExp = new RegExp(DEFAULT_IGNORE_PATTERN);
+        const customIgnoreRegExp = new RegExp(ignorePattern);
+        const applyDefaultPatterns = options.applyDefaultPatterns !== false;
+
 
         options.beforeLineComment = options.beforeLineComment || false;
         options.afterLineComment = options.afterLineComment || false;
@@ -270,6 +282,14 @@ module.exports = {
          * @returns {void}
          */
         function checkForEmptyLine(node, opts) {
+            if (applyDefaultPatterns && defaultIgnoreRegExp.test(node.value)) {
+                return;
+            }
+
+            if (ignorePattern && customIgnoreRegExp.test(node.value)) {
+                return;
+            }
+
             let after = opts.after,
                 before = opts.before;
 

--- a/lib/rules/lines-around-comment.js
+++ b/lib/rules/lines-around-comment.js
@@ -109,9 +109,8 @@ module.exports = {
     create(context) {
 
         const options = context.options[0] ? Object.assign({}, context.options[0]) : {};
-        const DEFAULT_IGNORE_PATTERN = "^\\s*(?:eslint|jshint\\s+|jslint\\s+|istanbul\\s+|globals?\\s+|exported\\s+|jscs|falls?\\s?through)";
         const ignorePattern = options.ignorePattern;
-        const defaultIgnoreRegExp = new RegExp(DEFAULT_IGNORE_PATTERN);
+        const defaultIgnoreRegExp = new RegExp(astUtils.COMMENTS_IGNORE_PATTERN);
         const customIgnoreRegExp = new RegExp(ignorePattern);
         const applyDefaultPatterns = options.applyDefaultPatterns !== false;
 

--- a/lib/rules/lines-around-comment.js
+++ b/lib/rules/lines-around-comment.js
@@ -110,7 +110,7 @@ module.exports = {
 
         const options = context.options[0] ? Object.assign({}, context.options[0]) : {};
         const ignorePattern = options.ignorePattern;
-        const defaultIgnoreRegExp = new RegExp(astUtils.COMMENTS_IGNORE_PATTERN);
+        const defaultIgnoreRegExp = astUtils.COMMENTS_IGNORE_PATTERN;
         const customIgnoreRegExp = new RegExp(ignorePattern);
         const applyDefaultPatterns = options.applyDefaultPatterns !== false;
 

--- a/lib/rules/lines-around-comment.js
+++ b/lib/rules/lines-around-comment.js
@@ -97,7 +97,7 @@ module.exports = {
                     ignorePattern: {
                         type: "string"
                     },
-                    applyDefaultPatterns: {
+                    applyDefaultIgnorePatterns: {
                         type: "boolean"
                     }
                 },
@@ -112,7 +112,7 @@ module.exports = {
         const ignorePattern = options.ignorePattern;
         const defaultIgnoreRegExp = astUtils.COMMENTS_IGNORE_PATTERN;
         const customIgnoreRegExp = new RegExp(ignorePattern);
-        const applyDefaultPatterns = options.applyDefaultPatterns !== false;
+        const applyDefaultIgnorePatterns = options.applyDefaultIgnorePatterns !== false;
 
 
         options.beforeLineComment = options.beforeLineComment || false;
@@ -281,7 +281,7 @@ module.exports = {
          * @returns {void}
          */
         function checkForEmptyLine(node, opts) {
-            if (applyDefaultPatterns && defaultIgnoreRegExp.test(node.value)) {
+            if (applyDefaultIgnorePatterns && defaultIgnoreRegExp.test(node.value)) {
                 return;
             }
 

--- a/tests/lib/rules/lines-around-comment.js
+++ b/tests/lib/rules/lines-around-comment.js
@@ -820,7 +820,12 @@ ruleTester.run("lines-around-comment", rule, {
         "foo;\n/* fall through */",
         "foo;\n/* falls through */",
         {
-            code: "foo\n/* pragma */", options: [{ ignorePattern: "pragma" }]
+            code: "foo\n/* this is pragmatic */",
+            options: [{ ignorePattern: "pragma" }]
+        },
+        {
+            code: "foo\n/* this is pragmatic */",
+            options: [{ applyDefaultPatterns: false, ignorePattern: "pragma" }]
         }
     ],
 
@@ -1534,6 +1539,18 @@ ruleTester.run("lines-around-comment", rule, {
         {
             code: "foo;\n/* falls through */",
             output: "foo;\n\n/* falls through */",
+            options: [{ applyDefaultPatterns: false }],
+            errors: [{ message: beforeMessage, type: "Block" }]
+        },
+        {
+            code: "foo\n/* something else */",
+            output: "foo\n\n/* something else */",
+            options: [{ ignorePattern: "pragma" }],
+            errors: [{ message: beforeMessage, type: "Block" }]
+        },
+        {
+            code: "foo\n/* eslint */",
+            output: "foo\n\n/* eslint */",
             options: [{ applyDefaultPatterns: false }],
             errors: [{ message: beforeMessage, type: "Block" }]
         }

--- a/tests/lib/rules/lines-around-comment.js
+++ b/tests/lib/rules/lines-around-comment.js
@@ -791,6 +791,36 @@ ruleTester.run("lines-around-comment", rule, {
                 allowArrayEnd: true
             }],
             parserOptions: { ecmaVersion: 6 }
+        },
+
+        // ignorePattern
+        {
+            code:
+            "foo;\n\n" +
+            "/* eslint-disable no-underscore-dangle */\n\n" +
+            "this._values = values;\n" +
+            "this._values2 = true;\n" +
+            "/* eslint-enable no-underscore-dangle */\n" +
+            "bar",
+            options: [{
+                beforeBlockComment: true,
+                afterBlockComment: true
+            }]
+        },
+        "foo;\n/* eslint */",
+        "foo;\n/* jshint */",
+        "foo;\n/* jslint */",
+        "foo;\n/* istanbul */",
+        "foo;\n/* global */",
+        "foo;\n/* globals */",
+        "foo;\n/* exported */",
+        "foo;\n/* jscs */",
+        "foo;\n/* fallthrough */",
+        "foo;\n/* fallsthrough */",
+        "foo;\n/* fall through */",
+        "foo;\n/* falls through */",
+        {
+            code: "foo\n/* pragma */", options: [{ ignorePattern: "pragma" }]
         }
     ],
 
@@ -1414,6 +1444,98 @@ ruleTester.run("lines-around-comment", rule, {
             }],
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: afterMessage, type: "Block", line: 4 }]
+        },
+
+        // ignorePattern
+        {
+            code:
+            "foo;\n\n" +
+            "/* eslint-disable no-underscore-dangle */\n\n" +
+            "this._values = values;\n" +
+            "this._values2 = true;\n" +
+            "/* eslint-enable no-underscore-dangle */\n" +
+            "bar",
+            options: [{
+                beforeBlockComment: true,
+                afterBlockComment: true,
+                applyDefaultPatterns: false
+            }],
+            errors: [
+                { message: beforeMessage, type: "Block", line: 7 },
+                { message: afterMessage, type: "Block", line: 7 }
+            ]
+        },
+        {
+            code: "foo;\n/* eslint */",
+            output: "foo;\n\n/* eslint */",
+            options: [{ applyDefaultPatterns: false }],
+            errors: [{ message: beforeMessage, type: "Block" }]
+        },
+        {
+            code: "foo;\n/* jshint */",
+            output: "foo;\n\n/* jshint */",
+            options: [{ applyDefaultPatterns: false }],
+            errors: [{ message: beforeMessage, type: "Block" }]
+        },
+        {
+            code: "foo;\n/* jslint */",
+            output: "foo;\n\n/* jslint */",
+            options: [{ applyDefaultPatterns: false }],
+            errors: [{ message: beforeMessage, type: "Block" }]
+        },
+        {
+            code: "foo;\n/* istanbul */",
+            output: "foo;\n\n/* istanbul */",
+            options: [{ applyDefaultPatterns: false }],
+            errors: [{ message: beforeMessage, type: "Block" }]
+        },
+        {
+            code: "foo;\n/* global */",
+            output: "foo;\n\n/* global */",
+            options: [{ applyDefaultPatterns: false }],
+            errors: [{ message: beforeMessage, type: "Block" }]
+        },
+        {
+            code: "foo;\n/* globals */",
+            output: "foo;\n\n/* globals */",
+            options: [{ applyDefaultPatterns: false }],
+            errors: [{ message: beforeMessage, type: "Block" }]
+        },
+        {
+            code: "foo;\n/* exported */",
+            output: "foo;\n\n/* exported */",
+            options: [{ applyDefaultPatterns: false }],
+            errors: [{ message: beforeMessage, type: "Block" }]
+        },
+        {
+            code: "foo;\n/* jscs */",
+            output: "foo;\n\n/* jscs */",
+            options: [{ applyDefaultPatterns: false }],
+            errors: [{ message: beforeMessage, type: "Block" }]
+        },
+        {
+            code: "foo;\n/* fallthrough */",
+            output: "foo;\n\n/* fallthrough */",
+            options: [{ applyDefaultPatterns: false }],
+            errors: [{ message: beforeMessage, type: "Block" }]
+        },
+        {
+            code: "foo;\n/* fallsthrough */",
+            output: "foo;\n\n/* fallsthrough */",
+            options: [{ applyDefaultPatterns: false }],
+            errors: [{ message: beforeMessage, type: "Block" }]
+        },
+        {
+            code: "foo;\n/* fall through */",
+            output: "foo;\n\n/* fall through */",
+            options: [{ applyDefaultPatterns: false }],
+            errors: [{ message: beforeMessage, type: "Block" }]
+        },
+        {
+            code: "foo;\n/* falls through */",
+            output: "foo;\n\n/* falls through */",
+            options: [{ applyDefaultPatterns: false }],
+            errors: [{ message: beforeMessage, type: "Block" }]
         }
     ]
 

--- a/tests/lib/rules/lines-around-comment.js
+++ b/tests/lib/rules/lines-around-comment.js
@@ -815,10 +815,6 @@ ruleTester.run("lines-around-comment", rule, {
         "foo;\n/* globals */",
         "foo;\n/* exported */",
         "foo;\n/* jscs */",
-        "foo;\n/* fallthrough */",
-        "foo;\n/* fallsthrough */",
-        "foo;\n/* fall through */",
-        "foo;\n/* falls through */",
         {
             code: "foo\n/* this is pragmatic */",
             options: [{ ignorePattern: "pragma" }]
@@ -1519,30 +1515,6 @@ ruleTester.run("lines-around-comment", rule, {
             errors: [{ message: beforeMessage, type: "Block" }]
         },
         {
-            code: "foo;\n/* fallthrough */",
-            output: "foo;\n\n/* fallthrough */",
-            options: [{ applyDefaultPatterns: false }],
-            errors: [{ message: beforeMessage, type: "Block" }]
-        },
-        {
-            code: "foo;\n/* fallsthrough */",
-            output: "foo;\n\n/* fallsthrough */",
-            options: [{ applyDefaultPatterns: false }],
-            errors: [{ message: beforeMessage, type: "Block" }]
-        },
-        {
-            code: "foo;\n/* fall through */",
-            output: "foo;\n\n/* fall through */",
-            options: [{ applyDefaultPatterns: false }],
-            errors: [{ message: beforeMessage, type: "Block" }]
-        },
-        {
-            code: "foo;\n/* falls through */",
-            output: "foo;\n\n/* falls through */",
-            options: [{ applyDefaultPatterns: false }],
-            errors: [{ message: beforeMessage, type: "Block" }]
-        },
-        {
             code: "foo\n/* something else */",
             output: "foo\n\n/* something else */",
             options: [{ ignorePattern: "pragma" }],
@@ -1552,6 +1524,14 @@ ruleTester.run("lines-around-comment", rule, {
             code: "foo\n/* eslint */",
             output: "foo\n\n/* eslint */",
             options: [{ applyDefaultPatterns: false }],
+            errors: [{ message: beforeMessage, type: "Block" }]
+        },
+
+        // "fallthrough" patterns are not ignored by default
+        {
+            code: "foo;\n/* fallthrough */",
+            output: "foo;\n\n/* fallthrough */",
+            options: [],
             errors: [{ message: beforeMessage, type: "Block" }]
         }
     ]

--- a/tests/lib/rules/lines-around-comment.js
+++ b/tests/lib/rules/lines-around-comment.js
@@ -821,7 +821,7 @@ ruleTester.run("lines-around-comment", rule, {
         },
         {
             code: "foo\n/* this is pragmatic */",
-            options: [{ applyDefaultPatterns: false, ignorePattern: "pragma" }]
+            options: [{ applyDefaultIgnorePatterns: false, ignorePattern: "pragma" }]
         }
     ],
 
@@ -1459,7 +1459,7 @@ ruleTester.run("lines-around-comment", rule, {
             options: [{
                 beforeBlockComment: true,
                 afterBlockComment: true,
-                applyDefaultPatterns: false
+                applyDefaultIgnorePatterns: false
             }],
             errors: [
                 { message: beforeMessage, type: "Block", line: 7 },
@@ -1469,49 +1469,49 @@ ruleTester.run("lines-around-comment", rule, {
         {
             code: "foo;\n/* eslint */",
             output: "foo;\n\n/* eslint */",
-            options: [{ applyDefaultPatterns: false }],
+            options: [{ applyDefaultIgnorePatterns: false }],
             errors: [{ message: beforeMessage, type: "Block" }]
         },
         {
             code: "foo;\n/* jshint */",
             output: "foo;\n\n/* jshint */",
-            options: [{ applyDefaultPatterns: false }],
+            options: [{ applyDefaultIgnorePatterns: false }],
             errors: [{ message: beforeMessage, type: "Block" }]
         },
         {
             code: "foo;\n/* jslint */",
             output: "foo;\n\n/* jslint */",
-            options: [{ applyDefaultPatterns: false }],
+            options: [{ applyDefaultIgnorePatterns: false }],
             errors: [{ message: beforeMessage, type: "Block" }]
         },
         {
             code: "foo;\n/* istanbul */",
             output: "foo;\n\n/* istanbul */",
-            options: [{ applyDefaultPatterns: false }],
+            options: [{ applyDefaultIgnorePatterns: false }],
             errors: [{ message: beforeMessage, type: "Block" }]
         },
         {
             code: "foo;\n/* global */",
             output: "foo;\n\n/* global */",
-            options: [{ applyDefaultPatterns: false }],
+            options: [{ applyDefaultIgnorePatterns: false }],
             errors: [{ message: beforeMessage, type: "Block" }]
         },
         {
             code: "foo;\n/* globals */",
             output: "foo;\n\n/* globals */",
-            options: [{ applyDefaultPatterns: false }],
+            options: [{ applyDefaultIgnorePatterns: false }],
             errors: [{ message: beforeMessage, type: "Block" }]
         },
         {
             code: "foo;\n/* exported */",
             output: "foo;\n\n/* exported */",
-            options: [{ applyDefaultPatterns: false }],
+            options: [{ applyDefaultIgnorePatterns: false }],
             errors: [{ message: beforeMessage, type: "Block" }]
         },
         {
             code: "foo;\n/* jscs */",
             output: "foo;\n\n/* jscs */",
-            options: [{ applyDefaultPatterns: false }],
+            options: [{ applyDefaultIgnorePatterns: false }],
             errors: [{ message: beforeMessage, type: "Block" }]
         },
         {
@@ -1523,7 +1523,7 @@ ruleTester.run("lines-around-comment", rule, {
         {
             code: "foo\n/* eslint */",
             output: "foo\n\n/* eslint */",
-            options: [{ applyDefaultPatterns: false }],
+            options: [{ applyDefaultIgnorePatterns: false }],
             errors: [{ message: beforeMessage, type: "Block" }]
         },
 

--- a/tests/lib/rules/lines-around-comment.js
+++ b/tests/lib/rules/lines-around-comment.js
@@ -1456,6 +1456,15 @@ ruleTester.run("lines-around-comment", rule, {
             "this._values2 = true;\n" +
             "/* eslint-enable no-underscore-dangle */\n" +
             "bar",
+            output:
+            "foo;\n\n" +
+            "/* eslint-disable no-underscore-dangle */\n\n" +
+            "this._values = values;\n" +
+            "this._values2 = true;\n" +
+            "\n" +
+            "/* eslint-enable no-underscore-dangle */\n" +
+            "\n" +
+            "bar",
             options: [{
                 beforeBlockComment: true,
                 afterBlockComment: true,


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
**What rule do you want to change?**
`lines-around-comment`

**Does this change cause the rule to produce more or fewer warnings?**
Fewer

**How will the change be implemented? (New option, new default behavior, etc.)?**
New default behaviour and new options

**Please provide some example code that this change will affect:**

```js
/* eslint-disable no-underscore-dangle */
this._values = values;
this._values2 = true;
/* eslint-enable no-underscore-dangle */
```

**What does the rule currently do for this code?**
Complains about lack of spacing around the comments.

**What will the rule do after it's changed?**
Ignore the comments.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Ignore certain comment patterns used internally by eslint and other tools and add the ability to disable this behaviour and add custom patterns to ignore.

As [requested in the original issue](https://github.com/eslint/eslint/issues/4345#issuecomment-231229321) this also extracts the common regexp for reuse between the rules that need it.


**Is there anything you'd like reviewers to focus on?**
No.

