### PR TITLE
Fix: nonblock-statement-body-position multiline error (fixes #8202)

### DIFF
--- a/lib/rules/nonblock-statement-body-position.js
+++ b/lib/rules/nonblock-statement-body-position.js
@@ -77,7 +77,7 @@ module.exports = {
                     message: "Expected a linebreak before this statement.",
                     fix: fixer => fixer.insertTextBefore(node, "\n")
                 });
-            } else if (tokenBefore.loc.end.line !== node.loc.end.line && option === "beside") {
+            } else if (tokenBefore.loc.end.line !== node.loc.start.line && option === "beside") {
                 context.report({
                     node,
                     message: "Expected no linebreak before this statement.",

--- a/tests/lib/rules/nonblock-statement-body-position.js
+++ b/tests/lib/rules/nonblock-statement-body-position.js
@@ -32,6 +32,11 @@ ruleTester.run("nonblock-statement-body-position", rule, {
         "for (foo in bar) baz;",
         "for (foo of bar) baz;",
         "if (foo) bar; else baz;",
+        `
+            if (foo) bar(
+                baz
+            );
+        `,
         {
             code: "if (foo) bar();",
             options: ["beside"]


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (https://github.com/eslint/eslint/issues/8202)

**What changes did you make? (Give an overview)**

The nonblock-statement-body-position rule is intended to compare the *start* line of a statement with the end line of the previous token. Due to a typo, it was comparing the *end* line of the statement instead, which caused false positives for multiline statements.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular