### PR TITLE
Chore: use precalculated counts in stylish formatter

### DIFF
--- a/lib/formatters/stylish.js
+++ b/lib/formatters/stylish.js
@@ -28,7 +28,6 @@ function pluralize(word, count) {
 module.exports = function(results) {
 
     let output = "\n",
-        total = 0,
         errors = 0,
         warnings = 0,
         summaryColor = "yellow";
@@ -40,7 +39,9 @@ module.exports = function(results) {
             return;
         }
 
-        total += messages.length;
+        errors += result.errorCount;
+        warnings += result.warningCount;
+
         output += `${chalk.underline(result.filePath)}\n`;
 
         output += `${table(
@@ -50,10 +51,8 @@ module.exports = function(results) {
                 if (message.fatal || message.severity === 2) {
                     messageType = chalk.red("error");
                     summaryColor = "red";
-                    errors++;
                 } else {
                     messageType = chalk.yellow("warning");
-                    warnings++;
                 }
 
                 return [
@@ -73,6 +72,8 @@ module.exports = function(results) {
             }
         ).split("\n").map(el => el.replace(/(\d+)\s+(\d+)/, (m, p1, p2) => chalk.dim(`${p1}:${p2}`))).join("\n")}\n\n`;
     });
+
+    const total = errors + warnings;
 
     if (total > 0) {
         output += chalk[summaryColor].bold([


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Use the precalculated error and warning count in stylish

**Is there anything you'd like reviewers to focus on?**
Is there a reason why we weren't doing this before?

