### PR TITLE
Chore: add a fuzzer to detect bugs in core rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 npm-debug.log
 .DS_Store
 tmp/
+debug/
 .idea
 jsdoc/
 versions.json

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-eslint-plugin": "^0.7.2",
     "eslint-plugin-node": "^5.0.0",
     "eslint-release": "^0.10.1",
-    "eslump": "^1.5.1",
+    "eslump": "1.5.1",
     "esprima": "^3.1.3",
     "esprima-fb": "^15001.1001.0-dev-harmony-fb",
     "istanbul": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-eslint-plugin": "^0.7.2",
     "eslint-plugin-node": "^5.0.0",
     "eslint-release": "^0.10.1",
-    "eslump": "1.5.1",
+    "eslump": "1.6.0",
     "esprima": "^3.1.3",
     "esprima-fb": "^15001.1001.0-dev-harmony-fb",
     "istanbul": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "test": "node Makefile.js test",
     "lint": "node Makefile.js lint",
+    "fuzz": "node Makefile.js fuzz",
     "release": "node Makefile.js release",
     "ci-release": "node Makefile.js ciRelease",
     "alpharelease": "node Makefile.js prerelease -- alpha",
@@ -83,6 +84,7 @@
     "eslint-plugin-eslint-plugin": "^0.7.2",
     "eslint-plugin-node": "^5.0.0",
     "eslint-release": "^0.10.1",
+    "eslump": "^1.5.1",
     "esprima": "^3.1.3",
     "esprima-fb": "^15001.1001.0-dev-harmony-fb",
     "istanbul": "^0.4.5",

