### PR TITLE
Update: deprecate `applyDefaultPatterns` in `line-comment-position`

### DIFF
--- a/docs/rules/line-comment-position.md
+++ b/docs/rules/line-comment-position.md
@@ -77,23 +77,25 @@ Examples of **incorrect** code for the `ignorePattern` option:
 1 + 1; // invalid comment
 ```
 
-### applyDefaultPatterns
+### applyDefaultIgnorePatterns
 
 Default ignore patterns are applied even when `ignorePattern` is provided. If you want to omit default patterns, set this option to `false`.
 
-Examples of **correct** code for the `{ "applyDefaultPatterns": false }` option:
+Examples of **correct** code for the `{ "applyDefaultIgnorePatterns": false }` option:
 
 ```js
-/*eslint line-comment-position: ["error", { "ignorePattern": "pragma", "applyDefaultPatterns": false }]*/
+/*eslint line-comment-position: ["error", { "ignorePattern": "pragma", "applyDefaultIgnorePatterns": false }]*/
 1 + 1; // pragma valid comment
 ```
 
-Examples of **incorrect** code for the `{ "applyDefaultPatterns": false }` option:
+Examples of **incorrect** code for the `{ "applyDefaultIgnorePatterns": false }` option:
 
 ```js
-/*eslint line-comment-position: ["error", { "ignorePattern": "pragma", "applyDefaultPatterns": false }]*/
+/*eslint line-comment-position: ["error", { "ignorePattern": "pragma", "applyDefaultIgnorePatterns": false }]*/
 1 + 1; // falls through
 ```
+
+**Deprecated:** the object property `applyDefaultPatterns` is deprecated. Please use the property `applyDefaultIgnorePatterns` instead.
 
 ## When Not To Use It
 

--- a/lib/rules/line-comment-position.js
+++ b/lib/rules/line-comment-position.js
@@ -35,6 +35,9 @@ module.exports = {
                             },
                             applyDefaultPatterns: {
                                 type: "boolean"
+                            },
+                            applyDefaultIgnorePatterns: {
+                                type: "boolean"
                             }
                         },
                         additionalProperties: false
@@ -49,7 +52,7 @@ module.exports = {
 
         let above,
             ignorePattern,
-            applyDefaultPatterns = true;
+            applyDefaultIgnorePatterns = true;
 
         if (!options || typeof options === "string") {
             above = !options || options === "above";
@@ -57,7 +60,12 @@ module.exports = {
         } else {
             above = options.position === "above";
             ignorePattern = options.ignorePattern;
-            applyDefaultPatterns = options.applyDefaultPatterns !== false;
+
+            if (options.hasOwnProperty("applyDefaultIgnorePatterns")) {
+                applyDefaultIgnorePatterns = options.applyDefaultIgnorePatterns !== false;
+            } else {
+                applyDefaultIgnorePatterns = options.applyDefaultPatterns !== false;
+            }
         }
 
         const defaultIgnoreRegExp = astUtils.COMMENTS_IGNORE_PATTERN;
@@ -71,7 +79,7 @@ module.exports = {
 
         return {
             LineComment(node) {
-                if (applyDefaultPatterns && (defaultIgnoreRegExp.test(node.value) || fallThroughRegExp.test(node.value))) {
+                if (applyDefaultIgnorePatterns && (defaultIgnoreRegExp.test(node.value) || fallThroughRegExp.test(node.value))) {
                     return;
                 }
 

--- a/tests/lib/rules/line-comment-position.js
+++ b/tests/lib/rules/line-comment-position.js
@@ -100,7 +100,27 @@ ruleTester.run("line-comment-position", rule, {
         },
         {
             code: "// jscs: disable\n1 + 1;",
+            options: [{ position: "beside", applyDefaultIgnorePatterns: false }],
+            errors: [{
+                message: "Expected comment to be beside code.",
+                type: "Line",
+                line: 1,
+                column: 1
+            }]
+        },
+        {   // deprecated option still works
+            code: "// jscs: disable\n1 + 1;",
             options: [{ position: "beside", applyDefaultPatterns: false }],
+            errors: [{
+                message: "Expected comment to be beside code.",
+                type: "Line",
+                line: 1,
+                column: 1
+            }]
+        },
+        {   // new option name takes precedence
+            code: "// jscs: disable\n1 + 1;",
+            options: [{ position: "beside", applyDefaultIgnorePatterns: false, applyDefaultPatterns: true }],
             errors: [{
                 message: "Expected comment to be beside code.",
                 type: "Line",


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
**What rule do you want to change?**
`line-comment-position`

**Does this change cause the rule to produce more or fewer warnings?**
The same.

**How will the change be implemented? (New option, new default behavior, etc.)?**
New option name `applyDefaultIgnorePatterns` replacing old one `applyDefaultPatterns`.

**Please provide some example code that this change will affect:**

```js
/*eslint line-comment-position: ["error", { "position": "beside", "applyDefaultPatterns": false }]*/
// jscs-disable
1 + 1;
```
**What does the rule currently do for this code?**
Complains about comment not being beside code.

**What will the rule do after it's changed?**
Same behaviour, under the new option name, if used.

**What changes did you make? (Give an overview)**
Following the discussion in https://github.com/eslint/eslint/pull/8155  I have rename the option name so it's clearer and consistent with `lines-around-comments`.

**Is there anything you'd like reviewers to focus on?**
Old option is still present and functional, so it's not a breaking change.

