### PR TITLE
Chore: convert Traverser to ES6 class (refs #7849)

### DIFF
--- a/lib/util/traverser.js
+++ b/lib/util/traverser.js
@@ -14,41 +14,32 @@ const estraverse = require("estraverse");
 // Helpers
 //------------------------------------------------------------------------------
 
-const KEY_BLACKLIST = [
+const KEY_BLACKLIST = new Set([
     "parent",
     "leadingComments",
     "trailingComments"
-];
+]);
 
 /**
  * Wrapper around an estraverse controller that ensures the correct keys
  * are visited.
  * @constructor
  */
-function Traverser() {
-
-    const controller = Object.create(new estraverse.Controller()),
-        originalTraverse = controller.traverse;
-
-    // intercept call to traverse() and add the fallback key to the visitor
-    controller.traverse = function(node, visitor) {
+class Traverser extends estraverse.Controller {
+    traverse(node, visitor) {
         visitor.fallback = Traverser.getKeys;
-        return originalTraverse.call(this, node, visitor);
-    };
+        return super.traverse(node, visitor);
+    }
 
-    return controller;
+    /**
+     * Calculates the keys to use for traversal.
+     * @param {ASTNode} node The node to read keys from.
+     * @returns {string[]} An array of keys to visit on the node.
+     * @private
+     */
+    static getKeys(node) {
+        return Object.keys(node).filter(key => !KEY_BLACKLIST.has(key));
+    }
 }
 
-/**
- * Calculates the keys to use for traversal.
- * @param {ASTNode} node The node to read keys from.
- * @returns {string[]} An array of keys to visit on the node.
- * @private
- */
-Traverser.getKeys = function(node) {
-    return Object.keys(node).filter(key => KEY_BLACKLIST.indexOf(key) === -1);
-};
-
 module.exports = Traverser;
-
-

--- a/tests/lib/util/traverser.js
+++ b/tests/lib/util/traverser.js
@@ -1,0 +1,43 @@
+"use strict";
+
+const assert = require("chai").assert;
+const Traverser = require("../../../lib/util/traverser");
+
+describe("Traverser", () => {
+    it("traverses all keys except 'parent', 'leadingComments', and 'trailingComments'", () => {
+        const traverser = new Traverser();
+        const fakeAst = {
+            type: "Program",
+            body: [
+                {
+                    type: "ExpressionStatement",
+                    leadingComments: {
+                        type: "Line"
+                    },
+                    trailingComments: {
+                        type: "Block"
+                    }
+                },
+                {
+                    type: "FooStatement",
+                    foo: {
+                        type: "BarStatement"
+                    }
+                }
+            ]
+        };
+
+        fakeAst.body[0].parent = fakeAst;
+
+        const enteredNodes = [];
+        const exitedNodes = [];
+
+        traverser.traverse(fakeAst, {
+            enter: node => enteredNodes.push(node),
+            leave: node => exitedNodes.push(node)
+        });
+
+        assert.deepEqual(enteredNodes, [fakeAst, fakeAst.body[0], fakeAst.body[1], fakeAst.body[1].foo]);
+        assert.deepEqual(exitedNodes, [fakeAst.body[0], fakeAst.body[1].foo, fakeAst.body[1], fakeAst]);
+    });
+});


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

**What changes did you make? (Give an overview)**

This converts `Traverser` (our wrapper around estraverse) into an ES6 class. Since `Traverser` is not a public API, this should not be a breaking change.

This also adds tests for `Traverser` (there were no tests before).

Based on `npm run perf` numbers, this improves end-to-end performance by 4%. :tada:

**Is there anything you'd like reviewers to focus on?**

Looking at the history of the `Traverser` wrapper, I see that it was introduced to fix https://github.com/eslint/eslint/issues/5476 (a bug which broke a lot of projects that used babel-eslint). I'm not sure I understand the exact circumstances that caused that bug, but we should make sure this change isn't doing anything that will cause the bug to reappear. Pinging @hzoo since he probably knows more about this.

The regression build reports no errors with this change.