--- a/tests/tools/eslint-fuzzer.js
+++ b/tests/tools/eslint-fuzzer.js
@@ -1,0 +1,257 @@
+"use strict";
+
+const assert = require("chai").assert;
+const eslint = require("../..");
+const espree = require("espree");
+const sinon = require("sinon");
+const configRule = require("../../lib/config/config-rule");
+
+describe("eslint-fuzzer", function() {
+    let fakeRule, fuzz;
+
+    /*
+     * These tests take awhile because isolating which rule caused an error requires running eslint up to hundreds of
+     * times, one rule at a time.
+     */
+    this.timeout(15000); // eslint-disable-line no-invalid-this
+
+    const coreRules = eslint.linter.getRules();
+    const fixableRuleNames = Array.from(coreRules)
+      .filter(rulePair => rulePair[1].meta && rulePair[1].meta.fixable)
+      .map(rulePair => rulePair[0]);
+    const CRASH_BUG = new TypeError("error thrown from a rule");
+
+    // A comment to disable all core fixable rules
+    const disableFixableRulesComment = `// eslint-disable-line ${fixableRuleNames.join(",")}`;
+
+    before(() => {
+        const realCoreRuleConfigs = configRule.createCoreRuleConfigs();
+
+        // Make sure the config generator generates a config for "test-fuzzer-rule"
+        sinon.stub(configRule, "createCoreRuleConfigs").returns(Object.assign(realCoreRuleConfigs, { "test-fuzzer-rule": [2] }));
+
+        // Create a closure around `fakeRule` so that tests can reassign it and have the changes take effect.
+        eslint.linter.defineRule("test-fuzzer-rule", Object.assign(context => fakeRule(context), { meta: { fixable: "code" } }));
+
+        fuzz = require("../../tools/eslint-fuzzer");
+    });
+
+    after(() => {
+        eslint.linter.reset();
+        configRule.createCoreRuleConfigs.restore();
+    });
+
+    describe("when running in crash-only mode", () => {
+        describe("when a rule crashes on the given input", () => {
+            it("should report the crash with a minimal config", () => {
+                fakeRule = () => ({
+                    Program() {
+                        throw CRASH_BUG;
+                    }
+                });
+
+                const results = fuzz({ count: 1, codeGenerator: () => "foo", checkAutofixes: false, eslint });
+
+                assert.strictEqual(results.length, 1);
+                assert.strictEqual(results[0].type, "crash");
+                assert.strictEqual(results[0].text, "foo");
+                assert.deepEqual(results[0].config.rules, { "test-fuzzer-rule": 2 });
+                assert.strictEqual(results[0].error, CRASH_BUG.stack);
+            });
+        });
+
+        describe("when no rules crash", () => {
+            it("should return an empty array", () => {
+                fakeRule = () => ({});
+
+                assert.deepEqual(fuzz({ count: 1, codeGenerator: () => "foo", checkAutofixes: false, eslint }), []);
+            });
+        });
+    });
+
+    describe("when running in crash-and-autofix mode", () => {
+        const INVALID_SYNTAX = "this is not valid javascript syntax";
+        let expectedSyntaxError;
+
+        try {
+            espree.parse(INVALID_SYNTAX);
+        } catch (err) {
+            expectedSyntaxError = err;
+        }
+
+        describe("when a rule crashes on the given input", () => {
+            it("should report the crash with a minimal config", () => {
+                fakeRule = () => ({
+                    Program() {
+                        throw CRASH_BUG;
+                    }
+                });
+
+                const results = fuzz({ count: 1, codeGenerator: () => "foo", checkAutofixes: false, eslint });
+
+                assert.strictEqual(results.length, 1);
+                assert.strictEqual(results[0].type, "crash");
+                assert.strictEqual(results[0].text, "foo");
+                assert.deepEqual(results[0].config.rules, { "test-fuzzer-rule": 2 });
+                assert.strictEqual(results[0].error, CRASH_BUG.stack);
+            });
+        });
+
+        describe("when a rule's autofix produces valid syntax", () => {
+            it("does not report any errors", () => {
+
+                // Replaces programs that start with "foo" with "bar"
+                fakeRule = context => ({
+                    Program(node) {
+                        if (context.getSourceCode().text.startsWith("foo")) {
+                            context.report({
+                                node,
+                                message: "no foos allowed",
+                                fix: fixer => fixer.replaceText(node, `bar ${disableFixableRulesComment}`)
+                            });
+                        }
+                    }
+                });
+
+                const results = fuzz({
+                    count: 1,
+
+                    /*
+                     * To ensure that no other rules produce a different autofix and mess up the test, add a big disable
+                     * comment for all core fixable rules.
+                     */
+                    codeGenerator: () => `foo ${disableFixableRulesComment}`,
+                    checkAutofixes: true,
+                    eslint
+                });
+
+                assert.deepEqual(results, []);
+            });
+        });
+
+        describe("when a rule's autofix produces invalid syntax on the first pass", () => {
+            it("reports an autofix error with a minimal config", () => {
+
+                // Replaces programs that start with "foo" invalid syntax
+                fakeRule = context => ({
+                    Program(node) {
+                        const sourceCode = context.getSourceCode();
+
+                        if (sourceCode.text.startsWith("foo")) {
+                            context.report({
+                                node,
+                                message: "no foos allowed",
+                                fix: fixer => fixer.replaceTextRange([0, sourceCode.text.length], INVALID_SYNTAX)
+                            });
+                        }
+                    }
+                });
+
+                const results = fuzz({
+                    count: 1,
+                    codeGenerator: () => `foo ${disableFixableRulesComment}`,
+                    checkAutofixes: true,
+                    eslint
+                });
+
+                assert.strictEqual(results.length, 1);
+                assert.strictEqual(results[0].type, "autofix");
+                assert.strictEqual(results[0].text, `foo ${disableFixableRulesComment}`);
+                assert.deepEqual(results[0].config.rules, { "test-fuzzer-rule": 2 });
+                assert.deepEqual(results[0].error, {
+                    ruleId: null,
+                    fatal: true,
+                    severity: 2,
+                    source: INVALID_SYNTAX,
+                    message: `Parsing error: ${expectedSyntaxError.message}`,
+                    line: expectedSyntaxError.lineNumber,
+                    column: expectedSyntaxError.column
+                });
+            });
+        });
+
+        describe("when a rule's autofix produces invalid syntax on the second pass", () => {
+            it("reports an autofix error with a minimal config and the text from the second pass", () => {
+                const intermediateCode = `bar ${disableFixableRulesComment}`;
+
+                // Replaces programs that start with "foo" invalid syntax
+                fakeRule = context => ({
+                    Program(node) {
+                        const sourceCode = context.getSourceCode();
+
+                        if (sourceCode.text.startsWith("foo") || sourceCode.text.startsWith("bar")) {
+                            context.report({
+                                node,
+                                message: "no foos allowed",
+                                fix(fixer) {
+                                    return fixer.replaceTextRange(
+                                        [0, sourceCode.text.length],
+                                        sourceCode.text === intermediateCode ? INVALID_SYNTAX : intermediateCode
+                                    );
+                                }
+                            });
+                        }
+                    }
+                });
+
+                const results = fuzz({
+                    count: 1,
+                    codeGenerator: () => `foo ${disableFixableRulesComment}`,
+                    checkAutofixes: true,
+                    eslint
+                });
+
+                assert.strictEqual(results.length, 1);
+                assert.strictEqual(results[0].type, "autofix");
+                assert.strictEqual(results[0].text, intermediateCode);
+                assert.deepEqual(results[0].config.rules, { "test-fuzzer-rule": 2 });
+                assert.deepEqual(results[0].error, {
+                    ruleId: null,
+                    fatal: true,
+                    severity: 2,
+                    source: INVALID_SYNTAX,
+                    message: `Parsing error: ${expectedSyntaxError.message}`,
+                    line: expectedSyntaxError.lineNumber,
+                    column: expectedSyntaxError.column
+                });
+            });
+        });
+
+        describe("when a rule crashes on the second autofix pass", () => {
+            it("reports a crash error with a minimal config", () => {
+
+                // Replaces programs that start with "foo" with invalid syntax
+                fakeRule = context => ({
+                    Program(node) {
+                        const sourceCode = context.getSourceCode();
+
+                        if (sourceCode.text.startsWith("foo")) {
+                            context.report({
+                                node,
+                                message: "no foos allowed",
+                                fix: fixer => fixer.replaceText(node, "bar")
+                            });
+                        } else if (sourceCode.text.startsWith("bar")) {
+                            throw CRASH_BUG;
+                        }
+                    }
+                });
+
+                const results = fuzz({
+                    count: 1,
+                    codeGenerator: () => `foo ${disableFixableRulesComment}`,
+                    checkAutofixes: true,
+                    eslint
+                });
+
+                assert.strictEqual(results.length, 1);
+                assert.strictEqual(results[0].type, "crash");
+
+                // TODO: (not-an-aardvark) It might be more useful to output the intermediate code here.
+                assert.strictEqual(results[0].text, `foo ${disableFixableRulesComment}`);
+                assert.deepEqual(results[0].config.rules, { "test-fuzzer-rule": 2 });
+                assert.strictEqual(results[0].error, CRASH_BUG.stack);
+            });
+        });
+    });
+});

