### PR TITLE
Docs: add note about git's linebreak handling to linebreak-style docs

### DIFF
--- a/docs/rules/linebreak-style.md
+++ b/docs/rules/linebreak-style.md
@@ -67,9 +67,19 @@ function foo(params) { // \r\n
 } // \r\n
 ```
 
+## Using this rule with version control systems
+
+Version control systems sometimes have special behavior for linebreaks. To make it easy for developers to contribute to your codebase from different platforms, you may want to configure your VCS to handle linebreaks appropriately.
+
+For example, the default behavior of [git](https://git-scm.com/) on Windows systems is to convert LF linebreaks to CRLF when checking out files, but to store the linebreaks as LF when committing a change. This will cause the `linebreak-style` rule to report errors if configured with the `"unix"` setting, because the files that ESLint sees will have CRLF linebreaks. If you use git, you may want to add a line to your [`.gitattributes` file](https://git-scm.com/docs/gitattributes) to prevent git from converting linebreaks in `.js` files:
+
+```
+*.js text eol=lf
+```
+
 ## When Not To Use It
 
-If you aren't concerned about having different line endings within you code, then you can safely turn this rule off.
+If you aren't concerned about having different line endings within your code, then you can safely turn this rule off.
 
 ## Compatibility
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This commit adds a note to the linebreak-style docs about how git handles linebreaks on windows, and suggests using a `.gitattributes` file to control git's behavior.

(refs https://github.com/eslint/eslint/pull/7823)

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
