### PR TITLE
New: padded-blocks implicit blocks

### DIFF
--- a/lib/rules/padded-blocks.js
+++ b/lib/rules/padded-blocks.js
@@ -36,6 +36,9 @@ module.exports = {
                             },
                             classes: {
                                 enum: ["always", "never"]
+                            },
+                            implicitBlocks: {
+                                enum: ["always", "never"]
                             }
                         },
                         additionalProperties: false,
@@ -61,6 +64,9 @@ module.exports = {
             }
             if (config.hasOwnProperty("classes")) {
                 options.classes = config.classes === "always";
+            }
+            if (config.hasOwnProperty("implicitBlocks")) {
+                options.implicitBlocks = config.implicitBlocks === "always";
             }
         }
 
@@ -148,6 +154,10 @@ module.exports = {
                     return options.switches;
                 case "ClassBody":
                     return options.classes;
+                case "IfStatement":
+                case "ForStatement":
+                case "WhileStatement":
+                    return options.implicitBlocks;
 
                 /* istanbul ignore next */
                 default:
@@ -217,6 +227,39 @@ module.exports = {
                 }
             }
         }
+        
+        function checkImplicitBlockPadding(node, implicitBlock) {
+            const statement = sourceCode.getFirstToken(node),
+                  statementEndingBrace = sourceCode.getLastTokenBetween(statement, implicitBlock),
+                  firstBlockToken = getFirstBlockToken(statementEndingBrace),
+                  tokenBeforeFirst = sourceCode.getTokenBefore(firstBlockToken, { includeComments: true }),
+                  blockHasTopPadding = isPaddingBetweenTokens(tokenBeforeFirst, firstBlockToken);
+            
+            if (requirePaddingFor(node)) {
+                if (!blockHasTopPadding) {
+                    context.report({
+                        node,
+                        loc: { line: tokenBeforeFirst.loc.start.line, column: tokenBeforeFirst.loc.start.column },
+                        fix(fixer) {
+                            return fixer.insertTextAfter(tokenBeforeFirst, "\n");
+                        },
+                        message: ALWAYS_MESSAGE,
+                    });
+                }
+            }
+            else {
+                if (blockHasTopPadding) {
+                    context.report({
+                        node,
+                        loc: { line: tokenBeforeFirst.loc.start.line, column: tokenBeforeFirst.loc.start.column },
+                        fix(fixer) {
+                            return fixer.replaceTextRange([tokenBeforeFirst.end, firstBlockToken.start - firstBlockToken.loc.start.column], "\n");
+                        },
+                        message: NEVER_MESSAGE,
+                    });
+                }
+            }
+        }
 
         const rule = {};
 
@@ -244,6 +287,19 @@ module.exports = {
                     return;
                 }
                 checkPadding(node);
+            };
+        }
+
+        if (options.hasOwnProperty("implicitBlocks")) {
+            rule.IfStatement = function (node) {
+                if (node.consequent.type !== "BlockStatement") {
+                    checkImplicitBlockPadding(node, node.consequent);
+                }
+            };
+            rule.ForStatement = rule.WhileStatement = function (node) {
+                if (node.body.type !== "BlockStatement") {
+                    checkImplicitBlockPadding(node, node.body);
+                }
             };
         }
 