--- a/tests/tools/eslint-fuzzer.js
+++ b/tests/tools/eslint-fuzzer.js
@@ -15,10 +15,11 @@ describe("eslint-fuzzer", function() {
      */
     this.timeout(15000); // eslint-disable-line no-invalid-this
 
-    const coreRules = eslint.linter.getRules();
+    const linter = new eslint.Linter();
+    const coreRules = linter.getRules();
     const fixableRuleNames = Array.from(coreRules)
-      .filter(rulePair => rulePair[1].meta && rulePair[1].meta.fixable)
-      .map(rulePair => rulePair[0]);
+        .filter(rulePair => rulePair[1].meta && rulePair[1].meta.fixable)
+        .map(rulePair => rulePair[0]);
     const CRASH_BUG = new TypeError("error thrown from a rule");
 
     // A comment to disable all core fixable rules
@@ -31,13 +32,13 @@ describe("eslint-fuzzer", function() {
         sinon.stub(configRule, "createCoreRuleConfigs").returns(Object.assign(realCoreRuleConfigs, { "test-fuzzer-rule": [2] }));
 
         // Create a closure around `fakeRule` so that tests can reassign it and have the changes take effect.
-        eslint.linter.defineRule("test-fuzzer-rule", Object.assign(context => fakeRule(context), { meta: { fixable: "code" } }));
+        linter.defineRule("test-fuzzer-rule", Object.assign(context => fakeRule(context), { meta: { fixable: "code" } }));
 
         fuzz = require("../../tools/eslint-fuzzer");
     });
 
     after(() => {
-        eslint.linter.reset();
+        linter.reset();
         configRule.createCoreRuleConfigs.restore();
     });
 
@@ -50,7 +51,7 @@ describe("eslint-fuzzer", function() {
                     }
                 });
 
-                const results = fuzz({ count: 1, codeGenerator: () => "foo", checkAutofixes: false, eslint });
+                const results = fuzz({ count: 1, codeGenerator: () => "foo", checkAutofixes: false, linter });
 
                 assert.strictEqual(results.length, 1);
                 assert.strictEqual(results[0].type, "crash");
@@ -64,7 +65,7 @@ describe("eslint-fuzzer", function() {
             it("should return an empty array", () => {
                 fakeRule = () => ({});
 
-                assert.deepEqual(fuzz({ count: 1, codeGenerator: () => "foo", checkAutofixes: false, eslint }), []);
+                assert.deepEqual(fuzz({ count: 1, codeGenerator: () => "foo", checkAutofixes: false, linter }), []);
             });
         });
     });
