### PR TITLE
Chore: refactor space-before-function-paren rule

### DIFF
--- a/lib/rules/space-before-function-paren.js
+++ b/lib/rules/space-before-function-paren.js
@@ -51,31 +51,9 @@ module.exports = {
     },
 
     create(context) {
-
-        const configuration = context.options[0],
-            sourceCode = context.getSourceCode();
-        let requireAnonymousFunctionSpacing = true,
-            forbidAnonymousFunctionSpacing = false,
-            requireNamedFunctionSpacing = true,
-            forbidNamedFunctionSpacing = false,
-            requireArrowFunctionSpacing = false,
-            forbidArrowFunctionSpacing = false;
-
-        if (typeof configuration === "object") {
-            requireAnonymousFunctionSpacing = (
-                !configuration.anonymous || configuration.anonymous === "always");
-            forbidAnonymousFunctionSpacing = configuration.anonymous === "never";
-            requireNamedFunctionSpacing = (
-                !configuration.named || configuration.named === "always");
-            forbidNamedFunctionSpacing = configuration.named === "never";
-            requireArrowFunctionSpacing = configuration.asyncArrow === "always";
-            forbidArrowFunctionSpacing = configuration.asyncArrow === "never";
-        } else if (configuration === "never") {
-            requireAnonymousFunctionSpacing = false;
-            forbidAnonymousFunctionSpacing = true;
-            requireNamedFunctionSpacing = false;
-            forbidNamedFunctionSpacing = true;
-        }
+        const sourceCode = context.getSourceCode();
+        const baseConfig = typeof context.options[0] === "string" ? context.options[0] : "always";
+        const overrideConfig = typeof context.options[0] === "object" ? context.options[0] : {};
 
         /**
          * Determines whether a function has a name.
@@ -100,69 +78,58 @@ module.exports = {
         }
 
         /**
-         * Validates the spacing before function parentheses.
-         * @param {ASTNode} node The node to be validated.
-         * @returns {void}
+         * Gets the config for a given function
+         * @param {ASTNode} node The function node
+         * @returns {string} "always", "never", or "ignore"
          */
-        function validateSpacingBeforeParentheses(node) {
-            const isArrow = node.type === "ArrowFunctionExpression";
-            const isNamed = !isArrow && isNamedFunction(node);
-            const isAnonymousGenerator = node.generator && !isNamed;
-            const isNormalArrow = isArrow && !node.async;
-            const isArrowWithoutParens = isArrow && sourceCode.getFirstToken(node, 1).value !== "(";
-            let forbidSpacing, requireSpacing;
+        function getConfigForFunction(node) {
+            if (node.type === "ArrowFunctionExpression") {
 
-            // isAnonymousGenerator → `generator-star-spacing` should warn it. E.g. `function* () {}`
-            // isNormalArrow → ignore always.
-            // isArrowWithoutParens → ignore always. E.g. `async a => a`
-            if (isAnonymousGenerator || isNormalArrow || isArrowWithoutParens) {
-                return;
-            }
+                // Always ignore non-async functions and arrow functions without parens, e.g. async foo => bar
+                if (node.async && astUtils.isOpeningParenToken(sourceCode.getFirstToken(node, { skip: 1 }))) {
 
-            if (isArrow) {
-                forbidSpacing = forbidArrowFunctionSpacing;
-                requireSpacing = requireArrowFunctionSpacing;
-            } else if (isNamed) {
-                forbidSpacing = forbidNamedFunctionSpacing;
-                requireSpacing = requireNamedFunctionSpacing;
-            } else {
-                forbidSpacing = forbidAnonymousFunctionSpacing;
-                requireSpacing = requireAnonymousFunctionSpacing;
-            }
-
-            const rightToken = sourceCode.getFirstToken(node, astUtils.isOpeningParenToken);
-            const leftToken = sourceCode.getTokenBefore(rightToken);
-            const location = leftToken.loc.end;
-
-            if (sourceCode.isSpaceBetweenTokens(leftToken, rightToken)) {
-                if (forbidSpacing) {
-                    context.report({
-                        node,
-                        loc: location,
-                        message: "Unexpected space before function parentheses.",
-                        fix(fixer) {
-                            return fixer.removeRange([leftToken.range[1], rightToken.range[0]]);
-                        }
-                    });
+                    // For backwards compatibility, the base config does not apply to async arrow functions.
+                    return overrideConfig.asyncArrow || "ignore";
                 }
-            } else {
-                if (requireSpacing) {
-                    context.report({
-                        node,
-                        loc: location,
-                        message: "Missing space before function parentheses.",
-                        fix(fixer) {
-                            return fixer.insertTextAfter(leftToken, " ");
-                        }
-                    });
-                }
+            } else if (isNamedFunction(node)) {
+                return overrideConfig.named || baseConfig;
+
+            // `generator-star-spacing` should warn anonymous generators. E.g. `function* () {}`
+            } else if (!node.generator) {
+                return overrideConfig.anonymous || baseConfig;
             }
+
+            return "ignore";
         }
 
         return {
-            FunctionDeclaration: validateSpacingBeforeParentheses,
-            FunctionExpression: validateSpacingBeforeParentheses,
-            ArrowFunctionExpression: validateSpacingBeforeParentheses
+            ":function"(node) {
+                const functionConfig = getConfigForFunction(node);
+
+                if (functionConfig === "ignore") {
+                    return;
+                }
+
+                const rightToken = sourceCode.getFirstToken(node, astUtils.isOpeningParenToken);
+                const leftToken = sourceCode.getTokenBefore(rightToken);
+                const hasSpacing = sourceCode.isSpaceBetweenTokens(leftToken, rightToken);
+
+                if (hasSpacing && functionConfig === "never") {
+                    context.report({
+                        node,
+                        loc: leftToken.loc.end,
+                        message: "Unexpected space before function parentheses.",
+                        fix: fixer => fixer.removeRange([leftToken.range[1], rightToken.range[0]])
+                    });
+                } else if (!hasSpacing && functionConfig === "always") {
+                    context.report({
+                        node,
+                        loc: leftToken.loc.end,
+                        message: "Missing space before function parentheses.",
+                        fix: fixer => fixer.insertTextAfter(leftToken, " ")
+                    });
+                }
+            }
         };
     }
 };


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This commit refactors the space-before-function-paren rule to avoid using different variables for each option. This should make the options easier to change in the future. It also updates the rule listeners to use selectors.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular