### PR TITLE
Docs: Remove extra header line from LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,3 @@
-ESLint
 Copyright JS Foundation and other contributors, https://js.foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Currently, GitHub is not able to auto-detect that this repo has the MIT license because we have an extra line at the top of the `LICENSE` file. When GitHub auto-detects a license, it is able to (a) display the license name in the repository header bar, and (b) display information about the license when someone views the `LICENSE` file. This commit updates the `LICENSE` file to remove the extra line so that GitHub can auto-detect the license.

**Is there anything you'd like reviewers to focus on?**

cc @kborchers: This is an editorial change to the license file in this repo. Is there anything that we need to be aware of legally for this change? (My guess is that this is fine because it's not modifying the terms/legalese of the license at all, but I assume the JSF has to approve any changes to the license file.)