### PR TITLE
Add Import/Export Declaration checks to `indent`

### DIFF
--- a/docs/rules/indent.md
+++ b/docs/rules/indent.md
@@ -71,6 +71,8 @@ This rule has an object option:
 * `"SwitchCase"` (default: 0) enforces indentation level for `case` clauses in `switch` statements
 * `"VariableDeclarator"` (default: 1) enforces indentation level for `var` declarators; can also take an object to define separate rules for `var`, `let` and `const` declarations.
 * `"outerIIFEBody"` (default: 1) enforces indentation level for file-level IIFEs.
+* `"ImportDeclaration"` (default: 1) enforces indentation level for `import` specifiers.
+* `"ExportDeclaration"` (default: 1) enforces indentation level for `export` specifiers.
 * `"MemberExpression"` (off by default) enforces indentation level for multi-line property chains (except in variable declarations and assignments)
 * `"FunctionDeclaration"` takes an object to define rules for function declarations.
     * `parameters` (off by default) enforces indentation level for parameters in a function declaration. This can either be a number indicating indentation level, or the string `"first"` indicating that all parameters of the declaration must be aligned with the first parameter.
@@ -224,6 +226,273 @@ let a,
 const a = 1,
       b = 2,
       c = 3;
+```
+
+### ImportDeclaration
+
+Examples of **incorrect** code for this rule with the options `2, 2, { "ImportDeclaration": 0 }`:
+
+```js
+/*eslint indent: ["error", 2, { "ImportDeclaration": 0 }]*/
+
+import {
+  foo
+} from 'bar';
+```
+
+```js
+/*eslint indent: ["error", 2, { "ImportDeclaration": 0 }]*/
+
+  import {
+foo
+} from 'bar';
+```
+
+```js
+/*eslint indent: ["error", 2, { "ImportDeclaration": 0 }]*/
+
+import {
+foo
+  } from 'bar';
+```
+
+```js
+/*eslint indent: ["error", 2, { "ImportDeclaration": 0 }]*/
+
+import {
+foo
+}
+  from 'bar';
+```
+
+Examples of **correct** code for this rule with the options `2, 2, { "ImportDeclaration": 0 }`:
+
+```js
+/*eslint indent: ["error", 2, { "ImportDeclaration": 0 }]*/
+/*eslint-env es6*/
+
+import {
+foo
+} from 'bar';
+```
+
+```js
+/*eslint indent: ["error", 2, { "ImportDeclaration": 0 }]*/
+/*eslint-env es6*/
+
+import {
+foo
+}
+from 'bar';
+```
+
+```js
+/*eslint indent: ["error", 2, { "ImportDeclaration": 0 }]*/
+/*eslint-env es6*/
+
+import foo
+from 'bar';
+```
+
+Examples of **incorrect** code for this rule with the options `2, 2, { "ImportDeclaration": 1 }`:
+
+```js
+/*eslint indent: ["error", 2, { "ImportDeclaration": 1 }]*/
+
+import {
+foo
+} from 'bar';
+```
+
+```js
+/*eslint indent: ["error", 2, { "ImportDeclaration": 1 }]*/
+
+  import {
+  foo
+} from 'bar';
+```
+
+```js
+/*eslint indent: ["error", 2, { "ImportDeclaration": 1 }]*/
+
+import {
+  foo
+  } from 'bar';
+```
+
+```js
+/*eslint indent: ["error", 2, { "ImportDeclaration": 1 }]*/
+
+import {
+    foo
+} from 'bar';
+```
+
+```js
+/*eslint indent: ["error", 2, { "ImportDeclaration": 1 }]*/
+
+import {
+  foo
+}
+from 'bar';
+```
+
+```js
+/*eslint indent: ["error", 2, { "ImportDeclaration": 1 }]*/
+
+import foo
+from 'bar';
+```
+
+Examples of **correct** code for this rule with the options `2, 2, { "ImportDeclaration": 1 }`:
+
+```js
+/*eslint indent: ["error", 2, { "ImportDeclaration": 1 }]*/
+/*eslint-env es6*/
+
+import {
+  foo
+} from 'bar';
+```
+
+```js
+/*eslint indent: ["error", 2, { "ImportDeclaration": 1 }]*/
+/*eslint-env es6*/
+
+import {
+  foo
+}
+  from 'bar';
+```
+
+```js
+/*eslint indent: ["error", 2, { "ImportDeclaration": 1 }]*/
+/*eslint-env es6*/
+
+import foo
+  from 'bar';
+```
+
+### ExportDeclaration
+
+Examples of **incorrect** code for this rule with the options `2, 2, { "ExportDeclaration": 0 }`:
+
+```js
+/*eslint indent: ["error", 2, { "ExportDeclaration": 0 }]*/
+
+export {
+  foo
+} from 'bar';
+```
+
+```js
+/*eslint indent: ["error", 2, { "ExportDeclaration": 0 }]*/
+
+  export {
+foo
+} from 'bar';
+```
+
+```js
+/*eslint indent: ["error", 2, { "ExportDeclaration": 0 }]*/
+
+export {
+foo
+  } from 'bar';
+```
+
+```js
+/*eslint indent: ["error", 2, { "ExportDeclaration": 0 }]*/
+
+export {
+foo
+}
+  from 'bar';
+```
+
+Examples of **correct** code for this rule with the options `2, 2, { "ExportDeclaration": 0 }`:
+
+```js
+/*eslint indent: ["error", 2, { "ExportDeclaration": 0 }]*/
+/*eslint-env es6*/
+
+export {
+foo
+} from 'bar';
+```
+
+```js
+/*eslint indent: ["error", 2, { "ExportDeclaration": 0 }]*/
+/*eslint-env es6*/
+
+export {
+foo
+}
+from 'bar';
+```
+
+Examples of **incorrect** code for this rule with the options `2, 2, { "ExportDeclaration": 1 }`:
+
+```js
+/*eslint indent: ["error", 2, { "ExportDeclaration": 1 }]*/
+
+export {
+foo
+} from 'bar';
+```
+
+```js
+/*eslint indent: ["error", 2, { "ExportDeclaration": 1 }]*/
+
+  export {
+  foo
+} from 'bar';
+```
+
+```js
+/*eslint indent: ["error", 2, { "ExportDeclaration": 1 }]*/
+
+export {
+  foo
+  } from 'bar';
+```
+
+```js
+/*eslint indent: ["error", 2, { "ExportDeclaration": 1 }]*/
+
+export {
+    foo
+} from 'bar';
+```
+
+```js
+/*eslint indent: ["error", 2, { "ExportDeclaration": 1 }]*/
+
+export {
+  foo
+}
+from 'bar';
+```
+
+Examples of **correct** code for this rule with the options `2, 2, { "ExportDeclaration": 1 }`:
+
+```js
+/*eslint indent: ["error", 2, { "ExportDeclaration": 1 }]*/
+/*eslint-env es6*/
+
+export {
+  foo
+} from 'bar';
+```
+
+```js
+/*eslint indent: ["error", 2, { "ExportDeclaration": 1 }]*/
+/*eslint-env es6*/
+
+export {
+  foo
+}
+  from 'bar';
 ```
 
 ### outerIIFEBody

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -72,6 +72,14 @@ module.exports = {
                             }
                         ]
                     },
+                    ImportDeclaration: {
+                        type: "integer",
+                        minimum: 0
+                    },
+                    ExportDeclaration: {
+                        type: "integer",
+                        minimum: 0
+                    },
                     outerIIFEBody: {
                         type: "integer",
                         minimum: 0
@@ -178,6 +186,8 @@ module.exports = {
                 let: DEFAULT_VARIABLE_INDENT,
                 const: DEFAULT_VARIABLE_INDENT
             },
+            ImportDeclaration: DEFAULT_VARIABLE_INDENT,
+            ExportDeclaration: DEFAULT_VARIABLE_INDENT,
             outerIIFEBody: null,
             FunctionDeclaration: {
                 parameters: DEFAULT_PARAMETER_INDENT,
@@ -219,6 +229,14 @@ module.exports = {
                     };
                 } else if (typeof variableDeclaratorRules === "object") {
                     Object.assign(options.VariableDeclarator, variableDeclaratorRules);
+                }
+
+                if (typeof opts.ExportDeclaration === "number") {
+                    options.ExportDeclaration = opts.ExportDeclaration;
+                }
+
+                if (typeof opts.ImportDeclaration === "number") {
+                    options.ImportDeclaration = opts.ImportDeclaration;
                 }
 
                 if (typeof opts.outerIIFEBody === "number") {
@@ -797,6 +815,63 @@ module.exports = {
             checkLastNodeLineIndent(node, nodeIndent + (isNodeInVarOnTop(node, parentVarNode) ? options.VariableDeclarator[parentVarNode.parent.kind] * indentSize : 0));
         }
 
+
+        /**
+         * Check indent for import and export declarations
+         * @param {ASTNode} node node to examine
+         * @returns {void}
+         */
+        function checkIndentInImportOrExportDeclaration(node) {
+
+            // Skip inline
+            if (isSingleLineNode(node)) {
+                return;
+            } else if (node.declaration) {
+                return;
+            }
+
+            let elements = node.specifiers;
+
+            // filter out empty elements example would be [ , 2] so remove first element as espree considers it as null
+            elements = elements.filter(elem => elem !== null);
+
+            const nodeIndent = 0;
+            const elementsIndent = indentSize * (node.type === "ImportDeclaration" ? options.ImportDeclaration : options.ExportDeclaration);
+
+            checkFirstNodeLineIndent(node, nodeIndent);
+
+            checkNodesIndent(elements, elementsIndent);
+
+            if (elements.length > 0) {
+
+                // Skip last block line check if last item in same line
+                if (elements[elements.length - 1].loc.end.line === node.loc.end.line) {
+                    return;
+                }
+            }
+
+            // enforce closing bracket at indent 0
+            {
+                const closingBracketToken = sourceCode.getTokens(node)
+                    .find(token => token.type === "Punctuator" && token.value === "}");
+
+                if (closingBracketToken) {
+                    checkNodeIndent(closingBracketToken, nodeIndent);
+                }
+            }
+
+            // if `from '...'` is on it's own line, validate it's indentation
+            {
+                const fromToken = sourceCode.getTokens(node)
+                    .find(token => token.type === "Identifier" && token.value === "from");
+                const tokenBeforeFrom = sourceCode.getTokenBefore(fromToken);
+
+                if (fromToken.loc.start.line !== tokenBeforeFrom.loc.start.line) {
+                    checkNodeIndent(fromToken, elementsIndent);
+                }
+            }
+        }
+
         /**
          * Check if the node or node body is a BlockStatement or not
          * @param {ASTNode} node node to test
@@ -1000,6 +1075,14 @@ module.exports = {
                 if (node.declarations[node.declarations.length - 1].loc.start.line > node.declarations[0].loc.start.line) {
                     checkIndentInVariableDeclarations(node);
                 }
+            },
+
+            ImportDeclaration(node) {
+                checkIndentInImportOrExportDeclaration(node);
+            },
+
+            ExportNamedDeclaration(node) {
+                checkIndentInImportOrExportDeclaration(node);
             },
 
             ObjectExpression(node) {

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -1924,6 +1924,112 @@ ruleTester.run("indent", rule, {
             "             ['foo', 'bar',\n" +
             "              'baz']);",
             options: [2, { ArrayExpression: "first", CallExpression: { arguments: "first" } }]
+        },
+        {
+            code:
+            "import {\n" +
+            "  foo\n" +
+            "} from 'bar';\n",
+            options: [2],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" }
+        },
+        {
+            code:
+            "import {\n" +
+            "  foo\n" +
+            "} from 'bar';\n",
+            options: [2],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" }
+        },
+        {
+            code:
+            "import {\n" +
+            "    foo\n" +
+            "} from 'bar';\n",
+            options: [4],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" }
+        },
+        {
+            code:
+            "import {\n" +
+            "\tfoo\n" +
+            "} from 'bar';\n",
+            options: ["tab"],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" }
+        },
+        {
+            code:
+            "import foo\n" +
+            "\tfrom 'bart';\n",
+            options: ["tab"],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" }
+        },
+        {
+            code:
+            "import { foo }\n" +
+            "\tfrom 'bar';\n",
+            options: ["tab"],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" }
+        },
+        {
+            code:
+            "import foo\n" +
+            "\tfrom 'bar';\n",
+            options: ["tab"],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" }
+        },
+        {
+            code:
+            "import { foo }\n" +
+            "  from 'bar';\n",
+            options: [2],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" }
+        },
+        {
+            code:
+            "export {\n" +
+            "  foo\n" +
+            "} from 'bar';\n",
+            options: [2],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" }
+        },
+        {
+            code:
+            "export {\n" +
+            "  foo\n" +
+            "} from 'bar';\n",
+            options: [2],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" }
+        },
+        {
+            code:
+            "export {\n" +
+            "    foo\n" +
+            "} from 'bar';\n",
+            options: [4],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" }
+        },
+        {
+            code:
+            "export {\n" +
+            "\tfoo\n" +
+            "} from 'bar';\n",
+            options: ["tab"],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" }
+        },
+        {
+            code:
+            "export { foo }\n" +
+            "\tfrom 'bar';\n",
+            options: ["tab"],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" }
+        },
+        {
+            code:
+            "export { foo }\n" +
+            "  from 'bar';\n",
+            options: [2],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" }
         }
     ],
     invalid: [
@@ -3934,6 +4040,183 @@ ruleTester.run("indent", rule, {
             "             'baz']);",
             options: [2, { ArrayExpression: "first", CallExpression: { arguments: "first" } }],
             errors: expectedErrors([2, 13, 12, "ArrayExpression"])
+        },
+        {
+            code:
+            "import {\n" +
+            "    foo\n" +
+            "} from 'bar';\n",
+            options: [2],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: expectedErrors([2, 2, 4, "ImportSpecifier"]),
+            output:
+            "import {\n" +
+            "  foo\n" +
+            "} from 'bar';\n"
+        },
+        {
+            code:
+            "import {\n" +
+            "foo\n" +
+            "} from 'bar';\n",
+            options: [2],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: expectedErrors([2, 2, 0, "ImportSpecifier"]),
+            output:
+            "import {\n" +
+            "  foo\n" +
+            "} from 'bar';\n"
+        },
+        {
+            code:
+            "  import {\n" +
+            "  foo\n" +
+            "} from 'bar';\n",
+            options: [2],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: expectedErrors([1, 0, 2, "ImportDeclaration"]),
+            output:
+            "import {\n" +
+            "  foo\n" +
+            "} from 'bar';\n"
+        },
+        {
+            code:
+            "import {\n" +
+            "  foo\n" +
+            "  }\n" +
+            "from 'bar';\n",
+            options: [2],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: expectedErrors([
+                [3, 0, 2, "Punctuator"],
+                [4, 2, 0, "Identifier"]
+            ]),
+            output:
+            "import {\n" +
+            "  foo\n" +
+            "}\n" +
+            "  from 'bar';\n"
+        },
+        {
+            code:
+            "import {\n" +
+            "  foo\n" +
+            "  } from 'bar';\n",
+            options: [2],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: expectedErrors([3, 0, 2, "Punctuator"]),
+            output:
+            "import {\n" +
+            "  foo\n" +
+            "} from 'bar';\n"
+        },
+        {
+            code:
+            "import {\n" +
+            "\tfoo\n" +
+            "} from 'bar';\n",
+            options: [2],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: expectedErrors([2, 2, "1 tab", "ImportSpecifier"]),
+            output:
+            "import {\n" +
+            "  foo\n" +
+            "} from 'bar';\n"
+        },
+        {
+            code:
+            "import foo\n" +
+            "from 'bar';\n",
+            options: [2],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: expectedErrors([2, 2, 0, "Identifier"]),
+            output:
+            "import foo\n" +
+            "  from 'bar';\n"
+        },
+        {
+            code:
+            "export {\n" +
+            "    foo\n" +
+            "} from 'bar';\n",
+            options: [2],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: expectedErrors([2, 2, 4, "ExportSpecifier"]),
+            output:
+            "export {\n" +
+            "  foo\n" +
+            "} from 'bar';\n"
+        },
+        {
+            code:
+            "export {\n" +
+            "foo\n" +
+            "} from 'bar';\n",
+            options: [2],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: expectedErrors([2, 2, 0, "ExportSpecifier"]),
+            output:
+            "export {\n" +
+            "  foo\n" +
+            "} from 'bar';\n"
+        },
+        {
+            code:
+            "  export {\n" +
+            "  foo\n" +
+            "} from 'bar';\n",
+            options: [2],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: expectedErrors([1, 0, 2, "ExportNamedDeclaration"]),
+            output:
+            "export {\n" +
+            "  foo\n" +
+            "} from 'bar';\n"
+        },
+        {
+            code:
+            "export {\n" +
+            "  foo\n" +
+            "  }\n" +
+            "from 'bar';\n",
+            options: [2],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: expectedErrors([
+                [3, 0, 2, "Punctuator"],
+                [4, 2, 0, "Identifier"]
+            ]),
+            output:
+            "export {\n" +
+            "  foo\n" +
+            "}\n" +
+            "  from 'bar';\n"
+        },
+        {
+            code:
+            "export {\n" +
+            "  foo\n" +
+            "  } from 'bar';\n",
+            options: [2],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: expectedErrors([3, 0, 2, "Punctuator"]),
+            output:
+            "export {\n" +
+            "  foo\n" +
+            "} from 'bar';\n"
+        },
+        {
+            code:
+            "export {\n" +
+            "\tfoo\n" +
+            "} from 'bar';\n",
+            options: [2],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: expectedErrors([2, 2, "1 tab", "ExportSpecifier"]),
+            output:
+            "export {\n" +
+            "  foo\n" +
+            "} from 'bar';\n"
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What rule do you want to change?**
[`indent`](http://eslint.org/docs/rules/indent)

**Does this change cause the rule to produce more or fewer warnings?**
More

**How will the change be implemented? (New option, new default behavior, etc.)?**
New option

**Please provide some example code that this change will affect:**
Please see new tests added to `tests/lib/rules/indent.js` ([valid](https://github.com/justinanastos/eslint/blob/fix/indent-import-declaration/tests/lib/rules/indent.js#L1929-L1988), [invalid](https://github.com/justinanastos/eslint/blob/fix/indent-import-declaration/tests/lib/rules/indent.js#L3999-L4092)) and docs added to [`/docs/rules/indent.md#importdeclaration`](https://github.com/justinanastos/eslint/blob/fix/indent-import-declaration/docs/rules/indent.md#importdeclaration)

**What does the rule currently do for this code?**
`ImportDeclaration`s are ignored by the `indent` rule.

**What will the rule do after it's changed?**

- `ImportDeclaration`s will have the `import` line checked for `0` indent 
- `ImportDeclaration`s will have `ImportSpecifier`s validated similarly to `VariableDeclaration`s
- `ImportDeclaration`s will have their closing line checked for `0` indent
- `ImportDeclaration`s will have their `from` token checked if it's own line to have a proper indent
- `ExportDeclaration`s will have the `export` line checked for `0` indent 
- `ExportDeclaration`s will have `ExportSpecifier`s validated similarly to `VariableDeclaration`s
- `ExportDeclaration`s will have their closing line checked for `0` indent
- `ExportDeclaration`s will have their `from` token checked if it's own line to have a proper indent

Fixes https://github.com/eslint/eslint/issues/8342