### PR TITLE
Fix: broken code path of direct nested loops (fixes #8248)

### DIFF
--- a/lib/code-path-analysis/code-path-analyzer.js
+++ b/lib/code-path-analysis/code-path-analyzer.js
@@ -512,13 +512,8 @@ function processCodePathToExit(analyzer, node) {
             break;
     }
 
-    /*
-     * Skip updating the current segment to avoid creating useless segments if
-     * the node type is the same as the parent node type.
-     */
-    if (!dontForward && (!node.parent || node.type !== node.parent.type)) {
-
-        // Emits onCodePathSegmentStart events if updated.
+    // Emits onCodePathSegmentStart events if updated.
+    if (!dontForward) {
         forwardCurrentToHead(analyzer, node);
     }
     debug.dumpState(node, state, true);

--- a/lib/code-path-analysis/debug-helpers.js
+++ b/lib/code-path-analysis/debug-helpers.js
@@ -107,22 +107,23 @@ module.exports = {
                 text += "style=\"rounded,dashed,filled\",fillcolor=\"#FF9800\",label=\"<<unreachable>>\\n";
             }
 
-            if (segment.internal.nodes.length > 0) {
-                text += segment.internal.nodes.map(node => {
-                    switch (node.type) {
-                        case "Identifier": return `${node.type} (${node.name})`;
-                        case "Literal": return `${node.type} (${node.value})`;
-                        default: return node.type;
-                    }
-                }).join("\\n");
-            } else if (segment.internal.exitNodes.length > 0) {
-                text += segment.internal.exitNodes.map(node => {
-                    switch (node.type) {
-                        case "Identifier": return `${node.type}:exit (${node.name})`;
-                        case "Literal": return `${node.type}:exit (${node.value})`;
-                        default: return `${node.type}:exit`;
-                    }
-                }).join("\\n");
+            if (segment.internal.nodes.length > 0 || segment.internal.exitNodes.length > 0) {
+                text += [].concat(
+                    segment.internal.nodes.map(node => {
+                        switch (node.type) {
+                            case "Identifier": return `${node.type} (${node.name})`;
+                            case "Literal": return `${node.type} (${node.value})`;
+                            default: return node.type;
+                        }
+                    }),
+                    segment.internal.exitNodes.map(node => {
+                        switch (node.type) {
+                            case "Identifier": return `${node.type}:exit (${node.name})`;
+                            case "Literal": return `${node.type}:exit (${node.value})`;
+                            default: return `${node.type}:exit`;
+                        }
+                    })
+                ).join("\\n");
             } else {
                 text += "????";
             }

--- a/tests/fixtures/code-path-analysis/for--direct-nest.js
+++ b/tests/fixtures/code-path-analysis/for--direct-nest.js
@@ -1,0 +1,30 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_5->s1_6->s1_7->s1_5;
+s1_2->s1_9;
+s1_5->s1_8->s1_4->s1_2;
+s1_9->final;
+*/
+for (var i = 0; i < 10; ++i)
+    for (var j = 0; j < 10; ++j)
+        foo
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nForStatement\nVariableDeclaration\nVariableDeclarator\nIdentifier (i)\nLiteral (0)\nIdentifier:exit (i)\nLiteral:exit (0)\nVariableDeclarator:exit\nVariableDeclaration:exit"];
+    s1_2[label="BinaryExpression\nIdentifier (i)\nLiteral (10)\nIdentifier:exit (i)\nLiteral:exit (10)\nBinaryExpression:exit"];
+    s1_3[label="ForStatement\nVariableDeclaration\nVariableDeclarator\nIdentifier (j)\nLiteral (0)\nIdentifier:exit (j)\nLiteral:exit (0)\nVariableDeclarator:exit\nVariableDeclaration:exit"];
+    s1_5[label="BinaryExpression\nIdentifier (j)\nLiteral (10)\nIdentifier:exit (j)\nLiteral:exit (10)\nBinaryExpression:exit"];
+    s1_6[label="ExpressionStatement\nIdentifier (foo)\nIdentifier:exit (foo)\nExpressionStatement:exit"];
+    s1_7[label="UpdateExpression\nIdentifier (j)\nIdentifier:exit (j)\nUpdateExpression:exit"];
+    s1_9[label="ForStatement:exit\nProgram:exit"];
+    s1_8[label="ForStatement:exit"];
+    s1_4[label="UpdateExpression\nIdentifier (i)\nIdentifier:exit (i)\nUpdateExpression:exit"];
+    initial->s1_1->s1_2->s1_3->s1_5->s1_6->s1_7->s1_5;
+    s1_2->s1_9;
+    s1_5->s1_8->s1_4->s1_2;
+    s1_9->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/for-in--direct-nest.js
+++ b/tests/fixtures/code-path-analysis/for-in--direct-nest.js
@@ -1,0 +1,30 @@
+/*expected
+initial->s1_1->s1_3->s1_2->s1_4->s1_6->s1_5->s1_7->s1_5;
+s1_3->s1_9;
+s1_6->s1_8->s1_2;
+s1_7->s1_8->s1_9->final;
+*/
+for (var a in {}) 
+    for (var b in {})
+        foo;
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nForInStatement"];
+    s1_3[label="ObjectExpression\nObjectExpression:exit"];
+    s1_2[label="VariableDeclaration\nVariableDeclarator\nIdentifier (a)\nIdentifier:exit (a)\nVariableDeclarator:exit\nVariableDeclaration:exit"];
+    s1_4[label="ForInStatement"];
+    s1_6[label="ObjectExpression\nObjectExpression:exit"];
+    s1_5[label="VariableDeclaration\nVariableDeclarator\nIdentifier (b)\nIdentifier:exit (b)\nVariableDeclarator:exit\nVariableDeclaration:exit"];
+    s1_7[label="ExpressionStatement\nIdentifier (foo)\nIdentifier:exit (foo)\nExpressionStatement:exit"];
+    s1_9[label="ForInStatement:exit\nProgram:exit"];
+    s1_8[label="ForInStatement:exit"];
+    initial->s1_1->s1_3->s1_2->s1_4->s1_6->s1_5->s1_7->s1_5;
+    s1_3->s1_9;
+    s1_6->s1_8->s1_2;
+    s1_7->s1_8->s1_9->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/for-of--direct-nest.js
+++ b/tests/fixtures/code-path-analysis/for-of--direct-nest.js
@@ -1,0 +1,30 @@
+/*expected
+initial->s1_1->s1_3->s1_2->s1_4->s1_6->s1_5->s1_7->s1_5;
+s1_3->s1_9;
+s1_6->s1_8->s1_2;
+s1_7->s1_8->s1_9->final;
+*/
+for (var a of []) 
+    for (var b of [])
+        foo;
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nForOfStatement"];
+    s1_3[label="ArrayExpression\nArrayExpression:exit"];
+    s1_2[label="VariableDeclaration\nVariableDeclarator\nIdentifier (a)\nIdentifier:exit (a)\nVariableDeclarator:exit\nVariableDeclaration:exit"];
+    s1_4[label="ForOfStatement"];
+    s1_6[label="ArrayExpression\nArrayExpression:exit"];
+    s1_5[label="VariableDeclaration\nVariableDeclarator\nIdentifier (b)\nIdentifier:exit (b)\nVariableDeclarator:exit\nVariableDeclaration:exit"];
+    s1_7[label="ExpressionStatement\nIdentifier (foo)\nIdentifier:exit (foo)\nExpressionStatement:exit"];
+    s1_9[label="ForOfStatement:exit\nProgram:exit"];
+    s1_8[label="ForOfStatement:exit"];
+    initial->s1_1->s1_3->s1_2->s1_4->s1_6->s1_5->s1_7->s1_5;
+    s1_3->s1_9;
+    s1_6->s1_8->s1_2;
+    s1_7->s1_8->s1_9->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/if-3.js
+++ b/tests/fixtures/code-path-analysis/if-3.js
@@ -1,7 +1,7 @@
 /*expected
 initial->s1_1->s1_2->s1_9;
-s1_1->s1_3->s1_4->s1_5->s1_6->s1_9;
-s1_3->s1_7->s1_9;
+s1_1->s1_3->s1_4->s1_5->s1_6->s1_8->s1_9;
+s1_3->s1_7->s1_8;
 s1_4->s1_6;
 s1_9->final;
 */
@@ -20,17 +20,18 @@ digraph {
     node[shape=box,style="rounded,filled",fillcolor=white];
     initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
     final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
-    s1_1[label="Program\nIfStatement\nIdentifier (a)"];
-    s1_2[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_1[label="Program\nIfStatement\nIdentifier (a)\nIdentifier:exit (a)"];
+    s1_2[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)\nIdentifier:exit (foo)\nCallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit"];
     s1_9[label="IfStatement:exit\nProgram:exit"];
-    s1_3[label="IfStatement\nIdentifier (b)"];
-    s1_4[label="BlockStatement\nIfStatement\nIdentifier (c)"];
-    s1_5[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (bar)"];
+    s1_3[label="IfStatement\nIdentifier (b)\nIdentifier:exit (b)"];
+    s1_4[label="BlockStatement\nIfStatement\nIdentifier (c)\nIdentifier:exit (c)"];
+    s1_5[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (bar)\nIdentifier:exit (bar)\nCallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit"];
     s1_6[label="IfStatement:exit\nBlockStatement:exit"];
-    s1_7[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (hoge)"];
+    s1_8[label="IfStatement:exit"];
+    s1_7[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (hoge)\nIdentifier:exit (hoge)\nCallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit"];
     initial->s1_1->s1_2->s1_9;
-    s1_1->s1_3->s1_4->s1_5->s1_6->s1_9;
-    s1_3->s1_7->s1_9;
+    s1_1->s1_3->s1_4->s1_5->s1_6->s1_8->s1_9;
+    s1_3->s1_7->s1_8;
     s1_4->s1_6;
     s1_9->final;
 }

--- a/tests/fixtures/code-path-analysis/if-6.js
+++ b/tests/fixtures/code-path-analysis/if-6.js
@@ -1,0 +1,37 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_6->s1_8->s1_9;
+s1_1->s1_9;
+s1_2->s1_7->s1_8;
+s1_3->s1_5->s1_6;
+s1_9->final;
+*/
+if (a)
+    if (b)
+        if (c)
+            foo;
+        else
+            bar;
+    else
+        baz;
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nIfStatement\nIdentifier (a)\nIdentifier:exit (a)"];
+    s1_2[label="IfStatement\nIdentifier (b)\nIdentifier:exit (b)"];
+    s1_3[label="IfStatement\nIdentifier (c)\nIdentifier:exit (c)"];
+    s1_4[label="ExpressionStatement\nIdentifier (foo)\nIdentifier:exit (foo)\nExpressionStatement:exit"];
+    s1_6[label="IfStatement:exit"];
+    s1_8[label="IfStatement:exit"];
+    s1_9[label="IfStatement:exit\nProgram:exit"];
+    s1_7[label="ExpressionStatement\nIdentifier (baz)\nIdentifier:exit (baz)\nExpressionStatement:exit"];
+    s1_5[label="ExpressionStatement\nIdentifier (bar)\nIdentifier:exit (bar)\nExpressionStatement:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_6->s1_8->s1_9;
+    s1_1->s1_9;
+    s1_2->s1_7->s1_8;
+    s1_3->s1_5->s1_6;
+    s1_9->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/logical--if-and-3.js
+++ b/tests/fixtures/code-path-analysis/logical--if-and-3.js
@@ -1,9 +1,10 @@
 /*expected
 initial->s1_1->s1_2->s1_3->s1_9;
-s1_1->s1_4->s1_5->s1_6->s1_9;
-s1_2->s1_4->s1_7->s1_9;
+s1_1->s1_4->s1_5->s1_6->s1_8->s1_9;
+s1_2->s1_4->s1_7->s1_8;
 s1_5->s1_7;
 s1_9->final;
+
 */
 if (a && b) {
     foo();
@@ -18,17 +19,18 @@ digraph {
     node[shape=box,style="rounded,filled",fillcolor=white];
     initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
     final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
-    s1_1[label="Program\nIfStatement\nLogicalExpression\nIdentifier (a)"];
-    s1_2[label="Identifier (b)"];
-    s1_3[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_1[label="Program\nIfStatement\nLogicalExpression\nIdentifier (a)\nIdentifier:exit (a)"];
+    s1_2[label="Identifier (b)\nIdentifier:exit (b)\nLogicalExpression:exit"];
+    s1_3[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)\nIdentifier:exit (foo)\nCallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit"];
     s1_9[label="IfStatement:exit\nProgram:exit"];
-    s1_4[label="IfStatement\nLogicalExpression\nIdentifier (c)"];
-    s1_5[label="Identifier (d)"];
-    s1_6[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (bar)"];
-    s1_7[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (qiz)"];
+    s1_4[label="IfStatement\nLogicalExpression\nIdentifier (c)\nIdentifier:exit (c)"];
+    s1_5[label="Identifier (d)\nIdentifier:exit (d)\nLogicalExpression:exit"];
+    s1_6[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (bar)\nIdentifier:exit (bar)\nCallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit"];
+    s1_8[label="IfStatement:exit"];
+    s1_7[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (qiz)\nIdentifier:exit (qiz)\nCallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit"];
     initial->s1_1->s1_2->s1_3->s1_9;
-    s1_1->s1_4->s1_5->s1_6->s1_9;
-    s1_2->s1_4->s1_7->s1_9;
+    s1_1->s1_4->s1_5->s1_6->s1_8->s1_9;
+    s1_2->s1_4->s1_7->s1_8;
     s1_5->s1_7;
     s1_9->final;
 }

--- a/tests/fixtures/code-path-analysis/logical--if-or-3.js
+++ b/tests/fixtures/code-path-analysis/logical--if-or-3.js
@@ -1,9 +1,10 @@
 /*expected
 initial->s1_1->s1_2->s1_3->s1_9;
 s1_1->s1_3;
-s1_2->s1_4->s1_5->s1_6->s1_9;
+s1_2->s1_4->s1_5->s1_6->s1_8->s1_9;
 s1_4->s1_6;
-s1_5->s1_7->s1_9->final;
+s1_5->s1_7->s1_8;
+s1_9->final;
 */
 if (a || b) {
     foo();
@@ -18,18 +19,20 @@ digraph {
     node[shape=box,style="rounded,filled",fillcolor=white];
     initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
     final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
-    s1_1[label="Program\nIfStatement\nLogicalExpression\nIdentifier (a)"];
-    s1_2[label="Identifier (b)"];
-    s1_3[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_1[label="Program\nIfStatement\nLogicalExpression\nIdentifier (a)\nIdentifier:exit (a)"];
+    s1_2[label="Identifier (b)\nIdentifier:exit (b)\nLogicalExpression:exit"];
+    s1_3[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)\nIdentifier:exit (foo)\nCallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit"];
     s1_9[label="IfStatement:exit\nProgram:exit"];
-    s1_4[label="IfStatement\nLogicalExpression\nIdentifier (c)"];
-    s1_5[label="Identifier (d)"];
-    s1_6[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (bar)"];
-    s1_7[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (qiz)"];
+    s1_4[label="IfStatement\nLogicalExpression\nIdentifier (c)\nIdentifier:exit (c)"];
+    s1_5[label="Identifier (d)\nIdentifier:exit (d)\nLogicalExpression:exit"];
+    s1_6[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (bar)\nIdentifier:exit (bar)\nCallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit"];
+    s1_8[label="IfStatement:exit"];
+    s1_7[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (qiz)\nIdentifier:exit (qiz)\nCallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit"];
     initial->s1_1->s1_2->s1_3->s1_9;
     s1_1->s1_3;
-    s1_2->s1_4->s1_5->s1_6->s1_9;
+    s1_2->s1_4->s1_5->s1_6->s1_8->s1_9;
     s1_4->s1_6;
-    s1_5->s1_7->s1_9->final;
+    s1_5->s1_7->s1_8;
+    s1_9->final;
 }
 */

--- a/tests/fixtures/code-path-analysis/while--direct-nest.js
+++ b/tests/fixtures/code-path-analysis/while--direct-nest.js
@@ -1,0 +1,28 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_4;
+s1_2->s1_7;
+s1_4->s1_6->s1_2;
+s1_7->final;
+*/
+while (a)
+    while (b)
+        foo
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nWhileStatement"];
+    s1_2[label="Identifier (a)\nIdentifier:exit (a)"];
+    s1_3[label="WhileStatement"];
+    s1_4[label="Identifier (b)\nIdentifier:exit (b)"];
+    s1_5[label="ExpressionStatement\nIdentifier (foo)\nIdentifier:exit (foo)\nExpressionStatement:exit"];
+    s1_7[label="WhileStatement:exit\nProgram:exit"];
+    s1_6[label="WhileStatement:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_4;
+    s1_2->s1_7;
+    s1_4->s1_6->s1_2;
+    s1_7->final;
+} 
+*/

--- a/tests/lib/rules/constructor-super.js
+++ b/tests/lib/rules/constructor-super.js
@@ -208,6 +208,16 @@ ruleTester.run("constructor-super", rule, {
         {
             code: "class A extends B { constructor() { return; super(); } }",
             errors: [{ message: "Expected to call 'super()'.", type: "MethodDefinition" }]
+        },
+
+        // https://github.com/eslint/eslint/issues/8248
+        {
+            code: `class Foo extends Bar {
+                constructor() {
+                    for (a in b) for (c in d);
+                }
+            } /*WIP*/`,
+            errors: [{ message: "Expected to call 'super()'.", type: "MethodDefinition" }]
         }
     ]
 });

--- a/tests/lib/rules/constructor-super.js
+++ b/tests/lib/rules/constructor-super.js
@@ -216,7 +216,7 @@ ruleTester.run("constructor-super", rule, {
                 constructor() {
                     for (a in b) for (c in d);
                 }
-            } /*WIP*/`,
+            }`,
             errors: [{ message: "Expected to call 'super()'.", type: "MethodDefinition" }]
         }
     ]


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

Fixes #8248.

**What changes did you make? (Give an overview)**

This PR fixes the broken code path about the direct nest of same kind loops.
The fix is below. Other diffs are for tests.

```diff
@@ -512,13 +512,8 @@ function processCodePathToExit(analyzer, node) {
             break;
     }
 
-    /*
-     * Skip updating the current segment to avoid creating useless segments if
-     * the node type is the same as the parent node type.
-     */
-    if (!dontForward && (!node.parent || node.type !== node.parent.type)) {
-
-        // Emits onCodePathSegmentStart events if updated.
+    // Emits onCodePathSegmentStart events if updated.
+    if (!dontForward) {
         forwardCurrentToHead(analyzer, node);
     }
     debug.dumpState(node, state, true);
```

I had been trying to optimize the code path, but it has been breaking.
I just removed the broken optimizing code.

As a result, the code path about the direct nest of same kind loops is recovered.
For example:

```js
while (a)
    while (b)
        foo()
```

<details><summary>Before: outer loop's looping path is lacking.</summary>

![image](https://cloud.githubusercontent.com/assets/1937871/24038814/68fd7878-0b46-11e7-8871-a928a635e838.png)

</details>

<details><summary>After: OK.</summary>

![image](https://cloud.githubusercontent.com/assets/1937871/24038773/387f610c-0b46-11e7-91ce-bdb93f17ab62.png)

</details>

----

**Is there anything you'd like reviewers to focus on?**

http://www.webgraphviz.com/ is useful to confirm test's code path with DOT diagrams.
