### PR TITLE
Update: add deprecated indent-legacy rule as v3.x indent rule snapshot

### DIFF
--- a/conf/eslint-recommended.js
+++ b/conf/eslint-recommended.js
@@ -55,6 +55,7 @@ module.exports = {
         "id-length": "off",
         "id-match": "off",
         "indent": "off",
+        "indent-legacy": "off",
         "init-declarations": "off",
         "jsx-quotes": "off",
         "key-spacing": "off",

--- a/docs/rules/indent-legacy.md
+++ b/docs/rules/indent-legacy.md
@@ -1,0 +1,533 @@
+# enforce consistent indentation (indent-legacy)
+
+ESLint 4.0.0 introduced a rewrite of the [`indent`](/docs/rules/indent) rule, which now reports more errors than it did in previous versions. To ease the process of migrating to 4.0.0, the `indent-legacy` rule was introduced as a snapshot of the `indent` rule from ESLint 3.x. If your build is failing after the upgrade to 4.0.0, you can disable `indent` and enable `indent-legacy` as a quick fix. Eventually, you should switch back to the `indent` rule to get bugfixes and improvements in future versions.
+
+---
+
+There are several common guidelines which require specific indentation of nested blocks and statements, like:
+
+```js
+function hello(indentSize, type) {
+    if (indentSize === 4 && type !== 'tab') {
+        console.log('Each next indentation will increase on 4 spaces');
+    }
+}
+```
+
+These are the most common scenarios recommended in different style guides:
+
+* Two spaces, not longer and no tabs: Google, npm, Node.js, Idiomatic, Felix
+* Tabs: jQuery
+* Four spaces: Crockford
+
+## Rule Details
+
+This rule enforces a consistent indentation style. The default style is `4 spaces`.
+
+## Options
+
+This rule has a mixed option:
+
+For example, for 2-space indentation:
+
+```json
+{
+    "indent": ["error", 2]
+}
+```
+
+Or for tabbed indentation:
+
+```json
+{
+    "indent": ["error", "tab"]
+}
+```
+
+Examples of **incorrect** code for this rule with the default options:
+
+```js
+/*eslint indent: "error"*/
+
+if (a) {
+  b=c;
+  function foo(d) {
+    e=f;
+  }
+}
+```
+
+Examples of **correct** code for this rule with the default options:
+
+```js
+/*eslint indent: "error"*/
+
+if (a) {
+    b=c;
+    function foo(d) {
+        e=f;
+    }
+}
+```
+
+This rule has an object option:
+
+* `"SwitchCase"` (default: 0) enforces indentation level for `case` clauses in `switch` statements
+* `"VariableDeclarator"` (default: 1) enforces indentation level for `var` declarators; can also take an object to define separate rules for `var`, `let` and `const` declarations.
+* `"outerIIFEBody"` (default: 1) enforces indentation level for file-level IIFEs.
+* `"MemberExpression"` (off by default) enforces indentation level for multi-line property chains (except in variable declarations and assignments)
+* `"FunctionDeclaration"` takes an object to define rules for function declarations.
+    * `parameters` (off by default) enforces indentation level for parameters in a function declaration. This can either be a number indicating indentation level, or the string `"first"` indicating that all parameters of the declaration must be aligned with the first parameter.
+    * `body` (default: 1) enforces indentation level for the body of a function declaration.
+* `"FunctionExpression"` takes an object to define rules for function expressions.
+    * `parameters` (off by default) enforces indentation level for parameters in a function expression. This can either be a number indicating indentation level, or the string `"first"` indicating that all parameters of the expression must be aligned with the first parameter.
+    * `body` (default: 1) enforces indentation level for the body of a function expression.
+* `"CallExpression"` takes an object to define rules for function call expressions.
+    * `arguments` (off by default) enforces indentation level for arguments in a call expression. This can either be a number indicating indentation level, or the string `"first"` indicating that all arguments of the expression must be aligned with the first argument.
+* `"ArrayExpression"` (default: 1) enforces indentation level for elements in arrays. It can also be set to the string `"first"`, indicating that all the elements in the array should be aligned with the first element.
+* `"ObjectExpression"` (default: 1) enforces indentation level for properties in objects. It can be set to the string `"first"`, indicating that all properties in the object should be aligned with the first property.
+
+Level of indentation denotes the multiple of the indent specified. Example:
+
+* Indent of 4 spaces with `VariableDeclarator` set to `2` will indent the multi-line variable declarations with 8 spaces.
+* Indent of 2 spaces with `VariableDeclarator` set to `2` will indent the multi-line variable declarations with 4 spaces.
+* Indent of 2 spaces with `VariableDeclarator` set to `{"var": 2, "let": 2, "const": 3}` will indent the multi-line variable declarations with 4 spaces for `var` and `let`, 6 spaces for `const` statements.
+* Indent of tab with `VariableDeclarator` set to `2` will indent the multi-line variable declarations with 2 tabs.
+* Indent of 2 spaces with `SwitchCase` set to `0` will not indent `case` clauses with respect to `switch` statements.
+* Indent of 2 spaces with `SwitchCase` set to `1` will indent `case` clauses with 2 spaces with respect to `switch` statements.
+* Indent of 2 spaces with `SwitchCase` set to `2` will indent `case` clauses with 4 spaces with respect to `switch` statements.
+* Indent of tab with `SwitchCase` set to `2` will indent `case` clauses with 2 tabs with respect to `switch` statements.
+* Indent of 2 spaces with `MemberExpression` set to `0` will indent the multi-line property chains with 0 spaces.
+* Indent of 2 spaces with `MemberExpression` set to `1` will indent the multi-line property chains with 2 spaces.
+* Indent of 2 spaces with `MemberExpression` set to `2` will indent the multi-line property chains with 4 spaces.
+* Indent of 4 spaces with `MemberExpression` set to `0` will indent the multi-line property chains with 0 spaces.
+* Indent of 4 spaces with `MemberExpression` set to `1` will indent the multi-line property chains with 4 spaces.
+* Indent of 4 spaces with `MemberExpression` set to `2` will indent the multi-line property chains with 8 spaces.
+
+### tab
+
+Examples of **incorrect** code for this rule with the `"tab"` option:
+
+```js
+/*eslint indent: ["error", "tab"]*/
+
+if (a) {
+     b=c;
+function foo(d) {
+           e=f;
+ }
+}
+```
+
+Examples of **correct** code for this rule with the `"tab"` option:
+
+```js
+/*eslint indent: ["error", "tab"]*/
+
+if (a) {
+/*tab*/b=c;
+/*tab*/function foo(d) {
+/*tab*//*tab*/e=f;
+/*tab*/}
+}
+```
+
+### SwitchCase
+
+Examples of **incorrect** code for this rule with the `2, { "SwitchCase": 1 }` options:
+
+```js
+/*eslint indent: ["error", 2, { "SwitchCase": 1 }]*/
+
+switch(a){
+case "a":
+    break;
+case "b":
+    break;
+}
+```
+
+Examples of **correct** code for this rule with the `2, { "SwitchCase": 1 }` option:
+
+```js
+/*eslint indent: ["error", 2, { "SwitchCase": 1 }]*/
+
+switch(a){
+  case "a":
+    break;
+  case "b":
+    break;
+}
+```
+
+### VariableDeclarator
+
+Examples of **incorrect** code for this rule with the `2, { "VariableDeclarator": 1 }` options:
+
+```js
+/*eslint indent: ["error", 2, { "VariableDeclarator": 1 }]*/
+/*eslint-env es6*/
+
+var a,
+    b,
+    c;
+let a,
+    b,
+    c;
+const a = 1,
+    b = 2,
+    c = 3;
+```
+
+Examples of **correct** code for this rule with the `2, { "VariableDeclarator": 1 }` options:
+
+```js
+/*eslint indent: ["error", 2, { "VariableDeclarator": 1 }]*/
+/*eslint-env es6*/
+
+var a,
+  b,
+  c;
+let a,
+  b,
+  c;
+const a = 1,
+  b = 2,
+  c = 3;
+```
+
+Examples of **correct** code for this rule with the `2, { "VariableDeclarator": 2 }` options:
+
+```js
+/*eslint indent: ["error", 2, { "VariableDeclarator": 2 }]*/
+/*eslint-env es6*/
+
+var a,
+    b,
+    c;
+let a,
+    b,
+    c;
+const a = 1,
+    b = 2,
+    c = 3;
+```
+
+Examples of **correct** code for this rule with the `2, { "VariableDeclarator": { "var": 2, "let": 2, "const": 3 } }` options:
+
+```js
+/*eslint indent: ["error", 2, { "VariableDeclarator": { "var": 2, "let": 2, "const": 3 } }]*/
+/*eslint-env es6*/
+
+var a,
+    b,
+    c;
+let a,
+    b,
+    c;
+const a = 1,
+      b = 2,
+      c = 3;
+```
+
+### outerIIFEBody
+
+Examples of **incorrect** code for this rule with the options `2, { "outerIIFEBody": 0 }`:
+
+```js
+/*eslint indent: ["error", 2, { "outerIIFEBody": 0 }]*/
+
+(function() {
+
+  function foo(x) {
+    return x + 1;
+  }
+
+})();
+
+
+if(y) {
+console.log('foo');
+}
+```
+
+Examples of **correct** code for this rule with the options `2, {"outerIIFEBody": 0}`:
+
+```js
+/*eslint indent: ["error", 2, { "outerIIFEBody": 0 }]*/
+
+(function() {
+
+function foo(x) {
+  return x + 1;
+}
+
+})();
+
+
+if(y) {
+   console.log('foo');
+}
+```
+
+### MemberExpression
+
+Examples of **incorrect** code for this rule with the `2, { "MemberExpression": 1 }` options:
+
+```js
+/*eslint indent: ["error", 2, { "MemberExpression": 1 }]*/
+
+foo
+.bar
+.baz()
+```
+
+Examples of **correct** code for this rule with the `2, { "MemberExpression": 1 }` option:
+
+```js
+/*eslint indent: ["error", 2, { "MemberExpression": 1 }]*/
+
+foo
+  .bar
+  .baz();
+
+// Any indentation is permitted in variable declarations and assignments.
+var bip = aardvark.badger
+                  .coyote;
+```
+
+### FunctionDeclaration
+
+Examples of **incorrect** code for this rule with the `2, { "FunctionDeclaration": {"body": 1, "parameters": 2} }` option:
+
+```js
+/*eslint indent: ["error", 2, { "FunctionDeclaration": {"body": 1, "parameters": 2} }]*/
+
+function foo(bar,
+  baz,
+  qux) {
+    qux();
+}
+```
+
+Examples of **correct** code for this rule with the `2, { "FunctionDeclaration": {"body": 1, "parameters": 2} }` option:
+
+```js
+/*eslint indent: ["error", 2, { "FunctionDeclaration": {"body": 1, "parameters": 2} }]*/
+
+function foo(bar,
+    baz,
+    qux) {
+  qux();
+}
+```
+
+Examples of **incorrect** code for this rule with the `2, { "FunctionDeclaration": {"parameters": "first"} }` option:
+
+```js
+/*eslint indent: ["error", 2, {"FunctionDeclaration": {"parameters": "first"}}]*/
+
+function foo(bar, baz,
+  qux, boop) {
+  qux();
+}
+```
+
+Examples of **correct** code for this rule with the `2, { "FunctionDeclaration": {"parameters": "first"} }` option:
+
+```js
+/*eslint indent: ["error", 2, {"FunctionDeclaration": {"parameters": "first"}}]*/
+
+function foo(bar, baz,
+             qux, boop) {
+  qux();
+}
+```
+
+### FunctionExpression
+
+Examples of **incorrect** code for this rule with the `2, { "FunctionExpression": {"body": 1, "parameters": 2} }` option:
+
+```js
+/*eslint indent: ["error", 2, { "FunctionExpression": {"body": 1, "parameters": 2} }]*/
+
+var foo = function(bar,
+  baz,
+  qux) {
+    qux();
+}
+```
+
+Examples of **correct** code for this rule with the `2, { "FunctionExpression": {"body": 1, "parameters": 2} }` option:
+
+```js
+/*eslint indent: ["error", 2, { "FunctionExpression": {"body": 1, "parameters": 2} }]*/
+
+var foo = function(bar,
+    baz,
+    qux) {
+  qux();
+}
+```
+
+Examples of **incorrect** code for this rule with the `2, { "FunctionExpression": {"parameters": "first"} }` option:
+
+```js
+/*eslint indent: ["error", 2, {"FunctionExpression": {"parameters": "first"}}]*/
+
+var foo = function(bar, baz,
+  qux, boop) {
+  qux();
+}
+```
+
+Examples of **correct** code for this rule with the `2, { "FunctionExpression": {"parameters": "first"} }` option:
+
+```js
+/*eslint indent: ["error", 2, {"FunctionExpression": {"parameters": "first"}}]*/
+
+var foo = function(bar, baz,
+                   qux, boop) {
+  qux();
+}
+```
+
+### CallExpression
+
+Examples of **incorrect** code for this rule with the `2, { "CallExpression": {"arguments": 1} }` option:
+
+```js
+/*eslint indent: ["error", 2, { "CallExpression": {"arguments": 1} }]*/
+
+foo(bar,
+    baz,
+      qux
+);
+```
+
+Examples of **correct** code for this rule with the `2, { "CallExpression": {"arguments": 1} }` option:
+
+```js
+/*eslint indent: ["error", 2, { "CallExpression": {"arguments": 1} }]*/
+
+foo(bar,
+  baz,
+  qux
+);
+```
+
+Examples of **incorrect** code for this rule with the `2, { "CallExpression": {"arguments": "first"} }` option:
+
+```js
+/*eslint indent: ["error", 2, {"CallExpression": {"arguments": "first"}}]*/
+
+foo(bar, baz,
+  baz, boop, beep);
+```
+
+Examples of **correct** code for this rule with the `2, { "CallExpression": {"arguments": "first"} }` option:
+
+```js
+/*eslint indent: ["error", 2, {"CallExpression": {"arguments": "first"}}]*/
+
+foo(bar, baz,
+    baz, boop, beep);
+```
+
+### ArrayExpression
+
+Examples of **incorrect** code for this rule with the `2, { "ArrayExpression": 1 }` option:
+
+```js
+/*eslint indent: ["error", 2, { "ArrayExpression": 1 }]*/
+
+var foo = [
+    bar,
+baz,
+      qux
+];
+```
+
+Examples of **correct** code for this rule with the `2, { "ArrayExpression": 1 }` option:
+
+```js
+/*eslint indent: ["error", 2, { "ArrayExpression": 1 }]*/
+
+var foo = [
+  bar,
+  baz,
+  qux
+];
+```
+
+Examples of **incorrect** code for this rule with the `2, { "ArrayExpression": "first" }` option:
+
+```js
+/*eslint indent: ["error", 2, {"ArrayExpression": "first"}]*/
+
+var foo = [bar,
+  baz,
+  qux
+];
+```
+
+Examples of **correct** code for this rule with the `2, { "ArrayExpression": "first" }` option:
+
+```js
+/*eslint indent: ["error", 2, {"ArrayExpression": "first"}]*/
+
+var foo = [bar,
+           baz,
+           qux
+];
+```
+
+### ObjectExpression
+
+Examples of **incorrect** code for this rule with the `2, { "ObjectExpression": 1 }` option:
+
+```js
+/*eslint indent: ["error", 2, { "ObjectExpression": 1 }]*/
+
+var foo = {
+    bar: 1,
+baz: 2,
+      qux: 3
+};
+```
+
+Examples of **correct** code for this rule with the `2, { "ObjectExpression": 1 }` option:
+
+```js
+/*eslint indent: ["error", 2, { "ObjectExpression": 1 }]*/
+
+var foo = {
+  bar: 1,
+  baz: 2,
+  qux: 3
+};
+```
+
+Examples of **incorrect** code for this rule with the `2, { "ObjectExpression": "first" }` option:
+
+```js
+/*eslint indent: ["error", 2, {"ObjectExpression": "first"}]*/
+
+var foo = { bar: 1,
+  baz: 2 };
+```
+
+Examples of **correct** code for this rule with the `2, { "ObjectExpression": "first" }` option:
+
+```js
+/*eslint indent: ["error", 2, {"ObjectExpression": "first"}]*/
+
+var foo = { bar: 1,
+            baz: 2 };
+```
+
+
+## Compatibility
+
+* **JSHint**: `indent`
+* **JSCS**: [validateIndentation](http://jscs.info/rule/validateIndentation)

--- a/lib/rules/indent-legacy.js
+++ b/lib/rules/indent-legacy.js
@@ -18,6 +18,7 @@ const astUtils = require("../ast-utils");
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/* istanbul ignore next: this rule has known coverage issues, but it's deprecated and shouldn't be updated in the future anyway. */
 module.exports = {
     meta: {
         docs: {

--- a/lib/rules/indent-legacy.js
+++ b/lib/rules/indent-legacy.js
@@ -1,0 +1,1125 @@
+/**
+ * @fileoverview This option sets a specific tab width for your code
+ *
+ * This rule has been ported and modified from nodeca.
+ * @author Vitaly Puzrin
+ * @author Gyandeep Singh
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const astUtils = require("../ast-utils");
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "enforce consistent indentation",
+            category: "Stylistic Issues",
+            recommended: false,
+            replacedBy: ["indent"]
+        },
+
+        deprecated: true,
+
+        fixable: "whitespace",
+
+        schema: [
+            {
+                oneOf: [
+                    {
+                        enum: ["tab"]
+                    },
+                    {
+                        type: "integer",
+                        minimum: 0
+                    }
+                ]
+            },
+            {
+                type: "object",
+                properties: {
+                    SwitchCase: {
+                        type: "integer",
+                        minimum: 0
+                    },
+                    VariableDeclarator: {
+                        oneOf: [
+                            {
+                                type: "integer",
+                                minimum: 0
+                            },
+                            {
+                                type: "object",
+                                properties: {
+                                    var: {
+                                        type: "integer",
+                                        minimum: 0
+                                    },
+                                    let: {
+                                        type: "integer",
+                                        minimum: 0
+                                    },
+                                    const: {
+                                        type: "integer",
+                                        minimum: 0
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    outerIIFEBody: {
+                        type: "integer",
+                        minimum: 0
+                    },
+                    MemberExpression: {
+                        type: "integer",
+                        minimum: 0
+                    },
+                    FunctionDeclaration: {
+                        type: "object",
+                        properties: {
+                            parameters: {
+                                oneOf: [
+                                    {
+                                        type: "integer",
+                                        minimum: 0
+                                    },
+                                    {
+                                        enum: ["first"]
+                                    }
+                                ]
+                            },
+                            body: {
+                                type: "integer",
+                                minimum: 0
+                            }
+                        }
+                    },
+                    FunctionExpression: {
+                        type: "object",
+                        properties: {
+                            parameters: {
+                                oneOf: [
+                                    {
+                                        type: "integer",
+                                        minimum: 0
+                                    },
+                                    {
+                                        enum: ["first"]
+                                    }
+                                ]
+                            },
+                            body: {
+                                type: "integer",
+                                minimum: 0
+                            }
+                        }
+                    },
+                    CallExpression: {
+                        type: "object",
+                        properties: {
+                            parameters: {
+                                oneOf: [
+                                    {
+                                        type: "integer",
+                                        minimum: 0
+                                    },
+                                    {
+                                        enum: ["first"]
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    ArrayExpression: {
+                        oneOf: [
+                            {
+                                type: "integer",
+                                minimum: 0
+                            },
+                            {
+                                enum: ["first"]
+                            }
+                        ]
+                    },
+                    ObjectExpression: {
+                        oneOf: [
+                            {
+                                type: "integer",
+                                minimum: 0
+                            },
+                            {
+                                enum: ["first"]
+                            }
+                        ]
+                    }
+                },
+                additionalProperties: false
+            }
+        ]
+    },
+
+    create(context) {
+        const DEFAULT_VARIABLE_INDENT = 1;
+        const DEFAULT_PARAMETER_INDENT = null; // For backwards compatibility, don't check parameter indentation unless specified in the config
+        const DEFAULT_FUNCTION_BODY_INDENT = 1;
+
+        let indentType = "space";
+        let indentSize = 4;
+        const options = {
+            SwitchCase: 0,
+            VariableDeclarator: {
+                var: DEFAULT_VARIABLE_INDENT,
+                let: DEFAULT_VARIABLE_INDENT,
+                const: DEFAULT_VARIABLE_INDENT
+            },
+            outerIIFEBody: null,
+            FunctionDeclaration: {
+                parameters: DEFAULT_PARAMETER_INDENT,
+                body: DEFAULT_FUNCTION_BODY_INDENT
+            },
+            FunctionExpression: {
+                parameters: DEFAULT_PARAMETER_INDENT,
+                body: DEFAULT_FUNCTION_BODY_INDENT
+            },
+            CallExpression: {
+                arguments: DEFAULT_PARAMETER_INDENT
+            },
+            ArrayExpression: 1,
+            ObjectExpression: 1
+        };
+
+        const sourceCode = context.getSourceCode();
+
+        if (context.options.length) {
+            if (context.options[0] === "tab") {
+                indentSize = 1;
+                indentType = "tab";
+            } else /* istanbul ignore else : this will be caught by options validation */ if (typeof context.options[0] === "number") {
+                indentSize = context.options[0];
+                indentType = "space";
+            }
+
+            if (context.options[1]) {
+                const opts = context.options[1];
+
+                options.SwitchCase = opts.SwitchCase || 0;
+                const variableDeclaratorRules = opts.VariableDeclarator;
+
+                if (typeof variableDeclaratorRules === "number") {
+                    options.VariableDeclarator = {
+                        var: variableDeclaratorRules,
+                        let: variableDeclaratorRules,
+                        const: variableDeclaratorRules
+                    };
+                } else if (typeof variableDeclaratorRules === "object") {
+                    Object.assign(options.VariableDeclarator, variableDeclaratorRules);
+                }
+
+                if (typeof opts.outerIIFEBody === "number") {
+                    options.outerIIFEBody = opts.outerIIFEBody;
+                }
+
+                if (typeof opts.MemberExpression === "number") {
+                    options.MemberExpression = opts.MemberExpression;
+                }
+
+                if (typeof opts.FunctionDeclaration === "object") {
+                    Object.assign(options.FunctionDeclaration, opts.FunctionDeclaration);
+                }
+
+                if (typeof opts.FunctionExpression === "object") {
+                    Object.assign(options.FunctionExpression, opts.FunctionExpression);
+                }
+
+                if (typeof opts.CallExpression === "object") {
+                    Object.assign(options.CallExpression, opts.CallExpression);
+                }
+
+                if (typeof opts.ArrayExpression === "number" || typeof opts.ArrayExpression === "string") {
+                    options.ArrayExpression = opts.ArrayExpression;
+                }
+
+                if (typeof opts.ObjectExpression === "number" || typeof opts.ObjectExpression === "string") {
+                    options.ObjectExpression = opts.ObjectExpression;
+                }
+            }
+        }
+
+        const caseIndentStore = {};
+
+        /**
+         * Creates an error message for a line, given the expected/actual indentation.
+         * @param {int} expectedAmount The expected amount of indentation characters for this line
+         * @param {int} actualSpaces The actual number of indentation spaces that were found on this line
+         * @param {int} actualTabs The actual number of indentation tabs that were found on this line
+         * @returns {string} An error message for this line
+         */
+        function createErrorMessage(expectedAmount, actualSpaces, actualTabs) {
+            const expectedStatement = `${expectedAmount} ${indentType}${expectedAmount === 1 ? "" : "s"}`; // e.g. "2 tabs"
+            const foundSpacesWord = `space${actualSpaces === 1 ? "" : "s"}`; // e.g. "space"
+            const foundTabsWord = `tab${actualTabs === 1 ? "" : "s"}`; // e.g. "tabs"
+            let foundStatement;
+
+            if (actualSpaces > 0 && actualTabs > 0) {
+                foundStatement = `${actualSpaces} ${foundSpacesWord} and ${actualTabs} ${foundTabsWord}`; // e.g. "1 space and 2 tabs"
+            } else if (actualSpaces > 0) {
+
+                // Abbreviate the message if the expected indentation is also spaces.
+                // e.g. 'Expected 4 spaces but found 2' rather than 'Expected 4 spaces but found 2 spaces'
+                foundStatement = indentType === "space" ? actualSpaces : `${actualSpaces} ${foundSpacesWord}`;
+            } else if (actualTabs > 0) {
+                foundStatement = indentType === "tab" ? actualTabs : `${actualTabs} ${foundTabsWord}`;
+            } else {
+                foundStatement = "0";
+            }
+
+            return `Expected indentation of ${expectedStatement} but found ${foundStatement}.`;
+        }
+
+        /**
+         * Reports a given indent violation
+         * @param {ASTNode} node Node violating the indent rule
+         * @param {int} needed Expected indentation character count
+         * @param {int} gottenSpaces Indentation space count in the actual node/code
+         * @param {int} gottenTabs Indentation tab count in the actual node/code
+         * @param {Object=} loc Error line and column location
+         * @param {boolean} isLastNodeCheck Is the error for last node check
+         * @param {int} lastNodeCheckEndOffset Number of charecters to skip from the end
+         * @returns {void}
+         */
+        function report(node, needed, gottenSpaces, gottenTabs, loc, isLastNodeCheck) {
+            if (gottenSpaces && gottenTabs) {
+
+                // To avoid conflicts with `no-mixed-spaces-and-tabs`, don't report lines that have both spaces and tabs.
+                return;
+            }
+
+            const desiredIndent = (indentType === "space" ? " " : "\t").repeat(needed);
+
+            const textRange = isLastNodeCheck
+                ? [node.range[1] - node.loc.end.column, node.range[1] - node.loc.end.column + gottenSpaces + gottenTabs]
+                : [node.range[0] - node.loc.start.column, node.range[0] - node.loc.start.column + gottenSpaces + gottenTabs];
+
+            context.report({
+                node,
+                loc,
+                message: createErrorMessage(needed, gottenSpaces, gottenTabs),
+                fix: fixer => fixer.replaceTextRange(textRange, desiredIndent)
+            });
+        }
+
+        /**
+         * Get the actual indent of node
+         * @param {ASTNode|Token} node Node to examine
+         * @param {boolean} [byLastLine=false] get indent of node's last line
+         * @param {boolean} [excludeCommas=false] skip comma on start of line
+         * @returns {Object} The node's indent. Contains keys `space` and `tab`, representing the indent of each character. Also
+         contains keys `goodChar` and `badChar`, where `goodChar` is the amount of the user's desired indentation character, and
+         `badChar` is the amount of the other indentation character.
+         */
+        function getNodeIndent(node, byLastLine) {
+            const token = byLastLine ? sourceCode.getLastToken(node) : sourceCode.getFirstToken(node);
+            const srcCharsBeforeNode = sourceCode.getText(token, token.loc.start.column).split("");
+            const indentChars = srcCharsBeforeNode.slice(0, srcCharsBeforeNode.findIndex(char => char !== " " && char !== "\t"));
+            const spaces = indentChars.filter(char => char === " ").length;
+            const tabs = indentChars.filter(char => char === "\t").length;
+
+            return {
+                space: spaces,
+                tab: tabs,
+                goodChar: indentType === "space" ? spaces : tabs,
+                badChar: indentType === "space" ? tabs : spaces
+            };
+        }
+
+        /**
+         * Checks node is the first in its own start line. By default it looks by start line.
+         * @param {ASTNode} node The node to check
+         * @param {boolean} [byEndLocation=false] Lookup based on start position or end
+         * @returns {boolean} true if its the first in the its start line
+         */
+        function isNodeFirstInLine(node, byEndLocation) {
+            const firstToken = byEndLocation === true ? sourceCode.getLastToken(node, 1) : sourceCode.getTokenBefore(node),
+                startLine = byEndLocation === true ? node.loc.end.line : node.loc.start.line,
+                endLine = firstToken ? firstToken.loc.end.line : -1;
+
+            return startLine !== endLine;
+        }
+
+        /**
+         * Check indent for node
+         * @param {ASTNode} node Node to check
+         * @param {int} neededIndent needed indent
+         * @param {boolean} [excludeCommas=false] skip comma on start of line
+         * @returns {void}
+         */
+        function checkNodeIndent(node, neededIndent) {
+            const actualIndent = getNodeIndent(node, false);
+
+            if (
+                node.type !== "ArrayExpression" &&
+                node.type !== "ObjectExpression" &&
+                (actualIndent.goodChar !== neededIndent || actualIndent.badChar !== 0) &&
+                isNodeFirstInLine(node)
+            ) {
+                report(node, neededIndent, actualIndent.space, actualIndent.tab);
+            }
+
+            if (node.type === "IfStatement" && node.alternate) {
+                const elseToken = sourceCode.getTokenBefore(node.alternate);
+
+                checkNodeIndent(elseToken, neededIndent);
+
+                if (!isNodeFirstInLine(node.alternate)) {
+                    checkNodeIndent(node.alternate, neededIndent);
+                }
+            }
+
+            if (node.type === "TryStatement" && node.handler) {
+                const catchToken = sourceCode.getFirstToken(node.handler);
+
+                checkNodeIndent(catchToken, neededIndent);
+            }
+
+            if (node.type === "TryStatement" && node.finalizer) {
+                const finallyToken = sourceCode.getTokenBefore(node.finalizer);
+
+                checkNodeIndent(finallyToken, neededIndent);
+            }
+
+            if (node.type === "DoWhileStatement") {
+                const whileToken = sourceCode.getTokenAfter(node.body);
+
+                checkNodeIndent(whileToken, neededIndent);
+            }
+        }
+
+        /**
+         * Check indent for nodes list
+         * @param {ASTNode[]} nodes list of node objects
+         * @param {int} indent needed indent
+         * @param {boolean} [excludeCommas=false] skip comma on start of line
+         * @returns {void}
+         */
+        function checkNodesIndent(nodes, indent) {
+            nodes.forEach(node => checkNodeIndent(node, indent));
+        }
+
+        /**
+         * Check last node line indent this detects, that block closed correctly
+         * @param {ASTNode} node Node to examine
+         * @param {int} lastLineIndent needed indent
+         * @returns {void}
+         */
+        function checkLastNodeLineIndent(node, lastLineIndent) {
+            const lastToken = sourceCode.getLastToken(node);
+            const endIndent = getNodeIndent(lastToken, true);
+
+            if ((endIndent.goodChar !== lastLineIndent || endIndent.badChar !== 0) && isNodeFirstInLine(node, true)) {
+                report(
+                    node,
+                    lastLineIndent,
+                    endIndent.space,
+                    endIndent.tab,
+                    { line: lastToken.loc.start.line, column: lastToken.loc.start.column },
+                    true
+                );
+            }
+        }
+
+        /**
+         * Check last node line indent this detects, that block closed correctly
+         * This function for more complicated return statement case, where closing parenthesis may be followed by ';'
+         * @param {ASTNode} node Node to examine
+         * @param {int} firstLineIndent first line needed indent
+         * @returns {void}
+         */
+        function checkLastReturnStatementLineIndent(node, firstLineIndent) {
+
+            // in case if return statement ends with ');' we have traverse back to ')'
+            // otherwise we'll measure indent for ';' and replace ')'
+            const lastToken = sourceCode.getLastToken(node, astUtils.isClosingParenToken);
+            const textBeforeClosingParenthesis = sourceCode.getText(lastToken, lastToken.loc.start.column).slice(0, -1);
+
+            if (textBeforeClosingParenthesis.trim()) {
+
+                // There are tokens before the closing paren, don't report this case
+                return;
+            }
+
+            const endIndent = getNodeIndent(lastToken, true);
+
+            if (endIndent.goodChar !== firstLineIndent) {
+                report(
+                    node,
+                    firstLineIndent,
+                    endIndent.space,
+                    endIndent.tab,
+                    { line: lastToken.loc.start.line, column: lastToken.loc.start.column },
+                    true
+                );
+            }
+        }
+
+        /**
+         * Check first node line indent is correct
+         * @param {ASTNode} node Node to examine
+         * @param {int} firstLineIndent needed indent
+         * @returns {void}
+         */
+        function checkFirstNodeLineIndent(node, firstLineIndent) {
+            const startIndent = getNodeIndent(node, false);
+
+            if ((startIndent.goodChar !== firstLineIndent || startIndent.badChar !== 0) && isNodeFirstInLine(node)) {
+                report(
+                    node,
+                    firstLineIndent,
+                    startIndent.space,
+                    startIndent.tab,
+                    { line: node.loc.start.line, column: node.loc.start.column }
+                );
+            }
+        }
+
+        /**
+         * Returns a parent node of given node based on a specified type
+         * if not present then return null
+         * @param {ASTNode} node node to examine
+         * @param {string} type type that is being looked for
+         * @param {string} stopAtList end points for the evaluating code
+         * @returns {ASTNode|void} if found then node otherwise null
+         */
+        function getParentNodeByType(node, type, stopAtList) {
+            let parent = node.parent;
+
+            if (!stopAtList) {
+                stopAtList = ["Program"];
+            }
+
+            while (parent.type !== type && stopAtList.indexOf(parent.type) === -1 && parent.type !== "Program") {
+                parent = parent.parent;
+            }
+
+            return parent.type === type ? parent : null;
+        }
+
+        /**
+         * Returns the VariableDeclarator based on the current node
+         * if not present then return null
+         * @param {ASTNode} node node to examine
+         * @returns {ASTNode|void} if found then node otherwise null
+         */
+        function getVariableDeclaratorNode(node) {
+            return getParentNodeByType(node, "VariableDeclarator");
+        }
+
+        /**
+         * Check to see if the node is part of the multi-line variable declaration.
+         * Also if its on the same line as the varNode
+         * @param {ASTNode} node node to check
+         * @param {ASTNode} varNode variable declaration node to check against
+         * @returns {boolean} True if all the above condition satisfy
+         */
+        function isNodeInVarOnTop(node, varNode) {
+            return varNode &&
+                varNode.parent.loc.start.line === node.loc.start.line &&
+                varNode.parent.declarations.length > 1;
+        }
+
+        /**
+         * Check to see if the argument before the callee node is multi-line and
+         * there should only be 1 argument before the callee node
+         * @param {ASTNode} node node to check
+         * @returns {boolean} True if arguments are multi-line
+         */
+        function isArgBeforeCalleeNodeMultiline(node) {
+            const parent = node.parent;
+
+            if (parent.arguments.length >= 2 && parent.arguments[1] === node) {
+                return parent.arguments[0].loc.end.line > parent.arguments[0].loc.start.line;
+            }
+
+            return false;
+        }
+
+        /**
+         * Check to see if the node is a file level IIFE
+         * @param {ASTNode} node The function node to check.
+         * @returns {boolean} True if the node is the outer IIFE
+         */
+        function isOuterIIFE(node) {
+            const parent = node.parent;
+            let stmt = parent.parent;
+
+            /*
+             * Verify that the node is an IIEF
+             */
+            if (
+                parent.type !== "CallExpression" ||
+                parent.callee !== node) {
+
+                return false;
+            }
+
+            /*
+             * Navigate legal ancestors to determine whether this IIEF is outer
+             */
+            while (
+                stmt.type === "UnaryExpression" && (
+                    stmt.operator === "!" ||
+                    stmt.operator === "~" ||
+                    stmt.operator === "+" ||
+                    stmt.operator === "-") ||
+                stmt.type === "AssignmentExpression" ||
+                stmt.type === "LogicalExpression" ||
+                stmt.type === "SequenceExpression" ||
+                stmt.type === "VariableDeclarator") {
+
+                stmt = stmt.parent;
+            }
+
+            return ((
+                    stmt.type === "ExpressionStatement" ||
+                    stmt.type === "VariableDeclaration") &&
+                stmt.parent && stmt.parent.type === "Program"
+            );
+        }
+
+        /**
+         * Check indent for function block content
+         * @param {ASTNode} node A BlockStatement node that is inside of a function.
+         * @returns {void}
+         */
+        function checkIndentInFunctionBlock(node) {
+
+            /*
+             * Search first caller in chain.
+             * Ex.:
+             *
+             * Models <- Identifier
+             *   .User
+             *   .find()
+             *   .exec(function() {
+             *   // function body
+             * });
+             *
+             * Looks for 'Models'
+             */
+            const calleeNode = node.parent; // FunctionExpression
+            let indent;
+
+            if (calleeNode.parent &&
+                (calleeNode.parent.type === "Property" ||
+                calleeNode.parent.type === "ArrayExpression")) {
+
+                // If function is part of array or object, comma can be put at left
+                indent = getNodeIndent(calleeNode, false, false).goodChar;
+            } else {
+
+                // If function is standalone, simple calculate indent
+                indent = getNodeIndent(calleeNode).goodChar;
+            }
+
+            if (calleeNode.parent.type === "CallExpression") {
+                const calleeParent = calleeNode.parent;
+
+                if (calleeNode.type !== "FunctionExpression" && calleeNode.type !== "ArrowFunctionExpression") {
+                    if (calleeParent && calleeParent.loc.start.line < node.loc.start.line) {
+                        indent = getNodeIndent(calleeParent).goodChar;
+                    }
+                } else {
+                    if (isArgBeforeCalleeNodeMultiline(calleeNode) &&
+                        calleeParent.callee.loc.start.line === calleeParent.callee.loc.end.line &&
+                        !isNodeFirstInLine(calleeNode)) {
+                        indent = getNodeIndent(calleeParent).goodChar;
+                    }
+                }
+            }
+
+            // function body indent should be indent + indent size, unless this
+            // is a FunctionDeclaration, FunctionExpression, or outer IIFE and the corresponding options are enabled.
+            let functionOffset = indentSize;
+
+            if (options.outerIIFEBody !== null && isOuterIIFE(calleeNode)) {
+                functionOffset = options.outerIIFEBody * indentSize;
+            } else if (calleeNode.type === "FunctionExpression") {
+                functionOffset = options.FunctionExpression.body * indentSize;
+            } else if (calleeNode.type === "FunctionDeclaration") {
+                functionOffset = options.FunctionDeclaration.body * indentSize;
+            }
+            indent += functionOffset;
+
+            // check if the node is inside a variable
+            const parentVarNode = getVariableDeclaratorNode(node);
+
+            if (parentVarNode && isNodeInVarOnTop(node, parentVarNode)) {
+                indent += indentSize * options.VariableDeclarator[parentVarNode.parent.kind];
+            }
+
+            if (node.body.length > 0) {
+                checkNodesIndent(node.body, indent);
+            }
+
+            checkLastNodeLineIndent(node, indent - functionOffset);
+        }
+
+
+        /**
+         * Checks if the given node starts and ends on the same line
+         * @param {ASTNode} node The node to check
+         * @returns {boolean} Whether or not the block starts and ends on the same line.
+         */
+        function isSingleLineNode(node) {
+            const lastToken = sourceCode.getLastToken(node),
+                startLine = node.loc.start.line,
+                endLine = lastToken.loc.end.line;
+
+            return startLine === endLine;
+        }
+
+        /**
+         * Check to see if the first element inside an array is an object and on the same line as the node
+         * If the node is not an array then it will return false.
+         * @param {ASTNode} node node to check
+         * @returns {boolean} success/failure
+         */
+        function isFirstArrayElementOnSameLine(node) {
+            if (node.type === "ArrayExpression" && node.elements[0]) {
+                return node.elements[0].loc.start.line === node.loc.start.line && node.elements[0].type === "ObjectExpression";
+            }
+            return false;
+
+        }
+
+        /**
+         * Check indent for array block content or object block content
+         * @param {ASTNode} node node to examine
+         * @returns {void}
+         */
+        function checkIndentInArrayOrObjectBlock(node) {
+
+            // Skip inline
+            if (isSingleLineNode(node)) {
+                return;
+            }
+
+            let elements = (node.type === "ArrayExpression") ? node.elements : node.properties;
+
+            // filter out empty elements example would be [ , 2] so remove first element as espree considers it as null
+            elements = elements.filter(elem => elem !== null);
+
+            let nodeIndent;
+            let elementsIndent;
+            const parentVarNode = getVariableDeclaratorNode(node);
+
+            // TODO - come up with a better strategy in future
+            if (isNodeFirstInLine(node)) {
+                const parent = node.parent;
+
+                nodeIndent = getNodeIndent(parent).goodChar;
+                if (!parentVarNode || parentVarNode.loc.start.line !== node.loc.start.line) {
+                    if (parent.type !== "VariableDeclarator" || parentVarNode === parentVarNode.parent.declarations[0]) {
+                        if (parent.type === "VariableDeclarator" && parentVarNode.loc.start.line === parent.loc.start.line) {
+                            nodeIndent = nodeIndent + (indentSize * options.VariableDeclarator[parentVarNode.parent.kind]);
+                        } else if (parent.type === "ObjectExpression" || parent.type === "ArrayExpression") {
+                            const parentElements = node.parent.type === "ObjectExpression" ? node.parent.properties : node.parent.elements;
+
+                            if (parentElements[0] && parentElements[0].loc.start.line === parent.loc.start.line && parentElements[0].loc.end.line !== parent.loc.start.line) {
+
+                                /*
+                                 * If the first element of the array spans multiple lines, don't increase the expected indentation of the rest.
+                                 * e.g. [{
+                                 *        foo: 1
+                                 *      },
+                                 *      {
+                                 *        bar: 1
+                                 *      }]
+                                 * the second object is not indented.
+                                 */
+                            } else if (typeof options[parent.type] === "number") {
+                                nodeIndent += options[parent.type] * indentSize;
+                            } else {
+                                nodeIndent = parentElements[0].loc.start.column;
+                            }
+                        } else if (parent.type === "CallExpression" || parent.type === "NewExpression") {
+                            if (typeof options.CallExpression.arguments === "number") {
+                                nodeIndent += options.CallExpression.arguments * indentSize;
+                            } else if (options.CallExpression.arguments === "first") {
+                                if (parent.arguments.indexOf(node) !== -1) {
+                                    nodeIndent = parent.arguments[0].loc.start.column;
+                                }
+                            } else {
+                                nodeIndent += indentSize;
+                            }
+                        } else if (parent.type === "LogicalExpression" || parent.type === "ArrowFunctionExpression") {
+                            nodeIndent += indentSize;
+                        }
+                    }
+                } else if (!parentVarNode && !isFirstArrayElementOnSameLine(parent) && parent.type !== "MemberExpression" && parent.type !== "ExpressionStatement" && parent.type !== "AssignmentExpression" && parent.type !== "Property") {
+                    nodeIndent = nodeIndent + indentSize;
+                }
+
+                checkFirstNodeLineIndent(node, nodeIndent);
+            } else {
+                nodeIndent = getNodeIndent(node).goodChar;
+            }
+
+            if (options[node.type] === "first") {
+                elementsIndent = elements.length ? elements[0].loc.start.column : 0; // If there are no elements, elementsIndent doesn't matter.
+            } else {
+                elementsIndent = nodeIndent + indentSize * options[node.type];
+            }
+
+            /*
+             * Check if the node is a multiple variable declaration; if so, then
+             * make sure indentation takes that into account.
+             */
+            if (isNodeInVarOnTop(node, parentVarNode)) {
+                elementsIndent += indentSize * options.VariableDeclarator[parentVarNode.parent.kind];
+            }
+
+            checkNodesIndent(elements, elementsIndent);
+
+            if (elements.length > 0) {
+
+                // Skip last block line check if last item in same line
+                if (elements[elements.length - 1].loc.end.line === node.loc.end.line) {
+                    return;
+                }
+            }
+
+            checkLastNodeLineIndent(node, nodeIndent + (isNodeInVarOnTop(node, parentVarNode) ? options.VariableDeclarator[parentVarNode.parent.kind] * indentSize : 0));
+        }
+
+        /**
+         * Check if the node or node body is a BlockStatement or not
+         * @param {ASTNode} node node to test
+         * @returns {boolean} True if it or its body is a block statement
+         */
+        function isNodeBodyBlock(node) {
+            return node.type === "BlockStatement" || node.type === "ClassBody" || (node.body && node.body.type === "BlockStatement") ||
+                (node.consequent && node.consequent.type === "BlockStatement");
+        }
+
+        /**
+         * Check indentation for blocks
+         * @param {ASTNode} node node to check
+         * @returns {void}
+         */
+        function blockIndentationCheck(node) {
+
+            // Skip inline blocks
+            if (isSingleLineNode(node)) {
+                return;
+            }
+
+            if (node.parent && (
+                    node.parent.type === "FunctionExpression" ||
+                    node.parent.type === "FunctionDeclaration" ||
+                    node.parent.type === "ArrowFunctionExpression"
+            )) {
+                checkIndentInFunctionBlock(node);
+                return;
+            }
+
+            let indent;
+            let nodesToCheck = [];
+
+            /*
+             * For this statements we should check indent from statement beginning,
+             * not from the beginning of the block.
+             */
+            const statementsWithProperties = [
+                "IfStatement", "WhileStatement", "ForStatement", "ForInStatement", "ForOfStatement", "DoWhileStatement", "ClassDeclaration", "TryStatement"
+            ];
+
+            if (node.parent && statementsWithProperties.indexOf(node.parent.type) !== -1 && isNodeBodyBlock(node)) {
+                indent = getNodeIndent(node.parent).goodChar;
+            } else if (node.parent && node.parent.type === "CatchClause") {
+                indent = getNodeIndent(node.parent.parent).goodChar;
+            } else {
+                indent = getNodeIndent(node).goodChar;
+            }
+
+            if (node.type === "IfStatement" && node.consequent.type !== "BlockStatement") {
+                nodesToCheck = [node.consequent];
+            } else if (Array.isArray(node.body)) {
+                nodesToCheck = node.body;
+            } else {
+                nodesToCheck = [node.body];
+            }
+
+            if (nodesToCheck.length > 0) {
+                checkNodesIndent(nodesToCheck, indent + indentSize);
+            }
+
+            if (node.type === "BlockStatement") {
+                checkLastNodeLineIndent(node, indent);
+            }
+        }
+
+        /**
+         * Filter out the elements which are on the same line of each other or the node.
+         * basically have only 1 elements from each line except the variable declaration line.
+         * @param {ASTNode} node Variable declaration node
+         * @returns {ASTNode[]} Filtered elements
+         */
+        function filterOutSameLineVars(node) {
+            return node.declarations.reduce((finalCollection, elem) => {
+                const lastElem = finalCollection[finalCollection.length - 1];
+
+                if ((elem.loc.start.line !== node.loc.start.line && !lastElem) ||
+                    (lastElem && lastElem.loc.start.line !== elem.loc.start.line)) {
+                    finalCollection.push(elem);
+                }
+
+                return finalCollection;
+            }, []);
+        }
+
+        /**
+         * Check indentation for variable declarations
+         * @param {ASTNode} node node to examine
+         * @returns {void}
+         */
+        function checkIndentInVariableDeclarations(node) {
+            const elements = filterOutSameLineVars(node);
+            const nodeIndent = getNodeIndent(node).goodChar;
+            const lastElement = elements[elements.length - 1];
+
+            const elementsIndent = nodeIndent + indentSize * options.VariableDeclarator[node.kind];
+
+            checkNodesIndent(elements, elementsIndent);
+
+            // Only check the last line if there is any token after the last item
+            if (sourceCode.getLastToken(node).loc.end.line <= lastElement.loc.end.line) {
+                return;
+            }
+
+            const tokenBeforeLastElement = sourceCode.getTokenBefore(lastElement);
+
+            if (tokenBeforeLastElement.value === ",") {
+
+                // Special case for comma-first syntax where the semicolon is indented
+                checkLastNodeLineIndent(node, getNodeIndent(tokenBeforeLastElement).goodChar);
+            } else {
+                checkLastNodeLineIndent(node, elementsIndent - indentSize);
+            }
+        }
+
+        /**
+         * Check and decide whether to check for indentation for blockless nodes
+         * Scenarios are for or while statements without braces around them
+         * @param {ASTNode} node node to examine
+         * @returns {void}
+         */
+        function blockLessNodes(node) {
+            if (node.body.type !== "BlockStatement") {
+                blockIndentationCheck(node);
+            }
+        }
+
+        /**
+         * Returns the expected indentation for the case statement
+         * @param {ASTNode} node node to examine
+         * @param {int} [switchIndent] indent for switch statement
+         * @returns {int} indent size
+         */
+        function expectedCaseIndent(node, switchIndent) {
+            const switchNode = (node.type === "SwitchStatement") ? node : node.parent;
+            let caseIndent;
+
+            if (caseIndentStore[switchNode.loc.start.line]) {
+                return caseIndentStore[switchNode.loc.start.line];
+            }
+            if (typeof switchIndent === "undefined") {
+                switchIndent = getNodeIndent(switchNode).goodChar;
+            }
+
+            if (switchNode.cases.length > 0 && options.SwitchCase === 0) {
+                caseIndent = switchIndent;
+            } else {
+                caseIndent = switchIndent + (indentSize * options.SwitchCase);
+            }
+
+            caseIndentStore[switchNode.loc.start.line] = caseIndent;
+            return caseIndent;
+
+        }
+
+        /**
+         * Checks wether a return statement is wrapped in ()
+         * @param {ASTNode} node node to examine
+         * @returns {boolean} the result
+         */
+        function isWrappedInParenthesis(node) {
+            const regex = /^return\s*?\(\s*?\);*?/;
+
+            const statementWithoutArgument = sourceCode.getText(node).replace(
+                sourceCode.getText(node.argument), "");
+
+            return regex.test(statementWithoutArgument);
+        }
+
+        return {
+            Program(node) {
+                if (node.body.length > 0) {
+
+                    // Root nodes should have no indent
+                    checkNodesIndent(node.body, getNodeIndent(node).goodChar);
+                }
+            },
+
+            ClassBody: blockIndentationCheck,
+
+            BlockStatement: blockIndentationCheck,
+
+            WhileStatement: blockLessNodes,
+
+            ForStatement: blockLessNodes,
+
+            ForInStatement: blockLessNodes,
+
+            ForOfStatement: blockLessNodes,
+
+            DoWhileStatement: blockLessNodes,
+
+            IfStatement(node) {
+                if (node.consequent.type !== "BlockStatement" && node.consequent.loc.start.line > node.loc.start.line) {
+                    blockIndentationCheck(node);
+                }
+            },
+
+            VariableDeclaration(node) {
+                if (node.declarations[node.declarations.length - 1].loc.start.line > node.declarations[0].loc.start.line) {
+                    checkIndentInVariableDeclarations(node);
+                }
+            },
+
+            ObjectExpression(node) {
+                checkIndentInArrayOrObjectBlock(node);
+            },
+
+            ArrayExpression(node) {
+                checkIndentInArrayOrObjectBlock(node);
+            },
+
+            MemberExpression(node) {
+
+                if (typeof options.MemberExpression === "undefined") {
+                    return;
+                }
+
+                if (isSingleLineNode(node)) {
+                    return;
+                }
+
+                // The typical layout of variable declarations and assignments
+                // alter the expectation of correct indentation. Skip them.
+                // TODO: Add appropriate configuration options for variable
+                // declarations and assignments.
+                if (getParentNodeByType(node, "VariableDeclarator", ["FunctionExpression", "ArrowFunctionExpression"])) {
+                    return;
+                }
+
+                if (getParentNodeByType(node, "AssignmentExpression", ["FunctionExpression"])) {
+                    return;
+                }
+
+                const propertyIndent = getNodeIndent(node).goodChar + indentSize * options.MemberExpression;
+
+                const checkNodes = [node.property];
+
+                const dot = context.getTokenBefore(node.property);
+
+                if (dot.type === "Punctuator" && dot.value === ".") {
+                    checkNodes.push(dot);
+                }
+
+                checkNodesIndent(checkNodes, propertyIndent);
+            },
+
+            SwitchStatement(node) {
+
+                // Switch is not a 'BlockStatement'
+                const switchIndent = getNodeIndent(node).goodChar;
+                const caseIndent = expectedCaseIndent(node, switchIndent);
+
+                checkNodesIndent(node.cases, caseIndent);
+
+
+                checkLastNodeLineIndent(node, switchIndent);
+            },
+
+            SwitchCase(node) {
+
+                // Skip inline cases
+                if (isSingleLineNode(node)) {
+                    return;
+                }
+                const caseIndent = expectedCaseIndent(node);
+
+                checkNodesIndent(node.consequent, caseIndent + indentSize);
+            },
+
+            FunctionDeclaration(node) {
+                if (isSingleLineNode(node)) {
+                    return;
+                }
+                if (options.FunctionDeclaration.parameters === "first" && node.params.length) {
+                    checkNodesIndent(node.params.slice(1), node.params[0].loc.start.column);
+                } else if (options.FunctionDeclaration.parameters !== null) {
+                    checkNodesIndent(node.params, getNodeIndent(node).goodChar + indentSize * options.FunctionDeclaration.parameters);
+                }
+            },
+
+            FunctionExpression(node) {
+                if (isSingleLineNode(node)) {
+                    return;
+                }
+                if (options.FunctionExpression.parameters === "first" && node.params.length) {
+                    checkNodesIndent(node.params.slice(1), node.params[0].loc.start.column);
+                } else if (options.FunctionExpression.parameters !== null) {
+                    checkNodesIndent(node.params, getNodeIndent(node).goodChar + indentSize * options.FunctionExpression.parameters);
+                }
+            },
+
+            ReturnStatement(node) {
+                if (isSingleLineNode(node)) {
+                    return;
+                }
+
+                const firstLineIndent = getNodeIndent(node).goodChar;
+
+                // in case if return statement is wrapped in parenthesis
+                if (isWrappedInParenthesis(node)) {
+                    checkLastReturnStatementLineIndent(node, firstLineIndent);
+                } else {
+                    checkNodeIndent(node, firstLineIndent);
+                }
+            },
+
+            CallExpression(node) {
+                if (isSingleLineNode(node)) {
+                    return;
+                }
+                if (options.CallExpression.arguments === "first" && node.arguments.length) {
+                    checkNodesIndent(node.arguments.slice(1), node.arguments[0].loc.start.column);
+                } else if (options.CallExpression.arguments !== null) {
+                    checkNodesIndent(node.arguments, getNodeIndent(node).goodChar + indentSize * options.CallExpression.arguments);
+                }
+            }
+
+        };
+
+    }
+};

--- a/tests/fixtures/rules/indent-legacy/indent-invalid-fixture-1.js
+++ b/tests/fixtures/rules/indent-legacy/indent-invalid-fixture-1.js
@@ -1,0 +1,530 @@
+if (a) {
+  var b = c;
+  var d = e
+    * f;
+    var e = f; // <-
+// NO ERROR: DON'T VALIDATE EMPTY OR COMMENT ONLY LINES
+  function g() {
+    if (h) {
+      var i = j;
+      } // <-
+    } // <-
+
+  while (k) l++;
+  while (m) {
+  n--; // ->
+    } // <-
+
+  do {
+    o = p +
+  q; // NO ERROR: DON'T VALIDATE MULTILINE STATEMENTS
+    o = p +
+    q;
+    } while(r); // <-
+
+  for (var s in t) {
+    u++;
+  }
+
+    for (;;) { // <- Fix this when issue #3737 gets resolved
+      v++; // <-
+  }
+
+  if ( w ) {
+    x++;
+  } else if (y) {
+      z++; // <-
+    aa++;
+    } else { // <-
+  bb++; // ->
+} // ->
+}
+
+/**/var b; // NO ERROR: single line multi-line comments followed by code is OK
+/*
+ *
+ */ var b; // ERROR: multi-line comments followed by code is not OK
+
+var arr = [
+  a,
+  b,
+  c,
+  function (){
+    d
+    }, // <-
+  {},
+  {
+    a: b,
+    c: d,
+    d: e
+  },
+  [
+    f,
+    g,
+    h,
+    i
+  ],
+  [j]
+];
+
+var obj = {
+  a: {
+    b: {
+      c: d,
+      e: f,
+      g: h +
+    i // NO ERROR: DON'T VALIDATE MULTILINE STATEMENTS
+    }
+  },
+  g: [
+    h,
+    i,
+    j,
+    k
+  ]
+};
+
+var arrObject = {a:[
+  a,
+  b, // NO ERROR: INDENT ONCE WHEN MULTIPLE INDENTED EXPRESSIONS ARE ON SAME LINE
+  c
+]};
+
+var objArray = [{
+  a: b,
+  b: c, // NO ERROR: INDENT ONCE WHEN MULTIPLE INDENTED EXPRESSIONS ARE ON SAME LINE
+  c: d
+}];
+
+var arrArray = [[
+  a,
+  b, // NO ERROR: INDENT ONCE WHEN MULTIPLE INDENTED EXPRESSIONS ARE ON SAME LINE
+  c
+]];
+
+var objObject = {a:{
+  a: b,
+  b: c, // NO ERROR: INDENT ONCE WHEN MULTIPLE INDENTED EXPRESSIONS ARE ON SAME LINE
+  c: d
+}};
+
+
+switch (a) {
+  case 'a':
+  var a = 'b'; // ->
+    break;
+  case 'b':
+    var a = 'b';
+    break;
+  case 'c':
+      var a = 'b'; // <-
+    break;
+  case 'd':
+    var a = 'b';
+  break; // ->
+  case 'f':
+    var a = 'b';
+    break;
+  case 'g':     {
+    var a = 'b';
+    break;
+  }
+  case 'z':
+  default:
+      break; // <-
+}
+
+a.b('hi')
+   .c(a.b()) // <-
+   .d(); // <-
+
+if ( a ) {
+  if ( b ) {
+d.e(f) // ->
+  .g() // NO ERROR: DON'T VALIDATE MULTILINE STATEMENTS
+  .h(); // NO ERROR: DON'T VALIDATE MULTILINE STATEMENTS
+
+    i.j(m)
+      .k() // NO ERROR: DON'T VALIDATE MULTILINE STATEMENTS
+      .l(); // NO ERROR: DON'T VALIDATE MULTILINE STATEMENTS
+
+      n.o(p) // <-
+        .q() // NO ERROR: DON'T VALIDATE MULTILINE STATEMENTS
+        .r(); // NO ERROR: DON'T VALIDATE MULTILINE STATEMENTS
+  }
+}
+
+var a = b,
+  c = function () {
+  h = i; // ->
+    j = k;
+      l = m; // <-
+  },
+  e = {
+    f: g,
+    n: o,
+    p: q
+  },
+  r = [
+    s,
+    t,
+    u
+  ];
+
+var a = function () {
+b = c; // ->
+  d = e;
+    f = g; // <-
+};
+
+function c(a, b) {
+  if (a || (a &&
+            b)) { // NO ERROR: DON'T VALIDATE MULTILINE STATEMENTS
+    return d;
+  }
+}
+
+if ( a
+  || b ) {
+var x; // ->
+  var c,
+    d = function(a,
+                  b) {
+    a; // ->
+      b;
+        c; // <-
+    }
+}
+
+
+a({
+  d: 1
+});
+
+a(
+1
+);
+
+a(
+  b({
+    d: 1
+  })
+);
+
+a(
+  b(
+    c({
+      d: 1,
+      e: 1,
+      f: 1
+    })
+  )
+);
+
+a({ d: 1 });
+
+aa(
+   b({ // NO ERROR: aligned with previous opening paren
+     c: d,
+     e: f,
+     f: g
+   })
+);
+
+aaaaaa(
+  b,
+  c,
+  {
+    d: a
+  }
+);
+
+a(b, c,
+  d, e,
+    f, g  // NO ERROR: alignment of arguments of callExpression not checked
+  );  // NO ERROR: this has nothing to do with indentation, this is CallExpression spacing
+
+a(
+  ); // NO ERROR: this has nothing to do with indentation, this is CallExpression spacing
+
+aaaaaa(
+  b,
+  c, {
+    d: a
+  }, {
+    e: f
+  }
+);
+
+a.b()
+  .c(function(){
+    var a;
+  }).d.e;
+
+if (a == 'b') {
+  if (c && d) e = f
+  else g('h').i('j')
+}
+
+a = function (b, c) {
+  return a(function () {
+    var d = e
+    var f = g
+    var h = i
+
+    if (!j) k('l', (m = n))
+    if (o) p
+    else if (q) r
+  })
+}
+
+var a = function() {
+  "b"
+    .replace(/a/, "a")
+    .replace(/bc?/, function(e) {
+      return "b" + (e.f === 2 ? "c" : "f");
+    })
+    .replace(/d/, "d");
+};
+
+$(b)
+  .on('a', 'b', function() { $(c).e('f'); })
+  .on('g', 'h', function() { $(i).j('k'); });
+
+a
+  .b('c',
+           'd'); // NO ERROR: this has nothing to do with indentation, this is CallExpression spacing
+
+a
+  .b('c', [ 'd', function(e) {
+    e++;
+  }]);
+
+var a = function() {
+      a++;
+    b++; // <-
+        c++; // <-
+    },
+    b;
+
+var b = [
+      a,
+      b,
+      c
+    ],
+    c;
+
+var c = {
+      a: 1,
+      b: 2,
+      c: 3
+    },
+    d;
+
+// holes in arrays indentation
+x = [
+ 1,
+ 1,
+ 1,
+ 1,
+ 1,
+ 1,
+ 1,
+ 1,
+ 1,
+ 1
+];
+
+try {
+  a++;
+    b++; // <-
+c++; // ->
+} catch (d) {
+  e++;
+    f++; // <-
+g++; // ->
+} finally {
+  h++;
+    i++; // <-
+j++; // ->
+}
+
+if (array.some(function(){
+  return true;
+})) {
+a++; // ->
+  b++;
+    c++; // <-
+}
+
+var a = b.c(function() {
+      d++;
+    }),
+    e;
+
+switch (true) {
+  case (a
+  && b):
+case (c // ->
+&& d):
+    case (e // <-
+    && f):
+  case (g
+&& h):
+      var i = j; // <-
+    var k = l;
+  var m = n; // ->
+}
+
+if (a) {
+  b();
+}
+else {
+c(); // ->
+  d();
+    e(); // <-
+}
+
+if (a) b();
+else {
+c(); // ->
+  d();
+    e(); // <-
+}
+
+if (a) {
+  b();
+} else c();
+
+if (a) {
+  b();
+}
+else c();
+
+a();
+
+if( "very very long multi line" +
+      "with weird indentation" ) {
+  b();
+a(); // ->
+    c(); // <-
+}
+
+a( "very very long multi line" +
+    "with weird indentation", function() {
+  b();
+a(); // ->
+    c(); // <-
+});
+
+a = function(content, dom) {
+  b();
+    c(); // <-
+d(); // ->
+};
+
+a = function(content, dom) {
+      b();
+        c(); // <-
+    d(); // ->
+    };
+
+a = function(content, dom) {
+    b(); // ->
+    };
+
+a = function(content, dom) {
+b(); // ->
+    };
+
+a('This is a terribly long description youll ' +
+  'have to read', function () {
+  b();
+  c();
+});
+
+if (
+  array.some(function(){
+    return true;
+  })
+) {
+a++; // ->
+  b++;
+    c++; // <-
+}
+
+function c(d) {
+  return {
+    e: function(f, g) {
+    }
+  };
+}
+
+function a(b) {
+  switch(x) {
+    case 1:
+      if (foo) {
+        return 5;
+      }
+  }
+}
+
+function a(b) {
+  switch(x) {
+    case 1:
+      c;
+  }
+}
+
+function a(b) {
+  switch(x) {
+    case 1: c;
+  }
+}
+
+function test() {
+  var a = 1;
+  {
+    a();
+  }
+}
+
+{
+  a();
+}
+
+function a(b) {
+  switch(x) {
+    case 1:
+        {
+        a();
+      }
+      break;
+    default:
+      {
+        b();
+        }
+  }
+}
+
+switch (a) {
+  default:
+    if (b)
+      c();
+}
+
+function test(x) {
+  switch (x) {
+    case 1:
+      return function() {
+        var a = 5;
+        return a;
+      };
+  }
+}
+
+switch (a) {
+  default:
+    if (b)
+      c();
+}

--- a/tests/fixtures/rules/indent-legacy/indent-valid-fixture-1.js
+++ b/tests/fixtures/rules/indent-legacy/indent-valid-fixture-1.js
@@ -1,0 +1,530 @@
+if (a) {
+  var b = c;
+  var d = e
+    * f;
+  var e = f; // <-
+// NO ERROR: DON'T VALIDATE EMPTY OR COMMENT ONLY LINES
+  function g() {
+    if (h) {
+      var i = j;
+    } // <-
+  } // <-
+
+  while (k) l++;
+  while (m) {
+    n--; // ->
+  } // <-
+
+  do {
+    o = p +
+  q; // NO ERROR: DON'T VALIDATE MULTILINE STATEMENTS
+    o = p +
+    q;
+  } while(r); // <-
+
+  for (var s in t) {
+    u++;
+  }
+
+  for (;;) { // <- Fix this when issue #3737 gets resolved
+      v++; // <-
+    }
+
+  if ( w ) {
+    x++;
+  } else if (y) {
+    z++; // <-
+    aa++;
+  } else { // <-
+    bb++; // ->
+  } // ->
+}
+
+/**/var b; // NO ERROR: single line multi-line comments followed by code is OK
+/*
+ *
+*/ var b; // ERROR: multi-line comments followed by code is not OK
+
+var arr = [
+  a,
+  b,
+  c,
+  function (){
+    d
+  }, // <-
+  {},
+  {
+    a: b,
+    c: d,
+    d: e
+  },
+  [
+    f,
+    g,
+    h,
+    i
+  ],
+  [j]
+];
+
+var obj = {
+  a: {
+    b: {
+      c: d,
+      e: f,
+      g: h +
+    i // NO ERROR: DON'T VALIDATE MULTILINE STATEMENTS
+    }
+  },
+  g: [
+    h,
+    i,
+    j,
+    k
+  ]
+};
+
+var arrObject = {a:[
+  a,
+  b, // NO ERROR: INDENT ONCE WHEN MULTIPLE INDENTED EXPRESSIONS ARE ON SAME LINE
+  c
+]};
+
+var objArray = [{
+  a: b,
+  b: c, // NO ERROR: INDENT ONCE WHEN MULTIPLE INDENTED EXPRESSIONS ARE ON SAME LINE
+  c: d
+}];
+
+var arrArray = [[
+  a,
+  b, // NO ERROR: INDENT ONCE WHEN MULTIPLE INDENTED EXPRESSIONS ARE ON SAME LINE
+  c
+]];
+
+var objObject = {a:{
+  a: b,
+  b: c, // NO ERROR: INDENT ONCE WHEN MULTIPLE INDENTED EXPRESSIONS ARE ON SAME LINE
+  c: d
+}};
+
+
+switch (a) {
+  case 'a':
+    var a = 'b'; // ->
+    break;
+  case 'b':
+    var a = 'b';
+    break;
+  case 'c':
+    var a = 'b'; // <-
+    break;
+  case 'd':
+    var a = 'b';
+    break; // ->
+  case 'f':
+    var a = 'b';
+    break;
+  case 'g':     {
+    var a = 'b';
+    break;
+  }
+  case 'z':
+  default:
+    break; // <-
+}
+
+a.b('hi')
+  .c(a.b()) // <-
+  .d(); // <-
+
+if ( a ) {
+  if ( b ) {
+    d.e(f) // ->
+  .g() // NO ERROR: DON'T VALIDATE MULTILINE STATEMENTS
+  .h(); // NO ERROR: DON'T VALIDATE MULTILINE STATEMENTS
+
+    i.j(m)
+      .k() // NO ERROR: DON'T VALIDATE MULTILINE STATEMENTS
+      .l(); // NO ERROR: DON'T VALIDATE MULTILINE STATEMENTS
+
+    n.o(p) // <-
+        .q() // NO ERROR: DON'T VALIDATE MULTILINE STATEMENTS
+        .r(); // NO ERROR: DON'T VALIDATE MULTILINE STATEMENTS
+  }
+}
+
+var a = b,
+  c = function () {
+    h = i; // ->
+    j = k;
+    l = m; // <-
+  },
+  e = {
+    f: g,
+    n: o,
+    p: q
+  },
+  r = [
+    s,
+    t,
+    u
+  ];
+
+var a = function () {
+  b = c; // ->
+  d = e;
+  f = g; // <-
+};
+
+function c(a, b) {
+  if (a || (a &&
+            b)) { // NO ERROR: DON'T VALIDATE MULTILINE STATEMENTS
+    return d;
+  }
+}
+
+if ( a
+  || b ) {
+  var x; // ->
+  var c,
+    d = function(a,
+                  b) {
+      a; // ->
+      b;
+      c; // <-
+    }
+}
+
+
+a({
+  d: 1
+});
+
+a(
+1
+);
+
+a(
+  b({
+    d: 1
+  })
+);
+
+a(
+  b(
+    c({
+      d: 1,
+      e: 1,
+      f: 1
+    })
+  )
+);
+
+a({ d: 1 });
+
+aa(
+   b({ // NO ERROR: aligned with previous opening paren
+     c: d,
+     e: f,
+     f: g
+   })
+);
+
+aaaaaa(
+  b,
+  c,
+  {
+    d: a
+  }
+);
+
+a(b, c,
+  d, e,
+    f, g  // NO ERROR: alignment of arguments of callExpression not checked
+  );  // NO ERROR: this has nothing to do with indentation, this is CallExpression spacing
+
+a(
+  ); // NO ERROR: this has nothing to do with indentation, this is CallExpression spacing
+
+aaaaaa(
+  b,
+  c, {
+    d: a
+  }, {
+    e: f
+  }
+);
+
+a.b()
+  .c(function(){
+    var a;
+  }).d.e;
+
+if (a == 'b') {
+  if (c && d) e = f
+  else g('h').i('j')
+}
+
+a = function (b, c) {
+  return a(function () {
+    var d = e
+    var f = g
+    var h = i
+
+    if (!j) k('l', (m = n))
+    if (o) p
+    else if (q) r
+  })
+}
+
+var a = function() {
+  "b"
+    .replace(/a/, "a")
+    .replace(/bc?/, function(e) {
+      return "b" + (e.f === 2 ? "c" : "f");
+    })
+    .replace(/d/, "d");
+};
+
+$(b)
+  .on('a', 'b', function() { $(c).e('f'); })
+  .on('g', 'h', function() { $(i).j('k'); });
+
+a
+  .b('c',
+           'd'); // NO ERROR: this has nothing to do with indentation, this is CallExpression spacing
+
+a
+  .b('c', [ 'd', function(e) {
+    e++;
+  }]);
+
+var a = function() {
+    a++;
+    b++; // <-
+    c++; // <-
+  },
+  b;
+
+var b = [
+    a,
+    b,
+    c
+  ],
+  c;
+
+var c = {
+    a: 1,
+    b: 2,
+    c: 3
+  },
+  d;
+
+// holes in arrays indentation
+x = [
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1,
+  1
+];
+
+try {
+  a++;
+  b++; // <-
+  c++; // ->
+} catch (d) {
+  e++;
+  f++; // <-
+  g++; // ->
+} finally {
+  h++;
+  i++; // <-
+  j++; // ->
+}
+
+if (array.some(function(){
+  return true;
+})) {
+  a++; // ->
+  b++;
+  c++; // <-
+}
+
+var a = b.c(function() {
+    d++;
+  }),
+  e;
+
+switch (true) {
+  case (a
+  && b):
+  case (c // ->
+&& d):
+  case (e // <-
+    && f):
+  case (g
+&& h):
+    var i = j; // <-
+    var k = l;
+    var m = n; // ->
+}
+
+if (a) {
+  b();
+}
+else {
+  c(); // ->
+  d();
+  e(); // <-
+}
+
+if (a) b();
+else {
+  c(); // ->
+  d();
+  e(); // <-
+}
+
+if (a) {
+  b();
+} else c();
+
+if (a) {
+  b();
+}
+else c();
+
+a();
+
+if( "very very long multi line" +
+      "with weird indentation" ) {
+  b();
+  a(); // ->
+  c(); // <-
+}
+
+a( "very very long multi line" +
+    "with weird indentation", function() {
+  b();
+  a(); // ->
+  c(); // <-
+});
+
+a = function(content, dom) {
+  b();
+  c(); // <-
+  d(); // ->
+};
+
+a = function(content, dom) {
+  b();
+  c(); // <-
+  d(); // ->
+};
+
+a = function(content, dom) {
+  b(); // ->
+};
+
+a = function(content, dom) {
+  b(); // ->
+};
+
+a('This is a terribly long description youll ' +
+  'have to read', function () {
+  b();
+  c();
+});
+
+if (
+  array.some(function(){
+    return true;
+  })
+) {
+  a++; // ->
+  b++;
+  c++; // <-
+}
+
+function c(d) {
+  return {
+    e: function(f, g) {
+    }
+  };
+}
+
+function a(b) {
+  switch(x) {
+    case 1:
+      if (foo) {
+        return 5;
+      }
+  }
+}
+
+function a(b) {
+  switch(x) {
+    case 1:
+      c;
+  }
+}
+
+function a(b) {
+  switch(x) {
+    case 1: c;
+  }
+}
+
+function test() {
+  var a = 1;
+  {
+    a();
+  }
+}
+
+{
+  a();
+}
+
+function a(b) {
+  switch(x) {
+    case 1:
+      {
+          a();
+        }
+      break;
+    default:
+      {
+        b();
+      }
+  }
+}
+
+switch (a) {
+  default:
+    if (b)
+      c();
+}
+
+function test(x) {
+  switch (x) {
+    case 1:
+      return function() {
+        var a = 5;
+        return a;
+      };
+  }
+}
+
+switch (a) {
+  default:
+    if (b)
+      c();
+}

--- a/tests/lib/rules/indent-legacy.js
+++ b/tests/lib/rules/indent-legacy.js
@@ -1,0 +1,3939 @@
+/**
+ * @fileoverview This option sets a specific tab width for your code
+ * @author Dmitriy Shekhovtsov
+ * @author Gyandeep Singh
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../lib/rules/indent-legacy"),
+    RuleTester = require("../../../lib/testers/rule-tester");
+const fs = require("fs");
+const path = require("path");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const fixture = fs.readFileSync(path.join(__dirname, "../../fixtures/rules/indent-legacy/indent-invalid-fixture-1.js"), "utf8");
+const fixedFixture = fs.readFileSync(path.join(__dirname, "../../fixtures/rules/indent-legacy/indent-valid-fixture-1.js"), "utf8");
+
+/**
+ * Create error message object for failure cases with a single 'found' indentation type
+ * @param {string} indentType indent type of string or tab
+ * @param {array} errors error info
+ * @returns {Object} returns the error messages collection
+ * @private
+ */
+function expectedErrors(indentType, errors) {
+    if (Array.isArray(indentType)) {
+        errors = indentType;
+        indentType = "space";
+    }
+
+    if (!errors[0].length) {
+        errors = [errors];
+    }
+
+    return errors.map(err => {
+        let message;
+
+        if (typeof err[1] === "string" && typeof err[2] === "string") {
+            message = `Expected indentation of ${err[1]} but found ${err[2]}.`;
+        } else {
+            const chars = indentType + (err[1] === 1 ? "" : "s");
+
+            message = `Expected indentation of ${err[1]} ${chars} but found ${err[2]}.`;
+        }
+        return { message, type: err[3], line: err[0] };
+    });
+}
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("indent-legacy", rule, {
+    valid: [
+        {
+            code:
+            "bridge.callHandler(\n" +
+            "  'getAppVersion', 'test23', function(responseData) {\n" +
+            "    window.ah.mobileAppVersion = responseData;\n" +
+            "  }\n" +
+            ");\n",
+            options: [2]
+        },
+        {
+            code:
+            "var a = [\n" +
+            "  , /*{\n" +
+            "  }, */{\n" +
+            "    name: 'foo',\n" +
+            "  }\n" +
+            "];\n",
+            options: [2]
+        },
+        {
+            code:
+            "bridge.callHandler(\n" +
+            "  'getAppVersion', 'test23', function(responseData) {\n" +
+            "    window.ah.mobileAppVersion = responseData;\n" +
+            "  });\n",
+            options: [2]
+        },
+        {
+            code:
+            "bridge.callHandler(\n" +
+            "  'getAppVersion',\n" +
+            "  null,\n" +
+            "  function responseCallback(responseData) {\n" +
+            "    window.ah.mobileAppVersion = responseData;\n" +
+            "  }\n" +
+            ");\n",
+            options: [2]
+        },
+        {
+            code:
+            "bridge.callHandler(\n" +
+            "  'getAppVersion',\n" +
+            "  null,\n" +
+            "  function responseCallback(responseData) {\n" +
+            "    window.ah.mobileAppVersion = responseData;\n" +
+            "  });\n",
+            options: [2]
+        },
+        {
+            code:
+            "function doStuff(keys) {\n" +
+            "    _.forEach(\n" +
+            "        keys,\n" +
+            "        key => {\n" +
+            "            doSomething(key);\n" +
+            "        }\n" +
+            "   );\n" +
+            "}\n",
+            options: [4],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code:
+            "example(\n" +
+            "    function () {\n" +
+            "        console.log('example');\n" +
+            "    }\n" +
+            ");\n",
+            options: [4]
+        },
+        {
+            code:
+            "let foo = somethingList\n" +
+            "    .filter(x => {\n" +
+            "        return x;\n" +
+            "    })\n" +
+            "    .map(x => {\n" +
+            "        return 100 * x;\n" +
+            "    });\n",
+            options: [4],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code:
+            "var x = 0 &&\n" +
+            "    {\n" +
+            "        a: 1,\n" +
+            "        b: 2\n" +
+            "    };",
+            options: [4]
+        },
+        {
+            code:
+            "var x = 0 &&\n" +
+            "\t{\n" +
+            "\t\ta: 1,\n" +
+            "\t\tb: 2\n" +
+            "\t};",
+            options: ["tab"]
+        },
+        {
+            code:
+            "var x = 0 &&\n" +
+            "    {\n" +
+            "        a: 1,\n" +
+            "        b: 2\n" +
+            "    }||\n" +
+            "    {\n" +
+            "        c: 3,\n" +
+            "        d: 4\n" +
+            "    };",
+            options: [4]
+        },
+        {
+            code:
+            "var x = [\n" +
+            "    'a',\n" +
+            "    'b',\n" +
+            "    'c'\n" +
+            "];",
+            options: [4]
+        },
+        {
+            code:
+            "var x = ['a',\n" +
+            "    'b',\n" +
+            "    'c',\n" +
+            "];",
+            options: [4]
+        },
+        {
+            code:
+            "var x = 0 && 1;",
+            options: [4]
+        },
+        {
+            code:
+            "var x = 0 && { a: 1, b: 2 };",
+            options: [4]
+        },
+        {
+            code:
+            "var x = 0 &&\n" +
+            "    (\n" +
+            "        1\n" +
+            "    );",
+            options: [4]
+        },
+        {
+            code:
+            "var x = 0 && { a: 1, b: 2 };",
+            options: [4]
+        },
+        {
+            code:
+            "require('http').request({hostname: 'localhost',\n" +
+            "  port: 80}, function(res) {\n" +
+            "  res.end();\n" +
+            "});\n",
+            options: [2]
+        },
+        {
+            code:
+            "function test() {\n" +
+            "  return client.signUp(email, PASSWORD, { preVerified: true })\n" +
+            "    .then(function (result) {\n" +
+            "      // hi\n" +
+            "    })\n" +
+            "    .then(function () {\n" +
+            "      return FunctionalHelpers.clearBrowserState(self, {\n" +
+            "        contentServer: true,\n" +
+            "        contentServer1: true\n" +
+            "      });\n" +
+            "    });\n" +
+            "}",
+            options: [2]
+        },
+        {
+            code:
+            "it('should... some lengthy test description that is forced to be' +\n" +
+            "  'wrapped into two lines since the line length limit is set', () => {\n" +
+            "  expect(true).toBe(true);\n" +
+            "});\n",
+            options: [2],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code:
+            "function test() {\n" +
+            "    return client.signUp(email, PASSWORD, { preVerified: true })\n" +
+            "        .then(function (result) {\n" +
+            "            var x = 1;\n" +
+            "            var y = 1;\n" +
+            "        }, function(err){\n" +
+            "            var o = 1 - 2;\n" +
+            "            var y = 1 - 2;\n" +
+            "            return true;\n" +
+            "        })\n" +
+            "}",
+            options: [4]
+        },
+        {
+            code:
+            "function test() {\n" +
+            "    return client.signUp(email, PASSWORD, { preVerified: true })\n" +
+            "    .then(function (result) {\n" +
+            "        var x = 1;\n" +
+            "        var y = 1;\n" +
+            "    }, function(err){\n" +
+            "        var o = 1 - 2;\n" +
+            "        var y = 1 - 2;\n" +
+            "        return true;\n" +
+            "    });\n" +
+            "}",
+            options: [4, { MemberExpression: 0 }]
+        },
+
+        {
+            code:
+            "// hi",
+            options: [2, { VariableDeclarator: 1, SwitchCase: 1 }]
+        },
+        {
+            code:
+            "var Command = function() {\n" +
+            "  var fileList = [],\n" +
+            "      files = []\n" +
+            "\n" +
+            "  files.concat(fileList)\n" +
+            "};\n",
+            options: [2, { VariableDeclarator: { var: 2, let: 2, const: 3 } }]
+        },
+        {
+            code:
+                "  ",
+            options: [2, { VariableDeclarator: 1, SwitchCase: 1 }]
+        },
+        {
+            code:
+            "if(data) {\n" +
+            "  console.log('hi');\n" +
+            "  b = true;};",
+            options: [2, { VariableDeclarator: 1, SwitchCase: 1 }]
+        },
+        {
+            code:
+            "foo = () => {\n" +
+            "  console.log('hi');\n" +
+            "  return true;};",
+            options: [2, { VariableDeclarator: 1, SwitchCase: 1 }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code:
+            "function test(data) {\n" +
+            "  console.log('hi');\n" +
+            "  return true;};",
+            options: [2, { VariableDeclarator: 1, SwitchCase: 1 }]
+        },
+        {
+            code:
+            "var test = function(data) {\n" +
+            "  console.log('hi');\n" +
+            "};",
+            options: [2, { VariableDeclarator: 1, SwitchCase: 1 }]
+        },
+        {
+            code:
+            "arr.forEach(function(data) {\n" +
+            "  otherdata.forEach(function(zero) {\n" +
+            "    console.log('hi');\n" +
+            "  }) });",
+            options: [2, { VariableDeclarator: 1, SwitchCase: 1 }]
+        },
+        {
+            code:
+            "a = [\n" +
+            "    ,3\n" +
+            "]",
+            options: [4, { VariableDeclarator: 1, SwitchCase: 1 }]
+        },
+        {
+            code:
+            "[\n" +
+            "  ['gzip', 'gunzip'],\n" +
+            "  ['gzip', 'unzip'],\n" +
+            "  ['deflate', 'inflate'],\n" +
+            "  ['deflateRaw', 'inflateRaw'],\n" +
+            "].forEach(function(method) {\n" +
+            "  console.log(method);\n" +
+            "});\n",
+            options: [2, { SwitchCase: 1, VariableDeclarator: 2 }]
+        },
+        {
+            code:
+            "test(123, {\n" +
+            "    bye: {\n" +
+            "        hi: [1,\n" +
+            "            {\n" +
+            "                b: 2\n" +
+            "            }\n" +
+            "        ]\n" +
+            "    }\n" +
+            "});",
+            options: [4, { VariableDeclarator: 1, SwitchCase: 1 }]
+        },
+        {
+            code:
+            "var xyz = 2,\n" +
+            "    lmn = [\n" +
+            "        {\n" +
+            "            a: 1\n" +
+            "        }\n" +
+            "    ];",
+            options: [4, { VariableDeclarator: 1, SwitchCase: 1 }]
+        },
+        {
+            code:
+            "lmn = [{\n" +
+            "    a: 1\n" +
+            "},\n" +
+            "{\n" +
+            "    b: 2\n" +
+            "}," +
+            "{\n" +
+            "    x: 2\n" +
+            "}];",
+            options: [4, { VariableDeclarator: 1, SwitchCase: 1 }]
+        },
+        {
+            code:
+            "abc({\n" +
+            "    test: [\n" +
+            "        [\n" +
+            "            c,\n" +
+            "            xyz,\n" +
+            "            2\n" +
+            "        ].join(',')\n" +
+            "    ]\n" +
+            "});",
+            options: [4, { VariableDeclarator: 1, SwitchCase: 1 }]
+        },
+        {
+            code:
+            "abc = {\n" +
+            "  test: [\n" +
+            "    [\n" +
+            "      c,\n" +
+            "      xyz,\n" +
+            "      2\n" +
+            "    ]\n" +
+            "  ]\n" +
+            "};",
+            options: [2, { VariableDeclarator: 1, SwitchCase: 1 }]
+        },
+        {
+            code:
+            "abc(\n" +
+            "  {\n" +
+            "    a: 1,\n" +
+            "    b: 2\n" +
+            "  }\n" +
+            ");",
+            options: [2, { VariableDeclarator: 1, SwitchCase: 1 }]
+        },
+        {
+            code:
+            "abc({\n" +
+            "    a: 1,\n" +
+            "    b: 2\n" +
+            "});",
+            options: [4, { VariableDeclarator: 1, SwitchCase: 1 }]
+        },
+        {
+            code:
+            "var abc = \n" +
+            "  [\n" +
+            "    c,\n" +
+            "    xyz,\n" +
+            "    {\n" +
+            "      a: 1,\n" +
+            "      b: 2\n" +
+            "    }\n" +
+            "  ];",
+            options: [2, { VariableDeclarator: 1, SwitchCase: 1 }]
+        },
+        {
+            code:
+            "var abc = [\n" +
+            "  c,\n" +
+            "  xyz,\n" +
+            "  {\n" +
+            "    a: 1,\n" +
+            "    b: 2\n" +
+            "  }\n" +
+            "];",
+            options: [2, { VariableDeclarator: 1, SwitchCase: 1 }]
+        },
+        {
+            code:
+            "var abc = 5,\n" +
+            "    c = 2,\n" +
+            "    xyz = \n" +
+            "    {\n" +
+            "      a: 1,\n" +
+            "      b: 2\n" +
+            "    };",
+            options: [2, { VariableDeclarator: 2, SwitchCase: 1 }]
+        },
+        {
+            code:
+            "var abc = \n" +
+            "    {\n" +
+            "      a: 1,\n" +
+            "      b: 2\n" +
+            "    };",
+            options: [2, { VariableDeclarator: 2, SwitchCase: 1 }]
+        },
+        {
+            code:
+            "var a = new abc({\n" +
+            "        a: 1,\n" +
+            "        b: 2\n" +
+            "    }),\n" +
+            "    b = 2;",
+            options: [4, { VariableDeclarator: 1, SwitchCase: 1 }]
+        },
+        {
+            code:
+            "var a = 2,\n" +
+            "  c = {\n" +
+            "    a: 1,\n" +
+            "    b: 2\n" +
+            "  },\n" +
+            "  b = 2;",
+            options: [2, { VariableDeclarator: 1, SwitchCase: 1 }]
+        },
+        {
+            code:
+            "var x = 2,\n" +
+            "    y = {\n" +
+            "      a: 1,\n" +
+            "      b: 2\n" +
+            "    },\n" +
+            "    b = 2;",
+            options: [2, { VariableDeclarator: 2, SwitchCase: 1 }]
+        },
+        {
+            code:
+            "var e = {\n" +
+            "      a: 1,\n" +
+            "      b: 2\n" +
+            "    },\n" +
+            "    b = 2;",
+            options: [2, { VariableDeclarator: 2, SwitchCase: 1 }]
+        },
+        {
+            code:
+            "var a = {\n" +
+            "  a: 1,\n" +
+            "  b: 2\n" +
+            "};",
+            options: [2, { VariableDeclarator: 2, SwitchCase: 1 }]
+        },
+        {
+            code:
+            "function test() {\n" +
+            "  if (true ||\n " +
+            "            false){\n" +
+            "    console.log(val);\n" +
+            "  }\n" +
+            "}",
+            options: [2, { VariableDeclarator: 2, SwitchCase: 1 }]
+        },
+        {
+            code:
+            "for (var val in obj)\n" +
+            "  if (true)\n" +
+            "    console.log(val);",
+            options: [2, { VariableDeclarator: 2, SwitchCase: 1 }]
+        },
+        {
+            code:
+            "if(true)\n" +
+            "  if (true)\n" +
+            "    if (true)\n" +
+            "      console.log(val);",
+            options: [2, { VariableDeclarator: 2, SwitchCase: 1 }]
+        },
+        {
+            code:
+            "function hi(){     var a = 1;\n" +
+            "  y++;                   x++;\n" +
+            "}",
+            options: [2, { VariableDeclarator: 2, SwitchCase: 1 }]
+        },
+        {
+            code:
+            "for(;length > index; index++)if(NO_HOLES || index in self){\n" +
+            "  x++;\n" +
+            "}",
+            options: [2, { VariableDeclarator: 2, SwitchCase: 1 }]
+        },
+        {
+            code:
+            "function test(){\n" +
+            "  switch(length){\n" +
+            "    case 1: return function(a){\n" +
+            "      return fn.call(that, a);\n" +
+            "    };\n" +
+            "  }\n" +
+            "}",
+            options: [2, { VariableDeclarator: 2, SwitchCase: 1 }]
+        },
+        {
+            code:
+            "var geometry = 2,\n" +
+            "rotate = 2;",
+            options: [2, { VariableDeclarator: 0 }]
+        },
+        {
+            code:
+            "var geometry,\n" +
+            "    rotate;",
+            options: [4, { VariableDeclarator: 1 }]
+        },
+        {
+            code:
+            "var geometry,\n" +
+            "\trotate;",
+            options: ["tab", { VariableDeclarator: 1 }]
+        },
+        {
+            code:
+            "var geometry,\n" +
+            "  rotate;",
+            options: [2, { VariableDeclarator: 1 }]
+        },
+        {
+            code:
+            "var geometry,\n" +
+            "    rotate;",
+            options: [2, { VariableDeclarator: 2 }]
+        },
+        {
+            code:
+            "let geometry,\n" +
+            "    rotate;",
+            options: [2, { VariableDeclarator: 2 }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code:
+            "const geometry = 2,\n" +
+            "    rotate = 3;",
+            options: [2, { VariableDeclarator: 2 }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code:
+            "var geometry, box, face1, face2, colorT, colorB, sprite, padding, maxWidth,\n" +
+            "  height, rotate;",
+            options: [2, { SwitchCase: 1 }]
+        },
+        {
+            code:
+            "var geometry, box, face1, face2, colorT, colorB, sprite, padding, maxWidth;",
+            options: [2, { SwitchCase: 1 }]
+        },
+        {
+            code:
+            "if (1 < 2){\n" +
+            "//hi sd \n" +
+            "}",
+            options: [2]
+        },
+        {
+            code:
+            "while (1 < 2){\n" +
+            "  //hi sd \n" +
+            "}",
+            options: [2]
+        },
+        {
+            code:
+            "while (1 < 2) console.log('hi');",
+            options: [2]
+        },
+
+        {
+            code:
+            "[a, b,\n" +
+            "    c].forEach((index) => {\n" +
+            "        index;\n" +
+            "    });\n",
+            options: [4],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code:
+            "[a, b, c].forEach((index) => {\n" +
+            "    index;\n" +
+            "});\n",
+            options: [4],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code:
+            "[a, b, c].forEach(function(index){\n" +
+            "    return index;\n" +
+            "});\n",
+            options: [4],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code:
+            "switch (x) {\n" +
+            "    case \"foo\":\n" +
+            "        a();\n" +
+            "        break;\n" +
+            "    case \"bar\":\n" +
+            "        switch (y) {\n" +
+            "            case \"1\":\n" +
+            "                break;\n" +
+            "            case \"2\":\n" +
+            "                a = 6;\n" +
+            "                break;\n" +
+            "        }\n" +
+            "    case \"test\":\n" +
+            "        break;\n" +
+            "}",
+            options: [4, { SwitchCase: 1 }]
+        },
+        {
+            code:
+            "switch (x) {\n" +
+            "        case \"foo\":\n" +
+            "            a();\n" +
+            "            break;\n" +
+            "        case \"bar\":\n" +
+            "            switch (y) {\n" +
+            "                    case \"1\":\n" +
+            "                        break;\n" +
+            "                    case \"2\":\n" +
+            "                        a = 6;\n" +
+            "                        break;\n" +
+            "            }\n" +
+            "        case \"test\":\n" +
+            "            break;\n" +
+            "}",
+            options: [4, { SwitchCase: 2 }]
+        },
+        {
+            code:
+            "switch (a) {\n" +
+            "case \"foo\":\n" +
+            "    a();\n" +
+            "    break;\n" +
+            "case \"bar\":\n" +
+            "    switch(x){\n" +
+            "    case '1':\n" +
+            "        break;\n" +
+            "    case '2':\n" +
+            "        a = 6;\n" +
+            "        break;\n" +
+            "    }\n" +
+            "}"
+        },
+        {
+            code:
+            "switch (a) {\n" +
+            "case \"foo\":\n" +
+            "    a();\n" +
+            "    break;\n" +
+            "case \"bar\":\n" +
+            "    if(x){\n" +
+            "        a = 2;\n" +
+            "    }\n" +
+            "    else{\n" +
+            "        a = 6;\n" +
+            "    }\n" +
+            "}"
+        },
+        {
+            code:
+            "switch (a) {\n" +
+            "case \"foo\":\n" +
+            "    a();\n" +
+            "    break;\n" +
+            "case \"bar\":\n" +
+            "    if(x){\n" +
+            "        a = 2;\n" +
+            "    }\n" +
+            "    else\n" +
+            "        a = 6;\n" +
+            "}"
+        },
+        {
+            code:
+            "switch (a) {\n" +
+            "case \"foo\":\n" +
+            "    a();\n" +
+            "    break;\n" +
+            "case \"bar\":\n" +
+            "    a(); break;\n" +
+            "case \"baz\":\n" +
+            "    a(); break;\n" +
+            "}"
+        },
+        {
+            code: "switch (0) {\n}"
+        },
+        {
+            code:
+            "function foo() {\n" +
+            "    var a = \"a\";\n" +
+            "    switch(a) {\n" +
+            "    case \"a\":\n" +
+            "        return \"A\";\n" +
+            "    case \"b\":\n" +
+            "        return \"B\";\n" +
+            "    }\n" +
+            "}\n" +
+            "foo();"
+        },
+        {
+            code:
+            "switch(value){\n" +
+            "    case \"1\":\n" +
+            "    case \"2\":\n" +
+            "        a();\n" +
+            "        break;\n" +
+            "    default:\n" +
+            "        a();\n" +
+            "        break;\n" +
+            "}\n" +
+            "switch(value){\n" +
+            "    case \"1\":\n" +
+            "        a();\n" +
+            "        break;\n" +
+            "    case \"2\":\n" +
+            "        break;\n" +
+            "    default:\n" +
+            "        break;\n" +
+            "}",
+            options: [4, { SwitchCase: 1 }]
+        },
+        {
+            code:
+                "var obj = {foo: 1, bar: 2};\n" +
+                "with (obj) {\n" +
+                "    console.log(foo + bar);\n" +
+                "}\n"
+        },
+        {
+            code:
+                "if (a) {\n" +
+                "    (1 + 2 + 3);\n" + // no error on this line
+                "}"
+        },
+        {
+            code:
+                "switch(value){ default: a(); break; }\n"
+        },
+        {
+            code: "import {addons} from 'react/addons'\nimport React from 'react'",
+            options: [2],
+            parserOptions: { sourceType: "module" }
+        },
+        {
+            code:
+            "var a = 1,\n" +
+            "    b = 2,\n" +
+            "    c = 3;\n",
+            options: [4]
+        },
+        {
+            code:
+            "var a = 1\n" +
+            "   ,b = 2\n" +
+            "   ,c = 3;\n",
+            options: [4]
+        },
+        {
+            code: "while (1 < 2) console.log('hi')\n",
+            options: [2]
+        },
+        {
+            code:
+                "function salutation () {\n" +
+                "  switch (1) {\n" +
+                "    case 0: return console.log('hi')\n" +
+                "    case 1: return console.log('hey')\n" +
+                "  }\n" +
+                "}\n",
+            options: [2, { SwitchCase: 1 }]
+        },
+        {
+            code:
+                "var items = [\n" +
+                "  {\n" +
+                "    foo: 'bar'\n" +
+                "  }\n" +
+                "];\n",
+            options: [2, { VariableDeclarator: 2 }]
+        },
+        {
+            code:
+                "const a = 1,\n" +
+                "      b = 2;\n" +
+                "const items1 = [\n" +
+                "  {\n" +
+                "    foo: 'bar'\n" +
+                "  }\n" +
+                "];\n" +
+                "const items2 = Items(\n" +
+                "  {\n" +
+                "    foo: 'bar'\n" +
+                "  }\n" +
+                ");\n",
+            options: [2, { VariableDeclarator: 3 }],
+            parserOptions: { ecmaVersion: 6 }
+
+        },
+        {
+            code:
+                "const geometry = 2,\n" +
+                "      rotate = 3;\n" +
+                "var a = 1,\n" +
+                "  b = 2;\n" +
+                "let light = true,\n" +
+                "    shadow = false;",
+            options: [2, { VariableDeclarator: { const: 3, let: 2 } }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code:
+            "const abc = 5,\n" +
+            "      c = 2,\n" +
+            "      xyz = \n" +
+            "      {\n" +
+            "        a: 1,\n" +
+            "        b: 2\n" +
+            "      };\n" +
+            "let abc2 = 5,\n" +
+            "  c2 = 2,\n" +
+            "  xyz2 = \n" +
+            "  {\n" +
+            "    a: 1,\n" +
+            "    b: 2\n" +
+            "  };\n" +
+            "var abc3 = 5,\n" +
+            "    c3 = 2,\n" +
+            "    xyz3 = \n" +
+            "    {\n" +
+            "      a: 1,\n" +
+            "      b: 2\n" +
+            "    };\n",
+            options: [2, { VariableDeclarator: { var: 2, const: 3 }, SwitchCase: 1 }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code:
+                "module.exports =\n" +
+                "{\n" +
+                "  'Unit tests':\n" +
+                "  {\n" +
+                "    rootPath: './',\n" +
+                "    environment: 'node',\n" +
+                "    tests:\n" +
+                "    [\n" +
+                "      'test/test-*.js'\n" +
+                "    ],\n" +
+                "    sources:\n" +
+                "    [\n" +
+                "      '*.js',\n" +
+                "      'test/**.js'\n" +
+                "    ]\n" +
+                "  }\n" +
+                "};",
+            options: [2]
+        },
+        {
+            code:
+                "var path     = require('path')\n" +
+                "  , crypto    = require('crypto')\n" +
+                "  ;\n",
+            options: [2]
+        },
+        {
+            code:
+                "var a = 1\n" +
+                "   ,b = 2\n" +
+                "   ;"
+        },
+        {
+            code:
+                "export function create (some,\n" +
+                "                        argument) {\n" +
+                "  return Object.create({\n" +
+                "    a: some,\n" +
+                "    b: argument\n" +
+                "  });\n" +
+                "};",
+            parserOptions: { sourceType: "module" },
+            options: [2]
+        },
+        {
+            code:
+                "export function create (id, xfilter, rawType,\n" +
+                "                        width=defaultWidth, height=defaultHeight,\n" +
+                "                        footerHeight=defaultFooterHeight,\n" +
+                "                        padding=defaultPadding) {\n" +
+                "  // ... function body, indented two spaces\n" +
+                "}\n",
+            parserOptions: { sourceType: "module" },
+            options: [2]
+        },
+        {
+            code:
+                "var obj = {\n" +
+                "  foo: function () {\n" +
+                "    return new p()\n" +
+                "      .then(function (ok) {\n" +
+                "        return ok;\n" +
+                "      }, function () {\n" +
+                "        // ignore things\n" +
+                "      });\n" +
+                "  }\n" +
+                "};\n",
+            options: [2]
+        },
+        {
+            code:
+                "a.b()\n" +
+                "  .c(function(){\n" +
+                "    var a;\n" +
+                "  }).d.e;\n",
+            options: [2]
+        },
+        {
+            code:
+                "const YO = 'bah',\n" +
+                "      TE = 'mah'\n" +
+                "\n" +
+                "var res,\n" +
+                "    a = 5,\n" +
+                "    b = 4\n",
+            parserOptions: { ecmaVersion: 6 },
+            options: [2, { VariableDeclarator: { var: 2, let: 2, const: 3 } }]
+        },
+        {
+            code:
+                "const YO = 'bah',\n" +
+                "      TE = 'mah'\n" +
+                "\n" +
+                "var res,\n" +
+                "    a = 5,\n" +
+                "    b = 4\n" +
+                "\n" +
+                "if (YO) console.log(TE)",
+            parserOptions: { ecmaVersion: 6 },
+            options: [2, { VariableDeclarator: { var: 2, let: 2, const: 3 } }]
+        },
+        {
+            code:
+                "var foo = 'foo',\n" +
+                "  bar = 'bar',\n" +
+                "  baz = function() {\n" +
+                "      \n" +
+                "  }\n" +
+                "\n" +
+                "function hello () {\n" +
+                "    \n" +
+                "}\n",
+            options: [2]
+        },
+        {
+            code:
+                "var obj = {\n" +
+                "  send: function () {\n" +
+                "    return P.resolve({\n" +
+                "      type: 'POST'\n" +
+                "    })\n" +
+                "      .then(function () {\n" +
+                "        return true;\n" +
+                "      }, function () {\n" +
+                "        return false;\n" +
+                "      });\n" +
+                "  }\n" +
+                "};\n",
+            options: [2]
+        },
+        {
+            code:
+                "var obj = {\n" +
+                "  send: function () {\n" +
+                "    return P.resolve({\n" +
+                "      type: 'POST'\n" +
+                "    })\n" +
+                "    .then(function () {\n" +
+                "      return true;\n" +
+                "    }, function () {\n" +
+                "      return false;\n" +
+                "    });\n" +
+                "  }\n" +
+                "};\n",
+            options: [2, { MemberExpression: 0 }]
+        },
+        {
+            code:
+                "const someOtherFunction = argument => {\n" +
+                "        console.log(argument);\n" +
+                "    },\n" +
+                "    someOtherValue = 'someOtherValue';\n",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code:
+            "[\n" +
+            "  'a',\n" +
+            "  'b'\n" +
+            "].sort().should.deepEqual([\n" +
+            "  'x',\n" +
+            "  'y'\n" +
+            "]);\n",
+            options: [2]
+        },
+        {
+            code:
+            "var a = 1,\n" +
+            "    B = class {\n" +
+            "      constructor(){}\n" +
+            "      a(){}\n" +
+            "      get b(){}\n" +
+            "    };",
+            options: [2, { VariableDeclarator: 2, SwitchCase: 1 }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code:
+            "var a = 1,\n" +
+            "    B = \n" +
+            "    class {\n" +
+            "      constructor(){}\n" +
+            "      a(){}\n" +
+            "      get b(){}\n" +
+            "    },\n" +
+            "    c = 3;",
+            options: [2, { VariableDeclarator: 2, SwitchCase: 1 }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code:
+            "class A{\n" +
+            "    constructor(){}\n" +
+            "    a(){}\n" +
+            "    get b(){}\n" +
+            "}",
+            options: [4, { VariableDeclarator: 1, SwitchCase: 1 }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code:
+            "var A = class {\n" +
+            "    constructor(){}\n" +
+            "    a(){}\n" +
+            "    get b(){}\n" +
+            "}",
+            options: [4, { VariableDeclarator: 1, SwitchCase: 1 }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code:
+            "var a = {\n" +
+            "  some: 1\n" +
+            ", name: 2\n" +
+            "};\n",
+            options: [2]
+        },
+        {
+            code:
+            "a.c = {\n" +
+            "    aa: function() {\n" +
+            "        'test1';\n" +
+            "        return 'aa';\n" +
+            "    }\n" +
+            "    , bb: function() {\n" +
+            "        return this.bb();\n" +
+            "    }\n" +
+            "};\n",
+            options: [4]
+        },
+        {
+            code:
+            "var a =\n" +
+            "{\n" +
+            "    actions:\n" +
+            "    [\n" +
+            "        {\n" +
+            "            name: 'compile'\n" +
+            "        }\n" +
+            "    ]\n" +
+            "};\n",
+            options: [4, { VariableDeclarator: 0, SwitchCase: 1 }]
+        },
+        {
+            code:
+            "var a =\n" +
+            "[\n" +
+            "    {\n" +
+            "        name: 'compile'\n" +
+            "    }\n" +
+            "];\n",
+            options: [4, { VariableDeclarator: 0, SwitchCase: 1 }]
+        },
+        {
+            code:
+            "const func = function (opts) {\n" +
+            "    return Promise.resolve()\n" +
+            "    .then(() => {\n" +
+            "        [\n" +
+            "            'ONE', 'TWO'\n" +
+            "        ].forEach(command => { doSomething(); });\n" +
+            "    });\n" +
+            "};",
+            parserOptions: { ecmaVersion: 6 },
+            options: [4, { MemberExpression: 0 }]
+        },
+        {
+            code:
+            "const func = function (opts) {\n" +
+            "    return Promise.resolve()\n" +
+            "        .then(() => {\n" +
+            "            [\n" +
+            "                'ONE', 'TWO'\n" +
+            "            ].forEach(command => { doSomething(); });\n" +
+            "        });\n" +
+            "};",
+            parserOptions: { ecmaVersion: 6 },
+            options: [4]
+        },
+        {
+            code:
+            "var haveFun = function () {\n" +
+            "    SillyFunction(\n" +
+            "        {\n" +
+            "            value: true,\n" +
+            "        },\n" +
+            "        {\n" +
+            "            _id: true,\n" +
+            "        }\n" +
+            "    );\n" +
+            "};",
+            options: [4]
+        },
+        {
+            code:
+            "var haveFun = function () {\n" +
+            "    new SillyFunction(\n" +
+            "        {\n" +
+            "            value: true,\n" +
+            "        },\n" +
+            "        {\n" +
+            "            _id: true,\n" +
+            "        }\n" +
+            "    );\n" +
+            "};",
+            options: [4]
+        },
+        {
+            code:
+            "let object1 = {\n" +
+            "  doThing() {\n" +
+            "    return _.chain([])\n" +
+            "      .map(v => (\n" +
+            "        {\n" +
+            "          value: true,\n" +
+            "        }\n" +
+            "      ))\n" +
+            "      .value();\n" +
+            "  }\n" +
+            "};",
+            parserOptions: { ecmaVersion: 6 },
+            options: [2]
+        },
+        {
+            code:
+            "class Foo\n" +
+            "  extends Bar {\n" +
+            "  baz() {}\n" +
+            "}",
+            parserOptions: { ecmaVersion: 6 },
+            options: [2]
+        },
+        {
+            code:
+            "class Foo extends\n" +
+            "  Bar {\n" +
+            "  baz() {}\n" +
+            "}",
+            parserOptions: { ecmaVersion: 6 },
+            options: [2]
+        },
+        {
+            code:
+            "fs.readdirSync(path.join(__dirname, '../rules')).forEach(name => {\n" +
+            "  files[name] = foo;\n" +
+            "});",
+            options: [2, { outerIIFEBody: 0 }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code:
+            "(function(){\n" +
+            "function foo(x) {\n" +
+            "  return x + 1;\n" +
+            "}\n" +
+            "})();",
+            options: [2, { outerIIFEBody: 0 }]
+        },
+        {
+            code:
+            "(function(){\n" +
+            "        function foo(x) {\n" +
+            "            return x + 1;\n" +
+            "        }\n" +
+            "})();",
+            options: [4, { outerIIFEBody: 2 }]
+        },
+        {
+            code:
+            "(function(x, y){\n" +
+            "function foo(x) {\n" +
+            "  return x + 1;\n" +
+            "}\n" +
+            "})(1, 2);",
+            options: [2, { outerIIFEBody: 0 }]
+        },
+        {
+            code:
+            "(function(){\n" +
+            "function foo(x) {\n" +
+            "  return x + 1;\n" +
+            "}\n" +
+            "}());",
+            options: [2, { outerIIFEBody: 0 }]
+        },
+        {
+            code:
+            "!function(){\n" +
+            "function foo(x) {\n" +
+            "  return x + 1;\n" +
+            "}\n" +
+            "}();",
+            options: [2, { outerIIFEBody: 0 }]
+        },
+        {
+            code:
+            "!function(){\n" +
+            "\t\t\tfunction foo(x) {\n" +
+            "\t\t\t\treturn x + 1;\n" +
+            "\t\t\t}\n" +
+            "}();",
+            options: ["tab", { outerIIFEBody: 3 }]
+        },
+        {
+            code:
+            "var out = function(){\n" +
+            "  function fooVar(x) {\n" +
+            "    return x + 1;\n" +
+            "  }\n" +
+            "};",
+            options: [2, { outerIIFEBody: 0 }]
+        },
+        {
+            code:
+            "var ns = function(){\n" +
+            "function fooVar(x) {\n" +
+            "  return x + 1;\n" +
+            "}\n" +
+            "}();",
+            options: [2, { outerIIFEBody: 0 }]
+        },
+        {
+            code:
+            "ns = function(){\n" +
+            "function fooVar(x) {\n" +
+            "  return x + 1;\n" +
+            "}\n" +
+            "}();",
+            options: [2, { outerIIFEBody: 0 }]
+        },
+        {
+            code:
+            "var ns = (function(){\n" +
+            "function fooVar(x) {\n" +
+            "  return x + 1;\n" +
+            "}\n" +
+            "}(x));",
+            options: [2, { outerIIFEBody: 0 }]
+        },
+        {
+            code:
+            "var ns = (function(){\n" +
+            "        function fooVar(x) {\n" +
+            "            return x + 1;\n" +
+            "        }\n" +
+            "}(x));",
+            options: [4, { outerIIFEBody: 2 }]
+        },
+        {
+            code:
+            "var obj = {\n" +
+            "  foo: function() {\n" +
+            "    return true;\n" +
+            "  }\n" +
+            "};",
+            options: [2, { outerIIFEBody: 0 }]
+        },
+        {
+            code:
+            "while (\n" +
+            "  function() {\n" +
+            "    return true;\n" +
+            "  }()) {\n" +
+            "\n" +
+            "  x = x + 1;\n" +
+            "};",
+            options: [2, { outerIIFEBody: 20 }]
+        },
+        {
+            code:
+            "(() => {\n" +
+            "function foo(x) {\n" +
+            "  return x + 1;\n" +
+            "}\n" +
+            "})();",
+            parserOptions: { ecmaVersion: 6 },
+            options: [2, { outerIIFEBody: 0 }]
+        },
+        {
+            code:
+            "function foo() {\n" +
+            "}",
+            options: ["tab", { outerIIFEBody: 0 }]
+        },
+        {
+            code:
+            ";(() => {\n" +
+            "function foo(x) {\n" +
+            "  return x + 1;\n" +
+            "}\n" +
+            "})();",
+            parserOptions: { ecmaVersion: 6 },
+            options: [2, { outerIIFEBody: 0 }]
+        },
+        {
+            code:
+            "if(data) {\n" +
+            "  console.log('hi');\n" +
+            "}",
+            options: [2, { outerIIFEBody: 0 }]
+        },
+        {
+            code:
+            "Buffer.length",
+            options: [4, { MemberExpression: 1 }]
+        },
+        {
+            code:
+            "Buffer\n" +
+            "    .indexOf('a')\n" +
+            "    .toString()",
+            options: [4, { MemberExpression: 1 }]
+        },
+        {
+            code:
+            "Buffer.\n" +
+            "    length",
+            options: [4, { MemberExpression: 1 }]
+        },
+        {
+            code:
+            "Buffer\n" +
+            "    .foo\n" +
+            "    .bar",
+            options: [4, { MemberExpression: 1 }]
+        },
+        {
+            code:
+            "Buffer\n" +
+            "\t.foo\n" +
+            "\t.bar",
+            options: ["tab", { MemberExpression: 1 }]
+        },
+        {
+            code:
+            "Buffer\n" +
+            "    .foo\n" +
+            "    .bar",
+            options: [2, { MemberExpression: 2 }]
+        },
+        {
+            code:
+            "MemberExpression\n" +
+            ".is" +
+            "  .off" +
+            "    .by" +
+            " .default();",
+            options: [4]
+        },
+        {
+            code:
+            "foo = bar.baz()\n" +
+            "        .bip();",
+            options: [4, { MemberExpression: 1 }]
+        },
+        {
+            code:
+            "if (foo) {\n" +
+            "  bar();\n" +
+            "} else if (baz) {\n" +
+            "  foobar();\n" +
+            "} else if (qux) {\n" +
+            "  qux();\n" +
+            "}",
+            options: [2]
+        },
+        {
+            code:
+            "function foo(aaa,\n" +
+            "  bbb, ccc, ddd) {\n" +
+            "    bar();\n" +
+            "}",
+            options: [2, { FunctionDeclaration: { parameters: 1, body: 2 } }]
+        },
+        {
+            code:
+            "function foo(aaa, bbb,\n" +
+            "      ccc, ddd) {\n" +
+            "  bar();\n" +
+            "}",
+            options: [2, { FunctionDeclaration: { parameters: 3, body: 1 } }]
+        },
+        {
+            code:
+            "function foo(aaa,\n" +
+            "    bbb,\n" +
+            "    ccc) {\n" +
+            "            bar();\n" +
+            "}",
+            options: [4, { FunctionDeclaration: { parameters: 1, body: 3 } }]
+        },
+        {
+            code:
+            "function foo(aaa,\n" +
+            "             bbb, ccc,\n" +
+            "             ddd, eee, fff) {\n" +
+            "  bar();\n" +
+            "}",
+            options: [2, { FunctionDeclaration: { parameters: "first", body: 1 } }]
+        },
+        {
+            code:
+            "function foo(aaa, bbb)\n" +
+            "{\n" +
+            "      bar();\n" +
+            "}",
+            options: [2, { FunctionDeclaration: { body: 3 } }]
+        },
+        {
+            code:
+            "function foo(\n" +
+            "  aaa,\n" +
+            "  bbb) {\n" +
+            "    bar();\n" +
+            "}",
+            options: [2, { FunctionDeclaration: { parameters: "first", body: 2 } }]
+        },
+        {
+            code:
+            "var foo = function(aaa,\n" +
+            "    bbb,\n" +
+            "    ccc,\n" +
+            "    ddd) {\n" +
+            "bar();\n" +
+            "}",
+            options: [2, { FunctionExpression: { parameters: 2, body: 0 } }]
+        },
+        {
+            code:
+            "var foo = function(aaa,\n" +
+            "  bbb,\n" +
+            "  ccc) {\n" +
+            "                    bar();\n" +
+            "}",
+            options: [2, { FunctionExpression: { parameters: 1, body: 10 } }]
+        },
+        {
+            code:
+            "var foo = function(aaa,\n" +
+            "                   bbb, ccc, ddd,\n" +
+            "                   eee, fff) {\n" +
+            "    bar();\n" +
+            "}",
+            options: [4, { FunctionExpression: { parameters: "first", body: 1 } }]
+        },
+        {
+            code:
+            "var foo = function(\n" +
+            "  aaa, bbb, ccc,\n" +
+            "  ddd, eee) {\n" +
+            "      bar();\n" +
+            "}",
+            options: [2, { FunctionExpression: { parameters: "first", body: 3 } }]
+        },
+        {
+            code:
+            "function foo() {\n" +
+            "  bar();\n" +
+            "  \tbaz();\n" +
+            "\t   \t\t\t  \t\t\t  \t   \tqux();\n" +
+            "}",
+            options: [2]
+        },
+        {
+            code:
+            "function foo() {\n" +
+            "  function bar() {\n" +
+            "    baz();\n" +
+            "  }\n" +
+            "}",
+            options: [2, { FunctionDeclaration: { body: 1 } }]
+        },
+        {
+            code:
+            "function foo() {\n" +
+            "  bar();\n" +
+            "   \t\t}",
+            options: [2]
+        },
+        {
+            code:
+            "function foo() {\n" +
+            "  function bar(baz,\n" +
+            "      qux) {\n" +
+            "    foobar();\n" +
+            "  }\n" +
+            "}",
+            options: [2, { FunctionDeclaration: { body: 1, parameters: 2 } }]
+        },
+        {
+            code:
+            "function foo() {\n" +
+            "  var bar = function(baz,\n" +
+            "        qux) {\n" +
+            "    foobar();\n" +
+            "  };\n" +
+            "}",
+            options: [2, { FunctionExpression: { parameters: 3 } }]
+        },
+        {
+            code:
+            "function foo() {\n" +
+            "  return (bar === 1 || bar === 2 &&\n" +
+            "    (/Function/.test(grandparent.type))) &&\n" +
+            "    directives(parent).indexOf(node) >= 0;\n" +
+            "}",
+            options: [2]
+        },
+        {
+            code:
+            "function foo() {\n" +
+            "  return (bar === 1 || bar === 2) &&\n" +
+            "    (z === 3 || z === 4);\n" +
+            "}",
+            options: [2]
+        },
+        {
+            code:
+            "function foo() {\n" +
+            "  return ((bar === 1 || bar === 2) &&\n" +
+            "    (z === 3 || z === 4)\n" +
+            "  );\n" +
+            "}",
+            options: [2]
+        },
+        {
+            code:
+            "function foo() {\n" +
+            "  return ((bar === 1 || bar === 2) &&\n" +
+            "    (z === 3 || z === 4));\n" +
+            "}",
+            options: [2]
+        }, {
+            code:
+            "foo(\n" +
+            "  bar,\n" +
+            "  baz,\n" +
+            "  qux\n" +
+            ");",
+            options: [2, { CallExpression: { arguments: 1 } }]
+        }, {
+            code:
+            "foo(\n" +
+            "\tbar,\n" +
+            "\tbaz,\n" +
+            "\tqux\n" +
+            ");",
+            options: ["tab", { CallExpression: { arguments: 1 } }]
+        }, {
+            code:
+            "foo(bar,\n" +
+            "        baz,\n" +
+            "        qux);",
+            options: [4, { CallExpression: { arguments: 2 } }]
+        }, {
+            code:
+            "foo(\n" +
+            "bar,\n" +
+            "baz,\n" +
+            "qux\n" +
+            ");",
+            options: [2, { CallExpression: { arguments: 0 } }]
+        }, {
+            code:
+            "foo(bar,\n" +
+            "    baz,\n" +
+            "    qux\n" +
+            ");",
+            options: [2, { CallExpression: { arguments: "first" } }]
+        }, {
+            code:
+            "foo(bar, baz,\n" +
+            "    qux, barbaz,\n" +
+            "    barqux, bazqux);",
+            options: [2, { CallExpression: { arguments: "first" } }]
+        }, {
+            code:
+            "foo(\n" +
+            "                        bar, baz,\n" +
+            "                        qux);",
+            options: [2, { CallExpression: { arguments: "first" } }]
+        }, {
+            code:
+            "foo(bar,\n" +
+            "        1 + 2,\n" +
+            "        !baz,\n" +
+            "        new Car('!')\n" +
+            ");",
+            options: [2, { CallExpression: { arguments: 4 } }]
+        },
+
+        // https://github.com/eslint/eslint/issues/7484
+        {
+            code:
+            "var foo = function() {\n" +
+            "  return bar(\n" +
+            "    [{\n" +
+            "    }].concat(baz)\n" +
+            "  );\n" +
+            "};",
+            options: [2]
+        },
+
+        // https://github.com/eslint/eslint/issues/7573
+        {
+            code:
+            "return (\n" +
+            "    foo\n" +
+            ");",
+            parserOptions: { ecmaFeatures: { globalReturn: true } }
+        },
+        {
+            code:
+            "return (\n" +
+            "    foo\n" +
+            ")",
+            parserOptions: { ecmaFeatures: { globalReturn: true } }
+        },
+        {
+            code:
+            "var foo = [\n" +
+            "    bar,\n" +
+            "    baz\n" +
+            "]"
+        },
+        {
+            code:
+            "var foo = [bar,\n" +
+            "    baz,\n" +
+            "    qux\n" +
+            "]"
+        },
+        {
+            code:
+            "var foo = [bar,\n" +
+            "baz,\n" +
+            "qux\n" +
+            "]",
+            options: [2, { ArrayExpression: 0 }]
+        },
+        {
+            code:
+            "var foo = [bar,\n" +
+            "                baz,\n" +
+            "                qux\n" +
+            "]",
+            options: [2, { ArrayExpression: 8 }]
+        },
+        {
+            code:
+            "var foo = [bar,\n" +
+            "           baz,\n" +
+            "           qux\n" +
+            "]",
+            options: [2, { ArrayExpression: "first" }]
+        },
+        {
+            code:
+            "var foo = [bar,\n" +
+            "           baz, qux\n" +
+            "]",
+            options: [2, { ArrayExpression: "first" }]
+        },
+        {
+            code:
+            "var foo = [\n" +
+            "        { bar: 1,\n" +
+            "          baz: 2 },\n" +
+            "        { bar: 3,\n" +
+            "          qux: 4 }\n" +
+            "]",
+            options: [4, { ArrayExpression: 2, ObjectExpression: "first" }]
+        },
+        {
+            code:
+            "var foo = {\n" +
+            "bar: 1,\n" +
+            "baz: 2\n" +
+            "};",
+            options: [2, { ObjectExpression: 0 }]
+        },
+        {
+            code:
+            "var foo = { foo: 1, bar: 2,\n" +
+            "            baz: 3 }",
+            options: [2, { ObjectExpression: "first" }]
+        },
+        {
+            code:
+            "var foo = [\n" +
+            "        {\n" +
+            "            foo: 1\n" +
+            "        }\n" +
+            "]",
+            options: [4, { ArrayExpression: 2 }]
+        },
+        {
+            code:
+            "function foo() {\n" +
+            "  [\n" +
+            "          foo\n" +
+            "  ]\n" +
+            "}",
+            options: [2, { ArrayExpression: 4 }]
+        },
+        {
+            code: "[\n]",
+            options: [2, { ArrayExpression: "first" }]
+        },
+        {
+            code: "[\n]",
+            options: [2, { ArrayExpression: 1 }]
+        },
+        {
+            code: "{\n}",
+            options: [2, { ObjectExpression: "first" }]
+        },
+        {
+            code: "{\n}",
+            options: [2, { ObjectExpression: 1 }]
+        },
+        {
+            code:
+            "var foo = [\n" +
+            "  [\n" +
+            "    1\n" +
+            "  ]\n" +
+            "]",
+            options: [2, { ArrayExpression: "first" }]
+        },
+        {
+            code:
+            "var foo = [ 1,\n" +
+            "            [\n" +
+            "              2\n" +
+            "            ]\n" +
+            "];",
+            options: [2, { ArrayExpression: "first" }]
+        },
+        {
+            code:
+            "var foo = bar(1,\n" +
+            "              [ 2,\n" +
+            "                3\n" +
+            "              ]\n" +
+            ");",
+            options: [4, { ArrayExpression: "first", CallExpression: { arguments: "first" } }]
+        },
+        {
+            code:
+            "var foo =\n" +
+            "    [\n" +
+            "    ]()",
+            options: [4, { CallExpression: { arguments: "first" }, ArrayExpression: "first" }]
+        },
+
+        // https://github.com/eslint/eslint/issues/7732
+        {
+            code:
+            "const lambda = foo => {\n" +
+            "  Object.assign({},\n" +
+            "    filterName,\n" +
+            "    {\n" +
+            "      display\n" +
+            "    }\n" +
+            "  );" +
+            "}",
+            options: [2, { ObjectExpression: 1 }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code:
+            "const lambda = foo => {\n" +
+            "  Object.assign({},\n" +
+            "    filterName,\n" +
+            "    {\n" +
+            "      display\n" +
+            "    }\n" +
+            "  );" +
+            "}",
+            options: [2, { ObjectExpression: "first" }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+
+        // https://github.com/eslint/eslint/issues/7733
+        {
+            code:
+            "var foo = function() {\n" +
+            "\twindow.foo('foo',\n" +
+            "\t\t{\n" +
+            "\t\t\tfoo: 'bar'," +
+            "\t\t\tbar: {\n" +
+            "\t\t\t\tfoo: 'bar'\n" +
+            "\t\t\t}\n" +
+            "\t\t}\n" +
+            "\t);\n" +
+            "}",
+            options: ["tab"]
+        },
+        {
+            code:
+            "echo = spawn('cmd.exe',\n" +
+            "             ['foo', 'bar',\n" +
+            "              'baz']);",
+            options: [2, { ArrayExpression: "first", CallExpression: { arguments: "first" } }]
+        }
+    ],
+    invalid: [
+        {
+            code:
+                "var a = b;\n" +
+                "if (a) {\n" +
+                "b();\n" +
+                "}\n",
+            options: [2],
+            errors: expectedErrors([[3, 2, 0, "ExpressionStatement"]]),
+            output:
+                "var a = b;\n" +
+                "if (a) {\n" +
+                "  b();\n" +
+                "}\n"
+        },
+        {
+            code:
+            "require('http').request({hostname: 'localhost',\n" +
+            "                  port: 80}, function(res) {\n" +
+            "  res.end();\n" +
+            "});\n",
+            output:
+            "require('http').request({hostname: 'localhost',\n" +
+            "  port: 80}, function(res) {\n" +
+            "  res.end();\n" +
+            "});\n",
+            options: [2],
+            errors: expectedErrors([[2, 2, 18, "Property"]])
+        },
+        {
+            code:
+                "if (array.some(function(){\n" +
+                "  return true;\n" +
+                "})) {\n" +
+                "a++; // ->\n" +
+                "  b++;\n" +
+                "    c++; // <-\n" +
+                "}\n",
+            output:
+                "if (array.some(function(){\n" +
+                "  return true;\n" +
+                "})) {\n" +
+                "  a++; // ->\n" +
+                "  b++;\n" +
+                "  c++; // <-\n" +
+                "}\n",
+            options: [2],
+            errors: expectedErrors([[4, 2, 0, "ExpressionStatement"], [6, 2, 4, "ExpressionStatement"]])
+        },
+        {
+            code: "if (a){\n\tb=c;\n\t\tc=d;\ne=f;\n}",
+            output: "if (a){\n\tb=c;\n\tc=d;\n\te=f;\n}",
+            options: ["tab"],
+            errors: expectedErrors("tab", [[3, 1, 2, "ExpressionStatement"], [4, 1, 0, "ExpressionStatement"]])
+        },
+        {
+            code: "if (a){\n    b=c;\n      c=d;\n e=f;\n}",
+            output: "if (a){\n    b=c;\n    c=d;\n    e=f;\n}",
+            options: [4],
+            errors: expectedErrors([[3, 4, 6, "ExpressionStatement"], [4, 4, 1, "ExpressionStatement"]])
+        },
+        {
+            code: fixture,
+            output: fixedFixture,
+            options: [2, { SwitchCase: 1, MemberExpression: 1 }],
+            errors: expectedErrors([
+                [5, 2, 4, "VariableDeclaration"],
+                [10, 4, 6, "BlockStatement"],
+                [11, 2, 4, "BlockStatement"],
+                [15, 4, 2, "ExpressionStatement"],
+                [16, 2, 4, "BlockStatement"],
+                [23, 2, 4, "BlockStatement"],
+                [29, 2, 4, "ForStatement"],
+                [31, 4, 2, "BlockStatement"],
+                [36, 4, 6, "ExpressionStatement"],
+                [38, 2, 4, "BlockStatement"],
+                [39, 4, 2, "ExpressionStatement"],
+                [40, 2, 0, "BlockStatement"],
+                [46, 0, 1, "VariableDeclaration"],
+                [54, 2, 4, "BlockStatement"],
+                [114, 4, 2, "VariableDeclaration"],
+                [120, 4, 6, "VariableDeclaration"],
+                [124, 4, 2, "BreakStatement"],
+                [134, 4, 6, "BreakStatement"],
+                [138, 2, 3, "Punctuator"],
+                [139, 2, 3, "Punctuator"],
+                [143, 4, 0, "ExpressionStatement"],
+                [151, 4, 6, "ExpressionStatement"],
+                [159, 4, 2, "ExpressionStatement"],
+                [161, 4, 6, "ExpressionStatement"],
+                [175, 2, 0, "ExpressionStatement"],
+                [177, 2, 4, "ExpressionStatement"],
+                [189, 2, 0, "VariableDeclaration"],
+                [193, 6, 4, "ExpressionStatement"],
+                [195, 6, 8, "ExpressionStatement"],
+                [304, 4, 6, "ExpressionStatement"],
+                [306, 4, 8, "ExpressionStatement"],
+                [307, 2, 4, "BlockStatement"],
+                [308, 2, 4, "VariableDeclarator"],
+                [311, 4, 6, "Identifier"],
+                [312, 4, 6, "Identifier"],
+                [313, 4, 6, "Identifier"],
+                [314, 2, 4, "ArrayExpression"],
+                [315, 2, 4, "VariableDeclarator"],
+                [318, 4, 6, "Property"],
+                [319, 4, 6, "Property"],
+                [320, 4, 6, "Property"],
+                [321, 2, 4, "ObjectExpression"],
+                [322, 2, 4, "VariableDeclarator"],
+                [326, 2, 1, "Literal"],
+                [327, 2, 1, "Literal"],
+                [328, 2, 1, "Literal"],
+                [329, 2, 1, "Literal"],
+                [330, 2, 1, "Literal"],
+                [331, 2, 1, "Literal"],
+                [332, 2, 1, "Literal"],
+                [333, 2, 1, "Literal"],
+                [334, 2, 1, "Literal"],
+                [335, 2, 1, "Literal"],
+                [340, 2, 4, "ExpressionStatement"],
+                [341, 2, 0, "ExpressionStatement"],
+                [344, 2, 4, "ExpressionStatement"],
+                [345, 2, 0, "ExpressionStatement"],
+                [348, 2, 4, "ExpressionStatement"],
+                [349, 2, 0, "ExpressionStatement"],
+                [355, 2, 0, "ExpressionStatement"],
+                [357, 2, 4, "ExpressionStatement"],
+                [361, 4, 6, "ExpressionStatement"],
+                [362, 2, 4, "BlockStatement"],
+                [363, 2, 4, "VariableDeclarator"],
+                [368, 2, 0, "SwitchCase"],
+                [370, 2, 4, "SwitchCase"],
+                [374, 4, 6, "VariableDeclaration"],
+                [376, 4, 2, "VariableDeclaration"],
+                [383, 2, 0, "ExpressionStatement"],
+                [385, 2, 4, "ExpressionStatement"],
+                [390, 2, 0, "ExpressionStatement"],
+                [392, 2, 4, "ExpressionStatement"],
+                [409, 2, 0, "ExpressionStatement"],
+                [410, 2, 4, "ExpressionStatement"],
+                [416, 2, 0, "ExpressionStatement"],
+                [417, 2, 4, "ExpressionStatement"],
+                [422, 2, 4, "ExpressionStatement"],
+                [423, 2, 0, "ExpressionStatement"],
+                [427, 2, 6, "ExpressionStatement"],
+                [428, 2, 8, "ExpressionStatement"],
+                [429, 2, 4, "ExpressionStatement"],
+                [430, 0, 4, "BlockStatement"],
+                [433, 2, 4, "ExpressionStatement"],
+                [434, 0, 4, "BlockStatement"],
+                [437, 2, 0, "ExpressionStatement"],
+                [438, 0, 4, "BlockStatement"],
+                [451, 2, 0, "ExpressionStatement"],
+                [453, 2, 4, "ExpressionStatement"],
+                [499, 6, 8, "BlockStatement"],
+                [500, 10, 8, "ExpressionStatement"],
+                [501, 8, 6, "BlockStatement"],
+                [506, 6, 8, "BlockStatement"]
+            ])
+        },
+        {
+            code:
+                "switch(value){\n" +
+                "    case \"1\":\n" +
+                "        a();\n" +
+                "    break;\n" +
+                "    case \"2\":\n" +
+                "        a();\n" +
+                "    break;\n" +
+                "    default:\n" +
+                "        a();\n" +
+                "        break;\n" +
+                "}",
+            output:
+                "switch(value){\n" +
+                "    case \"1\":\n" +
+                "        a();\n" +
+                "        break;\n" +
+                "    case \"2\":\n" +
+                "        a();\n" +
+                "        break;\n" +
+                "    default:\n" +
+                "        a();\n" +
+                "        break;\n" +
+                "}",
+            options: [4, { SwitchCase: 1 }],
+            errors: expectedErrors([[4, 8, 4, "BreakStatement"], [7, 8, 4, "BreakStatement"]])
+        },
+        {
+            code:
+            "var x = 0 &&\n" +
+            "    {\n" +
+            "       a: 1,\n" +
+            "          b: 2\n" +
+            "    };",
+            output:
+            "var x = 0 &&\n" +
+            "    {\n" +
+            "        a: 1,\n" +
+            "        b: 2\n" +
+            "    };",
+            options: [4],
+            errors: expectedErrors([[3, 8, 7, "Property"], [4, 8, 10, "Property"]])
+        },
+        {
+            code:
+                "switch(value){\n" +
+                "    case \"1\":\n" +
+                "        a();\n" +
+                "        break;\n" +
+                "    case \"2\":\n" +
+                "        a();\n" +
+                "        break;\n" +
+                "    default:\n" +
+                "    break;\n" +
+                "}",
+            output:
+                "switch(value){\n" +
+                "    case \"1\":\n" +
+                "        a();\n" +
+                "        break;\n" +
+                "    case \"2\":\n" +
+                "        a();\n" +
+                "        break;\n" +
+                "    default:\n" +
+                "        break;\n" +
+                "}",
+            options: [4, { SwitchCase: 1 }],
+            errors: expectedErrors([9, 8, 4, "BreakStatement"])
+        },
+        {
+            code:
+                "switch(value){\n" +
+                "    case \"1\":\n" +
+                "    case \"2\":\n" +
+                "        a();\n" +
+                "        break;\n" +
+                "    default:\n" +
+                "        break;\n" +
+                "}\n" +
+                "switch(value){\n" +
+                "    case \"1\":\n" +
+                "    break;\n" +
+                "    case \"2\":\n" +
+                "        a();\n" +
+                "    break;\n" +
+                "    default:\n" +
+                "        a();\n" +
+                "    break;\n" +
+                "}",
+            output:
+                "switch(value){\n" +
+                "    case \"1\":\n" +
+                "    case \"2\":\n" +
+                "        a();\n" +
+                "        break;\n" +
+                "    default:\n" +
+                "        break;\n" +
+                "}\n" +
+                "switch(value){\n" +
+                "    case \"1\":\n" +
+                "        break;\n" +
+                "    case \"2\":\n" +
+                "        a();\n" +
+                "        break;\n" +
+                "    default:\n" +
+                "        a();\n" +
+                "        break;\n" +
+                "}",
+            options: [4, { SwitchCase: 1 }],
+            errors: expectedErrors([[11, 8, 4, "BreakStatement"], [14, 8, 4, "BreakStatement"], [17, 8, 4, "BreakStatement"]])
+        },
+        {
+            code:
+                "switch(value){\n" +
+                "case \"1\":\n" +
+                "        a();\n" +
+                "        break;\n" +
+                "    case \"2\":\n" +
+                "        break;\n" +
+                "    default:\n" +
+                "        break;\n" +
+                "}",
+            output:
+                "switch(value){\n" +
+                "case \"1\":\n" +
+                "    a();\n" +
+                "    break;\n" +
+                "case \"2\":\n" +
+                "    break;\n" +
+                "default:\n" +
+                "    break;\n" +
+                "}",
+            options: [4],
+            errors: expectedErrors([
+                [3, 4, 8, "ExpressionStatement"],
+                [4, 4, 8, "BreakStatement"],
+                [5, 0, 4, "SwitchCase"],
+                [6, 4, 8, "BreakStatement"],
+                [7, 0, 4, "SwitchCase"],
+                [8, 4, 8, "BreakStatement"]
+            ])
+        },
+        {
+            code:
+                "var obj = {foo: 1, bar: 2};\n" +
+                "with (obj) {\n" +
+                "console.log(foo + bar);\n" +
+                "}\n",
+            output:
+                "var obj = {foo: 1, bar: 2};\n" +
+                "with (obj) {\n" +
+                "    console.log(foo + bar);\n" +
+                "}\n",
+            errors: expectedErrors([3, 4, 0, "ExpressionStatement"])
+        },
+        {
+            code:
+                "switch (a) {\n" +
+                "case '1':\n" +
+                "b();\n" +
+                "break;\n" +
+                "default:\n" +
+                "c();\n" +
+                "break;\n" +
+                "}\n",
+            output:
+                "switch (a) {\n" +
+                "    case '1':\n" +
+                "        b();\n" +
+                "        break;\n" +
+                "    default:\n" +
+                "        c();\n" +
+                "        break;\n" +
+                "}\n",
+            options: [4, { SwitchCase: 1 }],
+            errors: expectedErrors([
+                [2, 4, 0, "SwitchCase"],
+                [3, 8, 0, "ExpressionStatement"],
+                [4, 8, 0, "BreakStatement"],
+                [5, 4, 0, "SwitchCase"],
+                [6, 8, 0, "ExpressionStatement"],
+                [7, 8, 0, "BreakStatement"]
+            ])
+        },
+        {
+            code:
+            "var foo = function(){\n" +
+            "    foo\n" +
+            "          .bar\n" +
+            "}",
+            output:
+            "var foo = function(){\n" +
+            "    foo\n" +
+            "        .bar\n" +
+            "}",
+            options: [4, { MemberExpression: 1 }],
+            errors: expectedErrors(
+                [3, 8, 10, "Punctuator"]
+            )
+        },
+        {
+            code:
+            "var foo = function(){\n" +
+            "    foo\n" +
+            "             .bar\n" +
+            "}",
+            output:
+            "var foo = function(){\n" +
+            "    foo\n" +
+            "            .bar\n" +
+            "}",
+            options: [4, { MemberExpression: 2 }],
+            errors: expectedErrors(
+                [3, 12, 13, "Punctuator"]
+            )
+        },
+        {
+            code:
+            "var foo = () => {\n" +
+            "    foo\n" +
+            "             .bar\n" +
+            "}",
+            output:
+            "var foo = () => {\n" +
+            "    foo\n" +
+            "            .bar\n" +
+            "}",
+            options: [4, { MemberExpression: 2 }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: expectedErrors(
+                [3, 12, 13, "Punctuator"]
+            )
+        },
+        {
+            code:
+            "TestClass.prototype.method = function () {\n" +
+            "  return Promise.resolve(3)\n" +
+            "      .then(function (x) {\n" +
+            "        return x;\n" +
+            "      });\n" +
+            "};",
+            output:
+            "TestClass.prototype.method = function () {\n" +
+            "  return Promise.resolve(3)\n" +
+            "    .then(function (x) {\n" +
+            "        return x;\n" +
+            "      });\n" +
+            "};",
+            options: [2, { MemberExpression: 1 }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: expectedErrors(
+                [
+                    [3, 4, 6, "Punctuator"]
+                ]
+            )
+        },
+        {
+            code:
+                "while (a) \n" +
+                "b();",
+            output:
+                "while (a) \n" +
+                "    b();",
+            options: [4],
+            errors: expectedErrors([
+                [2, 4, 0, "ExpressionStatement"]
+            ])
+        },
+        {
+            code:
+            "for (;;) \n" +
+            "b();",
+            output:
+            "for (;;) \n" +
+            "    b();",
+            options: [4],
+            errors: expectedErrors([
+                [2, 4, 0, "ExpressionStatement"]
+            ])
+        },
+        {
+            code:
+            "for (a in x) \n" +
+            "b();",
+            output:
+            "for (a in x) \n" +
+            "    b();",
+            options: [4],
+            errors: expectedErrors([
+                [2, 4, 0, "ExpressionStatement"]
+            ])
+        },
+        {
+            code:
+            "do \n" +
+            "b();\n" +
+            "while(true)",
+            output:
+            "do \n" +
+            "    b();\n" +
+            "while(true)",
+            options: [4],
+            errors: expectedErrors([
+                [2, 4, 0, "ExpressionStatement"]
+            ])
+        },
+        {
+            code:
+            "if(true) \n" +
+            "b();",
+            output:
+            "if(true) \n" +
+            "    b();",
+            options: [4],
+            errors: expectedErrors([
+                [2, 4, 0, "ExpressionStatement"]
+            ])
+        },
+        {
+            code:
+            "var test = {\n" +
+            "      a: 1,\n" +
+            "    b: 2\n" +
+            "    };\n",
+            output:
+            "var test = {\n" +
+            "  a: 1,\n" +
+            "  b: 2\n" +
+            "};\n",
+            options: [2],
+            errors: expectedErrors([
+                [2, 2, 6, "Property"],
+                [3, 2, 4, "Property"],
+                [4, 0, 4, "ObjectExpression"]
+            ])
+        },
+        {
+            code:
+            "var a = function() {\n" +
+            "      a++;\n" +
+            "    b++;\n" +
+            "          c++;\n" +
+            "    },\n" +
+            "    b;\n",
+            output:
+            "var a = function() {\n" +
+            "        a++;\n" +
+            "        b++;\n" +
+            "        c++;\n" +
+            "    },\n" +
+            "    b;\n",
+            options: [4],
+            errors: expectedErrors([
+                [2, 8, 6, "ExpressionStatement"],
+                [3, 8, 4, "ExpressionStatement"],
+                [4, 8, 10, "ExpressionStatement"]
+            ])
+        },
+        {
+            code:
+            "var a = 1,\n" +
+            "b = 2,\n" +
+            "c = 3;\n",
+            output:
+            "var a = 1,\n" +
+            "    b = 2,\n" +
+            "    c = 3;\n",
+            options: [4],
+            errors: expectedErrors([
+                [2, 4, 0, "VariableDeclarator"],
+                [3, 4, 0, "VariableDeclarator"]
+            ])
+        },
+        {
+            code:
+            "[a, b, \nc].forEach((index) => {\n" +
+            "  index;\n" +
+            "});\n",
+            output:
+            "[a, b, \n" +
+            "    c].forEach((index) => {\n" +
+            "    index;\n" +
+            "});\n",
+            options: [4],
+            parserOptions: { ecmaVersion: 6 },
+            errors: expectedErrors([
+                [2, 4, 0, "Identifier"],
+                [3, 4, 2, "ExpressionStatement"]
+            ])
+        },
+        {
+            code:
+            "[a, b, \nc].forEach(function(index){\n" +
+            "  return index;\n" +
+            "});\n",
+            output:
+            "[a, b, \n" +
+            "    c].forEach(function(index){\n" +
+            "    return index;\n" +
+            "});\n",
+            options: [4],
+            parserOptions: { ecmaVersion: 6 },
+            errors: expectedErrors([
+                [2, 4, 0, "Identifier"],
+                [3, 4, 2, "ReturnStatement"]
+            ])
+        },
+        {
+            code:
+            "[a, b, \nc].forEach(function(index){\n" +
+            "    return index;\n" +
+            "});\n",
+            output:
+            "[a, b, \n" +
+            "    c].forEach(function(index){\n" +
+            "    return index;\n" +
+            "});\n",
+            options: [4],
+            parserOptions: { ecmaVersion: 6 },
+            errors: expectedErrors([[2, 4, 0, "Identifier"]])
+        },
+        {
+            code:
+            "[a, b, c].forEach((index) => {\n" +
+            "  index;\n" +
+            "});\n",
+            output:
+            "[a, b, c].forEach((index) => {\n" +
+            "    index;\n" +
+            "});\n",
+            options: [4],
+            parserOptions: { ecmaVersion: 6 },
+            errors: expectedErrors([
+                [2, 4, 2, "ExpressionStatement"]
+            ])
+        },
+        {
+            code:
+            "[a, b, c].forEach(function(index){\n" +
+            "  return index;\n" +
+            "});\n",
+            output:
+            "[a, b, c].forEach(function(index){\n" +
+            "    return index;\n" +
+            "});\n",
+            options: [4],
+            parserOptions: { ecmaVersion: 6 },
+            errors: expectedErrors([
+                [2, 4, 2, "ReturnStatement"]
+            ])
+        },
+        {
+            code:
+            "var x = ['a',\n" +
+            "         'b',\n" +
+            "         'c'\n" +
+            "];",
+            output:
+            "var x = ['a',\n" +
+            "    'b',\n" +
+            "    'c'\n" +
+            "];",
+            options: [4],
+            errors: expectedErrors([
+                [2, 4, 9, "Literal"],
+                [3, 4, 9, "Literal"]
+            ])
+        },
+        {
+            code:
+            "var x = [\n" +
+            "         'a',\n" +
+            "         'b',\n" +
+            "         'c'\n" +
+            "];",
+            output:
+            "var x = [\n" +
+            "    'a',\n" +
+            "    'b',\n" +
+            "    'c'\n" +
+            "];",
+            options: [4],
+            errors: expectedErrors([
+                [2, 4, 9, "Literal"],
+                [3, 4, 9, "Literal"],
+                [4, 4, 9, "Literal"]
+            ])
+        },
+        {
+            code:
+            "var x = [\n" +
+            "         'a',\n" +
+            "         'b',\n" +
+            "         'c',\n" +
+            "'d'];",
+            output:
+            "var x = [\n" +
+            "    'a',\n" +
+            "    'b',\n" +
+            "    'c',\n" +
+            "    'd'];",
+            options: [4],
+            errors: expectedErrors([
+                [2, 4, 9, "Literal"],
+                [3, 4, 9, "Literal"],
+                [4, 4, 9, "Literal"],
+                [5, 4, 0, "Literal"]
+            ])
+        },
+        {
+            code:
+            "var x = [\n" +
+            "         'a',\n" +
+            "         'b',\n" +
+            "         'c'\n" +
+            "  ];",
+            output:
+            "var x = [\n" +
+            "    'a',\n" +
+            "    'b',\n" +
+            "    'c'\n" +
+            "];",
+            options: [4],
+            parserOptions: { ecmaVersion: 6 },
+            errors: expectedErrors([
+                [2, 4, 9, "Literal"],
+                [3, 4, 9, "Literal"],
+                [4, 4, 9, "Literal"],
+                [5, 0, 2, "ArrayExpression"]
+            ])
+        },
+        {
+            code: "while (1 < 2)\nconsole.log('foo')\n  console.log('bar')",
+            output: "while (1 < 2)\n  console.log('foo')\nconsole.log('bar')",
+            options: [2],
+            errors: expectedErrors([
+                [2, 2, 0, "ExpressionStatement"],
+                [3, 0, 2, "ExpressionStatement"]
+            ])
+        },
+        {
+            code:
+            "function salutation () {\n" +
+            "  switch (1) {\n" +
+            "  case 0: return console.log('hi')\n" +
+            "    case 1: return console.log('hey')\n" +
+            "  }\n" +
+            "}\n",
+            output:
+            "function salutation () {\n" +
+            "  switch (1) {\n" +
+            "    case 0: return console.log('hi')\n" +
+            "    case 1: return console.log('hey')\n" +
+            "  }\n" +
+            "}\n",
+            options: [2, { SwitchCase: 1 }],
+            errors: expectedErrors([
+                [3, 4, 2, "SwitchCase"]
+            ])
+        },
+        {
+            code:
+            "var geometry, box, face1, face2, colorT, colorB, sprite, padding, maxWidth,\n" +
+            "height, rotate;",
+            output:
+            "var geometry, box, face1, face2, colorT, colorB, sprite, padding, maxWidth,\n" +
+            "  height, rotate;",
+            options: [2, { SwitchCase: 1 }],
+            errors: expectedErrors([
+                [2, 2, 0, "VariableDeclarator"]
+            ])
+        },
+        {
+            code:
+            "switch (a) {\n" +
+            "case '1':\n" +
+            "b();\n" +
+            "break;\n" +
+            "default:\n" +
+            "c();\n" +
+            "break;\n" +
+            "}\n",
+            output:
+            "switch (a) {\n" +
+            "        case '1':\n" +
+            "            b();\n" +
+            "            break;\n" +
+            "        default:\n" +
+            "            c();\n" +
+            "            break;\n" +
+            "}\n",
+            options: [4, { SwitchCase: 2 }],
+            errors: expectedErrors([
+                [2, 8, 0, "SwitchCase"],
+                [3, 12, 0, "ExpressionStatement"],
+                [4, 12, 0, "BreakStatement"],
+                [5, 8, 0, "SwitchCase"],
+                [6, 12, 0, "ExpressionStatement"],
+                [7, 12, 0, "BreakStatement"]
+            ])
+        },
+        {
+            code:
+            "var geometry,\n" +
+            "rotate;",
+            output:
+            "var geometry,\n" +
+            "  rotate;",
+            options: [2, { VariableDeclarator: 1 }],
+            errors: expectedErrors([
+                [2, 2, 0, "VariableDeclarator"]
+            ])
+        },
+        {
+            code:
+            "var geometry,\n" +
+            "  rotate;",
+            output:
+            "var geometry,\n" +
+            "    rotate;",
+            options: [2, { VariableDeclarator: 2 }],
+            errors: expectedErrors([
+                [2, 4, 2, "VariableDeclarator"]
+            ])
+        },
+        {
+            code:
+            "var geometry,\n" +
+            "\trotate;",
+            output:
+            "var geometry,\n" +
+            "\t\trotate;",
+            options: ["tab", { VariableDeclarator: 2 }],
+            errors: expectedErrors("tab", [
+                [2, 2, 1, "VariableDeclarator"]
+            ])
+        },
+        {
+            code:
+            "let geometry,\n" +
+            "  rotate;",
+            output:
+            "let geometry,\n" +
+            "    rotate;",
+            options: [2, { VariableDeclarator: 2 }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: expectedErrors([
+                [2, 4, 2, "VariableDeclarator"]
+            ])
+        },
+        {
+            code:
+            "if(true)\n" +
+            "  if (true)\n" +
+            "    if (true)\n" +
+            "    console.log(val);",
+            output:
+            "if(true)\n" +
+            "  if (true)\n" +
+            "    if (true)\n" +
+            "      console.log(val);",
+            options: [2, { VariableDeclarator: 2, SwitchCase: 1 }],
+            errors: expectedErrors([
+                [4, 6, 4, "ExpressionStatement"]
+            ])
+        },
+        {
+            code:
+            "var a = {\n" +
+            "    a: 1,\n" +
+            "    b: 2\n" +
+            "}",
+            output:
+            "var a = {\n" +
+            "  a: 1,\n" +
+            "  b: 2\n" +
+            "}",
+            options: [2, { VariableDeclarator: 2, SwitchCase: 1 }],
+            errors: expectedErrors([
+                [2, 2, 4, "Property"],
+                [3, 2, 4, "Property"]
+            ])
+        },
+        {
+            code:
+            "var a = [\n" +
+            "    a,\n" +
+            "    b\n" +
+            "]",
+            output:
+            "var a = [\n" +
+            "  a,\n" +
+            "  b\n" +
+            "]",
+            options: [2, { VariableDeclarator: 2, SwitchCase: 1 }],
+            errors: expectedErrors([
+                [2, 2, 4, "Identifier"],
+                [3, 2, 4, "Identifier"]
+            ])
+        },
+        {
+            code:
+            "let a = [\n" +
+            "    a,\n" +
+            "    b\n" +
+            "]",
+            output:
+            "let a = [\n" +
+            "  a,\n" +
+            "  b\n" +
+            "]",
+            options: [2, { VariableDeclarator: { let: 2 }, SwitchCase: 1 }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: expectedErrors([
+                [2, 2, 4, "Identifier"],
+                [3, 2, 4, "Identifier"]
+            ])
+        },
+        {
+            code:
+            "var a = new Test({\n" +
+            "      a: 1\n" +
+            "  }),\n" +
+            "    b = 4;\n",
+            output:
+            "var a = new Test({\n" +
+            "        a: 1\n" +
+            "    }),\n" +
+            "    b = 4;\n",
+            options: [4],
+            errors: expectedErrors([
+                [2, 8, 6, "Property"],
+                [3, 4, 2, "ObjectExpression"]
+            ])
+        },
+        {
+            code:
+            "var a = new Test({\n" +
+            "      a: 1\n" +
+            "    }),\n" +
+            "    b = 4;\n" +
+            "const c = new Test({\n" +
+            "      a: 1\n" +
+            "    }),\n" +
+            "    d = 4;\n",
+            output:
+            "var a = new Test({\n" +
+            "      a: 1\n" +
+            "    }),\n" +
+            "    b = 4;\n" +
+            "const c = new Test({\n" +
+            "    a: 1\n" +
+            "  }),\n" +
+            "  d = 4;\n",
+            options: [2, { VariableDeclarator: { var: 2 } }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: expectedErrors([
+                [6, 4, 6, "Property"],
+                [7, 2, 4, "ObjectExpression"],
+                [8, 2, 4, "VariableDeclarator"]
+            ])
+        },
+        {
+            code:
+            "var abc = 5,\n" +
+            "    c = 2,\n" +
+            "    xyz = \n" +
+            "     {\n" +
+            "       a: 1,\n" +
+            "        b: 2\n" +
+            "     };",
+            output:
+            "var abc = 5,\n" +
+            "    c = 2,\n" +
+            "    xyz = \n" +
+            "    {\n" +
+            "      a: 1,\n" +
+            "      b: 2\n" +
+            "    };",
+            options: [2, { VariableDeclarator: 2, SwitchCase: 1 }],
+            errors: expectedErrors([
+                [4, 4, 5, "ObjectExpression"],
+                [5, 6, 7, "Property"],
+                [6, 6, 8, "Property"],
+                [7, 4, 5, "ObjectExpression"]
+            ])
+        },
+        {
+            code:
+            "var abc = \n" +
+            "     {\n" +
+            "       a: 1,\n" +
+            "        b: 2\n" +
+            "     };",
+            output:
+            "var abc = \n" +
+            "    {\n" +
+            "      a: 1,\n" +
+            "      b: 2\n" +
+            "    };",
+            options: [2, { VariableDeclarator: 2, SwitchCase: 1 }],
+            errors: expectedErrors([
+                [2, 4, 5, "ObjectExpression"],
+                [3, 6, 7, "Property"],
+                [4, 6, 8, "Property"],
+                [5, 4, 5, "ObjectExpression"]
+            ])
+        },
+        {
+            code:
+                "var path     = require('path')\n" +
+                " , crypto    = require('crypto')\n" +
+                ";\n",
+            output:
+                "var path     = require('path')\n" +
+                " , crypto    = require('crypto')\n" +
+                " ;\n",
+            options: [2],
+            errors: expectedErrors([
+                [3, 1, 0, "VariableDeclaration"]
+            ])
+        },
+        {
+            code:
+                "var a = 1\n" +
+                "   ,b = 2\n" +
+                ";",
+            output:
+                "var a = 1\n" +
+                "   ,b = 2\n" +
+                "   ;",
+            errors: expectedErrors([
+                [3, 3, 0, "VariableDeclaration"]
+            ])
+        },
+        {
+            code:
+            "class A{\n" +
+            "  constructor(){}\n" +
+            "    a(){}\n" +
+            "    get b(){}\n" +
+            "}",
+            output:
+            "class A{\n" +
+            "    constructor(){}\n" +
+            "    a(){}\n" +
+            "    get b(){}\n" +
+            "}",
+            options: [4, { VariableDeclarator: 1, SwitchCase: 1 }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: expectedErrors([[2, 4, 2, "MethodDefinition"]])
+        },
+        {
+            code:
+            "var A = class {\n" +
+            "  constructor(){}\n" +
+            "    a(){}\n" +
+            "  get b(){}\n" +
+            "};",
+            output:
+            "var A = class {\n" +
+            "    constructor(){}\n" +
+            "    a(){}\n" +
+            "    get b(){}\n" +
+            "};",
+            options: [4, { VariableDeclarator: 1, SwitchCase: 1 }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: expectedErrors([[2, 4, 2, "MethodDefinition"], [4, 4, 2, "MethodDefinition"]])
+        },
+        {
+            code:
+            "var a = 1,\n" +
+            "    B = class {\n" +
+            "    constructor(){}\n" +
+            "      a(){}\n" +
+            "      get b(){}\n" +
+            "    };",
+            output:
+            "var a = 1,\n" +
+            "    B = class {\n" +
+            "      constructor(){}\n" +
+            "      a(){}\n" +
+            "      get b(){}\n" +
+            "    };",
+            options: [2, { VariableDeclarator: 2, SwitchCase: 1 }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: expectedErrors([[3, 6, 4, "MethodDefinition"]])
+        },
+        {
+            code:
+            "{\n" +
+            "    if(a){\n" +
+            "        foo();\n" +
+            "    }\n" +
+            "  else{\n" +
+            "        bar();\n" +
+            "    }\n" +
+            "}\n",
+            output:
+            "{\n" +
+            "    if(a){\n" +
+            "        foo();\n" +
+            "    }\n" +
+            "    else{\n" +
+            "        bar();\n" +
+            "    }\n" +
+            "}\n",
+            options: [4],
+            errors: expectedErrors([[5, 4, 2, "Keyword"]])
+        },
+        {
+            code:
+            "{\n" +
+            "    if(a){\n" +
+            "        foo();\n" +
+            "    }\n" +
+            "  else\n" +
+            "        bar();\n" +
+            "    \n" +
+            "}\n",
+            output:
+            "{\n" +
+            "    if(a){\n" +
+            "        foo();\n" +
+            "    }\n" +
+            "    else\n" +
+            "        bar();\n" +
+            "    \n" +
+            "}\n",
+            options: [4],
+            errors: expectedErrors([[5, 4, 2, "Keyword"]])
+        },
+        {
+            code:
+            "{\n" +
+            "    if(a)\n" +
+            "        foo();\n" +
+            "  else\n" +
+            "        bar();\n" +
+            "}\n",
+            output:
+            "{\n" +
+            "    if(a)\n" +
+            "        foo();\n" +
+            "    else\n" +
+            "        bar();\n" +
+            "}\n",
+            options: [4],
+            errors: expectedErrors([[4, 4, 2, "Keyword"]])
+        },
+        {
+            code:
+            "(function(){\n" +
+            "  function foo(x) {\n" +
+            "    return x + 1;\n" +
+            "  }\n" +
+            "})();",
+            output:
+            "(function(){\n" +
+            "function foo(x) {\n" +
+            "    return x + 1;\n" +
+            "  }\n" +
+            "})();",
+            options: [2, { outerIIFEBody: 0 }],
+            errors: expectedErrors([[2, 0, 2, "FunctionDeclaration"]])
+        },
+        {
+            code:
+            "(function(){\n" +
+            "    function foo(x) {\n" +
+            "        return x + 1;\n" +
+            "    }\n" +
+            "})();",
+            output:
+            "(function(){\n" +
+            "        function foo(x) {\n" +
+            "        return x + 1;\n" +
+            "    }\n" +
+            "})();",
+            options: [4, { outerIIFEBody: 2 }],
+            errors: expectedErrors([[2, 8, 4, "FunctionDeclaration"]])
+        },
+        {
+            code:
+            "if(data) {\n" +
+            "console.log('hi');\n" +
+            "}",
+            output:
+            "if(data) {\n" +
+            "  console.log('hi');\n" +
+            "}",
+            options: [2, { outerIIFEBody: 0 }],
+            errors: expectedErrors([[2, 2, 0, "ExpressionStatement"]])
+        },
+        {
+            code:
+            "var ns = function(){\n" +
+            "    function fooVar(x) {\n" +
+            "        return x + 1;\n" +
+            "    }\n" +
+            "}(x);",
+            output:
+            "var ns = function(){\n" +
+            "        function fooVar(x) {\n" +
+            "        return x + 1;\n" +
+            "    }\n" +
+            "}(x);",
+            options: [4, { outerIIFEBody: 2 }],
+            errors: expectedErrors([[2, 8, 4, "FunctionDeclaration"]])
+        },
+        {
+            code:
+            "var obj = {\n" +
+            "  foo: function() {\n" +
+            "  return true;\n" +
+            "  }()\n" +
+            "};\n",
+            output:
+            "var obj = {\n" +
+            "  foo: function() {\n" +
+            "    return true;\n" +
+            "  }()\n" +
+            "};\n",
+            options: [2, { outerIIFEBody: 0 }],
+            errors: expectedErrors([[3, 4, 2, "ReturnStatement"]])
+        },
+        {
+            code:
+            "typeof function() {\n" +
+            "    function fooVar(x) {\n" +
+            "      return x + 1;\n" +
+            "    }\n" +
+            "}();",
+            output:
+            "typeof function() {\n" +
+            "  function fooVar(x) {\n" +
+            "      return x + 1;\n" +
+            "    }\n" +
+            "}();",
+            options: [2, { outerIIFEBody: 2 }],
+            errors: expectedErrors([[2, 2, 4, "FunctionDeclaration"]])
+        },
+        {
+            code:
+            "{\n" +
+            "\t!function(x) {\n" +
+            "\t\t\t\treturn x + 1;\n" +
+            "\t}()\n" +
+            "};",
+            output:
+            "{\n" +
+            "\t!function(x) {\n" +
+            "\t\treturn x + 1;\n" +
+            "\t}()\n" +
+            "};",
+            options: ["tab", { outerIIFEBody: 3 }],
+            errors: expectedErrors("tab", [[3, 2, 4, "ReturnStatement"]])
+        },
+        {
+            code:
+            "Buffer\n" +
+            ".toString()",
+            output:
+            "Buffer\n" +
+            "    .toString()",
+            options: [4, { MemberExpression: 1 }],
+            errors: expectedErrors([[2, 4, 0, "Punctuator"]])
+        },
+        {
+            code:
+            "Buffer\n" +
+            "    .indexOf('a')\n" +
+            ".toString()",
+            output:
+            "Buffer\n" +
+            "    .indexOf('a')\n" +
+            "    .toString()",
+            options: [4, { MemberExpression: 1 }],
+            errors: expectedErrors([[3, 4, 0, "Punctuator"]])
+        },
+        {
+            code:
+            "Buffer.\n" +
+            "length",
+            output:
+            "Buffer.\n" +
+            "    length",
+            options: [4, { MemberExpression: 1 }],
+            errors: expectedErrors([[2, 4, 0, "Identifier"]])
+        },
+        {
+            code:
+            "Buffer.\n" +
+            "\t\tlength",
+            output:
+            "Buffer.\n" +
+            "\tlength",
+            options: ["tab", { MemberExpression: 1 }],
+            errors: expectedErrors("tab", [[2, 1, 2, "Identifier"]])
+        },
+        {
+            code:
+            "Buffer\n" +
+            "  .foo\n" +
+            "  .bar",
+            output:
+            "Buffer\n" +
+            "    .foo\n" +
+            "    .bar",
+            options: [2, { MemberExpression: 2 }],
+            errors: expectedErrors([[2, 4, 2, "Punctuator"], [3, 4, 2, "Punctuator"]])
+        },
+        {
+
+            // Indentation with multiple else statements: https://github.com/eslint/eslint/issues/6956
+
+            code:
+            "if (foo) bar();\n" +
+            "else if (baz) foobar();\n" +
+            "  else if (qux) qux();",
+            output:
+            "if (foo) bar();\n" +
+            "else if (baz) foobar();\n" +
+            "else if (qux) qux();",
+            options: [2],
+            errors: expectedErrors([3, 0, 2, "Keyword"])
+        },
+        {
+            code:
+            "if (foo) bar();\n" +
+            "else if (baz) foobar();\n" +
+            "  else qux();",
+            output:
+            "if (foo) bar();\n" +
+            "else if (baz) foobar();\n" +
+            "else qux();",
+            options: [2],
+            errors: expectedErrors([3, 0, 2, "Keyword"])
+        },
+        {
+            code:
+            "foo();\n" +
+            "  if (baz) foobar();\n" +
+            "  else qux();",
+            output:
+            "foo();\n" +
+            "if (baz) foobar();\n" +
+            "else qux();",
+            options: [2],
+            errors: expectedErrors([[2, 0, 2, "IfStatement"], [3, 0, 2, "Keyword"]])
+        },
+        {
+            code:
+            "if (foo) bar();\n" +
+            "else if (baz) foobar();\n" +
+            "     else if (bip) {\n" +
+            "       qux();\n" +
+            "     }",
+            output:
+            "if (foo) bar();\n" +
+            "else if (baz) foobar();\n" +
+            "else if (bip) {\n" +
+            "       qux();\n" + // (fixed on the next pass)
+            "     }",
+            options: [2],
+            errors: expectedErrors([3, 0, 5, "Keyword"])
+        },
+        {
+            code:
+            "if (foo) bar();\n" +
+            "else if (baz) {\n" +
+            "    foobar();\n" +
+            "     } else if (boop) {\n" +
+            "       qux();\n" +
+            "     }",
+            output:
+            "if (foo) bar();\n" +
+            "else if (baz) {\n" +
+            "  foobar();\n" +
+            "} else if (boop) {\n" +
+            "       qux();\n" + // (fixed on the next pass)
+            "     }",
+            options: [2],
+            errors: expectedErrors([[3, 2, 4, "ExpressionStatement"], [4, 0, 5, "BlockStatement"]])
+        },
+        {
+            code:
+            "function foo(aaa,\n" +
+            "    bbb, ccc, ddd) {\n" +
+            "      bar();\n" +
+            "}",
+            output:
+            "function foo(aaa,\n" +
+            "  bbb, ccc, ddd) {\n" +
+            "    bar();\n" +
+            "}",
+            options: [2, { FunctionDeclaration: { parameters: 1, body: 2 } }],
+            errors: expectedErrors([[2, 2, 4, "Identifier"], [3, 4, 6, "ExpressionStatement"]])
+        },
+        {
+            code:
+            "function foo(aaa, bbb,\n" +
+            "  ccc, ddd) {\n" +
+            "bar();\n" +
+            "}",
+            output:
+            "function foo(aaa, bbb,\n" +
+            "      ccc, ddd) {\n" +
+            "  bar();\n" +
+            "}",
+            options: [2, { FunctionDeclaration: { parameters: 3, body: 1 } }],
+            errors: expectedErrors([[2, 6, 2, "Identifier"], [3, 2, 0, "ExpressionStatement"]])
+        },
+        {
+            code:
+            "function foo(aaa,\n" +
+            "        bbb,\n" +
+            "  ccc) {\n" +
+            "      bar();\n" +
+            "}",
+            output:
+            "function foo(aaa,\n" +
+            "    bbb,\n" +
+            "    ccc) {\n" +
+            "            bar();\n" +
+            "}",
+            options: [4, { FunctionDeclaration: { parameters: 1, body: 3 } }],
+            errors: expectedErrors([[2, 4, 8, "Identifier"], [3, 4, 2, "Identifier"], [4, 12, 6, "ExpressionStatement"]])
+        },
+        {
+            code:
+            "function foo(aaa,\n" +
+            "  bbb, ccc,\n" +
+            "                   ddd, eee, fff) {\n" +
+            "   bar();\n" +
+            "}",
+            output:
+            "function foo(aaa,\n" +
+            "             bbb, ccc,\n" +
+            "             ddd, eee, fff) {\n" +
+            "  bar();\n" +
+            "}",
+            options: [2, { FunctionDeclaration: { parameters: "first", body: 1 } }],
+            errors: expectedErrors([[2, 13, 2, "Identifier"], [3, 13, 19, "Identifier"], [4, 2, 3, "ExpressionStatement"]])
+        },
+        {
+            code:
+            "function foo(aaa, bbb)\n" +
+            "{\n" +
+            "bar();\n" +
+            "}",
+            output:
+            "function foo(aaa, bbb)\n" +
+            "{\n" +
+            "      bar();\n" +
+            "}",
+            options: [2, { FunctionDeclaration: { body: 3 } }],
+            errors: expectedErrors([3, 6, 0, "ExpressionStatement"])
+        },
+        {
+            code:
+            "function foo(\n" +
+            "aaa,\n" +
+            "    bbb) {\n" +
+            "bar();\n" +
+            "}",
+            output:
+            "function foo(\n" +
+            "aaa,\n" +
+            "bbb) {\n" +
+            "    bar();\n" +
+            "}",
+            options: [2, { FunctionDeclaration: { parameters: "first", body: 2 } }],
+            errors: expectedErrors([[3, 0, 4, "Identifier"], [4, 4, 0, "ExpressionStatement"]])
+        },
+        {
+            code:
+            "var foo = function(aaa,\n" +
+            "  bbb,\n" +
+            "    ccc,\n" +
+            "      ddd) {\n" +
+            "  bar();\n" +
+            "}",
+            output:
+            "var foo = function(aaa,\n" +
+            "    bbb,\n" +
+            "    ccc,\n" +
+            "    ddd) {\n" +
+            "bar();\n" +
+            "}",
+            options: [2, { FunctionExpression: { parameters: 2, body: 0 } }],
+            errors: expectedErrors([[2, 4, 2, "Identifier"], [4, 4, 6, "Identifier"], [5, 0, 2, "ExpressionStatement"]])
+        },
+        {
+            code:
+            "var foo = function(aaa,\n" +
+            "   bbb,\n" +
+            " ccc) {\n" +
+            "  bar();\n" +
+            "}",
+            output:
+            "var foo = function(aaa,\n" +
+            "  bbb,\n" +
+            "  ccc) {\n" +
+            "                    bar();\n" +
+            "}",
+            options: [2, { FunctionExpression: { parameters: 1, body: 10 } }],
+            errors: expectedErrors([[2, 2, 3, "Identifier"], [3, 2, 1, "Identifier"], [4, 20, 2, "ExpressionStatement"]])
+        },
+        {
+            code:
+            "var foo = function(aaa,\n" +
+            "  bbb, ccc, ddd,\n" +
+            "                        eee, fff) {\n" +
+            "        bar();\n" +
+            "}",
+            output:
+            "var foo = function(aaa,\n" +
+            "                   bbb, ccc, ddd,\n" +
+            "                   eee, fff) {\n" +
+            "    bar();\n" +
+            "}",
+            options: [4, { FunctionExpression: { parameters: "first", body: 1 } }],
+            errors: expectedErrors([[2, 19, 2, "Identifier"], [3, 19, 24, "Identifier"], [4, 4, 8, "ExpressionStatement"]])
+        },
+        {
+            code:
+            "var foo = function(\n" +
+            "aaa, bbb, ccc,\n" +
+            "    ddd, eee) {\n" +
+            "  bar();\n" +
+            "}",
+            output:
+            "var foo = function(\n" +
+            "aaa, bbb, ccc,\n" +
+            "ddd, eee) {\n" +
+            "      bar();\n" +
+            "}",
+            options: [2, { FunctionExpression: { parameters: "first", body: 3 } }],
+            errors: expectedErrors([[3, 0, 4, "Identifier"], [4, 6, 2, "ExpressionStatement"]])
+        },
+        {
+            code:
+            "var foo = bar;\n" +
+            "\t\t\tvar baz = qux;",
+            output:
+            "var foo = bar;\n" +
+            "var baz = qux;",
+            options: [2],
+            errors: expectedErrors([2, "0 spaces", "3 tabs", "VariableDeclaration"])
+        },
+        {
+            code:
+            "function foo() {\n" +
+            "\tbar();\n" +
+            "  baz();\n" +
+            "              qux();\n" +
+            "}",
+            output:
+            "function foo() {\n" +
+            "\tbar();\n" +
+            "\tbaz();\n" +
+            "\tqux();\n" +
+            "}",
+            options: ["tab"],
+            errors: expectedErrors("tab", [[3, "1 tab", "2 spaces", "ExpressionStatement"], [4, "1 tab", "14 spaces", "ExpressionStatement"]])
+        },
+        {
+            code:
+            "function foo() {\n" +
+            "  bar();\n" +
+            "\t\t}",
+            output:
+            "function foo() {\n" +
+            "  bar();\n" +
+            "}",
+            options: [2],
+            errors: expectedErrors([[3, "0 spaces", "2 tabs", "BlockStatement"]])
+        },
+        {
+            code:
+            "function foo() {\n" +
+            "  function bar() {\n" +
+            "        baz();\n" +
+            "  }\n" +
+            "}",
+            output:
+            "function foo() {\n" +
+            "  function bar() {\n" +
+            "    baz();\n" +
+            "  }\n" +
+            "}",
+            options: [2, { FunctionDeclaration: { body: 1 } }],
+            errors: expectedErrors([3, 4, 8, "ExpressionStatement"])
+        },
+        {
+            code:
+            "function foo() {\n" +
+            "  function bar(baz,\n" +
+            "    qux) {\n" +
+            "    foobar();\n" +
+            "  }\n" +
+            "}",
+            output:
+            "function foo() {\n" +
+            "  function bar(baz,\n" +
+            "      qux) {\n" +
+            "    foobar();\n" +
+            "  }\n" +
+            "}",
+            options: [2, { FunctionDeclaration: { body: 1, parameters: 2 } }],
+            errors: expectedErrors([3, 6, 4, "Identifier"])
+        },
+        {
+            code:
+            "function foo() {\n" +
+            "  var bar = function(baz,\n" +
+            "          qux) {\n" +
+            "    foobar();\n" +
+            "  };\n" +
+            "}",
+            output:
+            "function foo() {\n" +
+            "  var bar = function(baz,\n" +
+            "        qux) {\n" +
+            "    foobar();\n" +
+            "  };\n" +
+            "}",
+            options: [2, { FunctionExpression: { parameters: 3 } }],
+            errors: expectedErrors([3, 8, 10, "Identifier"])
+        },
+        {
+            code:
+            "{\n" +
+            "    try {\n" +
+            "    }\n" +
+            "catch (err) {\n" +
+            "    }\n" +
+            "finally {\n" +
+            "    }\n" +
+            "}",
+            output:
+            "{\n" +
+            "    try {\n" +
+            "    }\n" +
+            "    catch (err) {\n" +
+            "    }\n" +
+            "    finally {\n" +
+            "    }\n" +
+            "}",
+            errors: expectedErrors([
+                [4, 4, 0, "Keyword"],
+                [6, 4, 0, "Keyword"]
+            ])
+        },
+        {
+            code:
+            "{\n" +
+            "    do {\n" +
+            "    }\n" +
+            "while (true)\n" +
+            "}",
+            output:
+            "{\n" +
+            "    do {\n" +
+            "    }\n" +
+            "    while (true)\n" +
+            "}",
+            errors: expectedErrors([4, 4, 0, "Keyword"])
+        },
+        {
+            code:
+            "function foo() {\n" +
+            "  bar();\n" +
+            "\t\t}",
+            output:
+            "function foo() {\n" +
+            "  bar();\n" +
+            "}",
+            options: [2],
+            errors: expectedErrors([[3, "0 spaces", "2 tabs", "BlockStatement"]])
+        },
+        {
+            code:
+            "function foo() {\n" +
+            "  return (\n" +
+            "    1\n" +
+            "    )\n" +
+            "}",
+            output:
+            "function foo() {\n" +
+            "  return (\n" +
+            "    1\n" +
+            "  )\n" +
+            "}",
+            options: [2],
+            errors: expectedErrors([[4, "2 spaces", "4", "ReturnStatement"]])
+        },
+        {
+            code:
+            "function foo() {\n" +
+            "  return (\n" +
+            "    1\n" +
+            "    );\n" +
+            "}",
+            output:
+            "function foo() {\n" +
+            "  return (\n" +
+            "    1\n" +
+            "  );\n" +
+            "}",
+            options: [2],
+            errors: expectedErrors([[4, "2 spaces", "4", "ReturnStatement"]])
+        },
+        {
+            code:
+            "function foo() {\n" +
+            "  bar();\n" +
+            "\t\t}",
+            output:
+            "function foo() {\n" +
+            "  bar();\n" +
+            "}",
+            options: [2],
+            errors: expectedErrors([[3, "0 spaces", "2 tabs", "BlockStatement"]])
+        },
+        {
+            code:
+            "function test(){\n" +
+            "  switch(length){\n" +
+            "    case 1: return function(a){\n" +
+            "    return fn.call(that, a);\n" +
+            "    };\n" +
+            "  }\n" +
+            "}",
+            output:
+            "function test(){\n" +
+            "  switch(length){\n" +
+            "    case 1: return function(a){\n" +
+            "      return fn.call(that, a);\n" +
+            "    };\n" +
+            "  }\n" +
+            "}",
+            options: [2, { VariableDeclarator: 2, SwitchCase: 1 }],
+            errors: expectedErrors([[4, "6 spaces", "4", "ReturnStatement"]])
+        },
+        {
+            code:
+            "function foo() {\n" +
+            "   return 1\n" +
+            "}",
+            output:
+            "function foo() {\n" +
+            "  return 1\n" +
+            "}",
+            options: [2],
+            errors: expectedErrors([[2, "2 spaces", "3", "ReturnStatement"]])
+        },
+        {
+            code:
+            "function foo() {\n" +
+            "   return 1;\n" +
+            "}",
+            output:
+            "function foo() {\n" +
+            "  return 1;\n" +
+            "}",
+            options: [2],
+            errors: expectedErrors([[2, "2 spaces", "3", "ReturnStatement"]])
+        },
+        {
+            code:
+            "foo(\n" +
+            "bar,\n" +
+            "  baz,\n" +
+            "    qux);",
+            output:
+            "foo(\n" +
+            "  bar,\n" +
+            "  baz,\n" +
+            "  qux);",
+            options: [2, { CallExpression: { arguments: 1 } }],
+            errors: expectedErrors([[2, 2, 0, "Identifier"], [4, 2, 4, "Identifier"]])
+        },
+        {
+            code:
+            "foo(\n" +
+            "\tbar,\n" +
+            "\tbaz);",
+            output:
+            "foo(\n" +
+            "    bar,\n" +
+            "    baz);",
+            options: [2, { CallExpression: { arguments: 2 } }],
+            errors: expectedErrors([[2, "4 spaces", "1 tab", "Identifier"], [3, "4 spaces", "1 tab", "Identifier"]])
+        },
+        {
+            code:
+            "foo(bar,\n" +
+            "\t\tbaz,\n" +
+            "\t\tqux);",
+            output:
+            "foo(bar,\n" +
+            "\tbaz,\n" +
+            "\tqux);",
+            options: ["tab", { CallExpression: { arguments: 1 } }],
+            errors: expectedErrors("tab", [[2, 1, 2, "Identifier"], [3, 1, 2, "Identifier"]])
+        },
+        {
+            code:
+            "foo(bar, baz,\n" +
+            "         qux);",
+            output:
+            "foo(bar, baz,\n" +
+            "    qux);",
+            options: [2, { CallExpression: { arguments: "first" } }],
+            errors: expectedErrors([2, 4, 9, "Identifier"])
+        },
+        {
+            code:
+            "foo(\n" +
+            "          bar,\n" +
+            "    baz);",
+            output:
+            "foo(\n" +
+            "          bar,\n" +
+            "          baz);",
+            options: [2, { CallExpression: { arguments: "first" } }],
+            errors: expectedErrors([3, 10, 4, "Identifier"])
+        },
+        {
+            code:
+            "foo(bar,\n" +
+            "  1 + 2,\n" +
+            "              !baz,\n" +
+            "        new Car('!')\n" +
+            ");",
+            output:
+            "foo(bar,\n" +
+            "      1 + 2,\n" +
+            "      !baz,\n" +
+            "      new Car('!')\n" +
+            ");",
+            options: [2, { CallExpression: { arguments: 3 } }],
+            errors: expectedErrors([[2, 6, 2, "BinaryExpression"], [3, 6, 14, "UnaryExpression"], [4, 6, 8, "NewExpression"]])
+        },
+
+        // https://github.com/eslint/eslint/issues/7573
+        {
+            code:
+            "return (\n" +
+            "    foo\n" +
+            "    );",
+            output:
+            "return (\n" +
+            "    foo\n" +
+            ");",
+            parserOptions: { ecmaFeatures: { globalReturn: true } },
+            errors: expectedErrors([3, 0, 4, "ReturnStatement"])
+        },
+        {
+            code:
+            "return (\n" +
+            "    foo\n" +
+            "    )",
+            output:
+            "return (\n" +
+            "    foo\n" +
+            ")",
+            parserOptions: { ecmaFeatures: { globalReturn: true } },
+            errors: expectedErrors([3, 0, 4, "ReturnStatement"])
+        },
+
+        // https://github.com/eslint/eslint/issues/7604
+        {
+            code:
+            "if (foo) {\n" +
+            "        /* comment */bar();\n" +
+            "}",
+            output:
+            "if (foo) {\n" +
+            "    /* comment */bar();\n" +
+            "}",
+            errors: expectedErrors([2, 4, 8, "ExpressionStatement"])
+        },
+        {
+            code:
+            "foo('bar',\n" +
+            "        /** comment */{\n" +
+            "        ok: true" +
+            "    });",
+            output:
+            "foo('bar',\n" +
+            "    /** comment */{\n" +
+            "        ok: true" +
+            "    });",
+            errors: expectedErrors([2, 4, 8, "ObjectExpression"])
+        },
+        {
+            code:
+            "var foo = [\n" +
+            "           bar,\n" +
+            "  baz\n" +
+            "          ]",
+            output:
+            "var foo = [\n" +
+            "    bar,\n" +
+            "    baz\n" +
+            "]",
+            errors: expectedErrors([[2, 4, 11, "Identifier"], [3, 4, 2, "Identifier"], [4, 0, 10, "ArrayExpression"]])
+        },
+        {
+            code:
+            "var foo = [bar,\n" +
+            "baz,\n" +
+            "    qux\n" +
+            "]",
+            output:
+            "var foo = [bar,\n" +
+            "    baz,\n" +
+            "    qux\n" +
+            "]",
+            errors: expectedErrors([2, 4, 0, "Identifier"])
+        },
+        {
+            code:
+            "var foo = [bar,\n" +
+            "  baz,\n" +
+            "  qux\n" +
+            "]",
+            output:
+            "var foo = [bar,\n" +
+            "baz,\n" +
+            "qux\n" +
+            "]",
+            options: [2, { ArrayExpression: 0 }],
+            errors: expectedErrors([[2, 0, 2, "Identifier"], [3, 0, 2, "Identifier"]])
+        },
+        {
+            code:
+            "var foo = [bar,\n" +
+            "  baz,\n" +
+            "  qux\n" +
+            "]",
+            output:
+            "var foo = [bar,\n" +
+            "                baz,\n" +
+            "                qux\n" +
+            "]",
+            options: [2, { ArrayExpression: 8 }],
+            errors: expectedErrors([[2, 16, 2, "Identifier"], [3, 16, 2, "Identifier"]])
+        },
+        {
+            code:
+            "var foo = [bar,\n" +
+            "    baz,\n" +
+            "    qux\n" +
+            "]",
+            output:
+            "var foo = [bar,\n" +
+            "           baz,\n" +
+            "           qux\n" +
+            "]",
+            options: [2, { ArrayExpression: "first" }],
+            errors: expectedErrors([[2, 11, 4, "Identifier"], [3, 11, 4, "Identifier"]])
+        },
+        {
+            code:
+            "var foo = [bar,\n" +
+            "    baz, qux\n" +
+            "]",
+            output:
+            "var foo = [bar,\n" +
+            "           baz, qux\n" +
+            "]",
+            options: [2, { ArrayExpression: "first" }],
+            errors: expectedErrors([2, 11, 4, "Identifier"])
+        },
+        {
+            code:
+            "var foo = [\n" +
+            "        { bar: 1,\n" +
+            "            baz: 2 },\n" +
+            "        { bar: 3,\n" +
+            "            qux: 4 }\n" +
+            "]",
+            output:
+            "var foo = [\n" +
+            "        { bar: 1,\n" +
+            "          baz: 2 },\n" +
+            "        { bar: 3,\n" +
+            "          qux: 4 }\n" +
+            "]",
+            options: [4, { ArrayExpression: 2, ObjectExpression: "first" }],
+            errors: expectedErrors([[3, 10, 12, "Property"], [5, 10, 12, "Property"]])
+        },
+        {
+            code:
+            "var foo = {\n" +
+            "  bar: 1,\n" +
+            "  baz: 2\n" +
+            "};",
+            output:
+            "var foo = {\n" +
+            "bar: 1,\n" +
+            "baz: 2\n" +
+            "};",
+            options: [2, { ObjectExpression: 0 }],
+            errors: expectedErrors([[2, 0, 2, "Property"], [3, 0, 2, "Property"]])
+        },
+        {
+            code:
+            "var quux = { foo: 1, bar: 2,\n" +
+            "baz: 3 }",
+            output:
+            "var quux = { foo: 1, bar: 2,\n" +
+            "             baz: 3 }",
+            options: [2, { ObjectExpression: "first" }],
+            errors: expectedErrors([2, 13, 0, "Property"])
+        },
+        {
+            code:
+            "function foo() {\n" +
+            "    [\n" +
+            "            foo\n" +
+            "    ]\n" +
+            "}",
+            output:
+            "function foo() {\n" +
+            "  [\n" +
+            "            foo\n" +
+            "    ]\n" +
+            "}",
+            options: [2, { ArrayExpression: 4 }],
+            errors: expectedErrors([2, 2, 4, "ExpressionStatement"])
+        },
+        {
+            code:
+            "echo = spawn('cmd.exe',\n" +
+            "            ['foo', 'bar',\n" +
+            "             'baz']);",
+            output:
+            "echo = spawn('cmd.exe',\n" +
+            "             ['foo', 'bar',\n" +
+            "             'baz']);",
+            options: [2, { ArrayExpression: "first", CallExpression: { arguments: "first" } }],
+            errors: expectedErrors([2, 13, 12, "ArrayExpression"])
+        }
+    ]
+});


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] New rule

**What changes did you make? (Give an overview)**

The indent rewrite in https://github.com/eslint/eslint/pull/7618 will cause the indent rule to report more errors when it is merged for v4.0.0. To make the migration process easier, this commit introduces an indent-legacy rule as a snapshot of the v3.x version of the indent rule. The indent-legacy rule is immediately deprecated in favor of the indent rule.

**Is there anything you'd like reviewers to focus on?**

Although this is not a breaking change, it should not be merged until 4.0.0. I've added the "do not merge" label for now.

This rule proposal was accepted in the [2017-03-16 TSC meeting](https://github.com/eslint/tsc-meetings/blob/452d118d368d1e3eedb11af8b0264943eab15ce2/notes/2017/2017-03-16.md).

All of the new files in this diff are copies of previously-existing files, with a few small modifications:

* The `meta` information for `indent-legacy` is updated to indicate that the rule is deprecated.
* The `RuleTester` logic in the `indent-legacy` tests is updated to ensure that the `indent-legacy` rule is tested rather than the `indent` rule.
* A paragraph is added to the top of the `indent-legacy` documentation page to explain the purpose of the rule and to direct people to the `indent` rule instead.