### PR TITLE
Docs: update space-before-function-paren docs for 4.0 (fixes #8430)

### DIFF
--- a/docs/rules/space-before-function-paren.md
+++ b/docs/rules/space-before-function-paren.md
@@ -33,7 +33,7 @@ This rule has a string option or an object option:
     "space-before-function-paren": ["error", {
         "anonymous": "always",
         "named": "always",
-        "asyncArrow": "ignore"
+        "asyncArrow": "always"
     }],
 }
 ```
@@ -44,13 +44,11 @@ This rule has a string option or an object option:
 The string option does not check async arrow function expressions for backward compatibility.
 
 You can also use a separate option for each type of function.
-Each of the following options can be set to `"always"`, `"never"`, or `"ignore"`.
-Default is `"always"` basically.
+Each of the following options can be set to `"always"`, `"never"`, or `"ignore"`. The default is `"always"`.
 
 * `anonymous` is for anonymous function expressions (e.g. `function () {}`).
 * `named` is for named function expressions (e.g. `function foo () {}`).
 * `asyncArrow` is for async arrow function expressions (e.g. `async () => {}`).
-  `asyncArrow` is set to `"ignore"` by default for backwards compatibility.
 
 ### "always"
 
@@ -83,6 +81,8 @@ var foo = {
         // ...
     }
 };
+
+var foo = async() => 1
 ```
 
 Examples of **correct** code for this rule with the default `"always"` option:
@@ -115,9 +115,7 @@ var foo = {
     }
 };
 
-// async arrow function expressions are ignored by default.
 var foo = async () => 1
-var foo = async() => 1
 ```
 
 ### "never"
@@ -151,6 +149,8 @@ var foo = {
         // ...
     }
 };
+
+var foo = async () => 1
 ```
 
 Examples of **correct** code for this rule with the `"never"` option:
@@ -183,8 +183,6 @@ var foo = {
     }
 };
 
-// async arrow function expressions are ignored by default.
-var foo = async () => 1
 var foo = async() => 1
 ```
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

https://github.com/eslint/eslint/commit/7dd890db194faec55cfd0485118c1a8fdf0b076d changed the default options for the `space-before-function-paren` rule, but it did not update the docs to indicate the change. This commit updates the docs.

Fixes #8430

**Is there anything you'd like reviewers to focus on?**

Nothing in particular