### PR TITLE
Fix: don't classify plugins that throw errors as "missing" (fixes #6874)

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "ejs": "^2.5.6",
     "eslint-plugin-eslint-plugin": "^0.7.1",
     "eslint-plugin-node": "^4.2.1",
+    "eslint-plugin-throws-on-load": "^1.0.0",
     "eslint-release": "^0.10.1",
     "esprima": "^3.1.3",
     "esprima-fb": "^15001.1001.0-dev-harmony-fb",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "ejs": "^2.5.6",
     "eslint-plugin-eslint-plugin": "^0.7.1",
     "eslint-plugin-node": "^4.2.1",
-    "eslint-plugin-throws-on-load": "^1.0.0",
     "eslint-release": "^0.10.1",
     "esprima": "^3.1.3",
     "esprima-fb": "^15001.1001.0-dev-harmony-fb",

--- a/tests/lib/config/plugins.js
+++ b/tests/lib/config/plugins.js
@@ -43,7 +43,12 @@ describe("Plugins", () => {
                 "eslint-plugin-example": plugin,
                 "@scope/eslint-plugin-example": scopedPlugin,
                 "./environments": Environments,
-                "../rules": Rules
+                "../rules": Rules,
+                "eslint-plugin-throws-on-load": {
+                    get rules() {
+                        throw new Error("error thrown while loading this module");
+                    }
+                }
             });
         });
 

--- a/tests/lib/config/plugins.js
+++ b/tests/lib/config/plugins.js
@@ -106,6 +106,21 @@ describe("Plugins", () => {
             }, /Failed to load plugin/);
         });
 
+        it("should rethrow an error that a plugin throws on load", () => {
+            try {
+                StubbedPlugins.load("throws-on-load");
+            } catch (err) {
+                assert.strictEqual(
+                    err.message,
+                    "error thrown while loading this module",
+                    "should rethrow the same error that was thrown on plugin load"
+                );
+
+                return;
+            }
+            assert.fail(null, null, "should throw an error if a plugin fails to load");
+        });
+
         it("should load a scoped plugin when referenced by short name", () => {
             StubbedPlugins.load("@scope/example");
             assert.equal(StubbedPlugins.get("@scope/example"), scopedPlugin);


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (https://github.com/eslint/eslint/issues/6874)

**What changes did you make? (Give an overview)**

Previously, if a plugin threw an error on load, ESLint would display the "missing plugin" error message. This was confusing for plugin developers, because it would be difficult to distinguish between an installation error and a broken plugin.

This fix avoids the confusion by treating the errors as fatal and crashing with a stack trace if a plugin throws when it loads, as described in https://github.com/eslint/eslint/issues/7668#issuecomment-263148418.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular