### PR TITLE
Update: let RuleTester cases assert that no autofix occurs (fixes #8157)

### DIFF
--- a/docs/developer-guide/working-with-plugins.md
+++ b/docs/developer-guide/working-with-plugins.md
@@ -175,7 +175,7 @@ In addition to the properties above, invalid test cases can also have the follow
     * `column` (number): The 0-based column number of the reported location
     * `endLine` (number): The 1-based line number of the end of the reported location
     * `endColumn` (number): The 0-based column number of the end of the reported location
-* `output` (string, optional): Asserts the output that will be produced when using this rule for a single pass of autofixing (e.g. with the `--fix` command line flag).
+* `output` (string, optional): Asserts the output that will be produced when using this rule for a single pass of autofixing (e.g. with the `--fix` command line flag). If this is `null`, asserts that none of the reported problems suggest autofixes.
 
 Any additional properties of a test case will be passed directly to the linter as config options. For example, a test case can have a `parserOptions` property to configure parser behavior.
 

--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -519,9 +519,17 @@ RuleTester.prototype = {
             }
 
             if (item.hasOwnProperty("output")) {
-                const fixResult = SourceCodeFixer.applyFixes(eslint.getSourceCode(), messages);
+                if (item.output === null) {
+                    assert.strictEqual(
+                        messages.filter(message => message.fix).length,
+                        0,
+                        "Expected no autofixes to be suggested"
+                    );
+                } else {
+                    const fixResult = SourceCodeFixer.applyFixes(eslint.getSourceCode(), messages);
 
-                assert.equal(fixResult.output, item.output, "Output is incorrect.");
+                    assert.equal(fixResult.output, item.output, "Output is incorrect.");
+                }
             }
 
             assertASTDidntChange(result.beforeAST, result.afterAST);

--- a/tests/fixtures/testers/rule-tester/fixes-one-problem.js
+++ b/tests/fixtures/testers/rule-tester/fixes-one-problem.js
@@ -1,0 +1,23 @@
+/**
+ * @fileoverview A test rule that reports two problems and only provides a fix for one of them
+ * @author Teddy Katz
+ */
+
+"use strict";
+
+module.exports = context => {
+    return {
+        Program(node) {
+            context.report({
+                node,
+                message: "No programs allowed."
+            });
+
+            context.report({
+                node,
+                message: "Seriously, no programs allowed.",
+                fix: fixer => fixer.remove(node)
+            });
+        }
+    }
+};

--- a/tests/lib/rules/arrow-body-style.js
+++ b/tests/lib/rules/arrow-body-style.js
@@ -104,7 +104,7 @@ ruleTester.run("arrow-body-style", rule, {
         },
         {
             code: "var foo = () => { return; };",
-            output: "var foo = () => { return; };", // not fixed
+            output: null, // not fixed
             options: ["as-needed", { requireReturnForObjectLiteral: true }],
             errors: [
                 { line: 1, column: 17, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
@@ -136,7 +136,7 @@ ruleTester.run("arrow-body-style", rule, {
         },
         {
             code: "var foo = (retv, name) => {\nretv[name] = true;\nreturn retv;\n};",
-            output: "var foo = (retv, name) => {\nretv[name] = true;\nreturn retv;\n};", // not fixed
+            output: null, // not fixed
             options: ["never"],
             errors: [
                 { line: 1, column: 27, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
@@ -188,9 +188,7 @@ ruleTester.run("arrow-body-style", rule, {
             code:
             "var foo = () => { return bar }\n" +
             "[1, 2, 3].map(foo)",
-            output:
-            "var foo = () => { return bar }\n" +
-            "[1, 2, 3].map(foo)",
+            output: null,
             options: ["never"],
             errors: [
                 { line: 1, column: 17, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
@@ -202,9 +200,7 @@ ruleTester.run("arrow-body-style", rule, {
             code:
             "var foo = () => { return bar }\n" +
             "(1).toString();",
-            output:
-            "var foo = () => { return bar }\n" +
-            "(1).toString();",
+            output: null,
             options: ["never"],
             errors: [
                 { line: 1, column: 17, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }

--- a/tests/lib/rules/brace-style.js
+++ b/tests/lib/rules/brace-style.js
@@ -558,7 +558,7 @@ ruleTester.run("brace-style", rule, {
         // Comment interferes with fix
         {
             code: "if (foo) // comment \n{\nbar();\n}",
-            output: "if (foo) // comment \n{\nbar();\n}",
+            output: null,
             errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }]
         },
 

--- a/tests/lib/rules/curly.js
+++ b/tests/lib/rules/curly.js
@@ -352,7 +352,7 @@ ruleTester.run("curly", rule, {
         },
         {
             code: "if (a) { if (b) console.log(1); else console.log(2) } else console.log(3)",
-            output: "if (a) { if (b) console.log(1); else console.log(2) } else console.log(3)",
+            output: null,
             options: ["multi"],
             errors: [
                 {
@@ -706,7 +706,7 @@ ruleTester.run("curly", rule, {
         },
         {
             code: "if (foo) {bar()} baz()",
-            output: "if (foo) {bar()} baz()",
+            output: null,
             options: ["multi"],
             errors: [
                 {
@@ -730,7 +730,7 @@ ruleTester.run("curly", rule, {
         // Don't remove curly braces if it would cause issues due to ASI.
         {
             code: "if (foo) { bar }\n++baz;",
-            output: "if (foo) { bar }\n++baz;",
+            output: null,
             options: ["multi"],
             errors: [{ message: "Unnecessary { after 'if' condition.", type: "IfStatement" }]
         },
@@ -742,25 +742,25 @@ ruleTester.run("curly", rule, {
         },
         {
             code: "if (foo) { bar++ }\nbaz;",
-            output: "if (foo) { bar++ }\nbaz;",
+            output: null,
             options: ["multi"],
             errors: [{ message: "Unnecessary { after 'if' condition.", type: "IfStatement" }]
         },
         {
             code: "if (foo) { bar }\n[1, 2, 3].map(foo);",
-            output: "if (foo) { bar }\n[1, 2, 3].map(foo);",
+            output: null,
             options: ["multi"],
             errors: [{ message: "Unnecessary { after 'if' condition.", type: "IfStatement" }]
         },
         {
             code: "if (foo) { bar }\n(1).toString();",
-            output: "if (foo) { bar }\n(1).toString();",
+            output: null,
             options: ["multi"],
             errors: [{ message: "Unnecessary { after 'if' condition.", type: "IfStatement" }]
         },
         {
             code: "if (foo) { bar }\n/regex/.test('foo');",
-            output: "if (foo) { bar }\n/regex/.test('foo');",
+            output: null,
             options: ["multi"],
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Unnecessary { after 'if' condition.", type: "IfStatement" }]
@@ -797,20 +797,20 @@ ruleTester.run("curly", rule, {
         },
         {
             code: "if (foo) { var foo = () => {} } else {}",
-            output: "if (foo) { var foo = () => {} } else {}",
+            output: null,
             options: ["multi"],
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Unnecessary { after 'if' condition.", type: "IfStatement" }]
         },
         {
             code: "if (foo) { var foo = function() {} } else {}",
-            output: "if (foo) { var foo = function() {} } else {}",
+            output: null,
             options: ["multi"],
             errors: [{ message: "Unnecessary { after 'if' condition.", type: "IfStatement" }]
         },
         {
             code: "if (foo) { var foo = function*() {} } else {}",
-            output: "if (foo) { var foo = function*() {} } else {}",
+            output: null,
             options: ["multi"],
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Unnecessary { after 'if' condition.", type: "IfStatement" }]

--- a/tests/lib/rules/dot-notation.js
+++ b/tests/lib/rules/dot-notation.js
@@ -136,12 +136,12 @@ ruleTester.run("dot-notation", rule, {
         {
             code: "foo[ /* comment */ 'bar' ]",
             errors: [{ message: "[\"bar\"] is better written in dot notation." }],
-            output: "foo[ /* comment */ 'bar' ]" // Not fixed due to comment
+            output: null // Not fixed due to comment
         },
         {
             code: "foo[ 'bar' /* comment */ ]",
             errors: [{ message: "[\"bar\"] is better written in dot notation." }],
-            output: "foo[ 'bar' /* comment */ ]" // Not fixed due to comment
+            output: null // Not fixed due to comment
         },
         {
             code: "foo[    'bar'    ];",
@@ -152,7 +152,7 @@ ruleTester.run("dot-notation", rule, {
             code: "foo. /* comment */ while",
             options: [{ allowKeywords: false }],
             errors: [{ message: ".while is a syntax error." }],
-            output: "foo. /* comment */ while" // Not fixed due to comment
+            output: null // Not fixed due to comment
         }
     ]
 });

--- a/tests/lib/rules/eqeqeq.js
+++ b/tests/lib/rules/eqeqeq.js
@@ -87,6 +87,6 @@ ruleTester.run("eqeqeq", rule, {
         { code: "(a == b) == (c)", errors: [{ message: "Expected '===' and instead saw '=='.", type: "BinaryExpression", line: 1 }, { message: "Expected '===' and instead saw '=='.", type: "BinaryExpression", line: 1 }] },
         { code: "(a != b) != (c)", errors: [{ message: "Expected '!==' and instead saw '!='.", type: "BinaryExpression", line: 1 }, { message: "Expected '!==' and instead saw '!='.", type: "BinaryExpression", line: 1 }] }
 
-    // If no output is provided, assert that the output is the same as the original code.
-    ].map(invalidCase => Object.assign({ output: invalidCase.code }, invalidCase))
+    // If no output is provided, assert that no output is produced.
+    ].map(invalidCase => Object.assign({ output: null }, invalidCase))
 });

--- a/tests/lib/rules/func-call-spacing.js
+++ b/tests/lib/rules/func-call-spacing.js
@@ -271,27 +271,27 @@ ruleTester.run("func-call-spacing", rule, {
         {
             code: "f\n();",
             errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression" }],
-            output: "f\n();" // no change
+            output: null // no change
         },
         {
             code: "f\r();",
             errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression" }],
-            output: "f\r();" // no change
+            output: null // no change
         },
         {
             code: "f\u2028();",
             errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression" }],
-            output: "f\u2028();" // no change
+            output: null // no change
         },
         {
             code: "f\u2029();",
             errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression" }],
-            output: "f\u2029();" // no change
+            output: null // no change
         },
         {
             code: "f\r\n();",
             errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression" }],
-            output: "f\r\n();" // no change
+            output: null // no change
         },
 
         // "never"
@@ -375,7 +375,7 @@ ruleTester.run("func-call-spacing", rule, {
                     type: "CallExpression"
                 }
             ],
-            output: "f\n();" // no change
+            output: null // no change
         },
         {
             code: [
@@ -392,11 +392,7 @@ ruleTester.run("func-call-spacing", rule, {
                     column: 23
                 }
             ],
-            output: [
-                "this.cancelled.add(request)",
-                "this.decrement(request)",
-                "(0, request.reject)(new api.Cancel())"
-            ].join("\n") // no change
+            output: null // no change
         },
         {
             code: [
@@ -412,10 +408,7 @@ ruleTester.run("func-call-spacing", rule, {
                     column: 9
                 }
             ],
-            output: [
-                "var a = foo",
-                "(function(global) {}(this));"
-            ].join("\n") // no change
+            output: null // no change
         },
         {
             code: [
@@ -431,10 +424,7 @@ ruleTester.run("func-call-spacing", rule, {
                     column: 9
                 }
             ],
-            output: [
-                "var a = foo",
-                "(0, baz())"
-            ].join("\n") // no change
+            output: null // no change
         },
         {
             code: "f\r();",
@@ -445,7 +435,7 @@ ruleTester.run("func-call-spacing", rule, {
                     type: "CallExpression"
                 }
             ],
-            output: "f\r();" // no change
+            output: null // no change
         },
         {
             code: "f\u2028();",
@@ -456,7 +446,7 @@ ruleTester.run("func-call-spacing", rule, {
                     type: "CallExpression"
                 }
             ],
-            output: "f\u2028();" // no change
+            output: null // no change
         },
         {
             code: "f\u2029();",
@@ -467,7 +457,7 @@ ruleTester.run("func-call-spacing", rule, {
                     type: "CallExpression"
                 }
             ],
-            output: "f\u2029();" // no change
+            output: null // no change
         },
         {
             code: "f\r\n();",
@@ -478,7 +468,7 @@ ruleTester.run("func-call-spacing", rule, {
                     type: "CallExpression"
                 }
             ],
-            output: "f\r\n();" // no change
+            output: null // no change
         },
 
         // "always"

--- a/tests/lib/rules/newline-before-return.js
+++ b/tests/lib/rules/newline-before-return.js
@@ -159,7 +159,7 @@ ruleTester.run("newline-before-return", rule, {
         {
             code: "function a() {\nif (b) {\nc();\n}\n//comment\nreturn b;\n}",
             errors: ["Expected newline before return statement."],
-            output: "function a() {\nif (b) {\nc();\n}\n//comment\nreturn b;\n}"
+            output: null
         },
         {
             code: "function a() {\n/*comment\ncomment*/\nif (b) {\nc();\nreturn b;\n} else {\n//comment\n\nreturn d;\n}\n/*multi-line\ncomment*/\nreturn e;\n}",
@@ -174,17 +174,17 @@ ruleTester.run("newline-before-return", rule, {
         {
             code: "function a() {\nif (b) { return; } /*multi-line\ncomment*/\nreturn c;\n}",
             errors: ["Expected newline before return statement."],
-            output: "function a() {\nif (b) { return; } /*multi-line\ncomment*/\nreturn c;\n}"
+            output: null
         },
         {
             code: "function a() {\nif (b) { return; }\n/*multi-line\ncomment*/ return c;\n}",
             errors: ["Expected newline before return statement."],
-            output: "function a() {\nif (b) { return; }\n/*multi-line\ncomment*/ return c;\n}"
+            output: null
         },
         {
             code: "function a() {\nif (b) { return; } /*multi-line\ncomment*/ return c;\n}",
             errors: ["Expected newline before return statement."],
-            output: "function a() {\nif (b) { return; } /*multi-line\ncomment*/ return c;\n}"
+            output: null
         },
         {
             code: "var a;\nreturn;",
@@ -224,22 +224,22 @@ ruleTester.run("newline-before-return", rule, {
         {
             code: "function a() {\nvar b; /*multi-line\ncomment*/\nreturn c;\n}",
             errors: ["Expected newline before return statement."],
-            output: "function a() {\nvar b; /*multi-line\ncomment*/\nreturn c;\n}"
+            output: null
         },
         {
             code: "function a() {\nvar b;\n/*multi-line\ncomment*/ return c;\n}",
             errors: ["Expected newline before return statement."],
-            output: "function a() {\nvar b;\n/*multi-line\ncomment*/ return c;\n}"
+            output: null
         },
         {
             code: "function a() {\nvar b; /*multi-line\ncomment*/ return c;\n}",
             errors: ["Expected newline before return statement."],
-            output: "function a() {\nvar b; /*multi-line\ncomment*/ return c;\n}"
+            output: null
         },
         {
             code: "function a() {\nvar b;\n//comment\nreturn;\n}",
             errors: ["Expected newline before return statement."],
-            output: "function a() {\nvar b;\n//comment\nreturn;\n}"
+            output: null
         },
         {
             code: "function a() {\nvar b; //comment\nreturn;\n}",
@@ -249,17 +249,17 @@ ruleTester.run("newline-before-return", rule, {
         {
             code: "function a() {\nvar b;\n/* comment */ return;\n}",
             errors: ["Expected newline before return statement."],
-            output: "function a() {\nvar b;\n/* comment */ return;\n}"
+            output: null
         },
         {
             code: "function a() {\nvar b;\n//comment\n/* comment */ return;\n}",
             errors: ["Expected newline before return statement."],
-            output: "function a() {\nvar b;\n//comment\n/* comment */ return;\n}"
+            output: null
         },
         {
             code: "function a() {\nvar b; /* comment */ return;\n}",
             errors: ["Expected newline before return statement."],
-            output: "function a() {\nvar b; /* comment */ return;\n}"
+            output: null
         },
         {
             code: "function a() {\nvar b; /* comment */\nreturn;\n}",

--- a/tests/lib/rules/no-else-return.js
+++ b/tests/lib/rules/no-else-return.js
@@ -87,12 +87,12 @@ ruleTester.run("no-else-return", rule, {
         },
         {
             code: "function foo11() { if (foo) return bar \nelse { [1, 2, 3].map(foo) } }",
-            output: "function foo11() { if (foo) return bar \nelse { [1, 2, 3].map(foo) } }",
+            output: null,
             errors: [{ message: "Unnecessary 'else' after 'return'.", type: "BlockStatement" }]
         },
         {
             code: "function foo12() { if (foo) return bar \nelse { baz() } \n[1, 2, 3].map(foo) }",
-            output: "function foo12() { if (foo) return bar \nelse { baz() } \n[1, 2, 3].map(foo) }",
+            output: null,
             errors: [{ message: "Unnecessary 'else' after 'return'.", type: "BlockStatement" }]
         },
         {
@@ -107,12 +107,12 @@ ruleTester.run("no-else-return", rule, {
         },
         {
             code: "function foo15() { if (foo) return bar; else { baz() } qaz() }",
-            output: "function foo15() { if (foo) return bar; else { baz() } qaz() }",
+            output: null,
             errors: [{ message: "Unnecessary 'else' after 'return'.", type: "BlockStatement" }]
         },
         {
             code: "function foo16() { if (foo) return bar \nelse { baz() } qaz() }",
-            output: "function foo16() { if (foo) return bar \nelse { baz() } qaz() }",
+            output: null,
             errors: [{ message: "Unnecessary 'else' after 'return'.", type: "BlockStatement" }]
         },
         {
@@ -122,7 +122,7 @@ ruleTester.run("no-else-return", rule, {
         },
         {
             code: "function foo18() { if (foo) return function() {} \nelse [1, 2, 3].map(bar) }",
-            output: "function foo18() { if (foo) return function() {} \nelse [1, 2, 3].map(bar) }",
+            output: null,
             errors: [{ message: "Unnecessary 'else' after 'return'.", type: "ExpressionStatement" }]
         }
     ]

--- a/tests/lib/rules/no-extra-boolean-cast.js
+++ b/tests/lib/rules/no-extra-boolean-cast.js
@@ -189,7 +189,7 @@ ruleTester.run("no-extra-boolean-cast", rule, {
         },
         {
             code: "!Boolean(...foo);",
-            output: "!Boolean(...foo);",
+            output: null,
             parserOptions: { ecmaVersion: 2015 },
             errors: [{
                 message: "Redundant Boolean call.",
@@ -198,7 +198,7 @@ ruleTester.run("no-extra-boolean-cast", rule, {
         },
         {
             code: "!Boolean(foo, bar());",
-            output: "!Boolean(foo, bar());",
+            output: null,
             errors: [{
                 message: "Redundant Boolean call.",
                 type: "CallExpression"

--- a/tests/lib/rules/no-implicit-coercion.js
+++ b/tests/lib/rules/no-implicit-coercion.js
@@ -104,12 +104,12 @@ ruleTester.run("no-implicit-coercion", rule, {
         {
             code: "~foo.indexOf(1)",
             errors: [{ message: "use `foo.indexOf(1) !== -1` instead.", type: "UnaryExpression" }],
-            output: "~foo.indexOf(1)"
+            output: null
         },
         {
             code: "~foo.bar.indexOf(2)",
             errors: [{ message: "use `foo.bar.indexOf(2) !== -1` instead.", type: "UnaryExpression" }],
-            output: "~foo.bar.indexOf(2)"
+            output: null
         },
         {
             code: "+foo",
@@ -199,7 +199,7 @@ ruleTester.run("no-implicit-coercion", rule, {
         {
             code: "var a = ~foo.indexOf(1)", options: [{ boolean: true, allow: ["!!"] }],
             errors: [{ message: "use `foo.indexOf(1) !== -1` instead.", type: "UnaryExpression" }],
-            output: "var a = ~foo.indexOf(1)"
+            output: null
         },
         {
             code: "var a = 1 * foo", options: [{ boolean: true, allow: ["+"] }],

--- a/tests/lib/rules/no-lonely-if.js
+++ b/tests/lib/rules/no-lonely-if.js
@@ -76,14 +76,7 @@ ruleTester.run("no-lonely-if", rule, {
             "    bar();\n" +
             "  }\n" +
             "}",
-            output: // Not fixed, comment interferes
-            "if (a) {\n" +
-            "  foo();\n" +
-            "} else {\n" +
-            "  /* otherwise, do the other thing */ if (b) {\n" +
-            "    bar();\n" +
-            "  }\n" +
-            "}",
+            output: null,
             errors
         },
         {
@@ -112,14 +105,7 @@ ruleTester.run("no-lonely-if", rule, {
             "    bar();\n" +
             "  } /* this comment will prevent this test case from being autofixed. */\n" +
             "}",
-            output:
-            "if (a) {\n" +
-            "  foo();\n" +
-            "} else {\n" +
-            "  if (b) {\n" +
-            "    bar();\n" +
-            "  } /* this comment will prevent this test case from being autofixed. */\n" +
-            "}",
+            output: null,
             errors
         },
         {
@@ -131,7 +117,7 @@ ruleTester.run("no-lonely-if", rule, {
 
             // Not fixed; removing the braces would cause a SyntaxError.
             code: "if (foo) {} else { if (bar) baz() } qux();",
-            output: "if (foo) {} else { if (bar) baz() } qux();",
+            output: null,
             errors
         },
         {
@@ -150,12 +136,7 @@ ruleTester.run("no-lonely-if", rule, {
             "  if (bar) baz()\n" +
             "}\n" +
             "[1, 2, 3].forEach(foo);",
-            output:
-            "if (foo) {\n" +
-            "} else {\n" +
-            "  if (bar) baz()\n" +
-            "}\n" +
-            "[1, 2, 3].forEach(foo);",
+            output: null,
             errors
         },
         {
@@ -167,12 +148,7 @@ ruleTester.run("no-lonely-if", rule, {
             "  if (bar) baz++\n" +
             "}\n" +
             "foo;",
-            output:
-            "if (foo) {\n" +
-            "} else {\n" +
-            "  if (bar) baz++\n" +
-            "}\n" +
-            "foo;",
+            output: null,
             errors
         },
         {
@@ -200,13 +176,7 @@ ruleTester.run("no-lonely-if", rule, {
             "  if (b) bar()\n" +
             "}\n" +
             "`template literal`;",
-            output:
-            "if (a) {\n" +
-            "  foo();\n" +
-            "} else {\n" +
-            "  if (b) bar()\n" +
-            "}\n" +
-            "`template literal`;",
+            output: null,
             parserOptions: { ecmaVersion: 6 },
             errors
         },

--- a/tests/lib/rules/no-undef-init.js
+++ b/tests/lib/rules/no-undef-init.js
@@ -42,13 +42,13 @@ ruleTester.run("no-undef-init", rule, {
         },
         {
             code: "var [a] = undefined;",
-            output: "var [a] = undefined;",
+            output: null,
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "It's not necessary to initialize '[a]' to undefined.", type: "VariableDeclarator" }]
         },
         {
             code: "var {a} = undefined;",
-            output: "var {a} = undefined;",
+            output: null,
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "It's not necessary to initialize '{a}' to undefined.", type: "VariableDeclarator" }]
         }

--- a/tests/lib/rules/no-unneeded-ternary.js
+++ b/tests/lib/rules/no-unneeded-ternary.js
@@ -138,7 +138,7 @@ ruleTester.run("no-unneeded-ternary", rule, {
         },
         {
             code: "var a = foo() ? false : false;",
-            output: "var a = foo() ? false : false;",
+            output: null,
             errors: [{
                 message: "Unnecessary use of boolean literals in conditional expression.",
                 type: "ConditionalExpression",

--- a/tests/lib/rules/no-unused-labels.js
+++ b/tests/lib/rules/no-unused-labels.js
@@ -66,12 +66,12 @@ ruleTester.run("no-unused-labels", rule, {
         },
         {
             code: "A: /* comment */ foo",
-            output: "A: /* comment */ foo",
+            output: null,
             errors: ["'A:' is defined but never used."]
         },
         {
             code: "A /* comment */: foo",
-            output: "A /* comment */: foo",
+            output: null,
             errors: ["'A:' is defined but never used."]
         }
 

--- a/tests/lib/rules/no-useless-computed-key.js
+++ b/tests/lib/rules/no-useless-computed-key.js
@@ -58,13 +58,13 @@ ruleTester.run("no-useless-computed-key", rule, {
             }]
         }, {
             code: "({ [/* this comment prevents a fix */ 'x']: 0 })",
-            output: "({ [/* this comment prevents a fix */ 'x']: 0 })",
+            output: null,
             errors: [{
                 message: "Unnecessarily computed property ['x'] found.", type: "Property"
             }]
         }, {
             code: "({ ['x' /* this comment also prevents a fix */]: 0 })",
-            output: "({ ['x' /* this comment also prevents a fix */]: 0 })",
+            output: null,
             errors: [{
                 message: "Unnecessarily computed property ['x'] found.", type: "Property"
             }]

--- a/tests/lib/rules/no-var.js
+++ b/tests/lib/rules/no-var.js
@@ -94,14 +94,14 @@ ruleTester.run("no-var", rule, {
         },
         {
             code: "for (var i = 0, i = 0; false;);",
-            output: "for (var i = 0, i = 0; false;);",
+            output: null,
             errors: [
                 { message: "Unexpected var, use let or const instead.", type: "VariableDeclaration" }
             ]
         },
         {
             code: "var i = 0; for (var i = 1; false;); console.log(i);",
-            output: "var i = 0; for (var i = 1; false;); console.log(i);",
+            output: null,
             errors: [
                 { message: "Unexpected var, use let or const instead.", type: "VariableDeclaration" },
                 { message: "Unexpected var, use let or const instead.", type: "VariableDeclaration" }
@@ -111,7 +111,7 @@ ruleTester.run("no-var", rule, {
         // Not fix if it's redeclared or it's used from outside of the scope or it's declared on a case chunk.
         {
             code: "var a, b, c; var a;",
-            output: "var a, b, c; var a;",
+            output: null,
             errors: [
                 "Unexpected var, use let or const instead.",
                 "Unexpected var, use let or const instead."
@@ -119,7 +119,7 @@ ruleTester.run("no-var", rule, {
         },
         {
             code: "var a; if (b) { var a; }",
-            output: "var a; if (b) { var a; }",
+            output: null,
             errors: [
                 "Unexpected var, use let or const instead.",
                 "Unexpected var, use let or const instead."
@@ -127,35 +127,35 @@ ruleTester.run("no-var", rule, {
         },
         {
             code: "if (foo) { var a, b, c; } a;",
-            output: "if (foo) { var a, b, c; } a;",
+            output: null,
             errors: [
                 "Unexpected var, use let or const instead."
             ]
         },
         {
             code: "for (var i = 0; i < 10; ++i) {} i;",
-            output: "for (var i = 0; i < 10; ++i) {} i;",
+            output: null,
             errors: [
                 "Unexpected var, use let or const instead."
             ]
         },
         {
             code: "for (var a in obj) {} a;",
-            output: "for (var a in obj) {} a;",
+            output: null,
             errors: [
                 "Unexpected var, use let or const instead."
             ]
         },
         {
             code: "for (var a of list) {} a;",
-            output: "for (var a of list) {} a;",
+            output: null,
             errors: [
                 "Unexpected var, use let or const instead."
             ]
         },
         {
             code: "switch (a) { case 0: var b = 1 }",
-            output: "switch (a) { case 0: var b = 1 }",
+            output: null,
             errors: [
                 "Unexpected var, use let or const instead."
             ]
@@ -164,14 +164,14 @@ ruleTester.run("no-var", rule, {
         // Don't fix if the variable is in a loop and the behavior might change.
         {
             code: "for (var a of b) { arr.push(() => a); }",
-            output: "for (var a of b) { arr.push(() => a); }",
+            output: null,
             errors: [
                 "Unexpected var, use let or const instead."
             ]
         },
         {
             code: "for (let a of b) { var c; console.log(c); c = 'hello'; }",
-            output: "for (let a of b) { var c; console.log(c); c = 'hello'; }",
+            output: null,
             errors: [
                 "Unexpected var, use let or const instead."
             ]
@@ -180,14 +180,14 @@ ruleTester.run("no-var", rule, {
         // https://github.com/eslint/eslint/issues/7950
         {
             code: "var a = a",
-            output: "var a = a",
+            output: null,
             errors: [
                 "Unexpected var, use let or const instead."
             ]
         },
         {
             code: "var {a = a} = {}",
-            output: "var {a = a} = {}",
+            output: null,
             parserOptions: { ecmaVersion: 2015 },
             errors: [
                 "Unexpected var, use let or const instead."
@@ -195,7 +195,7 @@ ruleTester.run("no-var", rule, {
         },
         {
             code: "var {a = b, b} = {}",
-            output: "var {a = b, b} = {}",
+            output: null,
             parserOptions: { ecmaVersion: 2015 },
             errors: [
                 "Unexpected var, use let or const instead."
@@ -211,7 +211,7 @@ ruleTester.run("no-var", rule, {
         },
         {
             code: "var a = b, b = 1",
-            output: "var a = b, b = 1",
+            output: null,
             parserOptions: { ecmaVersion: 2015 },
             errors: [
                 "Unexpected var, use let or const instead."
@@ -231,7 +231,7 @@ ruleTester.run("no-var", rule, {
         // So this rule does not fix it for safe.
         {
             code: "function foo() { a } var a = 1; foo()",
-            output: "function foo() { a } var a = 1; foo()",
+            output: null,
             parserOptions: { ecmaVersion: 2015 },
             errors: [
                 "Unexpected var, use let or const instead."
@@ -241,7 +241,7 @@ ruleTester.run("no-var", rule, {
         // https://github.com/eslint/eslint/issues/7961
         {
             code: "if (foo) var bar = 1;",
-            output: "if (foo) var bar = 1;",
+            output: null,
             errors: [
                 { message: "Unexpected var, use let or const instead.", type: "VariableDeclaration" }
             ]

--- a/tests/lib/rules/no-whitespace-before-property.js
+++ b/tests/lib/rules/no-whitespace-before-property.js
@@ -511,12 +511,12 @@ ruleTester.run("no-whitespace-before-property", rule, {
         },
         {
             code: "5 .toExponential()",
-            output: "5 .toExponential()", // This case is not fixed; can't be sure whether 5..toExponential or (5).toExponential is preferred
+            output: null, // This case is not fixed; can't be sure whether 5..toExponential or (5).toExponential is preferred
             errors: ["Unexpected whitespace before property toExponential."]
         },
         {
             code: "5       .toExponential()",
-            output: "5       .toExponential()", // Not fixed
+            output: null, // Not fixed
             errors: ["Unexpected whitespace before property toExponential."]
         },
         {

--- a/tests/lib/rules/object-property-newline.js
+++ b/tests/lib/rules/object-property-newline.js
@@ -389,7 +389,7 @@ ruleTester.run("object-property-newline", rule, {
         },
         {
             code: "({ foo: 1, /* comment */ bar: 2 })",
-            output: "({ foo: 1, /* comment */ bar: 2 })", // not fixed due to comment
+            output: null, // not fixed due to comment
             errors: [
                 {
                     message: "Object properties must go on a new line.",

--- a/tests/lib/rules/operator-assignment.js
+++ b/tests/lib/rules/operator-assignment.js
@@ -98,11 +98,11 @@ ruleTester.run("operator-assignment", rule, {
         errors: EXPECTED_OPERATOR_ASSIGNMENT
     }, {
         code: "x = y * x",
-        output: "x = y * x", // not fixed (possible change in behavior if y and x have valueOf() functions)
+        output: null, // not fixed (possible change in behavior if y and x have valueOf() functions)
         errors: EXPECTED_OPERATOR_ASSIGNMENT
     }, {
         code: "x = (y * z) * x",
-        output: "x = (y * z) * x", // not fixed (possible change in behavior if y/z and x have valueOf() functions)
+        output: null, // not fixed (possible change in behavior if y/z and x have valueOf() functions)
         errors: EXPECTED_OPERATOR_ASSIGNMENT
     }, {
         code: "x = x / y",
@@ -142,7 +142,7 @@ ruleTester.run("operator-assignment", rule, {
         errors: EXPECTED_OPERATOR_ASSIGNMENT
     }, {
         code: "x.y[z['a']][0].b = x.y[z['a']][0].b * 2",
-        output: "x.y[z['a']][0].b = x.y[z['a']][0].b * 2", // not fixed; might activate getters more than before
+        output: null, // not fixed; might activate getters more than before
         errors: EXPECTED_OPERATOR_ASSIGNMENT
     }, {
         code: "x = x + y",
@@ -165,20 +165,20 @@ ruleTester.run("operator-assignment", rule, {
         errors: UNEXPECTED_OPERATOR_ASSIGNMENT
     }, {
         code: "foo.bar.baz = foo.bar.baz + qux",
-        output: "foo.bar.baz = foo.bar.baz + qux", // not fixed; fixing would cause a foo.bar getter to activate once rather than twice
+        output: null, // not fixed; fixing would cause a foo.bar getter to activate once rather than twice
         errors: EXPECTED_OPERATOR_ASSIGNMENT
     }, {
         code: "foo.bar.baz += qux",
-        output: "foo.bar.baz += qux", // not fixed; fixing would cause a foo.bar getter to activate twice rather than once
+        output: null, // not fixed; fixing would cause a foo.bar getter to activate twice rather than once
         options: ["never"],
         errors: UNEXPECTED_OPERATOR_ASSIGNMENT
     }, {
         code: "foo[bar] = foo[bar] + baz",
-        output: "foo[bar] = foo[bar] + baz", // not fixed; fixing would cause bar.toString() to get called once instead of twice
+        output: null, // not fixed; fixing would cause bar.toString() to get called once instead of twice
         errors: EXPECTED_OPERATOR_ASSIGNMENT
     }, {
         code: "foo[bar] >>>= baz",
-        output: "foo[bar] >>>= baz", // not fixed; fixing would cause bar.toString() to get called twice instead of once
+        output: null, // not fixed; fixing would cause bar.toString() to get called twice instead of once
         options: ["never"],
         errors: UNEXPECTED_OPERATOR_ASSIGNMENT
     }, {

--- a/tests/lib/rules/operator-linebreak.js
+++ b/tests/lib/rules/operator-linebreak.js
@@ -446,23 +446,23 @@ ruleTester.run("operator-linebreak", rule, {
         },
         {
             code: "foo//comment\n+\nbar",
-            output: "foo//comment\n+\nbar",
+            output: null,
             errors: [{ message: util.format(BAD_LN_BRK_MSG, "+"), type: "BinaryExpression", line: 2, column: 2 }]
         },
         {
             code: "foo\n+//comment\nbar",
-            output: "foo\n+//comment\nbar",
+            output: null,
             options: ["before"],
             errors: [{ message: util.format(BAD_LN_BRK_MSG, "+"), type: "BinaryExpression", line: 2, column: 2 }]
         },
         {
             code: "foo /* a */ \n+ /* b */ bar",
-            output: "foo /* a */ \n+ /* b */ bar", // Not fixed because there is a comment on both sides
+            output: null, // Not fixed because there is a comment on both sides
             errors: [{ message: util.format(AFTER_MSG, "+"), type: "BinaryExpression", line: 2, column: 2 }]
         },
         {
             code: "foo /* a */ +\n /* b */ bar",
-            output: "foo /* a */ +\n /* b */ bar", // Not fixed because there is a comment on both sides
+            output: null, // Not fixed because there is a comment on both sides
             options: ["before"],
             errors: [{ message: util.format(BEFORE_MSG, "+"), type: "BinaryExpression", line: 1, column: 14 }]
         }

--- a/tests/lib/rules/prefer-arrow-callback.js
+++ b/tests/lib/rules/prefer-arrow-callback.js
@@ -111,13 +111,13 @@ ruleTester.run("prefer-arrow-callback", rule, {
             code: "foo(function() { this; });",
             options: [{ allowUnboundThis: false }],
             errors,
-            output: "foo(function() { this; });" // No fix applied
+            output: null // No fix applied
         },
         {
             code: "foo(function() { (() => this); });",
             options: [{ allowUnboundThis: false }],
             errors,
-            output: "foo(function() { (() => this); });" // No fix applied
+            output: null // No fix applied
         },
         {
             code: "qux(function(foo, bar, baz) { return foo * 2; })",
@@ -142,7 +142,7 @@ ruleTester.run("prefer-arrow-callback", rule, {
         {
             code: "qux(function(baz, baz) { })",
             errors,
-            output: "qux(function(baz, baz) { })" // Duplicate parameter names are a SyntaxError in arrow functions
+            output: null // Duplicate parameter names are a SyntaxError in arrow functions
         },
         {
             code: "qux(function( /* no params */ ) { })",

--- a/tests/lib/rules/prefer-const.js
+++ b/tests/lib/rules/prefer-const.js
@@ -112,12 +112,12 @@ ruleTester.run("prefer-const", rule, {
         },
         {
             code: "let [x = -1, y] = [1,2]; y = 0;",
-            output: "let [x = -1, y] = [1,2]; y = 0;",
+            output: null,
             errors: [{ message: "'x' is never reassigned. Use 'const' instead.", type: "Identifier" }]
         },
         {
             code: "let {a: x = -1, b: y} = {a:1,b:2}; y = 0;",
-            output: "let {a: x = -1, b: y} = {a:1,b:2}; y = 0;",
+            output: null,
             errors: [{ message: "'x' is never reassigned. Use 'const' instead.", type: "Identifier" }]
         },
         {
@@ -137,7 +137,7 @@ ruleTester.run("prefer-const", rule, {
         },
         {
             code: "(function() { let [x = -1, y] = [1,2]; y = 0; })();",
-            output: "(function() { let [x = -1, y] = [1,2]; y = 0; })();",
+            output: null,
             errors: [{ message: "'x' is never reassigned. Use 'const' instead.", type: "Identifier" }]
         },
         {
@@ -147,7 +147,7 @@ ruleTester.run("prefer-const", rule, {
         },
         {
             code: "(function() { let {a: x = -1, b: y} = {a:1,b:2}; y = 0; })();",
-            output: "(function() { let {a: x = -1, b: y} = {a:1,b:2}; y = 0; })();",
+            output: null,
             errors: [{ message: "'x' is never reassigned. Use 'const' instead.", type: "Identifier" }]
         },
         {
@@ -177,14 +177,7 @@ ruleTester.run("prefer-const", rule, {
                 "   }",
                 "};"
             ].join("\n"),
-            output: [
-                "var foo = function() {",
-                "    for (const b of c) {",
-                "       let a;",
-                "       a = 1;",
-                "   }",
-                "};"
-            ].join("\n"),
+            output: null,
             errors: [
                 { message: "'a' is never reassigned. Use 'const' instead.", type: "Identifier" }
             ]
@@ -198,14 +191,7 @@ ruleTester.run("prefer-const", rule, {
                 "   }",
                 "};"
             ].join("\n"),
-            output: [
-                "var foo = function() {",
-                "    for (const b of c) {",
-                "       let a;",
-                "       ({a} = 1);",
-                "   }",
-                "};"
-            ].join("\n"),
+            output: null,
             errors: [
                 { message: "'a' is never reassigned. Use 'const' instead.", type: "Identifier" }
             ]
@@ -213,29 +199,29 @@ ruleTester.run("prefer-const", rule, {
 
         {
             code: "let x; x = 0;",
-            output: "let x; x = 0;",
+            output: null,
             errors: [{ message: "'x' is never reassigned. Use 'const' instead.", type: "Identifier", column: 8 }]
         },
         {
             code: "switch (a) { case 0: let x; x = 0; }",
-            output: "switch (a) { case 0: let x; x = 0; }",
+            output: null,
             errors: [{ message: "'x' is never reassigned. Use 'const' instead.", type: "Identifier", column: 29 }]
         },
         {
             code: "(function() { let x; x = 1; })();",
-            output: "(function() { let x; x = 1; })();",
+            output: null,
             errors: [{ message: "'x' is never reassigned. Use 'const' instead.", type: "Identifier", column: 22 }]
         },
 
         {
             code: "let {a = 0, b} = obj; b = 0; foo(a, b);",
-            output: "let {a = 0, b} = obj; b = 0; foo(a, b);",
+            output: null,
             options: [{ destructuring: "any" }],
             errors: [{ message: "'a' is never reassigned. Use 'const' instead.", type: "Identifier" }]
         },
         {
             code: "let {a: {b, c}} = {a: {b: 1, c: 2}}; b = 3;",
-            output: "let {a: {b, c}} = {a: {b: 1, c: 2}}; b = 3;",
+            output: null,
             options: [{ destructuring: "any" }],
             errors: [{ message: "'c' is never reassigned. Use 'const' instead.", type: "Identifier" }]
         },
@@ -250,7 +236,7 @@ ruleTester.run("prefer-const", rule, {
         },
         {
             code: "let a, b; ({a = 0, b} = obj); b = 0; foo(a, b);",
-            output: "let a, b; ({a = 0, b} = obj); b = 0; foo(a, b);",
+            output: null,
             options: [{ destructuring: "any" }],
             errors: [{ message: "'a' is never reassigned. Use 'const' instead.", type: "Identifier" }]
         },
@@ -281,7 +267,7 @@ ruleTester.run("prefer-const", rule, {
         },
         {
             code: "let a, b; ({a = 0, b} = obj); foo(a, b);",
-            output: "let a, b; ({a = 0, b} = obj); foo(a, b);",
+            output: null,
             options: [{ destructuring: "all" }],
             errors: [
                 { message: "'a' is never reassigned. Use 'const' instead.", type: "Identifier" },
@@ -290,7 +276,7 @@ ruleTester.run("prefer-const", rule, {
         },
         {
             code: "let {a = 0, b} = obj, c = a; b = a;",
-            output: "let {a = 0, b} = obj, c = a; b = a;",
+            output: null,
             options: [{ destructuring: "any" }],
             errors: [
                 { message: "'a' is never reassigned. Use 'const' instead.", type: "Identifier" },
@@ -299,7 +285,7 @@ ruleTester.run("prefer-const", rule, {
         },
         {
             code: "let {a = 0, b} = obj, c = a; b = a;",
-            output: "let {a = 0, b} = obj, c = a; b = a;",
+            output: null,
             options: [{ destructuring: "all" }],
             errors: [{ message: "'c' is never reassigned. Use 'const' instead.", type: "Identifier" }]
         },
@@ -307,7 +293,7 @@ ruleTester.run("prefer-const", rule, {
         // Warnings are located at declaration if there are reading references before assignments.
         {
             code: "let x; function foo() { bar(x); } x = 0;",
-            output: "let x; function foo() { bar(x); } x = 0;",
+            output: null,
             errors: [{ message: "'x' is never reassigned. Use 'const' instead.", type: "Identifier", column: 5 }]
         },
 

--- a/tests/lib/rules/prefer-numeric-literals.js
+++ b/tests/lib/rules/prefer-numeric-literals.js
@@ -44,19 +44,19 @@ ruleTester.run("prefer-numeric-literals", rule, {
             errors: [{ message: "Use hexadecimal literals instead of parseInt()." }]
         }, {
             code: "parseInt('7999', 8);",
-            output: "parseInt('7999', 8);", // not fixed, unexpected 9 in parseInt string
+            output: null, // not fixed, unexpected 9 in parseInt string
             errors: [{ message: "Use octal literals instead of parseInt()." }]
         }, {
             code: "parseInt('1234', 2);",
-            output: "parseInt('1234', 2);", // not fixed, invalid binary string
+            output: null, // not fixed, invalid binary string
             errors: [{ message: "Use binary literals instead of parseInt()." }]
         }, {
             code: "parseInt('1234.5', 8);",
-            output: "parseInt('1234.5', 8);", // not fixed, this isn't an integer
+            output: null, // not fixed, this isn't an integer
             errors: [{ message: "Use octal literals instead of parseInt()." }]
         }, {
             code: "parseInt('1️⃣3️⃣3️⃣7️⃣', 16);",
-            output: "parseInt('1️⃣3️⃣3️⃣7️⃣', 16);", // not fixed, javascript doesn't support emoji literals
+            output: null, // not fixed, javascript doesn't support emoji literals
             errors: [{ message: "Use hexadecimal literals instead of parseInt()." }]
         }
     ]

--- a/tests/lib/rules/prefer-spread.js
+++ b/tests/lib/rules/prefer-spread.js
@@ -66,28 +66,28 @@ ruleTester.run("prefer-spread", rule, {
 
             // Not fixed: a.b.c might activate getters
             code: "a.b.c.foo.apply(a.b.c, args);",
-            output: "a.b.c.foo.apply(a.b.c, args);",
+            output: null,
             errors
         },
         {
 
             // Not fixed: a.b(x, y).c might activate getters
             code: "a.b(x, y).c.foo.apply(a.b(x, y).c, args);",
-            output: "a.b(x, y).c.foo.apply(a.b(x, y).c, args);",
+            output: null,
             errors
         },
         {
 
             // Not fixed (not an identifier)
             code: "[].concat.apply([ ], args);",
-            output: "[].concat.apply([ ], args);",
+            output: null,
             errors
         },
         {
 
             // Not fixed (not an identifier)
             code: "[].concat.apply([\n/*empty*/\n], args);",
-            output: "[].concat.apply([\n/*empty*/\n], args);",
+            output: null,
             errors
         }
     ]

--- a/tests/lib/rules/quotes.js
+++ b/tests/lib/rules/quotes.js
@@ -249,25 +249,25 @@ ruleTester.run("quotes", rule, {
         // https://github.com/eslint/eslint/issues/7610
         {
             code: "`use strict`;",
-            output: "`use strict`;",
+            output: null,
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Strings must use doublequote.", type: "TemplateLiteral" }]
         },
         {
             code: "function foo() { `use strict`; foo(); }",
-            output: "function foo() { `use strict`; foo(); }",
+            output: null,
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Strings must use doublequote.", type: "TemplateLiteral" }]
         },
         {
             code: "foo = function() { `use strict`; foo(); }",
-            output: "foo = function() { `use strict`; foo(); }",
+            output: null,
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Strings must use doublequote.", type: "TemplateLiteral" }]
         },
         {
             code: "() => { `use strict`; foo(); }",
-            output: "() => { `use strict`; foo(); }",
+            output: null,
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Strings must use doublequote.", type: "TemplateLiteral" }]
         },

--- a/tests/lib/rules/sort-imports.js
+++ b/tests/lib/rules/sort-imports.js
@@ -213,7 +213,7 @@ ruleTester.run("sort-imports", rule, {
         },
         {
             code: "import {zzzzz, /* comment */ aaaaa} from 'foo.js';",
-            output: "import {zzzzz, /* comment */ aaaaa} from 'foo.js';", // not fixed due to comment
+            output: null, // not fixed due to comment
             errors: [{
                 message: "Member 'aaaaa' of the import declaration should be sorted alphabetically.",
                 type: "ImportSpecifier"
@@ -221,7 +221,7 @@ ruleTester.run("sort-imports", rule, {
         },
         {
             code: "import {zzzzz /* comment */, aaaaa} from 'foo.js';",
-            output: "import {zzzzz /* comment */, aaaaa} from 'foo.js';", // not fixed due to comment
+            output: null, // not fixed due to comment
             errors: [{
                 message: "Member 'aaaaa' of the import declaration should be sorted alphabetically.",
                 type: "ImportSpecifier"
@@ -229,7 +229,7 @@ ruleTester.run("sort-imports", rule, {
         },
         {
             code: "import {/* comment */ zzzzz, aaaaa} from 'foo.js';",
-            output: "import {/* comment */ zzzzz, aaaaa} from 'foo.js';", // not fixed due to comment
+            output: null, // not fixed due to comment
             errors: [{
                 message: "Member 'aaaaa' of the import declaration should be sorted alphabetically.",
                 type: "ImportSpecifier"
@@ -237,7 +237,7 @@ ruleTester.run("sort-imports", rule, {
         },
         {
             code: "import {zzzzz, aaaaa /* comment */} from 'foo.js';",
-            output: "import {zzzzz, aaaaa /* comment */} from 'foo.js';", // not fixed due to comment
+            output: null, // not fixed due to comment
             errors: [{
                 message: "Member 'aaaaa' of the import declaration should be sorted alphabetically.",
                 type: "ImportSpecifier"

--- a/tests/lib/rules/template-tag-spacing.js
+++ b/tests/lib/rules/template-tag-spacing.js
@@ -99,14 +99,14 @@ ruleTester.run("template-tag-spacing", rule, {
         },
         {
             code: "tag // here's a comment \n`bar`",
-            output: "tag // here's a comment \n`bar`",
+            output: null,
             errors: [
                 { message: "Unexpected space between template tag and template literal." }
             ]
         },
         {
             code: "tag // here's a comment \n`bar`",
-            output: "tag // here's a comment \n`bar`",
+            output: null,
             errors: [
                 { message: "Unexpected space between template tag and template literal." }
             ],

--- a/tests/lib/testers/rule-tester.js
+++ b/tests/lib/testers/rule-tester.js
@@ -249,6 +249,55 @@ describe("RuleTester", () => {
         }, /Output is incorrect/);
     });
 
+    it("should not throw an error when the expected output is null and no errors produce output", () => {
+        assert.doesNotThrow(() => {
+            ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+                valid: [
+                    "bar = baz;"
+                ],
+                invalid: [
+                    { code: "eval(x)", errors: 1, output: null },
+                    { code: "eval(x); eval(y);", errors: 2, output: null }
+                ]
+            });
+        });
+    });
+
+    it("should throw an error when the expected output is null and problems produce output", () => {
+        assert.throws(() => {
+            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+                valid: [
+                    "bar = baz;"
+                ],
+                invalid: [
+                    { code: "var foo = bar;", output: null, errors: 1 }
+                ]
+            });
+        }, /Expected no autofixes to be suggested/);
+
+        assert.throws(() => {
+            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+                valid: [
+                    "bar = baz;"
+                ],
+                invalid: [
+                    { code: "var foo = bar; var qux = boop;", output: null, errors: 2 }
+                ]
+            });
+        }, /Expected no autofixes to be suggested/);
+    });
+
+    it("should throw an error when the expected output is null and only some problems produce output", () => {
+        assert.throws(() => {
+            ruleTester.run("fixes-one-problem", require("../../fixtures/testers/rule-tester/fixes-one-problem"), {
+                valid: [],
+                invalid: [
+                    { code: "foo", output: null, errors: 2 }
+                ]
+            });
+        }, /Expected no autofixes to be suggested/);
+    });
+
     it("should throw an error if invalid code specifies wrong type", () => {
 
         assert.throws(() => {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Add something to the core (see https://github.com/eslint/eslint/issues/8157)

**What changes did you make? (Give an overview)**

This allows rules to assert that no errors produce any autofix suggestions by specifying `output: null`.

**Is there anything you'd like reviewers to focus on?**

~~This is built on https://github.com/eslint/eslint/pull/8162, which updates the `RuleTester` documentation. I added the "do not merge" label to this PR because it should be rebased after https://github.com/eslint/eslint/pull/8162 is merged.~~
