### PR TITLE
Chore: remove unused files from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /node_modules
-test.js
 coverage/
 build/
 npm-debug.log
@@ -9,7 +8,6 @@ tmp/
 jsdoc/
 versions.json
 *.iml
-.eslintcache
 .cache
 /packages/**/node_modules
 /.vscode


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

The `test.js` file has been in gitignore since the initial commit of this repo. I'm not sure why it was ignored initially, but I'm pretty sure that name doesn't need to be ignored anymore.

The `.eslintcache` file doesn't need to be ignored because we use `.cache/js_cache` rather than `.eslintcache` for our cache file.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular