### PR TITLE
Update: add fix for "no-confusing-arrow" rule

### DIFF
--- a/lib/rules/no-confusing-arrow.js
+++ b/lib/rules/no-confusing-arrow.js
@@ -33,6 +33,8 @@ module.exports = {
             recommended: false
         },
 
+        fixable: "code",
+
         schema: [{
             type: "object",
             properties: {
@@ -55,7 +57,15 @@ module.exports = {
             const body = node.body;
 
             if (isConditional(body) && !(config.allowParens && astUtils.isParenthesised(sourceCode, body))) {
-                context.report({ node, message: "Arrow function used ambiguously with a conditional expression." });
+                context.report({
+                    node,
+                    message: "Arrow function used ambiguously with a conditional expression.",
+                    fix(fixer) {
+
+                        // if `allowParens` is not set to true dont bother wrapping in parens
+                        return config.allowParens && fixer.replaceText(node.body, `(${sourceCode.getText(node.body)})`);
+                    }
+                });
             }
         }
 

--- a/tests/lib/rules/no-confusing-arrow.js
+++ b/tests/lib/rules/no-confusing-arrow.js
@@ -28,19 +28,41 @@ ruleTester.run("no-confusing-arrow", rule, {
     invalid: [
         {
             code: "a => 1 ? 2 : 3",
+            output: null,
             errors: [{ message: "Arrow function used ambiguously with a conditional expression." }]
         },
         {
             code: "var x = a => 1 ? 2 : 3",
+            output: null,
             errors: [{ message: "Arrow function used ambiguously with a conditional expression." }]
         },
         {
             code: "var x = (a) => 1 ? 2 : 3",
+            output: null,
             errors: [{ message: "Arrow function used ambiguously with a conditional expression." }]
         },
         {
             code: "var x = a => (1 ? 2 : 3)",
+            output: null,
             errors: [{ message: "Arrow function used ambiguously with a conditional expression." }]
+        },
+        {
+            code: "a => 1 ? 2 : 3",
+            output: "a => (1 ? 2 : 3)",
+            errors: [{ message: "Arrow function used ambiguously with a conditional expression." }],
+            options: [{ allowParens: true }]
+        },
+        {
+            code: "var x = a => 1 ? 2 : 3",
+            output: "var x = a => (1 ? 2 : 3)",
+            errors: [{ message: "Arrow function used ambiguously with a conditional expression." }],
+            options: [{ allowParens: true }]
+        },
+        {
+            code: "var x = (a) => 1 ? 2 : 3",
+            output: "var x = (a) => (1 ? 2 : 3)",
+            errors: [{ message: "Arrow function used ambiguously with a conditional expression." }],
+            options: [{ allowParens: true }]
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[X] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Added a fix function to `no-confusing-arrow` which will auto wrap an arrow function body if `allowParens` is set to true.

**Is there anything you'd like reviewers to focus on?**
I'm doing an early return from the `fix` if `allowParens` not enabled, can you please advise if it acceptable to return `undefined` from the `fix` function in such a case. 
_(my testing seems to indicate that its fine, just wanted to double check)_

