### PR TITLE
Breaking: Remove array-callback-return from recommended (fixes #8428)

### DIFF
--- a/conf/eslint-recommended.js
+++ b/conf/eslint-recommended.js
@@ -17,7 +17,7 @@ module.exports = {
         /* eslint-enable sort-keys */
         "accessor-pairs": "off",
         "array-bracket-spacing": "off",
-        "array-callback-return": "error",
+        "array-callback-return": "off",
         "arrow-body-style": "off",
         "arrow-parens": "off",
         "arrow-spacing": "off",

--- a/docs/user-guide/migrating-to-4.0.0.md
+++ b/docs/user-guide/migrating-to-4.0.0.md
@@ -32,9 +32,8 @@ The lists below are ordered roughly by the number of users each change is expect
 
 ## <a name="eslint-recommended-changes"/> `eslint:recommended` changes
 
-Three new rules have been added to the [`eslint:recommended`](http://eslint.org/docs/user-guide/configuring#using-eslintrecommended) config:
+Two new rules have been added to the [`eslint:recommended`](http://eslint.org/docs/user-guide/configuring#using-eslintrecommended) config:
 
-* [`array-callback-return`](/docs/rules/array-callback-return) requires predicate functions to return a value when using functional patterns such as `map` and `filter`.
 * [`no-compare-neg-zero`](/docs/rules/no-compare-neg-zero) disallows comparisons to `-0`
 * [`no-useless-escape`](/docs/rules/no-useless-escape) disallows uselessly-escaped characters in strings and regular expressions
 
@@ -45,7 +44,6 @@ Three new rules have been added to the [`eslint:recommended`](http://eslint.org/
   "extends": "eslint:recommended",
 
   "rules": {
-    "array-callback-return": "off",
     "no-compare-neg-zero": "off",
     "no-useless-escape": "off"
   }

--- a/lib/rules/array-callback-return.js
+++ b/lib/rules/array-callback-return.js
@@ -138,7 +138,7 @@ module.exports = {
         docs: {
             description: "enforce `return` statements in callbacks of array methods",
             category: "Best Practices",
-            recommended: true
+            recommended: false
         },
 
         schema: []


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
As noted in https://github.com/eslint/eslint/issues/8428, there's no way for ESLint to know that the `.map` it is warning on for `array-callback-return` is actually `Array.prototype.map`. As a result, this rule does not feel like a good fit for `eslint:recommended`.

**Is there anything you'd like reviewers to focus on?**


