### PR TITLE
Fix: dot-notation autofix produces invalid syntax for integer properties

### DIFF
--- a/lib/rules/dot-notation.js
+++ b/lib/rules/dot-notation.js
@@ -79,9 +79,11 @@ module.exports = {
                                     return null;
                                 }
 
+                                const textBeforeDot = astUtils.isDecimalInteger(node.object) ? " " : "";
+
                                 return fixer.replaceTextRange(
                                     [leftBracket.range[0], rightBracket.range[1]],
-                                    `.${node.property.value}`
+                                    `${textBeforeDot}.${node.property.value}`
                                 );
                             }
                         });

--- a/tests/lib/rules/dot-notation.js
+++ b/tests/lib/rules/dot-notation.js
@@ -168,6 +168,11 @@ ruleTester.run("dot-notation", rule, {
             code: "(foo)['bar']",
             output: "(foo).bar",
             errors: [{ message: "[\"bar\"] is better written in dot notation." }]
+        },
+        {
+            code: "1['toString']",
+            output: "1 .toString",
+            errors: [{ message: "[\"toString\"] is better written in dot notation." }]
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix

**Tell us about your environment**

* **ESLint Version:** master
* **Node Version:** 7.7.4
* **npm Version:** 4.1.2

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

```yml
rules:
  dot-notation: error
```

**What did you do? Please include the actual source code causing the issue.**

```js
1['toString']
```

**What did you expect to happen?**

I expected the autofixer to produce valid syntax:

```js
1 .toString
```

**What actually happened? Please include the actual, raw output from ESLint.**

The autofixer produced invalid syntax:

```js
1.toString
```

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Previously, when fixing a computed property access from a number literal, the dot-notation autofixer would place a dot immediately after the number literal. However, a dot after a decimal integer literal gets parsed as a decimal point, not a property accessor. This commit updates the fixer to insert a space before the dot when the object is a decimal integer literal.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
