### PR TITLE
Fix: no-param-reassign false positive on destructuring (fixes #8279)

### DIFF
--- a/lib/rules/no-param-reassign.js
+++ b/lib/rules/no-param-reassign.js
@@ -96,8 +96,15 @@ module.exports = {
                         }
                         break;
 
-                    default:
+                    // EXCLUDES: e.g. ({ [foo]: a }) = bar;
+                    case "Property":
+                        if (parent.key === node) {
+                            return false;
+                        }
+
                         break;
+
+                    // no default
                 }
 
                 node = parent;

--- a/tests/lib/rules/no-param-reassign.js
+++ b/tests/lib/rules/no-param-reassign.js
@@ -93,6 +93,12 @@ ruleTester.run("no-param-reassign", rule, {
             parserOptions: { ecmaVersion: 6 },
             options: [{ props: true }],
             errors: [{ message: "Assignment to property of function parameter 'bar'." }]
+        },
+        {
+            code: "function foo(a) { ({a} = obj); }",
+            parserOptions: { ecmaVersion: 6 },
+            options: [{ props: true }],
+            errors: [{ message: "Assignment to function parameter 'a'." }]
         }
     ]
 });

--- a/tests/lib/rules/no-param-reassign.js
+++ b/tests/lib/rules/no-param-reassign.js
@@ -35,7 +35,12 @@ ruleTester.run("no-param-reassign", rule, {
         { code: "function foo(a) { ++a.b; }", options: [{ props: true, ignorePropertyModificationsFor: ["a"] }] },
         { code: "function foo(a) { delete a.b; }", options: [{ props: true, ignorePropertyModificationsFor: ["a"] }] },
         { code: "function foo(a, z) { a.b = 0; x.y = 0; }", options: [{ props: true, ignorePropertyModificationsFor: ["a", "x"] }] },
-        { code: "function foo(a) { a.b.c = 0;}", options: [{ props: true, ignorePropertyModificationsFor: ["a"] }] }
+        { code: "function foo(a) { a.b.c = 0;}", options: [{ props: true, ignorePropertyModificationsFor: ["a"] }] },
+        {
+            code: "function foo(a) { ({ [a]: variable }) = value }",
+            options: [{ props: true }],
+            parserOptions: { ecmaVersion: 6 }
+        }
     ],
 
     invalid: [
@@ -81,6 +86,12 @@ ruleTester.run("no-param-reassign", rule, {
             code: "function foo(bar) { [bar.a] = []; }",
             parserOptions: { ecmaVersion: 6 },
             options: [{ props: true, ignorePropertyModificationsFor: ["a"] }],
+            errors: [{ message: "Assignment to property of function parameter 'bar'." }]
+        },
+        {
+            code: "function foo(bar) { ({foo: bar.a} = {}); }",
+            parserOptions: { ecmaVersion: 6 },
+            options: [{ props: true }],
             errors: [{ message: "Assignment to property of function parameter 'bar'." }]
         }
     ]


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (https://github.com/eslint/eslint/issues/8279)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates no-param-reassign to stop traversing up the AST if it encounters a Property node where the variable reference is part of the key.

This fix keeps the general strategy of the rule in place. However, while I haven't investigated it in depth, the rule strategy seems a bit fragile -- it reports any reference to a variable on the left side of an assignment, excluding some specific cases such as computed properties. It's possible there are more cases like this that cause false positives -- if so, we might want to rethink how this rule is implemented.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
