### PR TITLE
Update: `enforceForArrowConditionals` to `no-extra-parens` (fixes #6196)

### DIFF
--- a/docs/rules/no-extra-parens.md
+++ b/docs/rules/no-extra-parens.md
@@ -22,6 +22,7 @@ This rule has an object option for exceptions to the `"all"` option:
 * `"returnAssign": false` allows extra parentheses around assignments in `return` statements
 * `"nestedBinaryExpressions": false` allows extra parentheses in nested binary expressions
 * `"ignoreJSX": "none|all|multi-line|single-line"` allows extra parentheses around no/all/multi-line/single-line JSX components. Defaults to `none`.
+* `"enforceForArrowConditionals": false` allows extra parentheses around ternary expressions which are the body of an arrow function
 
 ### all
 
@@ -163,6 +164,17 @@ Examples of **correct** code for this rule with the `all` and `{ "ignoreJSX": "s
 /* eslint no-extra-parens: ["error", "all", { ignoreJSX: "single-line" }] */
 const Component = (<div />)
 const Component = (<div><p /></div>)
+```
+
+### enforceForArrowConditionals
+
+Examples of **correct** code for this rule with the `"all"` and `{ "enforceForArrowConditionals": false }` options:
+
+```js
+/* eslint no-extra-parens: ["error", "all", { "enforceForArrowConditionals": false }] */
+
+const b = a => 1 ? 2 : 3;
+const d = c => (1 ? 2 : 3);
 ```
 
 ### functions

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -44,7 +44,8 @@ module.exports = {
                                 conditionalAssign: { type: "boolean" },
                                 nestedBinaryExpressions: { type: "boolean" },
                                 returnAssign: { type: "boolean" },
-                                ignoreJSX: { enum: ["none", "all", "single-line", "multi-line"] }
+                                ignoreJSX: { enum: ["none", "all", "single-line", "multi-line"] },
+                                enforceForArrowConditionals: { type: "boolean" }
                             },
                             additionalProperties: false
                         }
@@ -67,6 +68,9 @@ module.exports = {
         const NESTED_BINARY = ALL_NODES && context.options[1] && context.options[1].nestedBinaryExpressions === false;
         const EXCEPT_RETURN_ASSIGN = ALL_NODES && context.options[1] && context.options[1].returnAssign === false;
         const IGNORE_JSX = ALL_NODES && context.options[1] && context.options[1].ignoreJSX;
+        const IGNORE_ARROW_CONDITIONALS = ALL_NODES && context.options[1] &&
+            context.options[1].enforceForArrowConditionals === false;
+
         const PRECEDENCE_OF_ASSIGNMENT_EXPR = precedence({ type: "AssignmentExpression" });
         const PRECEDENCE_OF_UPDATE_EXPR = precedence({ type: "UpdateExpression" });
 
@@ -428,6 +432,13 @@ module.exports = {
 
             ArrowFunctionExpression(node) {
                 if (isReturnAssignException(node)) {
+                    return;
+                }
+
+                if (node.body.type === "ConditionalExpression" &&
+                    IGNORE_ARROW_CONDITIONALS &&
+                    !isParenthesisedTwice(node.body)
+                ) {
                     return;
                 }
 

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -369,6 +369,10 @@ ruleTester.run("no-extra-parens", rule, {
             "/>)"
         ].join("\n"), options: ["all", { ignoreJSX: "multi-line" }] },
 
+        // ["all", { enforceForArrowConditionals: false }]
+        { code: "var a = b => 1 ? 2 : 3", options: ["all", { enforceForArrowConditionals: false }], parserOptions: { ecmaVersion: 6 } },
+        { code: "var a = (b) => (1 ? 2 : 3)", options: ["all", { enforceForArrowConditionals: false }], parserOptions: { ecmaVersion: 6 } },
+
         {
             code: "let a = [ ...b ]",
             parserOptions: { ecmaVersion: 2015 }
@@ -921,6 +925,32 @@ ruleTester.run("no-extra-parens", rule, {
         ].join("\n"), "const Component = <div>\n<p />\n</div>", "JSXElement", 1, {
             options: ["all", { ignoreJSX: "none" }]
         }),
+
+        // ["all", { enforceForArrowConditionals: true }]
+        {
+            code: "var a = (b) => (1 ? 2 : 3)",
+            parserOptions: { ecmaVersion: 6 },
+            options: ["all", { enforceForArrowConditionals: true }],
+            errors: [
+                {
+                    message: "Gratuitous parentheses around expression."
+                }
+            ],
+            output: "var a = (b) => 1 ? 2 : 3"
+        },
+
+        // ["all", { enforceForArrowConditionals: false }]
+        {
+            code: "var a = (b) => ((1 ? 2 : 3))",
+            parserOptions: { ecmaVersion: 6 },
+            options: ["all", { enforceForArrowConditionals: false }],
+            errors: [
+                {
+                    message: "Gratuitous parentheses around expression."
+                }
+            ],
+            output: "var a = (b) => (1 ? 2 : 3)"
+        },
 
         // https://github.com/eslint/eslint/issues/8175
         invalid(


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What rule do you want to change?**

`no-extra-parens`

**Does this change cause the rule to produce more or fewer warnings?**

Fewer.

**How will the change be implemented? (New option, new default behavior, etc.)?**

Option.

**Please provide some example code that this change will affect:**

```js
const d = c => (1 ? 2 : 3)
```

**What does the rule currently do for this code?**

Report error on extra parenthesis.

**What will the rule do after it's changed?**

Don't report on extra parent.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Allow using parenthesis around conditional expression in arrow function. Now if you enable `no-confusing-arrow` and `no-extra-parens` you get error on this code:

```js
const d = c => (1 ? 2 : 3)
```

At the moment, if your enable two rules this violates one of the principles:

> No conflicts. No rule must directly conflict with another rule. For example, if we have a rule requiring semicolons, we cannot also have a rule disallowing semicolons (which is why we have one rule, semi, that does both).

Ref: https://github.com/eslint/eslint/issues/6196

**Is there anything you'd like reviewers to focus on?**

No