--- a/lib/rules/padded-blocks.js
+++ b/lib/rules/padded-blocks.js
@@ -37,7 +37,7 @@ module.exports = {
                             classes: {
                                 enum: ["always", "never"]
                             },
-                            implicitBlocks: {
+                            "implicit-blocks": {
                                 enum: ["always", "never"]
                             }
                         },
@@ -65,8 +65,8 @@ module.exports = {
             if (config.hasOwnProperty("classes")) {
                 options.classes = config.classes === "always";
             }
-            if (config.hasOwnProperty("implicitBlocks")) {
-                options.implicitBlocks = config.implicitBlocks === "always";
+            if (config.hasOwnProperty("implicit-blocks")) {
+                options["implicit-blocks"] = config["implicit-blocks"] === "always";
             }
         }
 
@@ -157,7 +157,7 @@ module.exports = {
                 case "IfStatement":
                 case "ForStatement":
                 case "WhileStatement":
-                    return options.implicitBlocks;
+                    return options["implicit-blocks"];
 
                 /* istanbul ignore next */
                 default:
@@ -323,7 +323,7 @@ module.exports = {
             };
         }
 
-        if (options.hasOwnProperty("implicitBlocks")) {
+        if (options.hasOwnProperty("implicit-blocks")) {
             rule.IfStatement = function (node) {
                 if (node.consequent.type !== "BlockStatement") {
                     checkImplicitBlockPadding(node, node.consequent);

--- a/lib/rules/padded-blocks.js
+++ b/lib/rules/padded-blocks.js
@@ -260,6 +260,39 @@ module.exports = {
                 }
             }
         }
+        
+        function checkElseImplicitBlockPadding(ifNode) {
+            const elseNode = ifNode.alternate,
+                  statement = sourceCode.getTokenBefore(elseNode),
+                  firstBlockToken = getFirstBlockToken(statement),
+                  tokenBeforeFirst = sourceCode.getTokenBefore(firstBlockToken, { includeComments: true }),
+                  blockHasTopPadding = isPaddingBetweenTokens(tokenBeforeFirst, firstBlockToken);
+            
+            if (requirePaddingFor(ifNode)) {
+                if (!blockHasTopPadding) {
+                    context.report({
+                        elseNode,
+                        loc: { line: tokenBeforeFirst.loc.start.line, column: tokenBeforeFirst.loc.start.column },
+                        fix(fixer) {
+                            return fixer.insertTextAfter(tokenBeforeFirst, "\n");
+                        },
+                        message: ALWAYS_MESSAGE,
+                    });
+                }
+            }
+            else {
+                if (blockHasTopPadding) {
+                    context.report({
+                        elseNode,
+                        loc: { line: tokenBeforeFirst.loc.start.line, column: tokenBeforeFirst.loc.start.column },
+                        fix(fixer) {
+                            return fixer.replaceTextRange([tokenBeforeFirst.end, firstBlockToken.start - firstBlockToken.loc.start.column], "\n");
+                        },
+                        message: NEVER_MESSAGE,
+                    });
+                }
+            }
+        }
 
         const rule = {};
 
@@ -294,6 +327,9 @@ module.exports = {
             rule.IfStatement = function (node) {
                 if (node.consequent.type !== "BlockStatement") {
                     checkImplicitBlockPadding(node, node.consequent);
+                }
+                if (node.alternate && node.alternate.type !== "BlockStatement") {
+                    checkElseImplicitBlockPadding(node);
                 }
             };
             rule.ForStatement = rule.WhileStatement = function (node) {

--- a/lib/rules/padded-blocks.js
+++ b/lib/rules/padded-blocks.js
@@ -227,14 +227,20 @@ module.exports = {
                 }
             }
         }
-        
+
+        /**
+         * `checkPadding` for non-block statements.
+         * @param {ASTNode} node The AST node of a non-block statement.
+         * @param {ASTNode} implicitBlock The inner AST node of a non-block statement.
+         * @returns {void} undefined.
+         */
         function checkImplicitBlockPadding(node, implicitBlock) {
             const statement = sourceCode.getFirstToken(node),
-                  statementEndingBrace = sourceCode.getLastTokenBetween(statement, implicitBlock),
-                  firstBlockToken = getFirstBlockToken(statementEndingBrace),
-                  tokenBeforeFirst = sourceCode.getTokenBefore(firstBlockToken, { includeComments: true }),
-                  blockHasTopPadding = isPaddingBetweenTokens(tokenBeforeFirst, firstBlockToken);
-            
+                statementEndingBrace = sourceCode.getLastTokenBetween(statement, implicitBlock),
+                firstBlockToken = getFirstBlockToken(statementEndingBrace),
+                tokenBeforeFirst = sourceCode.getTokenBefore(firstBlockToken, { includeComments: true }),
+                blockHasTopPadding = isPaddingBetweenTokens(tokenBeforeFirst, firstBlockToken);
+
             if (requirePaddingFor(node)) {
                 if (!blockHasTopPadding) {
                     context.report({
@@ -243,11 +249,10 @@ module.exports = {
                         fix(fixer) {
                             return fixer.insertTextAfter(tokenBeforeFirst, "\n");
                         },
-                        message: ALWAYS_MESSAGE,
+                        message: ALWAYS_MESSAGE
                     });
                 }
-            }
-            else {
+            } else {
                 if (blockHasTopPadding) {
                     context.report({
                         node,
@@ -255,19 +260,24 @@ module.exports = {
                         fix(fixer) {
                             return fixer.replaceTextRange([tokenBeforeFirst.end, firstBlockToken.start - firstBlockToken.loc.start.column], "\n");
                         },
-                        message: NEVER_MESSAGE,
+                        message: NEVER_MESSAGE
                     });
                 }
             }
         }
-        
+
+        /**
+         * `checkPadding` for `else` statements.
+         * @param {ASTNode} ifNode The AST node of a preceding `IfStatement`.
+         * @returns {void} undefined.
+         */
         function checkElseImplicitBlockPadding(ifNode) {
             const elseNode = ifNode.alternate,
-                  statement = sourceCode.getTokenBefore(elseNode),
-                  firstBlockToken = getFirstBlockToken(statement),
-                  tokenBeforeFirst = sourceCode.getTokenBefore(firstBlockToken, { includeComments: true }),
-                  blockHasTopPadding = isPaddingBetweenTokens(tokenBeforeFirst, firstBlockToken);
-            
+                statement = sourceCode.getTokenBefore(elseNode),
+                firstBlockToken = getFirstBlockToken(statement),
+                tokenBeforeFirst = sourceCode.getTokenBefore(firstBlockToken, { includeComments: true }),
+                blockHasTopPadding = isPaddingBetweenTokens(tokenBeforeFirst, firstBlockToken);
+
             if (requirePaddingFor(ifNode)) {
                 if (!blockHasTopPadding) {
                     context.report({
@@ -276,11 +286,10 @@ module.exports = {
                         fix(fixer) {
                             return fixer.insertTextAfter(tokenBeforeFirst, "\n");
                         },
-                        message: ALWAYS_MESSAGE,
+                        message: ALWAYS_MESSAGE
                     });
                 }
-            }
-            else {
+            } else {
                 if (blockHasTopPadding) {
                     context.report({
                         elseNode,
@@ -288,7 +297,7 @@ module.exports = {
                         fix(fixer) {
                             return fixer.replaceTextRange([tokenBeforeFirst.end, firstBlockToken.start - firstBlockToken.loc.start.column], "\n");
                         },
-                        message: NEVER_MESSAGE,
+                        message: NEVER_MESSAGE
                     });
                 }
             }
@@ -324,7 +333,7 @@ module.exports = {
         }
 
         if (options.hasOwnProperty("implicit-blocks")) {
-            rule.IfStatement = function (node) {
+            rule.IfStatement = function(node) {
                 if (node.consequent.type !== "BlockStatement") {
                     checkImplicitBlockPadding(node, node.consequent);
                 }
@@ -332,7 +341,7 @@ module.exports = {
                     checkElseImplicitBlockPadding(node);
                 }
             };
-            rule.ForStatement = rule.WhileStatement = function (node) {
+            rule.ForStatement = rule.WhileStatement = function(node) {
                 if (node.body.type !== "BlockStatement") {
                     checkImplicitBlockPadding(node, node.body);
                 }


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))

**What rule do you want to change?**
padded-blocks

**Does this change cause the rule to produce more or fewer warnings?**
More, if the option is set.

**How will the change be implemented? (New option, new default behavior, etc.)?**
New option. `implicit-blocks` would be my suggestion, yet.

**Please provide some example code that this change will affect:**
```js
module.exports = {
    root: true,
    parserOptions: {
        ecmaVersion: 8,
    },
    rules: {
        'padded-blocks': [2, {
            blocks: 'never',
            classes: 'never',
            switches: 'never',
        }],
    },
};
```
```js
if (true)

  'yay1';

else

if (true)

  'yay2';

else

  'yay3';

for (;;)

  'yay4';

while (true)

  'yay5';
```

**What does the rule currently do for this code?**
Nothing.

**What will the rule do after it's changed?**
```js
module.exports = {
    root: true,
    parserOptions: {
        ecmaVersion: 8,
    },
    rules: {
        'padded-blocks': [2, {
            blocks: 'never',
            classes: 'never',
            switches: 'never',
            'implicit-blocks': 'never',
        }],
    },
};
```
**`$ eslint test.js --fix`**
```js
if (true)
  'yay1';

else
if (true)
  'yay2';

else
  'yay3';

for (;;)
  'yay4';

while (true)
  'yay5';
```

**What changes did you make? (Give an overview)**
- Added option `implicit-blocks`
- Enhanced `requirePaddingFor()` to support the new option
- Added `checkImplicitBlockPadding()` and `checkElseImplicitBlockPadding()`
- Added a few linter hooks

**Is there anything you'd like reviewers to focus on?**
As there are 3 `checkPadding()` functions now, would it be better to put those `context.report()`'s in a separate function, as they are pretty much the same?