### PR TITLE
Breaking: convert SourceCode to ES6 class (refs #8231)

### DIFF
--- a/lib/token-store/index.js
+++ b/lib/token-store/index.js
@@ -17,6 +17,10 @@ const PaddedTokenCursor = require("./padded-token-cursor");
 // Helpers
 //------------------------------------------------------------------------------
 
+const TOKENS = Symbol("tokens");
+const COMMENTS = Symbol("comments");
+const INDEX_MAP = Symbol("indexMap");
+
 /**
  * Creates the map from locations to indices in `tokens`.
  *
@@ -200,9 +204,9 @@ module.exports = class TokenStore {
      * @param {Comment[]} comments - The array of comments.
      */
     constructor(tokens, comments) {
-        this.tokens = tokens;
-        this.comments = comments.slice(0);
-        this.indexMap = createIndexMap(tokens, comments);
+        this[TOKENS] = tokens;
+        this[COMMENTS] = comments.slice(0);
+        this[INDEX_MAP] = createIndexMap(tokens, comments);
     }
 
     //--------------------------------------------------------------------------
@@ -219,9 +223,9 @@ module.exports = class TokenStore {
     getTokenByRangeStart(offset, options) {
         const includeComments = options && options.includeComments;
         const token = cursors.forward.createBaseCursor(
-            this.tokens,
-            this.comments,
-            this.indexMap,
+            this[TOKENS],
+            this[COMMENTS],
+            this[INDEX_MAP],
             offset,
             -1,
             includeComments
@@ -245,9 +249,9 @@ module.exports = class TokenStore {
     getFirstToken(node, options) {
         return createCursorWithSkip(
             cursors.forward,
-            this.tokens,
-            this.comments,
-            this.indexMap,
+            this[TOKENS],
+            this[COMMENTS],
+            this[INDEX_MAP],
             node.range[0],
             node.range[1],
             options
@@ -266,9 +270,9 @@ module.exports = class TokenStore {
     getLastToken(node, options) {
         return createCursorWithSkip(
             cursors.backward,
-            this.tokens,
-            this.comments,
-            this.indexMap,
+            this[TOKENS],
+            this[COMMENTS],
+            this[INDEX_MAP],
             node.range[0],
             node.range[1],
             options
@@ -287,9 +291,9 @@ module.exports = class TokenStore {
     getTokenBefore(node, options) {
         return createCursorWithSkip(
             cursors.backward,
-            this.tokens,
-            this.comments,
-            this.indexMap,
+            this[TOKENS],
+            this[COMMENTS],
+            this[INDEX_MAP],
             -1,
             node.range[0],
             options
@@ -308,9 +312,9 @@ module.exports = class TokenStore {
     getTokenAfter(node, options) {
         return createCursorWithSkip(
             cursors.forward,
-            this.tokens,
-            this.comments,
-            this.indexMap,
+            this[TOKENS],
+            this[COMMENTS],
+            this[INDEX_MAP],
             node.range[1],
             -1,
             options
@@ -330,9 +334,9 @@ module.exports = class TokenStore {
     getFirstTokenBetween(left, right, options) {
         return createCursorWithSkip(
             cursors.forward,
-            this.tokens,
-            this.comments,
-            this.indexMap,
+            this[TOKENS],
+            this[COMMENTS],
+            this[INDEX_MAP],
             left.range[1],
             right.range[0],
             options
@@ -352,9 +356,9 @@ module.exports = class TokenStore {
     getLastTokenBetween(left, right, options) {
         return createCursorWithSkip(
             cursors.backward,
-            this.tokens,
-            this.comments,
-            this.indexMap,
+            this[TOKENS],
+            this[COMMENTS],
+            this[INDEX_MAP],
             left.range[1],
             right.range[0],
             options
@@ -403,9 +407,9 @@ module.exports = class TokenStore {
     getFirstTokens(node, options) {
         return createCursorWithCount(
             cursors.forward,
-            this.tokens,
-            this.comments,
-            this.indexMap,
+            this[TOKENS],
+            this[COMMENTS],
+            this[INDEX_MAP],
             node.range[0],
             node.range[1],
             options
@@ -424,9 +428,9 @@ module.exports = class TokenStore {
     getLastTokens(node, options) {
         return createCursorWithCount(
             cursors.backward,
-            this.tokens,
-            this.comments,
-            this.indexMap,
+            this[TOKENS],
+            this[COMMENTS],
+            this[INDEX_MAP],
             node.range[0],
             node.range[1],
             options
@@ -445,9 +449,9 @@ module.exports = class TokenStore {
     getTokensBefore(node, options) {
         return createCursorWithCount(
             cursors.backward,
-            this.tokens,
-            this.comments,
-            this.indexMap,
+            this[TOKENS],
+            this[COMMENTS],
+            this[INDEX_MAP],
             -1,
             node.range[0],
             options
@@ -466,9 +470,9 @@ module.exports = class TokenStore {
     getTokensAfter(node, options) {
         return createCursorWithCount(
             cursors.forward,
-            this.tokens,
-            this.comments,
-            this.indexMap,
+            this[TOKENS],
+            this[COMMENTS],
+            this[INDEX_MAP],
             node.range[1],
             -1,
             options
@@ -488,9 +492,9 @@ module.exports = class TokenStore {
     getFirstTokensBetween(left, right, options) {
         return createCursorWithCount(
             cursors.forward,
-            this.tokens,
-            this.comments,
-            this.indexMap,
+            this[TOKENS],
+            this[COMMENTS],
+            this[INDEX_MAP],
             left.range[1],
             right.range[0],
             options
@@ -510,9 +514,9 @@ module.exports = class TokenStore {
     getLastTokensBetween(left, right, options) {
         return createCursorWithCount(
             cursors.backward,
-            this.tokens,
-            this.comments,
-            this.indexMap,
+            this[TOKENS],
+            this[COMMENTS],
+            this[INDEX_MAP],
             left.range[1],
             right.range[0],
             options
@@ -537,9 +541,9 @@ module.exports = class TokenStore {
      */
     getTokens(node, beforeCount, afterCount) {
         return createCursorWithPadding(
-            this.tokens,
-            this.comments,
-            this.indexMap,
+            this[TOKENS],
+            this[COMMENTS],
+            this[INDEX_MAP],
             node.range[0],
             node.range[1],
             beforeCount,
@@ -566,9 +570,9 @@ module.exports = class TokenStore {
      */
     getTokensBetween(left, right, padding) {
         return createCursorWithPadding(
-            this.tokens,
-            this.comments,
-            this.indexMap,
+            this[TOKENS],
+            this[COMMENTS],
+            this[INDEX_MAP],
             left.range[1],
             right.range[0],
             padding,

--- a/lib/token-store/index.js
+++ b/lib/token-store/index.js
@@ -261,10 +261,7 @@ module.exports = class TokenStore {
     /**
      * Gets the last token of the given node.
      * @param {ASTNode} node - The AST node.
-     * @param {number|Function|Object} [options=0] - The option object. If this is a number then it's `options.skip`. If this is a function then it's `options.filter`.
-     * @param {boolean} [options.includeComments=false] - The flag to iterate comments as well.
-     * @param {Function|null} [options.filter=null] - The predicate function to choose tokens.
-     * @param {number} [options.skip=0] - The count of tokens the cursor skips.
+     * @param {number|Function|Object} [options=0] - The option object. Same options as getFirstToken()
      * @returns {Token|null} An object representing the token.
      */
     getLastToken(node, options) {
@@ -282,10 +279,7 @@ module.exports = class TokenStore {
     /**
      * Gets the token that precedes a given node or token.
      * @param {ASTNode|Token|Comment} node - The AST node or token.
-     * @param {number|Function|Object} [options=0] - The option object. If this is a number then it's `options.skip`. If this is a function then it's `options.filter`.
-     * @param {boolean} [options.includeComments=false] - The flag to iterate comments as well.
-     * @param {Function|null} [options.filter=null] - The predicate function to choose tokens.
-     * @param {number} [options.skip=0] - The count of tokens the cursor skips.
+     * @param {number|Function|Object} [options=0] - The option object. Same options as getFirstToken()
      * @returns {Token|null} An object representing the token.
      */
     getTokenBefore(node, options) {
@@ -303,10 +297,7 @@ module.exports = class TokenStore {
     /**
      * Gets the token that follows a given node or token.
      * @param {ASTNode|Token|Comment} node - The AST node or token.
-     * @param {number|Function|Object} [options=0] - The option object. If this is a number then it's `options.skip`. If this is a function then it's `options.filter`.
-     * @param {boolean} [options.includeComments=false] - The flag to iterate comments as well.
-     * @param {Function|null} [options.filter=null] - The predicate function to choose tokens.
-     * @param {number} [options.skip=0] - The count of tokens the cursor skips.
+     * @param {number|Function|Object} [options=0] - The option object. Same options as getFirstToken()
      * @returns {Token|null} An object representing the token.
      */
     getTokenAfter(node, options) {
@@ -325,10 +316,7 @@ module.exports = class TokenStore {
      * Gets the first token between two non-overlapping nodes.
      * @param {ASTNode|Token|Comment} left - Node before the desired token range.
      * @param {ASTNode|Token|Comment} right - Node after the desired token range.
-     * @param {number|Function|Object} [options=0] - The option object. If this is a number then it's `options.skip`. If this is a function then it's `options.filter`.
-     * @param {boolean} [options.includeComments=false] - The flag to iterate comments as well.
-     * @param {Function|null} [options.filter=null] - The predicate function to choose tokens.
-     * @param {number} [options.skip=0] - The count of tokens the cursor skips.
+     * @param {number|Function|Object} [options=0] - The option object. Same options as getFirstToken()
      * @returns {Token|null} An object representing the token.
      */
     getFirstTokenBetween(left, right, options) {
@@ -347,11 +335,8 @@ module.exports = class TokenStore {
      * Gets the last token between two non-overlapping nodes.
      * @param {ASTNode|Token|Comment} left Node before the desired token range.
      * @param {ASTNode|Token|Comment} right Node after the desired token range.
-     * @param {number|Function|Object} [options=0] The option object. If this is a number then it's `options.skip`. If this is a function then it's `options.filter`.
-     * @param {boolean} [options.includeComments=false] - The flag to iterate comments as well.
-     * @param {Function|null} [options.filter=null] - The predicate function to choose tokens.
-     * @param {number} [options.skip=0] - The count of tokens the cursor skips.
-     * @returns {Token|null} Tokens between left and right.
+     * @param {number|Function|Object} [options=0] - The option object. Same options as getFirstToken()
+     * @returns {Token|null} An object representing the token.
      */
     getLastTokenBetween(left, right, options) {
         return createCursorWithSkip(
@@ -419,10 +404,7 @@ module.exports = class TokenStore {
     /**
      * Gets the last `count` tokens of the given node.
      * @param {ASTNode} node - The AST node.
-     * @param {number|Function|Object} [options=0] - The option object. If this is a number then it's `options.count`. If this is a function then it's `options.filter`.
-     * @param {boolean} [options.includeComments=false] - The flag to iterate comments as well.
-     * @param {Function|null} [options.filter=null] - The predicate function to choose tokens.
-     * @param {number} [options.count=0] - The maximum count of tokens the cursor iterates.
+     * @param {number|Function|Object} [options=0] - The option object. Same options as getFirstTokens()
      * @returns {Token[]} Tokens.
      */
     getLastTokens(node, options) {
@@ -440,10 +422,7 @@ module.exports = class TokenStore {
     /**
      * Gets the `count` tokens that precedes a given node or token.
      * @param {ASTNode|Token|Comment} node - The AST node or token.
-     * @param {number|Function|Object} [options=0] - The option object. If this is a number then it's `options.count`. If this is a function then it's `options.filter`.
-     * @param {boolean} [options.includeComments=false] - The flag to iterate comments as well.
-     * @param {Function|null} [options.filter=null] - The predicate function to choose tokens.
-     * @param {number} [options.count=0] - The maximum count of tokens the cursor iterates.
+     * @param {number|Function|Object} [options=0] - The option object. Same options as getFirstTokens()
      * @returns {Token[]} Tokens.
      */
     getTokensBefore(node, options) {
@@ -461,10 +440,7 @@ module.exports = class TokenStore {
     /**
      * Gets the `count` tokens that follows a given node or token.
      * @param {ASTNode|Token|Comment} node - The AST node or token.
-     * @param {number|Function|Object} [options=0] - The option object. If this is a number then it's `options.count`. If this is a function then it's `options.filter`.
-     * @param {boolean} [options.includeComments=false] - The flag to iterate comments as well.
-     * @param {Function|null} [options.filter=null] - The predicate function to choose tokens.
-     * @param {number} [options.count=0] - The maximum count of tokens the cursor iterates.
+     * @param {number|Function|Object} [options=0] - The option object. Same options as getFirstTokens()
      * @returns {Token[]} Tokens.
      */
     getTokensAfter(node, options) {
@@ -483,10 +459,7 @@ module.exports = class TokenStore {
      * Gets the first `count` tokens between two non-overlapping nodes.
      * @param {ASTNode|Token|Comment} left - Node before the desired token range.
      * @param {ASTNode|Token|Comment} right - Node after the desired token range.
-     * @param {number|Function|Object} [options=0] - The option object. If this is a number then it's `options.count`. If this is a function then it's `options.filter`.
-     * @param {boolean} [options.includeComments=false] - The flag to iterate comments as well.
-     * @param {Function|null} [options.filter=null] - The predicate function to choose tokens.
-     * @param {number} [options.count=0] - The maximum count of tokens the cursor iterates.
+     * @param {number|Function|Object} [options=0] - The option object. Same options as getFirstTokens()
      * @returns {Token[]} Tokens between left and right.
      */
     getFirstTokensBetween(left, right, options) {
@@ -505,10 +478,7 @@ module.exports = class TokenStore {
      * Gets the last `count` tokens between two non-overlapping nodes.
      * @param {ASTNode|Token|Comment} left Node before the desired token range.
      * @param {ASTNode|Token|Comment} right Node after the desired token range.
-     * @param {number|Function|Object} [options=0] The option object. If this is a number then it's `options.count`. If this is a function then it's `options.filter`.
-     * @param {boolean} [options.includeComments=false] - The flag to iterate comments as well.
-     * @param {Function|null} [options.filter=null] - The predicate function to choose tokens.
-     * @param {number} [options.count=0] - The maximum count of tokens the cursor iterates.
+     * @param {number|Function|Object} [options=0] - The option object. Same options as getFirstTokens()
      * @returns {Token[]} Tokens between left and right.
      */
     getLastTokensBetween(left, right, options) {

--- a/lib/token-store/index.js
+++ b/lib/token-store/index.js
@@ -17,30 +17,6 @@ const PaddedTokenCursor = require("./padded-token-cursor");
 // Helpers
 //------------------------------------------------------------------------------
 
-const PUBLIC_METHODS = Object.freeze([
-    "getTokenByRangeStart",
-
-    "getFirstToken",
-    "getLastToken",
-    "getTokenBefore",
-    "getTokenAfter",
-    "getFirstTokenBetween",
-    "getLastTokenBetween",
-
-    "getFirstTokens",
-    "getLastTokens",
-    "getTokensBefore",
-    "getTokensAfter",
-    "getFirstTokensBetween",
-    "getLastTokensBetween",
-
-    "getTokens",
-    "getTokensBetween",
-
-    "getTokenOrCommentBefore",
-    "getTokenOrCommentAfter"
-]);
-
 /**
  * Creates the map from locations to indices in `tokens`.
  *
@@ -600,5 +576,3 @@ module.exports = class TokenStore {
         ).getAllTokens();
     }
 };
-
-module.exports.PUBLIC_METHODS = PUBLIC_METHODS;

--- a/lib/util/source-code.js
+++ b/lib/util/source-code.js
@@ -106,7 +106,7 @@ function sortedMerge(tokens, comments) {
 // Public Interface
 //------------------------------------------------------------------------------
 
-class SourceCode {
+class SourceCode extends TokenStore {
 
     /**
      * Represents parsed source code.
@@ -116,6 +116,8 @@ class SourceCode {
      */
     constructor(text, ast) {
         validate(ast);
+
+        super(ast.tokens, ast.comments);
 
         /**
          * The flag to indicate that the source code has Unicode BOM.
@@ -163,13 +165,6 @@ class SourceCode {
         this.lines.push(this.text.slice(this.lineStartIndices[this.lineStartIndices.length - 1]));
 
         this.tokensAndComments = sortedMerge(ast.tokens, ast.comments);
-
-        // create token store methods
-        const tokenStore = new TokenStore(ast.tokens, ast.comments);
-
-        for (const methodName of TokenStore.PUBLIC_METHODS) {
-            this[methodName] = tokenStore[methodName].bind(tokenStore);
-        }
 
         // don't allow modification of this object
         Object.freeze(this);

--- a/lib/util/source-code.js
+++ b/lib/util/source-code.js
@@ -106,86 +106,85 @@ function sortedMerge(tokens, comments) {
 // Public Interface
 //------------------------------------------------------------------------------
 
-/**
- * Represents parsed source code.
- * @param {string} text - The source code text.
- * @param {ASTNode} ast - The Program node of the AST representing the code. This AST should be created from the text that BOM was stripped.
- * @constructor
- */
-function SourceCode(text, ast) {
-    validate(ast);
+class SourceCode {
 
     /**
-     * The flag to indicate that the source code has Unicode BOM.
-     * @type boolean
+     * Represents parsed source code.
+     * @param {string} text - The source code text.
+     * @param {ASTNode} ast - The Program node of the AST representing the code. This AST should be created from the text that BOM was stripped.
+     * @constructor
      */
-    this.hasBOM = (text.charCodeAt(0) === 0xFEFF);
+    constructor(text, ast) {
+        validate(ast);
 
-    /**
-     * The original text source code.
-     * BOM was stripped from this text.
-     * @type string
-     */
-    this.text = (this.hasBOM ? text.slice(1) : text);
+        /**
+         * The flag to indicate that the source code has Unicode BOM.
+         * @type boolean
+         */
+        this.hasBOM = (text.charCodeAt(0) === 0xFEFF);
 
-    /**
-     * The parsed AST for the source code.
-     * @type ASTNode
-     */
-    this.ast = ast;
+        /**
+         * The original text source code.
+         * BOM was stripped from this text.
+         * @type string
+         */
+        this.text = (this.hasBOM ? text.slice(1) : text);
 
-    /**
-     * The source code split into lines according to ECMA-262 specification.
-     * This is done to avoid each rule needing to do so separately.
-     * @type string[]
-     */
-    this.lines = [];
-    this.lineStartIndices = [0];
+        /**
+         * The parsed AST for the source code.
+         * @type ASTNode
+         */
+        this.ast = ast;
 
-    const lineEndingPattern = astUtils.createGlobalLinebreakMatcher();
-    let match;
+        /**
+         * The source code split into lines according to ECMA-262 specification.
+         * This is done to avoid each rule needing to do so separately.
+         * @type string[]
+         */
+        this.lines = [];
+        this.lineStartIndices = [0];
 
-    /*
-     * Previously, this was implemented using a regex that
-     * matched a sequence of non-linebreak characters followed by a
-     * linebreak, then adding the lengths of the matches. However,
-     * this caused a catastrophic backtracking issue when the end
-     * of a file contained a large number of non-newline characters.
-     * To avoid this, the current implementation just matches newlines
-     * and uses match.index to get the correct line start indices.
-     */
-    while ((match = lineEndingPattern.exec(this.text))) {
-        this.lines.push(this.text.slice(this.lineStartIndices[this.lineStartIndices.length - 1], match.index));
-        this.lineStartIndices.push(match.index + match[0].length);
+        const lineEndingPattern = astUtils.createGlobalLinebreakMatcher();
+        let match;
+
+        /*
+         * Previously, this was implemented using a regex that
+         * matched a sequence of non-linebreak characters followed by a
+         * linebreak, then adding the lengths of the matches. However,
+         * this caused a catastrophic backtracking issue when the end
+         * of a file contained a large number of non-newline characters.
+         * To avoid this, the current implementation just matches newlines
+         * and uses match.index to get the correct line start indices.
+         */
+        while ((match = lineEndingPattern.exec(this.text))) {
+            this.lines.push(this.text.slice(this.lineStartIndices[this.lineStartIndices.length - 1], match.index));
+            this.lineStartIndices.push(match.index + match[0].length);
+        }
+        this.lines.push(this.text.slice(this.lineStartIndices[this.lineStartIndices.length - 1]));
+
+        this.tokensAndComments = sortedMerge(ast.tokens, ast.comments);
+
+        // create token store methods
+        const tokenStore = new TokenStore(ast.tokens, ast.comments);
+
+        for (const methodName of TokenStore.PUBLIC_METHODS) {
+            this[methodName] = tokenStore[methodName].bind(tokenStore);
+        }
+
+        // don't allow modification of this object
+        Object.freeze(this);
+        Object.freeze(this.lines);
     }
-    this.lines.push(this.text.slice(this.lineStartIndices[this.lineStartIndices.length - 1]));
 
-    this.tokensAndComments = sortedMerge(ast.tokens, ast.comments);
-
-    // create token store methods
-    const tokenStore = new TokenStore(ast.tokens, ast.comments);
-
-    for (const methodName of TokenStore.PUBLIC_METHODS) {
-        this[methodName] = tokenStore[methodName].bind(tokenStore);
+    /**
+     * Split the source code into multiple lines based on the line delimiters
+     * @param {string} text Source code as a string
+     * @returns {string[]} Array of source code lines
+     * @public
+     */
+    static splitLines(text) {
+        return text.split(astUtils.createGlobalLinebreakMatcher());
     }
-
-    // don't allow modification of this object
-    Object.freeze(this);
-    Object.freeze(this.lines);
-}
-
-/**
- * Split the source code into multiple lines based on the line delimiters
- * @param {string} text Source code as a string
- * @returns {string[]} Array of source code lines
- * @public
- */
-SourceCode.splitLines = function(text) {
-    return text.split(astUtils.createGlobalLinebreakMatcher());
-};
-
-SourceCode.prototype = {
-    constructor: SourceCode,
 
     /**
      * Gets the source code for the given node.
@@ -200,9 +199,7 @@ SourceCode.prototype = {
                 node.range[1] + (afterCount || 0));
         }
         return this.text;
-
-
-    },
+    }
 
     /**
      * Gets the entire source text split into an array of lines.
@@ -210,7 +207,7 @@ SourceCode.prototype = {
      */
     getLines() {
         return this.lines;
-    },
+    }
 
     /**
      * Retrieves an array containing all comments in the source code.
@@ -218,7 +215,7 @@ SourceCode.prototype = {
      */
     getAllComments() {
         return this.ast.comments;
-    },
+    }
 
     /**
      * Gets all comments for the given node.
@@ -226,7 +223,7 @@ SourceCode.prototype = {
      * @returns {Object} The list of comments indexed by their position.
      * @public
      */
-    getComments(node) {
+    getComments(node) { // eslint-disable-line class-methods-use-this
 
         let leadingComments = node.leadingComments || [];
         const trailingComments = node.trailingComments || [];
@@ -246,7 +243,7 @@ SourceCode.prototype = {
             leading: leadingComments,
             trailing: trailingComments
         };
-    },
+    }
 
     /**
      * Retrieves the JSDoc comment for a given node.
@@ -255,7 +252,7 @@ SourceCode.prototype = {
      *      given node or null if not found.
      * @public
      */
-    getJSDocComment(node) {
+    getJSDocComment(node) { // eslint-disable-line class-methods-use-this
 
         let parent = node.parent;
 
@@ -288,7 +285,7 @@ SourceCode.prototype = {
             default:
                 return null;
         }
-    },
+    }
 
     /**
      * Gets the deepest node containing a range index.
@@ -317,7 +314,7 @@ SourceCode.prototype = {
         });
 
         return result ? Object.assign({ parent: resultParent }, result) : null;
-    },
+    }
 
     /**
      * Determines if two tokens have at least one whitespace character
@@ -332,7 +329,7 @@ SourceCode.prototype = {
         const text = this.text.slice(first.range[1], second.range[0]);
 
         return /\s/.test(text.replace(/\/\*.*?\*\//g, ""));
-    },
+    }
 
     /**
     * Converts a source text index into a (line, column) pair.
@@ -366,8 +363,7 @@ SourceCode.prototype = {
         const lineNumber = lodash.sortedLastIndex(this.lineStartIndices, index);
 
         return { line: lineNumber, column: index - this.lineStartIndices[lineNumber - 1] };
-
-    },
+    }
 
     /**
     * Converts a (line, column) pair into a range index.
@@ -410,7 +406,6 @@ SourceCode.prototype = {
 
         return positionIndex;
     }
-};
-
+}
 
 module.exports = SourceCode;


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This converts SourceCode to an ES6 class. This will not break clients that were using SourceCode as documented, but it could break clients that are relying on undocumented behavior in SourceCode (e.g. enumerable methods).

Also see: https://github.com/eslint/eslint/issues/8231

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
