### PR TITLE
Breaking: convert RuleTester to ES6 class (refs #8231)

### DIFF
--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -129,69 +129,9 @@ function freezeDeeply(x) {
 // Public Interface
 //------------------------------------------------------------------------------
 
-/**
- * Creates a new instance of RuleTester.
- * @param {Object} [testerConfig] Optional, extra configuration for the tester
- * @constructor
- */
-function RuleTester(testerConfig) {
-
-    /**
-     * The configuration to use for this tester. Combination of the tester
-     * configuration and the default configuration.
-     * @type {Object}
-     */
-    this.testerConfig = lodash.merge(
-
-        // we have to clone because merge uses the first argument for recipient
-        lodash.cloneDeep(defaultConfig),
-        testerConfig
-    );
-
-    /**
-     * Rule definitions to define before tests.
-     * @type {Object}
-     */
-    this.rules = {};
-}
-
-/**
- * Set the configuration to use for all future tests
- * @param {Object} config the configuration to use.
- * @returns {void}
- */
-RuleTester.setDefaultConfig = function(config) {
-    if (typeof config !== "object") {
-        throw new Error("RuleTester.setDefaultConfig: config must be an object");
-    }
-    defaultConfig = config;
-
-    // Make sure the rules object exists since it is assumed to exist later
-    defaultConfig.rules = defaultConfig.rules || {};
-};
-
-/**
- * Get the current configuration used for all tests
- * @returns {Object} the current configuration
- */
-RuleTester.getDefaultConfig = function() {
-    return defaultConfig;
-};
-
-/**
- * Reset the configuration to the initial configuration of the tester removing
- * any changes made until now.
- * @returns {void}
- */
-RuleTester.resetDefaultConfig = function() {
-    defaultConfig = lodash.cloneDeep(testerDefaultConfig);
-};
-
 // default separators for testing
 const DESCRIBE = Symbol("describe");
 const IT = Symbol("it");
-
-RuleTester[DESCRIBE] = RuleTester[IT] = null;
 
 /**
  * This is `it` or `describe` if those don't exist.
@@ -204,39 +144,91 @@ function defaultHandler(text, method) {
     return method.apply(this);
 }
 
-// If people use `mocha test.js --watch` command, `describe` and `it` function
-// instances are different for each execution. So this should get fresh instance
-// always.
-Object.defineProperties(RuleTester, {
-    describe: {
-        get() {
-            return (
-                RuleTester[DESCRIBE] ||
-                (typeof describe === "function" ? describe : defaultHandler)
-            );
-        },
-        set(value) {
-            RuleTester[DESCRIBE] = value;
-        },
-        configurable: true,
-        enumerable: true
-    },
-    it: {
-        get() {
-            return (
-                RuleTester[IT] ||
-                (typeof it === "function" ? it : defaultHandler)
-            );
-        },
-        set(value) {
-            RuleTester[IT] = value;
-        },
-        configurable: true,
-        enumerable: true
-    }
-});
+class RuleTester {
 
-RuleTester.prototype = {
+    /**
+     * Creates a new instance of RuleTester.
+     * @param {Object} [testerConfig] Optional, extra configuration for the tester
+     * @constructor
+     */
+    constructor(testerConfig) {
+
+        /**
+         * The configuration to use for this tester. Combination of the tester
+         * configuration and the default configuration.
+         * @type {Object}
+         */
+        this.testerConfig = lodash.merge(
+
+            // we have to clone because merge uses the first argument for recipient
+            lodash.cloneDeep(defaultConfig),
+            testerConfig
+        );
+
+        /**
+         * Rule definitions to define before tests.
+         * @type {Object}
+         */
+        this.rules = {};
+    }
+
+    /**
+     * Set the configuration to use for all future tests
+     * @param {Object} config the configuration to use.
+     * @returns {void}
+     */
+    static setDefaultConfig(config) {
+        if (typeof config !== "object") {
+            throw new Error("RuleTester.setDefaultConfig: config must be an object");
+        }
+        defaultConfig = config;
+
+        // Make sure the rules object exists since it is assumed to exist later
+        defaultConfig.rules = defaultConfig.rules || {};
+    }
+
+    /**
+     * Get the current configuration used for all tests
+     * @returns {Object} the current configuration
+     */
+    static getDefaultConfig() {
+        return defaultConfig;
+    }
+
+    /**
+     * Reset the configuration to the initial configuration of the tester removing
+     * any changes made until now.
+     * @returns {void}
+     */
+    static resetDefaultConfig() {
+        defaultConfig = lodash.cloneDeep(testerDefaultConfig);
+    }
+
+
+    // If people use `mocha test.js --watch` command, `describe` and `it` function
+    // instances are different for each execution. So `describe` and `it` should get fresh instance
+    // always.
+    static get describe() {
+        return (
+            this[DESCRIBE] ||
+            (typeof describe === "function" ? describe : defaultHandler)
+        );
+    }
+
+    static set describe(value) {
+        this[DESCRIBE] = value;
+    }
+
+    static get it() {
+        return (
+            this[IT] ||
+            (typeof it === "function" ? it : defaultHandler)
+        );
+    }
+
+    static set it(value) {
+        this[IT] = value;
+    }
 
     /**
      * Define a rule for one particular run of tests.
@@ -246,7 +238,7 @@ RuleTester.prototype = {
      */
     defineRule(name, rule) {
         this.rules[name] = rule;
-    },
+    }
 
     /**
      * Adds a new rule test to execute.
@@ -561,7 +553,8 @@ RuleTester.prototype = {
 
         return result.suite;
     }
-};
+}
 
+RuleTester[DESCRIBE] = RuleTester[IT] = null;
 
 module.exports = RuleTester;


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This converts RuleTester to an ES6 class. This will not break clients that were using RuleTester as documented, but it could break clients that are relying on undocumented behavior in RuleTester (e.g. enumerable methods).

Also see: https://github.com/eslint/eslint/issues/8231

**Is there anything you'd like reviewers to focus on?**

Nothing in particular