### PR TITLE
Update: fix false negative of no-useless-escape in template literal tags

### DIFF
--- a/lib/rules/no-useless-escape.js
+++ b/lib/rules/no-useless-escape.js
@@ -147,7 +147,13 @@ module.exports = {
         function check(node) {
             const isTemplateElement = node.type === "TemplateElement";
 
-            if (isTemplateElement && node.parent && node.parent.parent && node.parent.parent.type === "TaggedTemplateExpression") {
+            if (
+                isTemplateElement &&
+                node.parent &&
+                node.parent.parent &&
+                node.parent.parent.type === "TaggedTemplateExpression" &&
+                node.parent === node.parent.parent.quasi
+            ) {
 
                 // Don't report tagged template literals, because the backslash character is accessible to the tag function.
                 return;

--- a/tests/lib/rules/no-useless-escape.js
+++ b/tests/lib/rules/no-useless-escape.js
@@ -269,6 +269,11 @@ ruleTester.run("no-useless-escape", rule, {
             code: "`multiline template\nliteral with useless \\escape`",
             parserOptions: { ecmaVersion: 6 },
             errors: [{ line: 2, column: 22, message: "Unnecessary escape character: \\e.", type: "TemplateElement" }]
+        },
+        {
+            code: "`\\a```",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ line: 1, column: 2, message: "Unnecessary escape character: \\a.", type: "TemplateElement" }]
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix

**Tell us about your environment**

* **ESLint Version:** master
* **Node Version:** 7.7.2
* **npm Version:** 4.1.2

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

```yml
rules:
  no-useless-escape: error
parserOptions:
  ecmaVersion: 2015
```

**What did you do? Please include the actual source code causing the issue.**

```js
`\a```
```

**What did you expect to happen?**

I expected the `\a` to be reported as a useless escape.

**What actually happened? Please include the actual, raw output from ESLint.**

No errors were reported.

**What changes did you make? (Give an overview)**

This fixes a check in `no-useless-escape` for tagged template literals. Previously, the rule would exclude any `TemplateLiteral` whose parent was a `TaggedTemplateExpression`. This is because backslashes in the "literal" part of a tagged template can be observed by the tag function. However, this doesn't apply to the tag itself, so if a template literal is a tag for another template literal, the rule should check for useless escapes in the tag.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular