### PR TITLE
Breaking: Traverse into type annotations (fixes #7129)

### DIFF
--- a/lib/util/traverser.js
+++ b/lib/util/traverser.js
@@ -21,6 +21,18 @@ const KEY_BLACKLIST = new Set([
 ]);
 
 /**
+ * Modify estraverse's visitor keys to traverse type annotations.
+ */
+estraverse.VisitorKeys.Identifier.push("typeAnnotation");
+estraverse.VisitorKeys.FunctionDeclaration.push("returnType");
+estraverse.VisitorKeys.FunctionExpression.push("returnType");
+estraverse.VisitorKeys.ArrowFunctionExpression.push("returnType");
+estraverse.VisitorKeys.MethodDefinition.push("returnType");
+estraverse.VisitorKeys.ObjectPattern.push("typeAnnotation");
+estraverse.VisitorKeys.ArrayPattern.push("typeAnnotation");
+estraverse.VisitorKeys.RestElement.push("typeAnnotation");
+
+/**
  * Wrapper around an estraverse controller that ensures the correct keys
  * are visited.
  * @constructor
@@ -41,5 +53,9 @@ class Traverser extends estraverse.Controller {
         return Object.keys(node).filter(key => !KEY_BLACKLIST.has(key));
     }
 }
+
+//------------------------------------------------------------------------------
+// Public Interface
+//------------------------------------------------------------------------------
 
 module.exports = Traverser;

--- a/tests/lib/util/traverser.js
+++ b/tests/lib/util/traverser.js
@@ -3,9 +3,30 @@
 const assert = require("chai").assert;
 const Traverser = require("../../../lib/util/traverser");
 
+/**
+ * Traverses an AST and returns the traversal order (both for entering and leaving nodes).
+ * @param {ASTNode} ast The Program node of the AST to check.
+ * @returns {Object} An object containing an enteredNodes and exitedNodes array.
+ * @private
+ */
+function traverseAst(ast) {
+    const traverser = new Traverser();
+    const enteredNodes = [];
+    const exitedNodes = [];
+
+    traverser.traverse(ast, {
+        enter: node => enteredNodes.push(node),
+        leave: node => exitedNodes.push(node)
+    });
+
+    return {
+        enteredNodes,
+        exitedNodes
+    };
+}
+
 describe("Traverser", () => {
     it("traverses all keys except 'parent', 'leadingComments', and 'trailingComments'", () => {
-        const traverser = new Traverser();
         const fakeAst = {
             type: "Program",
             body: [
@@ -29,15 +50,155 @@ describe("Traverser", () => {
 
         fakeAst.body[0].parent = fakeAst;
 
-        const enteredNodes = [];
-        const exitedNodes = [];
+        const traversalResults = traverseAst(fakeAst);
 
-        traverser.traverse(fakeAst, {
-            enter: node => enteredNodes.push(node),
-            leave: node => exitedNodes.push(node)
+        assert.deepEqual(traversalResults.enteredNodes, [fakeAst, fakeAst.body[0], fakeAst.body[1], fakeAst.body[1].foo]);
+        assert.deepEqual(traversalResults.exitedNodes, [fakeAst.body[0], fakeAst.body[1].foo, fakeAst.body[1], fakeAst]);
+    });
+
+    describe("type annotations", () => {
+        it("traverses type annotations in Identifiers", () => {
+            const fakeAst = {
+                type: "Program",
+                body: [
+                    {
+                        type: "Identifier",
+                        typeAnnotation: {
+                            type: "foo"
+                        }
+                    }
+                ]
+            };
+            const traversalResults = traverseAst(fakeAst);
+
+            assert.deepEqual(traversalResults.enteredNodes, [fakeAst, fakeAst.body[0], fakeAst.body[0].typeAnnotation]);
+            assert.deepEqual(traversalResults.exitedNodes, [fakeAst.body[0].typeAnnotation, fakeAst.body[0], fakeAst]);
         });
 
-        assert.deepEqual(enteredNodes, [fakeAst, fakeAst.body[0], fakeAst.body[1], fakeAst.body[1].foo]);
-        assert.deepEqual(exitedNodes, [fakeAst.body[0], fakeAst.body[1].foo, fakeAst.body[1], fakeAst]);
+        it("traverses return types in FunctionDeclarations", () => {
+            const fakeAst = {
+                type: "Program",
+                body: [
+                    {
+                        type: "FunctionDeclaration",
+                        returnType: {
+                            type: "foo"
+                        }
+                    }
+                ]
+            };
+            const traversalResults = traverseAst(fakeAst);
+
+            assert.deepEqual(traversalResults.enteredNodes, [fakeAst, fakeAst.body[0], fakeAst.body[0].returnType]);
+            assert.deepEqual(traversalResults.exitedNodes, [fakeAst.body[0].returnType, fakeAst.body[0], fakeAst]);
+        });
+
+        it("traverses return types in FunctionExpressions", () => {
+            const fakeAst = {
+                type: "Program",
+                body: [
+                    {
+                        type: "FunctionExpression",
+                        returnType: {
+                            type: "foo"
+                        }
+                    }
+                ]
+            };
+            const traversalResults = traverseAst(fakeAst);
+
+            assert.deepEqual(traversalResults.enteredNodes, [fakeAst, fakeAst.body[0], fakeAst.body[0].returnType]);
+            assert.deepEqual(traversalResults.exitedNodes, [fakeAst.body[0].returnType, fakeAst.body[0], fakeAst]);
+        });
+
+        it("traverses return types in ArrowFunctionExpressions", () => {
+            const fakeAst = {
+                type: "Program",
+                body: [
+                    {
+                        type: "ArrowFunctionExpression",
+                        returnType: {
+                            type: "foo"
+                        }
+                    }
+                ]
+            };
+            const traversalResults = traverseAst(fakeAst);
+
+            assert.deepEqual(traversalResults.enteredNodes, [fakeAst, fakeAst.body[0], fakeAst.body[0].returnType]);
+            assert.deepEqual(traversalResults.exitedNodes, [fakeAst.body[0].returnType, fakeAst.body[0], fakeAst]);
+        });
+
+        it("traverses return types in MethodDefinitions", () => {
+            const fakeAst = {
+                type: "Program",
+                body: [
+                    {
+                        type: "MethodDefinition",
+                        returnType: {
+                            type: "foo"
+                        }
+                    }
+                ]
+            };
+            const traversalResults = traverseAst(fakeAst);
+
+            assert.deepEqual(traversalResults.enteredNodes, [fakeAst, fakeAst.body[0], fakeAst.body[0].returnType]);
+            assert.deepEqual(traversalResults.exitedNodes, [fakeAst.body[0].returnType, fakeAst.body[0], fakeAst]);
+        });
+
+        it("traverses type annotations in ObjectPatterns", () => {
+            const fakeAst = {
+                type: "Program",
+                body: [
+                    {
+                        type: "ObjectPattern",
+                        typeAnnotation: {
+                            type: "foo"
+                        }
+                    }
+                ]
+            };
+            const traversalResults = traverseAst(fakeAst);
+
+            assert.deepEqual(traversalResults.enteredNodes, [fakeAst, fakeAst.body[0], fakeAst.body[0].typeAnnotation]);
+            assert.deepEqual(traversalResults.exitedNodes, [fakeAst.body[0].typeAnnotation, fakeAst.body[0], fakeAst]);
+        });
+
+        it("traverses type annotations in ArrayPatterns", () => {
+            const fakeAst = {
+                type: "Program",
+                body: [
+                    {
+                        type: "ArrayPattern",
+                        typeAnnotation: {
+                            type: "foo"
+                        }
+                    }
+                ]
+            };
+            const traversalResults = traverseAst(fakeAst);
+
+            assert.deepEqual(traversalResults.enteredNodes, [fakeAst, fakeAst.body[0], fakeAst.body[0].typeAnnotation]);
+            assert.deepEqual(traversalResults.exitedNodes, [fakeAst.body[0].typeAnnotation, fakeAst.body[0], fakeAst]);
+        });
+
+        it("traverses type annotations in RestElements", () => {
+            const fakeAst = {
+                type: "Program",
+                body: [
+                    {
+                        type: "RestElement",
+                        typeAnnotation: {
+                            type: "foo"
+                        }
+                    }
+                ]
+            };
+            const traversalResults = traverseAst(fakeAst);
+
+            assert.deepEqual(traversalResults.enteredNodes, [fakeAst, fakeAst.body[0], fakeAst.body[0].typeAnnotation]);
+            assert.deepEqual(traversalResults.exitedNodes, [fakeAst.body[0].typeAnnotation, fakeAst.body[0], fakeAst]);
+        });
     });
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Fixes #7129. Modified `estraverse.VisitorKeys` to include type annotation traversal.

**Is there anything you'd like reviewers to focus on?**
Do you think these tests are adequate? I initially had a test that checked that the type annotations for params of a function would be visited, but then thought that seemed like overkill. Happy to add them back if consensus is to add them, though.
