### PR TITLE
Update: Report identifiers that are assigned strings in no-implied-eval.

### DIFF
--- a/lib/rules/no-implied-eval.js
+++ b/lib/rules/no-implied-eval.js
@@ -6,6 +6,12 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const astUtils = require("../ast-utils");
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
@@ -34,6 +40,16 @@ module.exports = {
         //--------------------------------------------------------------------------
 
         /**
+         * Report an implied eval violation.
+         * @param {ASTNode} node The node to report on.
+         * @returns {*} null, only reports to context.
+         * @private
+         */
+        function report(node) {
+            context.report({ node, message: "Implied eval. Consider passing a function instead of a string." });
+        }
+
+        /**
          * Get the last element of an array, without modifying arr, like pop(), but non-destructive.
          * @param {array} arr What to inspect
          * @returns {*} The last element of arr
@@ -55,6 +71,34 @@ module.exports = {
                 hasImpliedEvalName = CALLEE_RE.test(property.name) || CALLEE_RE.test(property.value);
 
             return object.name === "window" && hasImpliedEvalName;
+        }
+
+        /**
+         * Determines if the argument could be an implicit eval expression.
+         *
+         * @param {ASTNode} node The CallExpression to check.
+         * @returns {boolean} true if the node matches, false if not.
+         * @private
+         */
+        function checkArgumentTypeImplicitEval(node) {
+            if (node.arguments.length > 0 && node.arguments[0].type === "Identifier" &&
+                CALLEE_RE.test(node.callee.name)) {
+                const scope = context.getScope(),
+                    variable = astUtils.getVariableByName(scope, node.arguments[0].name);
+
+                if (variable && variable.defs && variable.defs[0] &&
+                    variable.defs[0].name && variable.defs[0].name.parent) {
+
+                    const originalRef = variable.defs[0].name.parent.init;
+
+                    if (originalRef && (originalRef.type === "Literal" || originalRef.type === "TemplateLiteral")) {
+                        report(node);
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
 
         /**
@@ -105,7 +149,7 @@ module.exports = {
                 // remove the entire substack, to avoid duplicate reports
                 const substack = impliedEvalAncestorsStack.pop();
 
-                context.report({ node: substack[0], message: "Implied eval. Consider passing a function instead of a string." });
+                report(substack[0]);
             }
         }
 
@@ -120,6 +164,8 @@ module.exports = {
                     // call expressions create a new substack
                     impliedEvalAncestorsStack.push([node]);
                 }
+
+                checkArgumentTypeImplicitEval(node);
             },
 
             "CallExpression:exit"(node) {

--- a/tests/lib/rules/no-implied-eval.js
+++ b/tests/lib/rules/no-implied-eval.js
@@ -26,6 +26,9 @@ ruleTester.run("no-implied-eval", rule, {
         // normal usage
         "setInterval(function() { x = 1; }, 100);",
 
+        // Make sure we don't blow up on arrow functions
+        { code: "window.setTimeout(() => { x = 1; }, 100)", parserOptions: { ecmaVersion: 6 } },
+
         // only checks on top-level statements or window.*
         "foo.setTimeout('hi')",
 
@@ -61,6 +64,7 @@ ruleTester.run("no-implied-eval", rule, {
 
     invalid: [
         { code: "setTimeout(\"x = 1;\");", errors: [expectedError] },
+        { code: "var foo = \"x = 1;\"; setTimeout(foo);", errors: [expectedError] },
         { code: "setTimeout(\"x = 1;\", 100);", errors: [expectedError] },
         { code: "setInterval(\"x = 1;\");", errors: [expectedError] },
         { code: "execScript(\"x = 1;\");", errors: [expectedError] },


### PR DESCRIPTION
This now reports code like `var foo = "x = 1"; setTimeout(foo)`.

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))

**What rule do you want to change?**

`no-implied-eval` 

**Does this change cause the rule to produce more or fewer warnings?**

It causes the rule to produce more warnings but usually more correct warnings.

**How will the change be implemented? (New option, new default behavior, etc.)?**

No new option unless necessary (I wasn't sure if it should be some kind of `strict` option).

**Please provide some example code that this change will affect:**

This change now matches code like 

```js
var foo = "x = 1";
setTimeout(foo);
```

**What does the rule currently do for this code?**

It simply accepts it, although someone can implicitly eval various code.

**What will the rule do after it's changed?**

It raises a warning if it founds if the first argument to either `setTimeout`, `setInterval` or `execString` is a string, even if it's assigned to a var.

Please let me know if this needs more changes, it's the first contribution to eslint. Also, I wasn't sure if this should be behind some kind of `strict` option or not.