### PR TITLE
Docs Add missing space to `create` in `no-use-before-define`

### DIFF
--- a/lib/rules/no-use-before-define.js
+++ b/lib/rules/no-use-before-define.js
@@ -166,7 +166,7 @@ module.exports = {
         const options = parseOptions(context.options[0]);
 
         /**
-         * Determines whether a given use-before-define case should be reportedaccording to the options.
+         * Determines whether a given use-before-define case should be reported according to the options.
          * @param {escope.Variable} variable The variable that gets used before being defined
          * @param {escope.Reference} reference The reference to the variable
          * @returns {boolean} `true` if the usage should be reported


### PR DESCRIPTION
* Documentation Update *

Add missing space to docs in `create` function