### PR TITLE
Chore: add missing `output` property to tests

### DIFF
--- a/tests/lib/rules/brace-style.js
+++ b/tests/lib/rules/brace-style.js
@@ -479,6 +479,7 @@ ruleTester.run("brace-style", rule, {
         },
         {
             code: "try {  bar(); }\ncatch (e) { baz();  }",
+            output: "try {  bar(); }catch (e) { baz();  }",
             options: ["1tbs", { allowSingleLine: true }],
             errors: [{ message: CLOSE_MESSAGE, type: "Punctuator" }]
         },

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -2277,6 +2277,11 @@ ruleTester.run("indent", rule, {
             "    foo\n" +
             "          .bar\n" +
             "}",
+            output:
+            "var foo = function(){\n" +
+            "    foo\n" +
+            "        .bar\n" +
+            "}",
             options: [4, { MemberExpression: 1 }],
             errors: expectedErrors(
                 [3, 8, 10, "Punctuator"]
@@ -2287,6 +2292,11 @@ ruleTester.run("indent", rule, {
             "var foo = function(){\n" +
             "    foo\n" +
             "             .bar\n" +
+            "}",
+            output:
+            "var foo = function(){\n" +
+            "    foo\n" +
+            "            .bar\n" +
             "}",
             options: [4, { MemberExpression: 2 }],
             errors: expectedErrors(
@@ -2299,6 +2309,11 @@ ruleTester.run("indent", rule, {
             "    foo\n" +
             "             .bar\n" +
             "}",
+            output:
+            "var foo = () => {\n" +
+            "    foo\n" +
+            "            .bar\n" +
+            "}",
             options: [4, { MemberExpression: 2 }],
             parserOptions: { ecmaVersion: 6 },
             errors: expectedErrors(
@@ -2310,6 +2325,13 @@ ruleTester.run("indent", rule, {
             "TestClass.prototype.method = function () {\n" +
             "  return Promise.resolve(3)\n" +
             "      .then(function (x) {\n" +
+            "        return x;\n" +
+            "      });\n" +
+            "};",
+            output:
+            "TestClass.prototype.method = function () {\n" +
+            "  return Promise.resolve(3)\n" +
+            "    .then(function (x) {\n" +
             "        return x;\n" +
             "      });\n" +
             "};",
@@ -3022,6 +3044,12 @@ ruleTester.run("indent", rule, {
             "    return x + 1;\n" +
             "  }\n" +
             "})();",
+            output:
+            "(function(){\n" +
+            "function foo(x) {\n" +
+            "    return x + 1;\n" +
+            "  }\n" +
+            "})();",
             options: [2, { outerIIFEBody: 0 }],
             errors: expectedErrors([[2, 0, 2, "FunctionDeclaration"]])
         },
@@ -3029,6 +3057,12 @@ ruleTester.run("indent", rule, {
             code:
             "(function(){\n" +
             "    function foo(x) {\n" +
+            "        return x + 1;\n" +
+            "    }\n" +
+            "})();",
+            output:
+            "(function(){\n" +
+            "        function foo(x) {\n" +
             "        return x + 1;\n" +
             "    }\n" +
             "})();",
@@ -3040,6 +3074,10 @@ ruleTester.run("indent", rule, {
             "if(data) {\n" +
             "console.log('hi');\n" +
             "}",
+            output:
+            "if(data) {\n" +
+            "  console.log('hi');\n" +
+            "}",
             options: [2, { outerIIFEBody: 0 }],
             errors: expectedErrors([[2, 2, 0, "ExpressionStatement"]])
         },
@@ -3047,6 +3085,12 @@ ruleTester.run("indent", rule, {
             code:
             "var ns = function(){\n" +
             "    function fooVar(x) {\n" +
+            "        return x + 1;\n" +
+            "    }\n" +
+            "}(x);",
+            output:
+            "var ns = function(){\n" +
+            "        function fooVar(x) {\n" +
             "        return x + 1;\n" +
             "    }\n" +
             "}(x);",
@@ -3060,6 +3104,12 @@ ruleTester.run("indent", rule, {
             "  return true;\n" +
             "  }()\n" +
             "};\n",
+            output:
+            "var obj = {\n" +
+            "  foo: function() {\n" +
+            "    return true;\n" +
+            "  }()\n" +
+            "};\n",
             options: [2, { outerIIFEBody: 0 }],
             errors: expectedErrors([[3, 4, 2, "ReturnStatement"]])
         },
@@ -3067,6 +3117,12 @@ ruleTester.run("indent", rule, {
             code:
             "typeof function() {\n" +
             "    function fooVar(x) {\n" +
+            "      return x + 1;\n" +
+            "    }\n" +
+            "}();",
+            output:
+            "typeof function() {\n" +
+            "  function fooVar(x) {\n" +
             "      return x + 1;\n" +
             "    }\n" +
             "}();",

--- a/tests/lib/rules/key-spacing.js
+++ b/tests/lib/rules/key-spacing.js
@@ -1233,6 +1233,11 @@ ruleTester.run("key-spacing", rule, {
             "          , cats: cats",
             "};"
         ].join("\n"),
+        output: [
+            "var obj = { foo : foo",
+            "          , cats: cats",
+            "};"
+        ].join("\n"),
         options: [{ align: "colon" }],
         errors: [
             { message: "Extra space after key 'foo'.", line: 1, column: 13, type: "Identifier" }
@@ -1683,6 +1688,16 @@ ruleTester.run("key-spacing", rule, {
             "    key4: 4",
             "}"
         ].join("\n"),
+        output: [
+            "var obj = {",
+            "    key1: 1,",
+            "",
+            "    key2: 2,",
+            "    key3: 3,",
+            "",
+            "    key4: 4",
+            "}"
+        ].join("\n"),
         options: [{
             multiLine: {
                 beforeColon: false,
@@ -1707,6 +1722,16 @@ ruleTester.run("key-spacing", rule, {
             "",
             "    key2:    2,",
             "    key3:    3,",
+            "",
+            "    key4: 4",
+            "}"
+        ].join("\n"),
+        output: [
+            "var obj = {",
+            "    key1: 1,",
+            "",
+            "    key2: 2,",
+            "    key3: 3,",
             "",
             "    key4: 4",
             "}"

--- a/tests/lib/rules/lines-around-comment.js
+++ b/tests/lib/rules/lines-around-comment.js
@@ -1169,6 +1169,15 @@ ruleTester.run("lines-around-comment", rule, {
             "    // hi\n" +
             "  }\n" +
             "}",
+            output:
+            "function hi() {\n" +
+            "  return {\n" +
+            "    test: function() {\n" +
+            "    }\n" +
+            "    // hi\n" +
+            "\n" +
+            "  }\n" +
+            "}",
             options: [{
                 afterLineComment: true
             }],

--- a/tests/lib/rules/object-shorthand.js
+++ b/tests/lib/rules/object-shorthand.js
@@ -738,16 +738,19 @@ ruleTester.run("object-shorthand", rule, {
         // consistent
         {
             code: "var x = {a: a, b}",
+            output: null,
             options: ["consistent"],
             errors: [MIXED_SHORTHAND_ERROR]
         },
         {
             code: "var x = {b, c: d, f: g}",
+            output: null,
             options: ["consistent"],
             errors: [MIXED_SHORTHAND_ERROR]
         },
         {
             code: "var x = {foo, bar: baz, ...qux}",
+            output: null,
             parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } },
             options: ["consistent"],
             errors: [MIXED_SHORTHAND_ERROR]
@@ -756,28 +759,33 @@ ruleTester.run("object-shorthand", rule, {
         // consistent-as-needed
         {
             code: "var x = {a: a, b: b}",
+            output: null,
             options: ["consistent-as-needed"],
             errors: [ALL_SHORTHAND_ERROR]
         },
         {
             code: "var x = {a, z: function z(){}}",
+            output: null,
             options: ["consistent-as-needed"],
             errors: [MIXED_SHORTHAND_ERROR]
 
         },
         {
             code: "var x = {foo: function() {}}",
+            output: null,
             options: ["consistent-as-needed"],
             errors: [ALL_SHORTHAND_ERROR]
         },
         {
             code: "var x = {a: a, b: b, ...baz}",
+            output: null,
             parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } },
             options: ["consistent-as-needed"],
             errors: [ALL_SHORTHAND_ERROR]
         },
         {
             code: "var x = {foo, bar: bar, ...qux}",
+            output: null,
             parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } },
             options: ["consistent-as-needed"],
             errors: [MIXED_SHORTHAND_ERROR]

--- a/tests/lib/rules/semi.js
+++ b/tests/lib/rules/semi.js
@@ -140,10 +140,10 @@ ruleTester.run("semi", rule, {
         { code: "import theDefault, { named1, named2 } from 'src/mylib';", output: "import theDefault, { named1, named2 } from 'src/mylib'", options: ["never"], parserOptions: { sourceType: "module" }, errors: [{ message: "Extra semicolon.", type: "ImportDeclaration" }] },
         { code: "do{}while(true);", output: "do{}while(true)", options: ["never"], errors: [{ message: "Extra semicolon.", type: "DoWhileStatement", line: 1 }] },
 
-        { code: "if (foo) { bar()\n }", options: ["always", { omitLastInOneLineBlock: true }], errors: [{ message: "Missing semicolon." }] },
-        { code: "if (foo) {\n bar() }", options: ["always", { omitLastInOneLineBlock: true }], errors: [{ message: "Missing semicolon." }] },
-        { code: "if (foo) {\n bar(); baz() }", options: ["always", { omitLastInOneLineBlock: true }], errors: [{ message: "Missing semicolon." }] },
-        { code: "if (foo) { bar(); }", options: ["always", { omitLastInOneLineBlock: true }], errors: [{ message: "Extra semicolon." }] },
+        { code: "if (foo) { bar()\n }", output: "if (foo) { bar();\n }", options: ["always", { omitLastInOneLineBlock: true }], errors: [{ message: "Missing semicolon." }] },
+        { code: "if (foo) {\n bar() }", output: "if (foo) {\n bar(); }", options: ["always", { omitLastInOneLineBlock: true }], errors: [{ message: "Missing semicolon." }] },
+        { code: "if (foo) {\n bar(); baz() }", output: "if (foo) {\n bar(); baz(); }", options: ["always", { omitLastInOneLineBlock: true }], errors: [{ message: "Missing semicolon." }] },
+        { code: "if (foo) { bar(); }", output: "if (foo) { bar() }", options: ["always", { omitLastInOneLineBlock: true }], errors: [{ message: "Extra semicolon." }] },
 
 
         // exports, "always"

--- a/tests/lib/rules/sort-imports.js
+++ b/tests/lib/rules/sort-imports.js
@@ -136,30 +136,35 @@ ruleTester.run("sort-imports", rule, {
             code:
                 "import a from 'foo.js';\n" +
                 "import A from 'bar.js';",
+            output: null,
             errors: [expectedError]
         },
         {
             code:
                 "import b from 'foo.js';\n" +
                 "import a from 'bar.js';",
+            output: null,
             errors: [expectedError]
         },
         {
             code:
                 "import {b, c} from 'foo.js';\n" +
                 "import {a, d} from 'bar.js';",
+            output: null,
             errors: [expectedError]
         },
         {
             code:
                 "import * as foo from 'foo.js';\n" +
                 "import * as bar from 'bar.js';",
+            output: null,
             errors: [expectedError]
         },
         {
             code:
                 "import a from 'foo.js';\n" +
                 "import {b, c} from 'bar.js';",
+            output: null,
             errors: [{
                 message: "Expected 'multiple' syntax before 'single' syntax.",
                 type: "ImportDeclaration"
@@ -169,6 +174,7 @@ ruleTester.run("sort-imports", rule, {
             code:
                 "import a from 'foo.js';\n" +
                 "import * as b from 'bar.js';",
+            output: null,
             errors: [{
                 message: "Expected 'all' syntax before 'single' syntax.",
                 type: "ImportDeclaration"
@@ -178,6 +184,7 @@ ruleTester.run("sort-imports", rule, {
             code:
                 "import a from 'foo.js';\n" +
                 "import 'bar.js';",
+            output: null,
             errors: [{
                 message: "Expected 'none' syntax before 'single' syntax.",
                 type: "ImportDeclaration"
@@ -187,6 +194,7 @@ ruleTester.run("sort-imports", rule, {
             code:
                 "import b from 'bar.js';\n" +
                 "import * as a from 'foo.js';",
+            output: null,
             options: [{
                 memberSyntaxSortOrder: ["all", "single", "multiple", "none"]
             }],

--- a/tests/lib/rules/spaced-comment.js
+++ b/tests/lib/rules/spaced-comment.js
@@ -577,11 +577,13 @@ ruleTester.run("spaced-comment", rule, {
         // Parser errors
         {
             code: invalidShebangProgram,
+            output: null,
             errors: 1,
             options: ["always"]
         },
         {
             code: invalidShebangProgram,
+            output: null,
             errors: 1,
             options: ["never"]
         }

--- a/tests/lib/rules/strict.js
+++ b/tests/lib/rules/strict.js
@@ -92,30 +92,35 @@ ruleTester.run("strict", rule, {
         // "never" mode
         {
             code: "\"use strict\"; foo();",
+            output: null,
             options: ["never"],
             errors: [
                 { message: "Strict mode is not permitted.", type: "ExpressionStatement" }
             ]
         }, {
             code: "function foo() { 'use strict'; return; }",
+            output: null,
             options: ["never"],
             errors: [
                 { message: "Strict mode is not permitted.", type: "ExpressionStatement" }
             ]
         }, {
             code: "var foo = function() { 'use strict'; return; };",
+            output: null,
             options: ["never"],
             errors: [
                 { message: "Strict mode is not permitted.", type: "ExpressionStatement" }
             ]
         }, {
             code: "function foo() { return function() { 'use strict'; return; }; }",
+            output: null,
             options: ["never"],
             errors: [
                 { message: "Strict mode is not permitted.", type: "ExpressionStatement" }
             ]
         }, {
             code: "'use strict'; function foo() { \"use strict\"; return; }",
+            output: null,
             options: ["never"],
             errors: [
                 { message: "Strict mode is not permitted.", type: "ExpressionStatement" },
@@ -152,12 +157,14 @@ ruleTester.run("strict", rule, {
         // "global" mode
         {
             code: "foo();",
+            output: null,
             options: ["global"],
             errors: [
                 { message: "Use the global form of 'use strict'.", type: "Program" }
             ]
         }, {
             code: "function foo() { 'use strict'; return; }",
+            output: null,
             options: ["global"],
             errors: [
                 { message: "Use the global form of 'use strict'.", type: "Program" },
@@ -165,6 +172,7 @@ ruleTester.run("strict", rule, {
             ]
         }, {
             code: "var foo = function() { 'use strict'; return; }",
+            output: null,
             options: ["global"],
             errors: [
                 { message: "Use the global form of 'use strict'.", type: "Program" },
@@ -172,6 +180,7 @@ ruleTester.run("strict", rule, {
             ]
         }, {
             code: "var foo = () => { 'use strict'; return () => 1; }",
+            output: null,
             options: ["global"],
             parserOptions: { ecmaVersion: 6 },
             errors: [
@@ -180,12 +189,14 @@ ruleTester.run("strict", rule, {
             ]
         }, {
             code: "'use strict'; function foo() { 'use strict'; return; }",
+            output: null,
             options: ["global"],
             errors: [
                 { message: "Use the global form of 'use strict'.", type: "ExpressionStatement" }
             ]
         }, {
             code: "'use strict'; var foo = function() { 'use strict'; return; };",
+            output: null,
             options: ["global"],
             errors: [
                 { message: "Use the global form of 'use strict'.", type: "ExpressionStatement" }
@@ -228,12 +239,14 @@ ruleTester.run("strict", rule, {
         // "function" mode
         {
             code: "'use strict'; foo();",
+            output: null,
             options: ["function"],
             errors: [
                 { message: "Use the function form of 'use strict'.", type: "ExpressionStatement" }
             ]
         }, {
             code: "'use strict'; (function() { 'use strict'; return true; }());",
+            output: null,
             options: ["function"],
             errors: [
                 { message: "Use the function form of 'use strict'.", type: "ExpressionStatement" }
@@ -247,12 +260,14 @@ ruleTester.run("strict", rule, {
             ]
         }, {
             code: "(function() { return true; }());",
+            output: null,
             options: ["function"],
             errors: [
                 { message: "Use the function form of 'use strict'.", type: "FunctionExpression" }
             ]
         }, {
             code: "(() => { return true; })();",
+            output: null,
             options: ["function"],
             parserOptions: { ecmaVersion: 6 },
             errors: [
@@ -260,6 +275,7 @@ ruleTester.run("strict", rule, {
             ]
         }, {
             code: "(() => true)();",
+            output: null,
             options: ["function"],
             parserOptions: { ecmaVersion: 6 },
             errors: [
@@ -267,6 +283,7 @@ ruleTester.run("strict", rule, {
             ]
         }, {
             code: "var foo = function() { foo(); 'use strict'; return; }; function bar() { foo(); 'use strict'; }",
+            output: null,
             options: ["function"],
             errors: [
                 { message: "Use the function form of 'use strict'.", type: "FunctionExpression" },
@@ -314,24 +331,28 @@ ruleTester.run("strict", rule, {
             ]
         }, {
             code: "function foo() { return function() { 'use strict'; return; }; }",
+            output: null,
             options: ["function"],
             errors: [
                 { message: "Use the function form of 'use strict'.", type: "FunctionDeclaration" }
             ]
         }, {
             code: "var foo = function() { function bar() { 'use strict'; return; } return; }",
+            output: null,
             options: ["function"],
             errors: [
                 { message: "Use the function form of 'use strict'.", type: "FunctionExpression" }
             ]
         }, {
             code: "function foo() { 'use strict'; return; } var bar = function() { return; };",
+            output: null,
             options: ["function"],
             errors: [
                 { message: "Use the function form of 'use strict'.", type: "FunctionExpression" }
             ]
         }, {
             code: "var foo = function() { 'use strict'; return; }; function bar() { return; };",
+            output: null,
             options: ["function"],
             errors: [
                 { message: "Use the function form of 'use strict'.", type: "FunctionDeclaration" }
@@ -355,6 +376,7 @@ ruleTester.run("strict", rule, {
         },
         {
             code: "var foo = () => { return; };",
+            output: null,
             parserOptions: { ecmaVersion: 6 },
             options: ["function"],
             errors: [{ message: "Use the function form of 'use strict'.", type: "ArrowFunctionExpression" }]
@@ -387,6 +409,7 @@ ruleTester.run("strict", rule, {
         // "safe" mode corresponds to "global" if ecmaFeatures.globalReturn is true, otherwise "function"
         {
             code: "'use strict'; function foo() { return; }",
+            output: null,
             options: ["safe"],
             errors: [
                 { message: "Use the function form of 'use strict'.", type: "ExpressionStatement" },
@@ -395,6 +418,7 @@ ruleTester.run("strict", rule, {
         },
         {
             code: "function foo() { 'use strict'; return; }",
+            output: null,
             parserOptions: { ecmaFeatures: { globalReturn: true } },
             options: ["safe"],
             errors: [
@@ -426,6 +450,7 @@ ruleTester.run("strict", rule, {
         // Default to "safe" mode
         {
             code: "'use strict'; function foo() { return; }",
+            output: null,
             errors: [
                 { message: "Use the function form of 'use strict'.", type: "ExpressionStatement" },
                 { message: "Use the function form of 'use strict'.", type: "FunctionDeclaration" }
@@ -433,10 +458,12 @@ ruleTester.run("strict", rule, {
         },
         {
             code: "function foo() { return; }",
+            output: null,
             errors: [{ message: "Use the function form of 'use strict'.", type: "FunctionDeclaration" }]
         },
         {
             code: "function foo() { 'use strict'; return; }",
+            output: null,
             parserOptions: { ecmaFeatures: { globalReturn: true } },
             errors: [
                 { message: "Use the global form of 'use strict'.", type: "Program" },
@@ -465,18 +492,21 @@ ruleTester.run("strict", rule, {
         // Reports deprecated syntax: https://github.com/eslint/eslint/issues/6405
         {
             code: "function foo(a = 0) { 'use strict' }",
+            output: null,
             parserOptions: { ecmaVersion: 6 },
             options: [],
             errors: ["'use strict' directive inside a function with non-simple parameter list throws a syntax error since ES2016."]
         },
         {
             code: "(function() { 'use strict'; function foo(a = 0) { 'use strict' } }())",
+            output: null,
             parserOptions: { ecmaVersion: 6 },
             options: [],
             errors: ["'use strict' directive inside a function with non-simple parameter list throws a syntax error since ES2016."]
         },
         {
             code: "function foo(a = 0) { 'use strict' }",
+            output: null,
             parserOptions: { ecmaVersion: 6, ecmaFeatures: { globalReturn: true } },
             options: [],
             errors: [
@@ -486,18 +516,21 @@ ruleTester.run("strict", rule, {
         },
         {
             code: "'use strict'; function foo(a = 0) { 'use strict' }",
+            output: null,
             parserOptions: { ecmaVersion: 6, ecmaFeatures: { globalReturn: true } },
             options: [],
             errors: ["'use strict' directive inside a function with non-simple parameter list throws a syntax error since ES2016."]
         },
         {
             code: "function foo(a = 0) { 'use strict' }",
+            output: null,
             parserOptions: { ecmaVersion: 6 },
             options: ["never"],
             errors: ["'use strict' directive inside a function with non-simple parameter list throws a syntax error since ES2016."]
         },
         {
             code: "function foo(a = 0) { 'use strict' }",
+            output: null,
             parserOptions: { ecmaVersion: 6 },
             options: ["global"],
             errors: [
@@ -507,30 +540,35 @@ ruleTester.run("strict", rule, {
         },
         {
             code: "'use strict'; function foo(a = 0) { 'use strict' }",
+            output: null,
             parserOptions: { ecmaVersion: 6 },
             options: ["global"],
             errors: ["'use strict' directive inside a function with non-simple parameter list throws a syntax error since ES2016."]
         },
         {
             code: "function foo(a = 0) { 'use strict' }",
+            output: null,
             parserOptions: { ecmaVersion: 6 },
             options: ["function"],
             errors: ["'use strict' directive inside a function with non-simple parameter list throws a syntax error since ES2016."]
         },
         {
             code: "(function() { 'use strict'; function foo(a = 0) { 'use strict' } }())",
+            output: null,
             parserOptions: { ecmaVersion: 6 },
             options: ["function"],
             errors: ["'use strict' directive inside a function with non-simple parameter list throws a syntax error since ES2016."]
         },
         {
             code: "function foo(a = 0) { }",
+            output: null,
             parserOptions: { ecmaVersion: 6 },
             options: ["function"],
             errors: ["Wrap function 'foo' in a function with 'use strict' directive."]
         },
         {
             code: "(function() { function foo(a = 0) { } }())",
+            output: null,
             parserOptions: { ecmaVersion: 6 },
             options: ["function"],
             errors: ["Use the function form of 'use strict'."]


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Add output property to tests on fixable rules. Some had no fixes and should have a `null` value, other where missing the fixed output.

**Is there anything you'd like reviewers to focus on?**
I will add a check to ensure the property is present in a different PR. I think that would be a breaking change.

