### PR TITLE
Fix: Ignore hidden folders when resolving globs (fixes #8259)

### DIFF
--- a/lib/ignored-paths.js
+++ b/lib/ignored-paths.js
@@ -201,6 +201,12 @@ class IgnoredPaths {
 
         const ig = ignore().add(DEFAULT_IGNORE_DIRS);
 
+        if (this.options.dotfiles !== true) {
+
+            // Ignore hidden folders.  (This cannot be ".*", or else it's not possible to unignore hidden files)
+            ig.add([".*/*", "!../"]);
+        }
+
         if (this.options.ignore) {
             ig.add(this.ig.custom);
         }

--- a/tests/fixtures/ignored-paths/.eslintignoreWithUnignoredDefaults
+++ b/tests/fixtures/ignored-paths/.eslintignoreWithUnignoredDefaults
@@ -1,2 +1,3 @@
 !/node_modules/package
 !/bower_components/package
+!.hidden/package

--- a/tests/lib/ignored-paths.js
+++ b/tests/lib/ignored-paths.js
@@ -550,9 +550,10 @@ describe("IgnoredPaths", () => {
             assert.isTrue(shouldIgnore(resolve("bower_components/a")));
             assert.isTrue(shouldIgnore(resolve("bower_components/a/b")));
             assert.isFalse(shouldIgnore(resolve(".hidden")));
+            assert.isTrue(shouldIgnore(resolve(".hidden/a")));
         });
 
-        it("should ignore default folders there is an ignore file without unignored defaults", () => {
+        it("should ignore default folders when there is an ignore file without unignored defaults", () => {
             const cwd = getFixturePath();
             const ignoredPaths = new IgnoredPaths({ ignore: true, ignorePath: getFixturePath(".eslintignore"), cwd });
 
@@ -564,6 +565,7 @@ describe("IgnoredPaths", () => {
             assert.isTrue(shouldIgnore(resolve("bower_components/a")));
             assert.isTrue(shouldIgnore(resolve("bower_components/a/b")));
             assert.isFalse(shouldIgnore(resolve(".hidden")));
+            assert.isTrue(shouldIgnore(resolve(".hidden/a")));
         });
 
         it("should not ignore things which are re-included in ignore file", () => {
@@ -578,8 +580,10 @@ describe("IgnoredPaths", () => {
             assert.isTrue(shouldIgnore(resolve("bower_components/a")));
             assert.isTrue(shouldIgnore(resolve("bower_components/a/b")));
             assert.isFalse(shouldIgnore(resolve(".hidden")));
+            assert.isTrue(shouldIgnore(resolve(".hidden/a")));
             assert.isFalse(shouldIgnore(resolve("node_modules/package")));
             assert.isFalse(shouldIgnore(resolve("bower_components/package")));
+            assert.isFalse(shouldIgnore(resolve(".hidden/package")));
         });
 
         it("should ignore files which we try to re-include in ignore file when ignore option is disabled", () => {
@@ -594,8 +598,10 @@ describe("IgnoredPaths", () => {
             assert.isTrue(shouldIgnore(resolve("bower_components/a")));
             assert.isTrue(shouldIgnore(resolve("bower_components/a/b")));
             assert.isFalse(shouldIgnore(resolve(".hidden")));
+            assert.isTrue(shouldIgnore(resolve(".hidden/a")));
             assert.isTrue(shouldIgnore(resolve("node_modules/package")));
             assert.isTrue(shouldIgnore(resolve("bower_components/package")));
+            assert.isTrue(shouldIgnore(resolve(".hidden/package")));
         });
 
         it("should not ignore dirs which are re-included by ignorePattern", () => {
@@ -610,8 +616,20 @@ describe("IgnoredPaths", () => {
             assert.isTrue(shouldIgnore(resolve("bower_components/a")));
             assert.isTrue(shouldIgnore(resolve("bower_components/a/b")));
             assert.isFalse(shouldIgnore(resolve(".hidden")));
+            assert.isTrue(shouldIgnore(resolve(".hidden/a")));
             assert.isFalse(shouldIgnore(resolve("node_modules/package")));
             assert.isTrue(shouldIgnore(resolve("bower_components/package")));
+        });
+
+        it("should not ignore hidden dirs when dotfiles is enabled", () => {
+            const cwd = getFixturePath("no-ignore-file");
+            const ignoredPaths = new IgnoredPaths({ ignore: true, cwd, dotfiles: true });
+
+            const shouldIgnore = ignoredPaths.getIgnoredFoldersGlobChecker();
+            const resolve = createResolve(cwd);
+
+            assert.isFalse(shouldIgnore(resolve(".hidden")));
+            assert.isFalse(shouldIgnore(resolve(".hidden/a")));
         });
     });
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:


**What changes did you make? (Give an overview)**

This is a performance improvement, but should not be a change to linting functionality.  This is similar to avoiding glob resolution within `node_modules`.  With this change, `node-glob` will not attempt to  find all files within `.dotfolder` folders.  Similar to `node_modules`, this can be overridden in a user’s ignore file or in an ignore-pattern, and is also prevented if the `dotfiles` option is `true`.

**Is there anything you'd like reviewers to focus on?**

It would be good to double-check our tests around hidden files and folders, as well as perhaps manually trying a few situations.  From everything I tested, this works exactly like before, except faster. 🐎 