### PR TITLE
Fix: wrong comment when module not found in config (fixes #8192)

### DIFF
--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -184,6 +184,22 @@ function loadPackageJSONConfigFile(filePath) {
 }
 
 /**
+ * Creates an error to notify about a missing config to extend from.
+ * @param {string} configName The name of the missing config.
+ * @returns {Error} The error object to throw
+ * @private
+ */
+function configMissingError(configName) {
+    const error = new Error(`Failed to load config "${configName}" to extend from.`);
+
+    error.messageTemplate = "extend-config-missing";
+    error.messageData = {
+        configName
+    };
+    return error;
+}
+
+/**
  * Loads a configuration file regardless of the source. Inspects the file path
  * to determine the correctly way to load the config file.
  * @param {Object} file The path to the configuration.
@@ -199,6 +215,9 @@ function loadConfigFile(file) {
             config = loadJSConfigFile(filePath);
             if (file.configName) {
                 config = config.configs[file.configName];
+                if (!config) {
+                    throw configMissingError(file.configFullName);
+                }
             }
             break;
 
@@ -341,6 +360,33 @@ function getLookupPath(configFilePath) {
 }
 
 /**
+ * Resolves a eslint core config path
+ * @param {string} name The eslint config name.
+ * @returns {string} The resolved path of the config.
+ * @private
+ */
+function getEslintCoreConfigPath(name) {
+    if (name === "eslint:recommended") {
+
+       /*
+        * Add an explicit substitution for eslint:recommended to
+        * conf/eslint-recommended.js.
+        */
+        return path.resolve(__dirname, "../../conf/eslint-recommended.js");
+    }
+
+    if (name === "eslint:all") {
+
+       /*
+        * Add an explicit substitution for eslint:all to conf/eslint-all.js
+        */
+        return path.resolve(__dirname, "../../conf/eslint-all.js");
+    }
+
+    throw configMissingError(name);
+}
+
+/**
  * Applies values from the "extends" field in a configuration file.
  * @param {Object} config The configuration information.
  * @param {string} filePath The file path from which the configuration information
@@ -360,43 +406,23 @@ function applyExtends(config, filePath, relativeTo) {
 
     // Make the last element in an array take the highest precedence
     config = configExtends.reduceRight((previousValue, parentPath) => {
-
-        if (parentPath === "eslint:recommended") {
-
-            /*
-             * Add an explicit substitution for eslint:recommended to
-             * conf/eslint-recommended.js.
-             */
-            parentPath = path.resolve(__dirname, "../../conf/eslint-recommended.js");
-        } else if (parentPath === "eslint:all") {
-
-            /*
-             * Add an explicit substitution for eslint:all to conf/eslint-all.js
-             */
-            parentPath = path.resolve(__dirname, "../../conf/eslint-all.js");
-        } else if (isFilePath(parentPath)) {
-
-            /*
-             * If the `extends` path is relative, use the directory of the current configuration
-             * file as the reference point. Otherwise, use as-is.
-             */
-            parentPath = (!path.isAbsolute(parentPath)
-                ? path.join(relativeTo || path.dirname(filePath), parentPath)
-                : parentPath
-            );
-        }
-
         try {
+            if (parentPath.startsWith("eslint:")) {
+                parentPath = getEslintCoreConfigPath(parentPath);
+            } else if (isFilePath(parentPath)) {
+
+                /*
+                 * If the `extends` path is relative, use the directory of the current configuration
+                 * file as the reference point. Otherwise, use as-is.
+                 */
+                parentPath = (path.isAbsolute(parentPath)
+                    ? parentPath
+                    : path.join(relativeTo || path.dirname(filePath), parentPath)
+                );
+            }
             debug(`Loading ${parentPath}`);
             return ConfigOps.merge(load(parentPath, false, relativeTo), previousValue);
         } catch (e) {
-            if (parentPath.indexOf("plugin:") === 0 || parentPath.indexOf("eslint:") === 0) {
-                e.message = `Failed to load config "${parentPath}" to extend from.`;
-                e.messageTemplate = "extend-config-missing";
-                e.messageData = {
-                    configName: parentPath
-                };
-            }
 
             /*
              * If the file referenced by `extends` failed to load, add the path
@@ -462,7 +488,10 @@ function normalizePackageName(name, prefix) {
  * or package name.
  * @param {string} filePath The filepath to resolve.
  * @param {string} [relativeTo] The path to resolve relative to.
- * @returns {Object} A path that can be used directly to load the configuration.
+ * @returns {Object} An object containing 3 properties:
+ * - 'filePath' (required) the resolved path that can be used directly to load the configuration.
+ * - 'configName' the name of the configuration inside the plugin.
+ * - 'configFullName' the name of the configuration as used in the eslint config (e.g. 'plugin:node/recommended').
  * @private
  */
 function resolve(filePath, relativeTo) {
@@ -471,14 +500,15 @@ function resolve(filePath, relativeTo) {
     }
     let normalizedPackageName;
 
-    if (filePath.indexOf("plugin:") === 0) {
-        const packagePath = filePath.substr(7, filePath.lastIndexOf("/") - 7);
+    if (filePath.startsWith("plugin:")) {
+        const configFullName = filePath;
+        const pluginName = filePath.substr(7, filePath.lastIndexOf("/") - 7);
         const configName = filePath.substr(filePath.lastIndexOf("/") + 1, filePath.length - filePath.lastIndexOf("/") - 1);
 
-        normalizedPackageName = normalizePackageName(packagePath, "eslint-plugin");
+        normalizedPackageName = normalizePackageName(pluginName, "eslint-plugin");
         debug(`Attempting to resolve ${normalizedPackageName}`);
         filePath = resolver.resolve(normalizedPackageName, getLookupPath(relativeTo));
-        return { filePath, configName };
+        return { filePath, configName, configFullName };
     }
     normalizedPackageName = normalizePackageName(filePath, "eslint-config");
     debug(`Attempting to resolve ${normalizedPackageName}`);


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
PR https://github.com/eslint/eslint/pull/8100 modified the message when there was an error loading a plugin or config, but didn't account for other possible errors. In this case, `babel-eslint` was not present, and the error was misleading.

**Is there anything you'd like reviewers to focus on?**
Is there a cleaner way to check for this rather than using the error message?