### PR TITLE
New rule: getter-return

### DIFF
--- a/conf/eslint-recommended.js
+++ b/conf/eslint-recommended.js
@@ -48,6 +48,7 @@ module.exports = {
         "func-names": "off",
         "func-style": "off",
         "generator-star-spacing": "off",
+        "getter-return": "off",
         "global-require": "off",
         "guard-for-in": "off",
         "handle-callback-err": "off",

--- a/docs/rules/getter-return.md
+++ b/docs/rules/getter-return.md
@@ -70,6 +70,12 @@ class P{
 }
 ```
 
+## Options
+
+This rule has an object option:
+
+* `"allowImplicit": false` (default) disallows implicitly return a value.
+
 ## When Not To Use It
 
 If your project will not be using getter you do not need this rule.

--- a/docs/rules/getter-return.md
+++ b/docs/rules/getter-return.md
@@ -1,0 +1,5 @@
+# Enforces that a return statement is present in property getters (getter-return)
+
+## Rule Details
+
+## When Not To Use It

--- a/docs/rules/getter-return.md
+++ b/docs/rules/getter-return.md
@@ -74,11 +74,11 @@ class P{
 
 This rule has an object option:
 
-* `"allowImplicit": false` (default) disallows implicitly return a value.
+* `"allowImplicit": false` (default) disallows implicitly returning undefined with a return; statement.
 
 ## When Not To Use It
 
-If your project will not be using getter you do not need this rule.
+If your project will not be using ES5 property getters you do not need this rule.
 
 ## Further Reading
 

--- a/docs/rules/getter-return.md
+++ b/docs/rules/getter-return.md
@@ -1,6 +1,6 @@
 # Enforces that a return statement is present in property getters (getter-return)
 
-The get syntax binds an object property to a function that will be called when that property is looked up. It is firstly introduced in ECMAScript 5:
+The get syntax binds an object property to a function that will be called when that property is looked up. It was first introduced in ECMAScript 5:
 
 ```js
     var p = {

--- a/docs/rules/getter-return.md
+++ b/docs/rules/getter-return.md
@@ -1,5 +1,80 @@
 # Enforces that a return statement is present in property getters (getter-return)
 
+The get syntax binds an object property to a function that will be called when that property is looked up. It is firstly introduced in ECMAScript 5:
+
+```js
+    var p = {
+        get name(){
+            return "nicholas";
+        }
+    };
+
+    Object.defineProperty(p, "age", {
+        get: function (){
+            return 17;
+        }
+    });
+```
+
+Note that every `getter` is expected to return a value.
+
 ## Rule Details
 
+This rule enforces that a return statement is present in property getters.
+
+Examples of **incorrect** code for this rule:
+
+```js
+/*eslint getter-return: "error"*/
+
+p = {
+    get name(){
+        // no returns.
+    }
+};
+
+Object.defineProperty(p, "age", {
+    get: function (){
+        // no returns.
+    }
+});
+
+class P{
+    get name(){
+        // no returns.
+    }
+}
+```
+
+Examples of **correct** code for this rule:
+
+```js
+/*eslint getter-return: "error"*/
+
+p = {
+    get name(){
+        return "nicholas";
+    }
+};
+
+Object.defineProperty(p, "age", {
+    get: function (){
+        return 18;
+    }
+});
+
+class P{
+    get name(){
+        return "nicholas";
+    }
+}
+```
+
 ## When Not To Use It
+
+If your project will not be using getter you do not need this rule.
+
+## Further Reading
+
+* [MDN: Functions getter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get)
+* [Understanding ES6: Accessor Properties](https://leanpub.com/understandinges6/read/#leanpub-auto-accessor-properties)

--- a/docs/rules/getter-return.md
+++ b/docs/rules/getter-return.md
@@ -76,6 +76,17 @@ This rule has an object option:
 
 * `"allowImplicit": false` (default) disallows implicitly returning undefined with a return; statement.
 
+Examples of **correct** code for the `{ "allowImplicit": true }` option:
+
+```js
+/*eslint getter-return: ["error", { allowImplicit: true }]*/
+p = {
+    get name(){
+        return; // return undefined implicitly.
+    }
+};
+```
+
 ## When Not To Use It
 
 If your project will not be using ES5 property getters you do not need this rule.

--- a/lib/rules/getter-return.js
+++ b/lib/rules/getter-return.js
@@ -35,7 +35,7 @@ function isReachable(segment) {
  * @param {ASTNode} node - A function node to get.
  * @returns {ASTNode|Token} The node or the token of a location.
  */
-function getLocation(node) {
+function getId(node) {
     return node.id || node;
 }
 
@@ -92,7 +92,7 @@ module.exports = {
             ) {
                 context.report({
                     node,
-                    loc: getLocation(node, context.getSourceCode()).loc.start,
+                    loc: getId(node, context.getSourceCode()).loc.start,
                     message: funcInfo.hasReturn
                         ? "Expected to return a value at the end of {{name}}."
                         : "Expected to return a value in {{name}}.",

--- a/lib/rules/getter-return.js
+++ b/lib/rules/getter-return.js
@@ -90,9 +90,9 @@ module.exports = {
             ) {
                 context.report({
                     node,
-                    loc: getId(node, context.getSourceCode()).loc.start,
+                    loc: getId(node).loc.start,
                     message: funcInfo.hasReturn
-                        ? "Expected to return a value at the end of {{name}}."
+                        ? "Expected {{name}} to always return a value."
                         : "Expected to return a value in {{name}}.",
                     data: {
                         name: astUtils.getFunctionNameWithKind(funcInfo.node)

--- a/lib/rules/getter-return.js
+++ b/lib/rules/getter-return.js
@@ -15,8 +15,6 @@ const astUtils = require("../ast-utils");
 // Helpers
 //------------------------------------------------------------------------------
 
-const TARGET_NODE_TYPE = "FunctionExpression";
-
 /**
  * Checks a given code path segment is reachable.
  *
@@ -114,7 +112,7 @@ module.exports = {
                     codePath,
                     hasReturn: false,
                     shouldCheck:
-                        node.type === TARGET_NODE_TYPE &&
+                        node.type === "FunctionExpression" &&
                         node.body.type === "BlockStatement" &&
 
                         // check if it is a "getter", or a method named "get".

--- a/lib/rules/getter-return.js
+++ b/lib/rules/getter-return.js
@@ -55,7 +55,7 @@ module.exports = {
             {
                 type: "object",
                 properties: {
-                    noImplicit: {
+                    allowImplicit: {
                         type: "boolean"
                     }
                 }
@@ -65,7 +65,7 @@ module.exports = {
 
     create(context) {
 
-        const options = context.options[0] || {};
+        const options = context.options[0] || { allowImplicit: false };
 
         let funcInfo = {
             upper: null,
@@ -132,8 +132,8 @@ module.exports = {
                 if (funcInfo.shouldCheck) {
                     funcInfo.hasReturn = true;
 
-                    // if noImplicit: true, should also check node.argument
-                    if (options.noImplicit && !node.argument) {
+                    // if allowImplicit: true, should also check node.argument
+                    if (options.allowImplicit && !node.argument) {
                         context.report({
                             node,
                             message: "Expected to return a value in {{name}}.",

--- a/lib/rules/getter-return.js
+++ b/lib/rules/getter-return.js
@@ -47,7 +47,7 @@ module.exports = {
     meta: {
         docs: {
             description: "enforce `return` statements in getters",
-            category: "Best Practices",
+            category: "Possible Errors",
             recommended: false
         },
         fixable: null,

--- a/lib/rules/getter-return.js
+++ b/lib/rules/getter-return.js
@@ -1,0 +1,143 @@
+/**
+ * @fileoverview Enforces that a return statement is present in property getters.
+ * @author Aladdin-ADD(hh_2013@foxmail.com)
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const astUtils = require("../ast-utils");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+const TARGET_NODE_TYPE = /^(?:Arrow)?FunctionExpression$/;
+
+/**
+ * Checks a given code path segment is reachable.
+ *
+ * @param {CodePathSegment} segment - A segment to check.
+ * @returns {boolean} `true` if the segment is reachable.
+ */
+function isReachable(segment) {
+    return segment.reachable;
+}
+
+/**
+ * Gets a readable location.
+ *
+ * - FunctionExpression -> the function name or `function` keyword.
+ * - ArrowFunctionExpression -> `=>` token.
+ *
+ * @param {ASTNode} node - A function node to get.
+ * @param {SourceCode} sourceCode - A source code to get tokens.
+ * @returns {ASTNode|Token} The node or the token of a location.
+ */
+function getLocation(node, sourceCode) {
+    if (node.type === "ArrowFunctionExpression") {
+        return sourceCode.getTokenBefore(node.body);
+    }
+    return node.id || node;
+}
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "enforce `return` statements in getters",
+            category: "Best Practices",
+            recommended: false
+        },
+
+        schema: []
+    },
+
+    create(context) {
+        let funcInfo = {
+            upper: null,
+            codePath: null,
+            hasReturn: false,
+            shouldCheck: false,
+            node: null
+        };
+
+        /**
+         * Checks whether or not the last code path segment is reachable.
+         * Then reports this function if the segment is reachable.
+         *
+         * If the last code path segment is reachable, there are paths which are not
+         * returned or thrown.
+         *
+         * @param {ASTNode} node - A node to check.
+         * @returns {void}
+         */
+        function checkLastSegment(node) {
+            if (funcInfo.shouldCheck &&
+                funcInfo.codePath.currentSegments.some(isReachable)
+            ) {
+                context.report({
+                    node,
+                    loc: getLocation(node, context.getSourceCode()).loc.start,
+                    message: funcInfo.hasReturn
+                        ? "Expected to return a value at the end of {{name}}."
+                        : "Expected to return a value in {{name}}.",
+                    data: {
+                        name: astUtils.getFunctionNameWithKind(funcInfo.node)
+                    }
+                });
+            }
+        }
+
+        return {
+
+            // Stacks this function's information.
+            onCodePathStart(codePath, node) {
+                funcInfo = {
+                    upper: funcInfo,
+                    codePath,
+                    hasReturn: false,
+                    shouldCheck:
+                        TARGET_NODE_TYPE.test(node.type) &&
+                        node.body.type === "BlockStatement" &&
+                        node.parent.kind === "get" &&
+                        !node.async &&
+                        !node.generator,
+                    node
+                };
+            },
+
+            // Pops this function's information.
+            onCodePathEnd() {
+                funcInfo = funcInfo.upper;
+            },
+
+            // Checks the return statement is valid.
+            ReturnStatement(node) {
+                if (funcInfo.shouldCheck) {
+                    funcInfo.hasReturn = true;
+
+                    if (!node.argument) {
+                        context.report({
+                            node,
+                            message: "Expected to return a value in {{name}}.",
+                            data: {
+                                name: astUtils.getFunctionNameWithKind(funcInfo.node)
+                            }
+                        });
+                    }
+                }
+            },
+
+            // Reports a given function if the last path is reachable.
+            "FunctionExpression:exit": checkLastSegment,
+            "ArrowFunctionExpression:exit": checkLastSegment
+        };
+    }
+};

--- a/lib/rules/getter-return.js
+++ b/lib/rules/getter-return.js
@@ -134,7 +134,7 @@ module.exports = {
                     funcInfo.hasReturn = true;
 
                     // if allowImplicit: true, should also check node.argument
-                    if (options.allowImplicit && !node.argument) {
+                    if (!options.allowImplicit && !node.argument) {
                         context.report({
                             node,
                             message: "Expected to return a value in {{name}}.",

--- a/lib/rules/getter-return.js
+++ b/lib/rules/getter-return.js
@@ -58,7 +58,8 @@ module.exports = {
                     allowImplicit: {
                         type: "boolean"
                     }
-                }
+                },
+                additionalProperties: false
             }
         ]
     },

--- a/lib/rules/getter-return.js
+++ b/lib/rules/getter-return.js
@@ -133,7 +133,7 @@ module.exports = {
                 if (funcInfo.shouldCheck) {
                     funcInfo.hasReturn = true;
 
-                    // if allowImplicit: true, should also check node.argument
+                    // if allowImplicit: false, should also check node.argument
                     if (!options.allowImplicit && !node.argument) {
                         context.report({
                             node,

--- a/lib/rules/getter-return.js
+++ b/lib/rules/getter-return.js
@@ -15,7 +15,7 @@ const astUtils = require("../ast-utils");
 // Helpers
 //------------------------------------------------------------------------------
 
-const TARGET_NODE_TYPE = /^FunctionExpression$/;
+const TARGET_NODE_TYPE = "FunctionExpression";
 
 /**
  * Checks a given code path segment is reachable.
@@ -114,7 +114,7 @@ module.exports = {
                     codePath,
                     hasReturn: false,
                     shouldCheck:
-                        TARGET_NODE_TYPE.test(node.type) &&
+                        node.type === TARGET_NODE_TYPE &&
                         node.body.type === "BlockStatement" &&
 
                         // check if it is a "getter", or a method named "get".

--- a/lib/rules/getter-return.js
+++ b/lib/rules/getter-return.js
@@ -15,7 +15,7 @@ const astUtils = require("../ast-utils");
 // Helpers
 //------------------------------------------------------------------------------
 
-const TARGET_NODE_TYPE = /^(?:Arrow)?FunctionExpression$/;
+const TARGET_NODE_TYPE = /^FunctionExpression$/;
 
 /**
  * Checks a given code path segment is reachable.
@@ -31,16 +31,11 @@ function isReachable(segment) {
  * Gets a readable location.
  *
  * - FunctionExpression -> the function name or `function` keyword.
- * - ArrowFunctionExpression -> `=>` token.
  *
  * @param {ASTNode} node - A function node to get.
- * @param {SourceCode} sourceCode - A source code to get tokens.
  * @returns {ASTNode|Token} The node or the token of a location.
  */
-function getLocation(node, sourceCode) {
-    if (node.type === "ArrowFunctionExpression") {
-        return sourceCode.getTokenBefore(node.body);
-    }
+function getLocation(node) {
     return node.id || node;
 }
 
@@ -99,6 +94,8 @@ module.exports = {
 
             // Stacks this function's information.
             onCodePathStart(codePath, node) {
+                const parent = node.parent;
+
                 funcInfo = {
                     upper: funcInfo,
                     codePath,
@@ -106,9 +103,9 @@ module.exports = {
                     shouldCheck:
                         TARGET_NODE_TYPE.test(node.type) &&
                         node.body.type === "BlockStatement" &&
-                        node.parent.kind === "get" &&
-                        !node.async &&
-                        !node.generator,
+
+                        // check if it is a "getter", or a method named "get".
+                        (parent.kind === "get" || astUtils.getStaticPropertyName(parent) === "get"),
                     node
                 };
             },
@@ -136,8 +133,7 @@ module.exports = {
             },
 
             // Reports a given function if the last path is reachable.
-            "FunctionExpression:exit": checkLastSegment,
-            "ArrowFunctionExpression:exit": checkLastSegment
+            "FunctionExpression:exit": checkLastSegment
         };
     }
 };

--- a/lib/rules/getter-return.js
+++ b/lib/rules/getter-return.js
@@ -50,11 +50,23 @@ module.exports = {
             category: "Best Practices",
             recommended: false
         },
-
-        schema: []
+        fixable: null,
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    noImplicit: {
+                        type: "boolean"
+                    }
+                }
+            }
+        ]
     },
 
     create(context) {
+
+        const options = context.options[0] || {};
+
         let funcInfo = {
             upper: null,
             codePath: null,
@@ -120,7 +132,8 @@ module.exports = {
                 if (funcInfo.shouldCheck) {
                     funcInfo.hasReturn = true;
 
-                    if (!node.argument) {
+                    // if noImplicit: true, should also check node.argument
+                    if (options.noImplicit && !node.argument) {
                         context.report({
                             node,
                             message: "Expected to return a value in {{name}}.",

--- a/tests/lib/rules/getter-return.js
+++ b/tests/lib/rules/getter-return.js
@@ -51,6 +51,7 @@ ruleTester.run("enforce-return-in-getter", rule, {
 
         // TODO: why data: { name: "getter 'bar'"} is not working?
         // test obj: get
+        { code: "var foo = { get bar() {} };", parserOptions, errors: [{ message: noReturnMessage, data: { name: "getter 'bar'" } }] },
         { code: "var foo = { get bar() {return;} };", parserOptions, errors: [{ message: noReturnMessage, data: { name: "getter 'bar'" } }] },
         { code: "var foo = { get bar() {return; ;} };", parserOptions, errors: [{ message: noReturnMessage, data: { name: "getter 'bar'" } }] },
         { code: "var foo = { get bar() {return 1; return;} };", parserOptions, errors: [{ message: noReturnMessage, data: { name: "getter 'bar'" } }] },
@@ -61,6 +62,7 @@ ruleTester.run("enforce-return-in-getter", rule, {
         { code: "var foo = { get bar(){if(bar) {return;} return true;} };", parserOptions, errors: [{ message: noReturnMessage, data: { name: "getter 'bar'" } }] },
 
         // test class: get
+        { code: "class foo { get bar(){} }", parserOptions, errors: [{ message: noReturnMessage, data: { name: "getter 'bar'" } }] },
         { code: "class foo { get bar(){return;} }", parserOptions, errors: [{ message: noReturnMessage, data: { name: "getter 'bar'" } }] },
         { code: "class foo { get bar(){if(bar) {return true;}} }", parserOptions, errors: [{ message: noLastReturnMessage, data: { name: "getter 'bar'" } }] },
         { code: "class foo { get bar(){if(bar) {return;} return true;} }", parserOptions, errors: [{ message: noReturnMessage, data: { name: "getter 'bar'" } }] },

--- a/tests/lib/rules/getter-return.js
+++ b/tests/lib/rules/getter-return.js
@@ -23,13 +23,13 @@ const name = "getter 'bar'";
 const noReturnMessage = `Expected to return a value in ${name}.`;
 const noLastReturnMessage = `Expected to return a value at the end of ${name}.`;
 const parserOptions = { ecmaVersion: 6 };
-const options = [{ noImplicit: true }];
+const options = [{ allowImplicit: true }];
 
 ruleTester.run("getter-return", rule, {
 
     valid: [
 
-        // test obj: get, option: {noImplicit: false}
+        // test obj: get, option: {allowImplicit: false}
         { code: "var foo = { get bar(){return true;} };" },
         { code: "var foo = { get bar(){return;} };" },
         { code: "var foo = { bar: function(){return true;} };" },
@@ -39,7 +39,7 @@ ruleTester.run("getter-return", rule, {
         { code: "var foo = { bar(){~function (){}();return;} };", parserOptions },
         { code: "var foo = { bar(){~function (){return true;}();return;} };", parserOptions },
 
-        // test class: get, option: {noImplicit: false}
+        // test class: get, option: {allowImplicit: false}
         { code: "class foo { get bar(){return true;} }", parserOptions },
         { code: "class foo { get bar(){if(baz){return true;} else {return false;} } }", parserOptions },
         { code: "class foo { get bar(){if(baz){return;} else {return false;} } }", parserOptions },
@@ -48,7 +48,7 @@ ruleTester.run("getter-return", rule, {
         { code: "var foo = { get bar(){ ~function (){ return true; }(); return; } };", parserOptions, errors: [] },
         { code: "var foo = { get bar(){ ~function (){}(); return; } };", parserOptions, errors: [] },
 
-        // test object.defineProperty(s), option: {noImplicit: false}
+        // test object.defineProperty(s), option: {allowImplicit: false}
         { code: "Object.defineProperty(foo, \"bar\", { get: function () {return true;}});" },
         { code: "Object.defineProperty(foo, \"bar\", { get: function () {return;}});" },
         { code: "Object.defineProperies(foo, { bar: { get: function () {return true;}} });" },
@@ -58,7 +58,8 @@ ruleTester.run("getter-return", rule, {
         { code: "Object.defineProperies(foo, { bar: { get: function () { ~function (){ return true; }(); return true;}} });" },
         { code: "Object.defineProperies(foo, { bar: { get: function () { ~function (){}(); return;}} });" },
 
-        // test option: {noImplicit: true}
+
+        // test option: {allowImplicit: true}
         { code: "var foo = { get bar(){return true;} };", options },
         { code: "class foo { get bar(){return true;} }", options, parserOptions },
         { code: "Object.defineProperty(foo, \"bar\", { get: function () {return true;}});", options },
@@ -75,18 +76,18 @@ ruleTester.run("getter-return", rule, {
 
     invalid: [
 
-        // test obj: get, option: {noImplicit: false}
+        // test obj: get, option: {allowImplicit: false}
         { code: "var foo = { get bar() {} };", parserOptions, errors: [{ message: noReturnMessage }] },
         { code: "var foo = { get bar(){if(bar) {return true;}} };", parserOptions, errors: [{ message: noLastReturnMessage }] },
         { code: "var foo = { get bar(){if(bar) {return true;} ;} };", parserOptions, errors: [{ message: noLastReturnMessage }] },
 
-        // test class: get, option: {noImplicit: false}
+        // test class: get, option: {allowImplicit: false}
         { code: "class foo { get bar(){} }", parserOptions, errors: [{ message: noReturnMessage }] },
 
-        // test object.defineProperty, option: {noImplicit: false}
+        // test object.defineProperty, option: {allowImplicit: false}
         { code: "Object.defineProperty(foo, \"bar\", { get: function (){if(bar) {return true;}}});", errors: [{ message: "Expected to return a value at the end of method 'get'." }] },
 
-        // test option: {noImplicit: true}
+        // test option: {allowImplicit: true}
         { code: "var foo = { get bar() {return;} };", options, parserOptions, errors: [{ message: noReturnMessage }] },
         { code: "var foo = { get bar() {return; ;} };", options, parserOptions, errors: [{ message: noReturnMessage }] },
         { code: "var foo = { get bar() {return; return 1;} };", options, parserOptions, errors: [{ message: noReturnMessage }] },

--- a/tests/lib/rules/getter-return.js
+++ b/tests/lib/rules/getter-return.js
@@ -50,14 +50,14 @@ ruleTester.run("getter-return", rule, {
         // test object.defineProperty(s)
         // option: {allowImplicit: false}
         { code: "Object.defineProperty(foo, \"bar\", { get: function () {return true;}});" },
-        { code: "Object.defineProperies(foo, { bar: { get: function () {return true;}} });" },
         { code: "Object.defineProperty(foo, \"bar\", { get: function () { ~function (){ return true; }();return true;}});" },
+        { code: "Object.defineProperies(foo, { bar: { get: function () {return true;}} });" },
         { code: "Object.defineProperies(foo, { bar: { get: function () { ~function (){ return true; }(); return true;}} });" },
 
         // option: {allowImplicit: true}
         { code: "Object.defineProperty(foo, \"bar\", { get: function () {return true;}});", options },
-        { code: "Object.defineProperies(foo, { bar: { get: function () {return true;}} });", options },
         { code: "Object.defineProperty(foo, \"bar\", { get: function (){return;}});", options },
+        { code: "Object.defineProperies(foo, { bar: { get: function () {return true;}} });", options },
         { code: "Object.defineProperies(foo, { bar: { get: function () {return;}} });", options },
 
         // not getter.

--- a/tests/lib/rules/getter-return.js
+++ b/tests/lib/rules/getter-return.js
@@ -1,0 +1,48 @@
+/**
+ * @fileoverview Enforces that a return statement is present in property getters.
+ * @author Aladdin-ADD(hh_2013@foxmail.com)
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../lib/rules/getter-return");
+const RuleTester = require("../../../lib/testers/rule-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester();
+
+// TODO: data is not working, so specify a name: "getter 'bar'"
+const noReturnMessage = "Expected to return a value in getter 'bar'.";
+const noLastReturnMessage = "Expected to return a value at the end of getter 'bar'.";
+
+ruleTester.run("enforce-return-in-getter", rule, {
+
+    valid: [
+        { code: "var foo = { get: function(){} };" },
+        { code: "var foo = { get bar(){return true;} };" },
+        { code: "var foo = { bar(){return true;} };", env: { es6: true } },
+        { code: "var foo = { bar(){} };", env: { es6: true } },
+
+        { code: "class foo { get bar(){return true;} }", env: { es6: true } },
+        { code: "class foo { get(){} }", env: { es6: true } },
+        { code: "class foo { get(){return true;} }", env: { es6: true } },
+
+        { code: "var get = function(){};" }
+    ],
+
+    invalid: [
+
+        // TODO: why data: { name: "getter 'bar'"} is not working?
+        { code: "var foo = { get bar() {return;} }", env: { es6: true }, errors: [{ message: noReturnMessage, data: { name: "getter 'bar'" } }] },
+        { code: "var foo = { get bar(){if(bar) {return true;}} }", env: { es6: true }, errors: [{ message: noLastReturnMessage, data: { name: "getter 'bar'" } }] },
+        { code: "var foo = { get bar(){if(bar) {return;} return true;} }", env: { es6: true }, errors: [{ message: noReturnMessage, data: { name: "getter 'bar'" } }] }
+
+    ]
+});

--- a/tests/lib/rules/getter-return.js
+++ b/tests/lib/rules/getter-return.js
@@ -18,14 +18,14 @@ const RuleTester = require("../../../lib/testers/rule-tester");
 
 const ruleTester = new RuleTester();
 
-// TODO: data is not working, so specify a name: "getter 'bar'"
+// data is not working, so specify a name: "getter 'bar'"
 const name = "getter 'bar'";
 const noReturnMessage = `Expected to return a value in ${name}.`;
 const noLastReturnMessage = `Expected to return a value at the end of ${name}.`;
 const parserOptions = { ecmaVersion: 6 };
 const options = [{ noImplicit: true }];
 
-ruleTester.run("enforce-return-in-getter", rule, {
+ruleTester.run("getter-return", rule, {
 
     valid: [
 

--- a/tests/lib/rules/getter-return.js
+++ b/tests/lib/rules/getter-return.js
@@ -49,13 +49,11 @@ ruleTester.run("getter-return", rule, {
         // test option: {allowImplicit: true}
         { code: "var foo = { get bar() {return;} };", options },
         { code: "var foo = { get bar(){return true;} };", options },
+        { code: "var foo = { get bar(){if(bar) {return;} return true;} };", options },
         { code: "class foo { get bar(){return true;} }", options, parserOptions },
         { code: "class foo { get bar(){return;} }", options, parserOptions },
         { code: "Object.defineProperty(foo, \"bar\", { get: function () {return true;}});", options },
         { code: "Object.defineProperies(foo, { bar: { get: function () {return true;}} });", options },
-        { code: "var foo = { get bar() {return;} };", options, parserOptions },
-        { code: "var foo = { get bar(){if(bar) {return;} return true;} };", options, parserOptions },
-        { code: "class foo { get bar(){return;} }", options, parserOptions },
         { code: "Object.defineProperty(foo, \"bar\", { get: function (){return;}});", options },
         { code: "Object.defineProperies(foo, { bar: { get: function () {return;}} });", options },
 

--- a/tests/lib/rules/getter-return.js
+++ b/tests/lib/rules/getter-return.js
@@ -31,39 +31,33 @@ ruleTester.run("getter-return", rule, {
 
         // test obj: get, option: {allowImplicit: false}
         { code: "var foo = { get bar(){return true;} };" },
-        { code: "var foo = { get bar(){return;} };" },
         { code: "var foo = { bar: function(){return true;} };" },
         { code: "var foo = { bar: function(){return;} };" },
         { code: "var foo = { bar(){return true;} };", parserOptions },
-        { code: "var foo = { bar(){return;} };", parserOptions },
-        { code: "var foo = { bar(){~function (){}();return;} };", parserOptions },
-        { code: "var foo = { bar(){~function (){return true;}();return;} };", parserOptions },
 
         // test class: get, option: {allowImplicit: false}
         { code: "class foo { get bar(){return true;} }", parserOptions },
         { code: "class foo { get bar(){if(baz){return true;} else {return false;} } }", parserOptions },
-        { code: "class foo { get bar(){if(baz){return;} else {return false;} } }", parserOptions },
         { code: "class foo { get(){return true;} }", parserOptions },
-        { code: "var foo = { get bar(){if(bar) {return;} return true;} };", parserOptions, errors: [] },
-        { code: "var foo = { get bar(){ ~function (){ return true; }(); return; } };", parserOptions, errors: [] },
-        { code: "var foo = { get bar(){ ~function (){}(); return; } };", parserOptions, errors: [] },
 
         // test object.defineProperty(s), option: {allowImplicit: false}
         { code: "Object.defineProperty(foo, \"bar\", { get: function () {return true;}});" },
-        { code: "Object.defineProperty(foo, \"bar\", { get: function () {return;}});" },
         { code: "Object.defineProperies(foo, { bar: { get: function () {return true;}} });" },
-        { code: "Object.defineProperies(foo, { bar: { get: function () {return;}} });" },
         { code: "Object.defineProperty(foo, \"bar\", { get: function () { ~function (){ return true; }();return true;}});" },
-        { code: "Object.defineProperty(foo, \"bar\", { get: function () { ~function (){}();return;}});" },
         { code: "Object.defineProperies(foo, { bar: { get: function () { ~function (){ return true; }(); return true;}} });" },
-        { code: "Object.defineProperies(foo, { bar: { get: function () { ~function (){}(); return;}} });" },
-
 
         // test option: {allowImplicit: true}
+        { code: "var foo = { get bar() {return;} };", options },
         { code: "var foo = { get bar(){return true;} };", options },
         { code: "class foo { get bar(){return true;} }", options, parserOptions },
+        { code: "class foo { get bar(){return;} }", options, parserOptions },
         { code: "Object.defineProperty(foo, \"bar\", { get: function () {return true;}});", options },
         { code: "Object.defineProperies(foo, { bar: { get: function () {return true;}} });", options },
+        { code: "var foo = { get bar() {return;} };", options, parserOptions },
+        { code: "var foo = { get bar(){if(bar) {return;} return true;} };", options, parserOptions },
+        { code: "class foo { get bar(){return;} }", options, parserOptions },
+        { code: "Object.defineProperty(foo, \"bar\", { get: function (){return;}});", options },
+        { code: "Object.defineProperies(foo, { bar: { get: function () {return;}} });", options },
 
         // not getter.
         { code: "var get = function(){};" },
@@ -88,18 +82,9 @@ ruleTester.run("getter-return", rule, {
         { code: "Object.defineProperty(foo, \"bar\", { get: function (){if(bar) {return true;}}});", errors: [{ message: "Expected to return a value at the end of method 'get'." }] },
 
         // test option: {allowImplicit: true}
-        { code: "var foo = { get bar() {return;} };", options, parserOptions, errors: [{ message: noReturnMessage }] },
-        { code: "var foo = { get bar() {return; ;} };", options, parserOptions, errors: [{ message: noReturnMessage }] },
-        { code: "var foo = { get bar() {return; return 1;} };", options, parserOptions, errors: [{ message: noReturnMessage }] },
-        { code: "var foo = { get bar(){if(bar) {return true;} return;} };", options, parserOptions, errors: [{ message: noReturnMessage }] },
-        { code: "var foo = { get bar(){if(bar) {return;} return true;} };", options, parserOptions, errors: [{ message: noReturnMessage }] },
-        { code: "class foo { get bar(){return;} }", options, parserOptions, errors: [{ message: noReturnMessage }] },
-        { code: "class foo { get bar(){if(bar) {return true;}} }", options, parserOptions, errors: [{ message: noLastReturnMessage }] },
-        { code: "class foo { get bar(){if(bar) {return;} return true;} }", options, parserOptions, errors: [{ message: noReturnMessage }] },
-        { code: "Object.defineProperty(foo, \"bar\", { get: function (){return;}});", options, errors: [{ message: "Expected to return a value in method 'get'." }] },
-        { code: "Object.defineProperty(foo, \"bar\", { get: function (){if(bar) {return;} return true;}});", options, errors: [{ message: "Expected to return a value in method 'get'." }] },
-        { code: "Object.defineProperies(foo, { bar: { get: function () {return;}} });", options, errors: [{ message: "Expected to return a value in method 'get'." }] },
-
+        { code: "var foo = { get bar() {} };", options, errors: [{ message: noReturnMessage }] },
+        { code: "var foo = { get bar() {if (baz) {return;}} };", options, errors: [{ message: noLastReturnMessage }] },
+        { code: "Object.defineProperty(foo, \"bar\", { get: function (){}});", options, parserOptions, errors: [{ message: "Expected to return a value in method 'get'." }] },
         { code: "class foo { get bar(){} }", options, parserOptions, errors: [{ message: noReturnMessage }] }
 
     ]

--- a/tests/lib/rules/getter-return.js
+++ b/tests/lib/rules/getter-return.js
@@ -71,19 +71,24 @@ ruleTester.run("getter-return", rule, {
         // test obj: get, option: {allowImplicit: false}
         { code: "var foo = { get bar() {} };", parserOptions, errors: [{ message: noReturnMessage }] },
         { code: "var foo = { get bar(){if(bar) {return true;}} };", parserOptions, errors: [{ message: noLastReturnMessage }] },
-        { code: "var foo = { get bar(){if(bar) {return true;} ;} };", parserOptions, errors: [{ message: noLastReturnMessage }] },
+        { code: "var foo = { get bar() { ~function () {return true;}} };", parserOptions, errors: [{ message: noReturnMessage }] },
 
         // test class: get, option: {allowImplicit: false}
         { code: "class foo { get bar(){} }", parserOptions, errors: [{ message: noReturnMessage }] },
+        { code: "class foo { get bar(){ if (baz) { return true; }}}", parserOptions, errors: [{ noLastReturnMessage }] },
+        { code: "class foo { get bar(){ ~function () { return true; }}}", parserOptions, errors: [{ noLastReturnMessage }] },
 
-        // test object.defineProperty, option: {allowImplicit: false}
+        // test object.defineProperty(s), option: {allowImplicit: false}
+        { code: "Object.defineProperty(foo, \"bar\", { get: function (){}});", errors: [{ noReturnMessage}] },
         { code: "Object.defineProperty(foo, \"bar\", { get: function (){if(bar) {return true;}}});", errors: [{ message: "Expected to return a value at the end of method 'get'." }] },
+        { code: "Object.defineProperies(foo, { bar: { get: function () {}} });", options, errors: [{ noReturnMessage}] },
+        { code: "Object.defineProperies(foo, { bar: { get: function (){if(bar) {return true;}}}});", options, errors: [{ message: "Expected to return a value at the end of method 'get'." }] },
 
         // test option: {allowImplicit: true}
         { code: "var foo = { get bar() {} };", options, errors: [{ message: noReturnMessage }] },
+        { code: "class foo { get bar(){} }", options, parserOptions, errors: [{ message: noReturnMessage }] },
         { code: "var foo = { get bar() {if (baz) {return;}} };", options, errors: [{ message: noLastReturnMessage }] },
-        { code: "Object.defineProperty(foo, \"bar\", { get: function (){}});", options, parserOptions, errors: [{ message: "Expected to return a value in method 'get'." }] },
-        { code: "class foo { get bar(){} }", options, parserOptions, errors: [{ message: noReturnMessage }] }
+        { code: "Object.defineProperty(foo, \"bar\", { get: function (){}});", options, parserOptions, errors: [{ message: "Expected to return a value in method 'get'." }] }
 
     ]
 });

--- a/tests/lib/rules/getter-return.js
+++ b/tests/lib/rules/getter-return.js
@@ -23,54 +23,74 @@ const name = "getter 'bar'";
 const noReturnMessage = `Expected to return a value in ${name}.`;
 const noLastReturnMessage = `Expected to return a value at the end of ${name}.`;
 const parserOptions = { ecmaVersion: 6 };
+const options = [{ noImplicit: true }];
 
 ruleTester.run("enforce-return-in-getter", rule, {
 
     valid: [
 
-        // test obj: get
+        // test obj: get, option: {noImplicit: false}
         { code: "var foo = { get bar(){return true;} };" },
+        { code: "var foo = { get bar(){return;} };" },
         { code: "var foo = { bar: function(){return true;} };" },
+        { code: "var foo = { bar: function(){return;} };" },
         { code: "var foo = { bar(){return true;} };", parserOptions },
-        { code: "var foo = { bar: function(){} };" },
-        { code: "var foo = { bar(){} };", parserOptions },
+        { code: "var foo = { bar(){return;} };", parserOptions },
 
-        // test class: get
+        // test class: get, option: {noImplicit: false}
         { code: "class foo { get bar(){return true;} }", parserOptions },
         { code: "class foo { get bar(){if(baz){return true;} else {return false;} } }", parserOptions },
+        { code: "class foo { get bar(){if(baz){return;} else {return false;} } }", parserOptions },
         { code: "class foo { get(){return true;} }", parserOptions },
+        { code: "var foo = { get bar(){if(bar) {return;} return true;} };", parserOptions, errors: [] },
 
-        // add object.defineProperty
+        // test object.defineProperty(s), option: {noImplicit: false}
         { code: "Object.defineProperty(foo, \"bar\", { get: function () {return true;}});" },
+        { code: "Object.defineProperty(foo, \"bar\", { get: function () {return;}});" },
+        { code: "Object.defineProperies(foo, { bar: { get: function () {return true;}} });" },
+        { code: "Object.defineProperies(foo, { bar: { get: function () {return;}} });" },
+
+        // test option: {noImplicit: true}
+        { code: "var foo = { get bar(){return true;} };", options },
+        { code: "class foo { get bar(){return true;} }", options, parserOptions },
+        { code: "Object.defineProperty(foo, \"bar\", { get: function () {return true;}});", options },
+        { code: "Object.defineProperies(foo, { bar: { get: function () {return true;}} });", options },
 
         // not getter.
-        { code: "var get = function(){};" }
+        { code: "var get = function(){};" },
+        { code: "var get = function(){ return true; };" },
+        { code: "var foo = { bar: function(){} };" },
+        { code: "var foo = { bar: function(){ return true; } };" },
+        { code: "var foo = { bar(){} };", parserOptions },
+        { code: "var foo = { bar(){ return true; } };", parserOptions }
     ],
 
     invalid: [
 
-        // TODO: why data: { name: "getter 'bar'"} is not working?
         // test obj: get
-        { code: "var foo = { get bar() {} };", parserOptions, errors: [{ message: noReturnMessage, data: { name: "getter 'bar'" } }] },
-        { code: "var foo = { get bar() {return;} };", parserOptions, errors: [{ message: noReturnMessage, data: { name: "getter 'bar'" } }] },
-        { code: "var foo = { get bar() {return; ;} };", parserOptions, errors: [{ message: noReturnMessage, data: { name: "getter 'bar'" } }] },
-        { code: "var foo = { get bar() {return 1; return;} };", parserOptions, errors: [{ message: noReturnMessage, data: { name: "getter 'bar'" } }] },
-        { code: "var foo = { get bar() {return; return 1;} };", parserOptions, errors: [{ message: noReturnMessage, data: { name: "getter 'bar'" } }] },
-        { code: "var foo = { get bar(){if(bar) {return true;}} };", parserOptions, errors: [{ message: noLastReturnMessage, data: { name: "getter 'bar'" } }] },
-        { code: "var foo = { get bar(){if(bar) {return true;} return;} };", parserOptions, errors: [{ message: noReturnMessage, data: { name: "getter 'bar'" } }] },
-        { code: "var foo = { get bar(){if(bar) {return true;} ;} };", parserOptions, errors: [{ message: noLastReturnMessage, data: { name: "getter 'bar'" } }] },
-        { code: "var foo = { get bar(){if(bar) {return;} return true;} };", parserOptions, errors: [{ message: noReturnMessage, data: { name: "getter 'bar'" } }] },
+        { code: "var foo = { get bar() {} };", parserOptions, errors: [{ message: noReturnMessage }] },
+        { code: "var foo = { get bar() {return;} };", options, parserOptions, errors: [{ message: noReturnMessage }] },
+        { code: "var foo = { get bar() {return; ;} };", options, parserOptions, errors: [{ message: noReturnMessage }] },
+        { code: "var foo = { get bar() {return; return 1;} };", options, parserOptions, errors: [{ message: noReturnMessage }] },
+        { code: "var foo = { get bar(){if(bar) {return true;}} };", parserOptions, errors: [{ message: noLastReturnMessage }] },
+        { code: "var foo = { get bar(){if(bar) {return true;} return;} };", options, parserOptions, errors: [{ message: noReturnMessage }] },
+        { code: "var foo = { get bar(){if(bar) {return true;} ;} };", parserOptions, errors: [{ message: noLastReturnMessage }] },
+        { code: "var foo = { get bar(){if(bar) {return;} return true;} };", options, parserOptions, errors: [{ message: noReturnMessage }] },
 
         // test class: get
-        { code: "class foo { get bar(){} }", parserOptions, errors: [{ message: noReturnMessage, data: { name: "getter 'bar'" } }] },
-        { code: "class foo { get bar(){return;} }", parserOptions, errors: [{ message: noReturnMessage, data: { name: "getter 'bar'" } }] },
-        { code: "class foo { get bar(){if(bar) {return true;}} }", parserOptions, errors: [{ message: noLastReturnMessage, data: { name: "getter 'bar'" } }] },
-        { code: "class foo { get bar(){if(bar) {return;} return true;} }", parserOptions, errors: [{ message: noReturnMessage, data: { name: "getter 'bar'" } }] },
+        { code: "class foo { get bar(){} }", parserOptions, errors: [{ message: noReturnMessage }] },
+        { code: "class foo { get bar(){} }", options, parserOptions, errors: [{ message: noReturnMessage }] },
+        { code: "class foo { get bar(){return;} }", options, parserOptions, errors: [{ message: noReturnMessage }] },
+        { code: "class foo { get bar(){if(bar) {return true;}} }", options, parserOptions, errors: [{ message: noLastReturnMessage }] },
+        { code: "class foo { get bar(){if(bar) {return;} return true;} }", options, parserOptions, errors: [{ message: noReturnMessage }] },
 
-        // add object.defineProperty
-        { code: "Object.defineProperty(foo, \"bar\", { get: function (){return;}});", errors: [{ message: "Expected to return a value in method 'get'.", data: { name: "getter 'bar'" } }] },
-        { code: "Object.defineProperty(foo, \"bar\", { get: function (){if(bar) {return true;}}});", errors: [{ message: "Expected to return a value at the end of method 'get'.", data: { name: "getter 'bar'" } }] },
-        { code: "Object.defineProperty(foo, \"bar\", { get: function (){if(bar) {return;} return true;}});", errors: [{ message: "Expected to return a value in method 'get'.", data: { name: "getter 'bar'" } }] }
+        // test object.defineProperty
+        { code: "Object.defineProperty(foo, \"bar\", { get: function (){return;}});", options, errors: [{ message: "Expected to return a value in method 'get'." }] },
+        { code: "Object.defineProperty(foo, \"bar\", { get: function (){if(bar) {return true;}}});", errors: [{ message: "Expected to return a value at the end of method 'get'." }] },
+        { code: "Object.defineProperty(foo, \"bar\", { get: function (){if(bar) {return;} return true;}});", options: [{ noImplicit: true }], errors: [{ message: "Expected to return a value in method 'get'." }] },
+
+        // test option: {noImplicit: true}
+        { code: "Object.defineProperty(foo, \"bar\", { get: function (){return;}});", options, errors: [{ message: "Expected to return a value in method 'get'." }] }
 
     ]
 });

--- a/tests/lib/rules/getter-return.js
+++ b/tests/lib/rules/getter-return.js
@@ -21,36 +21,40 @@ const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
 // data is not working, so specify a name: "getter 'bar'"
 const name = "getter 'bar'";
 const noReturnMessage = `Expected to return a value in ${name}.`;
-const noLastReturnMessage = `Expected to return a value at the end of ${name}.`;
+const noLastReturnMessage = `Expected ${name} to always return a value.`;
 const options = [{ allowImplicit: true }];
 
 ruleTester.run("getter-return", rule, {
 
     valid: [
 
-        // test obj: get, option: {allowImplicit: false}
+        // test obj: get
+        // option: {allowImplicit: false}
         { code: "var foo = { get bar(){return true;} };" },
-        { code: "var foo = { bar: function(){return true;} };" },
-        { code: "var foo = { bar: function(){return;} };" },
-        { code: "var foo = { bar(){return true;} };" },
 
-        // test class: get, option: {allowImplicit: false}
+        // option: {allowImplicit: true}
+        { code: "var foo = { get bar() {return;} };", options },
+        { code: "var foo = { get bar(){return true;} };", options },
+        { code: "var foo = { get bar(){if(bar) {return;} return true;} };", options },
+
+        // test class: get
+        // option: {allowImplicit: false}
         { code: "class foo { get bar(){return true;} }" },
         { code: "class foo { get bar(){if(baz){return true;} else {return false;} } }" },
         { code: "class foo { get(){return true;} }" },
 
-        // test object.defineProperty(s), option: {allowImplicit: false}
+        // option: {allowImplicit: true}
+        { code: "class foo { get bar(){return true;} }", options },
+        { code: "class foo { get bar(){return;} }", options },
+
+        // test object.defineProperty(s)
+        // option: {allowImplicit: false}
         { code: "Object.defineProperty(foo, \"bar\", { get: function () {return true;}});" },
         { code: "Object.defineProperies(foo, { bar: { get: function () {return true;}} });" },
         { code: "Object.defineProperty(foo, \"bar\", { get: function () { ~function (){ return true; }();return true;}});" },
         { code: "Object.defineProperies(foo, { bar: { get: function () { ~function (){ return true; }(); return true;}} });" },
 
-        // test option: {allowImplicit: true}
-        { code: "var foo = { get bar() {return;} };", options },
-        { code: "var foo = { get bar(){return true;} };", options },
-        { code: "var foo = { get bar(){if(bar) {return;} return true;} };", options },
-        { code: "class foo { get bar(){return true;} }", options },
-        { code: "class foo { get bar(){return;} }", options },
+        // option: {allowImplicit: true}
         { code: "Object.defineProperty(foo, \"bar\", { get: function () {return true;}});", options },
         { code: "Object.defineProperies(foo, { bar: { get: function () {return true;}} });", options },
         { code: "Object.defineProperty(foo, \"bar\", { get: function (){return;}});", options },
@@ -59,37 +63,46 @@ ruleTester.run("getter-return", rule, {
         // not getter.
         { code: "var get = function(){};" },
         { code: "var get = function(){ return true; };" },
-        { code: "var foo = { bar: function(){} };" },
-        { code: "var foo = { bar: function(){ return true; } };" },
         { code: "var foo = { bar(){} };" },
-        { code: "var foo = { bar(){ return true; } };" }
+        { code: "var foo = { bar(){ return true; } };" },
+        { code: "var foo = { bar: function(){} };" },
+        { code: "var foo = { bar(){ return true; } };" },
+        { code: "var foo = { bar: function(){return;} };" },
+        { code: "var foo = { bar: function(){return true;} };" }
     ],
 
     invalid: [
 
-        // test obj: get, option: {allowImplicit: false}
+        // test obj: get
+        // option: {allowImplicit: false}
         { code: "var foo = { get bar() {} };", errors: [{ message: noReturnMessage }] },
-        { code: "var foo = { get bar(){if(bar) {return true;}} };", errors: [{ message: noLastReturnMessage }] },
+        { code: "var foo = { get bar(){if(baz) {return true;}} };", errors: [{ message: noLastReturnMessage }] },
         { code: "var foo = { get bar() { ~function () {return true;}} };", errors: [{ message: noReturnMessage }] },
 
-        // test class: get, option: {allowImplicit: false}
+        // option: {allowImplicit: true}
+        { code: "var foo = { get bar() {} };", options, errors: [{ message: noReturnMessage }] },
+        { code: "var foo = { get bar() {if (baz) {return;}} };", options, errors: [{ message: noLastReturnMessage }] },
+
+        // test class: get
+        // option: {allowImplicit: false}
         { code: "class foo { get bar(){} }", errors: [{ message: noReturnMessage }] },
         { code: "class foo { get bar(){ if (baz) { return true; }}}", errors: [{ noLastReturnMessage }] },
         { code: "class foo { get bar(){ ~function () { return true; }()}}", errors: [{ noLastReturnMessage }] },
 
-        // test object.defineProperty(s), option: {allowImplicit: false}
-        { code: "Object.defineProperty(foo, \"bar\", { get: function (){}});", errors: [{ noReturnMessage }] },
-        { code: "Object.defineProperty(foo, \"bar\", { get: function (){if(bar) {return true;}}});", errors: [{ message: "Expected to return a value at the end of method 'get'." }] },
-        { code: "Object.defineProperty(foo, \"bar\", { get: function (){ ~function () { return true; }()}});", errors: [{ noReturnMessage }] },
-        { code: "Object.defineProperies(foo, { bar: { get: function () {}} });", options, errors: [{ noReturnMessage }] },
-        { code: "Object.defineProperies(foo, { bar: { get: function (){if(bar) {return true;}}}});", options, errors: [{ message: "Expected to return a value at the end of method 'get'." }] },
-        { code: "Object.defineProperies(foo, { bar: { get: function () {~function () { return true; }()}} });", options, errors: [{ noReturnMessage }] },
-
-        // test option: {allowImplicit: true}
-        { code: "var foo = { get bar() {} };", options, errors: [{ message: noReturnMessage }] },
-        { code: "var foo = { get bar() {if (baz) {return;}} };", options, errors: [{ message: noLastReturnMessage }] },
+        // option: {allowImplicit: true}
         { code: "class foo { get bar(){} }", options, errors: [{ message: noReturnMessage }] },
         { code: "class foo { get bar(){if (baz) {return true;} } }", options, errors: [{ message: noLastReturnMessage }] },
+
+        // test object.defineProperty(s)
+        // option: {allowImplicit: false}
+        { code: "Object.defineProperty(foo, \"bar\", { get: function (){}});", errors: [{ noReturnMessage }] },
+        { code: "Object.defineProperty(foo, \"bar\", { get: function (){if(bar) {return true;}}});", errors: [{ message: "Expected method 'get' to always return a value." }] },
+        { code: "Object.defineProperty(foo, \"bar\", { get: function (){ ~function () { return true; }()}});", errors: [{ noReturnMessage }] },
+        { code: "Object.defineProperies(foo, { bar: { get: function () {}} });", options, errors: [{ noReturnMessage }] },
+        { code: "Object.defineProperies(foo, { bar: { get: function (){if(bar) {return true;}}}});", options, errors: [{ message: "Expected method 'get' to always return a value." }] },
+        { code: "Object.defineProperies(foo, { bar: { get: function () {~function () { return true; }()}} });", options, errors: [{ noReturnMessage }] },
+
+        // option: {allowImplicit: true}
         { code: "Object.defineProperty(foo, \"bar\", { get: function (){}});", options, errors: [{ message: "Expected to return a value in method 'get'." }] },
         { code: "Object.defineProperies(foo, { bar: { get: function () {}} });", options, errors: [{ noReturnMessage }] }
     ]

--- a/tests/lib/rules/getter-return.js
+++ b/tests/lib/rules/getter-return.js
@@ -16,13 +16,12 @@ const RuleTester = require("../../../lib/testers/rule-tester");
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
 
 // data is not working, so specify a name: "getter 'bar'"
 const name = "getter 'bar'";
 const noReturnMessage = `Expected to return a value in ${name}.`;
 const noLastReturnMessage = `Expected to return a value at the end of ${name}.`;
-const parserOptions = { ecmaVersion: 6 };
 const options = [{ allowImplicit: true }];
 
 ruleTester.run("getter-return", rule, {
@@ -33,12 +32,12 @@ ruleTester.run("getter-return", rule, {
         { code: "var foo = { get bar(){return true;} };" },
         { code: "var foo = { bar: function(){return true;} };" },
         { code: "var foo = { bar: function(){return;} };" },
-        { code: "var foo = { bar(){return true;} };", parserOptions },
+        { code: "var foo = { bar(){return true;} };" },
 
         // test class: get, option: {allowImplicit: false}
-        { code: "class foo { get bar(){return true;} }", parserOptions },
-        { code: "class foo { get bar(){if(baz){return true;} else {return false;} } }", parserOptions },
-        { code: "class foo { get(){return true;} }", parserOptions },
+        { code: "class foo { get bar(){return true;} }" },
+        { code: "class foo { get bar(){if(baz){return true;} else {return false;} } }" },
+        { code: "class foo { get(){return true;} }" },
 
         // test object.defineProperty(s), option: {allowImplicit: false}
         { code: "Object.defineProperty(foo, \"bar\", { get: function () {return true;}});" },
@@ -50,8 +49,8 @@ ruleTester.run("getter-return", rule, {
         { code: "var foo = { get bar() {return;} };", options },
         { code: "var foo = { get bar(){return true;} };", options },
         { code: "var foo = { get bar(){if(bar) {return;} return true;} };", options },
-        { code: "class foo { get bar(){return true;} }", options, parserOptions },
-        { code: "class foo { get bar(){return;} }", options, parserOptions },
+        { code: "class foo { get bar(){return true;} }", options },
+        { code: "class foo { get bar(){return;} }", options },
         { code: "Object.defineProperty(foo, \"bar\", { get: function () {return true;}});", options },
         { code: "Object.defineProperies(foo, { bar: { get: function () {return true;}} });", options },
         { code: "Object.defineProperty(foo, \"bar\", { get: function (){return;}});", options },
@@ -62,21 +61,21 @@ ruleTester.run("getter-return", rule, {
         { code: "var get = function(){ return true; };" },
         { code: "var foo = { bar: function(){} };" },
         { code: "var foo = { bar: function(){ return true; } };" },
-        { code: "var foo = { bar(){} };", parserOptions },
-        { code: "var foo = { bar(){ return true; } };", parserOptions }
+        { code: "var foo = { bar(){} };" },
+        { code: "var foo = { bar(){ return true; } };" }
     ],
 
     invalid: [
 
         // test obj: get, option: {allowImplicit: false}
-        { code: "var foo = { get bar() {} };", parserOptions, errors: [{ message: noReturnMessage }] },
-        { code: "var foo = { get bar(){if(bar) {return true;}} };", parserOptions, errors: [{ message: noLastReturnMessage }] },
-        { code: "var foo = { get bar() { ~function () {return true;}} };", parserOptions, errors: [{ message: noReturnMessage }] },
+        { code: "var foo = { get bar() {} };", errors: [{ message: noReturnMessage }] },
+        { code: "var foo = { get bar(){if(bar) {return true;}} };", errors: [{ message: noLastReturnMessage }] },
+        { code: "var foo = { get bar() { ~function () {return true;}} };", errors: [{ message: noReturnMessage }] },
 
         // test class: get, option: {allowImplicit: false}
-        { code: "class foo { get bar(){} }", parserOptions, errors: [{ message: noReturnMessage }] },
-        { code: "class foo { get bar(){ if (baz) { return true; }}}", parserOptions, errors: [{ noLastReturnMessage }] },
-        { code: "class foo { get bar(){ ~function () { return true; }()}}", parserOptions, errors: [{ noLastReturnMessage }] },
+        { code: "class foo { get bar(){} }", errors: [{ message: noReturnMessage }] },
+        { code: "class foo { get bar(){ if (baz) { return true; }}}", errors: [{ noLastReturnMessage }] },
+        { code: "class foo { get bar(){ ~function () { return true; }()}}", errors: [{ noLastReturnMessage }] },
 
         // test object.defineProperty(s), option: {allowImplicit: false}
         { code: "Object.defineProperty(foo, \"bar\", { get: function (){}});", errors: [{ noReturnMessage }] },
@@ -89,9 +88,9 @@ ruleTester.run("getter-return", rule, {
         // test option: {allowImplicit: true}
         { code: "var foo = { get bar() {} };", options, errors: [{ message: noReturnMessage }] },
         { code: "var foo = { get bar() {if (baz) {return;}} };", options, errors: [{ message: noLastReturnMessage }] },
-        { code: "class foo { get bar(){} }", options, parserOptions, errors: [{ message: noReturnMessage }] },
-        { code: "class foo { get bar(){if (baz) {return true;} } }", options, parserOptions, errors: [{ message: noLastReturnMessage }] },
-        { code: "Object.defineProperty(foo, \"bar\", { get: function (){}});", options, parserOptions, errors: [{ message: "Expected to return a value in method 'get'." }] },
+        { code: "class foo { get bar(){} }", options, errors: [{ message: noReturnMessage }] },
+        { code: "class foo { get bar(){if (baz) {return true;} } }", options, errors: [{ message: noLastReturnMessage }] },
+        { code: "Object.defineProperty(foo, \"bar\", { get: function (){}});", options, errors: [{ message: "Expected to return a value in method 'get'." }] },
         { code: "Object.defineProperies(foo, { bar: { get: function () {}} });", options, errors: [{ noReturnMessage }] }
     ]
 });

--- a/tests/lib/rules/getter-return.js
+++ b/tests/lib/rules/getter-return.js
@@ -76,19 +76,21 @@ ruleTester.run("getter-return", rule, {
         // test class: get, option: {allowImplicit: false}
         { code: "class foo { get bar(){} }", parserOptions, errors: [{ message: noReturnMessage }] },
         { code: "class foo { get bar(){ if (baz) { return true; }}}", parserOptions, errors: [{ noLastReturnMessage }] },
-        { code: "class foo { get bar(){ ~function () { return true; }}}", parserOptions, errors: [{ noLastReturnMessage }] },
+        { code: "class foo { get bar(){ ~function () { return true; }()}}", parserOptions, errors: [{ noLastReturnMessage }] },
 
         // test object.defineProperty(s), option: {allowImplicit: false}
-        { code: "Object.defineProperty(foo, \"bar\", { get: function (){}});", errors: [{ noReturnMessage}] },
+        { code: "Object.defineProperty(foo, \"bar\", { get: function (){}});", errors: [{ noReturnMessage }] },
+        { code: "Object.defineProperty(foo, \"bar\", { get: function (){ ~function () { return true; }()}});", errors: [{ noReturnMessage }] },
         { code: "Object.defineProperty(foo, \"bar\", { get: function (){if(bar) {return true;}}});", errors: [{ message: "Expected to return a value at the end of method 'get'." }] },
-        { code: "Object.defineProperies(foo, { bar: { get: function () {}} });", options, errors: [{ noReturnMessage}] },
+        { code: "Object.defineProperies(foo, { bar: { get: function () {}} });", options, errors: [{ noReturnMessage }] },
         { code: "Object.defineProperies(foo, { bar: { get: function (){if(bar) {return true;}}}});", options, errors: [{ message: "Expected to return a value at the end of method 'get'." }] },
 
         // test option: {allowImplicit: true}
         { code: "var foo = { get bar() {} };", options, errors: [{ message: noReturnMessage }] },
-        { code: "class foo { get bar(){} }", options, parserOptions, errors: [{ message: noReturnMessage }] },
         { code: "var foo = { get bar() {if (baz) {return;}} };", options, errors: [{ message: noLastReturnMessage }] },
-        { code: "Object.defineProperty(foo, \"bar\", { get: function (){}});", options, parserOptions, errors: [{ message: "Expected to return a value in method 'get'." }] }
-
+        { code: "class foo { get bar(){} }", options, parserOptions, errors: [{ message: noReturnMessage }] },
+        { code: "class foo { get bar(){if (baz) {return true;} } }", options, parserOptions, errors: [{ message: noLastReturnMessage }] },
+        { code: "Object.defineProperty(foo, \"bar\", { get: function (){}});", options, parserOptions, errors: [{ message: "Expected to return a value in method 'get'." }] },
+        { code: "Object.defineProperies(foo, { bar: { get: function () {}} });", options, errors: [{ noReturnMessage }] }
     ]
 });

--- a/tests/lib/rules/getter-return.js
+++ b/tests/lib/rules/getter-return.js
@@ -80,10 +80,11 @@ ruleTester.run("getter-return", rule, {
 
         // test object.defineProperty(s), option: {allowImplicit: false}
         { code: "Object.defineProperty(foo, \"bar\", { get: function (){}});", errors: [{ noReturnMessage }] },
-        { code: "Object.defineProperty(foo, \"bar\", { get: function (){ ~function () { return true; }()}});", errors: [{ noReturnMessage }] },
         { code: "Object.defineProperty(foo, \"bar\", { get: function (){if(bar) {return true;}}});", errors: [{ message: "Expected to return a value at the end of method 'get'." }] },
+        { code: "Object.defineProperty(foo, \"bar\", { get: function (){ ~function () { return true; }()}});", errors: [{ noReturnMessage }] },
         { code: "Object.defineProperies(foo, { bar: { get: function () {}} });", options, errors: [{ noReturnMessage }] },
         { code: "Object.defineProperies(foo, { bar: { get: function (){if(bar) {return true;}}}});", options, errors: [{ message: "Expected to return a value at the end of method 'get'." }] },
+        { code: "Object.defineProperies(foo, { bar: { get: function () {~function () { return true; }()}} });", options, errors: [{ noReturnMessage }] },
 
         // test option: {allowImplicit: true}
         { code: "var foo = { get bar() {} };", options, errors: [{ message: noReturnMessage }] },

--- a/tests/lib/rules/getter-return.js
+++ b/tests/lib/rules/getter-return.js
@@ -19,30 +19,56 @@ const RuleTester = require("../../../lib/testers/rule-tester");
 const ruleTester = new RuleTester();
 
 // TODO: data is not working, so specify a name: "getter 'bar'"
-const noReturnMessage = "Expected to return a value in getter 'bar'.";
-const noLastReturnMessage = "Expected to return a value at the end of getter 'bar'.";
+const name = "getter 'bar'";
+const noReturnMessage = `Expected to return a value in ${name}.`;
+const noLastReturnMessage = `Expected to return a value at the end of ${name}.`;
+const parserOptions = { ecmaVersion: 6 };
 
 ruleTester.run("enforce-return-in-getter", rule, {
 
     valid: [
-        { code: "var foo = { get: function(){} };" },
+
+        // test obj: get
         { code: "var foo = { get bar(){return true;} };" },
-        { code: "var foo = { bar(){return true;} };", env: { es6: true } },
-        { code: "var foo = { bar(){} };", env: { es6: true } },
+        { code: "var foo = { bar: function(){return true;} };" },
+        { code: "var foo = { bar(){return true;} };", parserOptions },
+        { code: "var foo = { bar: function(){} };" },
+        { code: "var foo = { bar(){} };", parserOptions },
 
-        { code: "class foo { get bar(){return true;} }", env: { es6: true } },
-        { code: "class foo { get(){} }", env: { es6: true } },
-        { code: "class foo { get(){return true;} }", env: { es6: true } },
+        // test class: get
+        { code: "class foo { get bar(){return true;} }", parserOptions },
+        { code: "class foo { get bar(){if(baz){return true;} else {return false;} } }", parserOptions },
+        { code: "class foo { get(){return true;} }", parserOptions },
 
+        // add object.defineProperty
+        { code: "Object.defineProperty(foo, \"bar\", { get: function () {return true;}});" },
+
+        // not getter.
         { code: "var get = function(){};" }
     ],
 
     invalid: [
 
         // TODO: why data: { name: "getter 'bar'"} is not working?
-        { code: "var foo = { get bar() {return;} }", env: { es6: true }, errors: [{ message: noReturnMessage, data: { name: "getter 'bar'" } }] },
-        { code: "var foo = { get bar(){if(bar) {return true;}} }", env: { es6: true }, errors: [{ message: noLastReturnMessage, data: { name: "getter 'bar'" } }] },
-        { code: "var foo = { get bar(){if(bar) {return;} return true;} }", env: { es6: true }, errors: [{ message: noReturnMessage, data: { name: "getter 'bar'" } }] }
+        // test obj: get
+        { code: "var foo = { get bar() {return;} };", parserOptions, errors: [{ message: noReturnMessage, data: { name: "getter 'bar'" } }] },
+        { code: "var foo = { get bar() {return; ;} };", parserOptions, errors: [{ message: noReturnMessage, data: { name: "getter 'bar'" } }] },
+        { code: "var foo = { get bar() {return 1; return;} };", parserOptions, errors: [{ message: noReturnMessage, data: { name: "getter 'bar'" } }] },
+        { code: "var foo = { get bar() {return; return 1;} };", parserOptions, errors: [{ message: noReturnMessage, data: { name: "getter 'bar'" } }] },
+        { code: "var foo = { get bar(){if(bar) {return true;}} };", parserOptions, errors: [{ message: noLastReturnMessage, data: { name: "getter 'bar'" } }] },
+        { code: "var foo = { get bar(){if(bar) {return true;} return;} };", parserOptions, errors: [{ message: noReturnMessage, data: { name: "getter 'bar'" } }] },
+        { code: "var foo = { get bar(){if(bar) {return true;} ;} };", parserOptions, errors: [{ message: noLastReturnMessage, data: { name: "getter 'bar'" } }] },
+        { code: "var foo = { get bar(){if(bar) {return;} return true;} };", parserOptions, errors: [{ message: noReturnMessage, data: { name: "getter 'bar'" } }] },
+
+        // test class: get
+        { code: "class foo { get bar(){return;} }", parserOptions, errors: [{ message: noReturnMessage, data: { name: "getter 'bar'" } }] },
+        { code: "class foo { get bar(){if(bar) {return true;}} }", parserOptions, errors: [{ message: noLastReturnMessage, data: { name: "getter 'bar'" } }] },
+        { code: "class foo { get bar(){if(bar) {return;} return true;} }", parserOptions, errors: [{ message: noReturnMessage, data: { name: "getter 'bar'" } }] },
+
+        // add object.defineProperty
+        { code: "Object.defineProperty(foo, \"bar\", { get: function (){return;}});", errors: [{ message: "Expected to return a value in method 'get'.", data: { name: "getter 'bar'" } }] },
+        { code: "Object.defineProperty(foo, \"bar\", { get: function (){if(bar) {return true;}}});", errors: [{ message: "Expected to return a value at the end of method 'get'.", data: { name: "getter 'bar'" } }] },
+        { code: "Object.defineProperty(foo, \"bar\", { get: function (){if(bar) {return;} return true;}});", errors: [{ message: "Expected to return a value in method 'get'.", data: { name: "getter 'bar'" } }] }
 
     ]
 });

--- a/tests/lib/rules/getter-return.js
+++ b/tests/lib/rules/getter-return.js
@@ -36,6 +36,8 @@ ruleTester.run("getter-return", rule, {
         { code: "var foo = { bar: function(){return;} };" },
         { code: "var foo = { bar(){return true;} };", parserOptions },
         { code: "var foo = { bar(){return;} };", parserOptions },
+        { code: "var foo = { bar(){~function (){}();return;} };", parserOptions },
+        { code: "var foo = { bar(){~function (){return true;}();return;} };", parserOptions },
 
         // test class: get, option: {noImplicit: false}
         { code: "class foo { get bar(){return true;} }", parserOptions },
@@ -43,12 +45,18 @@ ruleTester.run("getter-return", rule, {
         { code: "class foo { get bar(){if(baz){return;} else {return false;} } }", parserOptions },
         { code: "class foo { get(){return true;} }", parserOptions },
         { code: "var foo = { get bar(){if(bar) {return;} return true;} };", parserOptions, errors: [] },
+        { code: "var foo = { get bar(){ ~function (){ return true; }(); return; } };", parserOptions, errors: [] },
+        { code: "var foo = { get bar(){ ~function (){}(); return; } };", parserOptions, errors: [] },
 
         // test object.defineProperty(s), option: {noImplicit: false}
         { code: "Object.defineProperty(foo, \"bar\", { get: function () {return true;}});" },
         { code: "Object.defineProperty(foo, \"bar\", { get: function () {return;}});" },
         { code: "Object.defineProperies(foo, { bar: { get: function () {return true;}} });" },
         { code: "Object.defineProperies(foo, { bar: { get: function () {return;}} });" },
+        { code: "Object.defineProperty(foo, \"bar\", { get: function () { ~function (){ return true; }();return true;}});" },
+        { code: "Object.defineProperty(foo, \"bar\", { get: function () { ~function (){}();return;}});" },
+        { code: "Object.defineProperies(foo, { bar: { get: function () { ~function (){ return true; }(); return true;}} });" },
+        { code: "Object.defineProperies(foo, { bar: { get: function () { ~function (){}(); return;}} });" },
 
         // test option: {noImplicit: true}
         { code: "var foo = { get bar(){return true;} };", options },
@@ -67,30 +75,31 @@ ruleTester.run("getter-return", rule, {
 
     invalid: [
 
-        // test obj: get
+        // test obj: get, option: {noImplicit: false}
         { code: "var foo = { get bar() {} };", parserOptions, errors: [{ message: noReturnMessage }] },
+        { code: "var foo = { get bar(){if(bar) {return true;}} };", parserOptions, errors: [{ message: noLastReturnMessage }] },
+        { code: "var foo = { get bar(){if(bar) {return true;} ;} };", parserOptions, errors: [{ message: noLastReturnMessage }] },
+
+        // test class: get, option: {noImplicit: false}
+        { code: "class foo { get bar(){} }", parserOptions, errors: [{ message: noReturnMessage }] },
+
+        // test object.defineProperty, option: {noImplicit: false}
+        { code: "Object.defineProperty(foo, \"bar\", { get: function (){if(bar) {return true;}}});", errors: [{ message: "Expected to return a value at the end of method 'get'." }] },
+
+        // test option: {noImplicit: true}
         { code: "var foo = { get bar() {return;} };", options, parserOptions, errors: [{ message: noReturnMessage }] },
         { code: "var foo = { get bar() {return; ;} };", options, parserOptions, errors: [{ message: noReturnMessage }] },
         { code: "var foo = { get bar() {return; return 1;} };", options, parserOptions, errors: [{ message: noReturnMessage }] },
-        { code: "var foo = { get bar(){if(bar) {return true;}} };", parserOptions, errors: [{ message: noLastReturnMessage }] },
         { code: "var foo = { get bar(){if(bar) {return true;} return;} };", options, parserOptions, errors: [{ message: noReturnMessage }] },
-        { code: "var foo = { get bar(){if(bar) {return true;} ;} };", parserOptions, errors: [{ message: noLastReturnMessage }] },
         { code: "var foo = { get bar(){if(bar) {return;} return true;} };", options, parserOptions, errors: [{ message: noReturnMessage }] },
-
-        // test class: get
-        { code: "class foo { get bar(){} }", parserOptions, errors: [{ message: noReturnMessage }] },
-        { code: "class foo { get bar(){} }", options, parserOptions, errors: [{ message: noReturnMessage }] },
         { code: "class foo { get bar(){return;} }", options, parserOptions, errors: [{ message: noReturnMessage }] },
         { code: "class foo { get bar(){if(bar) {return true;}} }", options, parserOptions, errors: [{ message: noLastReturnMessage }] },
         { code: "class foo { get bar(){if(bar) {return;} return true;} }", options, parserOptions, errors: [{ message: noReturnMessage }] },
-
-        // test object.defineProperty
         { code: "Object.defineProperty(foo, \"bar\", { get: function (){return;}});", options, errors: [{ message: "Expected to return a value in method 'get'." }] },
-        { code: "Object.defineProperty(foo, \"bar\", { get: function (){if(bar) {return true;}}});", errors: [{ message: "Expected to return a value at the end of method 'get'." }] },
-        { code: "Object.defineProperty(foo, \"bar\", { get: function (){if(bar) {return;} return true;}});", options: [{ noImplicit: true }], errors: [{ message: "Expected to return a value in method 'get'." }] },
+        { code: "Object.defineProperty(foo, \"bar\", { get: function (){if(bar) {return;} return true;}});", options, errors: [{ message: "Expected to return a value in method 'get'." }] },
+        { code: "Object.defineProperies(foo, { bar: { get: function () {return;}} });", options, errors: [{ message: "Expected to return a value in method 'get'." }] },
 
-        // test option: {noImplicit: true}
-        { code: "Object.defineProperty(foo, \"bar\", { get: function (){return;}});", options, errors: [{ message: "Expected to return a value in method 'get'." }] }
+        { code: "class foo { get bar(){} }", options, parserOptions, errors: [{ message: noReturnMessage }] }
 
     ]
 });


### PR DESCRIPTION
fixes #8449 

**What is the purpose of this pull request? (put an "X" next to item)**
[ x] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
New rule: enforces that a return statement is present in property getters.

**Example code:**

```js
/*eslint getter-return: "error"*/

// Incorrect
class MyClass {
  get a() {
     this.retreiveVal('a');
  }
}

function MyConstructorFunction() {
  Object.defineProperty(this, 'a', {
    get: function () {
      this.retreiveVal('a');
    }
  });
}


// Correct
class MyClass {
  get a() {
     return this.retreiveVal('a');
  }
}

function MyConstructorFunction() {
  Object.defineProperty(this, 'a', {
    get: function () {
       return this.retreiveVal('a');
    }
  });
}
```

**Is there anything you'd like reviewers to focus on?**

+ I have confirmed the test coverage is 100%:
> 100% Statements 19/19 100% Branches 16/16 100% Functions 7/7 100% Lines 19/19
 
so the question is whether these test cases are fit for?

+ for code like this:
```js
  var foo = { get: function () {bar();} };
```
it is not a `getter` function, but naming a method `get` that does not return a value, is so confusing, causing an error may be somewhat reasonable.

+  My English is not so good(as you can see ^-^). More attention can be attached to the docs and comments. 