### PR TITLE
Fix: don't generate invalid options in config-rule

### DIFF
--- a/lib/config/config-rule.js
+++ b/lib/config/config-rule.js
@@ -223,7 +223,7 @@ class RuleConfigSet {
     /**
     * Add rule configurations from a schema object
     * @param  {Object} obj Schema item with type === "object"
-    * @returns {void}
+    * @returns {boolean} true if at least one schema for the object could be generated, false otherwise
     */
     addObject(obj) {
         const objectConfigSet = {
@@ -258,7 +258,10 @@ class RuleConfigSet {
 
         if (objectConfigSet.objectConfigs.length > 0) {
             this.ruleConfigs = this.ruleConfigs.concat(combineArrays(this.ruleConfigs, objectConfigSet.objectConfigs));
+            return true;
         }
+
+        return false;
     }
 }
 
@@ -271,20 +274,21 @@ function generateConfigsFromSchema(schema) {
     const configSet = new RuleConfigSet();
 
     if (Array.isArray(schema)) {
-        schema.forEach(opt => {
+        for (const opt of schema) {
             if (opt.enum) {
                 configSet.addEnums(opt.enum);
-            }
+            } else if (opt.type && opt.type === "object") {
+                if (!configSet.addObject(opt)) {
+                    break;
+                }
 
-            if (opt.type && opt.type === "object") {
-                configSet.addObject(opt);
-            }
+            // TODO (IanVS): support oneOf
+            } else {
 
-            if (opt.oneOf) {
-
-                // TODO (IanVS): not yet implemented
+                // If we don't know how to fill in this option, don't fill in any of the following options.
+                break;
             }
-        });
+        }
     }
     configSet.addErrorSeverity();
     return configSet.ruleConfigs;

--- a/tests/fixtures/config-rule/schemas.js
+++ b/tests/fixtures/config-rule/schemas.js
@@ -69,6 +69,22 @@ module.exports = {
         "additionalProperties": false
     }],
 
+    mixedObjectWithNothingEnum: [{
+        "type": "object",
+        "properties": {},
+        "additionalProperties": false
+    },
+    {
+        "enum": ["always", "never"]
+    }],
+
+    mixedStringEnum: [{
+        "type": "string"
+    },
+    {
+        "enum": ["always", "never"]
+    }],
+
     oneOf: [{
         "oneOf": [
             {

--- a/tests/lib/config/config-rule.js
+++ b/tests/lib/config/config-rule.js
@@ -230,13 +230,37 @@ describe("ConfigRule", () => {
             });
         });
 
-        describe("for a schema with an enum and an object with no usable properties", () => {
+        describe("for a schema with an enum followed by an object with no usable properties", () => {
             before(() => {
                 actualConfigs = ConfigRule.generateConfigsFromSchema(schema.mixedEnumObjectWithNothing);
             });
 
             it("should create config only for the enum", () => {
                 const expectedConfigs = [2, [2, "always"], [2, "never"]];
+
+                assert.sameDeepMembers(actualConfigs, expectedConfigs);
+            });
+        });
+
+        describe("for a schema with an enum preceded by an object with no usable properties", () => {
+            before(() => {
+                actualConfigs = ConfigRule.generateConfigsFromSchema(schema.mixedObjectWithNothingEnum);
+            });
+
+            it("should not create a config for the enum", () => {
+                const expectedConfigs = [2];
+
+                assert.sameDeepMembers(actualConfigs, expectedConfigs);
+            });
+        });
+
+        describe("for a schema with an enum preceded by a string", () => {
+            before(() => {
+                actualConfigs = ConfigRule.generateConfigsFromSchema(schema.mixedStringEnum);
+            });
+
+            it("should not create a config for the enum", () => {
+                const expectedConfigs = [2];
 
                 assert.sameDeepMembers(actualConfigs, expectedConfigs);
             });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**Tell us about your environment**

* **ESLint Version:** master
* **Node Version:** 7.7.4
* **npm Version:** 4.1.2

**What did you do? Please include the actual source code causing the issue.**

```js
const ruleConfigs = require("eslint/lib/config/config-rule").createCoreRuleConfigs();
```

**What did you expect to happen?**

I expected all the configs in `ruleConfigs` to be valid.

**What actually happened? Please include the actual, raw output from ESLint.**

Some of the configs were invalid. For example:

```js
console.log(ruleConfigs["id-match"]);
// => [ 2, [ 2, { properties: true } ], [ 2, { properties: false } ] ]
```

**What changes did you make? (Give an overview)**

Previously, the `config-rule` logic for generating rule options had a bug where it could generate invalid options. For example, it could generate these options for the `id-match` rule:

```json
[2, { "properties": true }]
```

This is invalid because the first option in `id-match` must be a string, and the second option must be an object. The config generator doesn't handle strings, but it was incorrectly skipping the string option and trying to fill in the config with an object after realizing that it couldn't generate a string. As a result, it placed the object where the string was supposed to go, so an invalid set of options was created. A similar issue can appear when generating configs for the `max-statements` rule.

Luckily, the `id-match` and `max-statements` rule are still able to run when passed an invalid config, and the invalid config never results in fewer errors being reported than the default, so the invalid options wouldn't ever get output to a config file. However, this is only the case due to implementation details in the two rules, and a new rule could be introduced in the future that crashes when given an invalid schema, so this is still worth fixing.

This commit fixes the issue by stopping early when the option generator reaches an option that it doesn't know how to fill in.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
