### PR TITLE
Support controlling template string spaces in fix output and warnings/errors

### DIFF
--- a/docs/rules/prefer-template.md
+++ b/docs/rules/prefer-template.md
@@ -16,6 +16,13 @@ var str = `Hello, ${name}!`;
 
 This rule is aimed to flag usage of `+` operators with strings.
 
+
+### trim
+
+The `trim` option is a boolean (default: `false`). Using a template string it is possible to have spaces on the inside of either of the brackets, but they will be flagged as an error and can be automatically removed by `--fix` when `trim` set to `true`.
+
+
+
 ## Examples
 
 Examples of **incorrect** code for this rule:
@@ -39,6 +46,23 @@ var str = `Time: ${12 * 60 * 60 * 1000}`;
 
 // This is reported by `no-useless-concat`.
 var str = "Hello, " + "World!";
+```
+
+### trim
+
+Examples of **correct** code for the `{ "trim": true }` option:
+
+```js
+/*eslint prefer-template: ["error", { "trim": true }]*/
+var str = `Time: ${(12 * 60 * 60 * 1000)}`;
+```
+
+Examples of **incorrect** code for the `{ "trim": true }` option:
+
+```js
+/*eslint prefer-template: ["error", { "trim": true }]*/
+// there are unnecessary spaces on the inside of the brackets
+var str = `Time: ${ (12 * 60 * 60 * 1000) }`;
 ```
 
 ## When Not To Use It

--- a/lib/rules/prefer-template.js
+++ b/lib/rules/prefer-template.js
@@ -50,6 +50,7 @@ function hasStringLiteral(node) {
     return astUtils.isStringLiteral(node);
 }
 
+
 /**
  * Checks whether or not a given binary expression has non string literals.
  * @param {ASTNode} node - A node to check.
@@ -94,6 +95,7 @@ function endsWithTemplateCurly(node) {
     return node.type !== "Literal" || typeof node.value !== "string";
 }
 
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -106,14 +108,38 @@ module.exports = {
             recommended: false
         },
 
-        schema: [],
+        schema: [
+            {
+                type: "object",
+                properties: {
+
+                    trim: {
+                        type: "boolean"
+                    }
+                }
+            }
+        ],
 
         fixable: "code"
     },
 
     create(context) {
         const sourceCode = context.getSourceCode();
+
+        const config = {
+            trim: false
+        };
+
+        const firstOption = context.options[0];
+
+        if (firstOption) {
+            config.trim = firstOption.trim || config.trim;
+        }
+
         let done = Object.create(null);
+
+        const whitespaceRX = /\W/g;
+        const emptyBeforeOrAfter = "";
 
         /**
         * Gets the non-token text between two nodes, ignoring any other tokens that appear between the two tokens.
@@ -129,6 +155,45 @@ module.exports = {
         }
 
         /**
+         * Determines if a variable has a sibling rest property
+         * @param {string} textNode - Text that appeared before or after a node to be placed inside template literal brackets.
+         * @returns {boolean} True if the string is extraneous whitespace to be removed, false if not.
+         * @private
+         */
+        function isExtraneousWhitespaceToBeRemoved(textNode) {
+            return textNode !== null && textNode.match(whitespaceRX);
+        }
+
+        /**
+         * Determines if a variable has a sibling rest property
+         * @param {Array} textNodes - Text that appeared before and after a node to be placed inside template literal brackets.
+         * @returns {boolean} True if the Array contains extraneous whitespace to be removed, false if not.
+         * @private
+         */
+        function hasExtraneousWhitespaceToBeRemoved(textNodes) {
+            if (config.trim) {
+                return textNodes.some(isExtraneousWhitespaceToBeRemoved);
+            }
+
+            return false;
+        }
+
+        /**
+         * Determines if a variable has a sibling rest property
+         * @param {Array} textNodes - Text that appeared before and after a node to be placed inside template literal brackets.
+         * @returns {Array} A map of the original Array to text nodes with extraneous whitespace removed.
+         * @private
+         */
+        function getNodesWithExtraneousWhitespaceRemoved(textNodes) {
+            return textNodes.map(textNode => {
+                if (isExtraneousWhitespaceToBeRemoved(textNode)) {
+                    return textNode.replace(whitespaceRX, emptyBeforeOrAfter);
+                }
+                return textNode;
+            });
+        }
+
+        /**
         * Returns a template literal form of the given node.
         * @param {ASTNode} currentNode A node that should be converted to a template literal
         * @param {string} textBeforeNode Text that should appear before the node
@@ -136,6 +201,8 @@ module.exports = {
         * @returns {string} A string form of this node, represented as a template literal
         */
         function getTemplateLiteral(currentNode, textBeforeNode, textAfterNode) {
+            const sourceCodeText = sourceCode.getText(currentNode);
+
             if (currentNode.type === "Literal" && typeof currentNode.value === "string") {
 
                 // If the current node is a string literal, escape any instances of ${ or ` to prevent them from being interpreted
