### PR TITLE
Fix: sort-vars crash on mixed destructuring declarations

### DIFF
--- a/lib/rules/sort-vars.js
+++ b/lib/rules/sort-vars.js
@@ -37,11 +37,9 @@ module.exports = {
 
         return {
             VariableDeclaration(node) {
-                node.declarations.reduce((memo, decl) => {
-                    if (decl.id.type === "ObjectPattern" || decl.id.type === "ArrayPattern") {
-                        return memo;
-                    }
+                const idDeclarations = node.declarations.filter(decl => decl.id.type === "Identifier");
 
+                idDeclarations.slice(1).reduce((memo, decl) => {
                     let lastVariableName = memo.id.name,
                         currenVariableName = decl.id.name;
 
@@ -56,7 +54,7 @@ module.exports = {
                     }
                     return decl;
 
-                }, node.declarations[0]);
+                }, idDeclarations[0]);
             }
         };
     }

--- a/tests/lib/rules/sort-vars.js
+++ b/tests/lib/rules/sort-vars.js
@@ -77,7 +77,13 @@ ruleTester.run("sort-vars", rule, {
             "            c;",
             "    }",
             "}"
-        ].join("\n"), env: { es6: true }, parserOptions: { sourceType: "module" } }
+        ].join("\n"), env: { es6: true }, parserOptions: { sourceType: "module" } },
+
+        {
+            code: "var {} = 1, a",
+            options: ignoreCaseArgs,
+            parserOptions: { ecmaVersion: 6 }
+        }
     ],
     invalid: [
         { code: "var b, a", errors: [expectedError] },
@@ -93,6 +99,13 @@ ruleTester.run("sort-vars", rule, {
         { code: "var d, a, [b, c] = {};", options: ignoreCaseArgs,
             parserOptions: { ecmaVersion: 6 }, errors: [expectedError] },
         { code: "var d, a, [b, {x: {c, e}}] = {};", options: ignoreCaseArgs,
-            parserOptions: { ecmaVersion: 6 }, errors: [expectedError] }
+            parserOptions: { ecmaVersion: 6 }, errors: [expectedError] },
+
+        {
+            code: "var {} = 1, b, a",
+            options: ignoreCaseArgs,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [expectedError]
+        }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix

**Tell us about your environment**

* **ESLint Version:** master
* **Node Version:** 7.7.2
* **npm Version:** 4.1.2

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

```yml
parserOptions:
  ecmaVersion: 2015
rules:
  sort-vars: [error, { ignoreCase: true }]
```

**What did you do? Please include the actual source code causing the issue.**

```js
var {a} = 1, b;
```

**What did you expect to happen?**

I expected ESLint to not crash.

**What actually happened? Please include the actual, raw output from ESLint.**

ESLint crashed.

```
Cannot read property 'toLowerCase' of undefined
TypeError: Cannot read property 'toLowerCase' of undefined
    at VariableDeclaration.node.declarations.reduce (/path/to/eslint/lib/rules/sort-vars.js:49:60)
    at Array.reduce (native)
    at EventEmitter.VariableDeclaration (/path/to/eslint/lib/rules/sort-vars.js:40:35)
    at emitOne (events.js:96:13)
    at EventEmitter.emit (events.js:191:7)
    at NodeEventGenerator.enterNode (/path/to/eslint/lib/util/node-event-generator.js:39:22)
    at CodePathAnalyzer.enterNode (/path/to/eslint/lib/code-path-analysis/code-path-analyzer.js:607:23)
    at CommentEventGenerator.enterNode (/path/to/eslint/lib/util/comment-event-generator.js:98:23)
    at Controller.enter (/path/to/eslint/lib/eslint.js:928:36)
    at Controller.__execute (/path/to/eslint/node_modules/estraverse/estraverse.js:397:31)

```

**What changes did you make? (Give an overview)**

By design, sort-vars ignores destructuring assignments. However, the rule previously didn't account for the case where the first declarator of a variable declaration was a destructuring assignment -- this led to a crash. This commit updates the rule to handle this case properly.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular