### PR TITLE
Update: no-unused-vars false negative about destructuring (fixes #8442)

### DIFF
--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -513,7 +513,7 @@ module.exports = {
                             }
 
                             // if "args" option is "after-used", skip all but the last parameter
-                            if (config.args === "after-used" && !isLastInNonIgnoredParameters(variable)) {
+                            if (config.args === "after-used" && astUtils.isFunction(def.name.parent) && !isLastInNonIgnoredParameters(variable)) {
                                 continue;
                             }
                         } else {

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -609,6 +609,54 @@ ruleTester.run("no-unused-vars", rule, {
         {
             code: "/*global\rfoo*/",
             errors: [{ message: "'foo' is defined but never used.", line: 2, column: 1 }]
+        },
+
+        // https://github.com/eslint/eslint/issues/8442
+        {
+            code: "(function ({ a }, b ) { return b; })();",
+            parserOptions: { ecmaVersion: 2015 },
+            errors: [
+                "'a' is defined but never used."
+            ]
+        },
+        {
+            code: "(function ({ a }, { b, c } ) { return b; })();",
+            parserOptions: { ecmaVersion: 2015 },
+            errors: [
+                "'a' is defined but never used.",
+                "'c' is defined but never used."
+            ]
+        },
+        {
+            code: "(function ({ a, b }, { c } ) { return b; })();",
+            parserOptions: { ecmaVersion: 2015 },
+            errors: [
+                "'a' is defined but never used.",
+                "'c' is defined but never used."
+            ]
+        },
+        {
+            code: "(function ([ a ], b ) { return b; })();",
+            parserOptions: { ecmaVersion: 2015 },
+            errors: [
+                "'a' is defined but never used."
+            ]
+        },
+        {
+            code: "(function ([ a ], [ b, c ] ) { return b; })();",
+            parserOptions: { ecmaVersion: 2015 },
+            errors: [
+                "'a' is defined but never used.",
+                "'c' is defined but never used."
+            ]
+        },
+        {
+            code: "(function ([ a, b ], [ c ] ) { return b; })();",
+            parserOptions: { ecmaVersion: 2015 },
+            errors: [
+                "'a' is defined but never used.",
+                "'c' is defined but never used."
+            ]
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

Fixes #8442.

**What changes did you make? (Give an overview)**

The rule should warn the variables which are in destructuring even if those exist in non-last parameters because those can always be removed.
This is semver-minor matter since a bug fix which increases warnings.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.