### PR TITLE
Chore: avoid cloning comments array in TokenStore

### DIFF
--- a/lib/token-store/index.js
+++ b/lib/token-store/index.js
@@ -191,21 +191,12 @@ module.exports = class TokenStore {
 
     /**
      * Initializes this token store.
-     *
-     * ※ `comments` needs to be cloned for backward compatibility.
-     * After this initialization, ESLint removes a shebang's comment from `comments`.
-     * However, so far we had been concatenating 'tokens' and 'comments' before,
-     * so the shebang's comment had remained in the concatenated array.
-     * As a result, both the result of `getTokenOrCommentAfter` and `getTokenOrCommentBefore`
-     * methods had included the shebang's comment.
-     * And some rules depends on this behavior.
-     *
      * @param {Token[]} tokens - The array of tokens.
      * @param {Comment[]} comments - The array of comments.
      */
     constructor(tokens, comments) {
         this[TOKENS] = tokens;
-        this[COMMENTS] = comments.slice(0);
+        this[COMMENTS] = comments;
         this[INDEX_MAP] = createIndexMap(tokens, comments);
     }
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Previously, the TokenStore constructor cloned the list of comments because core would sometimes mutate it afterwards in order to remove shebangs. Core no longer removes shebangs from the comment list, so it's no longer necessary for TokenStore to clone it.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular