### PR TITLE
Fix: no-extra-parens false positive with objects following arrows

### DIFF
--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -345,6 +345,11 @@ module.exports = {
         function report(node) {
             const leftParenToken = sourceCode.getTokenBefore(node);
             const rightParenToken = sourceCode.getTokenAfter(node);
+            const tokenBeforeLeftParen = sourceCode.getTokenBefore(leftParenToken);
+
+            if (tokenBeforeLeftParen && astUtils.isArrowToken(tokenBeforeLeftParen) && astUtils.isOpeningBraceToken(sourceCode.getFirstToken(node))) {
+                return;
+            }
 
             context.report({
                 node,
@@ -481,7 +486,7 @@ module.exports = {
                 }
 
                 if (node.body.type !== "BlockStatement") {
-                    if (sourceCode.getFirstToken(node.body).value !== "{" && hasExcessParens(node.body) && precedence(node.body) >= PRECEDENCE_OF_ASSIGNMENT_EXPR) {
+                    if (hasExcessParens(node.body) && precedence(node.body) >= PRECEDENCE_OF_ASSIGNMENT_EXPR) {
                         report(node.body);
                         return;
                     }

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -410,6 +410,22 @@ ruleTester.run("no-extra-parens", rule, {
         {
             code: "const A = class extends (B=C) {}",
             parserOptions: { ecmaVersion: 2015 }
+        },
+        {
+            code: "() => ({ foo: 1 })",
+            parserOptions: { ecmaVersion: 2015 }
+        },
+        {
+            code: "() => ({ foo: 1 }).foo",
+            parserOptions: { ecmaVersion: 2015 }
+        },
+        {
+            code: "() => ({ foo: 1 }.foo().bar).baz.qux()",
+            parserOptions: { ecmaVersion: 2015 }
+        },
+        {
+            code: "() => ({ foo: 1 }.foo().bar + baz)",
+            parserOptions: { ecmaVersion: 2015 }
         }
     ],
 
@@ -959,6 +975,18 @@ ruleTester.run("no-extra-parens", rule, {
             "Identifier",
             1,
             { parserOptions: { ecmaVersion: 2015 } }
-        )
+        ),
+        {
+            code: "() => (({ foo: 1 }).foo)",
+            output: "() => ({ foo: 1 }).foo",
+            parserOptions: { ecmaVersion: 2015 },
+            errors: [
+
+                // 2 errors are reported, but fixing one gets rid of the other
+                { message: "Gratuitous parentheses around expression.", type: "MemberExpression" },
+                { message: "Gratuitous parentheses around expression.", type: "ObjectExpression" }
+            ]
+
+        }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix

**Tell us about your environment**

* **ESLint Version:** master
* **Node Version:** 7.7.4
* **npm Version:** 4.1.2

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

```yml
parserOptions:
  ecmaVersion: 6
rules:
  no-extra-parens: error
```

**What did you do? Please include the actual source code causing the issue.**

```js
() => ({ foo: 1 }).foo;
```

**What did you expect to happen?**

I expected no error to be reported.

**What actually happened? Please include the actual, raw output from ESLint.**

An error was reported. The rule suggested fixing the code to

```js
() => { foo: 1 }.foo
```

which is invalid syntax.

**What changes did you make? (Give an overview)**

Previously, the no-extra-parens rule correctly did not report an error when an arrow function returned a parenthesized object expression. However, it would still report an error if an arrow function had a parenthesized object curly as its first token. This commit updates the rule to not report a paren between an arrow token and an opening curly token.

**Is there anything you'd like reviewers to focus on?**

I'm wondering if there's a better way to check for this case.
