### PR TITLE
Update: no-extra-parens overlooked spread and superClass (fixes #8175)

### DIFF
--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -67,6 +67,7 @@ module.exports = {
         const NESTED_BINARY = ALL_NODES && context.options[1] && context.options[1].nestedBinaryExpressions === false;
         const EXCEPT_RETURN_ASSIGN = ALL_NODES && context.options[1] && context.options[1].returnAssign === false;
         const IGNORE_JSX = ALL_NODES && context.options[1] && context.options[1].ignoreJSX;
+        const PRECEDENCE_OF_UPDATE_EXPR = precedence({ type: "UpdateExpression" });
 
         /**
          * Determines if this rule should be enforced for a node given the current configuration.
@@ -438,7 +439,9 @@ module.exports = {
                 return;
             }
 
-            const hasExtraParens = precedence(node.superClass) >= 18
+            // If `node.superClass` is a LeftHandSideExpression, parentheses are extra.
+            // Otherwise, parentheses are needed.
+            const hasExtraParens = precedence(node.superClass) > PRECEDENCE_OF_UPDATE_EXPR
                 ? hasExcessParens(node.superClass)
                 : hasDoubleExcessParens(node.superClass);
 

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -428,6 +428,36 @@ module.exports = {
             }
         }
 
+        /**
+         * Check the parentheses around the super class of the given class definition.
+         * @param {ASTNode} node The node of class declarations to check.
+         * @returns {void}
+         */
+        function dryClass(node) {
+            if (!node.superClass) {
+                return;
+            }
+
+            const hasExtraParens = precedence(node.superClass) >= 18
+                ? hasExcessParens(node.superClass)
+                : hasDoubleExcessParens(node.superClass);
+
+            if (hasExtraParens) {
+                report(node.superClass);
+            }
+        }
+
+        /**
+         * Check the parentheses around the argument of the given spread operator.
+         * @param {ASTNode} node The node of spread elements/properties to check.
+         * @returns {void}
+         */
+        function drySpreadOperator(node) {
+            if (node.argument && hasExcessParens(node.argument)) {
+                report(node.argument);
+            }
+        }
+
         return {
             ArrayExpression(node) {
                 [].forEach.call(node.elements, e => {
@@ -668,7 +698,14 @@ module.exports = {
                         report(node.argument);
                     }
                 }
-            }
+            },
+
+            ClassDeclaration: dryClass,
+            ClassExpression: dryClass,
+
+            SpreadElement: drySpreadOperator,
+            SpreadProperty: drySpreadOperator,
+            ExperimentalSpreadProperty: drySpreadOperator
         };
 
     }

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -367,7 +367,35 @@ ruleTester.run("no-extra-parens", rule, {
             "const Component = (<div",
             "  prop={true}",
             "/>)"
-        ].join("\n"), options: ["all", { ignoreJSX: "multi-line" }] }
+        ].join("\n"), options: ["all", { ignoreJSX: "multi-line" }] },
+
+        {
+            code: "let a = [ ...b ]",
+            parserOptions: { ecmaVersion: 2015 }
+        },
+        {
+            code: "let a = { ...b }",
+            parserOptions: {
+                ecmaVersion: 2015,
+                ecmaFeatures: { experimentalObjectRestSpread: true }
+            }
+        },
+        {
+            code: "class A extends B {}",
+            parserOptions: { ecmaVersion: 2015 }
+        },
+        {
+            code: "const A = class extends B {}",
+            parserOptions: { ecmaVersion: 2015 }
+        },
+        {
+            code: "class A extends (B=C) {}",
+            parserOptions: { ecmaVersion: 2015 }
+        },
+        {
+            code: "const A = class extends (B=C) {}",
+            parserOptions: { ecmaVersion: 2015 }
+        }
     ],
 
     invalid: [
@@ -841,6 +869,55 @@ ruleTester.run("no-extra-parens", rule, {
             "</div>)"
         ].join("\n"), "const Component = <div>\n<p />\n</div>", "JSXElement", 1, {
             options: ["all", { ignoreJSX: "none" }]
-        })
+        }),
+
+        // https://github.com/eslint/eslint/issues/8175
+        invalid(
+            "let a = [...(b)]",
+            "let a = [...b]",
+            "Identifier",
+            1,
+            { parserOptions: { ecmaVersion: 2015 } }
+        ),
+        invalid(
+            "let a = {...(b)}",
+            "let a = {...b}",
+            "Identifier",
+            1,
+            {
+                parserOptions: {
+                    ecmaVersion: 2015,
+                    ecmaFeatures: { experimentalObjectRestSpread: true }
+                }
+            }
+        ),
+        invalid(
+            "class A extends (B) {}",
+            "class A extends B {}",
+            "Identifier",
+            1,
+            { parserOptions: { ecmaVersion: 2015 } }
+        ),
+        invalid(
+            "const A = class extends (B) {}",
+            "const A = class extends B {}",
+            "Identifier",
+            1,
+            { parserOptions: { ecmaVersion: 2015 } }
+        ),
+        invalid(
+            "class A extends ((B=C)) {}",
+            "class A extends (B=C) {}",
+            "AssignmentExpression",
+            1,
+            { parserOptions: { ecmaVersion: 2015 } }
+        ),
+        invalid(
+            "const A = class extends ((B=C)) {}",
+            "const A = class extends (B=C) {}",
+            "AssignmentExpression",
+            1,
+            { parserOptions: { ecmaVersion: 2015 } }
+        )
     ]
 });


### PR DESCRIPTION
## What is the purpose of this pull request? (put an "X" next to item)

[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

Fixes #8175.

## What changes did you make? (Give an overview)

This PR fixes the overlooking of `no-extra-parens` around spread operators and super classes.

```js
//✘ BAD
let a = [ ...(b) ]
let b = { ...(c) }
class A extends (B) { }

//✔ GOOD
class C extends (D,E) { } // Allow this parentheses. 
                          // `SequenceExpression` is not a `LeftHandSideExpression`, 
                          // so if the parentheses are removed then will get a syntax error.

class F extends (await G()) { } // Arrow this parentheses.
```

- The argument of spread operators is an `AssignmentExpression`. So parentheses around the argument of spread operators should be always extra.
- The super class of `ClassDeclaration`/`ClassExpression` is an `LeftHandSideExpression`. If a super class is a `LeftHandSideExpression`, the parentheses of the super class should be extra.

## Is there anything you'd like reviewers to focus on?

I'm not familiar with `no-extra-parens` rule.
Is this fix correct?
