### PR TITLE
Breaking: convert CLIEngine to ES6 class (refs #8231)

### DIFF
--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -432,141 +432,99 @@ function getCacheFile(cacheFile, cwd) {
 // Public Interface
 //------------------------------------------------------------------------------
 
-/**
- * Creates a new instance of the core CLI engine.
- * @param {CLIEngineOptions} options The options for this instance.
- * @constructor
- */
-function CLIEngine(options) {
-
-    options = Object.assign(
-        Object.create(null),
-        defaultOptions,
-        { cwd: process.cwd() },
-        options
-    );
+class CLIEngine {
 
     /**
-     * Stored options for this instance
-     * @type {Object}
+     * Creates a new instance of the core CLI engine.
+     * @param {CLIEngineOptions} options The options for this instance.
+     * @constructor
      */
-    this.options = options;
+    constructor(options) {
 
-    const cacheFile = getCacheFile(this.options.cacheLocation || this.options.cacheFile, this.options.cwd);
+        options = Object.assign(
+            Object.create(null),
+            defaultOptions,
+            { cwd: process.cwd() },
+            options
+        );
 
-    /**
-     * Cache used to avoid operating on files that haven't changed since the
-     * last successful execution (e.g., file passed linting with no errors and
-     * no warnings).
-     * @type {Object}
-     */
-    this._fileCache = fileEntryCache.create(cacheFile);
+        /**
+         * Stored options for this instance
+         * @type {Object}
+         */
+        this.options = options;
 
-    // load in additional rules
-    if (this.options.rulePaths) {
-        const cwd = this.options.cwd;
+        const cacheFile = getCacheFile(this.options.cacheLocation || this.options.cacheFile, this.options.cwd);
 
-        this.options.rulePaths.forEach(rulesdir => {
-            debug(`Loading rules from ${rulesdir}`);
-            rules.load(rulesdir, cwd);
+        /**
+         * Cache used to avoid operating on files that haven't changed since the
+         * last successful execution (e.g., file passed linting with no errors and
+         * no warnings).
+         * @type {Object}
+         */
+        this._fileCache = fileEntryCache.create(cacheFile);
+
+        // load in additional rules
+        if (this.options.rulePaths) {
+            const cwd = this.options.cwd;
+
+            this.options.rulePaths.forEach(rulesdir => {
+                debug(`Loading rules from ${rulesdir}`);
+                rules.load(rulesdir, cwd);
+            });
+        }
+
+        Object.keys(this.options.rules || {}).forEach(name => {
+            validator.validateRuleOptions(name, this.options.rules[name], "CLI");
         });
     }
 
-    Object.keys(this.options.rules || {}).forEach(name => {
-        validator.validateRuleOptions(name, this.options.rules[name], "CLI");
-    });
-}
+    /**
+     * Returns results that only contains errors.
+     * @param {LintResult[]} results The results to filter.
+     * @returns {LintResult[]} The filtered results.
+     */
+    static getErrorResults(results) {
+        const filtered = [];
 
-/**
- * Returns the formatter representing the given format or null if no formatter
- * with the given name can be found.
- * @param {string} [format] The name of the format to load or the path to a
- *      custom formatter.
- * @returns {Function} The formatter function or null if not found.
- */
-CLIEngine.getFormatter = function(format) {
+        results.forEach(result => {
+            const filteredMessages = result.messages.filter(isErrorMessage);
 
-    let formatterPath;
+            if (filteredMessages.length > 0) {
+                filtered.push(
+                    Object.assign(result, {
+                        messages: filteredMessages,
+                        errorCount: filteredMessages.length,
+                        warningCount: 0
+                    })
+                );
+            }
+        });
 
-    // default is stylish
-    format = format || "stylish";
-
-    // only strings are valid formatters
-    if (typeof format === "string") {
-
-        // replace \ with / for Windows compatibility
-        format = format.replace(/\\/g, "/");
-
-        // if there's a slash, then it's a file
-        if (format.indexOf("/") > -1) {
-            const cwd = this.options ? this.options.cwd : process.cwd();
-
-            formatterPath = path.resolve(cwd, format);
-        } else {
-            formatterPath = `./formatters/${format}`;
-        }
-
-        try {
-            return require(formatterPath);
-        } catch (ex) {
-            ex.message = `There was a problem loading formatter: ${formatterPath}\nError: ${ex.message}`;
-            throw ex;
-        }
-
-    } else {
-        return null;
+        return filtered;
     }
-};
-
-/**
- * Returns results that only contains errors.
- * @param {LintResult[]} results The results to filter.
- * @returns {LintResult[]} The filtered results.
- */
-CLIEngine.getErrorResults = function(results) {
-    const filtered = [];
-
-    results.forEach(result => {
-        const filteredMessages = result.messages.filter(isErrorMessage);
-
-        if (filteredMessages.length > 0) {
-            filtered.push(
-                Object.assign(result, {
-                    messages: filteredMessages,
-                    errorCount: filteredMessages.length,
-                    warningCount: 0
-                })
-            );
-        }
-    });
-
-    return filtered;
-};
-
-/**
- * Outputs fixes from the given results to files.
- * @param {Object} report The report object created by CLIEngine.
- * @returns {void}
- */
-CLIEngine.outputFixes = function(report) {
-    report.results.filter(result => result.hasOwnProperty("output")).forEach(result => {
-        fs.writeFileSync(result.filePath, result.output);
-    });
-};
-
-CLIEngine.prototype = {
-
-    constructor: CLIEngine,
 
     /**
-     * Add a plugin by passing it's configuration
+     * Outputs fixes from the given results to files.
+     * @param {Object} report The report object created by CLIEngine.
+     * @returns {void}
+     */
+    static outputFixes(report) {
+        report.results.filter(result => result.hasOwnProperty("output")).forEach(result => {
+            fs.writeFileSync(result.filePath, result.output);
+        });
+    }
+
+
+    /**
+     * Add a plugin by passing its configuration
      * @param {string} name Name of the plugin.
      * @param {Object} pluginobject Plugin configuration object.
      * @returns {void}
      */
-    addPlugin(name, pluginobject) {
+    addPlugin(name, pluginobject) { // eslint-disable-line class-methods-use-this
         Plugins.define(name, pluginobject);
-    },
+    }
 
     /**
      * Resolves the patterns passed into executeOnFiles() into glob-based patterns
@@ -576,7 +534,7 @@ CLIEngine.prototype = {
      */
     resolveFileGlobPatterns(patterns) {
         return globUtil.resolveFileGlobPatterns(patterns, this.options);
-    },
+    }
 
     /**
      * Executes the current configuration on an array of file and directory names.
@@ -725,7 +683,7 @@ CLIEngine.prototype = {
             errorCount: stats.errorCount,
             warningCount: stats.warningCount
         };
-    },
+    }
 
     /**
      * Executes the current configuration on text.
@@ -761,7 +719,7 @@ CLIEngine.prototype = {
             errorCount: stats.errorCount,
             warningCount: stats.warningCount
         };
-    },
+    }
 
     /**
      * Returns a configuration object for the given file based on the CLI options.
@@ -774,7 +732,7 @@ CLIEngine.prototype = {
         const configHelper = new Config(this.options);
 
         return configHelper.getConfig(filePath);
-    },
+    }
 
     /**
      * Checks if a given path is ignored by ESLint.
@@ -786,12 +744,51 @@ CLIEngine.prototype = {
         const ignoredPaths = new IgnoredPaths(this.options);
 
         return ignoredPaths.contains(resolvedPath);
-    },
+    }
 
-    getFormatter: CLIEngine.getFormatter
+    /**
+     * Returns the formatter representing the given format or null if no formatter
+     * with the given name can be found.
+     * @param {string} [format] The name of the format to load or the path to a
+     *      custom formatter.
+     * @returns {Function} The formatter function or null if not found.
+     */
+    getFormatter(format) {
 
-};
+        let formatterPath;
+
+        // default is stylish
+        format = format || "stylish";
+
+        // only strings are valid formatters
+        if (typeof format === "string") {
+
+            // replace \ with / for Windows compatibility
+            format = format.replace(/\\/g, "/");
+
+            // if there's a slash, then it's a file
+            if (format.indexOf("/") > -1) {
+                const cwd = this.options ? this.options.cwd : process.cwd();
+
+                formatterPath = path.resolve(cwd, format);
+            } else {
+                formatterPath = `./formatters/${format}`;
+            }
+
+            try {
+                return require(formatterPath);
+            } catch (ex) {
+                ex.message = `There was a problem loading formatter: ${formatterPath}\nError: ${ex.message}`;
+                throw ex;
+            }
+
+        } else {
+            return null;
+        }
+    }
+}
 
 CLIEngine.version = pkg.version;
+CLIEngine.getFormatter = CLIEngine.prototype.getFormatter;
 
 module.exports = CLIEngine;


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This converts CLIEngine to an ES6 class. This will not break clients that were using CLIEngine as documented, but it could break clients that are relying on undocumented behavior in CLIEngine (e.g. enumerable methods).

Also see: https://github.com/eslint/eslint/issues/8231

**Is there anything you'd like reviewers to focus on?**

Nothing in particular