### PR TITLE
Chore: update sinon calls to deprecated API.

### DIFF
--- a/tests/lib/config/config-initializer.js
+++ b/tests/lib/config/config-initializer.js
@@ -71,7 +71,7 @@ describe("configInitializer", () => {
 
     beforeEach(() => {
         npmInstallStub = sinon.stub(npmUtil, "installSyncSaveDev");
-        npmCheckStub = sinon.stub(npmUtil, "checkDevDeps", packages => packages.reduce((status, pkg) => {
+        npmCheckStub = sinon.stub(npmUtil, "checkDevDeps").callsFake(packages => packages.reduce((status, pkg) => {
             status[pkg] = false;
             return status;
         }, {}));

--- a/tests/lib/util/path-util.js
+++ b/tests/lib/util/path-util.js
@@ -74,7 +74,7 @@ describe("pathUtil", () => {
             const filePath = "file/path.js";
             const basePath = "/absolute/file";
 
-            sinon.stub(process, "cwd", () => "/absolute/");
+            sinon.stub(process, "cwd").returns("/absolute/");
             const result = pathUtil.getRelativePath(filePath, basePath);
 
             assert.equal(result, "path.js");


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
sinon started complaining noisily about using a deprecated call:
```
sinon.stub(obj, 'meth', fn) is deprecated and will be removed from the public API in a future version of sinon.
 Use stub(obj, 'meth').callsFake(fn).
 Codemod available at https://github.com/hurrymaplelad/sinon-codemod
```

This PR removes the warning.
**Is there anything you'd like reviewers to focus on?**
No.

