### PR TITLE
Fix: no-implicit-coercion invalid autofix with consecutive identifiers

### DIFF
--- a/tests/lib/rules/no-implicit-coercion.js
+++ b/tests/lib/rules/no-implicit-coercion.js
@@ -221,6 +221,16 @@ ruleTester.run("no-implicit-coercion", rule, {
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "use `String(foo)` instead.", type: "BinaryExpression" }],
             output: "var a = String(foo)"
+        },
+        {
+            code: "typeof+foo",
+            output: "typeof Number(foo)",
+            errors: [{ message: "use `Number(foo)` instead.", type: "UnaryExpression" }]
+        },
+        {
+            code: "typeof +foo",
+            output: "typeof Number(foo)",
+            errors: [{ message: "use `Number(foo)` instead.", type: "UnaryExpression" }]
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix

**Tell us about your environment**

* **ESLint Version:** master
* **Node Version:** 7.7.4
* **npm Version:** 4.1.2

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

```yml
rules:
  no-implicit-coercion: error
```

**What did you do? Please include the actual source code causing the issue.**

```js
typeof+foo
```

**What did you expect to happen?**

I expected the code to get autofixed to

```js
typeof Number(foo)
```

**What actually happened? Please include the actual, raw output from ESLint.**

The code was autofixed to

```js
typeofNumber(foo)
```

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Previously, the no-implicit-coercion rule would convert code like `typeof+foo` to `typeofNumber(foo)`, combining the `typeof` keyword with the following identifier and changing the semantics. This commit updates the no-implicit-coercion autofixer to prevent that from happening.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular