### PR TITLE
Breaking: Traverse into decorators

### DIFF
--- a/lib/util/traverser.js
+++ b/lib/util/traverser.js
@@ -33,6 +33,16 @@ estraverse.VisitorKeys.ArrayPattern.push("typeAnnotation");
 estraverse.VisitorKeys.RestElement.push("typeAnnotation");
 
 /**
+ * Modify estraverse's visitor keys to traverse Decorators
+ */
+estraverse.VisitorKeys.Identifier.push("decorators");
+estraverse.VisitorKeys.ClassDeclaration.push("decorators");
+estraverse.VisitorKeys.FunctionExpression.push("decorators");
+estraverse.VisitorKeys.ObjectPattern.push("decorators");
+estraverse.VisitorKeys.ArrayPattern.push("decorators");
+estraverse.VisitorKeys.RestElement.push("decorators");
+
+/**
  * Wrapper around an estraverse controller that ensures the correct keys
  * are visited.
  * @constructor

--- a/tests/lib/util/traverser.js
+++ b/tests/lib/util/traverser.js
@@ -201,4 +201,153 @@ describe("Traverser", () => {
             assert.deepEqual(traversalResults.exitedNodes, [fakeAst.body[0].typeAnnotation, fakeAst.body[0], fakeAst]);
         });
     });
+
+    describe("decorators", () => {
+        it("traverses decorators in Identifier", () => {
+            const fakeAst = {
+                type: "Program",
+                body: [
+                    {
+                        type: "Identifier",
+                        decorators: [
+                            {
+                                type: "Identifier",
+                                name: "Foo"
+                            }
+                        ]
+                    }
+                ]
+            };
+            const traversalResults = traverseAst(fakeAst);
+
+            assert.deepEqual(traversalResults.enteredNodes, [fakeAst, fakeAst.body[0], fakeAst.body[0].decorators[0]]);
+            assert.deepEqual(traversalResults.exitedNodes, [fakeAst.body[0].decorators[0], fakeAst.body[0], fakeAst]);
+        });
+
+        it("traverses decorators in ClassDeclaration", () => {
+            const fakeAst = {
+                type: "Program",
+                body: [
+                    {
+                        type: "ClassDeclaration",
+                        decorators: [
+                            {
+                                type: "Identifier",
+                                name: "Foo"
+                            }
+                        ]
+                    }
+                ]
+            };
+            const traversalResults = traverseAst(fakeAst);
+
+            assert.deepEqual(traversalResults.enteredNodes, [fakeAst, fakeAst.body[0], fakeAst.body[0].decorators[0]]);
+            assert.deepEqual(traversalResults.exitedNodes, [fakeAst.body[0].decorators[0], fakeAst.body[0], fakeAst]);
+        });
+
+        it("traverses decorators in FunctionExpression", () => {
+            const fakeAst = {
+                type: "Program",
+                body: [
+                    {
+                        type: "FunctionExpression",
+                        decorators: [
+                            {
+                                type: "Identifier",
+                                name: "Foo"
+                            }
+                        ]
+                    }
+                ]
+            };
+            const traversalResults = traverseAst(fakeAst);
+
+            assert.deepEqual(traversalResults.enteredNodes, [fakeAst, fakeAst.body[0], fakeAst.body[0].decorators[0]]);
+            assert.deepEqual(traversalResults.exitedNodes, [fakeAst.body[0].decorators[0], fakeAst.body[0], fakeAst]);
+        });
+
+        it("traverses decorators in ObjectPattern", () => {
+            const fakeAst = {
+                type: "Program",
+                body: [
+                    {
+                        type: "ObjectPattern",
+                        decorators: [
+                            {
+                                type: "Identifier",
+                                name: "Foo"
+                            }
+                        ]
+                    }
+                ]
+            };
+            const traversalResults = traverseAst(fakeAst);
+
+            assert.deepEqual(traversalResults.enteredNodes, [fakeAst, fakeAst.body[0], fakeAst.body[0].decorators[0]]);
+            assert.deepEqual(traversalResults.exitedNodes, [fakeAst.body[0].decorators[0], fakeAst.body[0], fakeAst]);
+        });
+
+        it("traverses decorators in ArrayPattern", () => {
+            const fakeAst = {
+                type: "Program",
+                body: [
+                    {
+                        type: "ArrayPattern",
+                        decorators: [
+                            {
+                                type: "Identifier",
+                                name: "Foo"
+                            }
+                        ]
+                    }
+                ]
+            };
+            const traversalResults = traverseAst(fakeAst);
+
+            assert.deepEqual(traversalResults.enteredNodes, [fakeAst, fakeAst.body[0], fakeAst.body[0].decorators[0]]);
+            assert.deepEqual(traversalResults.exitedNodes, [fakeAst.body[0].decorators[0], fakeAst.body[0], fakeAst]);
+        });
+
+        it("traverses decorators in RestElement", () => {
+            const fakeAst = {
+                type: "Program",
+                body: [
+                    {
+                        type: "RestElement",
+                        decorators: [
+                            {
+                                type: "Identifier",
+                                name: "Foo"
+                            }
+                        ]
+                    }
+                ]
+            };
+            const traversalResults = traverseAst(fakeAst);
+
+            assert.deepEqual(traversalResults.enteredNodes, [fakeAst, fakeAst.body[0], fakeAst.body[0].decorators[0]]);
+            assert.deepEqual(traversalResults.exitedNodes, [fakeAst.body[0].decorators[0], fakeAst.body[0], fakeAst]);
+        });
+
+        it("traverses decorators in ClassProperty", () => {
+            const fakeAst = {
+                type: "Program",
+                body: [
+                    {
+                        type: "ClassProperty",
+                        decorators: [
+                            {
+                                type: "Identifier",
+                                name: "Foo"
+                            }
+                        ]
+                    }
+                ]
+            };
+            const traversalResults = traverseAst(fakeAst);
+
+            assert.deepEqual(traversalResults.enteredNodes, [fakeAst, fakeAst.body[0], fakeAst.body[0].decorators[0]]);
+            assert.deepEqual(traversalResults.exitedNodes, [fakeAst.body[0].decorators[0], fakeAst.body[0], fakeAst]);
+        });
+    });
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**
[X] Add something to the core


**What changes did you make? (Give an overview)**
Traverse decorators by updating estraverse's visitor keys. I noticed it was approved for v4 and would be nice to include along side type annotation support:
https://github.com/eslint/eslint/issues/7129#issuecomment-247445399


**Is there anything you'd like reviewers to focus on?**
I added a test for ClassProperty since decorators can be applied to them. I'm not sure what the ast Property is supposed to be. It was mentioned in the estree ast so maybe we should add that as well:
https://github.com/estree/estree/blob/master/experimental/decorators.md

I aslo rebased this change off of @kaicataldo PR, since the changes made to the Traverse test case make it much easier to write tests.