### PR TITLE
Build: change mock-fs path without SSH (fixes #8207)

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "load-perf": "^0.2.0",
     "markdownlint": "^0.3.1",
     "mocha": "^2.4.5",
-    "mock-fs": "git://github.com/not-an-aardvark/mock-fs/#06868bbd7724707f9324b237bdde28f05f7a01d5",
+    "mock-fs": "not-an-aardvark/mock-fs#06868bbd7724707f9324b237bdde28f05f7a01d5",
     "npm-license": "^0.3.2",
     "phantomjs-prebuilt": "^2.1.7",
     "proxyquire": "^1.7.10",


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Other, please explain: fixes #8207

**What changes did you make? (Give an overview)**

This PR changes the notation which requires SSH to using HTTPS.
There are environments which can not use SSH for WAN.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.
