### PR TITLE
Bug fix: check descriptor.node.loc existence

### DIFF
--- a/lib/rule-context.js
+++ b/lib/rule-context.js
@@ -127,11 +127,13 @@ class RuleContext {
                 fix = descriptor.fix(ruleFixer);
             }
 
+            const desNodeLocStart = descriptor.node && descriptor.node.loc && descriptor.node.loc.start;
+
             this.eslint.report(
                 this.id,
                 this.severity,
                 descriptor.node,
-                descriptor.loc || descriptor.node.loc.start,
+                descriptor.loc || desNodeLocStart,
                 descriptor.message,
                 descriptor.data,
                 fix,


### PR DESCRIPTION
The ["Working With Rules"](http://eslint.org/docs/developer-guide/working-with-rules) section of the docs clearly state the both `node` and `loc` are optional parameters to `context.report()`. However, a part of the code was written such that it assumed one had to exist. This fixes that.

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Not pasting the template since it's mostly unrelated; this is master right now, node/npm versions don't matter for this.

**What changes did you make? (Give an overview)**

I modified the code to deeply check object existence.

**Is there anything you'd like reviewers to focus on?**

All the tests pass, but, can you please verify that the docs are correct, and that both `node` and `loc` are optional?
