### PR TITLE
Fix: operator-assignment autofix errors with parentheses (fixes #8293)

### DIFF
--- a/lib/rules/operator-assignment.js
+++ b/lib/rules/operator-assignment.js
@@ -135,7 +135,7 @@ module.exports = {
                                 const equalsToken = getOperatorToken(node);
                                 const operatorToken = getOperatorToken(expr);
                                 const leftText = sourceCode.getText().slice(node.range[0], equalsToken.range[0]);
-                                const rightText = sourceCode.getText().slice(operatorToken.range[1], expr.right.range[1]);
+                                const rightText = sourceCode.getText().slice(operatorToken.range[1], node.right.range[1]);
 
                                 return fixer.replaceText(node, `${leftText}${expr.operator}=${rightText}`);
                             }

--- a/tests/lib/rules/operator-assignment.js
+++ b/tests/lib/rules/operator-assignment.js
@@ -155,6 +155,16 @@ ruleTester.run("operator-assignment", rule, {
         options: ["always"],
         errors: EXPECTED_OPERATOR_ASSIGNMENT
     }, {
+        code: "x = x + (y)",
+        output: "x += (y)",
+        options: ["always"],
+        errors: EXPECTED_OPERATOR_ASSIGNMENT
+    }, {
+        code: "x += (y)",
+        output: "x = x + (y)",
+        options: ["never"],
+        errors: UNEXPECTED_OPERATOR_ASSIGNMENT
+    }, {
         code: "x += y",
         output: "x = x + y",
         options: ["never"],


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix (https://github.com/eslint/eslint/issues/8293)
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates the operator-assignment autofixer to handle parenthesized values correctly. The fix in 41e3d9ce08b1a7f1f97d878a439b0143d19c7084 handles cases where expressions like `x = (x + y)` are parenthesized, but it handles cases like `x = x + (y)` incorrectly (it omits the closing paren).

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
