### PR TITLE
Update: fix space-unary-ops behavior with postfix UpdateExpressions

### DIFF
--- a/lib/rules/space-unary-ops.js
+++ b/lib/rules/space-unary-ops.js
@@ -288,9 +288,11 @@ module.exports = {
         * @returns {void}
         */
         function checkForSpaces(node) {
-            const tokens = sourceCode.getFirstTokens(node, 2),
-                firstToken = tokens[0],
-                secondToken = tokens[1];
+            const tokens = node.type === "UpdateExpression" && !node.prefix
+                ? sourceCode.getLastTokens(node, 2)
+                : sourceCode.getFirstTokens(node, 2);
+            const firstToken = tokens[0];
+            const secondToken = tokens[1];
 
             if ((node.type === "NewExpression" || node.prefix) && firstToken.type === "Keyword") {
                 checkUnaryWordOperatorForSpaces(node, firstToken, secondToken);

--- a/tests/lib/rules/space-unary-ops.js
+++ b/tests/lib/rules/space-unary-ops.js
@@ -37,6 +37,13 @@ ruleTester.run("space-unary-ops", rule, {
             options: [{ words: true }]
         },
         {
+            code: "foo .bar++"
+        },
+        {
+            code: "foo.bar --",
+            options: [{ nonwords: true }]
+        },
+        {
             code: "delete foo.bar",
             options: [{ words: true }]
         },
@@ -415,6 +422,21 @@ ruleTester.run("space-unary-ops", rule, {
             options: [{ nonwords: true }],
             errors: [{
                 message: "Unary operator '++' must be followed by whitespace."
+            }]
+        },
+        {
+            code: "foo .bar++",
+            output: "foo .bar ++",
+            options: [{ nonwords: true }],
+            errors: [{
+                message: "Space is required before unary expressions '++'."
+            }]
+        },
+        {
+            code: "foo.bar --",
+            output: "foo.bar--",
+            errors: [{
+                message: "Unexpected space before unary operator '--'."
             }]
         },
         {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix

**Tell us about your environment**

* **ESLint Version:** master
* **Node Version:** 7.8.0
* **npm Version:** 4.2.0

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

```yml
rules:
  space-unary-ops: error
```

**What did you do? Please include the actual source code causing the issue.**

```js
foo.bar ++;
```

**What did you expect to happen?**

I expected an error to be reported.

**What actually happened? Please include the actual, raw output from ESLint.**

No error was reported.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Previously, space-unary-ops would always evaluate the spacing between the first and second tokens of an UpdateExpression (e.g. `foo++`). This worked fine when the argument had one token, but it led to the wrong behavior if the argument had multiple tokens (e.g. in `foo.bar++`, the space between `foo` and `.` would be checked, rather than between `bar` and `++`). This commit updates the rule to check the *last* two tokens of postfix UpdateExpressions.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
