### PR TITLE
Fix: no-useless-computed-key invalid autofix for getters and setters

### DIFF
--- a/lib/rules/no-useless-computed-key.js
+++ b/lib/rules/no-useless-computed-key.js
@@ -9,6 +9,7 @@
 //------------------------------------------------------------------------------
 
 const astUtils = require("../ast-utils");
+const esUtils = require("esutils");
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -55,7 +56,17 @@ module.exports = {
                                 // If there are comments between the brackets and the property name, don't do a fix.
                                 return null;
                             }
-                            return fixer.replaceTextRange([leftSquareBracket.range[0], rightSquareBracket.range[1]], key.raw);
+
+                            const tokenBeforeLeftBracket = sourceCode.getTokenBefore(leftSquareBracket);
+
+                            // Insert a space before the key to avoid changing identifiers, e.g. ({ get[2]() {} }) to ({ get2() {} })
+                            const needsSpaceBeforeKey = tokenBeforeLeftBracket.range[1] === leftSquareBracket.range[0] &&
+                                esUtils.code.isIdentifierPartES6(tokenBeforeLeftBracket.value.slice(-1).charCodeAt(0)) &&
+                                esUtils.code.isIdentifierPartES6(key.raw.charCodeAt(0));
+
+                            const replacementKey = (needsSpaceBeforeKey ? " " : "") + key.raw;
+
+                            return fixer.replaceTextRange([leftSquareBracket.range[0], rightSquareBracket.range[1]], replacementKey);
                         }
                     });
                 }

--- a/tests/lib/rules/no-useless-computed-key.js
+++ b/tests/lib/rules/no-useless-computed-key.js
@@ -87,6 +87,81 @@ ruleTester.run("no-useless-computed-key", rule, {
             errors: [{
                 message: "Unnecessarily computed property ['x'] found.", type: "Property"
             }]
+        }, {
+            code: "({ get[.2]() {} })",
+            output: "({ get.2() {} })",
+            errors: [{
+                message: "Unnecessarily computed property [.2] found.", type: "Property"
+            }]
+        }, {
+            code: "({ set[.2](value) {} })",
+            output: "({ set.2(value) {} })",
+            errors: [{
+                message: "Unnecessarily computed property [.2] found.", type: "Property"
+            }]
+        }, {
+            code: "({ async[.2]() {} })",
+            output: "({ async.2() {} })",
+            parserOptions: { ecmaVersion: 8 },
+            errors: [{
+                message: "Unnecessarily computed property [.2] found.", type: "Property"
+            }]
+        }, {
+            code: "({ [2]() {} })",
+            output: "({ 2() {} })",
+            errors: [{
+                message: "Unnecessarily computed property [2] found.", type: "Property"
+            }]
+        }, {
+            code: "({ get [2]() {} })",
+            output: "({ get 2() {} })",
+            errors: [{
+                message: "Unnecessarily computed property [2] found.", type: "Property"
+            }]
+        }, {
+            code: "({ set [2](value) {} })",
+            output: "({ set 2(value) {} })",
+            errors: [{
+                message: "Unnecessarily computed property [2] found.", type: "Property"
+            }]
+        }, {
+            code: "({ async [2]() {} })",
+            output: "({ async 2() {} })",
+            parserOptions: { ecmaVersion: 8 },
+            errors: [{
+                message: "Unnecessarily computed property [2] found.", type: "Property"
+            }]
+        }, {
+            code: "({ get[2]() {} })",
+            output: "({ get 2() {} })",
+            errors: [{
+                message: "Unnecessarily computed property [2] found.", type: "Property"
+            }]
+        }, {
+            code: "({ set[2](value) {} })",
+            output: "({ set 2(value) {} })",
+            errors: [{
+                message: "Unnecessarily computed property [2] found.", type: "Property"
+            }]
+        }, {
+            code: "({ async[2]() {} })",
+            output: "({ async 2() {} })",
+            parserOptions: { ecmaVersion: 8 },
+            errors: [{
+                message: "Unnecessarily computed property [2] found.", type: "Property"
+            }]
+        }, {
+            code: "({ get['foo']() {} })",
+            output: "({ get'foo'() {} })",
+            errors: [{
+                message: "Unnecessarily computed property ['foo'] found.", type: "Property"
+            }]
+        }, {
+            code: "({ *[2]() {} })",
+            output: "({ *2() {} })",
+            errors: [{
+                message: "Unnecessarily computed property [2] found.", type: "Property"
+            }]
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix

**Tell us about your environment**

* **ESLint Version:** master
* **Node Version:** 7.7.4
* **npm Version:** 4.1.2

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

```yml
rules:
  no-useless-computed-key: error
```

**What did you do? Please include the actual source code causing the issue.**

```js
({ get[0]() {} });
```

**What did you expect to happen?**

I expected the code to be autofixed to

```js
({ get 0() {} });
```

**What actually happened? Please include the actual, raw output from ESLint.**

The code was autofixed to

```js
({ get0() {} });
```

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Previously, the no-useless-computed-key autofixer could sometimes place a key next to `get`, `set`, or `async` identifier in a property, causing the identifier and the key to combine and become a new identifier. This commit updates the autofixer to insert a space whenever that would happen to prevent the identifiers from combining.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular