### PR TITLE
Chore: rename no-extra-parens methods

### DIFF
--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -366,7 +366,7 @@ module.exports = {
          * @returns {void}
          * @private
          */
-        function dryUnaryUpdate(node) {
+        function checkUnaryUpdate(node) {
             if (node.type === "UnaryExpression" && node.argument.type === "BinaryExpression" && node.argument.operator === "**") {
                 return;
             }
@@ -382,7 +382,7 @@ module.exports = {
          * @returns {void}
          * @private
          */
-        function dryCallNew(node) {
+        function checkCallNew(node) {
             if (hasExcessParens(node.callee) && precedence(node.callee) >= precedence(node) && !(
                 node.type === "CallExpression" &&
                 (node.callee.type === "FunctionExpression" ||
@@ -412,7 +412,7 @@ module.exports = {
          * @returns {void}
          * @private
          */
-        function dryBinaryLogical(node) {
+        function checkBinaryLogical(node) {
             const prec = precedence(node);
             const leftPrecedence = precedence(node.left);
             const rightPrecedence = precedence(node.right);
@@ -434,7 +434,7 @@ module.exports = {
          * @param {ASTNode} node The node of class declarations to check.
          * @returns {void}
          */
-        function dryClass(node) {
+        function checkClass(node) {
             if (!node.superClass) {
                 return;
             }
@@ -455,7 +455,7 @@ module.exports = {
          * @param {ASTNode} node The node of spread elements/properties to check.
          * @returns {void}
          */
-        function drySpreadOperator(node) {
+        function checkSpreadOperator(node) {
             if (node.argument && hasExcessParens(node.argument)) {
                 report(node.argument);
             }
@@ -498,8 +498,8 @@ module.exports = {
                 }
             },
 
-            BinaryExpression: dryBinaryLogical,
-            CallExpression: dryCallNew,
+            BinaryExpression: checkBinaryLogical,
+            CallExpression: checkCallNew,
 
             ConditionalExpression(node) {
                 if (isReturnAssignException(node)) {
@@ -579,7 +579,7 @@ module.exports = {
                 }
             },
 
-            LogicalExpression: dryBinaryLogical,
+            LogicalExpression: checkBinaryLogical,
 
             MemberExpression(node) {
                 if (
@@ -609,7 +609,7 @@ module.exports = {
                 }
             },
 
-            NewExpression: dryCallNew,
+            NewExpression: checkCallNew,
 
             ObjectExpression(node) {
                 [].forEach.call(node.properties, e => {
@@ -665,9 +665,9 @@ module.exports = {
                 }
             },
 
-            UnaryExpression: dryUnaryUpdate,
-            UpdateExpression: dryUnaryUpdate,
-            AwaitExpression: dryUnaryUpdate,
+            UnaryExpression: checkUnaryUpdate,
+            UpdateExpression: checkUnaryUpdate,
+            AwaitExpression: checkUnaryUpdate,
 
             VariableDeclarator(node) {
                 if (node.init && hasExcessParens(node.init) &&
@@ -703,12 +703,12 @@ module.exports = {
                 }
             },
 
-            ClassDeclaration: dryClass,
-            ClassExpression: dryClass,
+            ClassDeclaration: checkClass,
+            ClassExpression: checkClass,
 
-            SpreadElement: drySpreadOperator,
-            SpreadProperty: drySpreadOperator,
-            ExperimentalSpreadProperty: drySpreadOperator
+            SpreadElement: checkSpreadOperator,
+            SpreadProperty: checkSpreadOperator,
+            ExperimentalSpreadProperty: checkSpreadOperator
         };
 
     }


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:
Based on the discussions [here](https://github.com/eslint/eslint/pull/8209#discussion_r104966785), I renamed some of the methods in the `no-extra-parens` rule to have a more clear prefix.

**What changes did you make? (Give an overview)**
See above.

**Is there anything you'd like reviewers to focus on?**
I think not!

