### PR TITLE
Fix: Don't autofix `+ +a` to `++a` in space-unary-ops

### DIFF
--- a/lib/rules/space-unary-ops.js
+++ b/lib/rules/space-unary-ops.js
@@ -69,6 +69,21 @@ module.exports = {
         }
 
         /**
+         * Check if it is safe to remove the spaces between the two tokens in
+         * the context of a non-word prefix unary operator. For example, `+ +1`
+         * cannot safely be changed to `++1`.
+         * @param {Token} firstToken The operator for a non-word prefix unary operator
+         * @param {Token} secondToken The first token of its operand
+         * @returns {boolean} Whether or not the spacing between the tokens can be removed
+         */
+        function canRemoveSpacesBetween(firstToken, secondToken) {
+            return !(
+                (firstToken.value === "+" && secondToken.value[0] === "+") ||
+                (firstToken.value === "-" && secondToken.value[0] === "-")
+            );
+        }
+
+        /**
         * Checks if an override exists for a given operator.
         * @param {ASTnode} node AST node
         * @param {string} operator Operator
@@ -244,7 +259,10 @@ module.exports = {
                             operator: firstToken.value
                         },
                         fix(fixer) {
-                            return fixer.removeRange([firstToken.range[1], secondToken.range[0]]);
+                            if (canRemoveSpacesBetween(firstToken, secondToken)) {
+                                return fixer.removeRange([firstToken.range[1], secondToken.range[0]]);
+                            }
+                            return null;
                         }
                     });
                 }

--- a/tests/lib/rules/space-unary-ops.js
+++ b/tests/lib/rules/space-unary-ops.js
@@ -418,6 +418,46 @@ ruleTester.run("space-unary-ops", rule, {
             }]
         },
         {
+            code: "+ +foo",
+            output: "+ +foo",
+            options: [{ nonwords: false }],
+            errors: [{
+                message: "Unexpected space after unary operator '+'."
+            }]
+        },
+        {
+            code: "+ ++foo",
+            output: "+ ++foo",
+            options: [{ nonwords: false }],
+            errors: [{
+                message: "Unexpected space after unary operator '+'."
+            }]
+        },
+        {
+            code: "- -foo",
+            output: "- -foo",
+            options: [{ nonwords: false }],
+            errors: [{
+                message: "Unexpected space after unary operator '-'."
+            }]
+        },
+        {
+            code: "- --foo",
+            output: "- --foo",
+            options: [{ nonwords: false }],
+            errors: [{
+                message: "Unexpected space after unary operator '-'."
+            }]
+        },
+        {
+            code: "+ -foo",
+            output: "+-foo",
+            options: [{ nonwords: false }],
+            errors: [{
+                message: "Unexpected space after unary operator '+'."
+            }]
+        },
+        {
             code: "function *foo() { yield(0) }",
             output: "function *foo() { yield (0) }",
             parserOptions: { ecmaVersion: 6 },

--- a/tests/lib/rules/space-unary-ops.js
+++ b/tests/lib/rules/space-unary-ops.js
@@ -419,7 +419,7 @@ ruleTester.run("space-unary-ops", rule, {
         },
         {
             code: "+ +foo",
-            output: "+ +foo",
+            output: null,
             options: [{ nonwords: false }],
             errors: [{
                 message: "Unexpected space after unary operator '+'."
@@ -427,7 +427,7 @@ ruleTester.run("space-unary-ops", rule, {
         },
         {
             code: "+ ++foo",
-            output: "+ ++foo",
+            output: null,
             options: [{ nonwords: false }],
             errors: [{
                 message: "Unexpected space after unary operator '+'."
@@ -435,7 +435,7 @@ ruleTester.run("space-unary-ops", rule, {
         },
         {
             code: "- -foo",
-            output: "- -foo",
+            output: null,
             options: [{ nonwords: false }],
             errors: [{
                 message: "Unexpected space after unary operator '-'."
@@ -443,7 +443,7 @@ ruleTester.run("space-unary-ops", rule, {
         },
         {
             code: "- --foo",
-            output: "- --foo",
+            output: null,
             options: [{ nonwords: false }],
             errors: [{
                 message: "Unexpected space after unary operator '-'."


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**Tell us about your environment**

* **ESLint Version:** 3.16.1
* **Node Version:** 6.9.4
* **npm Version:** 3.10.10

**What parser (default, Babel-ESLint, etc.) are you using?** default

**Please show your full configuration:**
```
module.exports = {
  rules: {
    "space-unary-ops": ['error'],
  }
};
```

**What did you do? Please include the actual source code causing the issue.**
I ran `eslint --fix` on this code:
```
console.log(+ +1);
```

**What did you expect to happen?**
I expected it to result in correct code.

**What actually happened? Please include the actual, raw output from ESLint.**
It changed the code to `console.log(++1);` and there was a parse error in eslint.
```
➜  eslint_test_4 git:(master) ./node_modules/.bin/eslint --fix test.js

/Users/alanpierce/code/eslint_test_4/test.js
  1:15  error  Parsing error: Assigning to rvalue

✖ 1 problem (1 error, 0 warnings)
```

**What changes did you make? (Give an overview)**
I changed `space-unary-ops` autofixing to be more defensive and skip the
autofix in some cases where it was incorrect.

Most of the time, it's legal to remove spacing between adjacent operator tokens,
but in a case like `+ +a` it changes the behavior, so we should skip autofixing.
Another example is `+ ++a`, and the `-` versions of all of these. Since there
are relatively few unary operators and `++` and `--` are only allowed in limited
contexts, there aren't a ton of cases to think through here, so hopefully this
is all of them.

**Is there anything you'd like reviewers to focus on?**
Might be good to think through any other correctness issues like this.