### PR TITLE
Breaking: `RuleTester` ensures tests in fixable rules define `output`

### DIFF
--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -531,6 +531,8 @@ RuleTester.prototype = {
 
                     assert.equal(fixResult.output, item.output, "Output is incorrect.");
                 }
+            } else if (rule.meta && rule.meta.fixable) {
+                assert.fail(null, null, "'output' property missing in test for a fixable rule. If no autofix should be performed, use 'output: null'.");
             }
 
             assertASTDidntChange(result.beforeAST, result.afterAST);

--- a/tests/fixtures/testers/rule-tester/fixable-rule-with-meta.js
+++ b/tests/fixtures/testers/rule-tester/fixable-rule-with-meta.js
@@ -1,0 +1,31 @@
+/**
+ * @fileoverview Fixable rule
+ * @author Alberto Rodríguez
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+"use strict";
+
+module.exports = {
+    meta: {
+        schema: [],
+        fixable: "code"
+    },
+
+    create(context) {
+        var sourceCode = context.getSourceCode();
+
+        return {
+            "Program"(node) {
+                context.report({
+                    node,
+                    message: "No programs allowed.",
+                    fix: fixer => fixer.remove(node)
+                });
+            }
+        };
+    }
+};

--- a/tests/lib/testers/rule-tester.js
+++ b/tests/lib/testers/rule-tester.js
@@ -221,6 +221,18 @@ describe("RuleTester", () => {
         });
     });
 
+    it("should throw an error when there is no ouput property and the rule is fixable", () => {
+
+        assert.throws(() => {
+            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/fixable-rule-with-meta"), {
+                valid: [],
+                invalid: [
+                    { code: "var foo = bar;", errors: [{ message: "No programs allowed.", type: "Program" }] }
+                ]
+            });
+        }, /'output' property missing/);
+    });
+
     it("should throw an error when the expected output doesn't match", () => {
 
         assert.throws(() => {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[X] Add something to the core
[] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
I added a check to ensure that if a rule is fixable, every invalid test defines an `output` property. If the rule doesn't change the output, it should have value `null`. This prevents forgetting to add the output to the test. For reference, we had 75 tests without `output` in our codebase (they were fixed in https://github.com/eslint/eslint/pull/8195).

**Is there anything you'd like reviewers to focus on?**
- Is there a valid reason were we would want to allow omitting `output` from a test?
- I labelled it as breaking. It won't affect end users, but it could cause errors to plugin developers code. Agree?

