### PR TITLE
Chore: use precalculated counts in codeframe formatter

### DIFF
--- a/lib/formatters/codeframe.js
+++ b/lib/formatters/codeframe.js
@@ -101,15 +101,10 @@ module.exports = function(results) {
     const resultsWithMessages = results.filter(result => result.messages.length > 0);
 
     let output = resultsWithMessages.reduce((resultsOutput, result) => {
-        const messages = result.messages.map(message => {
-            if (message.fatal || message.severity === 2) {
-                errors++;
-            } else {
-                warnings++;
-            }
+        const messages = result.messages.map(message => `${formatMessage(message, result)}\n\n`);
 
-            return `${formatMessage(message, result)}\n\n`;
-        });
+        errors += result.errorCount;
+        warnings += result.warningCount;
 
         return resultsOutput.concat(messages);
     }, []).join("\n");


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:
Chore. See below.

**What changes did you make? (Give an overview)**
Updated the codeframe formatter to use the precalculated error and warning counts, just like it was done in https://github.com/eslint/eslint/pull/8251.

**Is there anything you'd like reviewers to focus on?**
I think not!