@@ -87,7 +88,7 @@ describe("eslint-fuzzer", function() {
                     }
                 });
 
-                const results = fuzz({ count: 1, codeGenerator: () => "foo", checkAutofixes: false, eslint });
+                const results = fuzz({ count: 1, codeGenerator: () => "foo", checkAutofixes: false, linter });
 
                 assert.strictEqual(results.length, 1);
                 assert.strictEqual(results[0].type, "crash");
@@ -122,7 +123,7 @@ describe("eslint-fuzzer", function() {
                      */
                     codeGenerator: () => `foo ${disableFixableRulesComment}`,
                     checkAutofixes: true,
-                    eslint
+                    linter
                 });
 
                 assert.deepEqual(results, []);
@@ -132,7 +133,7 @@ describe("eslint-fuzzer", function() {
         describe("when a rule's autofix produces invalid syntax on the first pass", () => {
             it("reports an autofix error with a minimal config", () => {
 
-                // Replaces programs that start with "foo" invalid syntax
+                // Replaces programs that start with "foo" with invalid syntax
                 fakeRule = context => ({
                     Program(node) {
                         const sourceCode = context.getSourceCode();
@@ -151,7 +152,7 @@ describe("eslint-fuzzer", function() {
                     count: 1,
                     codeGenerator: () => `foo ${disableFixableRulesComment}`,
                     checkAutofixes: true,
-                    eslint
+                    linter
                 });
 
                 assert.strictEqual(results.length, 1);
@@ -174,7 +175,7 @@ describe("eslint-fuzzer", function() {
             it("reports an autofix error with a minimal config and the text from the second pass", () => {
                 const intermediateCode = `bar ${disableFixableRulesComment}`;
 
-                // Replaces programs that start with "foo" invalid syntax
+                // Replaces programs that start with "foo" with invalid syntax
                 fakeRule = context => ({
                     Program(node) {
                         const sourceCode = context.getSourceCode();
@@ -198,7 +199,7 @@ describe("eslint-fuzzer", function() {
                     count: 1,
                     codeGenerator: () => `foo ${disableFixableRulesComment}`,
                     checkAutofixes: true,
-                    eslint
+                    linter
                 });
 
                 assert.strictEqual(results.length, 1);
@@ -241,7 +242,7 @@ describe("eslint-fuzzer", function() {
                     count: 1,
                     codeGenerator: () => `foo ${disableFixableRulesComment}`,
                     checkAutofixes: true,
-                    eslint
+                    linter
                 });
 
                 assert.strictEqual(results.length, 1);

--- a/tools/eslint-fuzzer.js
+++ b/tools/eslint-fuzzer.js
@@ -1,0 +1,148 @@
+/**
+ * @fileoverview A fuzzer that runs eslint on randomly-generated code samples to detect bugs
+ * @author Teddy Katz
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const assert = require("assert");
+const lodash = require("lodash");
+
+const fromDescriptor = Object.getOwnPropertyDescriptor(Array, "from");
+const eslump = require("eslump");
+
+// XXX: Remove this (see https://github.com/shapesecurity/shift-fuzzer-js/issues/15)
+Object.defineProperty(Array, "from", fromDescriptor);
+
+const SourceCodeFixer = require("../lib/util/source-code-fixer");
+const ruleConfigs = require("../lib/config/config-rule").createCoreRuleConfigs();
+
+//------------------------------------------------------------------------------
+// Public API
+//------------------------------------------------------------------------------
+
+/**
+ * Generates random JS code, runs ESLint on it, and returns a list of detected crashes or autofix bugs
+ * @param {Object} options Config options for fuzzing
+ * @param {number} options.count The number of fuzz iterations.
+ * @param {Object} options.eslint The eslint object to test.
+ * @param {function(Object): string} [options.codeGenerator=eslump.generateRandomJS] A function to use to generate random
+ * code. Accepts an object argument with a `sourceType` key, indicating the source type of the generated code. The object
+ * might also be passed other keys.
+ * @param {boolean} [options.checkAutofixes=true] `true` if the fuzzer should check for autofix bugs. The fuzzer runs
+ * roughly 4 times slower with autofix checking enabled.
+ * @param {function()} [options.progressCallback] A function that gets called once for each code sample
+ * @returns {Object[]} A list of problems found. Each problem has the following properties:
+ * type (string): The type of problem. This is either "crash" (a rule crashes) or "autofix" (an autofix produces a syntax error)
+ * text (string): The text that ESLint should be run on to reproduce the problem
+ * config (object): The config object that should be used to reproduce the problem. The fuzzer will try to return a minimal
+ *     config (that only has one rule enabled), but this isn't always possible.
+ * error (*) The problem that occurred. For crashes, this will be the error stack. For autofix bugs, this will be
+ *     the parsing error object that was thrown when parsing the autofixed code.
+ */
+function fuzz(options) {
+    assert.strictEqual(typeof options, "object", "An options object must be provided");
+    assert.strictEqual(typeof options.count, "number", "The number of iterations (options.count) must be provided");
+    assert.strictEqual(typeof options.eslint, "object", "An eslint object (options.eslint) must be provided");
+
+    const eslint = options.eslint;
+    const codeGenerator = options.codeGenerator || (genOptions => eslump.generateRandomJS(Object.assign({ comments: true, whitespace: true }, genOptions)));
+    const checkAutofixes = options.checkAutofixes !== false;
+    const progressCallback = options.progressCallback || (() => {});
+
+    /**
+     * Tries to isolate the smallest config that reproduces a problem
+     * @param {string} text The source text to lint
+     * @param {Object} config A config object that causes a crash or autofix error
+     * @returns {Object} A config object with only one rule enabled that produces the same crash or autofix error, if possible.
+     * Otherwise, the same as `config`
+     */
+    function isolateBadConfig(text, config) {
+        for (const ruleId of Object.keys(config.rules)) {
+            const reducedConfig = Object.assign({}, config, { rules: { [ruleId]: config.rules[ruleId] } });
+            const cliEngine = new eslint.CLIEngine(reducedConfig);
+            let lintReport;
+
+            try {
+                lintReport = cliEngine.executeOnText(text);
+            } catch (err) {
+                return reducedConfig;
+            }
+
+            if (lintReport.results[0].messages.length === 1 && lintReport.results[0].messages[0].fatal) {
+                return reducedConfig;
+            }
+        }
+        return config;
+    }
+
+    /**
+     * Runs multipass autofix one pass at a time to find the last good source text before a fatal error occurs
+     * @param {string} originalText Syntactically valid source code that results in a syntax error or crash when autofixing with `config`
+     * @param {Object} config The config to lint with
+     * @returns {string} A possibly-modified version of originalText that results in the same syntax error or crash after only one pass
+     */
+    function isolateBadAutofixPass(originalText, config) {
+        let lastGoodText = originalText;
+        let currentText = originalText;
+
+        do {
+            let messages;
+
+            try {
+                messages = eslint.linter.verify(currentText, config);
+            } catch (err) {
+                return lastGoodText;
+            }
+
+            if (messages.length === 1 && messages[0].fatal) {
+                return lastGoodText;
+            }
+
+            lastGoodText = currentText;
+            currentText = SourceCodeFixer.applyFixes(eslint.linter.getSourceCode(), messages).output;
+        } while (lastGoodText !== currentText);
+
+        return lastGoodText;
+    }
+
+    const problems = [];
+
+    for (let i = 0; i < options.count; progressCallback(), i++) {
+        const sourceType = lodash.sample(["script", "module"]);
+        const text = codeGenerator({ sourceType });
+        const config = {
+            rules: lodash.mapValues(ruleConfigs, lodash.sample),
+            parserOptions: { sourceType, ecmaVersion: 2017 }
+        };
+
+        let autofixResult;
+
+        try {
+            if (checkAutofixes) {
+                const cliEngine = new eslint.CLIEngine(Object.assign(config, { useEslintrc: false, fix: true }));
+
+                autofixResult = cliEngine.executeOnText(text).results[0];
+            } else {
+                eslint.linter.verify(text, config);
+            }
+        } catch (err) {
+            problems.push({ type: "crash", text, config: isolateBadConfig(text, config), error: err.stack });
+            continue;
+        }
+
+        if (checkAutofixes && autofixResult.output && autofixResult.messages.length === 1 && autofixResult.messages[0].fatal) {
+            const lastGoodText = isolateBadAutofixPass(text, config);
+
+            problems.push({ type: "autofix", text: lastGoodText, config: isolateBadConfig(lastGoodText, config), error: autofixResult.messages[0] });
+        }
+    }
+
+    return problems;
+}
+
+module.exports = fuzz;

--- a/tools/fuzzer-runner.js
+++ b/tools/fuzzer-runner.js
@@ -1,0 +1,75 @@
+/**
+ * @fileoverview An opinionated wrapper around eslint-fuzzer
+ * @author Teddy Katz
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const ProgressBar = require("progress");
+const fuzz = require("./eslint-fuzzer");
+const eslint = require("..");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+// An estimate of how many times faster it is to do a crash-only fuzzer run versus an autofixing run.
+const ESTIMATED_CRASH_AUTOFIX_PERFORMANCE_RATIO = 4;
+
+// The number of crash-only tests to run for each autofix test. Right now, this is mostly arbitrary.
+const CRASH_AUTOFIX_TEST_COUNT_RATIO = 3;
+
+//------------------------------------------------------------------------------
+// Public API
+//------------------------------------------------------------------------------
+
+/**
+ * Runs the fuzzer and outputs a progress bar
+ * @param {Object} [options] Options for the fuzzer
+ * @param {number} [options.amount=300] A positive integer indicating how much testing to do. Larger values result in a higher
+ * chance of finding bugs, but cause the testing to take longer (linear increase). With the default value, the fuzzer
+ * takes about 15 seconds to run.
+ * @returns {Object[]} A list of objects, where each object represents a problem detected by the fuzzer. The objects have the same
+ * schema as objects returned from eslint-fuzzer.
+ */
+function run(options) {
+    const amount = options && options.amount || 300;
+
+    const crashTestCount = amount * CRASH_AUTOFIX_TEST_COUNT_RATIO;
+    const autofixTestCount = amount;
+
+    /*
+     * To keep the progress bar moving at a roughly constant speed, apply a different weight for finishing
+     * a crash-only fuzzer run versus an autofix fuzzer run.
+     */
+    const progressBar = new ProgressBar(
+        "Fuzzing rules [:bar] :percent, :elapseds elapsed, eta :etas",
+        { width: 30, total: crashTestCount + autofixTestCount * ESTIMATED_CRASH_AUTOFIX_PERFORMANCE_RATIO }
+    );
+
+    // Start displaying the progress bar.
+    progressBar.tick(0);
+
+    const crashTestResults = fuzz({
+        eslint,
+        count: crashTestCount,
+        checkAutofixes: false,
+        progressCallback: () => progressBar.tick(1)
+    });
+
+    const autofixTestResults = fuzz({
+        eslint,
+        count: autofixTestCount,
+        checkAutofixes: true,
+        progressCallback: () => progressBar.tick(ESTIMATED_CRASH_AUTOFIX_PERFORMANCE_RATIO)
+    });
+
+    return crashTestResults.concat(autofixTestResults);
+
+}
+
+module.exports = { run };

--- a/tools/fuzzer-runner.js
+++ b/tools/fuzzer-runner.js
@@ -12,6 +12,7 @@
 const ProgressBar = require("progress");
 const fuzz = require("./eslint-fuzzer");
 const eslint = require("..");
+const linter = new eslint.Linter();
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -55,17 +56,23 @@ function run(options) {
     progressBar.tick(0);
 
     const crashTestResults = fuzz({
-        eslint,
+        linter,
         count: crashTestCount,
         checkAutofixes: false,
-        progressCallback: () => progressBar.tick(1)
+        progressCallback: () => {
+            progressBar.tick(1);
+            progressBar.render();
+        }
     });
 
     const autofixTestResults = fuzz({
-        eslint,
+        linter,
         count: autofixTestCount,
         checkAutofixes: true,
-        progressCallback: () => progressBar.tick(ESTIMATED_CRASH_AUTOFIX_PERFORMANCE_RATIO)
+        progressCallback: () => {
+            progressBar.tick(ESTIMATED_CRASH_AUTOFIX_PERFORMANCE_RATIO);
+            progressBar.render();
+        }
     });
 
     return crashTestResults.concat(autofixTestResults);


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This commit adds a fuzzer to detect bugs in core rules. The fuzzer can detect two types of problems: crashes (where a rule throws an error given a certain syntax) and autofix errors (where an autofix results in a syntax error).

The fuzzer works by running eslint on randomly-generated code with a random config. The code is generated with [eslump](https://github.com/lydell/eslump), and the config is generated with the existing autoconfig logic.

I've been using and developing this fuzzer locally for the past few weeks. It has been immensely helpful for finding bugs in rules. (It discovered the bugs fixed by https://github.com/eslint/eslint/pull/8245, https://github.com/eslint/eslint/pull/8246, https://github.com/eslint/eslint/pull/8247, https://github.com/eslint/eslint/pull/8327, https://github.com/eslint/eslint/pull/8328, https://github.com/eslint/eslint/pull/8330, https://github.com/eslint/eslint/pull/8331, https://github.com/eslint/eslint/pull/8332, https://github.com/eslint/eslint/pull/8335, https://github.com/eslint/eslint/pull/8337, https://github.com/eslint/eslint/pull/8338, https://github.com/eslint/eslint/pull/8339, https://github.com/eslint/eslint/pull/8340, https://github.com/eslint/eslint/pull/8358, https://github.com/eslint/eslint/pull/8359, https://github.com/eslint/eslint/pull/8391, https://github.com/eslint/eslint/pull/8394, https://github.com/eslint/eslint/pull/8412, https://github.com/eslint/eslint/pull/8806, https://github.com/eslint/eslint/pull/8807, and https://github.com/eslint/eslint/pull/8808.)

The fuzzer can be run with `npm run fuzz`. Eventually, I think we should add the fuzzer to the normal `npm test` build. Right now it's still reporting a few errors sometimes, which we should probably investigate, but we shouldn't let that break the regular build.

**Is there anything you'd like reviewers to focus on?**

* I wasn't sure where to put the fuzzer, so I created a new top-level directory called `tools/`. Let me know if there's a better place to put it.
* The fuzzer outputs debugging info when it fails. Right now, the info is output to a top-level `debug/` folder, which is in gitignore. Let me know if there's a better place to put it.