### PR TITLE
Fix: no-multiple-empty-lines crash on space after last \n (fixes #8401)

### DIFF
--- a/lib/rules/no-multiple-empty-lines.js
+++ b/lib/rules/no-multiple-empty-lines.js
@@ -111,10 +111,19 @@ module.exports = {
                                 message,
                                 data: { max: maxAllowed, pluralizedLines: maxAllowed === 1 ? "line" : "lines" },
                                 fix(fixer) {
-                                    return fixer.removeRange([
-                                        sourceCode.getIndexFromLoc({ line: lastLineNumber + 1, column: 0 }),
-                                        sourceCode.getIndexFromLoc({ line: lineNumber - maxAllowed, column: 0 })
-                                    ]);
+                                    const rangeStart = sourceCode.getIndexFromLoc({ line: lastLineNumber + 1, column: 0 });
+
+                                    /*
+                                     * The end of the removal range is usually the start index of the next line.
+                                     * However, at the end of the file there is no next line, so the end of the
+                                     * range is just the length of the text.
+                                     */
+                                    const lineNumberAfterRemovedLines = lineNumber - maxAllowed;
+                                    const rangeEnd = lineNumberAfterRemovedLines <= allLines.length
+                                        ? sourceCode.getIndexFromLoc({ line: lineNumber - maxAllowed, column: 0 })
+                                        : sourceCode.text.length;
+
+                                    return fixer.removeRange([rangeStart, rangeEnd]);
                                 }
                             });
                         }

--- a/lib/rules/no-multiple-empty-lines.js
+++ b/lib/rules/no-multiple-empty-lines.js
@@ -120,7 +120,7 @@ module.exports = {
                                      */
                                     const lineNumberAfterRemovedLines = lineNumber - maxAllowed;
                                     const rangeEnd = lineNumberAfterRemovedLines <= allLines.length
-                                        ? sourceCode.getIndexFromLoc({ line: lineNumber - maxAllowed, column: 0 })
+                                        ? sourceCode.getIndexFromLoc({ line: lineNumberAfterRemovedLines, column: 0 })
                                         : sourceCode.text.length;
 
                                     return fixer.removeRange([rangeStart, rangeEnd]);

--- a/tests/lib/rules/no-multiple-empty-lines.js
+++ b/tests/lib/rules/no-multiple-empty-lines.js
@@ -316,6 +316,14 @@ ruleTester.run("no-multiple-empty-lines", rule, {
             code: `a\n\n\n\n${"a".repeat(1e5)}`,
             output: `a\n\n\n${"a".repeat(1e5)}`,
             errors: [getExpectedError(2)]
+        },
+        {
+
+            // https://github.com/eslint/eslint/issues/8401
+            code: "foo\n ",
+            output: "foo\n",
+            options: [{ max: 1, maxEOF: 0 }],
+            errors: [getExpectedErrorEOF(0)]
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (https://github.com/eslint/eslint/issues/8401)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Previously, no-multiple-empty-lines would crash if it tried to remove a trailing newline followed by a space from the end of a file. This commit fixes the crash.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
