### PR TITLE
Chore: Fix indentation errors in indent-legacy

### DIFF
--- a/lib/rules/indent-legacy.js
+++ b/lib/rules/indent-legacy.js
@@ -589,8 +589,8 @@ module.exports = {
             }
 
             return ((
-                    stmt.type === "ExpressionStatement" ||
-                    stmt.type === "VariableDeclaration") &&
+                stmt.type === "ExpressionStatement" ||
+                stmt.type === "VariableDeclaration") &&
                 stmt.parent && stmt.parent.type === "Program"
             );
         }
@@ -824,10 +824,10 @@ module.exports = {
             }
 
             if (node.parent && (
-                    node.parent.type === "FunctionExpression" ||
-                    node.parent.type === "FunctionDeclaration" ||
-                    node.parent.type === "ArrowFunctionExpression"
-            )) {
+                node.parent.type === "FunctionExpression" ||
+                node.parent.type === "FunctionDeclaration" ||
+                node.parent.type === "ArrowFunctionExpression")
+            ) {
                 checkIndentInFunctionBlock(node);
                 return;
             }


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain: Chore
<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
The master branch is now failing after merging in the `indent-legacy` rule because the new indent rule doesn't treat doubled up parentheses the same way the legacy rule did. Might be worth having a discussion about whether we want that behavior to exist in the new rule, but wanted to make sure we have our CI passing for the release today.

**Is there anything you'd like reviewers to focus on?**
The rule is also okay with the following, if there's a preference:
```js
return (
    (
        stmt.type === "ExpressionStatement" ||
        stmt.type === "VariableDeclaration"
    ) &&
    stmt.parent && stmt.parent.type === "Program"
);
```
```js
return (
    (
        stmt.type === "ExpressionStatement" ||
        stmt.type === "VariableDeclaration"
    ) && stmt.parent && stmt.parent.type === "Program"
);
```
```js
if (node.parent &&
    (
        node.parent.type === "FunctionExpression" ||
        node.parent.type === "FunctionDeclaration" ||
        node.parent.type === "ArrowFunctionExpression"
    )
)
```
