### PR TITLE
Breaking: infer endLine and endColumn from a reported node (fixes #8004)

### DIFF
--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -967,6 +967,8 @@ module.exports = (function() {
             assert.strictEqual(typeof node, "object", "Node must be an object");
         }
 
+        let endLocation;
+
         if (typeof location === "string") {
             assert.ok(node, "Node must be provided when reporting error if location is not provided");
 
@@ -975,10 +977,10 @@ module.exports = (function() {
             opts = message;
             message = location;
             location = node.loc.start;
+            endLocation = node.loc.end;
+        } else {
+            endLocation = location.end;
         }
-
-        // Store end location.
-        const endLocation = location.end;
 
         location = location.start || location;
 

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -841,6 +841,8 @@ describe("eslint", () => {
                 nodeType: "Program",
                 line: 1,
                 column: 1,
+                endLine: 1,
+                endColumn: 2,
                 source: "0"
             });
         });
@@ -859,6 +861,8 @@ describe("eslint", () => {
                 nodeType: "Program",
                 line: 1,
                 column: 1,
+                endLine: 1,
+                endColumn: 2,
                 source: "0"
             });
         });
@@ -877,6 +881,8 @@ describe("eslint", () => {
                 nodeType: "Program",
                 line: 1,
                 column: 1,
+                endLine: 1,
+                endColumn: 2,
                 source: "0",
                 fix: { range: [1, 1], text: "" }
             });
@@ -1066,7 +1072,7 @@ describe("eslint", () => {
             });
         });
 
-        it("should not have 'endLine' and 'endColumn' when there is not 'loc' property.", () => {
+        it("should have 'endLine' and 'endColumn' when there is not 'loc' property.", () => {
             eslint.on("Program", node => {
                 eslint.report(
                     "test-rule",
@@ -1076,10 +1082,12 @@ describe("eslint", () => {
                 );
             });
 
-            const messages = eslint.verify("0", config, "", true);
+            const sourceText = "foo + bar;";
 
-            assert.strictEqual(messages[0].endLine, void 0);
-            assert.strictEqual(messages[0].endColumn, void 0);
+            const messages = eslint.verify(sourceText, config, "", true);
+
+            assert.strictEqual(messages[0].endLine, 1);
+            assert.strictEqual(messages[0].endColumn, sourceText.length + 1); // (1-based column)
         });
 
         it("should have 'endLine' and 'endColumn' when 'loc' property has 'end' property.", () => {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Add something to the core

**What changes did you make? (Give an overview)**

Also see: https://github.com/eslint/eslint/issues/8004

Previously, rules could specify an endLine and endColumn in a report. However, when a rule reported a node without explicitly giving a location, only the start location of the node was included in the final report object. This commit updates the report-handling logic to ensure that the end location of the node is also included.

This is considered a potentially-breaking change because if a rule specifies a very large node to report, the report range will be very large, which could cause a poor user experience in editor integrations (e.g. if hundreds of lines are highlighted).

**Is there anything you'd like reviewers to focus on?**

This should not be merged until the TSC decides whether to accept https://github.com/eslint/eslint/issues/8004.