### PR TITLE
Docs: fix incorrect selector examples

### DIFF
--- a/docs/developer-guide/selectors.md
+++ b/docs/developer-guide/selectors.md
@@ -95,7 +95,7 @@ With the [no-restricted-syntax](/docs/rules/no-restricted-syntax) rule, you can 
 ```json
 {
   "rules": {
-    "no-restricted-syntax": ["error", "IfStatement > :not(BlockStatement).body"]
+    "no-restricted-syntax": ["error", "IfStatement > :not(BlockStatement).consequent"]
   }
 }
 ```
@@ -105,7 +105,7 @@ With the [no-restricted-syntax](/docs/rules/no-restricted-syntax) rule, you can 
 ```json
 {
   "rules": {
-    "no-restricted-syntax": ["error", "IfStatement[body.type!='BlockStatement']"]
+    "no-restricted-syntax": ["error", "IfStatement[consequent.type!='BlockStatement']"]
   }
 }
 ```


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update

**What changes did you make? (Give an overview)**

This fixes an incorrect example in the selector documentation.

**Is there anything you'd like reviewers to focus on?**

~~After this is merged, I'd like to make the commit on the live site too, so that we can fix the examples on the live site before the next release.~~ (edit: this has been updated on the live site)