### PR TITLE
Breaking: tweak space-before-function-paren default option (fixes #8267)

### DIFF
--- a/lib/rules/space-before-function-paren.js
+++ b/lib/rules/space-before-function-paren.js
@@ -87,9 +87,7 @@ module.exports = {
 
                 // Always ignore non-async functions and arrow functions without parens, e.g. async foo => bar
                 if (node.async && astUtils.isOpeningParenToken(sourceCode.getFirstToken(node, { skip: 1 }))) {
-
-                    // For backwards compatibility, the base config does not apply to async arrow functions.
-                    return overrideConfig.asyncArrow || "ignore";
+                    return overrideConfig.asyncArrow || baseConfig;
                 }
             } else if (isNamedFunction(node)) {
                 return overrideConfig.named || baseConfig;

--- a/tests/lib/rules/space-before-function-paren.js
+++ b/tests/lib/rules/space-before-function-paren.js
@@ -105,13 +105,8 @@ ruleTester.run("space-before-function-paren", rule, {
         { code: "async() => 1", options: [{ asyncArrow: "never" }], parserOptions: { ecmaVersion: 8 } },
         { code: "async () => 1", options: [{ asyncArrow: "ignore" }], parserOptions: { ecmaVersion: 8 } },
         { code: "async() => 1", options: [{ asyncArrow: "ignore" }], parserOptions: { ecmaVersion: 8 } },
-
-        // ignore by default for now.
         { code: "async () => 1", parserOptions: { ecmaVersion: 8 } },
-        { code: "async() => 1", parserOptions: { ecmaVersion: 8 } },
         { code: "async () => 1", options: ["always"], parserOptions: { ecmaVersion: 8 } },
-        { code: "async() => 1", options: ["always"], parserOptions: { ecmaVersion: 8 } },
-        { code: "async () => 1", options: ["never"], parserOptions: { ecmaVersion: 8 } },
         { code: "async() => 1", options: ["never"], parserOptions: { ecmaVersion: 8 } }
     ],
 
@@ -489,6 +484,26 @@ ruleTester.run("space-before-function-paren", rule, {
             options: [{ asyncArrow: "never" }],
             parserOptions: { ecmaVersion: 8 },
             errors: ["Unexpected space before function parentheses."]
+        },
+        {
+            code: "async() => 1",
+            output: "async () => 1",
+            parserOptions: { ecmaVersion: 8 },
+            errors: [{ message: "Missing space before function parentheses.", type: "ArrowFunctionExpression" }]
+        },
+        {
+            code: "async() => 1",
+            output: "async () => 1",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 8 },
+            errors: [{ message: "Missing space before function parentheses.", type: "ArrowFunctionExpression" }]
+        },
+        {
+            code: "async () => 1",
+            output: "async() => 1",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 8 },
+            errors: [{ message: "Unexpected space before function parentheses.", type: "ArrowFunctionExpression" }]
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Changes an existing rule (see https://github.com/eslint/eslint/issues/8267)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates the `asyncArrow` option for space-before-function-paren to be consistent with the other options in the rule. Previously, the user had to explicitly opt-in to async arrow function checking, for backwards compatibility.

**Is there anything you'd like reviewers to focus on?**

~~This builds on the changes in https://github.com/eslint/eslint/pull/8284, so it should not be merged until https://github.com/eslint/eslint/pull/8284 is merged. (For the changes that were introduced in this PR, ignore the first commit.)~~

~~Also, this should not be merged until https://github.com/eslint/eslint/issues/8267 is accepted.~~