@@ -153,7 +220,7 @@ module.exports = {
             }
 
             if (currentNode.type === "TemplateLiteral") {
-                return sourceCode.getText(currentNode);
+                return sourceCodeText;
             }
 
             if (isConcatenation(currentNode) && hasStringLiteral(currentNode) && hasNonStringLiteral(currentNode)) {
@@ -183,7 +250,16 @@ module.exports = {
                 return `${getTemplateLiteral(currentNode.left, textBeforeNode, null)}${textBeforePlus}+${textAfterPlus}${getTemplateLiteral(currentNode.right, textAfterNode, null)}`;
             }
 
-            return `\`\${${textBeforeNode || ""}${sourceCode.getText(currentNode)}${textAfterNode || ""}}\``;
+
+            let surroundingNodes = [textBeforeNode, textAfterNode];
+
+            if (hasExtraneousWhitespaceToBeRemoved(surroundingNodes)) {
+                surroundingNodes = getNodesWithExtraneousWhitespaceRemoved(surroundingNodes);
+                textBeforeNode = surroundingNodes[0];
+                textAfterNode = surroundingNodes[1];
+            }
+
+            return `\`\${${textBeforeNode || ""}${sourceCodeText}${textAfterNode || ""}}\``;
         }
 
         /**
@@ -217,8 +293,63 @@ module.exports = {
         }
 
         return {
-            Program() {
+            Program(node) {
                 done = Object.create(null);
+
+                const tokens = sourceCode.tokensAndComments;
+
+                const REJECTED_SPACE_MESSAGE = "There should be no spaces inside this bracket.";
+
+                tokens.forEach((token, i) => {
+                    const prevToken = tokens[i - 1];
+                    const nextToken = tokens[i + 1];
+
+                    if (token.type !== "Template" || !config.trim) {
+                        return;
+                    }
+
+                    if (token.value.match(/\}\w+\$\{/)) {
+                        if (sourceCode.isSpaceBetweenTokens(prevToken, token)) {
+                            context.report({
+                                node,
+                                loc: token.loc.start,
+                                message: REJECTED_SPACE_MESSAGE,
+                                fix(fixer) {
+                                    return fixer.removeRange([prevToken.range[1], token.range[0]]);
+                                }
+                            });
+                        }
+
+                        if (sourceCode.isSpaceBetweenTokens(token, nextToken)) {
+                            context.report({
+                                node,
+                                loc: token.loc.start,
+                                message: REJECTED_SPACE_MESSAGE,
+                                fix(fixer) {
+                                    return fixer.removeRange([token.range[1], nextToken.range[0]]);
+                                }
+                            });
+                        }
+                    } else if (token.value.match(/\$\{$/) && sourceCode.isSpaceBetweenTokens(token, nextToken)) {
+                        context.report({
+                            node,
+                            loc: token.loc.start,
+                            message: REJECTED_SPACE_MESSAGE,
+                            fix(fixer) {
+                                return fixer.removeRange([token.range[1], nextToken.range[0]]);
+                            }
+                        });
+                    } else if (token.value.match(/^\}.*`$/) && sourceCode.isSpaceBetweenTokens(prevToken, token)) {
+                        context.report({
+                            node,
+                            loc: token.loc.start,
+                            message: REJECTED_SPACE_MESSAGE,
+                            fix(fixer) {
+                                return fixer.removeRange([prevToken.range[1], token.range[0]]);
+                            }
+                        });
+                    }
+                });
             },
 
             Literal: checkForStringConcat,

--- a/tests/lib/rules/prefer-template.js
+++ b/tests/lib/rules/prefer-template.js
@@ -16,6 +16,8 @@ const RuleTester = require("../../../lib/testers/rule-tester");
 // Tests
 //------------------------------------------------------------------------------
 
+const UNEXPECTED_SPACE_ERROR_MESSAGE = "There should be no spaces inside this bracket.";
+
 const errors = [{
     message: "Unexpected string concatenation.",
     type: "BinaryExpression"
@@ -187,6 +189,48 @@ ruleTester.run("prefer-template", rule, {
             code: "foo + 'handles unicode escapes correctly: \\x27'", // "\x27" === "'"
             output: "`${foo  }handles unicode escapes correctly: \\x27`",
             errors
+        },
+        {
+            code: "foo + \"does not unescape an escaped single quote in a double-quoted string: \\'\"",
+            output: "`${foo}does not unescape an escaped single quote in a double-quoted string: \\'`",
+            options: [{ trim: true }],
+            errors
+        },
+        {
+            code: "foo + 'handles unicode escapes correctly: \\x27'", // "\x27" === "'"
+            output: "`${foo}handles unicode escapes correctly: \\x27`",
+            options: [{ trim: true }],
+            errors
+        },
+        {
+            code: "var foo = bar + ('baz') + 'qux' + (boop);",
+            output: "var foo = `${bar}baz` + `qux${boop}`;",
+            options: [{ trim: true }],
+            errors
+        },
+        {
+            code: "var foo = `${ bar }baz` + `qux${ boop }`;",
+            output: "var foo = `${bar}baz` + `qux${boop}`;",
+            options: [{ trim: true }],
+            errors: [UNEXPECTED_SPACE_ERROR_MESSAGE, UNEXPECTED_SPACE_ERROR_MESSAGE, UNEXPECTED_SPACE_ERROR_MESSAGE, UNEXPECTED_SPACE_ERROR_MESSAGE]
+        },
+        {
+            code: "var foo = `${                bar                }baz` + `qux${                boop                }`;",
+            output: "var foo = `${bar}baz` + `qux${boop}`;",
+            options: [{ trim: true }],
+            errors: [UNEXPECTED_SPACE_ERROR_MESSAGE, UNEXPECTED_SPACE_ERROR_MESSAGE, UNEXPECTED_SPACE_ERROR_MESSAGE, UNEXPECTED_SPACE_ERROR_MESSAGE]
+        },
+        {
+            code: "var foo = `bar${ baz }qux${ quux }`;",
+            output: "var foo = `bar${baz}qux${quux}`;",
+            options: [{ trim: true }],
+            errors: [UNEXPECTED_SPACE_ERROR_MESSAGE, UNEXPECTED_SPACE_ERROR_MESSAGE, UNEXPECTED_SPACE_ERROR_MESSAGE, UNEXPECTED_SPACE_ERROR_MESSAGE]
+        },
+        {
+            code: "var foo = `3 backslashes: \\\\\\${bar}${  baz}`;",
+            output: "var foo = `3 backslashes: \\\\\\${bar}${baz}`;",
+            options: [{ trim: true }],
+            errors: [UNEXPECTED_SPACE_ERROR_MESSAGE]
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
**What rule do you want to change?**
prefer-template

**Does this change cause the rule to produce more or fewer warnings?**
More

**How will the change be implemented? (New option, new default behavior, etc.)?**
New option

**Please provide some example code that this change will affect:**
```ks
[{
       code: "var foo = bar + ('baz') + 'qux' + (boop);",
       output: "var foo = `${bar}baz` + `qux${boop}`;",
       options: [{ trim: true }],
       errors
},
{
       code: "var foo = `${                bar                }baz` + `qux${                boop                }`;",
       output: "var foo = `${bar}baz` + `qux${boop}`;",
       options: [{ trim: true }]
}]
```

**What does the rule currently do for this code?**
It takes all inert whitespace tokens from string concatenation and inserts them within the template string brackets. In a survey I conducted at Netflix, ~85% of developers didn't want this behavior. Whitespace tokens that make sense around operators often do not within template braces. However, I don't want to unduly impact others with our preference and I can see cases where whitespace token translation makes sense, so I've tried introducing it as an option.

**What will the rule do after it's changed?**'
* Automatically remove spaces in template string
  brackets if trim option is specified
* Mark spaces in template string brackets as errors
  or warnings if trim option is specified
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Operating on code that's already template strings:
* In fix mode, the Program loop now looks before and after Template tokens matching opening and closing braces and removes whitespace if trim is specified
* In both fix mode and otherwise, the Program loop now looks before and after Template tokens matching opening and closing braces and reports whitespace if trim is specified

Operating on code that's concatenation code ready to be turned into template strings:
* When trim is true and concatenated strings are being transformed into template strings, extraneous whitespace is simply omitted from the template string output

**Is there anything you'd like reviewers to focus on?**

As my first major PR, will need advise on preferred
  identifier naming, test strategies et al cultural
  approaches to code. I need particular attention with the tests
