### PR TITLE
Breaking: New Linter API

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -757,13 +757,14 @@ target.browserify = function() {
     generateRulesIndex(TEMP_DIR);
 
     // 5. browserify the temp directory
-    nodeCLI.exec("browserify", "-x espree", `${TEMP_DIR}eslint.js`, "-o", `${BUILD_DIR}eslint.js`, "-s eslint", "--global-transform [ babelify --presets [ es2015 ] ]");
+    nodeCLI.exec("browserify", "-x espree", `${TEMP_DIR}linter.js`, "-o", `${BUILD_DIR}eslint.js`, "-s eslint", "--global-transform [ babelify --presets [ es2015 ] ]");
+    nodeCLI.exec("browserify", "-x espree", `${TEMP_DIR}rules.js`, "-o", `${TEMP_DIR}rules.js`, "-s rules", "--global-transform [ babelify --presets [ es2015 ] ]");
 
     // 6. Browserify espree
     nodeCLI.exec("browserify", "-r espree", "-o", `${TEMP_DIR}espree.js`);
 
     // 7. Concatenate Babel polyfill, Espree, and ESLint files together
-    cat("./node_modules/babel-polyfill/dist/polyfill.js", `${TEMP_DIR}espree.js`, `${BUILD_DIR}eslint.js`).to(`${BUILD_DIR}eslint.js`);
+    cat("./node_modules/babel-polyfill/dist/polyfill.js", `${TEMP_DIR}espree.js`, `${BUILD_DIR}eslint.js`, `${TEMP_DIR}rules.js`).to(`${BUILD_DIR}eslint.js`);
 
     // 8. remove temp directory
     rm("-r", TEMP_DIR);

--- a/conf/eslint-all.js
+++ b/conf/eslint-all.js
@@ -10,7 +10,8 @@
 //------------------------------------------------------------------------------
 
 const load = require("../lib/load-rules"),
-    rules = require("../lib/rules");
+    Rules = require("../lib/rules");
+const rules = new Rules();
 
 //------------------------------------------------------------------------------
 // Helpers

--- a/docs/developer-guide/nodejs-api.md
+++ b/docs/developer-guide/nodejs-api.md
@@ -49,15 +49,16 @@ var codeLines = SourceCode.splitLines(code);
  */
 ```
 
-## linter
+## Linter
 
-The `linter` object does the actual evaluation of the JavaScript code. It doesn't do any filesystem operations, it simply parses and reports on the code. In particular, the `linter` object does not process configuration objects or files. You can retrieve `linter` like this:
+The `Linter` object does the actual evaluation of the JavaScript code. It doesn't do any filesystem operations, it simply parses and reports on the code. In particular, the `Linter` object does not process configuration objects or files. You can retrieve instances of `Linter` like this:
 
 ```js
-var linter = require("eslint").linter;
+var Linter = require("eslint").Linter;
+var linter = new Linter();
 ```
 
-The most important method on `linter` is `verify()`, which initiates linting of the given text. This method accepts four arguments:
+The most important method on `Linter` is `verify()`, which initiates linting of the given text. This method accepts four arguments:
 
 * `code` - the source code to lint (a string or instance of `SourceCode`).
 * `config` - a configuration object that has been processed and normalized by CLIEngine using eslintrc files and/or other configuration arguments.
@@ -71,7 +72,8 @@ The most important method on `linter` is `verify()`, which initiates linting of 
 You can call `verify()` like this:
 
 ```js
-var linter = require("eslint").linter;
+var Linter = require("eslint").Linter;
+var linter = new Linter();
 
 var messages = linter.verify("var foo;", {
     rules: {
@@ -129,7 +131,8 @@ The information available for each linting message is:
 You can also get an instance of the `SourceCode` object used inside of `linter` by using the `getSourceCode()` method:
 
 ```js
-var linter = require("eslint").linter;
+var Linter = require("eslint").Linter;
+var linter = new Linter();
 
 var messages = linter.verify("var foo = bar;", {
     rules: {
@@ -143,6 +146,22 @@ console.log(code.text);     // "var foo = bar;"
 ```
 
 In this way, you can retrieve the text and AST used for the last run of `linter.verify()`.
+
+## linter
+
+The `eslint.linter` object (deprecated) is an instance of the `Linter` class as defined [above](#Linter). `eslint.linter` exists for backwards compatibility, but we do not recommend using it because any mutations to it are shared among every module that uses `eslint`. Instead, please create your own instance of `eslint.Linter`.
+
+```js
+var linter = require("eslint").linter;
+
+var messages = linter.verify("var foo;", {
+    rules: {
+        semi: 2
+    }
+}, { filename: "foo.js" });
+```
+
+Note: This API is deprecated as of 4.0.0.
 
 ## CLIEngine
 
@@ -566,3 +585,4 @@ CLIEngine.outputFixes(report);
 ## Deprecated APIs
 
 * `cli` - the `cli` object has been deprecated in favor of `CLIEngine`. As of v1.0.0, `cli` is no longer exported and should not be used by external tools.
+* `linter` - the `linter` object has has been deprecated in favor of `Linter`, as of v4.0.0

--- a/lib/api.js
+++ b/lib/api.js
@@ -5,8 +5,11 @@
 
 "use strict";
 
+const Linter = require("./linter");
+
 module.exports = {
-    linter: require("./eslint"),
+    linter: new Linter(),
+    Linter,
     CLIEngine: require("./cli-engine"),
     RuleTester: require("./testers/rule-tester"),
     SourceCode: require("./util/source-code")

--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -17,12 +17,10 @@
 
 const fs = require("fs"),
     path = require("path"),
-    rules = require("./rules"),
-    eslint = require("./eslint"),
     defaultOptions = require("../conf/default-cli-options"),
+    Linter = require("./linter"),
     IgnoredPaths = require("./ignored-paths"),
     Config = require("./config"),
-    Plugins = require("./config/plugins"),
     fileEntryCache = require("file-entry-cache"),
     globUtil = require("./util/glob-util"),
     SourceCodeFixer = require("./util/source-code-fixer"),
@@ -143,11 +141,12 @@ function calculateStatsPerRun(results) {
  * @param {string} options.filename The filename from which the text was read.
  * @param {boolean} options.allowInlineConfig Flag indicating if inline comments
  *      should be allowed.
+ * @param {Linter} linter Linter context
  * @returns {Object} The result of the fix operation as returned from the
  *      SourceCodeFixer.
  * @private
  */
-function multipassFix(text, config, options) {
+function multipassFix(text, config, options, linter) {
     const MAX_PASSES = 10;
     let messages = [],
         fixedResult,
@@ -167,10 +166,10 @@ function multipassFix(text, config, options) {
         passNumber++;
 
         debug(`Linting code for ${options.filename} (pass ${passNumber})`);
-        messages = eslint.verify(text, config, options);
+        messages = linter.verify(text, config, options);
 
         debug(`Generating fixed text for ${options.filename} (pass ${passNumber})`);
-        fixedResult = SourceCodeFixer.applyFixes(eslint.getSourceCode(), messages);
+        fixedResult = SourceCodeFixer.applyFixes(linter.getSourceCode(), messages);
 
         // stop if there are any syntax errors.
         // 'fixedResult.output' is a empty string.
@@ -195,7 +194,7 @@ function multipassFix(text, config, options) {
      * the most up-to-date information.
      */
     if (fixedResult.fixed) {
-        fixedResult.messages = eslint.verify(text, config, options);
+        fixedResult.messages = linter.verify(text, config, options);
     }
 
 
@@ -214,13 +213,14 @@ function multipassFix(text, config, options) {
  * @param {string} filename An optional string representing the texts filename.
  * @param {boolean} fix Indicates if fixes should be processed.
  * @param {boolean} allowInlineConfig Allow/ignore comments that change config.
+ * @param {Linter} linter Linter context
  * @returns {LintResult} The results for linting on this text.
  * @private
  */
-function processText(text, configHelper, filename, fix, allowInlineConfig) {
+function processText(text, configHelper, filename, fix, allowInlineConfig, linter) {
 
     // clear all existing settings for a new file
-    eslint.reset();
+    linter.reset();
 
     let filePath,
         messages,
@@ -238,10 +238,10 @@ function processText(text, configHelper, filename, fix, allowInlineConfig) {
     const config = configHelper.getConfig(filePath);
 
     if (config.plugins) {
-        Plugins.loadAll(config.plugins);
+        configHelper.plugins.loadAll(config.plugins);
     }
 
-    const loadedPlugins = Plugins.getAll();
+    const loadedPlugins = configHelper.plugins.getAll();
 
     for (const plugin in loadedPlugins) {
         if (loadedPlugins[plugin].processors && Object.keys(loadedPlugins[plugin].processors).indexOf(fileExtension) >= 0) {
@@ -256,7 +256,7 @@ function processText(text, configHelper, filename, fix, allowInlineConfig) {
         const unprocessedMessages = [];
 
         parsedBlocks.forEach(block => {
-            unprocessedMessages.push(eslint.verify(block, config, {
+            unprocessedMessages.push(linter.verify(block, config, {
                 filename,
                 allowInlineConfig
             }));
@@ -272,10 +272,10 @@ function processText(text, configHelper, filename, fix, allowInlineConfig) {
             fixedResult = multipassFix(text, config, {
                 filename,
                 allowInlineConfig
-            });
+            }, linter);
             messages = fixedResult.messages;
         } else {
-            messages = eslint.verify(text, config, {
+            messages = linter.verify(text, config, {
                 filename,
                 allowInlineConfig
             });
@@ -310,13 +310,14 @@ function processText(text, configHelper, filename, fix, allowInlineConfig) {
  * @param {string} filename The filename of the file being checked.
  * @param {Object} configHelper The configuration options for ESLint.
  * @param {Object} options The CLIEngine options object.
+ * @param {Linter} linter Linter context
  * @returns {LintResult} The results for linting on this file.
  * @private
  */
-function processFile(filename, configHelper, options) {
+function processFile(filename, configHelper, options, linter) {
 
     const text = fs.readFileSync(path.resolve(filename), "utf8"),
-        result = processText(text, configHelper, filename, options.fix, options.allowInlineConfig);
+        result = processText(text, configHelper, filename, options.fix, options.allowInlineConfig, linter);
 
     return result;
 
@@ -471,6 +472,7 @@ class CLIEngine {
          * @type {Object}
          */
         this.options = options;
+        this.linter = new Linter();
 
         const cacheFile = getCacheFile(this.options.cacheLocation || this.options.cacheFile, this.options.cwd);
 
@@ -488,13 +490,15 @@ class CLIEngine {
 
             this.options.rulePaths.forEach(rulesdir => {
                 debug(`Loading rules from ${rulesdir}`);
-                rules.load(rulesdir, cwd);
+                this.linter.rules.load(rulesdir, cwd);
             });
         }
 
         Object.keys(this.options.rules || {}).forEach(name => {
-            validator.validateRuleOptions(name, this.options.rules[name], "CLI");
+            validator.validateRuleOptions(name, this.options.rules[name], "CLI", this.linter.rules);
         });
+
+        this.config = new Config(this.options, this.linter);
     }
 
     /**
@@ -542,8 +546,8 @@ class CLIEngine {
      * @param {Object} pluginobject Plugin configuration object.
      * @returns {void}
      */
-    addPlugin(name, pluginobject) { // eslint-disable-line class-methods-use-this
-        Plugins.define(name, pluginobject);
+    addPlugin(name, pluginobject) {
+        this.config.plugins.define(name, pluginobject);
     }
 
     /**
@@ -565,7 +569,7 @@ class CLIEngine {
         const results = [],
             options = this.options,
             fileCache = this._fileCache,
-            configHelper = new Config(options);
+            configHelper = this.config;
         let prevConfig; // the previous configuration used
 
         /**
@@ -602,9 +606,10 @@ class CLIEngine {
          * unsupported file extensions and any files that are already linted.
          * @param {string} filename The resolved filename of the file to be linted
          * @param {boolean} warnIgnored always warn when a file is ignored
+         * @param {Linter} linter Linter context
          * @returns {void}
          */
-        function executeOnFile(filename, warnIgnored) {
+        function executeOnFile(filename, warnIgnored, linter) {
             let hashOfConfig,
                 descriptor;
 
@@ -647,7 +652,7 @@ class CLIEngine {
 
             debug(`Processing ${filename}`);
 
-            const res = processFile(filename, configHelper, options);
+            const res = processFile(filename, configHelper, options, linter);
 
             if (options.cache) {
 
@@ -685,7 +690,7 @@ class CLIEngine {
         const fileList = globUtil.listFilesToProcess(patterns, options);
 
         fileList.forEach(fileInfo => {
-            executeOnFile(fileInfo.filename, fileInfo.ignored);
+            executeOnFile(fileInfo.filename, fileInfo.ignored, this.linter);
         });
 
         const stats = calculateStatsPerRun(results);
@@ -718,7 +723,7 @@ class CLIEngine {
 
         const results = [],
             options = this.options,
-            configHelper = new Config(options),
+            configHelper = this.config,
             ignoredPaths = new IgnoredPaths(options);
 
         // resolve filename based on options.cwd (for reporting, ignoredPaths also resolves)
@@ -731,7 +736,7 @@ class CLIEngine {
                 results.push(createIgnoreResult(filename, options.cwd));
             }
         } else {
-            results.push(processText(text, configHelper, filename, options.fix, options.allowInlineConfig));
+            results.push(processText(text, configHelper, filename, options.fix, options.allowInlineConfig, this.linter));
         }
 
         const stats = calculateStatsPerRun(results);
@@ -753,7 +758,7 @@ class CLIEngine {
      * @returns {Object} A configuration object for the file.
      */
     getConfigForFile(filePath) {
-        const configHelper = new Config(this.options);
+        const configHelper = this.config;
 
         return configHelper.getConfig(filePath);
     }

--- a/lib/config.js
+++ b/lib/config.js
@@ -43,10 +43,11 @@ function isObject(item) {
 /**
  * Load and parse a JSON config object from a file.
  * @param {string|Object} configToLoad the path to the JSON config file or the config object itself.
+ * @param {Config} configContext config instance object
  * @returns {Object} the parsed config object (empty object if there was a parse error)
  * @private
  */
-function loadConfig(configToLoad) {
+function loadConfig(configToLoad, configContext) {
     let config = {},
         filePath = "";
 
@@ -56,11 +57,11 @@ function loadConfig(configToLoad) {
             config = configToLoad;
 
             if (config.extends) {
-                config = ConfigFile.applyExtends(config, filePath);
+                config = ConfigFile.applyExtends(config, configContext, filePath);
             }
         } else {
             filePath = configToLoad;
-            config = ConfigFile.load(filePath);
+            config = ConfigFile.load(filePath, configContext);
         }
 
     }
@@ -70,10 +71,11 @@ function loadConfig(configToLoad) {
 
 /**
  * Get personal config object from ~/.eslintrc.
+ * @param {Config} configContext Plugin context for the config instance
  * @returns {Object} the personal config object (null if there is no personal config)
  * @private
  */
-function getPersonalConfig() {
+function getPersonalConfig(configContext) {
     let config;
 
     if (PERSONAL_CONFIG_DIR) {
@@ -81,7 +83,7 @@ function getPersonalConfig() {
 
         if (filename) {
             debug("Using personal config");
-            config = loadConfig(filename);
+            config = loadConfig(filename, configContext);
         }
     }
 
@@ -99,7 +101,7 @@ function hasRules(options) {
 
 /**
  * Get a local config object.
- * @param {Object} thisConfig A Config object.
+ * @param {Config} thisConfig A Config object.
  * @param {string} directory The directory to start looking in for a local config file.
  * @returns {Object} The local config object, or an empty object if there is no local config.
  */
@@ -127,7 +129,7 @@ function getLocalConfig(thisConfig, directory) {
         }
 
         debug(`Loading ${localConfigFile}`);
-        const localConfig = loadConfig(localConfigFile);
+        const localConfig = loadConfig(localConfigFile, thisConfig);
 
         // Don't consider a local config file found if the config is null
         if (!localConfig) {
@@ -152,7 +154,7 @@ function getLocalConfig(thisConfig, directory) {
          * - Otherwise, if no rules were manually passed in, throw and error.
          * - Note: This function is not called if useEslintrc is false.
          */
-        const personalConfig = getPersonalConfig();
+        const personalConfig = getPersonalConfig(thisConfig);
 
         if (personalConfig) {
             config = ConfigOps.merge(config, personalConfig);
@@ -186,9 +188,13 @@ class Config {
     /**
      * Config options
      * @param {Object} options Options to be passed in
+     * @param {Linter} linterContext Linter instance object
      */
-    constructor(options) {
+    constructor(options, linterContext) {
         options = options || {};
+
+        this.linterContext = linterContext;
+        this.plugins = new Plugins(linterContext.environments, linterContext.rules);
 
         this.ignore = options.ignore;
         this.ignorePath = options.ignorePath;
@@ -196,7 +202,7 @@ class Config {
         this.parser = options.parser;
         this.parserOptions = options.parserOptions || {};
 
-        this.baseConfig = options.baseConfig ? loadConfig(options.baseConfig) : { rules: {} };
+        this.baseConfig = options.baseConfig ? loadConfig(options.baseConfig, this) : { rules: {} };
 
         this.useEslintrc = (options.useEslintrc !== false);
 
@@ -219,16 +225,23 @@ class Config {
             return globals;
         }, {});
 
-        const useConfig = options.configFile;
-
         this.options = options;
 
-        if (useConfig) {
-            debug(`Using command line config ${useConfig}`);
-            if (isResolvable(useConfig) || isResolvable(`eslint-config-${useConfig}`) || useConfig.charAt(0) === "@") {
-                this.useSpecificConfig = loadConfig(useConfig);
+        this.loadConfigFile(options.configFile);
+    }
+
+    /**
+     * Loads the config from the configuration file
+     * @param {string} configFile - patch to the config file
+     * @returns {undefined}
+     */
+    loadConfigFile(configFile) {
+        if (configFile) {
+            debug(`Using command line config ${configFile}`);
+            if (isResolvable(configFile) || isResolvable(`eslint-config-${configFile}`) || configFile.charAt(0) === "@") {
+                this.useSpecificConfig = loadConfig(configFile, this);
             } else {
-                this.useSpecificConfig = loadConfig(path.resolve(this.options.cwd, useConfig));
+                this.useSpecificConfig = loadConfig(path.resolve(this.options.cwd, configFile), this);
             }
         }
     }
@@ -306,13 +319,13 @@ class Config {
         // Step 8: Merge in command line plugins
         if (this.options.plugins) {
             debug("Merging command line plugins");
-            Plugins.loadAll(this.options.plugins);
+            this.plugins.loadAll(this.options.plugins);
             config = ConfigOps.merge(config, { plugins: this.options.plugins });
         }
 
         // Step 9: Apply environments to the config if present
         if (config.env) {
-            config = ConfigOps.applyEnvironments(config);
+            config = ConfigOps.applyEnvironments(config, this.linterContext.environments);
         }
 
         this.cache[directory] = config;

--- a/lib/config/autoconfig.js
+++ b/lib/config/autoconfig.js
@@ -10,12 +10,13 @@
 //------------------------------------------------------------------------------
 
 const lodash = require("lodash"),
-    eslint = require("../eslint"),
+    Linter = require("../linter"),
     configRule = require("./config-rule"),
     ConfigOps = require("./config-ops"),
     recConfig = require("../../conf/eslint-recommended");
 
 const debug = require("debug")("eslint:autoconfig");
+const linter = new Linter();
 
 //------------------------------------------------------------------------------
 // Data
@@ -290,7 +291,7 @@ class Registry {
 
             ruleSets.forEach(ruleSet => {
                 const lintConfig = Object.assign({}, config, { rules: ruleSet });
-                const lintResults = eslint.verify(sourceCodes[filename], lintConfig);
+                const lintResults = linter.verify(sourceCodes[filename], lintConfig);
 
                 lintResults.forEach(result => {
 

--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -15,7 +15,6 @@ const fs = require("fs"),
     path = require("path"),
     ConfigOps = require("./config-ops"),
     validator = require("./config-validator"),
-    Plugins = require("./plugins"),
     pathUtil = require("../util/path-util"),
     ModuleResolver = require("../util/module-resolver"),
     pathIsInside = require("path-is-inside"),
@@ -386,6 +385,7 @@ function getEslintCoreConfigPath(name) {
 /**
  * Applies values from the "extends" field in a configuration file.
  * @param {Object} config The configuration information.
+ * @param {Config} configContext Plugin context for the config instance
  * @param {string} filePath The file path from which the configuration information
  *      was loaded.
  * @param {string} [relativeTo] The path to resolve relative to.
@@ -393,7 +393,7 @@ function getEslintCoreConfigPath(name) {
  *      loaded and merged.
  * @private
  */
-function applyExtends(config, filePath, relativeTo) {
+function applyExtends(config, configContext, filePath, relativeTo) {
     let configExtends = config.extends;
 
     // normalize into an array for easier handling
@@ -418,7 +418,7 @@ function applyExtends(config, filePath, relativeTo) {
                 );
             }
             debug(`Loading ${parentPath}`);
-            return ConfigOps.merge(load(parentPath, false, relativeTo), previousValue);
+            return ConfigOps.merge(load(parentPath, configContext, false, relativeTo), previousValue);
         } catch (e) {
 
             /*
@@ -520,12 +520,12 @@ function resolve(filePath, relativeTo) {
  * Loads a configuration file from the given file path.
  * @param {string} filePath The filename or package name to load the configuration
  *      information from.
+ * @param {Config} configContext Plugins context
  * @param {boolean} [applyEnvironments=false] Set to true to merge in environment settings.
  * @param {string} [relativeTo] The path to resolve relative to.
  * @returns {Object} The configuration information.
- * @private
  */
-function load(filePath, applyEnvironments, relativeTo) {
+function load(filePath, configContext, applyEnvironments, relativeTo) {
     const resolvedPath = resolve(filePath, relativeTo),
         dirname = path.dirname(resolvedPath.filePath),
         lookupPath = getLookupPath(dirname);
@@ -535,7 +535,7 @@ function load(filePath, applyEnvironments, relativeTo) {
 
         // ensure plugins are properly loaded first
         if (config.plugins) {
-            Plugins.loadAll(config.plugins);
+            configContext.plugins.loadAll(config.plugins);
         }
 
         // include full path of parser if present
@@ -548,20 +548,20 @@ function load(filePath, applyEnvironments, relativeTo) {
         }
 
         // validate the configuration before continuing
-        validator.validate(config, filePath);
+        validator.validate(config, filePath, configContext.linterContext.rules, configContext.linterContext.environments);
 
         /*
          * If an `extends` property is defined, it represents a configuration file to use as
          * a "parent". Load the referenced file and merge the configuration recursively.
          */
         if (config.extends) {
-            config = applyExtends(config, filePath, dirname);
+            config = applyExtends(config, configContext, filePath, dirname);
         }
 
         if (config.env && applyEnvironments) {
 
             // Merge in environment-specific globals and parserOptions.
-            config = ConfigOps.applyEnvironments(config);
+            config = ConfigOps.applyEnvironments(config, configContext.linterContext.environments);
         }
 
     }

--- a/lib/config/config-ops.js
+++ b/lib/config/config-ops.js
@@ -9,8 +9,6 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const Environments = require("./environments");
-
 const debug = require("debug")("eslint:config-ops");
 
 //------------------------------------------------------------------------------
@@ -46,10 +44,11 @@ module.exports = {
     /**
      * Creates an environment config based on the specified environments.
      * @param {Object<string,boolean>} env The environment settings.
+     * @param {Environments} envContext The environment context.
      * @returns {Object} A configuration object with the appropriate rules and globals
      *      set.
      */
-    createEnvironmentConfig(env) {
+    createEnvironmentConfig(env, envContext) {
 
         const envConfig = this.createEmptyConfig();
 
@@ -58,7 +57,7 @@ module.exports = {
             envConfig.env = env;
 
             Object.keys(env).filter(name => env[name]).forEach(name => {
-                const environment = Environments.get(name);
+                const environment = envContext.get(name);
 
                 if (environment) {
                     debug(`Creating config for environment ${name}`);
@@ -80,12 +79,13 @@ module.exports = {
      * Given a config with environment settings, applies the globals and
      * ecmaFeatures to the configuration and returns the result.
      * @param {Object} config The configuration information.
+     * @param {Environments} envContent env context.
      * @returns {Object} The updated configuration information.
      */
-    applyEnvironments(config) {
+    applyEnvironments(config, envContent) {
         if (config.env && typeof config.env === "object") {
             debug("Apply environment settings to config");
-            return this.merge(this.createEnvironmentConfig(config.env), config);
+            return this.merge(this.createEnvironmentConfig(config.env, envContent), config);
         }
 
         return config;

--- a/lib/config/config-rule.js
+++ b/lib/config/config-rule.js
@@ -9,9 +9,10 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const rules = require("../rules"),
+const Rules = require("../rules"),
     loadRules = require("../load-rules");
 
+const rules = new Rules();
 
 //------------------------------------------------------------------------------
 // Helpers

--- a/lib/config/config-validator.js
+++ b/lib/config/config-validator.js
@@ -9,9 +9,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const rules = require("../rules"),
-    Environments = require("./environments"),
-    schemaValidator = require("is-my-json-valid"),
+const schemaValidator = require("is-my-json-valid"),
     configSchema = require("../../conf/config-schema.json"),
     util = require("util");
 
@@ -26,10 +24,11 @@ const validators = {
 /**
  * Gets a complete options schema for a rule.
  * @param {string} id The rule's unique name.
+ * @param {Rules} rulesContext Rule context
  * @returns {Object} JSON Schema for the rule's options.
  */
-function getRuleOptionsSchema(id) {
-    const rule = rules.get(id),
+function getRuleOptionsSchema(id, rulesContext) {
+    const rule = rulesContext.get(id),
         schema = rule && rule.schema || rule && rule.meta && rule.meta.schema;
 
     // Given a tuple of schemas, insert warning level at the beginning
@@ -73,10 +72,11 @@ function validateRuleSeverity(options) {
 * Validates the non-severity options passed to a rule, based on its schema.
 * @param {string} id The rule's unique name
 * @param {array} localOptions The options for the rule, excluding severity
+* @param {Rules} rulesContext Rule context
 * @returns {void}
 */
-function validateRuleSchema(id, localOptions) {
-    const schema = getRuleOptionsSchema(id);
+function validateRuleSchema(id, localOptions, rulesContext) {
+    const schema = getRuleOptionsSchema(id, rulesContext);
 
     if (!validators.rules[id] && schema) {
         validators.rules[id] = schemaValidator(schema, { verbose: true });
@@ -97,14 +97,15 @@ function validateRuleSchema(id, localOptions) {
  * @param {string} id The rule's unique name.
  * @param {array|number} options The given options for the rule.
  * @param {string} source The name of the configuration source to report in any errors.
+ * @param {Rules} rulesContext Rule context
  * @returns {void}
  */
-function validateRuleOptions(id, options, source) {
+function validateRuleOptions(id, options, source, rulesContext) {
     try {
         const severity = validateRuleSeverity(options);
 
         if (severity !== 0 && !(typeof severity === "string" && severity.toLowerCase() === "off")) {
-            validateRuleSchema(id, Array.isArray(options) ? options.slice(1) : []);
+            validateRuleSchema(id, Array.isArray(options) ? options.slice(1) : [], rulesContext);
         }
     } catch (err) {
         throw new Error(`${source}:\n\tConfiguration for rule "${id}" is invalid:\n${err.message}`);
@@ -115,9 +116,10 @@ function validateRuleOptions(id, options, source) {
  * Validates an environment object
  * @param {Object} environment The environment config object to validate.
  * @param {string} source The name of the configuration source to report in any errors.
+ * @param {Environments} envContext Env context
  * @returns {void}
  */
-function validateEnvironment(environment, source) {
+function validateEnvironment(environment, source, envContext) {
 
     // not having an environment is ok
     if (!environment) {
@@ -125,7 +127,7 @@ function validateEnvironment(environment, source) {
     }
 
     Object.keys(environment).forEach(env => {
-        if (!Environments.get(env)) {
+        if (!envContext.get(env)) {
             const message = `${source}:\n\tEnvironment key "${env}" is unknown\n`;
 
             throw new Error(message);
@@ -137,15 +139,16 @@ function validateEnvironment(environment, source) {
  * Validates a rules config object
  * @param {Object} rulesConfig The rules config object to validate.
  * @param {string} source The name of the configuration source to report in any errors.
+ * @param {Rules} rulesContext Rule context
  * @returns {void}
  */
-function validateRules(rulesConfig, source) {
+function validateRules(rulesConfig, source, rulesContext) {
     if (!rulesConfig) {
         return;
     }
 
     Object.keys(rulesConfig).forEach(id => {
-        validateRuleOptions(id, rulesConfig[id], source);
+        validateRuleOptions(id, rulesConfig[id], source, rulesContext);
     });
 }
 
@@ -189,12 +192,14 @@ function validateConfigSchema(config, source) {
  * Validates an entire config object.
  * @param {Object} config The config object to validate.
  * @param {string} source The name of the configuration source to report in any errors.
+ * @param {Rules} rulesContext The rules context
+ * @param {Environments} envContext The env context
  * @returns {void}
  */
-function validate(config, source) {
+function validate(config, source, rulesContext, envContext) {
     validateConfigSchema(config, source);
-    validateRules(config.rules, source);
-    validateEnvironment(config.env, source);
+    validateRules(config.rules, source, rulesContext);
+    validateEnvironment(config.env, source, envContext);
 }
 
 //------------------------------------------------------------------------------

--- a/lib/config/environments.js
+++ b/lib/config/environments.js
@@ -11,32 +11,30 @@
 const envs = require("../../conf/environments");
 
 //------------------------------------------------------------------------------
-// Private
-//------------------------------------------------------------------------------
-
-let environments = new Map();
-
-/**
- * Loads the default environments.
- * @returns {void}
- * @private
- */
-function load() {
-    Object.keys(envs).forEach(envName => {
-        environments.set(envName, envs[envName]);
-    });
-}
-
-// always load default environments upfront
-load();
-
-//------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
 
-module.exports = {
+class Environments {
 
-    load,
+    /**
+     * create env context
+     */
+    constructor() {
+        this._environments = new Map();
+
+        this.load();
+    }
+
+    /**
+     * Loads the default environments.
+     * @returns {void}
+     * @private
+     */
+    load() {
+        Object.keys(envs).forEach(envName => {
+            this._environments.set(envName, envs[envName]);
+        });
+    }
 
     /**
      * Gets the environment with the given name.
@@ -44,8 +42,19 @@ module.exports = {
      * @returns {Object?} The environment object or null if not found.
      */
     get(name) {
-        return environments.get(name) || null;
-    },
+        return this._environments.get(name) || null;
+    }
+
+    /**
+     * Gets all the environment present
+     * @returns {Object} The environment object for each env name
+     */
+    getAll() {
+        return Array.from(this._environments).reduce((coll, env) => {
+            coll[env[0]] = env[1];
+            return coll;
+        }, {});
+    }
 
     /**
      * Defines an environment.
@@ -54,8 +63,8 @@ module.exports = {
      * @returns {void}
      */
     define(name, env) {
-        environments.set(name, env);
-    },
+        this._environments.set(name, env);
+    }
 
     /**
      * Imports all environments from a plugin.
@@ -69,14 +78,7 @@ module.exports = {
                 this.define(`${pluginName}/${envName}`, plugin.environments[envName]);
             });
         }
-    },
-
-    /**
-     * Resets all environments. Only use for tests!
-     * @returns {void}
-     */
-    testReset() {
-        environments = new Map();
-        load();
     }
-};
+}
+
+module.exports = Environments;

--- a/lib/config/plugins.js
+++ b/lib/config/plugins.js
@@ -8,56 +8,61 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const Environments = require("./environments"),
-    Rules = require("../rules");
-
 const debug = require("debug")("eslint:plugins");
 
 //------------------------------------------------------------------------------
 // Private
 //------------------------------------------------------------------------------
 
-let plugins = Object.create(null);
-
 const PLUGIN_NAME_PREFIX = "eslint-plugin-",
     NAMESPACE_REGEX = /^@.*\//i;
-
-/**
- * Removes the prefix `eslint-plugin-` from a plugin name.
- * @param {string} pluginName The name of the plugin which may have the prefix.
- * @returns {string} The name of the plugin without prefix.
- */
-function removePrefix(pluginName) {
-    return pluginName.indexOf(PLUGIN_NAME_PREFIX) === 0 ? pluginName.substring(PLUGIN_NAME_PREFIX.length) : pluginName;
-}
-
-/**
- * Gets the scope (namespace) of a plugin.
- * @param {string} pluginName The name of the plugin which may have the prefix.
- * @returns {string} The name of the plugins namepace if it has one.
- */
-function getNamespace(pluginName) {
-    return pluginName.match(NAMESPACE_REGEX) ? pluginName.match(NAMESPACE_REGEX)[0] : "";
-}
-
-/**
- * Removes the namespace from a plugin name.
- * @param {string} pluginName The name of the plugin which may have the prefix.
- * @returns {string} The name of the plugin without the namespace.
- */
-function removeNamespace(pluginName) {
-    return pluginName.replace(NAMESPACE_REGEX, "");
-}
 
 //------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
 
-module.exports = {
+/**
+ * Plugin class
+ */
+class Plugins {
 
-    removePrefix,
-    getNamespace,
-    removeNamespace,
+    /**
+     * Creates the plugins context
+     * @param {Environments} envContext - env context
+     * @param {Rules} rulesContext - rules context
+     */
+    constructor(envContext, rulesContext) {
+        this._plugins = Object.create(null);
+        this._environments = envContext;
+        this._rules = rulesContext;
+    }
+
+    /**
+     * Removes the prefix `eslint-plugin-` from a plugin name.
+     * @param {string} pluginName The name of the plugin which may have the prefix.
+     * @returns {string} The name of the plugin without prefix.
+     */
+    static removePrefix(pluginName) {
+        return pluginName.startsWith(PLUGIN_NAME_PREFIX) ? pluginName.substring(PLUGIN_NAME_PREFIX.length) : pluginName;
+    }
+
+    /**
+     * Gets the scope (namespace) of a plugin.
+     * @param {string} pluginName The name of the plugin which may have the prefix.
+     * @returns {string} The name of the plugins namepace if it has one.
+     */
+    static getNamespace(pluginName) {
+        return pluginName.match(NAMESPACE_REGEX) ? pluginName.match(NAMESPACE_REGEX)[0] : "";
+    }
+
+    /**
+     * Removes the namespace from a plugin name.
+     * @param {string} pluginName The name of the plugin which may have the prefix.
+     * @returns {string} The name of the plugin without the namespace.
+     */
+    static removeNamespace(pluginName) {
+        return pluginName.replace(NAMESPACE_REGEX, "");
+    }
 
     /**
      * Defines a plugin with a given name rather than loading from disk.
@@ -66,16 +71,16 @@ module.exports = {
      * @returns {void}
      */
     define(pluginName, plugin) {
-        const pluginNamespace = getNamespace(pluginName),
-            pluginNameWithoutNamespace = removeNamespace(pluginName),
-            pluginNameWithoutPrefix = removePrefix(pluginNameWithoutNamespace),
+        const pluginNamespace = Plugins.getNamespace(pluginName),
+            pluginNameWithoutNamespace = Plugins.removeNamespace(pluginName),
+            pluginNameWithoutPrefix = Plugins.removePrefix(pluginNameWithoutNamespace),
             shortName = pluginNamespace + pluginNameWithoutPrefix;
 
         // load up environments and rules
-        plugins[shortName] = plugin;
-        Environments.importPlugin(plugin, shortName);
-        Rules.importPlugin(plugin, shortName);
-    },
+        this._plugins[shortName] = plugin;
+        this._environments.importPlugin(plugin, shortName);
+        this._rules.importPlugin(plugin, shortName);
+    }
 
     /**
      * Gets a plugin with the given name.
@@ -83,16 +88,16 @@ module.exports = {
      * @returns {Object} The plugin or null if not loaded.
      */
     get(pluginName) {
-        return plugins[pluginName] || null;
-    },
+        return this._plugins[pluginName] || null;
+    }
 
     /**
      * Returns all plugins that are loaded.
      * @returns {Object} The plugins cache.
      */
     getAll() {
-        return plugins;
-    },
+        return this._plugins;
+    }
 
     /**
      * Loads a plugin with the given name.
@@ -101,9 +106,9 @@ module.exports = {
      * @throws {Error} If the plugin cannot be loaded.
      */
     load(pluginName) {
-        const pluginNamespace = getNamespace(pluginName),
-            pluginNameWithoutNamespace = removeNamespace(pluginName),
-            pluginNameWithoutPrefix = removePrefix(pluginNameWithoutNamespace),
+        const pluginNamespace = Plugins.getNamespace(pluginName),
+            pluginNameWithoutNamespace = Plugins.removeNamespace(pluginName),
+            pluginNameWithoutPrefix = Plugins.removePrefix(pluginNameWithoutNamespace),
             shortName = pluginNamespace + pluginNameWithoutPrefix,
             longName = pluginNamespace + PLUGIN_NAME_PREFIX + pluginNameWithoutPrefix;
         let plugin = null;
@@ -118,7 +123,7 @@ module.exports = {
             throw whitespaceError;
         }
 
-        if (!plugins[shortName]) {
+        if (!this._plugins[shortName]) {
             try {
                 plugin = require(longName);
             } catch (pluginLoadErr) {
@@ -144,7 +149,7 @@ module.exports = {
 
             this.define(pluginName, plugin);
         }
-    },
+    }
 
     /**
      * Loads all plugins from an array.
@@ -154,13 +159,7 @@ module.exports = {
      */
     loadAll(pluginNames) {
         pluginNames.forEach(this.load, this);
-    },
-
-    /**
-     * Resets plugin information. Use for tests only.
-     * @returns {void}
-     */
-    testReset() {
-        plugins = Object.create(null);
     }
-};
+}
+
+module.exports = Plugins;

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -1,6 +1,6 @@
 /**
- * @fileoverview Main ESLint object.
- * @author Nicholas C. Zakas
+ * @fileoverview Main Linter Class
+ * @author Gyandeep Singh
  */
 
 "use strict";
@@ -24,7 +24,7 @@ const assert = require("assert"),
     SourceCode = require("./util/source-code"),
     Traverser = require("./util/traverser"),
     RuleContext = require("./rule-context"),
-    rules = require("./rules"),
+    Rules = require("./rules"),
     timing = require("./timing"),
     astUtils = require("./ast-utils"),
 
@@ -158,19 +158,20 @@ function parseListConfig(string) {
  * @param {ASTNode} program The top node of the AST.
  * @param {Scope} globalScope The global scope.
  * @param {Object} config The existing configuration data.
+ * @param {Environments} envContext Env context
  * @returns {void}
  */
-function addDeclaredGlobals(program, globalScope, config) {
+function addDeclaredGlobals(program, globalScope, config, envContext) {
     const declaredGlobals = {},
         exportedGlobals = {},
         explicitGlobals = {},
-        builtin = Environments.get("builtin");
+        builtin = envContext.get("builtin");
 
     Object.assign(declaredGlobals, builtin);
 
     Object.keys(config.env).forEach(name => {
         if (config.env[name]) {
-            const env = Environments.get(name),
+            const env = envContext.get(name),
                 environmentGlobals = env && env.globals;
 
             if (environmentGlobals) {
@@ -314,11 +315,10 @@ function enableReporting(reportingConfig, start, rulesToEnable) {
  * @param {string} filename The file being checked.
  * @param {ASTNode} ast The top node of the AST.
  * @param {Object} config The existing configuration data.
- * @param {Object[]} reportingConfig The existing reporting configuration data.
- * @param {Object[]} messages The messages queue.
+ * @param {Linter} linterContext Linter context object
  * @returns {Object} Modified config object
  */
-function modifyConfigsFromComments(filename, ast, config, reportingConfig, messages) {
+function modifyConfigsFromComments(filename, ast, config, linterContext) {
 
     let commentConfig = {
         exported: {},
@@ -327,6 +327,8 @@ function modifyConfigsFromComments(filename, ast, config, reportingConfig, messa
         env: {}
     };
     const commentRules = {};
+    const messages = linterContext.messages;
+    const reportingConfig = linterContext.reportingConfig;
 
     ast.comments.forEach(comment => {
 
@@ -365,7 +367,7 @@ function modifyConfigsFromComments(filename, ast, config, reportingConfig, messa
                         Object.keys(items).forEach(name => {
                             const ruleValue = items[name];
 
-                            validator.validateRuleOptions(name, ruleValue, `${filename} line ${comment.loc.start.line}`);
+                            validator.validateRuleOptions(name, ruleValue, `${filename} line ${comment.loc.start.line}`, linterContext.rules);
                             commentRules[name] = ruleValue;
                         });
                         break;
@@ -387,7 +389,7 @@ function modifyConfigsFromComments(filename, ast, config, reportingConfig, messa
 
     // apply environment configs
     Object.keys(commentConfig.env).forEach(name => {
-        const env = Environments.get(name);
+        const env = linterContext.environments.get(name);
 
         if (env) {
             commentConfig = ConfigOps.merge(commentConfig, env);
@@ -446,11 +448,11 @@ function normalizeEcmaVersion(ecmaVersion, isModule) {
 /**
  * Process initial config to make it safe to extend by file comment config
  * @param  {Object} config Initial config
+ * @param  {Environments} envContext Env context
  * @returns {Object}        Processed config
  */
-function prepareConfig(config) {
+function prepareConfig(config, envContext) {
     config.globals = config.globals || {};
-
     const copiedRules = Object.assign({}, defaultConfig.rules);
     let parserOptions = Object.assign({}, defaultConfig.parserOptions);
 
@@ -472,7 +474,7 @@ function prepareConfig(config) {
     // merge in environment parserOptions
     if (typeof config.env === "object") {
         Object.keys(config.env).forEach(envName => {
-            const env = Environments.get(envName);
+            const env = envContext.get(envName);
 
             if (config.env[envName] && env && env.parserOptions) {
                 parserOptions = ConfigOps.merge(parserOptions, env.parserOptions);
@@ -581,6 +583,114 @@ function stripUnicodeBOM(text) {
     return text;
 }
 
+/**
+ * Get the severity level of a rule (0 - none, 1 - warning, 2 - error)
+ * Returns 0 if the rule config is not valid (an Array or a number)
+ * @param {Array|number} ruleConfig rule configuration
+ * @returns {number} 0, 1, or 2, indicating rule severity
+ */
+function getRuleSeverity(ruleConfig) {
+    if (typeof ruleConfig === "number") {
+        return ruleConfig;
+    } else if (Array.isArray(ruleConfig)) {
+        return ruleConfig[0];
+    }
+    return 0;
+
+}
+
+/**
+ * Get the options for a rule (not including severity), if any
+ * @param {Array|number} ruleConfig rule configuration
+ * @returns {Array} of rule options, empty Array if none
+ */
+function getRuleOptions(ruleConfig) {
+    if (Array.isArray(ruleConfig)) {
+        return ruleConfig.slice(1);
+    }
+    return [];
+
+}
+
+/**
+ * Parses text into an AST. Moved out here because the try-catch prevents
+ * optimization of functions, so it's best to keep the try-catch as isolated
+ * as possible
+ * @param {string} text The text to parse.
+ * @param {Object} config The ESLint configuration object.
+ * @param {string} filePath The path to the file being parsed.
+ * @returns {ASTNode|CustomParseResult} The AST or parse result if successful,
+ *      or null if not.
+ * @param {Array<Object>} messages Messages array for the linter object
+ * @returns {*} parsed text if successful otherwise null
+ * @private
+ */
+function parse(text, config, filePath, messages) {
+
+    let parser,
+        parserOptions = {
+            loc: true,
+            range: true,
+            raw: true,
+            tokens: true,
+            comment: true,
+            filePath
+        };
+
+    try {
+        parser = require(config.parser);
+    } catch (ex) {
+        messages.push({
+            ruleId: null,
+            fatal: true,
+            severity: 2,
+            source: null,
+            message: ex.message,
+            line: 0,
+            column: 0
+        });
+
+        return null;
+    }
+
+    // merge in any additional parser options
+    if (config.parserOptions) {
+        parserOptions = Object.assign({}, config.parserOptions, parserOptions);
+    }
+
+    /*
+     * Check for parsing errors first. If there's a parsing error, nothing
+     * else can happen. However, a parsing error does not throw an error
+     * from this method - it's just considered a fatal error message, a
+     * problem that ESLint identified just like any other.
+     */
+    try {
+        if (typeof parser.parseForESLint === "function") {
+            return parser.parseForESLint(text, parserOptions);
+        }
+        return parser.parse(text, parserOptions);
+
+    } catch (ex) {
+
+        // If the message includes a leading line number, strip it:
+        const message = ex.message.replace(/^line \d+:/i, "").trim();
+        const source = (ex.lineNumber) ? SourceCode.splitLines(text)[ex.lineNumber - 1] : null;
+
+        messages.push({
+            ruleId: null,
+            fatal: true,
+            severity: 2,
+            source,
+            message: `Parsing error: ${message}`,
+
+            line: ex.lineNumber,
+            column: ex.column
+        });
+
+        return null;
+    }
+}
+
 //------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
@@ -589,141 +699,41 @@ function stripUnicodeBOM(text) {
  * Object that is responsible for verifying JavaScript text
  * @name eslint
  */
-module.exports = (function() {
+class Linter extends EventEmitter {
 
-    const api = Object.create(new EventEmitter());
-    let messages = [],
-        currentConfig = null,
-        currentScopes = null,
-        scopeManager = null,
-        currentFilename = null,
-        traverser = null,
-        reportingConfig = [],
-        sourceCode = null;
+    constructor() {
+        super();
+        this.messages = [];
+        this.currentConfig = null;
+        this.currentScopes = null;
+        this.scopeManager = null;
+        this.currentFilename = null;
+        this.traverser = null;
+        this.reportingConfig = [];
+        this.sourceCode = null;
+        this.version = pkg.version;
 
-    /**
-     * Parses text into an AST. Moved out here because the try-catch prevents
-     * optimization of functions, so it's best to keep the try-catch as isolated
-     * as possible
-     * @param {string} text The text to parse.
-     * @param {Object} config The ESLint configuration object.
-     * @param {string} filePath The path to the file being parsed.
-     * @returns {ASTNode|CustomParseResult} The AST or parse result if successful,
-     *      or null if not.
-     * @private
-     */
-    function parse(text, config, filePath) {
+        this.rules = new Rules();
+        this.environments = new Environments();
 
-        let parser,
-            parserOptions = {
-                loc: true,
-                range: true,
-                raw: true,
-                tokens: true,
-                comment: true,
-                filePath
-            };
-
-        try {
-            parser = require(config.parser);
-        } catch (ex) {
-            messages.push({
-                ruleId: null,
-                fatal: true,
-                severity: 2,
-                source: null,
-                message: ex.message,
-                line: 0,
-                column: 0
-            });
-
-            return null;
-        }
-
-        // merge in any additional parser options
-        if (config.parserOptions) {
-            parserOptions = Object.assign({}, config.parserOptions, parserOptions);
-        }
-
-        /*
-         * Check for parsing errors first. If there's a parsing error, nothing
-         * else can happen. However, a parsing error does not throw an error
-         * from this method - it's just considered a fatal error message, a
-         * problem that ESLint identified just like any other.
-         */
-        try {
-            if (typeof parser.parseForESLint === "function") {
-                return parser.parseForESLint(text, parserOptions);
-            }
-            return parser.parse(text, parserOptions);
-
-        } catch (ex) {
-
-            // If the message includes a leading line number, strip it:
-            const message = ex.message.replace(/^line \d+:/i, "").trim();
-            const source = (ex.lineNumber) ? SourceCode.splitLines(text)[ex.lineNumber - 1] : null;
-
-            messages.push({
-                ruleId: null,
-                fatal: true,
-                severity: 2,
-                source,
-                message: `Parsing error: ${message}`,
-
-                line: ex.lineNumber,
-                column: ex.column
-            });
-
-            return null;
-        }
+        // set unlimited listeners (see https://github.com/eslint/eslint/issues/524)
+        this.setMaxListeners(0);
     }
-
-    /**
-     * Get the severity level of a rule (0 - none, 1 - warning, 2 - error)
-     * Returns 0 if the rule config is not valid (an Array or a number)
-     * @param {Array|number} ruleConfig rule configuration
-     * @returns {number} 0, 1, or 2, indicating rule severity
-     */
-    function getRuleSeverity(ruleConfig) {
-        if (typeof ruleConfig === "number") {
-            return ruleConfig;
-        } else if (Array.isArray(ruleConfig)) {
-            return ruleConfig[0];
-        }
-        return 0;
-
-    }
-
-    /**
-     * Get the options for a rule (not including severity), if any
-     * @param {Array|number} ruleConfig rule configuration
-     * @returns {Array} of rule options, empty Array if none
-     */
-    function getRuleOptions(ruleConfig) {
-        if (Array.isArray(ruleConfig)) {
-            return ruleConfig.slice(1);
-        }
-        return [];
-
-    }
-
-    // set unlimited listeners (see https://github.com/eslint/eslint/issues/524)
-    api.setMaxListeners(0);
 
     /**
      * Resets the internal state of the object.
      * @returns {void}
      */
-    api.reset = function() {
+    reset() {
         this.removeAllListeners();
-        messages = [];
-        currentConfig = null;
-        currentScopes = null;
-        scopeManager = null;
-        traverser = null;
-        reportingConfig = [];
-        sourceCode = null;
-    };
+        this.messages = [];
+        this.currentConfig = null;
+        this.currentScopes = null;
+        this.scopeManager = null;
+        this.traverser = null;
+        this.reportingConfig = [];
+        this.sourceCode = null;
+    }
 
     /**
      * Configuration object for the `verify` API. A JS representation of the eslintrc files.
@@ -749,7 +759,7 @@ module.exports = (function() {
      *      Useful if you want to validate JS without comments overriding rules.
      * @returns {Object[]} The results as an array of messages or null if no messages.
      */
-    api.verify = function(textOrSourceCode, config, filenameOrOptions, saveState) {
+    verify(textOrSourceCode, config, filenameOrOptions, saveState) {
         const text = (typeof textOrSourceCode === "string") ? textOrSourceCode : null;
         let ast,
             parseResult,
@@ -757,11 +767,11 @@ module.exports = (function() {
 
         // evaluate arguments
         if (typeof filenameOrOptions === "object") {
-            currentFilename = filenameOrOptions.filename;
+            this.currentFilename = filenameOrOptions.filename;
             allowInlineConfig = filenameOrOptions.allowInlineConfig;
             saveState = filenameOrOptions.saveState;
         } else {
-            currentFilename = filenameOrOptions;
+            this.currentFilename = filenameOrOptions;
         }
 
         if (!saveState) {
@@ -782,21 +792,22 @@ module.exports = (function() {
         }
 
         // process initial config to make it safe to extend
-        config = prepareConfig(config);
+        config = prepareConfig(config, this.environments);
 
         // only do this for text
         if (text !== null) {
 
             // there's no input, just exit here
             if (text.trim().length === 0) {
-                sourceCode = new SourceCode(text, blankScriptAST);
-                return messages;
+                this.sourceCode = new SourceCode(text, blankScriptAST);
+                return this.messages;
             }
 
             parseResult = parse(
                 stripUnicodeBOM(text).replace(astUtils.SHEBANG_MATCHER, (match, captured) => `//${captured}`),
                 config,
-                currentFilename
+                this.currentFilename,
+                this.messages
             );
 
             // if this result is from a parseForESLint() method, normalize
@@ -808,12 +819,12 @@ module.exports = (function() {
             }
 
             if (ast) {
-                sourceCode = new SourceCode(text, ast);
+                this.sourceCode = new SourceCode(text, ast);
             }
 
         } else {
-            sourceCode = textOrSourceCode;
-            ast = sourceCode.ast;
+            this.sourceCode = textOrSourceCode;
+            ast = this.sourceCode.ast;
         }
 
         // if espree failed to parse the file, there's no sense in setting up rules
@@ -821,7 +832,7 @@ module.exports = (function() {
 
             // parse global comments and modify config
             if (allowInlineConfig !== false) {
-                config = modifyConfigsFromComments(currentFilename, ast, config, reportingConfig, messages);
+                config = modifyConfigsFromComments(this.currentFilename, ast, config, this);
             }
 
             // ensure that severities are normalized in the config
@@ -831,7 +842,7 @@ module.exports = (function() {
             Object.keys(config.rules).filter(key => getRuleSeverity(config.rules[key]) > 0).forEach(key => {
                 let ruleCreator;
 
-                ruleCreator = rules.get(key);
+                ruleCreator = this.rules.get(key);
 
                 if (!ruleCreator) {
                     const replacementMsg = getRuleReplacementMessage(key);
@@ -841,7 +852,7 @@ module.exports = (function() {
                     } else {
                         ruleCreator = createStubRule(`Definition for rule '${key}' was not found`);
                     }
-                    rules.define(key, ruleCreator);
+                    this.rules.define(key, ruleCreator);
                 }
 
                 const severity = getRuleSeverity(config.rules[key]);
@@ -849,7 +860,7 @@ module.exports = (function() {
 
                 try {
                     const ruleContext = new RuleContext(
-                        key, api, severity, options,
+                        key, this, severity, options,
                         config.settings, config.parserOptions, config.parser,
                         ruleCreator.meta,
                         (parseResult && parseResult.services ? parseResult.services : {})
@@ -860,7 +871,7 @@ module.exports = (function() {
 
                     // add all the selectors from the rule as listeners
                     Object.keys(rule).forEach(selector => {
-                        api.on(selector, timing.enabled
+                        this.on(selector, timing.enabled
                             ? timing.time(key, rule[selector])
                             : rule[selector]
                         );
@@ -872,28 +883,28 @@ module.exports = (function() {
             });
 
             // save config so rules can access as necessary
-            currentConfig = config;
-            traverser = new Traverser();
+            this.currentConfig = config;
+            this.traverser = new Traverser();
 
-            const ecmaFeatures = currentConfig.parserOptions.ecmaFeatures;
-            const ecmaVersion = currentConfig.parserOptions.ecmaVersion;
+            const ecmaFeatures = this.currentConfig.parserOptions.ecmaFeatures || {};
+            const ecmaVersion = this.currentConfig.parserOptions.ecmaVersion || 5;
 
             // gather scope data that may be needed by the rules
-            scopeManager = eslintScope.analyze(ast, {
+            this.scopeManager = eslintScope.analyze(ast, {
                 ignoreEval: true,
                 nodejsScope: ecmaFeatures.globalReturn,
                 impliedStrict: ecmaFeatures.impliedStrict,
                 ecmaVersion,
-                sourceType: currentConfig.parserOptions.sourceType,
+                sourceType: this.currentConfig.parserOptions.sourceType || "script",
                 fallback: Traverser.getKeys
             });
 
-            currentScopes = scopeManager.scopes;
+            this.currentScopes = this.scopeManager.scopes;
 
             // augment global scope with declared global variables
-            addDeclaredGlobals(ast, currentScopes[0], currentConfig);
+            addDeclaredGlobals(ast, this.currentScopes[0], this.currentConfig, this.environments);
 
-            let eventGenerator = new NodeEventGenerator(api);
+            let eventGenerator = new NodeEventGenerator(this);
 
             eventGenerator = new CodePathAnalyzer(eventGenerator);
 
@@ -903,7 +914,7 @@ module.exports = (function() {
              * automatically be informed that this type of node has been found
              * and react accordingly.
              */
-            traverser.traverse(ast, {
+            this.traverser.traverse(ast, {
                 enter(node, parent) {
                     node.parent = parent;
                     eventGenerator.enterNode(node);
@@ -915,7 +926,7 @@ module.exports = (function() {
         }
 
         // sort by line and column
-        messages.sort((a, b) => {
+        this.messages.sort((a, b) => {
             const lineDiff = a.line - b.line;
 
             if (lineDiff === 0) {
@@ -925,8 +936,8 @@ module.exports = (function() {
 
         });
 
-        return messages;
-    };
+        return this.messages;
+    }
 
     /**
      * Reports a message from one of the rules.
@@ -943,7 +954,7 @@ module.exports = (function() {
      * @param {Object} meta Metadata of the rule
      * @returns {void}
      */
-    api.report = function(ruleId, severity, node, location, message, opts, fix, meta) {
+    report(ruleId, severity, node, location, message, opts, fix, meta) {
         if (node) {
             assert.strictEqual(typeof node, "object", "Node must be an object");
         }
@@ -965,7 +976,7 @@ module.exports = (function() {
 
         location = location.start || location;
 
-        if (isDisabledByReportingConfig(reportingConfig, ruleId, location)) {
+        if (isDisabledByReportingConfig(this.reportingConfig, ruleId, location)) {
             return;
         }
 
@@ -987,7 +998,7 @@ module.exports = (function() {
             line: location.line,
             column: location.column + 1, // switch to 1-base instead of 0-base
             nodeType: node && node.type,
-            source: sourceCode.lines[location.line - 1] || ""
+            source: this.sourceCode.lines[location.line - 1] || ""
         };
 
         // Define endLine and endColumn if exists.
@@ -1007,76 +1018,39 @@ module.exports = (function() {
             problem.fix = fix;
         }
 
-        messages.push(problem);
-    };
+        this.messages.push(problem);
+    }
 
     /**
      * Gets the SourceCode object representing the parsed source.
      * @returns {SourceCode} The SourceCode object.
      */
-    api.getSourceCode = function() {
-        return sourceCode;
-    };
-
-    // methods that exist on SourceCode object
-    const externalMethods = {
-        getSource: "getText",
-        getSourceLines: "getLines",
-        getAllComments: "getAllComments",
-        getNodeByRangeIndex: "getNodeByRangeIndex",
-        getComments: "getComments",
-        getCommentsBefore: "getCommentsBefore",
-        getCommentsAfter: "getCommentsAfter",
-        getCommentsInside: "getCommentsInside",
-        getJSDocComment: "getJSDocComment",
-        getFirstToken: "getFirstToken",
-        getFirstTokens: "getFirstTokens",
-        getLastToken: "getLastToken",
-        getLastTokens: "getLastTokens",
-        getTokenAfter: "getTokenAfter",
-        getTokenBefore: "getTokenBefore",
-        getTokenByRangeStart: "getTokenByRangeStart",
-        getTokens: "getTokens",
-        getTokensAfter: "getTokensAfter",
-        getTokensBefore: "getTokensBefore",
-        getTokensBetween: "getTokensBetween"
-    };
-
-    // copy over methods
-    Object.keys(externalMethods).forEach(methodName => {
-        const exMethodName = externalMethods[methodName];
-
-        // All functions expected to have less arguments than 5.
-        api[methodName] = function(a, b, c, d, e) {
-            if (sourceCode) {
-                return sourceCode[exMethodName](a, b, c, d, e);
-            }
-            return null;
-        };
-    });
+    getSourceCode() {
+        return this.sourceCode;
+    }
 
     /**
      * Gets nodes that are ancestors of current node.
      * @returns {ASTNode[]} Array of objects representing ancestors.
      */
-    api.getAncestors = function() {
-        return traverser.parents();
-    };
+    getAncestors() {
+        return this.traverser.parents();
+    }
 
     /**
      * Gets the scope for the current node.
      * @returns {Object} An object representing the current node's scope.
      */
-    api.getScope = function() {
-        const parents = traverser.parents();
+    getScope() {
+        const parents = this.traverser.parents();
 
         // Don't do this for Program nodes - they have no parents
         if (parents.length) {
 
             // if current node introduces a scope, add it to the list
-            const current = traverser.current();
+            const current = this.traverser.current();
 
-            if (currentConfig.parserOptions.ecmaVersion >= 6) {
+            if (this.currentConfig.parserOptions.ecmaVersion >= 6) {
                 if (["BlockStatement", "SwitchStatement", "CatchClause", "FunctionDeclaration", "FunctionExpression", "ArrowFunctionExpression"].indexOf(current.type) >= 0) {
                     parents.push(current);
                 }
@@ -1090,7 +1064,7 @@ module.exports = (function() {
             for (let i = parents.length - 1; i >= 0; --i) {
 
                 // Get the innermost scope
-                const scope = scopeManager.acquire(parents[i], true);
+                const scope = this.scopeManager.acquire(parents[i], true);
 
                 if (scope) {
                     if (scope.type === "function-expression-name") {
@@ -1104,8 +1078,8 @@ module.exports = (function() {
 
         }
 
-        return currentScopes[0];
-    };
+        return this.currentScopes[0];
+    }
 
     /**
      * Record that a particular variable has been used in code
@@ -1113,9 +1087,9 @@ module.exports = (function() {
      * @returns {boolean} True if the variable was found and marked as used,
      *      false if not.
      */
-    api.markVariableAsUsed = function(name) {
-        const hasGlobalReturn = currentConfig.parserOptions.ecmaFeatures && currentConfig.parserOptions.ecmaFeatures.globalReturn,
-            specialScope = hasGlobalReturn || currentConfig.parserOptions.sourceType === "module";
+    markVariableAsUsed(name) {
+        const hasGlobalReturn = this.currentConfig.parserOptions.ecmaFeatures && this.currentConfig.parserOptions.ecmaFeatures.globalReturn,
+            specialScope = hasGlobalReturn || this.currentConfig.parserOptions.sourceType === "module";
         let scope = this.getScope(),
             i,
             len;
@@ -1137,20 +1111,20 @@ module.exports = (function() {
         } while ((scope = scope.upper));
 
         return false;
-    };
+    }
 
     /**
      * Gets the filename for the currently parsed source.
      * @returns {string} The filename associated with the source being parsed.
      *     Defaults to "<input>" if no filename info is present.
      */
-    api.getFilename = function() {
-        if (typeof currentFilename === "string") {
-            return currentFilename;
+    getFilename() {
+        if (typeof this.currentFilename === "string") {
+            return this.currentFilename;
         }
         return "<input>";
 
-    };
+    }
 
     /**
      * Defines a new linting rule.
@@ -1158,38 +1132,36 @@ module.exports = (function() {
      * @param {Function} ruleModule Function from context to object mapping AST node types to event handlers
      * @returns {void}
      */
-    const defineRule = api.defineRule = function(ruleId, ruleModule) {
-        rules.define(ruleId, ruleModule);
-    };
+    defineRule(ruleId, ruleModule) {
+        this.rules.define(ruleId, ruleModule);
+    }
 
     /**
      * Defines many new linting rules.
      * @param {Object} rulesToDefine map from unique rule identifier to rule
      * @returns {void}
      */
-    api.defineRules = function(rulesToDefine) {
+    defineRules(rulesToDefine) {
         Object.getOwnPropertyNames(rulesToDefine).forEach(ruleId => {
-            defineRule(ruleId, rulesToDefine[ruleId]);
+            this.defineRule(ruleId, rulesToDefine[ruleId]);
         });
-    };
+    }
 
     /**
      * Gets the default eslint configuration.
      * @returns {Object} Object mapping rule IDs to their default configurations
      */
-    api.defaults = function() {
+    defaults() { // eslint-disable-line class-methods-use-this
         return defaultConfig;
-    };
+    }
 
     /**
      * Gets an object with all loaded rules.
      * @returns {Map} All loaded rules
      */
-    api.getRules = function() {
-        return rules.getAllLoadedRules();
-    };
-
-    api.version = pkg.version;
+    getRules() {
+        return this.rules.getAllLoadedRules();
+    }
 
     /**
      * Gets variables that are declared by a specified node.
@@ -1210,10 +1182,46 @@ module.exports = (function() {
      * @param {ASTNode} node A node to get.
      * @returns {eslint-scope.Variable[]} Variables that are declared by the node.
      */
-    api.getDeclaredVariables = function(node) {
-        return (scopeManager && scopeManager.getDeclaredVariables(node)) || [];
+    getDeclaredVariables(node) {
+        return (this.scopeManager && this.scopeManager.getDeclaredVariables(node)) || [];
+    }
+}
+
+// methods that exist on SourceCode object
+const externalMethods = {
+    getSource: "getText",
+    getSourceLines: "getLines",
+    getAllComments: "getAllComments",
+    getNodeByRangeIndex: "getNodeByRangeIndex",
+    getComments: "getComments",
+    getCommentsBefore: "getCommentsBefore",
+    getCommentsAfter: "getCommentsAfter",
+    getCommentsInside: "getCommentsInside",
+    getJSDocComment: "getJSDocComment",
+    getFirstToken: "getFirstToken",
+    getFirstTokens: "getFirstTokens",
+    getLastToken: "getLastToken",
+    getLastTokens: "getLastTokens",
+    getTokenAfter: "getTokenAfter",
+    getTokenBefore: "getTokenBefore",
+    getTokenByRangeStart: "getTokenByRangeStart",
+    getTokens: "getTokens",
+    getTokensAfter: "getTokensAfter",
+    getTokensBefore: "getTokensBefore",
+    getTokensBetween: "getTokensBetween"
+};
+
+// copy over methods
+Object.keys(externalMethods).forEach(methodName => {
+    const exMethodName = externalMethods[methodName];
+
+    // All functions expected to have less arguments than 5.
+    Linter.prototype[methodName] = function(a, b, c, d, e) {
+        if (this.sourceCode) {
+            return this.sourceCode[exMethodName](a, b, c, d, e);
+        }
+        return null;
     };
+});
 
-    return api;
-
-}());
+module.exports = Linter;

--- a/lib/load-rules.js
+++ b/lib/load-rules.js
@@ -12,6 +12,8 @@
 const fs = require("fs"),
     path = require("path");
 
+const rulesDirCache = {};
+
 //------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
@@ -29,6 +31,11 @@ module.exports = function(rulesDir, cwd) {
         rulesDir = path.resolve(cwd, rulesDir);
     }
 
+    // cache will help performance as IO operation are expensive
+    if (rulesDirCache[rulesDir]) {
+        return rulesDirCache[rulesDir];
+    }
+
     const rules = Object.create(null);
 
     fs.readdirSync(rulesDir).forEach(file => {
@@ -37,5 +44,7 @@ module.exports = function(rulesDir, cwd) {
         }
         rules[file.slice(0, -3)] = path.join(rulesDir, file);
     });
+    rulesDirCache[rulesDir] = rules;
+
     return rules;
 };

--- a/lib/rules.js
+++ b/lib/rules.js
@@ -12,114 +12,84 @@
 const loadRules = require("./load-rules");
 
 //------------------------------------------------------------------------------
-// Privates
-//------------------------------------------------------------------------------
-
-let rules = Object.create(null);
-
-//------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
 
-/**
- * Registers a rule module for rule id in storage.
- * @param {string} ruleId Rule id (file name).
- * @param {Function} ruleModule Rule handler.
- * @returns {void}
- */
-function define(ruleId, ruleModule) {
-    rules[ruleId] = ruleModule;
-}
+class Rules {
+    constructor() {
+        this._rules = Object.create(null);
 
-/**
- * Loads and registers all rules from passed rules directory.
- * @param {string} [rulesDir] Path to rules directory, may be relative. Defaults to `lib/rules`.
- * @param {string} cwd Current working directory
- * @returns {void}
- */
-function load(rulesDir, cwd) {
-    const newRules = loadRules(rulesDir, cwd);
-
-    Object.keys(newRules).forEach(ruleId => {
-        define(ruleId, newRules[ruleId]);
-    });
-}
-
-/**
- * Registers all given rules of a plugin.
- * @param {Object} plugin The plugin object to import.
- * @param {string} pluginName The name of the plugin without prefix (`eslint-plugin-`).
- * @returns {void}
- */
-function importPlugin(plugin, pluginName) {
-    if (plugin.rules) {
-        Object.keys(plugin.rules).forEach(ruleId => {
-            const qualifiedRuleId = `${pluginName}/${ruleId}`,
-                rule = plugin.rules[ruleId];
-
-            define(qualifiedRuleId, rule);
-        });
+        this.load();
     }
-}
-
-/**
- * Access rule handler by id (file name).
- * @param {string} ruleId Rule id (file name).
- * @returns {Function} Rule handler.
- */
-function getHandler(ruleId) {
-    if (typeof rules[ruleId] === "string") {
-        return require(rules[ruleId]);
-    }
-    return rules[ruleId];
-
-}
-
-/**
- * Get an object with all currently loaded rules
- * @returns {Map} All loaded rules
- */
-function getAllLoadedRules() {
-    const allRules = new Map();
-
-    Object.keys(rules).forEach(name => {
-        const rule = getHandler(name);
-
-        allRules.set(name, rule);
-    });
-    return allRules;
-}
-
-/**
- * Reset rules storage.
- * Should be used only in tests.
- * @returns {void}
- */
-function testClear() {
-    rules = Object.create(null);
-}
-
-module.exports = {
-    define,
-    load,
-    importPlugin,
-    get: getHandler,
-    getAllLoadedRules,
-    testClear,
 
     /**
-     * Resets rules to its starting state. Use for tests only.
+     * Registers a rule module for rule id in storage.
+     * @param {string} ruleId Rule id (file name).
+     * @param {Function} ruleModule Rule handler.
      * @returns {void}
      */
-    testReset() {
-        testClear();
-        load();
+    define(ruleId, ruleModule) {
+        this._rules[ruleId] = ruleModule;
     }
-};
 
-//------------------------------------------------------------------------------
-// Initialization
-//------------------------------------------------------------------------------
+    /**
+     * Loads and registers all rules from passed rules directory.
+     * @param {string} [rulesDir] Path to rules directory, may be relative. Defaults to `lib/rules`.
+     * @param {string} cwd Current working directory
+     * @returns {void}
+     */
+    load(rulesDir, cwd) {
+        const newRules = loadRules(rulesDir, cwd);
 
-// loads built-in rules
-load();
+        Object.keys(newRules).forEach(ruleId => {
+            this.define(ruleId, newRules[ruleId]);
+        });
+    }
+
+    /**
+     * Registers all given rules of a plugin.
+     * @param {Object} plugin The plugin object to import.
+     * @param {string} pluginName The name of the plugin without prefix (`eslint-plugin-`).
+     * @returns {void}
+     */
+    importPlugin(plugin, pluginName) {
+        if (plugin.rules) {
+            Object.keys(plugin.rules).forEach(ruleId => {
+                const qualifiedRuleId = `${pluginName}/${ruleId}`,
+                    rule = plugin.rules[ruleId];
+
+                this.define(qualifiedRuleId, rule);
+            });
+        }
+    }
+
+    /**
+     * Access rule handler by id (file name).
+     * @param {string} ruleId Rule id (file name).
+     * @returns {Function} Rule handler.
+     */
+    get(ruleId) {
+        if (typeof this._rules[ruleId] === "string") {
+            return require(this._rules[ruleId]);
+        }
+        return this._rules[ruleId];
+
+    }
+
+    /**
+     * Get an object with all currently loaded rules
+     * @returns {Map} All loaded rules
+     */
+    getAllLoadedRules() {
+        const allRules = new Map();
+
+        Object.keys(this._rules).forEach(name => {
+            const rule = this.get(name);
+
+            allRules.set(name, rule);
+        });
+        return allRules;
+    }
+}
+
+module.exports = Rules;

--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -45,8 +45,8 @@ const lodash = require("lodash"),
     util = require("util"),
     validator = require("../config/config-validator"),
     validate = require("is-my-json-valid"),
-    eslint = require("../eslint"),
-    rules = require("../rules"),
+    Linter = require("../linter"),
+    Environments = require("../config/environments"),
     metaSchema = require("../../conf/json-schema-schema.json"),
     SourceCodeFixer = require("../util/source-code-fixer");
 
@@ -170,6 +170,7 @@ class RuleTester {
          * @type {Object}
          */
         this.rules = {};
+        this.linter = new Linter();
     }
 
     /**
@@ -252,7 +253,8 @@ class RuleTester {
         const testerConfig = this.testerConfig,
             requiredScenarios = ["valid", "invalid"],
             scenarioErrors = [],
-            result = {};
+            result = {},
+            linter = this.linter;
 
         if (lodash.isNil(test) || typeof test !== "object") {
             throw new Error(`Test Scenarios for rule ${ruleName} : Could not find test scenario object`);
@@ -311,9 +313,9 @@ class RuleTester {
                 config.rules[ruleName] = 1;
             }
 
-            eslint.defineRule(ruleName, rule);
+            linter.defineRule(ruleName, rule);
 
-            const schema = validator.getRuleOptionsSchema(ruleName);
+            const schema = validator.getRuleOptionsSchema(ruleName, linter.rules);
 
             if (schema) {
                 validateSchema(schema);
@@ -325,29 +327,29 @@ class RuleTester {
                 }
             }
 
-            validator.validate(config, "rule-tester");
+            validator.validate(config, "rule-tester", linter.rules, new Environments());
 
             /*
              * Setup AST getters.
              * The goal is to check whether or not AST was modified when
              * running the rule under test.
              */
-            eslint.reset();
+            linter.reset();
 
-            eslint.on("Program", node => {
+            linter.on("Program", node => {
                 beforeAST = cloneDeeplyExcludesParent(node);
             });
 
-            eslint.on("Program:exit", node => {
+            linter.on("Program:exit", node => {
                 afterAST = node;
             });
 
             // Freezes rule-context properties.
-            const originalGet = rules.get;
+            const originalGet = linter.rules.get;
 
             try {
-                rules.get = function(ruleId) {
-                    const rule = originalGet(ruleId);
+                linter.rules.get = function(ruleId) {
+                    const rule = originalGet.call(linter.rules, ruleId);
 
                     if (typeof rule === "function") {
                         return function(context) {
@@ -374,12 +376,12 @@ class RuleTester {
                 };
 
                 return {
-                    messages: eslint.verify(code, config, filename, true),
+                    messages: linter.verify(code, config, filename, true),
                     beforeAST,
                     afterAST: cloneDeeplyExcludesParent(afterAST)
                 };
             } finally {
-                rules.get = originalGet;
+                linter.rules.get = originalGet;
             }
         }
 
@@ -521,7 +523,7 @@ class RuleTester {
                         "Expected no autofixes to be suggested"
                     );
                 } else {
-                    const fixResult = SourceCodeFixer.applyFixes(eslint.getSourceCode(), messages);
+                    const fixResult = SourceCodeFixer.applyFixes(linter.getSourceCode(), messages);
 
                     assert.equal(fixResult.output, item.output, "Output is incorrect.");
                 }
@@ -538,7 +540,7 @@ class RuleTester {
             RuleTester.describe("valid", () => {
                 test.valid.forEach(valid => {
                     RuleTester.it(typeof valid === "object" ? valid.code : valid, () => {
-                        eslint.defineRules(this.rules);
+                        linter.defineRules(this.rules);
                         testValidTemplate(ruleName, valid);
                     });
                 });
@@ -547,7 +549,7 @@ class RuleTester {
             RuleTester.describe("invalid", () => {
                 test.invalid.forEach(invalid => {
                     RuleTester.it(invalid.code, () => {
-                        eslint.defineRules(this.rules);
+                        linter.defineRules(this.rules);
                         testInvalidTemplate(ruleName, invalid);
                     });
                 });

--- a/lib/util/source-code-util.js
+++ b/lib/util/source-code-util.js
@@ -10,7 +10,6 @@
 //------------------------------------------------------------------------------
 
 const CLIEngine = require("../cli-engine"),
-    eslint = require("../eslint"),
     globUtil = require("./glob-util"),
     baseDefaultOptions = require("../../conf/default-cli-options");
 
@@ -38,7 +37,7 @@ function getSourceCodeOfFile(filename, options) {
 
         throw new Error(`(${filename}:${msg.line}:${msg.column}) ${msg.message}`);
     }
-    const sourceCode = eslint.getSourceCode();
+    const sourceCode = cli.linter.getSourceCode();
 
     return sourceCode;
 }

--- a/tests/bench/bench.js
+++ b/tests/bench/bench.js
@@ -1,9 +1,9 @@
-var eslint = require("../../lib/eslint"),
+var Linter = require("../../lib/linter"),
     fs = require("fs");
 
 var config = require("../../conf/eslint-recommended");
 
-var large = fs.readFileSync(__dirname + "/large.js", "utf8"), 
+var large = fs.readFileSync(__dirname + "/large.js", "utf8"),
     medium = fs.readFileSync(__dirname + "/medium.js", "utf8"),
     small = fs.readFileSync(__dirname + "/small.js", "utf8");
 
@@ -12,6 +12,7 @@ var runs = {
     medium: medium,
     small: small
 };
+var linter = new Linter();
 
 benchmark.runs = runs;
 benchmark(Boolean, 1);
@@ -32,7 +33,7 @@ function benchmark(grep, times) {
 
 function run(content, times) {
     while(times--) {
-        eslint.reset();
-        eslint.verify(content, config);
+        linter.reset();
+        linter.verify(content, config);
     }
 }

--- a/tests/lib/ast-utils.js
+++ b/tests/lib/ast-utils.js
@@ -13,7 +13,7 @@ const assert = require("chai").assert,
     sinon = require("sinon"),
     espree = require("espree"),
     astUtils = require("../../lib/ast-utils"),
-    eslint = require("../../lib/eslint"),
+    Linter = require("../../lib/linter"),
     SourceCode = require("../../lib/util/source-code");
 
 //------------------------------------------------------------------------------
@@ -27,6 +27,7 @@ const ESPREE_CONFIG = {
     range: true,
     loc: true
 };
+const linter = new Linter();
 
 describe("ast-utils", () => {
     const filename = "filename.js";
@@ -37,7 +38,7 @@ describe("ast-utils", () => {
     });
 
     afterEach(() => {
-        eslint.reset();
+        linter.reset();
         sandbox.verifyAndRestore();
     });
 
@@ -50,12 +51,12 @@ describe("ast-utils", () => {
              * @returns {void}
              */
             function checker(node) {
-                assert.isFalse(astUtils.isTokenOnSameLine(eslint.getTokenBefore(node), node));
+                assert.isFalse(astUtils.isTokenOnSameLine(linter.getTokenBefore(node), node));
             }
 
-            eslint.reset();
-            eslint.on("BlockStatement", checker);
-            eslint.verify("if(a)\n{}", {}, filename, true);
+            linter.reset();
+            linter.on("BlockStatement", checker);
+            linter.verify("if(a)\n{}", {}, filename, true);
         });
 
         it("should return true if its on sameline", () => {
@@ -66,12 +67,12 @@ describe("ast-utils", () => {
              * @returns {void}
              */
             function checker(node) {
-                assert.isTrue(astUtils.isTokenOnSameLine(eslint.getTokenBefore(node), node));
+                assert.isTrue(astUtils.isTokenOnSameLine(linter.getTokenBefore(node), node));
             }
 
-            eslint.reset();
-            eslint.on("BlockStatement", checker);
-            eslint.verify("if(a){}", {}, filename, true);
+            linter.reset();
+            linter.on("BlockStatement", checker);
+            linter.verify("if(a){}", {}, filename, true);
         });
     });
 
@@ -87,9 +88,9 @@ describe("ast-utils", () => {
                 assert.isTrue(astUtils.isNullOrUndefined(node.arguments[0]));
             }
 
-            eslint.reset();
-            eslint.on("CallExpression", checker);
-            eslint.verify("foo.apply(null, a, b);", {}, filename, true);
+            linter.reset();
+            linter.on("CallExpression", checker);
+            linter.verify("foo.apply(null, a, b);", {}, filename, true);
         });
 
         it("should return true if its undefined", () => {
@@ -103,9 +104,9 @@ describe("ast-utils", () => {
                 assert.isTrue(astUtils.isNullOrUndefined(node.arguments[0]));
             }
 
-            eslint.reset();
-            eslint.on("CallExpression", checker);
-            eslint.verify("foo.apply(undefined, a, b);", {}, filename, true);
+            linter.reset();
+            linter.on("CallExpression", checker);
+            linter.verify("foo.apply(undefined, a, b);", {}, filename, true);
         });
 
         it("should return false if its a number", () => {
@@ -119,9 +120,9 @@ describe("ast-utils", () => {
                 assert.isFalse(astUtils.isNullOrUndefined(node.arguments[0]));
             }
 
-            eslint.reset();
-            eslint.on("CallExpression", checker);
-            eslint.verify("foo.apply(1, a, b);", {}, filename, true);
+            linter.reset();
+            linter.on("CallExpression", checker);
+            linter.verify("foo.apply(1, a, b);", {}, filename, true);
         });
 
         it("should return false if its a string", () => {
@@ -135,9 +136,9 @@ describe("ast-utils", () => {
                 assert.isFalse(astUtils.isNullOrUndefined(node.arguments[0]));
             }
 
-            eslint.reset();
-            eslint.on("CallExpression", checker);
-            eslint.verify("foo.apply(`test`, a, b);", {}, filename, true);
+            linter.reset();
+            linter.on("CallExpression", checker);
+            linter.verify("foo.apply(`test`, a, b);", {}, filename, true);
         });
 
         it("should return false if its a boolean", () => {
@@ -151,9 +152,9 @@ describe("ast-utils", () => {
                 assert.isFalse(astUtils.isNullOrUndefined(node.arguments[0]));
             }
 
-            eslint.reset();
-            eslint.on("CallExpression", checker);
-            eslint.verify("foo.apply(false, a, b);", {}, filename, true);
+            linter.reset();
+            linter.on("CallExpression", checker);
+            linter.verify("foo.apply(false, a, b);", {}, filename, true);
         });
 
         it("should return false if its an object", () => {
@@ -167,9 +168,9 @@ describe("ast-utils", () => {
                 assert.isFalse(astUtils.isNullOrUndefined(node.arguments[0]));
             }
 
-            eslint.reset();
-            eslint.on("CallExpression", checker);
-            eslint.verify("foo.apply({}, a, b);", {}, filename, true);
+            linter.reset();
+            linter.on("CallExpression", checker);
+            linter.verify("foo.apply({}, a, b);", {}, filename, true);
         });
 
         it("should return false if it's a unicode regex", () => {
@@ -188,14 +189,14 @@ describe("ast-utils", () => {
              * @returns {void}
              */
             function checker(node) {
-                const variables = eslint.getDeclaredVariables(node);
+                const variables = linter.getDeclaredVariables(node);
 
                 assert.lengthOf(astUtils.getModifyingReferences(variables[0].references), 1);
             }
 
-            eslint.reset();
-            eslint.on("CatchClause", checker);
-            eslint.verify("try { } catch (e) { e = 10; }", { rules: {} }, filename, true);
+            linter.reset();
+            linter.on("CatchClause", checker);
+            linter.verify("try { } catch (e) { e = 10; }", { rules: {} }, filename, true);
         });
 
         // const
@@ -207,14 +208,14 @@ describe("ast-utils", () => {
              * @returns {void}
              */
             function checker(node) {
-                const variables = eslint.getDeclaredVariables(node);
+                const variables = linter.getDeclaredVariables(node);
 
                 assert.lengthOf(astUtils.getModifyingReferences(variables[0].references), 1);
             }
 
-            eslint.reset();
-            eslint.on("VariableDeclaration", checker);
-            eslint.verify("const a = 1; a = 2;", {}, filename, true);
+            linter.reset();
+            linter.on("VariableDeclaration", checker);
+            linter.verify("const a = 1; a = 2;", {}, filename, true);
         });
 
         it("should return false if reference is not assigned for const", () => {
@@ -225,14 +226,14 @@ describe("ast-utils", () => {
              * @returns {void}
              */
             function checker(node) {
-                const variables = eslint.getDeclaredVariables(node);
+                const variables = linter.getDeclaredVariables(node);
 
                 assert.lengthOf(astUtils.getModifyingReferences(variables[0].references), 0);
             }
 
-            eslint.reset();
-            eslint.on("VariableDeclaration", checker);
-            eslint.verify("const a = 1; c = 2;", {}, filename, true);
+            linter.reset();
+            linter.on("VariableDeclaration", checker);
+            linter.verify("const a = 1; c = 2;", {}, filename, true);
         });
 
         // class
@@ -244,15 +245,15 @@ describe("ast-utils", () => {
              * @returns {void}
              */
             function checker(node) {
-                const variables = eslint.getDeclaredVariables(node);
+                const variables = linter.getDeclaredVariables(node);
 
                 assert.lengthOf(astUtils.getModifyingReferences(variables[0].references), 1);
                 assert.lengthOf(astUtils.getModifyingReferences(variables[1].references), 0);
             }
 
-            eslint.reset();
-            eslint.on("ClassDeclaration", checker);
-            eslint.verify("class A { }\n A = 1;", {}, filename, true);
+            linter.reset();
+            linter.on("ClassDeclaration", checker);
+            linter.verify("class A { }\n A = 1;", {}, filename, true);
         });
 
         it("should return false if reference is not assigned for class", () => {
@@ -263,14 +264,14 @@ describe("ast-utils", () => {
              * @returns {void}
              */
             function checker(node) {
-                const variables = eslint.getDeclaredVariables(node);
+                const variables = linter.getDeclaredVariables(node);
 
                 assert.lengthOf(astUtils.getModifyingReferences(variables[0].references), 0);
             }
 
-            eslint.reset();
-            eslint.on("ClassDeclaration", checker);
-            eslint.verify("class A { } foo(A);", {}, filename, true);
+            linter.reset();
+            linter.on("ClassDeclaration", checker);
+            linter.verify("class A { } foo(A);", {}, filename, true);
         });
     });
 
@@ -462,9 +463,9 @@ describe("ast-utils", () => {
         function assertNodeTypeInLoop(code, nodeType, expectedInLoop) {
             const results = [];
 
-            eslint.reset();
-            eslint.on(nodeType, node => results.push(astUtils.isInLoop(node)));
-            eslint.verify(code, { parserOptions: { ecmaVersion: 6 } }, filename, true);
+            linter.reset();
+            linter.on(nodeType, node => results.push(astUtils.isInLoop(node)));
+            linter.verify(code, { parserOptions: { ecmaVersion: 6 } }, filename, true);
 
             assert.lengthOf(results, 1);
             assert.equal(results[0], expectedInLoop);
@@ -803,10 +804,10 @@ describe("ast-utils", () => {
                     called = true;
                 }
 
-                eslint.on("FunctionDeclaration", verify);
-                eslint.on("FunctionExpression", verify);
-                eslint.on("ArrowFunctionExpression", verify);
-                eslint.verify(key, { parserOptions: { ecmaVersion: 8 } }, "test.js", true);
+                linter.on("FunctionDeclaration", verify);
+                linter.on("FunctionExpression", verify);
+                linter.on("ArrowFunctionExpression", verify);
+                linter.verify(key, { parserOptions: { ecmaVersion: 8 } }, "test.js", true);
 
                 assert(called);
             });
@@ -881,16 +882,16 @@ describe("ast-utils", () => {
                  */
                 function verify(node) {
                     assert.deepEqual(
-                        astUtils.getFunctionHeadLoc(node, eslint.getSourceCode()),
+                        astUtils.getFunctionHeadLoc(node, linter.getSourceCode()),
                         expectedLoc
                     );
                     called = true;
                 }
 
-                eslint.on("FunctionDeclaration", verify);
-                eslint.on("FunctionExpression", verify);
-                eslint.on("ArrowFunctionExpression", verify);
-                eslint.verify(key, { parserOptions: { ecmaVersion: 8 } }, "test.js", true);
+                linter.on("FunctionDeclaration", verify);
+                linter.on("FunctionExpression", verify);
+                linter.on("ArrowFunctionExpression", verify);
+                linter.verify(key, { parserOptions: { ecmaVersion: 8 } }, "test.js", true);
 
                 assert(called);
             });

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -19,8 +19,7 @@ const assert = require("chai").assert,
     leche = require("leche"),
     fs = require("fs"),
     os = require("os"),
-    sh = require("shelljs"),
-    rules = require("../../lib/rules");
+    sh = require("shelljs");
 
 const proxyquire = require("proxyquire").noCallThru().noPreserveCache();
 
@@ -92,7 +91,6 @@ describe("cli", () => {
 
     after(() => {
         sh.rm("-r", fixtureDir);
-        rules.testReset();
     });
 
     describe("execute()", () => {

--- a/tests/lib/code-path-analysis/code-path.js
+++ b/tests/lib/code-path-analysis/code-path.js
@@ -10,7 +10,8 @@
 //------------------------------------------------------------------------------
 
 const assert = require("assert"),
-    eslint = require("../../../lib/eslint");
+    Linter = require("../../../lib/linter");
+const linter = new Linter();
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -25,13 +26,13 @@ const assert = require("assert"),
 function parseCodePaths(code) {
     const retv = [];
 
-    eslint.reset();
-    eslint.defineRule("test", () => ({
+    linter.reset();
+    linter.defineRule("test", () => ({
         onCodePathStart(codePath) {
             retv.push(codePath);
         }
     }));
-    eslint.verify(code, { rules: { test: 2 } });
+    linter.verify(code, { rules: { test: 2 } });
 
     return retv;
 }

--- a/tests/lib/config/config-file.js
+++ b/tests/lib/config/config-file.js
@@ -17,10 +17,13 @@ const assert = require("chai").assert,
     userHome = require("user-home"),
     shell = require("shelljs"),
     environments = require("../../../conf/environments"),
-    ConfigFile = require("../../../lib/config/config-file");
+    ConfigFile = require("../../../lib/config/config-file"),
+    Linter = require("../../../lib/linter"),
+    Config = require("../../../lib/config");
 
 const temp = require("temp").track();
 const proxyquire = require("proxyquire").noCallThru().noPreserveCache();
+const configContext = new Config({}, new Linter());
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -170,7 +173,7 @@ describe("ConfigFile", () => {
             const config = StubbedConfigFile.applyExtends({
                 extends: "foo",
                 rules: { eqeqeq: 2 }
-            }, "/whatever");
+            }, configContext, "/whatever");
 
             assert.deepEqual(config, {
                 extends: "foo",
@@ -190,7 +193,7 @@ describe("ConfigFile", () => {
             const StubbedConfigFile = proxyquire("../../../lib/config/config-file", configDeps);
             const config = StubbedConfigFile.applyExtends({
                 extends: "eslint:all"
-            }, "/whatever");
+            }, configContext, "/whatever");
 
             assert.equal(config.rules.eqeqeq, "error");
             assert.equal(config.rules.curly, "error");
@@ -209,7 +212,7 @@ describe("ConfigFile", () => {
                 StubbedConfigFile.applyExtends({
                     extends: "foo",
                     rules: { eqeqeq: 2 }
-                }, "/whatever");
+                }, configContext, "/whatever");
             }, /Cannot find module 'eslint-config-foo'/);
 
         });
@@ -226,7 +229,7 @@ describe("ConfigFile", () => {
                 StubbedConfigFile.applyExtends({
                     extends: "eslint:foo",
                     rules: { eqeqeq: 2 }
-                }, "/whatever");
+                }, configContext, "/whatever");
             }, /Failed to load config "eslint:foo" to extend from./);
 
         });
@@ -257,7 +260,7 @@ describe("ConfigFile", () => {
                 StubbedConfigFile.applyExtends({
                     extends: "plugin:test/bar",
                     rules: { eqeqeq: 2 }
-                }, "/whatever");
+                }, configContext, "/whatever");
             }, /Cannot find module 'babel-eslint'/);
 
         });
@@ -286,7 +289,7 @@ describe("ConfigFile", () => {
                 StubbedConfigFile.applyExtends({
                     extends: "plugin:test/bar",
                     rules: { eqeqeq: 2 }
-                }, "/whatever");
+                }, configContext, "/whatever");
             }, /Failed to load config "plugin:test\/bar" to extend from./);
 
         });
@@ -325,7 +328,7 @@ describe("ConfigFile", () => {
             const config = StubbedConfigFile.applyExtends({
                 extends: "foo",
                 rules: { eqeqeq: 2 }
-            }, "/whatever");
+            }, configContext, "/whatever");
 
             assert.deepEqual(config, {
                 extends: "foo",
@@ -345,7 +348,7 @@ describe("ConfigFile", () => {
             const config = ConfigFile.applyExtends({
                 extends: ".eslintrc.js",
                 rules: { eqeqeq: 2 }
-            }, getFixturePath("js/foo.js"));
+            }, configContext, getFixturePath("js/foo.js"));
 
             assert.deepEqual(config, {
                 extends: ".eslintrc.js",
@@ -365,7 +368,7 @@ describe("ConfigFile", () => {
             const config = ConfigFile.applyExtends({
                 extends: ".eslintrc.yaml",
                 rules: { eqeqeq: 2 }
-            }, getFixturePath("yaml/foo.js"));
+            }, configContext, getFixturePath("yaml/foo.js"));
 
             assert.deepEqual(config, {
                 extends: ".eslintrc.yaml",
@@ -384,7 +387,7 @@ describe("ConfigFile", () => {
             const config = ConfigFile.applyExtends({
                 extends: ".eslintrc.json",
                 rules: { eqeqeq: 2 }
-            }, getFixturePath("json/foo.js"));
+            }, configContext, getFixturePath("json/foo.js"));
 
             assert.deepEqual(config, {
                 extends: ".eslintrc.json",
@@ -404,7 +407,7 @@ describe("ConfigFile", () => {
             const config = ConfigFile.applyExtends({
                 extends: "../package-json/package.json",
                 rules: { eqeqeq: 2 }
-            }, getFixturePath("json/foo.js"));
+            }, configContext, getFixturePath("json/foo.js"));
 
             assert.deepEqual(config, {
                 extends: "../package-json/package.json",
@@ -424,16 +427,16 @@ describe("ConfigFile", () => {
 
         it("should throw error if file doesnt exist", () => {
             assert.throws(() => {
-                ConfigFile.load(getFixturePath("legacy/nofile.js"));
+                ConfigFile.load(getFixturePath("legacy/nofile.js"), configContext);
             });
 
             assert.throws(() => {
-                ConfigFile.load(getFixturePath("legacy/package.json"));
+                ConfigFile.load(getFixturePath("legacy/package.json"), configContext);
             });
         });
 
         it("should load information from a legacy file", () => {
-            const config = ConfigFile.load(getFixturePath("legacy/.eslintrc"));
+            const config = ConfigFile.load(getFixturePath("legacy/.eslintrc"), configContext);
 
             assert.deepEqual(config, {
                 parserOptions: {},
@@ -446,7 +449,7 @@ describe("ConfigFile", () => {
         });
 
         it("should load information from a JavaScript file", () => {
-            const config = ConfigFile.load(getFixturePath("js/.eslintrc.js"));
+            const config = ConfigFile.load(getFixturePath("js/.eslintrc.js"), configContext);
 
             assert.deepEqual(config, {
                 parserOptions: {},
@@ -460,12 +463,12 @@ describe("ConfigFile", () => {
 
         it("should throw error when loading invalid JavaScript file", () => {
             assert.throws(() => {
-                ConfigFile.load(getFixturePath("js/.eslintrc.broken.js"));
+                ConfigFile.load(getFixturePath("js/.eslintrc.broken.js"), configContext);
             }, /Cannot read config file/);
         });
 
         it("should interpret parser module name when present in a JavaScript file", () => {
-            const config = ConfigFile.load(getFixturePath("js/.eslintrc.parser.js"));
+            const config = ConfigFile.load(getFixturePath("js/.eslintrc.parser.js"), configContext);
 
             assert.deepEqual(config, {
                 parser: path.resolve(getFixturePath("js/node_modules/foo/index.js")),
@@ -479,7 +482,7 @@ describe("ConfigFile", () => {
         });
 
         it("should interpret parser path when present in a JavaScript file", () => {
-            const config = ConfigFile.load(getFixturePath("js/.eslintrc.parser2.js"));
+            const config = ConfigFile.load(getFixturePath("js/.eslintrc.parser2.js"), configContext);
 
             assert.deepEqual(config, {
                 parser: path.resolve(getFixturePath("js/not-a-config.js")),
@@ -493,7 +496,7 @@ describe("ConfigFile", () => {
         });
 
         it("should interpret parser module name or path when parser is set to default parser in a JavaScript file", () => {
-            const config = ConfigFile.load(getFixturePath("js/.eslintrc.parser3.js"));
+            const config = ConfigFile.load(getFixturePath("js/.eslintrc.parser3.js"), configContext);
 
             assert.deepEqual(config, {
                 parser: require.resolve("espree"),
@@ -507,7 +510,7 @@ describe("ConfigFile", () => {
         });
 
         it("should load information from a JSON file", () => {
-            const config = ConfigFile.load(getFixturePath("json/.eslintrc.json"));
+            const config = ConfigFile.load(getFixturePath("json/.eslintrc.json"), configContext);
 
             assert.deepEqual(config, {
                 parserOptions: {},
@@ -538,16 +541,16 @@ describe("ConfigFile", () => {
                 },
                 tmpFilename = "fresh-test.json",
                 tmpFilePath = writeTempConfigFile(initialConfig, tmpFilename);
-            let config = ConfigFile.load(tmpFilePath);
+            let config = ConfigFile.load(tmpFilePath, configContext);
 
             assert.deepEqual(config, initialConfig);
             writeTempConfigFile(updatedConfig, tmpFilename, path.dirname(tmpFilePath));
-            config = ConfigFile.load(tmpFilePath);
+            config = ConfigFile.load(tmpFilePath, configContext);
             assert.deepEqual(config, updatedConfig);
         });
 
         it("should load information from a package.json file", () => {
-            const config = ConfigFile.load(getFixturePath("package-json/package.json"));
+            const config = ConfigFile.load(getFixturePath("package-json/package.json"), configContext);
 
             assert.deepEqual(config, {
                 parserOptions: {},
@@ -559,12 +562,12 @@ describe("ConfigFile", () => {
 
         it("should throw error when loading invalid package.json file", () => {
             assert.throws(() => {
-                ConfigFile.load(getFixturePath("broken-package-json/package.json"));
+                ConfigFile.load(getFixturePath("broken-package-json/package.json"), configContext);
             }, /Cannot read config file/);
         });
 
         it("should load information from a package.json file and apply environments", () => {
-            const config = ConfigFile.load(getFixturePath("package-json/package.json"), true);
+            const config = ConfigFile.load(getFixturePath("package-json/package.json"), configContext, true);
 
             assert.deepEqual(config, {
                 parserOptions: { ecmaVersion: 6 },
@@ -597,11 +600,11 @@ describe("ConfigFile", () => {
                 },
                 tmpFilename = "package.json",
                 tmpFilePath = writeTempConfigFile(initialConfig, tmpFilename);
-            let config = ConfigFile.load(tmpFilePath);
+            let config = ConfigFile.load(tmpFilePath, configContext);
 
             assert.deepEqual(config, initialConfig.eslintConfig);
             writeTempConfigFile(updatedConfig, tmpFilename, path.dirname(tmpFilePath));
-            config = ConfigFile.load(tmpFilePath);
+            config = ConfigFile.load(tmpFilePath, configContext);
             assert.deepEqual(config, updatedConfig.eslintConfig);
         });
 
@@ -624,16 +627,16 @@ describe("ConfigFile", () => {
                 },
                 tmpFilename = ".eslintrc.js",
                 tmpFilePath = writeTempJsConfigFile(initialConfig, tmpFilename);
-            let config = ConfigFile.load(tmpFilePath);
+            let config = ConfigFile.load(tmpFilePath, configContext);
 
             assert.deepEqual(config, initialConfig);
             writeTempJsConfigFile(updatedConfig, tmpFilename, path.dirname(tmpFilePath));
-            config = ConfigFile.load(tmpFilePath);
+            config = ConfigFile.load(tmpFilePath, configContext);
             assert.deepEqual(config, updatedConfig);
         });
 
         it("should load information from a YAML file", () => {
-            const config = ConfigFile.load(getFixturePath("yaml/.eslintrc.yaml"));
+            const config = ConfigFile.load(getFixturePath("yaml/.eslintrc.yaml"), configContext);
 
             assert.deepEqual(config, {
                 parserOptions: {},
@@ -644,7 +647,7 @@ describe("ConfigFile", () => {
         });
 
         it("should load information from a YAML file", () => {
-            const config = ConfigFile.load(getFixturePath("yaml/.eslintrc.empty.yaml"));
+            const config = ConfigFile.load(getFixturePath("yaml/.eslintrc.empty.yaml"), configContext);
 
             assert.deepEqual(config, {
                 parserOptions: {},
@@ -655,7 +658,7 @@ describe("ConfigFile", () => {
         });
 
         it("should load information from a YAML file and apply environments", () => {
-            const config = ConfigFile.load(getFixturePath("yaml/.eslintrc.yaml"), true);
+            const config = ConfigFile.load(getFixturePath("yaml/.eslintrc.yaml"), configContext, true);
 
             assert.deepEqual(config, {
                 parserOptions: {},
@@ -666,7 +669,7 @@ describe("ConfigFile", () => {
         });
 
         it("should load information from a YML file", () => {
-            const config = ConfigFile.load(getFixturePath("yml/.eslintrc.yml"));
+            const config = ConfigFile.load(getFixturePath("yml/.eslintrc.yml"), configContext);
 
             assert.deepEqual(config, {
                 parserOptions: {},
@@ -677,7 +680,7 @@ describe("ConfigFile", () => {
         });
 
         it("should load information from a YML file and apply environments", () => {
-            const config = ConfigFile.load(getFixturePath("yml/.eslintrc.yml"), true);
+            const config = ConfigFile.load(getFixturePath("yml/.eslintrc.yml"), configContext, true);
 
             assert.deepEqual(config, {
                 parserOptions: { ecmaFeatures: { globalReturn: true } },
@@ -688,7 +691,7 @@ describe("ConfigFile", () => {
         });
 
         it("should load information from a YML file and apply extensions", () => {
-            const config = ConfigFile.load(getFixturePath("extends/.eslintrc.yml"), true);
+            const config = ConfigFile.load(getFixturePath("extends/.eslintrc.yml"), configContext, true);
 
             assert.deepEqual(config, {
                 extends: "../package-json/package.json",
@@ -700,7 +703,7 @@ describe("ConfigFile", () => {
         });
 
         it("should load information from `extends` chain.", () => {
-            const config = ConfigFile.load(getFixturePath("extends-chain/.eslintrc.json"));
+            const config = ConfigFile.load(getFixturePath("extends-chain/.eslintrc.json"), configContext);
 
             assert.deepEqual(config, {
                 env: {},
@@ -716,7 +719,7 @@ describe("ConfigFile", () => {
         });
 
         it("should load information from `extends` chain with relative path.", () => {
-            const config = ConfigFile.load(getFixturePath("extends-chain-2/.eslintrc.json"));
+            const config = ConfigFile.load(getFixturePath("extends-chain-2/.eslintrc.json"), configContext);
 
             assert.deepEqual(config, {
                 env: {},
@@ -731,7 +734,7 @@ describe("ConfigFile", () => {
         });
 
         it("should load information from `extends` chain in .eslintrc with relative path.", () => {
-            const config = ConfigFile.load(getFixturePath("extends-chain-2/relative.eslintrc.json"));
+            const config = ConfigFile.load(getFixturePath("extends-chain-2/relative.eslintrc.json"), configContext);
 
             assert.deepEqual(config, {
                 env: {},
@@ -746,7 +749,7 @@ describe("ConfigFile", () => {
         });
 
         it("should load information from `parser` in .eslintrc with relative path.", () => {
-            const config = ConfigFile.load(getFixturePath("extends-chain-2/parser.eslintrc.json"));
+            const config = ConfigFile.load(getFixturePath("extends-chain-2/parser.eslintrc.json"), configContext);
             const parserPath = getFixturePath("extends-chain-2/parser.js");
 
             assert.deepEqual(config, {
@@ -774,7 +777,7 @@ describe("ConfigFile", () => {
             });
 
             it("should load information from `extends` chain in .eslintrc with relative path.", () => {
-                const config = ConfigFile.load(path.join(fixturePath, "relative.eslintrc.json"));
+                const config = ConfigFile.load(path.join(fixturePath, "relative.eslintrc.json"), configContext);
 
                 assert.deepEqual(config, {
                     env: {},
@@ -789,7 +792,7 @@ describe("ConfigFile", () => {
             });
 
             it("should load information from `parser` in .eslintrc with relative path.", () => {
-                const config = ConfigFile.load(path.join(fixturePath, "parser.eslintrc.json"));
+                const config = ConfigFile.load(path.join(fixturePath, "parser.eslintrc.json"), configContext);
                 const parserPath = path.join(fixturePath, "parser.js");
 
                 assert.deepEqual(config, {
@@ -806,19 +809,15 @@ describe("ConfigFile", () => {
 
             it("should load information from a YML file and load plugins", () => {
 
-                const StubbedPlugins = proxyquire("../../../lib/config/plugins", {
-                    "eslint-plugin-test": {
-                        environments: {
-                            bar: { globals: { bar: true } }
-                        }
+                const stubConfig = new Config({}, new Linter());
+
+                stubConfig.plugins.define("eslint-plugin-test", {
+                    environments: {
+                        bar: { globals: { bar: true } }
                     }
                 });
 
-                const StubbedConfigFile = proxyquire("../../../lib/config/config-file", {
-                    "./plugins": StubbedPlugins
-                });
-
-                const config = StubbedConfigFile.load(getFixturePath("plugins/.eslintrc.yml"));
+                const config = ConfigFile.load(getFixturePath("plugins/.eslintrc.yml"), stubConfig);
 
                 assert.deepEqual(config, {
                     parserOptions: {},
@@ -834,7 +833,7 @@ describe("ConfigFile", () => {
 
         describe("even if config files have Unicode BOM,", () => {
             it("should read the JSON config file correctly.", () => {
-                const config = ConfigFile.load(getFixturePath("bom/.eslintrc.json"));
+                const config = ConfigFile.load(getFixturePath("bom/.eslintrc.json"), configContext);
 
                 assert.deepEqual(config, {
                     env: {},
@@ -847,7 +846,7 @@ describe("ConfigFile", () => {
             });
 
             it("should read the YAML config file correctly.", () => {
-                const config = ConfigFile.load(getFixturePath("bom/.eslintrc.yaml"));
+                const config = ConfigFile.load(getFixturePath("bom/.eslintrc.yaml"), configContext);
 
                 assert.deepEqual(config, {
                     env: {},
@@ -860,7 +859,7 @@ describe("ConfigFile", () => {
             });
 
             it("should read the config in package.json correctly.", () => {
-                const config = ConfigFile.load(getFixturePath("bom/package.json"));
+                const config = ConfigFile.load(getFixturePath("bom/package.json"), configContext);
 
                 assert.deepEqual(config, {
                     env: {},

--- a/tests/lib/config/config-ops.js
+++ b/tests/lib/config/config-ops.js
@@ -11,9 +11,10 @@
 const assert = require("chai").assert,
     leche = require("leche"),
     environments = require("../../../conf/environments"),
+    Environments = require("../../../lib/config/environments"),
     ConfigOps = require("../../../lib/config/config-ops");
 
-const proxyquire = require("proxyquire").noCallThru().noPreserveCache();
+const envContext = new Environments();
 
 //------------------------------------------------------------------------------
 // Tests
@@ -32,7 +33,7 @@ describe("ConfigOps", () => {
                 }
             };
 
-            const result = ConfigOps.applyEnvironments(config);
+            const result = ConfigOps.applyEnvironments(config, envContext);
 
             assert.deepEqual(result, {
                 env: config.env,
@@ -51,7 +52,7 @@ describe("ConfigOps", () => {
                 }
             };
 
-            const result = ConfigOps.applyEnvironments(config);
+            const result = ConfigOps.applyEnvironments(config, envContext);
 
             assert.equal(result, config);
         });
@@ -67,7 +68,7 @@ describe("ConfigOps", () => {
                 }
             };
 
-            const result = ConfigOps.applyEnvironments(config);
+            const result = ConfigOps.applyEnvironments(config, envContext);
 
             assert.deepEqual(result, {
                 env: config.env,
@@ -84,7 +85,7 @@ describe("ConfigOps", () => {
     describe("createEnvironmentConfig()", () => {
 
         it("should return empty config if called without any config", () => {
-            const config = ConfigOps.createEnvironmentConfig(null);
+            const config = ConfigOps.createEnvironmentConfig(null, envContext);
 
             assert.deepEqual(config, {
                 globals: {},
@@ -95,19 +96,7 @@ describe("ConfigOps", () => {
         });
 
         it("should return correct config for env with no globals", () => {
-            const StubbedConfigOps = proxyquire("../../../lib/config/config-ops", {
-                "./environments": {
-                    get() {
-                        return {
-                            parserOptions: {
-                                sourceType: "module"
-                            }
-                        };
-                    }
-                }
-            });
-
-            const config = StubbedConfigOps.createEnvironmentConfig({ test: true });
+            const config = ConfigOps.createEnvironmentConfig({ test: true }, new Environments());
 
             assert.deepEqual(config, {
                 globals: {},
@@ -115,14 +104,12 @@ describe("ConfigOps", () => {
                     test: true
                 },
                 rules: {},
-                parserOptions: {
-                    sourceType: "module"
-                }
+                parserOptions: {}
             });
         });
 
         it("should create the correct config for Node.js environment", () => {
-            const config = ConfigOps.createEnvironmentConfig({ node: true });
+            const config = ConfigOps.createEnvironmentConfig({ node: true }, envContext);
 
             assert.deepEqual(config, {
                 env: {
@@ -137,7 +124,7 @@ describe("ConfigOps", () => {
         });
 
         it("should create the correct config for ES6 environment", () => {
-            const config = ConfigOps.createEnvironmentConfig({ es6: true });
+            const config = ConfigOps.createEnvironmentConfig({ es6: true }, envContext);
 
             assert.deepEqual(config, {
                 env: {
@@ -152,7 +139,7 @@ describe("ConfigOps", () => {
         });
 
         it("should create empty config when no environments are specified", () => {
-            const config = ConfigOps.createEnvironmentConfig({});
+            const config = ConfigOps.createEnvironmentConfig({}, envContext);
 
             assert.deepEqual(config, {
                 env: {},
@@ -163,7 +150,7 @@ describe("ConfigOps", () => {
         });
 
         it("should create empty config when an unknown environment is specified", () => {
-            const config = ConfigOps.createEnvironmentConfig({ foo: true });
+            const config = ConfigOps.createEnvironmentConfig({ foo: true }, envContext);
 
             assert.deepEqual(config, {
                 env: {

--- a/tests/lib/config/config-validator.js
+++ b/tests/lib/config/config-validator.js
@@ -10,8 +10,9 @@
 //------------------------------------------------------------------------------
 
 const assert = require("chai").assert,
-    eslint = require("../../../lib/eslint"),
+    Linter = require("../../../lib/linter"),
     validator = require("../../../lib/config/config-validator");
+const linter = new Linter();
 
 //------------------------------------------------------------------------------
 // Tests
@@ -90,14 +91,14 @@ const mockRequiredOptionsRule = {
 describe("Validator", () => {
 
     beforeEach(() => {
-        eslint.defineRule("mock-rule", mockRule);
-        eslint.defineRule("mock-required-options-rule", mockRequiredOptionsRule);
+        linter.defineRule("mock-rule", mockRule);
+        linter.defineRule("mock-required-options-rule", mockRequiredOptionsRule);
     });
 
     describe("validate", () => {
 
         it("should do nothing with an empty config", () => {
-            const fn = validator.validate.bind(null, {}, "tests");
+            const fn = validator.validate.bind(null, {}, "tests", linter.rules, linter.environments);
 
             assert.doesNotThrow(fn);
         });
@@ -115,7 +116,10 @@ describe("Validator", () => {
                     parserOptions: { foo: "bar" },
                     rules: {}
                 },
-                "tests");
+                "tests",
+                linter.rules,
+                linter.environments
+            );
 
             assert.doesNotThrow(fn);
         });
@@ -125,20 +129,23 @@ describe("Validator", () => {
                 {
                     foo: true
                 },
-                "tests");
+                "tests",
+                linter.rules,
+                linter.environments
+            );
 
             assert.throws(fn, "Unexpected top-level property \"foo\".");
         });
 
         describe("root", () => {
             it("should throw with a string value", () => {
-                const fn = validator.validate.bind(null, { root: "true" });
+                const fn = validator.validate.bind(null, { root: "true" }, null, linter.rules, linter.environments);
 
                 assert.throws(fn, "Property \"root\" is the wrong type (expected boolean but got `\"true\"`).");
             });
 
             it("should throw with a numeric value", () => {
-                const fn = validator.validate.bind(null, { root: 0 });
+                const fn = validator.validate.bind(null, { root: 0 }, null, linter.rules, linter.environments);
 
                 assert.throws(fn, "Property \"root\" is the wrong type (expected boolean but got `0`).");
             });
@@ -146,13 +153,13 @@ describe("Validator", () => {
 
         describe("globals", () => {
             it("should throw with a string value", () => {
-                const fn = validator.validate.bind(null, { globals: "jQuery" });
+                const fn = validator.validate.bind(null, { globals: "jQuery" }, null, linter.rules, linter.environments);
 
                 assert.throws(fn, "Property \"globals\" is the wrong type (expected object but got `\"jQuery\"`).");
             });
 
             it("should throw with an array value", () => {
-                const fn = validator.validate.bind(null, { globals: ["jQuery"] });
+                const fn = validator.validate.bind(null, { globals: ["jQuery"] }, null, linter.rules, linter.environments);
 
                 assert.throws(fn, "Property \"globals\" is the wrong type (expected object but got `[\"jQuery\"]`).");
             });
@@ -160,7 +167,7 @@ describe("Validator", () => {
 
         describe("parser", () => {
             it("should not throw with a null value", () => {
-                const fn = validator.validate.bind(null, { parser: null });
+                const fn = validator.validate.bind(null, { parser: null }, null, linter.rules, linter.environments);
 
                 assert.doesNotThrow(fn);
             });
@@ -169,31 +176,31 @@ describe("Validator", () => {
         describe("env", () => {
 
             it("should throw with an array environment", () => {
-                const fn = validator.validate.bind(null, { env: [] });
+                const fn = validator.validate.bind(null, { env: [] }, null, linter.rules, linter.environments);
 
                 assert.throws(fn, "Property \"env\" is the wrong type (expected object but got `[]`).");
             });
 
             it("should throw with a primitive environment", () => {
-                const fn = validator.validate.bind(null, { env: 1 });
+                const fn = validator.validate.bind(null, { env: 1 }, null, linter.rules, linter.environments);
 
                 assert.throws(fn, "Property \"env\" is the wrong type (expected object but got `1`).");
             });
 
             it("should catch invalid environments", () => {
-                const fn = validator.validate.bind(null, { env: { browser: true, invalid: true } });
+                const fn = validator.validate.bind(null, { env: { browser: true, invalid: true } }, null, linter.rules, linter.environments);
 
                 assert.throws(fn, "Environment key \"invalid\" is unknown\n");
             });
 
             it("should catch disabled invalid environments", () => {
-                const fn = validator.validate.bind(null, { env: { browser: true, invalid: false } });
+                const fn = validator.validate.bind(null, { env: { browser: true, invalid: false } }, null, linter.rules, linter.environments);
 
                 assert.throws(fn, "Environment key \"invalid\" is unknown\n");
             });
 
             it("should do nothing with an undefined environment", () => {
-                const fn = validator.validate.bind(null, {});
+                const fn = validator.validate.bind(null, {}, null, linter.rules, linter.environments);
 
                 assert.doesNotThrow(fn);
             });
@@ -202,13 +209,13 @@ describe("Validator", () => {
 
         describe("plugins", () => {
             it("should not throw with an empty array", () => {
-                const fn = validator.validate.bind(null, { plugins: [] });
+                const fn = validator.validate.bind(null, { plugins: [] }, null, linter.rules, linter.environments);
 
                 assert.doesNotThrow(fn);
             });
 
             it("should throw with a string", () => {
-                const fn = validator.validate.bind(null, { plugins: "react" });
+                const fn = validator.validate.bind(null, { plugins: "react" }, null, linter.rules, linter.environments);
 
                 assert.throws(fn, "Property \"plugins\" is the wrong type (expected array but got `\"react\"`).");
             });
@@ -216,13 +223,13 @@ describe("Validator", () => {
 
         describe("settings", () => {
             it("should not throw with an empty object", () => {
-                const fn = validator.validate.bind(null, { settings: {} });
+                const fn = validator.validate.bind(null, { settings: {} }, null, linter.rules, linter.environments);
 
                 assert.doesNotThrow(fn);
             });
 
             it("should throw with an array", () => {
-                const fn = validator.validate.bind(null, { settings: ["foo"] });
+                const fn = validator.validate.bind(null, { settings: ["foo"] }, null, linter.rules, linter.environments);
 
                 assert.throws(fn, "Property \"settings\" is the wrong type (expected object but got `[\"foo\"]`).");
             });
@@ -230,19 +237,19 @@ describe("Validator", () => {
 
         describe("extends", () => {
             it("should not throw with an empty array", () => {
-                const fn = validator.validate.bind(null, { extends: [] });
+                const fn = validator.validate.bind(null, { extends: [] }, null, linter.rules, linter.environments);
 
                 assert.doesNotThrow(fn);
             });
 
             it("should not throw with a string", () => {
-                const fn = validator.validate.bind(null, { extends: "react" });
+                const fn = validator.validate.bind(null, { extends: "react" }, null, linter.rules, linter.environments);
 
                 assert.doesNotThrow(fn);
             });
 
             it("should throw with an object", () => {
-                const fn = validator.validate.bind(null, { extends: {} });
+                const fn = validator.validate.bind(null, { extends: {} }, null, linter.rules, linter.environments);
 
                 assert.throws(fn, "Property \"extends\" is the wrong type (expected string/array but got `{}`).");
             });
@@ -250,13 +257,13 @@ describe("Validator", () => {
 
         describe("parserOptions", () => {
             it("should not throw with an empty object", () => {
-                const fn = validator.validate.bind(null, { parserOptions: {} });
+                const fn = validator.validate.bind(null, { parserOptions: {} }, null, linter.rules, linter.environments);
 
                 assert.doesNotThrow(fn);
             });
 
             it("should throw with an array", () => {
-                const fn = validator.validate.bind(null, { parserOptions: ["foo"] });
+                const fn = validator.validate.bind(null, { parserOptions: ["foo"] }, null, linter.rules, linter.environments);
 
                 assert.throws(fn, "Property \"parserOptions\" is the wrong type (expected object but got `[\"foo\"]`).");
             });
@@ -265,83 +272,83 @@ describe("Validator", () => {
         describe("rules", () => {
 
             it("should do nothing with an empty rules object", () => {
-                const fn = validator.validate.bind(null, { rules: {} }, "tests");
+                const fn = validator.validate.bind(null, { rules: {} }, "tests", linter.rules, linter.environments);
 
                 assert.doesNotThrow(fn);
             });
 
             it("should do nothing with a valid config with rules", () => {
-                const fn = validator.validate.bind(null, { rules: { "mock-rule": [2, "second"] } }, "tests");
+                const fn = validator.validate.bind(null, { rules: { "mock-rule": [2, "second"] } }, "tests", linter.rules, linter.environments);
 
                 assert.doesNotThrow(fn);
             });
 
             it("should do nothing with a valid config when severity is off", () => {
-                const fn = validator.validate.bind(null, { rules: { "mock-rule": ["off", "second"] } }, "tests");
+                const fn = validator.validate.bind(null, { rules: { "mock-rule": ["off", "second"] } }, "tests", linter.rules, linter.environments);
 
                 assert.doesNotThrow(fn);
             });
 
             it("should do nothing with an invalid config when severity is off", () => {
-                const fn = validator.validate.bind(null, { rules: { "mock-required-options-rule": "off" } }, "tests");
+                const fn = validator.validate.bind(null, { rules: { "mock-required-options-rule": "off" } }, "tests", linter.rules, linter.environments);
 
                 assert.doesNotThrow(fn);
             });
 
             it("should do nothing with an invalid config when severity is an array with 'off'", () => {
-                const fn = validator.validate.bind(null, { rules: { "mock-required-options-rule": ["off"] } }, "tests");
+                const fn = validator.validate.bind(null, { rules: { "mock-required-options-rule": ["off"] } }, "tests", linter.rules, linter.environments);
 
                 assert.doesNotThrow(fn);
             });
 
             it("should do nothing with a valid config when severity is warn", () => {
-                const fn = validator.validate.bind(null, { rules: { "mock-rule": ["warn", "second"] } }, "tests");
+                const fn = validator.validate.bind(null, { rules: { "mock-rule": ["warn", "second"] } }, "tests", linter.rules, linter.environments);
 
                 assert.doesNotThrow(fn);
             });
 
             it("should do nothing with a valid config when severity is error", () => {
-                const fn = validator.validate.bind(null, { rules: { "mock-rule": ["error", "second"] } }, "tests");
+                const fn = validator.validate.bind(null, { rules: { "mock-rule": ["error", "second"] } }, "tests", linter.rules, linter.environments);
 
                 assert.doesNotThrow(fn);
             });
 
             it("should do nothing with a valid config when severity is Off", () => {
-                const fn = validator.validate.bind(null, { rules: { "mock-rule": ["Off", "second"] } }, "tests");
+                const fn = validator.validate.bind(null, { rules: { "mock-rule": ["Off", "second"] } }, "tests", linter.rules, linter.environments);
 
                 assert.doesNotThrow(fn);
             });
 
             it("should do nothing with a valid config when severity is Warn", () => {
-                const fn = validator.validate.bind(null, { rules: { "mock-rule": ["Warn", "second"] } }, "tests");
+                const fn = validator.validate.bind(null, { rules: { "mock-rule": ["Warn", "second"] } }, "tests", linter.rules, linter.environments);
 
                 assert.doesNotThrow(fn);
             });
 
             it("should do nothing with a valid config when severity is Error", () => {
-                const fn = validator.validate.bind(null, { rules: { "mock-rule": ["Error", "second"] } }, "tests");
+                const fn = validator.validate.bind(null, { rules: { "mock-rule": ["Error", "second"] } }, "tests", linter.rules, linter.environments);
 
                 assert.doesNotThrow(fn);
             });
 
             it("should catch invalid rule options", () => {
-                const fn = validator.validate.bind(null, { rules: { "mock-rule": [3, "third"] } }, "tests");
+                const fn = validator.validate.bind(null, { rules: { "mock-rule": [3, "third"] } }, "tests", linter.rules, linter.environments);
 
                 assert.throws(fn, "tests:\n\tConfiguration for rule \"mock-rule\" is invalid:\n\tSeverity should be one of the following: 0 = off, 1 = warn, 2 = error (you passed '3').\n");
             });
 
             it("should allow for rules with no options", () => {
-                eslint.defineRule("mock-no-options-rule", mockNoOptionsRule);
+                linter.defineRule("mock-no-options-rule", mockNoOptionsRule);
 
-                const fn = validator.validate.bind(null, { rules: { "mock-no-options-rule": 2 } }, "tests");
+                const fn = validator.validate.bind(null, { rules: { "mock-no-options-rule": 2 } }, "tests", linter.rules, linter.environments);
 
                 assert.doesNotThrow(fn);
             });
 
             it("should not allow options for rules with no options", () => {
-                eslint.defineRule("mock-no-options-rule", mockNoOptionsRule);
+                linter.defineRule("mock-no-options-rule", mockNoOptionsRule);
 
-                const fn = validator.validate.bind(null, { rules: { "mock-no-options-rule": [2, "extra"] } }, "tests");
+                const fn = validator.validate.bind(null, { rules: { "mock-no-options-rule": [2, "extra"] } }, "tests", linter.rules, linter.environments);
 
                 assert.throws(fn, "tests:\n\tConfiguration for rule \"mock-no-options-rule\" is invalid:\n\tValue \"extra\" has more items than allowed.\n");
             });
@@ -352,12 +359,12 @@ describe("Validator", () => {
     describe("getRuleOptionsSchema", () => {
 
         it("should return null for a missing rule", () => {
-            assert.equal(validator.getRuleOptionsSchema("non-existent-rule"), null);
+            assert.equal(validator.getRuleOptionsSchema("non-existent-rule", linter.rules), null);
         });
 
         it("should not modify object schema", () => {
-            eslint.defineRule("mock-object-rule", mockObjectRule);
-            assert.deepEqual(validator.getRuleOptionsSchema("mock-object-rule"), {
+            linter.defineRule("mock-object-rule", mockObjectRule);
+            assert.deepEqual(validator.getRuleOptionsSchema("mock-object-rule", linter.rules), {
                 enum: ["first", "second"]
             });
         });
@@ -367,43 +374,43 @@ describe("Validator", () => {
     describe("validateRuleOptions", () => {
 
         it("should throw for incorrect warning level number", () => {
-            const fn = validator.validateRuleOptions.bind(null, "mock-rule", 3, "tests");
+            const fn = validator.validateRuleOptions.bind(null, "mock-rule", 3, "tests", linter.rules);
 
             assert.throws(fn, "tests:\n\tConfiguration for rule \"mock-rule\" is invalid:\n\tSeverity should be one of the following: 0 = off, 1 = warn, 2 = error (you passed '3').\n");
         });
 
         it("should throw for incorrect warning level string", () => {
-            const fn = validator.validateRuleOptions.bind(null, "mock-rule", "booya", "tests");
+            const fn = validator.validateRuleOptions.bind(null, "mock-rule", "booya", "tests", linter.rules);
 
             assert.throws(fn, "tests:\n\tConfiguration for rule \"mock-rule\" is invalid:\n\tSeverity should be one of the following: 0 = off, 1 = warn, 2 = error (you passed '\"booya\"').\n");
         });
 
         it("should throw for invalid-type warning level", () => {
-            const fn = validator.validateRuleOptions.bind(null, "mock-rule", [["error"]], "tests");
+            const fn = validator.validateRuleOptions.bind(null, "mock-rule", [["error"]], "tests", linter.rules);
 
             assert.throws(fn, "tests:\n\tConfiguration for rule \"mock-rule\" is invalid:\n\tSeverity should be one of the following: 0 = off, 1 = warn, 2 = error (you passed '[ \"error\" ]').\n");
         });
 
         it("should only check warning level for nonexistent rules", () => {
-            const fn = validator.validateRuleOptions.bind(null, "non-existent-rule", [3, "foobar"], "tests");
+            const fn = validator.validateRuleOptions.bind(null, "non-existent-rule", [3, "foobar"], "tests", linter.rules);
 
             assert.throws(fn, "tests:\n\tConfiguration for rule \"non-existent-rule\" is invalid:\n\tSeverity should be one of the following: 0 = off, 1 = warn, 2 = error (you passed '3').\n");
         });
 
         it("should only check warning level for plugin rules", () => {
-            const fn = validator.validateRuleOptions.bind(null, "plugin/rule", 3, "tests");
+            const fn = validator.validateRuleOptions.bind(null, "plugin/rule", 3, "tests", linter.rules);
 
             assert.throws(fn, "tests:\n\tConfiguration for rule \"plugin/rule\" is invalid:\n\tSeverity should be one of the following: 0 = off, 1 = warn, 2 = error (you passed '3').\n");
         });
 
         it("should throw for incorrect configuration values", () => {
-            const fn = validator.validateRuleOptions.bind(null, "mock-rule", [2, "frist"], "tests");
+            const fn = validator.validateRuleOptions.bind(null, "mock-rule", [2, "frist"], "tests", linter.rules);
 
             assert.throws(fn, "tests:\n\tConfiguration for rule \"mock-rule\" is invalid:\n\tValue \"frist\" must be an enum value.\n");
         });
 
         it("should throw for too many configuration values", () => {
-            const fn = validator.validateRuleOptions.bind(null, "mock-rule", [2, "first", "second"], "tests");
+            const fn = validator.validateRuleOptions.bind(null, "mock-rule", [2, "first", "second"], "tests", linter.rules);
 
             assert.throws(fn, "tests:\n\tConfiguration for rule \"mock-rule\" is invalid:\n\tValue \"first,second\" has more items than allowed.\n");
         });

--- a/tests/lib/config/environments.js
+++ b/tests/lib/config/environments.js
@@ -17,47 +17,34 @@ const assert = require("chai").assert,
 //------------------------------------------------------------------------------
 
 describe("Environments", () => {
+    let environments = null;
+
+    beforeEach(() => {
+        environments = new Environments();
+    });
 
     describe("load()", () => {
 
         it("should have all default environments loaded", () => {
             Object.keys(envs).forEach(envName => {
-                assert.deepEqual(Environments.get(envName), envs[envName]);
-            });
-        });
-
-        it("should have all default environments loaded after being cleared", () => {
-            Environments.testReset();
-
-            Object.keys(envs).forEach(envName => {
-                assert.deepEqual(Environments.get(envName), envs[envName]);
+                assert.deepEqual(environments.get(envName), envs[envName]);
             });
         });
     });
 
     describe("define()", () => {
-
-        afterEach(() => {
-            Environments.testReset();
-        });
-
         it("should add an environment with the given name", () => {
             const env = { globals: { foo: true } };
 
-            Environments.define("foo", env);
+            environments.define("foo", env);
 
-            const result = Environments.get("foo");
+            const result = environments.get("foo");
 
             assert.deepEqual(result, env);
         });
     });
 
     describe("importPlugin()", () => {
-
-        afterEach(() => {
-            Environments.testReset();
-        });
-
         it("should import all environments from a plugin object", () => {
             const plugin = {
                 environments: {
@@ -70,15 +57,13 @@ describe("Environments", () => {
                 }
             };
 
-            Environments.importPlugin(plugin, "plugin");
+            environments.importPlugin(plugin, "plugin");
 
-            const fooEnv = Environments.get("plugin/foo"),
-                barEnv = Environments.get("plugin/bar");
+            const fooEnv = environments.get("plugin/foo"),
+                barEnv = environments.get("plugin/bar");
 
             assert.deepEqual(fooEnv, plugin.environments.foo);
             assert.deepEqual(barEnv, plugin.environments.bar);
         });
     });
-
-
 });

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -34,7 +34,8 @@ function compatRequire(name, windowName) {
 const assert = compatRequire("chai").assert,
     sinon = compatRequire("sinon"),
     path = compatRequire("path"),
-    eslint = compatRequire("../../lib/eslint", "eslint");
+    Rules = compatRequire("../../lib/rules", "rules"),
+    Linter = compatRequire("../../lib/linter", "eslint");
 
 //------------------------------------------------------------------------------
 // Constants
@@ -42,6 +43,8 @@ const assert = compatRequire("chai").assert,
 
 const TEST_CODE = "var answer = 6 * 7;",
     BROKEN_TEST_CODE = "var;";
+
+const linter = new Linter();
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -80,7 +83,8 @@ describe("eslint", () => {
     });
 
     afterEach(() => {
-        eslint.reset();
+        linter.reset();
+        linter.rules = new Rules();
         sandbox.verifyAndRestore();
     });
 
@@ -90,13 +94,13 @@ describe("eslint", () => {
         it("an error should be thrown when an error occurs inside of an event handler", () => {
             const config = { rules: {} };
 
-            eslint.reset();
-            eslint.on("Program", () => {
+            linter.reset();
+            linter.on("Program", () => {
                 throw new Error("Intentional error.");
             });
 
             assert.throws(() => {
-                eslint.verify(code, config, filename, true);
+                linter.verify(code, config, filename, true);
             }, Error);
         });
     });
@@ -106,9 +110,9 @@ describe("eslint", () => {
         it("should get proper lines when using \\n as a line break", () => {
             const code = "a;\nb;";
 
-            eslint.verify(code, {}, filename, true);
+            linter.verify(code, {}, filename, true);
 
-            const lines = eslint.getSourceLines();
+            const lines = linter.getSourceLines();
 
             assert.equal(lines[0], "a;");
             assert.equal(lines[1], "b;");
@@ -117,9 +121,9 @@ describe("eslint", () => {
         it("should get proper lines when using \\r\\n as a line break", () => {
             const code = "a;\r\nb;";
 
-            eslint.verify(code, {}, filename, true);
+            linter.verify(code, {}, filename, true);
 
-            const lines = eslint.getSourceLines();
+            const lines = linter.getSourceLines();
 
             assert.equal(lines[0], "a;");
             assert.equal(lines[1], "b;");
@@ -128,9 +132,9 @@ describe("eslint", () => {
         it("should get proper lines when using \\r as a line break", () => {
             const code = "a;\rb;";
 
-            eslint.verify(code, {}, filename, true);
+            linter.verify(code, {}, filename, true);
 
-            const lines = eslint.getSourceLines();
+            const lines = linter.getSourceLines();
 
             assert.equal(lines[0], "a;");
             assert.equal(lines[1], "b;");
@@ -139,9 +143,9 @@ describe("eslint", () => {
         it("should get proper lines when using \\u2028 as a line break", () => {
             const code = "a;\u2028b;";
 
-            eslint.verify(code, {}, filename, true);
+            linter.verify(code, {}, filename, true);
 
-            const lines = eslint.getSourceLines();
+            const lines = linter.getSourceLines();
 
             assert.equal(lines[0], "a;");
             assert.equal(lines[1], "b;");
@@ -150,9 +154,9 @@ describe("eslint", () => {
         it("should get proper lines when using \\u2029 as a line break", () => {
             const code = "a;\u2029b;";
 
-            eslint.verify(code, {}, filename, true);
+            linter.verify(code, {}, filename, true);
 
-            const lines = eslint.getSourceLines();
+            const lines = linter.getSourceLines();
 
             assert.equal(lines[0], "a;");
             assert.equal(lines[1], "b;");
@@ -165,10 +169,10 @@ describe("eslint", () => {
         const code = TEST_CODE;
 
         it("should retrieve SourceCode object after reset", () => {
-            eslint.reset();
-            eslint.verify(code, {}, filename, true);
+            linter.reset();
+            linter.verify(code, {}, filename, true);
 
-            const sourceCode = eslint.getSourceCode();
+            const sourceCode = linter.getSourceCode();
 
             assert.isObject(sourceCode);
             assert.equal(sourceCode.text, code);
@@ -176,10 +180,10 @@ describe("eslint", () => {
         });
 
         it("should retrieve SourceCode object without reset", () => {
-            eslint.reset();
-            eslint.verify(code, {}, filename);
+            linter.reset();
+            linter.verify(code, {}, filename);
 
-            const sourceCode = eslint.getSourceCode();
+            const sourceCode = linter.getSourceCode();
 
             assert.isObject(sourceCode);
             assert.equal(sourceCode.text, code);
@@ -198,7 +202,7 @@ describe("eslint", () => {
              * @returns {void}
              */
             function handler() {
-                const source = eslint.getSource();
+                const source = linter.getSource();
 
                 assert.equal(source, TEST_CODE);
             }
@@ -206,10 +210,10 @@ describe("eslint", () => {
             const config = { rules: {} },
                 spy = sandbox.spy(handler);
 
-            eslint.reset();
-            eslint.on("Program", spy);
+            linter.reset();
+            linter.on("Program", spy);
 
-            eslint.verify(code, config, filename, true);
+            linter.verify(code, config, filename, true);
             assert(spy.calledOnce);
         });
 
@@ -221,7 +225,7 @@ describe("eslint", () => {
              * @returns {void}
              */
             function handler(node) {
-                const source = eslint.getSource(node);
+                const source = linter.getSource(node);
 
                 assert.equal(source, TEST_CODE);
             }
@@ -229,10 +233,10 @@ describe("eslint", () => {
             const config = { rules: {} },
                 spy = sandbox.spy(handler);
 
-            eslint.reset();
-            eslint.on("Program", spy);
+            linter.reset();
+            linter.on("Program", spy);
 
-            eslint.verify(code, config, filename, true);
+            linter.verify(code, config, filename, true);
             assert(spy.calledOnce);
         });
 
@@ -244,7 +248,7 @@ describe("eslint", () => {
              * @returns {void}
              */
             function handler(node) {
-                const source = eslint.getSource(node, 2, 0);
+                const source = linter.getSource(node, 2, 0);
 
                 assert.equal(source, TEST_CODE);
             }
@@ -252,63 +256,63 @@ describe("eslint", () => {
             const config = { rules: {} },
                 spy = sandbox.spy(handler);
 
-            eslint.reset();
-            eslint.on("Program", spy);
+            linter.reset();
+            linter.on("Program", spy);
 
-            eslint.verify(code, config, filename, true);
+            linter.verify(code, config, filename, true);
             assert(spy.calledOnce);
         });
 
         it("should retrieve all text for binary expression", () => {
             const config = { rules: {} };
 
-            eslint.reset();
-            eslint.on("BinaryExpression", node => {
-                const source = eslint.getSource(node);
+            linter.reset();
+            linter.on("BinaryExpression", node => {
+                const source = linter.getSource(node);
 
                 assert.equal(source, "6 * 7");
             });
 
-            eslint.verify(code, config, filename, true);
+            linter.verify(code, config, filename, true);
         });
 
         it("should retrieve all text plus two characters before for binary expression", () => {
             const config = { rules: {} };
 
-            eslint.reset();
-            eslint.on("BinaryExpression", node => {
-                const source = eslint.getSource(node, 2);
+            linter.reset();
+            linter.on("BinaryExpression", node => {
+                const source = linter.getSource(node, 2);
 
                 assert.equal(source, "= 6 * 7");
             });
 
-            eslint.verify(code, config, filename, true);
+            linter.verify(code, config, filename, true);
         });
 
         it("should retrieve all text plus one character after for binary expression", () => {
             const config = { rules: {} };
 
-            eslint.reset();
-            eslint.on("BinaryExpression", node => {
-                const source = eslint.getSource(node, 0, 1);
+            linter.reset();
+            linter.on("BinaryExpression", node => {
+                const source = linter.getSource(node, 0, 1);
 
                 assert.equal(source, "6 * 7;");
             });
 
-            eslint.verify(code, config, filename, true);
+            linter.verify(code, config, filename, true);
         });
 
         it("should retrieve all text plus two characters before and one character after for binary expression", () => {
             const config = { rules: {} };
 
-            eslint.reset();
-            eslint.on("BinaryExpression", node => {
-                const source = eslint.getSource(node, 2, 1);
+            linter.reset();
+            linter.on("BinaryExpression", node => {
+                const source = linter.getSource(node, 2, 1);
 
                 assert.equal(source, "= 6 * 7;");
             });
 
-            eslint.verify(code, config, filename, true);
+            linter.verify(code, config, filename, true);
         });
 
     });
@@ -320,27 +324,27 @@ describe("eslint", () => {
 
             const config = { rules: {} };
 
-            eslint.reset();
-            eslint.on("BinaryExpression", () => {
-                const ancestors = eslint.getAncestors();
+            linter.reset();
+            linter.on("BinaryExpression", () => {
+                const ancestors = linter.getAncestors();
 
                 assert.equal(ancestors.length, 3);
             });
 
-            eslint.verify(code, config, filename, true);
+            linter.verify(code, config, filename, true);
         });
 
         it("should retrieve empty ancestors for root node", () => {
             const config = { rules: {} };
 
-            eslint.reset();
-            eslint.on("Program", () => {
-                const ancestors = eslint.getAncestors();
+            linter.reset();
+            linter.on("Program", () => {
+                const ancestors = linter.getAncestors();
 
                 assert.equal(ancestors.length, 0);
             });
 
-            eslint.verify(code, config, filename, true);
+            linter.verify(code, config, filename, true);
         });
     });
 
@@ -350,116 +354,116 @@ describe("eslint", () => {
         it("should retrieve a node starting at the given index", () => {
             const config = { rules: {} };
 
-            eslint.reset();
-            eslint.on("Program", () => {
-                const node = eslint.getNodeByRangeIndex(4);
+            linter.reset();
+            linter.on("Program", () => {
+                const node = linter.getNodeByRangeIndex(4);
 
                 assert.equal(node.type, "Identifier");
             });
 
-            eslint.verify(code, config, filename, true);
+            linter.verify(code, config, filename, true);
         });
 
         it("should retrieve a node containing the given index", () => {
             const config = { rules: {} };
 
-            eslint.reset();
-            eslint.on("Program", () => {
-                const node = eslint.getNodeByRangeIndex(6);
+            linter.reset();
+            linter.on("Program", () => {
+                const node = linter.getNodeByRangeIndex(6);
 
                 assert.equal(node.type, "Identifier");
             });
 
-            eslint.verify(code, config, filename, true);
+            linter.verify(code, config, filename, true);
         });
 
         it("should retrieve a node that is exactly the given index", () => {
             const config = { rules: {} };
 
-            eslint.reset();
-            eslint.on("Program", () => {
-                const node = eslint.getNodeByRangeIndex(13);
+            linter.reset();
+            linter.on("Program", () => {
+                const node = linter.getNodeByRangeIndex(13);
 
                 assert.equal(node.type, "Literal");
                 assert.equal(node.value, 6);
             });
 
-            eslint.verify(code, config, filename, true);
+            linter.verify(code, config, filename, true);
         });
 
         it("should retrieve a node ending with the given index", () => {
             const config = { rules: {} };
 
-            eslint.reset();
-            eslint.on("Program", () => {
-                const node = eslint.getNodeByRangeIndex(9);
+            linter.reset();
+            linter.on("Program", () => {
+                const node = linter.getNodeByRangeIndex(9);
 
                 assert.equal(node.type, "Identifier");
             });
 
-            eslint.verify(code, config, filename, true);
+            linter.verify(code, config, filename, true);
         });
 
         it("should retrieve the deepest node containing the given index", () => {
             const config = { rules: {} };
 
-            eslint.reset();
-            eslint.on("Program", () => {
-                let node = eslint.getNodeByRangeIndex(14);
+            linter.reset();
+            linter.on("Program", () => {
+                let node = linter.getNodeByRangeIndex(14);
 
                 assert.equal(node.type, "BinaryExpression");
-                node = eslint.getNodeByRangeIndex(3);
+                node = linter.getNodeByRangeIndex(3);
                 assert.equal(node.type, "VariableDeclaration");
             });
 
-            eslint.verify(code, config, filename, true);
+            linter.verify(code, config, filename, true);
         });
 
         it("should return null if the index is outside the range of any node", () => {
             const config = { rules: {} };
 
-            eslint.reset();
-            eslint.on("Program", () => {
-                let node = eslint.getNodeByRangeIndex(-1);
+            linter.reset();
+            linter.on("Program", () => {
+                let node = linter.getNodeByRangeIndex(-1);
 
                 assert.isNull(node);
-                node = eslint.getNodeByRangeIndex(-99);
+                node = linter.getNodeByRangeIndex(-99);
                 assert.isNull(node);
             });
 
-            eslint.verify(code, config, filename, true);
+            linter.verify(code, config, filename, true);
         });
 
         it("should attach the node's parent", () => {
             const config = { rules: {} };
 
-            eslint.reset();
-            eslint.on("Program", () => {
-                const node = eslint.getNodeByRangeIndex(14);
+            linter.reset();
+            linter.on("Program", () => {
+                const node = linter.getNodeByRangeIndex(14);
 
                 assert.property(node, "parent");
                 assert.equal(node.parent.type, "VariableDeclarator");
             });
 
-            eslint.verify(code, config, filename, true);
+            linter.verify(code, config, filename, true);
         });
 
         it("should not modify the node when attaching the parent", () => {
             const config = { rules: {} };
 
-            eslint.reset();
-            eslint.on("Program", () => {
-                let node = eslint.getNodeByRangeIndex(10);
+            linter.reset();
+            linter.on("Program", () => {
+                let node = linter.getNodeByRangeIndex(10);
 
                 assert.equal(node.type, "VariableDeclarator");
-                node = eslint.getNodeByRangeIndex(4);
+                node = linter.getNodeByRangeIndex(4);
                 assert.equal(node.type, "Identifier");
                 assert.property(node, "parent");
                 assert.equal(node.parent.type, "VariableDeclarator");
                 assert.notProperty(node.parent, "parent");
             });
 
-            eslint.verify(code, config, filename, true);
+            linter.verify(code, config, filename, true);
         });
 
     });
@@ -472,165 +476,165 @@ describe("eslint", () => {
         it("should retrieve the global scope correctly from a Program", () => {
             const config = { rules: {} };
 
-            eslint.reset();
-            eslint.on("Program", () => {
-                const scope = eslint.getScope();
+            linter.reset();
+            linter.on("Program", () => {
+                const scope = linter.getScope();
 
                 assert.equal(scope.type, "global");
             });
 
-            eslint.verify(code, config, filename, true);
+            linter.verify(code, config, filename, true);
         });
 
         it("should retrieve the function scope correctly from a FunctionDeclaration", () => {
             const config = { rules: {} };
 
-            eslint.reset();
-            eslint.on("FunctionDeclaration", () => {
-                const scope = eslint.getScope();
+            linter.reset();
+            linter.on("FunctionDeclaration", () => {
+                const scope = linter.getScope();
 
                 assert.equal(scope.type, "function");
             });
 
-            eslint.verify(code, config, filename, true);
+            linter.verify(code, config, filename, true);
         });
 
         it("should retrieve the function scope correctly from a LabeledStatement", () => {
             const config = { rules: {} };
 
-            eslint.reset();
-            eslint.on("LabeledStatement", () => {
-                const scope = eslint.getScope();
+            linter.reset();
+            linter.on("LabeledStatement", () => {
+                const scope = linter.getScope();
 
                 assert.equal(scope.type, "function");
                 assert.equal(scope.block.id.name, "foo");
             });
 
-            eslint.verify(code, config, filename, true);
+            linter.verify(code, config, filename, true);
         });
 
         it("should retrieve the function scope correctly from within an ArrowFunctionExpression", () => {
             const config = { rules: {}, ecmaFeatures: { arrowFunctions: true } };
 
-            eslint.reset();
-            eslint.on("ReturnStatement", () => {
-                const scope = eslint.getScope();
+            linter.reset();
+            linter.on("ReturnStatement", () => {
+                const scope = linter.getScope();
 
                 assert.equal(scope.type, "function");
                 assert.equal(scope.block.type, "ArrowFunctionExpression");
             });
 
-            eslint.verify(code, config, filename, true);
+            linter.verify(code, config, filename, true);
         });
 
         it("should retrieve the function scope correctly from within an SwitchStatement", () => {
             const config = { rules: {}, parserOptions: { ecmaVersion: 6 } };
 
-            eslint.reset();
-            eslint.on("SwitchStatement", () => {
-                const scope = eslint.getScope();
+            linter.reset();
+            linter.on("SwitchStatement", () => {
+                const scope = linter.getScope();
 
                 assert.equal(scope.type, "switch");
                 assert.equal(scope.block.type, "SwitchStatement");
             });
 
-            eslint.verify("switch(foo){ case 'a': var b = 'foo'; }", config, filename, true);
+            linter.verify("switch(foo){ case 'a': var b = 'foo'; }", config, filename, true);
         });
 
         it("should retrieve the function scope correctly from within a BlockStatement", () => {
             const config = { rules: {}, parserOptions: { ecmaVersion: 6 } };
 
-            eslint.reset();
-            eslint.on("BlockStatement", () => {
-                const scope = eslint.getScope();
+            linter.reset();
+            linter.on("BlockStatement", () => {
+                const scope = linter.getScope();
 
                 assert.equal(scope.type, "block");
                 assert.equal(scope.block.type, "BlockStatement");
             });
 
-            eslint.verify("var x; {let y = 1}", config, filename, true);
+            linter.verify("var x; {let y = 1}", config, filename, true);
         });
 
         it("should retrieve the function scope correctly from within a nested block statement", () => {
             const config = { rules: {}, parserOptions: { ecmaVersion: 6 } };
 
-            eslint.reset();
-            eslint.on("BlockStatement", () => {
-                const scope = eslint.getScope();
+            linter.reset();
+            linter.on("BlockStatement", () => {
+                const scope = linter.getScope();
 
                 assert.equal(scope.type, "block");
                 assert.equal(scope.block.type, "BlockStatement");
             });
 
-            eslint.verify("if (true) { let x = 1 }", config, filename, true);
+            linter.verify("if (true) { let x = 1 }", config, filename, true);
         });
 
         it("should retrieve the function scope correctly from within a FunctionDeclaration", () => {
             const config = { rules: {}, parserOptions: { ecmaVersion: 6 } };
 
-            eslint.reset();
-            eslint.on("FunctionDeclaration", () => {
-                const scope = eslint.getScope();
+            linter.reset();
+            linter.on("FunctionDeclaration", () => {
+                const scope = linter.getScope();
 
                 assert.equal(scope.type, "function");
                 assert.equal(scope.block.type, "FunctionDeclaration");
             });
 
-            eslint.verify("function foo() {}", config, filename, true);
+            linter.verify("function foo() {}", config, filename, true);
         });
 
         it("should retrieve the function scope correctly from within a FunctionExpression", () => {
             const config = { rules: {}, parserOptions: { ecmaVersion: 6 } };
 
-            eslint.reset();
-            eslint.on("FunctionExpression", () => {
-                const scope = eslint.getScope();
+            linter.reset();
+            linter.on("FunctionExpression", () => {
+                const scope = linter.getScope();
 
                 assert.equal(scope.type, "function");
                 assert.equal(scope.block.type, "FunctionExpression");
             });
 
-            eslint.verify("(function foo() {})();", config, filename, true);
+            linter.verify("(function foo() {})();", config, filename, true);
         });
 
         it("should retrieve the catch scope correctly from within a CatchClause", () => {
             const config = { rules: {}, parserOptions: { ecmaVersion: 6 } };
 
-            eslint.reset();
-            eslint.on("CatchClause", () => {
-                const scope = eslint.getScope();
+            linter.reset();
+            linter.on("CatchClause", () => {
+                const scope = linter.getScope();
 
                 assert.equal(scope.type, "catch");
                 assert.equal(scope.block.type, "CatchClause");
             });
 
-            eslint.verify("try {} catch (err) {}", config, filename, true);
+            linter.verify("try {} catch (err) {}", config, filename, true);
         });
 
         it("should retrieve module scope correctly from an ES6 module", () => {
             const config = { rules: {}, parserOptions: { sourceType: "module" } };
 
-            eslint.reset();
-            eslint.on("AssignmentExpression", () => {
-                const scope = eslint.getScope();
+            linter.reset();
+            linter.on("AssignmentExpression", () => {
+                const scope = linter.getScope();
 
                 assert.equal(scope.type, "module");
             });
 
-            eslint.verify("var foo = {}; foo.bar = 1;", config, filename, true);
+            linter.verify("var foo = {}; foo.bar = 1;", config, filename, true);
         });
 
         it("should retrieve function scope correctly when globalReturn is true", () => {
             const config = { rules: {}, parserOptions: { ecmaFeatures: { globalReturn: true } } };
 
-            eslint.reset();
-            eslint.on("AssignmentExpression", () => {
-                const scope = eslint.getScope();
+            linter.reset();
+            linter.on("AssignmentExpression", () => {
+                const scope = linter.getScope();
 
                 assert.equal(scope.type, "function");
             });
 
-            eslint.verify("var foo = {}; foo.bar = 1;", config, filename, true);
+            linter.verify("var foo = {}; foo.bar = 1;", config, filename, true);
         });
     });
 
@@ -638,82 +642,82 @@ describe("eslint", () => {
         it("should mark variables in current scope as used", () => {
             const code = "var a = 1, b = 2;";
 
-            eslint.reset();
-            eslint.on("Program:exit", () => {
-                eslint.markVariableAsUsed("a");
+            linter.reset();
+            linter.on("Program:exit", () => {
+                linter.markVariableAsUsed("a");
 
-                const scope = eslint.getScope();
+                const scope = linter.getScope();
 
                 assert.isTrue(getVariable(scope, "a").eslintUsed);
                 assert.notOk(getVariable(scope, "b").eslintUsed);
             });
 
-            eslint.verify(code, {}, filename, true);
+            linter.verify(code, {}, filename, true);
         });
         it("should mark variables in function args as used", () => {
             const code = "function abc(a, b) { return 1; }";
 
-            eslint.reset();
-            eslint.on("ReturnStatement", () => {
-                eslint.markVariableAsUsed("a");
+            linter.reset();
+            linter.on("ReturnStatement", () => {
+                linter.markVariableAsUsed("a");
 
-                const scope = eslint.getScope();
+                const scope = linter.getScope();
 
                 assert.isTrue(getVariable(scope, "a").eslintUsed);
                 assert.notOk(getVariable(scope, "b").eslintUsed);
             });
 
-            eslint.verify(code, {}, filename, true);
+            linter.verify(code, {}, filename, true);
         });
         it("should mark variables in higher scopes as used", () => {
             const code = "var a, b; function abc() { return 1; }";
 
-            eslint.reset();
-            eslint.on("ReturnStatement", () => {
-                eslint.markVariableAsUsed("a");
+            linter.reset();
+            linter.on("ReturnStatement", () => {
+                linter.markVariableAsUsed("a");
             });
-            eslint.on("Program:exit", () => {
-                const scope = eslint.getScope();
+            linter.on("Program:exit", () => {
+                const scope = linter.getScope();
 
                 assert.isTrue(getVariable(scope, "a").eslintUsed);
                 assert.notOk(getVariable(scope, "b").eslintUsed);
             });
 
-            eslint.verify(code, {}, filename, true);
+            linter.verify(code, {}, filename, true);
         });
 
         it("should mark variables in Node.js environment as used", () => {
             const code = "var a = 1, b = 2;";
 
-            eslint.reset();
-            eslint.on("Program:exit", () => {
-                const globalScope = eslint.getScope(),
+            linter.reset();
+            linter.on("Program:exit", () => {
+                const globalScope = linter.getScope(),
                     childScope = globalScope.childScopes[0];
 
-                eslint.markVariableAsUsed("a");
+                linter.markVariableAsUsed("a");
 
                 assert.isTrue(getVariable(childScope, "a").eslintUsed);
                 assert.isUndefined(getVariable(childScope, "b").eslintUsed);
             });
 
-            eslint.verify(code, { env: { node: true } }, filename, true);
+            linter.verify(code, { env: { node: true } }, filename, true);
         });
 
         it("should mark variables in modules as used", () => {
             const code = "var a = 1, b = 2;";
 
-            eslint.reset();
-            eslint.on("Program:exit", () => {
-                const globalScope = eslint.getScope(),
+            linter.reset();
+            linter.on("Program:exit", () => {
+                const globalScope = linter.getScope(),
                     childScope = globalScope.childScopes[0];
 
-                eslint.markVariableAsUsed("a");
+                linter.markVariableAsUsed("a");
 
                 assert.isTrue(getVariable(childScope, "a").eslintUsed);
                 assert.isUndefined(getVariable(childScope, "b").eslintUsed);
             });
 
-            eslint.verify(code, { parserOptions: { sourceType: "module" } }, filename, true);
+            linter.verify(code, { parserOptions: { sourceType: "module" } }, filename, true);
         });
     });
 
@@ -722,16 +726,16 @@ describe("eslint", () => {
         let config;
 
         beforeEach(() => {
-            eslint.reset();
+            linter.reset();
             config = { rules: {} };
         });
 
         it("should correctly parse a message when being passed all options", () => {
-            eslint.on("Program", node => {
-                eslint.report("test-rule", 2, node, node.loc.end, "hello {{dynamic}}", { dynamic: node.type });
+            linter.on("Program", node => {
+                linter.report("test-rule", 2, node, node.loc.end, "hello {{dynamic}}", { dynamic: node.type });
             });
 
-            const messages = eslint.verify("0", config, "", true);
+            const messages = linter.verify("0", config, "", true);
 
             assert.deepEqual(messages[0], {
                 severity: 2,
@@ -745,11 +749,11 @@ describe("eslint", () => {
         });
 
         it("should use the report the provided location when given", () => {
-            eslint.on("Program", node => {
-                eslint.report("test-rule", 2, node, { line: 42, column: 13 }, "hello world");
+            linter.on("Program", node => {
+                linter.report("test-rule", 2, node, { line: 42, column: 13 }, "hello world");
             });
 
-            const messages = eslint.verify("0", config, "", true);
+            const messages = linter.verify("0", config, "", true);
 
             assert.deepEqual(messages[0], {
                 severity: 2,
@@ -763,42 +767,42 @@ describe("eslint", () => {
         });
 
         it("should not throw an error if node is provided and location is not", () => {
-            eslint.on("Program", node => {
-                eslint.report("test-rule", 2, node, "hello world");
+            linter.on("Program", node => {
+                linter.report("test-rule", 2, node, "hello world");
             });
 
             assert.doesNotThrow(() => {
-                eslint.verify("0", config, "", true);
+                linter.verify("0", config, "", true);
             });
         });
 
         it("should not throw an error if location is provided and node is not", () => {
-            eslint.on("Program", () => {
-                eslint.report("test-rule", 2, null, { line: 1, column: 1 }, "hello world");
+            linter.on("Program", () => {
+                linter.report("test-rule", 2, null, { line: 1, column: 1 }, "hello world");
             });
 
             assert.doesNotThrow(() => {
-                eslint.verify("0", config, "", true);
+                linter.verify("0", config, "", true);
             });
         });
 
         it("should throw an error if neither node nor location is provided", () => {
-            eslint.on("Program", () => {
-                eslint.report("test-rule", 2, null, "hello world");
+            linter.on("Program", () => {
+                linter.report("test-rule", 2, null, "hello world");
             });
 
             assert.throws(() => {
-                eslint.verify("0", config, "", true);
+                linter.verify("0", config, "", true);
             }, /Node must be provided when reporting error if location is not provided$/);
         });
 
         it("should throw an error if node is not an object", () => {
-            eslint.on("Program", () => {
-                eslint.report("test-rule", 2, "not a node", "hello world");
+            linter.on("Program", () => {
+                linter.report("test-rule", 2, "not a node", "hello world");
             });
 
             assert.throws(() => {
-                eslint.verify("0", config, "", true);
+                linter.verify("0", config, "", true);
             }, /Node must be an object$/);
         });
 
@@ -808,31 +812,31 @@ describe("eslint", () => {
                 schema: []
             };
 
-            eslint.on("Program", node => {
-                eslint.report("test-rule", 2, node, "hello world", [], { range: [1, 1], text: "" }, meta);
+            linter.on("Program", node => {
+                linter.report("test-rule", 2, node, "hello world", [], { range: [1, 1], text: "" }, meta);
             });
 
             assert.throws(() => {
-                eslint.verify("0", config, "", true);
+                linter.verify("0", config, "", true);
             }, /Fixable rules should export a `meta\.fixable` property.$/);
         });
 
         it("should not throw an error if fix is passed and no metadata is passed", () => {
-            eslint.on("Program", node => {
-                eslint.report("test-rule", 2, node, "hello world", [], { range: [1, 1], text: "" });
+            linter.on("Program", node => {
+                linter.report("test-rule", 2, node, "hello world", [], { range: [1, 1], text: "" });
             });
 
             assert.doesNotThrow(() => {
-                eslint.verify("0", config, "", true);
+                linter.verify("0", config, "", true);
             });
         });
 
         it("should correctly parse a message with object keys as numbers", () => {
-            eslint.on("Program", node => {
-                eslint.report("test-rule", 2, node, "my message {{name}}{{0}}", { 0: "!", name: "testing" });
+            linter.on("Program", node => {
+                linter.report("test-rule", 2, node, "my message {{name}}{{0}}", { 0: "!", name: "testing" });
             });
 
-            const messages = eslint.verify("0", config, "", true);
+            const messages = linter.verify("0", config, "", true);
 
             assert.deepEqual(messages[0], {
                 severity: 2,
@@ -848,11 +852,11 @@ describe("eslint", () => {
         });
 
         it("should correctly parse a message with array", () => {
-            eslint.on("Program", node => {
-                eslint.report("test-rule", 2, node, "my message {{1}}{{0}}", ["!", "testing"]);
+            linter.on("Program", node => {
+                linter.report("test-rule", 2, node, "my message {{1}}{{0}}", ["!", "testing"]);
             });
 
-            const messages = eslint.verify("0", config, "", true);
+            const messages = linter.verify("0", config, "", true);
 
             assert.deepEqual(messages[0], {
                 severity: 2,
@@ -868,11 +872,11 @@ describe("eslint", () => {
         });
 
         it("should include a fix passed as the last argument when location is not passed", () => {
-            eslint.on("Program", node => {
-                eslint.report("test-rule", 2, node, "my message {{1}}{{0}}", ["!", "testing"], { range: [1, 1], text: "" });
+            linter.on("Program", node => {
+                linter.report("test-rule", 2, node, "my message {{1}}{{0}}", ["!", "testing"], { range: [1, 1], text: "" });
             });
 
-            const messages = eslint.verify("0", config, "", true);
+            const messages = linter.verify("0", config, "", true);
 
             assert.deepEqual(messages[0], {
                 severity: 2,
@@ -889,8 +893,8 @@ describe("eslint", () => {
         });
 
         it("should allow template parameter with inner whitespace", () => {
-            eslint.reset();
-            eslint.defineRule("test-rule", context => ({
+            linter.reset();
+            linter.defineRule("test-rule", context => ({
                 Literal(node) {
                     context.report(node, "message {{parameter name}}", {
                         "parameter name": "yay!"
@@ -900,14 +904,14 @@ describe("eslint", () => {
 
             config.rules["test-rule"] = 1;
 
-            const messages = eslint.verify("0", config);
+            const messages = linter.verify("0", config);
 
             assert.equal(messages[0].message, "message yay!");
         });
 
         it("should not crash if no template parameters are passed", () => {
-            eslint.reset();
-            eslint.defineRule("test-rule", context => ({
+            linter.reset();
+            linter.defineRule("test-rule", context => ({
                 Literal(node) {
                     context.report(node, "message {{code}}");
                 }
@@ -915,14 +919,14 @@ describe("eslint", () => {
 
             config.rules["test-rule"] = 1;
 
-            const messages = eslint.verify("0", config);
+            const messages = linter.verify("0", config);
 
             assert.equal(messages[0].message, "message {{code}}");
         });
 
         it("should allow template parameter with non-identifier characters", () => {
-            eslint.reset();
-            eslint.defineRule("test-rule", context => ({
+            linter.reset();
+            linter.defineRule("test-rule", context => ({
                 Literal(node) {
                     context.report(node, "message {{parameter-name}}", {
                         "parameter-name": "yay!"
@@ -932,14 +936,14 @@ describe("eslint", () => {
 
             config.rules["test-rule"] = 1;
 
-            const messages = eslint.verify("0", config);
+            const messages = linter.verify("0", config);
 
             assert.equal(messages[0].message, "message yay!");
         });
 
         it("should allow template parameter wrapped in braces", () => {
-            eslint.reset();
-            eslint.defineRule("test-rule", context => ({
+            linter.reset();
+            linter.defineRule("test-rule", context => ({
                 Literal(node) {
                     context.report(node, "message {{{param}}}", {
                         param: "yay!"
@@ -949,14 +953,14 @@ describe("eslint", () => {
 
             config.rules["test-rule"] = 1;
 
-            const messages = eslint.verify("0", config);
+            const messages = linter.verify("0", config);
 
             assert.equal(messages[0].message, "message {yay!}");
         });
 
         it("should ignore template parameter with no specified value", () => {
-            eslint.reset();
-            eslint.defineRule("test-rule", context => ({
+            linter.reset();
+            linter.defineRule("test-rule", context => ({
                 Literal(node) {
                     context.report(node, "message {{parameter}}", {});
                 }
@@ -964,14 +968,14 @@ describe("eslint", () => {
 
             config.rules["test-rule"] = 1;
 
-            const messages = eslint.verify("0", config);
+            const messages = linter.verify("0", config);
 
             assert.equal(messages[0].message, "message {{parameter}}");
         });
 
         it("should ignore template parameter with no specified value with warn severity", () => {
-            eslint.reset();
-            eslint.defineRule("test-rule", context => ({
+            linter.reset();
+            linter.defineRule("test-rule", context => ({
                 Literal(node) {
                     context.report(node, "message {{parameter}}", {});
                 }
@@ -979,15 +983,15 @@ describe("eslint", () => {
 
             config.rules["test-rule"] = "warn";
 
-            const messages = eslint.verify("0", config);
+            const messages = linter.verify("0", config);
 
             assert.equal(messages[0].severity, 1);
             assert.equal(messages[0].message, "message {{parameter}}");
         });
 
         it("should handle leading whitespace in template parameter", () => {
-            eslint.reset();
-            eslint.defineRule("test-rule", context => ({
+            linter.reset();
+            linter.defineRule("test-rule", context => ({
                 Literal(node) {
                     context.report(node, "message {{ parameter}}", {
                         parameter: "yay!"
@@ -997,14 +1001,14 @@ describe("eslint", () => {
 
             config.rules["test-rule"] = 1;
 
-            const messages = eslint.verify("0", config);
+            const messages = linter.verify("0", config);
 
             assert.equal(messages[0].message, "message yay!");
         });
 
         it("should handle trailing whitespace in template parameter", () => {
-            eslint.reset();
-            eslint.defineRule("test-rule", context => ({
+            linter.reset();
+            linter.defineRule("test-rule", context => ({
                 Literal(node) {
                     context.report(node, "message {{parameter }}", {
                         parameter: "yay!"
@@ -1014,14 +1018,14 @@ describe("eslint", () => {
 
             config.rules["test-rule"] = 1;
 
-            const messages = eslint.verify("0", config);
+            const messages = linter.verify("0", config);
 
             assert.equal(messages[0].message, "message yay!");
         });
 
         it("should still allow inner whitespace as well as leading/trailing", () => {
-            eslint.reset();
-            eslint.defineRule("test-rule", context => ({
+            linter.reset();
+            linter.defineRule("test-rule", context => ({
                 Literal(node) {
                     context.report(node, "message {{ parameter name }}", {
                         "parameter name": "yay!"
@@ -1031,14 +1035,14 @@ describe("eslint", () => {
 
             config.rules["test-rule"] = 1;
 
-            const messages = eslint.verify("0", config);
+            const messages = linter.verify("0", config);
 
             assert.equal(messages[0].message, "message yay!");
         });
 
         it("should still allow non-identifier characters as well as leading/trailing whitespace", () => {
-            eslint.reset();
-            eslint.defineRule("test-rule", context => ({
+            linter.reset();
+            linter.defineRule("test-rule", context => ({
                 Literal(node) {
                     context.report(node, "message {{ parameter-name }}", {
                         "parameter-name": "yay!"
@@ -1048,17 +1052,17 @@ describe("eslint", () => {
 
             config.rules["test-rule"] = 1;
 
-            const messages = eslint.verify("0", config);
+            const messages = linter.verify("0", config);
 
             assert.equal(messages[0].message, "message yay!");
         });
 
         it("should include a fix passed as the last argument when location is passed", () => {
-            eslint.on("Program", node => {
-                eslint.report("test-rule", 2, node, { line: 42, column: 23 }, "my message {{1}}{{0}}", ["!", "testing"], { range: [1, 1], text: "" });
+            linter.on("Program", node => {
+                linter.report("test-rule", 2, node, { line: 42, column: 23 }, "my message {{1}}{{0}}", ["!", "testing"], { range: [1, 1], text: "" });
             });
 
-            const messages = eslint.verify("0", config, "", true);
+            const messages = linter.verify("0", config, "", true);
 
             assert.deepEqual(messages[0], {
                 severity: 2,
@@ -1073,8 +1077,8 @@ describe("eslint", () => {
         });
 
         it("should have 'endLine' and 'endColumn' when there is not 'loc' property.", () => {
-            eslint.on("Program", node => {
-                eslint.report(
+            linter.on("Program", node => {
+                linter.report(
                     "test-rule",
                     2,
                     node,
@@ -1084,15 +1088,15 @@ describe("eslint", () => {
 
             const sourceText = "foo + bar;";
 
-            const messages = eslint.verify(sourceText, config, "", true);
+            const messages = linter.verify(sourceText, config, "", true);
 
             assert.strictEqual(messages[0].endLine, 1);
             assert.strictEqual(messages[0].endColumn, sourceText.length + 1); // (1-based column)
         });
 
         it("should have 'endLine' and 'endColumn' when 'loc' property has 'end' property.", () => {
-            eslint.on("Program", node => {
-                eslint.report(
+            linter.on("Program", node => {
+                linter.report(
                     "test-rule",
                     2,
                     node,
@@ -1101,15 +1105,15 @@ describe("eslint", () => {
                 );
             });
 
-            const messages = eslint.verify("0", config, "", true);
+            const messages = linter.verify("0", config, "", true);
 
             assert.strictEqual(messages[0].endLine, 1);
             assert.strictEqual(messages[0].endColumn, 2);
         });
 
         it("should not have 'endLine' and 'endColumn' when 'loc' property doe not have 'end' property.", () => {
-            eslint.on("Program", node => {
-                eslint.report(
+            linter.on("Program", node => {
+                linter.report(
                     "test-rule",
                     2,
                     node,
@@ -1118,7 +1122,7 @@ describe("eslint", () => {
                 );
             });
 
-            const messages = eslint.verify("0", config, "", true);
+            const messages = linter.verify("0", config, "", true);
 
             assert.strictEqual(messages[0].endLine, void 0);
             assert.strictEqual(messages[0].endColumn, void 0);
@@ -1139,14 +1143,14 @@ describe("eslint", () => {
                 spyIdentifier = sinon.spy(),
                 spyBinaryExpression = sinon.spy();
 
-            eslint.reset();
-            eslint.on("Literal", spyLiteral);
-            eslint.on("VariableDeclarator", spyVariableDeclarator);
-            eslint.on("VariableDeclaration", spyVariableDeclaration);
-            eslint.on("Identifier", spyIdentifier);
-            eslint.on("BinaryExpression", spyBinaryExpression);
+            linter.reset();
+            linter.on("Literal", spyLiteral);
+            linter.on("VariableDeclarator", spyVariableDeclarator);
+            linter.on("VariableDeclaration", spyVariableDeclaration);
+            linter.on("Identifier", spyIdentifier);
+            linter.on("BinaryExpression", spyBinaryExpression);
 
-            const messages = eslint.verify(code, config, filename, true);
+            const messages = linter.verify(code, config, filename, true);
 
             assert.equal(messages.length, 0);
             sinon.assert.calledOnce(spyVariableDeclaration);
@@ -1161,8 +1165,8 @@ describe("eslint", () => {
         const code = "test-rule";
 
         it("should pass settings to all rules", () => {
-            eslint.reset();
-            eslint.defineRule(code, context => ({
+            linter.reset();
+            linter.defineRule(code, context => ({
                 Literal(node) {
                     context.report(node, context.settings.info);
                 }
@@ -1172,15 +1176,15 @@ describe("eslint", () => {
 
             config.rules[code] = 1;
 
-            const messages = eslint.verify("0", config, filename);
+            const messages = linter.verify("0", config, filename);
 
             assert.equal(messages.length, 1);
             assert.equal(messages[0].message, "Hello");
         });
 
         it("should not have any settings if they were not passed in", () => {
-            eslint.reset();
-            eslint.defineRule(code, context => ({
+            linter.reset();
+            linter.defineRule(code, context => ({
                 Literal(node) {
                     if (Object.getOwnPropertyNames(context.settings).length !== 0) {
                         context.report(node, "Settings should be empty");
@@ -1192,7 +1196,7 @@ describe("eslint", () => {
 
             config.rules[code] = 1;
 
-            const messages = eslint.verify("0", config, filename);
+            const messages = linter.verify("0", config, filename);
 
             assert.equal(messages.length, 0);
         });
@@ -1209,28 +1213,28 @@ describe("eslint", () => {
                 }
             };
 
-            eslint.reset();
-            eslint.defineRule("test-rule", sandbox.mock().withArgs(
+            linter.reset();
+            linter.defineRule("test-rule", sandbox.mock().withArgs(
                 sinon.match({ parserOptions })
             ).returns({}));
 
             const config = { rules: { "test-rule": 2 }, parserOptions };
 
-            eslint.verify("0", config, filename);
+            linter.verify("0", config, filename);
         });
 
         it("should pass parserOptions to all rules when default parserOptions is used", () => {
 
             const parserOptions = {};
 
-            eslint.reset();
-            eslint.defineRule("test-rule", sandbox.mock().withArgs(
+            linter.reset();
+            linter.defineRule("test-rule", sandbox.mock().withArgs(
                 sinon.match({ parserOptions })
             ).returns({}));
 
             const config = { rules: { "test-rule": 2 } };
 
-            eslint.verify("0", config, filename);
+            linter.verify("0", config, filename);
         });
 
     });
@@ -1243,24 +1247,24 @@ describe("eslint", () => {
 
                 const alternateParser = "esprima-fb";
 
-                eslint.reset();
-                eslint.defineRule("test-rule", sandbox.mock().withArgs(
+                linter.reset();
+                linter.defineRule("test-rule", sandbox.mock().withArgs(
                     sinon.match({ parserPath: alternateParser })
                 ).returns({}));
 
                 const config = { rules: { "test-rule": 2 }, parser: alternateParser };
 
-                eslint.verify("0", config, filename);
+                linter.verify("0", config, filename);
             });
 
             it("should use parseForESLint() in custom parser when custom parser is specified", () => {
 
                 const alternateParser = path.resolve(__dirname, "../fixtures/parsers/enhanced-parser.js");
 
-                eslint.reset();
+                linter.reset();
 
                 const config = { rules: {}, parser: alternateParser };
-                const messages = eslint.verify("0", config, filename);
+                const messages = linter.verify("0", config, filename);
 
                 assert.equal(messages.length, 0);
             });
@@ -1269,8 +1273,8 @@ describe("eslint", () => {
 
                 const alternateParser = path.resolve(__dirname, "../fixtures/parsers/enhanced-parser.js");
 
-                eslint.reset();
-                eslint.defineRule("test-service-rule", context => ({
+                linter.reset();
+                linter.defineRule("test-service-rule", context => ({
                     Literal(node) {
                         context.report({
                             node,
@@ -1280,7 +1284,7 @@ describe("eslint", () => {
                 }));
 
                 const config = { rules: { "test-service-rule": 2 }, parser: alternateParser };
-                const messages = eslint.verify("0", config, filename);
+                const messages = linter.verify("0", config, filename);
 
                 assert.equal(messages.length, 1);
                 assert.equal(messages[0].message, "Hi!");
@@ -1289,16 +1293,16 @@ describe("eslint", () => {
 
         it("should pass parser as parserPath to all rules when default parser is used", () => {
 
-            const DEFAULT_PARSER = eslint.defaults().parser;
+            const DEFAULT_PARSER = linter.defaults().parser;
 
-            eslint.reset();
-            eslint.defineRule("test-rule", sandbox.mock().withArgs(
+            linter.reset();
+            linter.defineRule("test-rule", sandbox.mock().withArgs(
                 sinon.match({ parserPath: DEFAULT_PARSER })
             ).returns({}));
 
             const config = { rules: { "test-rule": 2 } };
 
-            eslint.verify("0", config, filename);
+            linter.verify("0", config, filename);
         });
 
     });
@@ -1312,9 +1316,9 @@ describe("eslint", () => {
                 config = { rules: {} };
 
             config.rules[rule] = 1;
-            eslint.reset();
+            linter.reset();
 
-            const messages = eslint.verify(code, config, filename, true);
+            const messages = linter.verify(code, config, filename, true);
 
             assert.equal(messages.length, 1);
             assert.equal(messages[0].ruleId, rule);
@@ -1325,9 +1329,9 @@ describe("eslint", () => {
                 config = { rules: {} };
 
             config.rules[rule] = "warn";
-            eslint.reset();
+            linter.reset();
 
-            const messages = eslint.verify(code, config, filename, true);
+            const messages = linter.verify(code, config, filename, true);
 
             assert.equal(messages.length, 1);
             assert.equal(messages[0].severity, 1);
@@ -1339,9 +1343,9 @@ describe("eslint", () => {
                 config = { rules: {} };
 
             config.rules[rule] = [1];
-            eslint.reset();
+            linter.reset();
 
-            const messages = eslint.verify(code, config, filename, true);
+            const messages = linter.verify(code, config, filename, true);
 
             assert.equal(messages.length, 1);
             assert.equal(messages[0].ruleId, rule);
@@ -1352,9 +1356,9 @@ describe("eslint", () => {
                 config = { rules: {} };
 
             config.rules[rule] = ["warn"];
-            eslint.reset();
+            linter.reset();
 
-            const messages = eslint.verify(code, config, filename, true);
+            const messages = linter.verify(code, config, filename, true);
 
             assert.equal(messages.length, 1);
             assert.equal(messages[0].severity, 1);
@@ -1366,9 +1370,9 @@ describe("eslint", () => {
                 config = { rules: {} };
 
             config.rules[rule] = "1";
-            eslint.reset();
+            linter.reset();
 
-            const messages = eslint.verify(code, config, filename, true);
+            const messages = linter.verify(code, config, filename, true);
 
             assert.equal(messages.length, 0);
         });
@@ -1376,8 +1380,8 @@ describe("eslint", () => {
         it("should process empty config", () => {
             const config = {};
 
-            eslint.reset();
-            const messages = eslint.verify(code, config, filename, true);
+            linter.reset();
+            const messages = linter.verify(code, config, filename, true);
 
             assert.equal(messages.length, 0);
         });
@@ -1397,15 +1401,15 @@ describe("eslint", () => {
                 spyIdentifier = sinon.spy(),
                 spyBinaryExpression = sinon.spy();
 
-            eslint.reset();
-            eslint.on("Literal", spyLiteral);
-            eslint.on("VariableDeclarator", spyVariableDeclarator);
-            eslint.on("VariableDeclaration", spyVariableDeclaration);
-            eslint.on("Identifier", spyIdentifier);
-            eslint.on("BinaryExpression", spyBinaryExpression);
-            eslint.reset();
+            linter.reset();
+            linter.on("Literal", spyLiteral);
+            linter.on("VariableDeclarator", spyVariableDeclarator);
+            linter.on("VariableDeclaration", spyVariableDeclaration);
+            linter.on("Identifier", spyIdentifier);
+            linter.on("BinaryExpression", spyBinaryExpression);
+            linter.reset();
 
-            const messages = eslint.verify(code, config, filename, true);
+            const messages = linter.verify(code, config, filename, true);
 
             assert.equal(messages.length, 0);
             sinon.assert.notCalled(spyVariableDeclaration);
@@ -1418,25 +1422,25 @@ describe("eslint", () => {
         it("text should not be available", () => {
             const config = { rules: {} };
 
-            eslint.reset();
-            const messages = eslint.verify(code, config, filename, true);
+            linter.reset();
+            const messages = linter.verify(code, config, filename, true);
 
-            eslint.reset();
+            linter.reset();
 
             assert.equal(messages.length, 0);
-            assert.isNull(eslint.getSource());
+            assert.isNull(linter.getSource());
         });
 
         it("source for nodes should not be available", () => {
             const config = { rules: {} };
 
-            eslint.reset();
-            const messages = eslint.verify(code, config, filename, true);
+            linter.reset();
+            const messages = linter.verify(code, config, filename, true);
 
-            eslint.reset();
+            linter.reset();
 
             assert.equal(messages.length, 0);
-            assert.isNull(eslint.getSource({}));
+            assert.isNull(linter.getSource({}));
         });
     });
 
@@ -1446,9 +1450,9 @@ describe("eslint", () => {
         it("variables should be available in global scope", () => {
             const config = { rules: {} };
 
-            eslint.reset();
-            eslint.on("Program", () => {
-                const scope = eslint.getScope();
+            linter.reset();
+            linter.on("Program", () => {
+                const scope = linter.getScope();
                 const a = getVariable(scope, "a"),
                     b = getVariable(scope, "b"),
                     c = getVariable(scope, "c"),
@@ -1464,7 +1468,7 @@ describe("eslint", () => {
                 assert.equal(d.writeable, true);
             });
 
-            eslint.verify(code, config, filename, true);
+            linter.verify(code, config, filename, true);
         });
     });
 
@@ -1474,9 +1478,9 @@ describe("eslint", () => {
         it("variables should be available in global scope", () => {
             const config = { rules: {} };
 
-            eslint.reset();
-            eslint.on("Program", () => {
-                const scope = eslint.getScope(),
+            linter.reset();
+            linter.on("Program", () => {
+                const scope = linter.getScope(),
                     a = getVariable(scope, "a"),
                     b = getVariable(scope, "b"),
                     c = getVariable(scope, "c");
@@ -1489,7 +1493,7 @@ describe("eslint", () => {
                 assert.equal(c.writeable, false);
             });
 
-            eslint.verify(code, config, filename, true);
+            linter.verify(code, config, filename, true);
         });
     });
 
@@ -1498,16 +1502,16 @@ describe("eslint", () => {
             const code = "/*eslint-env node*/ function f() {} /*eslint-env browser, foo*/";
             const config = { rules: {} };
 
-            eslint.reset();
-            eslint.on("Program", () => {
-                const scope = eslint.getScope(),
+            linter.reset();
+            linter.on("Program", () => {
+                const scope = linter.getScope(),
                     exports = getVariable(scope, "exports"),
                     window = getVariable(scope, "window");
 
                 assert.equal(exports.writeable, true);
                 assert.equal(window.writeable, false);
             });
-            eslint.verify(code, config, filename, true);
+            linter.verify(code, config, filename, true);
         });
     });
 
@@ -1517,16 +1521,16 @@ describe("eslint", () => {
         it("variables should be available in global scope", () => {
             const config = { rules: {} };
 
-            eslint.reset();
-            eslint.on("Program", () => {
-                const scope = eslint.getScope(),
+            linter.reset();
+            linter.on("Program", () => {
+                const scope = linter.getScope(),
                     exports = getVariable(scope, "exports"),
                     window = getVariable(scope, "window");
 
                 assert.equal(exports.writeable, true);
                 assert.equal(window, null);
             });
-            eslint.verify(code, config, filename, true);
+            linter.verify(code, config, filename, true);
         });
     });
 
@@ -1536,78 +1540,78 @@ describe("eslint", () => {
             const code = "/* exported horse */";
             const config = { rules: {} };
 
-            eslint.reset();
-            eslint.verify(code, config, filename, true);
+            linter.reset();
+            linter.verify(code, config, filename, true);
         });
 
         it("variables should be exported", () => {
             const code = "/* exported horse */\n\nvar horse = 'circus'";
             const config = { rules: {} };
 
-            eslint.reset();
-            eslint.on("Program", () => {
-                const scope = eslint.getScope(),
+            linter.reset();
+            linter.on("Program", () => {
+                const scope = linter.getScope(),
                     horse = getVariable(scope, "horse");
 
                 assert.equal(horse.eslintUsed, true);
             });
-            eslint.verify(code, config, filename, true);
+            linter.verify(code, config, filename, true);
         });
 
         it("undefined variables should not be exported", () => {
             const code = "/* exported horse */\n\nhorse = 'circus'";
             const config = { rules: {} };
 
-            eslint.reset();
-            eslint.on("Program", () => {
-                const scope = eslint.getScope(),
+            linter.reset();
+            linter.on("Program", () => {
+                const scope = linter.getScope(),
                     horse = getVariable(scope, "horse");
 
                 assert.equal(horse, null);
             });
-            eslint.verify(code, config, filename, true);
+            linter.verify(code, config, filename, true);
         });
 
         it("variables should be exported in strict mode", () => {
             const code = "/* exported horse */\n'use strict';\nvar horse = 'circus'";
             const config = { rules: {} };
 
-            eslint.reset();
-            eslint.on("Program", () => {
-                const scope = eslint.getScope(),
+            linter.reset();
+            linter.on("Program", () => {
+                const scope = linter.getScope(),
                     horse = getVariable(scope, "horse");
 
                 assert.equal(horse.eslintUsed, true);
             });
-            eslint.verify(code, config, filename, true);
+            linter.verify(code, config, filename, true);
         });
 
         it("variables should not be exported in the es6 module environment", () => {
             const code = "/* exported horse */\nvar horse = 'circus'";
             const config = { rules: {}, parserOptions: { sourceType: "module" } };
 
-            eslint.reset();
-            eslint.on("Program", () => {
-                const scope = eslint.getScope(),
+            linter.reset();
+            linter.on("Program", () => {
+                const scope = linter.getScope(),
                     horse = getVariable(scope, "horse");
 
                 assert.equal(horse, null); // there is no global scope at all
             });
-            eslint.verify(code, config, filename, true);
+            linter.verify(code, config, filename, true);
         });
 
         it("variables should not be exported when in the node environment", () => {
             const code = "/* exported horse */\nvar horse = 'circus'";
             const config = { rules: {}, env: { node: true } };
 
-            eslint.reset();
-            eslint.on("Program", () => {
-                const scope = eslint.getScope(),
+            linter.reset();
+            linter.on("Program", () => {
+                const scope = linter.getScope(),
                     horse = getVariable(scope, "horse");
 
                 assert.equal(horse, null); // there is no global scope at all
             });
-            eslint.verify(code, config, filename, true);
+            linter.verify(code, config, filename, true);
         });
     });
 
@@ -1618,13 +1622,13 @@ describe("eslint", () => {
 
             const config = { rules: {} };
 
-            eslint.reset();
-            eslint.on("Program", () => {
-                const scope = eslint.getScope();
+            linter.reset();
+            linter.on("Program", () => {
+                const scope = linter.getScope();
 
                 assert.equal(getVariable(scope, "a"), null);
             });
-            eslint.verify(code, config, filename, true);
+            linter.verify(code, config, filename, true);
         });
     });
 
@@ -1634,16 +1638,16 @@ describe("eslint", () => {
         it("should not introduce a global variable", () => {
             const config = { rules: {} };
 
-            eslint.reset();
-            eslint.on("Program", () => {
-                const scope = eslint.getScope();
+            linter.reset();
+            linter.on("Program", () => {
+                const scope = linter.getScope();
 
                 assert.equal(getVariable(scope, "a"), null);
                 assert.equal(getVariable(scope, "b"), null);
                 assert.equal(getVariable(scope, "foo"), null);
                 assert.equal(getVariable(scope, "c"), null);
             });
-            eslint.verify(code, config, filename, true);
+            linter.verify(code, config, filename, true);
         });
     });
 
@@ -1653,43 +1657,43 @@ describe("eslint", () => {
         it("builtin global variables should be available in the global scope", () => {
             const config = { rules: {} };
 
-            eslint.reset();
-            eslint.on("Program", () => {
-                const scope = eslint.getScope();
+            linter.reset();
+            linter.on("Program", () => {
+                const scope = linter.getScope();
 
                 assert.notEqual(getVariable(scope, "Object"), null);
                 assert.notEqual(getVariable(scope, "Array"), null);
                 assert.notEqual(getVariable(scope, "undefined"), null);
             });
-            eslint.verify(code, config, filename, true);
+            linter.verify(code, config, filename, true);
         });
 
         it("ES6 global variables should not be available by default", () => {
             const config = { rules: {} };
 
-            eslint.reset();
-            eslint.on("Program", () => {
-                const scope = eslint.getScope();
+            linter.reset();
+            linter.on("Program", () => {
+                const scope = linter.getScope();
 
                 assert.equal(getVariable(scope, "Promise"), null);
                 assert.equal(getVariable(scope, "Symbol"), null);
                 assert.equal(getVariable(scope, "WeakMap"), null);
             });
-            eslint.verify(code, config, filename, true);
+            linter.verify(code, config, filename, true);
         });
 
         it("ES6 global variables should be available in the es6 environment", () => {
             const config = { rules: {} };
 
-            eslint.reset();
-            eslint.on("Program", () => {
-                const scope = eslint.getScope();
+            linter.reset();
+            linter.on("Program", () => {
+                const scope = linter.getScope();
 
                 assert.notEqual(getVariable(scope, "Promise"), null);
                 assert.notEqual(getVariable(scope, "Symbol"), null);
                 assert.notEqual(getVariable(scope, "WeakMap"), null);
             });
-            eslint.verify(code, config, filename, true);
+            linter.verify(code, config, filename, true);
         });
     });
 
@@ -1698,9 +1702,9 @@ describe("eslint", () => {
             config = { rules: {} };
 
         it("getSource() should return an empty string", () => {
-            eslint.reset();
-            eslint.verify(code, config, filename, true);
-            assert.equal(eslint.getSource(), "");
+            linter.reset();
+            linter.verify(code, config, filename, true);
+            assert.equal(linter.getSource(), "");
         });
     });
 
@@ -1708,8 +1712,8 @@ describe("eslint", () => {
         const code = "new-rule";
 
         it("can add a rule dynamically", () => {
-            eslint.reset();
-            eslint.defineRule(code, context => ({
+            linter.reset();
+            linter.defineRule(code, context => ({
                 Literal(node) {
                     context.report(node, "message");
                 }
@@ -1719,7 +1723,7 @@ describe("eslint", () => {
 
             config.rules[code] = 1;
 
-            const messages = eslint.verify("0", config, filename);
+            const messages = linter.verify("0", config, filename);
 
             assert.equal(messages.length, 1);
             assert.equal(messages[0].ruleId, code);
@@ -1731,7 +1735,7 @@ describe("eslint", () => {
         const code = ["new-rule-0", "new-rule-1"];
 
         it("can add multiple rules dynamically", () => {
-            eslint.reset();
+            linter.reset();
             const config = { rules: {} };
             const newRules = {};
 
@@ -1745,9 +1749,9 @@ describe("eslint", () => {
                     };
                 };
             });
-            eslint.defineRules(newRules);
+            linter.defineRules(newRules);
 
-            const messages = eslint.verify("0", config, filename);
+            const messages = linter.verify("0", config, filename);
 
             assert.equal(messages.length, code.length);
             code.forEach(item => {
@@ -1763,8 +1767,8 @@ describe("eslint", () => {
         const code = "filename-rule";
 
         it("has access to the filename", () => {
-            eslint.reset();
-            eslint.defineRule(code, context => ({
+            linter.reset();
+            linter.defineRule(code, context => ({
                 Literal(node) {
                     context.report(node, context.getFilename());
                 }
@@ -1774,14 +1778,14 @@ describe("eslint", () => {
 
             config.rules[code] = 1;
 
-            const messages = eslint.verify("0", config, filename);
+            const messages = linter.verify("0", config, filename);
 
             assert.equal(messages[0].message, filename);
         });
 
         it("defaults filename to '<input>'", () => {
-            eslint.reset();
-            eslint.defineRule(code, context => ({
+            linter.reset();
+            linter.defineRule(code, context => ({
                 Literal(node) {
                     context.report(node, context.getFilename());
                 }
@@ -1791,7 +1795,7 @@ describe("eslint", () => {
 
             config.rules[code] = 1;
 
-            const messages = eslint.verify("0", config);
+            const messages = linter.verify("0", config);
 
             assert.equal(messages[0].message, "<input>");
         });
@@ -1803,7 +1807,7 @@ describe("eslint", () => {
             const code = "/*eslint no-alert:1*/ alert('test');";
             const config = { rules: {} };
 
-            const messages = eslint.verify(code, config, filename);
+            const messages = linter.verify(code, config, filename);
 
             assert.equal(messages.length, 1);
             assert.equal(messages[0].ruleId, "no-alert");
@@ -1816,12 +1820,12 @@ describe("eslint", () => {
             const codeA = "/*eslint strict: 0*/ function bar() { return 2; }";
             const codeB = "function foo() { return 1; }";
 
-            eslint.reset();
-            let messages = eslint.verify(codeA, config, filename, false);
+            linter.reset();
+            let messages = linter.verify(codeA, config, filename, false);
 
             assert.equal(messages.length, 0);
 
-            messages = eslint.verify(codeB, config, filename, false);
+            messages = linter.verify(codeB, config, filename, false);
             assert.equal(messages.length, 1);
         });
 
@@ -1830,12 +1834,12 @@ describe("eslint", () => {
             const codeA = "/*eslint quotes: 0*/ function bar() { return '2'; }";
             const codeB = "function foo() { return '1'; }";
 
-            eslint.reset();
-            let messages = eslint.verify(codeA, config, filename, false);
+            linter.reset();
+            let messages = linter.verify(codeA, config, filename, false);
 
             assert.equal(messages.length, 0);
 
-            messages = eslint.verify(codeB, config, filename, false);
+            messages = linter.verify(codeB, config, filename, false);
             assert.equal(messages.length, 1);
         });
 
@@ -1844,12 +1848,12 @@ describe("eslint", () => {
             const codeA = "/*eslint quotes: [0, \"single\"]*/ function bar() { return '2'; }";
             const codeB = "function foo() { return '1'; }";
 
-            eslint.reset();
-            let messages = eslint.verify(codeA, config, filename, false);
+            linter.reset();
+            let messages = linter.verify(codeA, config, filename, false);
 
             assert.equal(messages.length, 0);
 
-            messages = eslint.verify(codeB, config, filename, false);
+            messages = linter.verify(codeB, config, filename, false);
             assert.equal(messages.length, 1);
         });
 
@@ -1858,12 +1862,12 @@ describe("eslint", () => {
             const codeA = "/*eslint no-unused-vars: [0, {\"vars\": \"local\"}]*/ var a = 44;";
             const codeB = "var b = 55;";
 
-            eslint.reset();
-            let messages = eslint.verify(codeA, config, filename, false);
+            linter.reset();
+            let messages = linter.verify(codeA, config, filename, false);
 
             assert.equal(messages.length, 0);
 
-            messages = eslint.verify(codeB, config, filename, false);
+            messages = linter.verify(codeB, config, filename, false);
             assert.equal(messages.length, 1);
         });
     });
@@ -1874,7 +1878,7 @@ describe("eslint", () => {
         it("should report a violation", () => {
             const config = { rules: {} };
 
-            const fn = eslint.verify.bind(eslint, code, config, filename);
+            const fn = linter.verify.bind(linter, code, config, filename);
 
             assert.throws(fn, "filename.js line 1:\n\tConfiguration for rule \"no-alert\" is invalid:\n\tSeverity should be one of the following: 0 = off, 1 = warn, 2 = error (you passed 'true').\n");
         });
@@ -1886,7 +1890,7 @@ describe("eslint", () => {
         it("should not report a violation", () => {
             const config = { rules: { "no-alert": 1 } };
 
-            const messages = eslint.verify(code, config, filename);
+            const messages = linter.verify(code, config, filename);
 
             assert.equal(messages.length, 0);
         });
@@ -1898,7 +1902,7 @@ describe("eslint", () => {
         it("should report a violation", () => {
             const config = { rules: {} };
 
-            const messages = eslint.verify(code, config, filename);
+            const messages = linter.verify(code, config, filename);
 
             assert.equal(messages.length, 2);
             assert.equal(messages[0].ruleId, "no-alert");
@@ -1914,7 +1918,7 @@ describe("eslint", () => {
         it("should report a violation", () => {
             const config = { rules: { "no-console": 1, "no-alert": 0 } };
 
-            const messages = eslint.verify(code, config, filename);
+            const messages = linter.verify(code, config, filename);
 
             assert.equal(messages.length, 1);
             assert.equal(messages[0].ruleId, "no-alert");
@@ -1926,7 +1930,7 @@ describe("eslint", () => {
     describe("when evaluating code with comments to disable and enable configurable rule as part of plugin", () => {
 
         before(() => {
-            eslint.defineRule("test-plugin/test-rule", context => ({
+            linter.defineRule("test-plugin/test-rule", context => ({
                 Literal(node) {
                     if (node.value === "trigger violation") {
                         context.report(node, "Reporting violation.");
@@ -1939,8 +1943,8 @@ describe("eslint", () => {
             const config = { rules: {} };
             const code = "/*eslint test-plugin/test-rule: 2*/ var a = \"no violation\";";
 
-            eslint.reset();
-            const messages = eslint.verify(code, config, filename);
+            linter.reset();
+            const messages = linter.verify(code, config, filename);
 
             assert.equal(messages.length, 0);
         });
@@ -1949,7 +1953,7 @@ describe("eslint", () => {
             const code = "/*eslint test-plugin/test-rule:0*/ var a = \"trigger violation\"";
             const config = { rules: { "test-plugin/test-rule": 1 } };
 
-            const messages = eslint.verify(code, config, filename);
+            const messages = linter.verify(code, config, filename);
 
             assert.equal(messages.length, 0);
         });
@@ -1959,12 +1963,12 @@ describe("eslint", () => {
             const codeA = "/*eslint test-plugin/test-rule: 0*/ var a = \"trigger violation\";";
             const codeB = "var a = \"trigger violation\";";
 
-            eslint.reset();
-            let messages = eslint.verify(codeA, config, filename, false);
+            linter.reset();
+            let messages = linter.verify(codeA, config, filename, false);
 
             assert.equal(messages.length, 0);
 
-            messages = eslint.verify(codeB, config, filename, false);
+            messages = linter.verify(codeB, config, filename, false);
             assert.equal(messages.length, 1);
         });
     });
@@ -1980,7 +1984,7 @@ describe("eslint", () => {
             ].join("\n");
             const config = { rules: { "no-alert": 1 } };
 
-            const messages = eslint.verify(code, config, filename);
+            const messages = linter.verify(code, config, filename);
 
             assert.equal(messages.length, 1);
             assert.equal(messages[0].ruleId, "no-alert");
@@ -1997,7 +2001,7 @@ describe("eslint", () => {
             ].join("\n");
             const config = { rules: { "no-alert": 1 } };
 
-            const messages = eslint.verify(code, config, filename);
+            const messages = linter.verify(code, config, filename);
 
             assert.equal(messages.length, 0);
         });
@@ -2011,7 +2015,7 @@ describe("eslint", () => {
             ].join("");
             const config = { rules: { "no-alert": 1 } };
 
-            const messages = eslint.verify(code, config, filename);
+            const messages = linter.verify(code, config, filename);
 
             assert.equal(messages.length, 2);
             assert.equal(messages[0].column, 21);
@@ -2032,7 +2036,7 @@ describe("eslint", () => {
 
             const config = { rules: { "no-alert": 1 } };
 
-            const messages = eslint.verify(code, config, filename);
+            const messages = linter.verify(code, config, filename);
 
             assert.equal(messages.length, 0);
         });
@@ -2047,7 +2051,7 @@ describe("eslint", () => {
 
             const config = { rules: { "no-unused-vars": 1 } };
 
-            const messages = eslint.verify(code, config, filename);
+            const messages = linter.verify(code, config, filename);
 
             assert.equal(messages.length, 0);
         });
@@ -2060,7 +2064,7 @@ describe("eslint", () => {
 
             const config = { rules: { "no-unused-vars": 1 } };
 
-            const messages = eslint.verify(code, config, filename);
+            const messages = linter.verify(code, config, filename);
 
             assert.equal(messages.length, 0);
         });
@@ -2081,7 +2085,7 @@ describe("eslint", () => {
                     }
                 };
 
-                const messages = eslint.verify(code, config, filename);
+                const messages = linter.verify(code, config, filename);
 
                 assert.equal(messages.length, 1);
 
@@ -2101,7 +2105,7 @@ describe("eslint", () => {
                     }
                 };
 
-                const messages = eslint.verify(code, config, filename);
+                const messages = linter.verify(code, config, filename);
 
                 assert.equal(messages.length, 1);
 
@@ -2119,7 +2123,7 @@ describe("eslint", () => {
                     }
                 };
 
-                const messages = eslint.verify(code, config, filename);
+                const messages = linter.verify(code, config, filename);
 
                 assert.equal(messages.length, 1);
 
@@ -2138,7 +2142,7 @@ describe("eslint", () => {
                     }
                 };
 
-                const messages = eslint.verify(code, config, filename);
+                const messages = linter.verify(code, config, filename);
 
                 assert.equal(messages.length, 0);
             });
@@ -2157,7 +2161,7 @@ describe("eslint", () => {
                     }
                 };
 
-                const messages = eslint.verify(code, config, filename);
+                const messages = linter.verify(code, config, filename);
 
                 assert.equal(messages.length, 0);
             });
@@ -2176,7 +2180,7 @@ describe("eslint", () => {
                         "no-console": 1
                     }
                 };
-                const messages = eslint.verify(code, config, filename);
+                const messages = linter.verify(code, config, filename);
 
                 assert.equal(messages.length, 1);
                 assert.equal(messages[0].ruleId, "no-console");
@@ -2194,7 +2198,7 @@ describe("eslint", () => {
                         "no-console": 1
                     }
                 };
-                const messages = eslint.verify(code, config, filename);
+                const messages = linter.verify(code, config, filename);
 
                 assert.equal(messages.length, 2);
                 assert.equal(messages[0].ruleId, "no-alert");
@@ -2214,7 +2218,7 @@ describe("eslint", () => {
                         "no-console": 1
                     }
                 };
-                const messages = eslint.verify(code, config, filename);
+                const messages = linter.verify(code, config, filename);
 
                 assert.equal(messages.length, 1);
                 assert.equal(messages[0].ruleId, "no-console");
@@ -2233,7 +2237,7 @@ describe("eslint", () => {
                         "no-console": 1
                     }
                 };
-                const messages = eslint.verify(code, config, filename);
+                const messages = linter.verify(code, config, filename);
 
                 assert.equal(messages.length, 2);
                 assert.equal(messages[0].ruleId, "no-alert");
@@ -2254,7 +2258,7 @@ describe("eslint", () => {
                         "no-console": 1
                     }
                 };
-                const messages = eslint.verify(code, config, filename);
+                const messages = linter.verify(code, config, filename);
 
                 assert.equal(messages.length, 1);
                 assert.equal(messages[0].ruleId, "no-console");
@@ -2273,7 +2277,7 @@ describe("eslint", () => {
                         "no-console": 1
                     }
                 };
-                const messages = eslint.verify(code, config, filename);
+                const messages = linter.verify(code, config, filename);
 
                 assert.equal(messages.length, 3);
                 assert.equal(messages[0].ruleId, "no-alert");
@@ -2293,7 +2297,7 @@ describe("eslint", () => {
             ].join("\n");
             const config = { rules: { "no-alert": 1, "no-console": 1 } };
 
-            const messages = eslint.verify(code, config, filename);
+            const messages = linter.verify(code, config, filename);
 
             assert.equal(messages.length, 1);
 
@@ -2312,7 +2316,7 @@ describe("eslint", () => {
             ].join("\n");
             const config = { rules: { "no-alert": 1, "no-console": 1 } };
 
-            const messages = eslint.verify(code, config, filename);
+            const messages = linter.verify(code, config, filename);
 
             assert.equal(messages.length, 2);
 
@@ -2333,7 +2337,7 @@ describe("eslint", () => {
             ].join("\n");
             const config = { rules: { "no-alert": 1, "no-console": 1 } };
 
-            const messages = eslint.verify(code, config, filename);
+            const messages = linter.verify(code, config, filename);
 
             assert.equal(messages.length, 1);
 
@@ -2353,7 +2357,7 @@ describe("eslint", () => {
             ].join("\n");
             const config = { rules: { "no-alert": 1, "no-console": 1 } };
 
-            const messages = eslint.verify(code, config, filename);
+            const messages = linter.verify(code, config, filename);
 
             assert.equal(messages.length, 1);
 
@@ -2383,7 +2387,7 @@ describe("eslint", () => {
             ].join("\n");
             const config = { rules: { "no-alert": 1, "no-console": 1 } };
 
-            const messages = eslint.verify(code, config, filename);
+            const messages = linter.verify(code, config, filename);
 
             assert.equal(messages.length, 3);
 
@@ -2417,7 +2421,7 @@ describe("eslint", () => {
             ].join("\n");
             const config = { rules: { "no-alert": 1, "no-console": 1 } };
 
-            const messages = eslint.verify(code, config, filename);
+            const messages = linter.verify(code, config, filename);
 
             assert.equal(messages.length, 3);
 
@@ -2451,7 +2455,7 @@ describe("eslint", () => {
             ].join("\n");
             const config = { rules: { "no-alert": "warn", "no-console": "warn" } };
 
-            const messages = eslint.verify(code, config, filename);
+            const messages = linter.verify(code, config, filename);
 
             assert.equal(messages.length, 3);
 
@@ -2473,7 +2477,7 @@ describe("eslint", () => {
         it("should report a violation", () => {
             const config = { rules: { "no-console": 1, "no-alert": 0 } };
 
-            const messages = eslint.verify(code, config, filename);
+            const messages = linter.verify(code, config, filename);
 
             assert.equal(messages.length, 1);
             assert.equal(messages[0].ruleId, "no-alert");
@@ -2488,7 +2492,7 @@ describe("eslint", () => {
         it("should report a violation", () => {
             const config = { rules: { quotes: [2, "single"] } };
 
-            const messages = eslint.verify(code, config, filename);
+            const messages = linter.verify(code, config, filename);
 
             assert.equal(messages.length, 1);
             assert.equal(messages[0].ruleId, "quotes");
@@ -2503,7 +2507,7 @@ describe("eslint", () => {
         it("should report a violation", () => {
             const config = { rules: { quotes: [2, "single"] } };
 
-            const messages = eslint.verify(code, config, filename);
+            const messages = linter.verify(code, config, filename);
 
             assert.equal(messages.length, 1);
             assert.equal(messages[0].ruleId, "quotes");
@@ -2518,7 +2522,7 @@ describe("eslint", () => {
 
             const config = { rules: { "no-alert": 1 } };
 
-            const messages = eslint.verify(code, config, filename);
+            const messages = linter.verify(code, config, filename);
 
             assert.equal(messages.length, 2);
 
@@ -2543,7 +2547,7 @@ describe("eslint", () => {
 
             const config = { rules: { "no-alert": 1 } };
 
-            const messages = eslint.verify(code, config, filename);
+            const messages = linter.verify(code, config, filename);
 
             assert.equal(messages.length, 2);
 
@@ -2568,7 +2572,7 @@ describe("eslint", () => {
 
             const config = { rules: { "no-alert": 1 } };
 
-            const messages = eslint.verify(code, config, filename);
+            const messages = linter.verify(code, config, filename);
 
             assert.equal(messages.length, 2);
 
@@ -2593,7 +2597,7 @@ describe("eslint", () => {
         const code = "/* eslint max-len: [2, 100, 2, {ignoreUrls: true, ignorePattern: \"data:image\\/|\\s*require\\s*\\(|^\\s*loader\\.lazy|-\\*-\"}] */\nalert('test');";
 
         it("should not parse errors, should report a violation", () => {
-            const messages = eslint.verify(code, {}, filename);
+            const messages = linter.verify(code, {}, filename);
 
             assert.equal(messages.length, 1);
             assert.equal(messages[0].ruleId, "max-len");
@@ -2607,7 +2611,7 @@ describe("eslint", () => {
 
         it("should preserve line numbers", () => {
             const config = { rules: { "no-extra-semi": 1 } };
-            const messages = eslint.verify(code, config);
+            const messages = linter.verify(code, config);
 
             assert.equal(messages.length, 1);
             assert.equal(messages[0].ruleId, "no-extra-semi");
@@ -2618,15 +2622,15 @@ describe("eslint", () => {
         it("should have a comment with the shebang in it", () => {
             const config = { rules: { "no-extra-semi": 1 } };
 
-            eslint.reset();
+            linter.reset();
 
-            eslint.on("Program", () => {
-                const comments = eslint.getAllComments();
+            linter.on("Program", () => {
+                const comments = linter.getAllComments();
 
                 assert.equal(comments.length, 1);
                 assert.equal(comments[0].type, "Shebang");
             });
-            eslint.verify(code, config, "foo.js", true);
+            linter.verify(code, config, "foo.js", true);
         });
     });
 
@@ -2634,7 +2638,7 @@ describe("eslint", () => {
         const code = BROKEN_TEST_CODE;
 
         it("should report a violation with a useful parse error prefix", () => {
-            const messages = eslint.verify(code);
+            const messages = linter.verify(code);
 
             assert.equal(messages.length, 1);
             assert.equal(messages[0].severity, 2);
@@ -2653,7 +2657,7 @@ describe("eslint", () => {
                 "    x++;",
                 "}"
             ];
-            const messages = eslint.verify(inValidCode.join("\n"));
+            const messages = linter.verify(inValidCode.join("\n"));
 
             assert.equal(messages.length, 1);
             assert.equal(messages[0].severity, 2);
@@ -2665,12 +2669,12 @@ describe("eslint", () => {
 
     describe("when using an invalid (undefined) rule", () => {
         const code = TEST_CODE;
-        const results = eslint.verify(code, { rules: { foobar: 2 } });
+        const results = linter.verify(code, { rules: { foobar: 2 } });
         const result = results[0];
-        const warningResult = eslint.verify(code, { rules: { foobar: 1 } })[0];
-        const arrayOptionResults = eslint.verify(code, { rules: { foobar: [2, "always"] } });
-        const objectOptionResults = eslint.verify(code, { rules: { foobar: [1, { bar: false }] } });
-        const resultsMultiple = eslint.verify(code, { rules: { foobar: 2, barfoo: 1 } });
+        const warningResult = linter.verify(code, { rules: { foobar: 1 } })[0];
+        const arrayOptionResults = linter.verify(code, { rules: { foobar: [2, "always"] } });
+        const objectOptionResults = linter.verify(code, { rules: { foobar: [1, { bar: false }] } });
+        const resultsMultiple = linter.verify(code, { rules: { foobar: 2, barfoo: 1 } });
 
         it("should add a stub rule", () => {
             assert.isNotNull(result);
@@ -2704,7 +2708,7 @@ describe("eslint", () => {
 
     describe("when using a rule which has been replaced", () => {
         const code = TEST_CODE;
-        const results = eslint.verify(code, { rules: { "no-comma-dangle": 2 } });
+        const results = linter.verify(code, { rules: { "no-comma-dangle": 2 } });
 
         it("should report the new rule", () => {
             assert.equal(results[0].ruleId, "no-comma-dangle");
@@ -2717,14 +2721,14 @@ describe("eslint", () => {
 
         it("should throw an error", () => {
             assert.throws(() => {
-                eslint.verify(code, { rules: { foobar: null } });
+                linter.verify(code, { rules: { foobar: null } });
             }, /Invalid config for rule 'foobar'\./);
         });
     });
 
     describe("when calling defaults", () => {
         it("should return back config object", () => {
-            const config = eslint.defaults();
+            const config = linter.defaults();
 
             assert.isNotNull(config.rules);
         });
@@ -2732,7 +2736,7 @@ describe("eslint", () => {
 
     describe("when calling getRules", () => {
         it("should return all loaded rules", () => {
-            const rules = eslint.getRules();
+            const rules = linter.getRules();
 
             assert.isAbove(rules.size, 230);
             assert.isObject(rules.get("no-alert"));
@@ -2741,7 +2745,7 @@ describe("eslint", () => {
 
     describe("when calling version", () => {
         it("should return current version number", () => {
-            const version = eslint.version;
+            const version = linter.version;
 
             assert.isString(version);
             assert.isTrue(parseInt(version[0], 10) >= 3);
@@ -2754,7 +2758,7 @@ describe("eslint", () => {
 
             const config = { rules: { "no-undef": 1 } };
 
-            const messages = eslint.verify(code, config, filename);
+            const messages = linter.verify(code, config, filename);
 
             assert.equal(messages.length, 1);
         });
@@ -2764,7 +2768,7 @@ describe("eslint", () => {
 
             const config = { rules: { "no-undef": 1 } };
 
-            const messages = eslint.verify(code, config, filename);
+            const messages = linter.verify(code, config, filename);
 
             assert.equal(messages.length, 1);
         });
@@ -2776,7 +2780,7 @@ describe("eslint", () => {
 
             const config = { rules: { "no-undef": 1 } };
 
-            const messages = eslint.verify(code, config, filename);
+            const messages = linter.verify(code, config, filename);
 
             assert.equal(messages.length, 1);
             assert.equal(messages[0].ruleId, "no-undef");
@@ -2789,7 +2793,7 @@ describe("eslint", () => {
 
             const config = { rules: { "no-undef": 1 } };
 
-            const messages = eslint.verify(code, config, filename);
+            const messages = linter.verify(code, config, filename);
 
             assert.equal(messages.length, 0);
         });
@@ -2799,7 +2803,7 @@ describe("eslint", () => {
 
             const config = { rules: { "no-undef": 1 } };
 
-            const messages = eslint.verify(code, config, filename);
+            const messages = linter.verify(code, config, filename);
 
             assert.equal(messages.length, 0);
         });
@@ -2809,7 +2813,7 @@ describe("eslint", () => {
 
             const config = { rules: { "no-undef": 1 } };
 
-            const messages = eslint.verify(code, config, filename);
+            const messages = linter.verify(code, config, filename);
 
             assert.equal(messages.length, 0);
         });
@@ -2819,7 +2823,7 @@ describe("eslint", () => {
 
             const config = { rules: { "no-undef": 1 } };
 
-            const messages = eslint.verify(code, config, filename);
+            const messages = linter.verify(code, config, filename);
 
             assert.equal(messages.length, 0);
         });
@@ -2829,7 +2833,7 @@ describe("eslint", () => {
 
             const config = { rules: { "no-undef": 1 } };
 
-            const messages = eslint.verify(code, config, filename);
+            const messages = linter.verify(code, config, filename);
 
             assert.equal(messages.length, 0);
         });
@@ -2839,7 +2843,7 @@ describe("eslint", () => {
 
             const config = { rules: { "no-undef": 1 } };
 
-            const messages = eslint.verify(code, config, filename);
+            const messages = linter.verify(code, config, filename);
 
             assert.equal(messages.length, 0);
         });
@@ -2849,7 +2853,7 @@ describe("eslint", () => {
 
             const config = { rules: {} };
 
-            const messages = eslint.verify(code, config, filename);
+            const messages = linter.verify(code, config, filename);
 
             assert.equal(messages.length, 0);
         });
@@ -2859,7 +2863,7 @@ describe("eslint", () => {
 
             const config = { rules: { "no-undef": 1 } };
 
-            const messages = eslint.verify(code, config, filename);
+            const messages = linter.verify(code, config, filename);
 
             assert.equal(messages.length, 0);
         });
@@ -2876,7 +2880,7 @@ describe("eslint", () => {
                 }
             };
 
-            const messages = eslint.verify(code, config, {
+            const messages = linter.verify(code, config, {
                 filename,
                 allowInlineConfig: false
             });
@@ -2896,7 +2900,7 @@ describe("eslint", () => {
             };
             let ok = false;
 
-            eslint.defineRules({ test(context) {
+            linter.defineRules({ test(context) {
                 return {
                     Program() {
                         const scope = context.getScope();
@@ -2914,7 +2918,7 @@ describe("eslint", () => {
                 };
             } });
 
-            eslint.verify(code, config, { allowInlineConfig: false });
+            linter.verify(code, config, { allowInlineConfig: false });
             assert(ok);
         });
 
@@ -2929,7 +2933,7 @@ describe("eslint", () => {
                 }
             };
 
-            const messages = eslint.verify(code, config, {
+            const messages = linter.verify(code, config, {
                 filename,
                 allowInlineConfig: false
             });
@@ -2949,7 +2953,7 @@ describe("eslint", () => {
                 }
             };
 
-            const messages = eslint.verify(code, config, {
+            const messages = linter.verify(code, config, {
                 filename,
                 allowInlineConfig: false
             });
@@ -2967,7 +2971,7 @@ describe("eslint", () => {
                 }
             };
 
-            const messages = eslint.verify(code, config, {
+            const messages = linter.verify(code, config, {
                 filename,
                 allowInlineConfig: false
             });
@@ -2987,7 +2991,7 @@ describe("eslint", () => {
             };
             let ok = false;
 
-            eslint.defineRules({ test(context) {
+            linter.defineRules({ test(context) {
                 return {
                     Program() {
                         const scope = context.getScope();
@@ -3005,7 +3009,7 @@ describe("eslint", () => {
                 };
             } });
 
-            eslint.verify(code, config, { allowInlineConfig: false });
+            linter.verify(code, config, { allowInlineConfig: false });
             assert(ok);
         });
     });
@@ -3021,7 +3025,7 @@ describe("eslint", () => {
                 }
             };
 
-            const messages = eslint.verify(code, config, {
+            const messages = linter.verify(code, config, {
                 filename,
                 allowInlineConfig: true
             });
@@ -3037,12 +3041,12 @@ describe("eslint", () => {
 
             const config = { rules: {} };
 
-            eslint.reset();
-            eslint.on("ExpressionStatement", node => {
-                assert.equal(eslint.getSource(node), "'123';");
+            linter.reset();
+            linter.on("ExpressionStatement", node => {
+                assert.equal(linter.getSource(node), "'123';");
             });
 
-            eslint.verify(code, config, filename, true);
+            linter.verify(code, config, filename, true);
         });
     });
 
@@ -3050,32 +3054,32 @@ describe("eslint", () => {
         describe("filenames", () => {
             it("should allow filename to be passed on options object", () => {
 
-                eslint.verify("foo;", {}, { filename: "foo.js" });
-                const result = eslint.getFilename();
+                linter.verify("foo;", {}, { filename: "foo.js" });
+                const result = linter.getFilename();
 
                 assert.equal(result, "foo.js");
             });
 
             it("should allow filename to be passed as third argument", () => {
 
-                eslint.verify("foo;", {}, "foo.js");
-                const result = eslint.getFilename();
+                linter.verify("foo;", {}, "foo.js");
+                const result = linter.getFilename();
 
                 assert.equal(result, "foo.js");
             });
 
             it("should default filename to <input> when options object doesn't have filename", () => {
 
-                eslint.verify("foo;", {}, {});
-                const result = eslint.getFilename();
+                linter.verify("foo;", {}, {});
+                const result = linter.getFilename();
 
                 assert.equal(result, "<input>");
             });
 
             it("should default filename to <input> when only two arguments are passed", () => {
 
-                eslint.verify("foo;", {});
-                const result = eslint.getFilename();
+                linter.verify("foo;", {});
+                const result = linter.getFilename();
 
                 assert.equal(result, "<input>");
             });
@@ -3084,9 +3088,9 @@ describe("eslint", () => {
         describe("saveState", () => {
             it("should save the state when saveState is passed as an option", () => {
 
-                const spy = sinon.spy(eslint, "reset");
+                const spy = sinon.spy(linter, "reset");
 
-                eslint.verify("foo;", {}, { saveState: true });
+                linter.verify("foo;", {}, { saveState: true });
                 assert.equal(spy.callCount, 0);
             });
         });
@@ -3096,7 +3100,7 @@ describe("eslint", () => {
             const code = "foo()\n    alert('test')";
             const config = { rules: { "no-mixed-spaces-and-tabs": 1, "eol-last": 1, semi: [1, "always"] } };
 
-            const messages = eslint.verify(code, config, filename);
+            const messages = linter.verify(code, config, filename);
 
             assert.equal(messages.length, 3);
             assert.equal(messages[0].line, 1);
@@ -3110,7 +3114,7 @@ describe("eslint", () => {
         describe("ecmaVersion", () => {
             describe("it should properly parse let declaration when", () => {
                 it("the ECMAScript version number is 6", () => {
-                    const messages = eslint.verify("let x = 5;", {
+                    const messages = linter.verify("let x = 5;", {
                         parserOptions: {
                             ecmaVersion: 6
                         }
@@ -3120,7 +3124,7 @@ describe("eslint", () => {
                 });
 
                 it("the ECMAScript version number is 2015", () => {
-                    const messages = eslint.verify("let x = 5;", {
+                    const messages = linter.verify("let x = 5;", {
                         parserOptions: {
                             ecmaVersion: 2015
                         }
@@ -3131,7 +3135,7 @@ describe("eslint", () => {
             });
 
             it("should fail to parse exponentiation operator when the ECMAScript version number is 2015", () => {
-                const messages = eslint.verify("x ** y;", {
+                const messages = linter.verify("x ** y;", {
                     parserOptions: {
                         ecmaVersion: 2015
                     }
@@ -3142,7 +3146,7 @@ describe("eslint", () => {
 
             describe("should properly parse exponentiation operator when", () => {
                 it("the ECMAScript version number is 7", () => {
-                    const messages = eslint.verify("x ** y;", {
+                    const messages = linter.verify("x ** y;", {
                         parserOptions: {
                             ecmaVersion: 7
                         }
@@ -3152,7 +3156,7 @@ describe("eslint", () => {
                 });
 
                 it("the ECMAScript version number is 2016", () => {
-                    const messages = eslint.verify("x ** y;", {
+                    const messages = linter.verify("x ** y;", {
                         parserOptions: {
                             ecmaVersion: 2016
                         }
@@ -3165,7 +3169,7 @@ describe("eslint", () => {
 
         it("should properly parse object spread when passed ecmaFeatures", () => {
 
-            const messages = eslint.verify("var x = { ...y };", {
+            const messages = linter.verify("var x = { ...y };", {
                 parserOptions: {
                     ecmaVersion: 6,
                     ecmaFeatures: {
@@ -3179,7 +3183,7 @@ describe("eslint", () => {
 
         it("should properly parse global return when passed ecmaFeatures", () => {
 
-            const messages = eslint.verify("return;", {
+            const messages = linter.verify("return;", {
                 parserOptions: {
                     ecmaFeatures: {
                         globalReturn: true
@@ -3192,7 +3196,7 @@ describe("eslint", () => {
 
         it("should properly parse global return when in Node.js environment", () => {
 
-            const messages = eslint.verify("return;", {
+            const messages = linter.verify("return;", {
                 env: {
                     node: true
                 }
@@ -3203,7 +3207,7 @@ describe("eslint", () => {
 
         it("should not parse global return when in Node.js environment with globalReturn explicitly off", () => {
 
-            const messages = eslint.verify("return;", {
+            const messages = linter.verify("return;", {
                 env: {
                     node: true
                 },
@@ -3220,7 +3224,7 @@ describe("eslint", () => {
 
         it("should not parse global return when Node.js environment is false", () => {
 
-            const messages = eslint.verify("return;", {}, filename);
+            const messages = linter.verify("return;", {}, filename);
 
             assert.equal(messages.length, 1);
             assert.equal(messages[0].message, "Parsing error: 'return' outside of function");
@@ -3228,14 +3232,14 @@ describe("eslint", () => {
 
         it("should properly parse sloppy-mode code when impliedStrict is false", () => {
 
-            const messages = eslint.verify("var private;", {}, filename);
+            const messages = linter.verify("var private;", {}, filename);
 
             assert.equal(messages.length, 0);
         });
 
         it("should not parse sloppy-mode code when impliedStrict is true", () => {
 
-            const messages = eslint.verify("var private;", {
+            const messages = linter.verify("var private;", {
                 parserOptions: {
                     ecmaFeatures: {
                         impliedStrict: true
@@ -3249,7 +3253,7 @@ describe("eslint", () => {
 
         it("should properly parse valid code when impliedStrict is true", () => {
 
-            const messages = eslint.verify("var foo;", {
+            const messages = linter.verify("var foo;", {
                 parserOptions: {
                     ecmaFeatures: {
                         impliedStrict: true
@@ -3262,7 +3266,7 @@ describe("eslint", () => {
 
         it("should properly parse JSX when passed ecmaFeatures", () => {
 
-            const messages = eslint.verify("var x = <div/>;", {
+            const messages = linter.verify("var x = <div/>;", {
                 parserOptions: {
                     ecmaFeatures: {
                         jsx: true
@@ -3275,7 +3279,7 @@ describe("eslint", () => {
 
         it("should report an error when JSX code is encountered and JSX is not enabled", () => {
             const code = "var myDivElement = <div className=\"foo\" />;";
-            const messages = eslint.verify(code, {}, "filename");
+            const messages = linter.verify(code, {}, "filename");
 
             assert.equal(messages.length, 1);
             assert.equal(messages[0].line, 1);
@@ -3285,14 +3289,14 @@ describe("eslint", () => {
 
         it("should not report an error when JSX code is encountered and JSX is enabled", () => {
             const code = "var myDivElement = <div className=\"foo\" />;";
-            const messages = eslint.verify(code, { parserOptions: { ecmaFeatures: { jsx: true } } }, "filename");
+            const messages = linter.verify(code, { parserOptions: { ecmaFeatures: { jsx: true } } }, "filename");
 
             assert.equal(messages.length, 0);
         });
 
         it("should not report an error when JSX code contains a spread operator and JSX is enabled", () => {
             const code = "var myDivElement = <div {...this.props} />;";
-            const messages = eslint.verify(code, { parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } }, "filename");
+            const messages = linter.verify(code, { parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } }, "filename");
 
             assert.equal(messages.length, 0);
         });
@@ -3321,13 +3325,13 @@ describe("eslint", () => {
                 "var unicode = '\\u{20BB7}';"
             ].join("\n");
 
-            const messages = eslint.verify(code, null, "eslint-env es6");
+            const messages = linter.verify(code, null, "eslint-env es6");
 
             assert.equal(messages.length, 0);
         });
 
         it("should be able to return in global if there is a comment which has \"eslint-env node\"", () => {
-            const messages = eslint.verify("/* eslint-env node */ return;", null, "eslint-env node");
+            const messages = linter.verify("/* eslint-env node */ return;", null, "eslint-env node");
 
             assert.equal(messages.length, 0);
         });
@@ -3336,7 +3340,7 @@ describe("eslint", () => {
             const code = "/* global foo */\n/* global bar, baz */";
             let ok = false;
 
-            eslint.defineRules({ test(context) {
+            linter.defineRules({ test(context) {
                 return {
                     Program() {
                         const scope = context.getScope();
@@ -3365,17 +3369,17 @@ describe("eslint", () => {
                 };
             } });
 
-            eslint.verify(code, { rules: { test: 2 } });
+            linter.verify(code, { rules: { test: 2 } });
             assert(ok);
         });
 
         it("should not crash when we reuse the SourceCode object", () => {
-            eslint.verify("function render() { return <div className='test'>{hello}</div> }", { parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } });
-            eslint.verify(eslint.getSourceCode(), { parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } });
+            linter.verify("function render() { return <div className='test'>{hello}</div> }", { parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } });
+            linter.verify(linter.getSourceCode(), { parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } });
         });
 
         it("should allow 'await' as a property name in modules", () => {
-            const result = eslint.verify(
+            const result = linter.verify(
                 "obj.await",
                 { parserOptions: { ecmaVersion: 6, sourceType: "module" } }
             );
@@ -3389,7 +3393,7 @@ describe("eslint", () => {
 
             Object.freeze(config);
             assert.doesNotThrow(() => {
-                eslint.verify("var foo", config);
+                linter.verify("var foo", config);
             });
         });
     });
@@ -3412,7 +3416,7 @@ describe("eslint", () => {
         beforeEach(() => {
             let ok = false;
 
-            eslint.defineRules({ test(context) {
+            linter.defineRules({ test(context) {
                 return {
                     Program() {
                         scope = context.getScope();
@@ -3420,7 +3424,7 @@ describe("eslint", () => {
                     }
                 };
             } });
-            eslint.verify(code, { rules: { test: 2 }, globals: { e: true, f: false } });
+            linter.verify(code, { rules: { test: 2 }, globals: { e: true, f: false } });
             assert(ok);
         });
 
@@ -3501,7 +3505,7 @@ describe("eslint", () => {
          * @returns {void}
          */
         function checkEmpty(node) {
-            assert.equal(0, eslint.getDeclaredVariables(node).length);
+            assert.equal(0, linter.getDeclaredVariables(node).length);
         }
 
         /**
@@ -3512,7 +3516,7 @@ describe("eslint", () => {
          * @returns {void}
          */
         function verify(code, type, expectedNamesList) {
-            eslint.defineRules({ test(context) {
+            linter.defineRules({ test(context) {
                 const rule = {
                     Program: checkEmpty,
                     EmptyStatement: checkEmpty,
@@ -3576,7 +3580,7 @@ describe("eslint", () => {
                 };
                 return rule;
             } });
-            eslint.verify(code, {
+            linter.verify(code, {
                 rules: { test: 2 },
                 parserOptions: {
                     ecmaVersion: 6,
@@ -3734,39 +3738,39 @@ describe("eslint", () => {
 
         it("should properly parse import statements when sourceType is module", () => {
             const code = "import foo from 'foo';";
-            const messages = eslint.verify(code, { parserOptions: { sourceType: "module" } });
+            const messages = linter.verify(code, { parserOptions: { sourceType: "module" } });
 
             assert.equal(messages.length, 0);
         });
 
         it("should properly parse import all statements when sourceType is module", () => {
             const code = "import * as foo from 'foo';";
-            const messages = eslint.verify(code, { parserOptions: { sourceType: "module" } });
+            const messages = linter.verify(code, { parserOptions: { sourceType: "module" } });
 
             assert.equal(messages.length, 0);
         });
 
         it("should properly parse default export statements when sourceType is module", () => {
             const code = "export default function initialize() {}";
-            const messages = eslint.verify(code, { parserOptions: { sourceType: "module" } });
+            const messages = linter.verify(code, { parserOptions: { sourceType: "module" } });
 
             assert.equal(messages.length, 0);
         });
 
         it("should not crash when invalid parentheses syntax is encountered", () => {
-            eslint.verify("left = (aSize.width/2) - ()");
+            linter.verify("left = (aSize.width/2) - ()");
         });
 
         it("should not crash when let is used inside of switch case", () => {
-            eslint.verify("switch(foo) { case 1: let bar=2; }", { parserOptions: { ecmaVersion: 6 } });
+            linter.verify("switch(foo) { case 1: let bar=2; }", { parserOptions: { ecmaVersion: 6 } });
         });
 
         it("should not crash when parsing destructured assignment", () => {
-            eslint.verify("var { a='a' } = {};", { parserOptions: { ecmaVersion: 6 } });
+            linter.verify("var { a='a' } = {};", { parserOptions: { ecmaVersion: 6 } });
         });
 
         it("should report syntax error when a keyword exists in object property shorthand", () => {
-            const messages = eslint.verify("let a = {this}", { parserOptions: { ecmaVersion: 6 } });
+            const messages = linter.verify("let a = {this}", { parserOptions: { ecmaVersion: 6 } });
 
             assert.equal(messages.length, 1);
             assert.equal(messages[0].fatal, true);
@@ -3777,8 +3781,8 @@ describe("eslint", () => {
             // This test focuses on the instance of https://github.com/eslint/eslint/blob/v2.0.0-alpha-2/conf/environments.js#L26-L28
 
             // This `verify()` takes the instance and runs https://github.com/eslint/eslint/blob/v2.0.0-alpha-2/lib/eslint.js#L416
-            eslint.defineRule("test", () => ({}));
-            eslint.verify("var a = 0;", {
+            linter.defineRule("test", () => ({}));
+            linter.verify("var a = 0;", {
                 env: { node: true },
                 parserOptions: { sourceType: "module" },
                 rules: { test: 2 }
@@ -3787,7 +3791,7 @@ describe("eslint", () => {
             // This `verify()` takes the instance and tests that the instance was not modified.
             let ok = false;
 
-            eslint.defineRule("test", context => {
+            linter.defineRule("test", context => {
                 assert(
                     context.parserOptions.ecmaFeatures.globalReturn,
                     "`ecmaFeatures.globalReturn` of the node environment should not be modified."
@@ -3795,7 +3799,7 @@ describe("eslint", () => {
                 ok = true;
                 return {};
             });
-            eslint.verify("var a = 0;", {
+            linter.verify("var a = 0;", {
                 env: { node: true },
                 rules: { test: 2 }
             });
@@ -3817,21 +3821,21 @@ describe("eslint", () => {
                 const parser = path.join(parserFixtures, "stub-parser.js");
                 const parseSpy = sinon.spy(require(parser), "parse");
 
-                eslint.verify(code, { parser }, filename, true);
+                linter.verify(code, { parser }, filename, true);
 
                 sinon.assert.calledWithMatch(parseSpy, "", { filePath: filename });
             });
 
             it("should not report an error when JSX code contains a spread operator and JSX is enabled", () => {
                 const code = "var myDivElement = <div {...this.props} />;";
-                const messages = eslint.verify(code, { parser: "esprima-fb" }, "filename");
+                const messages = linter.verify(code, { parser: "esprima-fb" }, "filename");
 
                 assert.equal(messages.length, 0);
             });
 
             it("should return an error when the custom parser can't be found", () => {
                 const code = "var myDivElement = <div {...this.props} />;";
-                const messages = eslint.verify(code, { parser: "esprima-fbxyz" }, "filename");
+                const messages = linter.verify(code, { parser: "esprima-fbxyz" }, "filename");
 
                 assert.equal(messages.length, 1);
                 assert.equal(messages[0].severity, 2);
@@ -3840,7 +3844,7 @@ describe("eslint", () => {
 
             it("should strip leading line: prefix from parser error", () => {
                 const parser = path.join(parserFixtures, "line-error.js");
-                const messages = eslint.verify(";", { parser }, "filename");
+                const messages = linter.verify(";", { parser }, "filename");
 
                 assert.equal(messages.length, 1);
                 assert.equal(messages[0].severity, 2);
@@ -3850,7 +3854,7 @@ describe("eslint", () => {
 
             it("should not modify a parser error message without a leading line: prefix", () => {
                 const parser = path.join(parserFixtures, "no-line-error.js");
-                const messages = eslint.verify(";", { parser }, "filename");
+                const messages = linter.verify(";", { parser }, "filename");
 
                 assert.equal(messages.length, 1);
                 assert.equal(messages[0].severity, 2);

--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -1,0 +1,73 @@
+/**
+ * @fileoverview Test file for Linter class
+ * @author Gyandeep Singh
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const assert = require("chai").assert,
+    Linter = require("../../lib/linter");
+
+//------------------------------------------------------------------------------
+// Tests
+// All the core logic has been tested inside eslint.js file
+// Here we will be focusing more on the mutability portion of it
+//------------------------------------------------------------------------------
+
+/**
+ * extract the keys into an array
+ * @param {Map} mapObj - Map type object
+ * @returns {Array<*>} collection of all the keys
+ * @private
+ */
+function extractMapKeys(mapObj) {
+    const keys = [];
+
+    for (const key of mapObj.keys()) {
+        keys.push(key);
+    }
+
+    return keys;
+}
+
+describe("Linter", () => {
+    describe("mutability", () => {
+        let linter1 = null;
+        let linter2 = null;
+
+        beforeEach(() => {
+            linter1 = new Linter();
+            linter2 = new Linter();
+        });
+
+        describe("rules", () => {
+            it("with no changes, same rules are loaded", () => {
+                assert.sameDeepMembers(extractMapKeys(linter1.getRules()), extractMapKeys(linter2.getRules()));
+            });
+
+            it("loading rule in one doesnt change the other", () => {
+                linter1.defineRule("mock-rule", () => ({}));
+
+                assert.isTrue(linter1.getRules().has("mock-rule"), "mock rule is present");
+                assert.isFalse(linter2.getRules().has("mock-rule"), "mock rule is not present");
+            });
+        });
+
+        describe("environments", () => {
+            it("with no changes same env are loaded", () => {
+                assert.sameDeepMembers([linter1.environments.getAll()], [linter2.environments.getAll()]);
+            });
+
+            it("defining env in one doesnt change the other", () => {
+                linter1.environments.define("mock-env", true);
+
+                assert.isTrue(linter1.environments.get("mock-env"), "mock env is present");
+                assert.isNull(linter2.environments.get("mock-env"), "mock env is not present");
+            });
+        });
+    });
+});

--- a/tests/lib/rule-context.js
+++ b/tests/lib/rule-context.js
@@ -12,8 +12,10 @@
 const sinon = require("sinon"),
     assert = require("chai").assert,
     leche = require("leche"),
-    realESLint = require("../../lib/eslint"),
+    Linter = require("../../lib/linter"),
     RuleContext = require("../../lib/rule-context");
+
+const realESLint = new Linter();
 
 //------------------------------------------------------------------------------
 // Tests

--- a/tests/lib/rules.js
+++ b/tests/lib/rules.js
@@ -10,16 +10,17 @@
 //------------------------------------------------------------------------------
 
 const assert = require("chai").assert,
-    rules = require("../../lib/rules");
+    Rules = require("../../lib/rules");
 
 //------------------------------------------------------------------------------
 // Tests
 //------------------------------------------------------------------------------
 
 describe("rules", () => {
+    let rules = null;
 
     beforeEach(() => {
-        rules.testReset();
+        rules = new Rules();
     });
 
     describe("when given an invalid rules directory", () => {

--- a/tests/lib/testers/rule-tester.js
+++ b/tests/lib/testers/rule-tester.js
@@ -12,7 +12,6 @@
 
 const sinon = require("sinon"),
     EventEmitter = require("events"),
-    eslint = require("../../../lib/eslint"),
     RuleTester = require("../../../lib/testers/rule-tester"),
     assert = require("chai").assert;
 
@@ -588,7 +587,7 @@ describe("RuleTester", () => {
     it("should pass-through the parser to the rule", () => {
 
         assert.doesNotThrow(() => {
-            const spy = sinon.spy(eslint, "verify");
+            const spy = sinon.spy(ruleTester.linter, "verify");
 
             ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [

--- a/tests/lib/util/source-code.js
+++ b/tests/lib/util/source-code.js
@@ -14,7 +14,7 @@ const fs = require("fs"),
     espree = require("espree"),
     sinon = require("sinon"),
     leche = require("leche"),
-    eslint = require("../../../lib/eslint"),
+    Linter = require("../../../lib/linter"),
     SourceCode = require("../../../lib/util/source-code"),
     astUtils = require("../../../lib/ast-utils");
 
@@ -29,7 +29,7 @@ const DEFAULT_CONFIG = {
     range: true,
     loc: true
 };
-
+const linter = new Linter();
 const AST = espree.parse("let foo = bar;", DEFAULT_CONFIG),
     TEST_CODE = "var answer = 6 * 7;",
     SHEBANG_TEST_CODE = `#!/usr/bin/env node\n${TEST_CODE}`;
@@ -215,7 +215,7 @@ describe("SourceCode", () => {
             filename = "foo.js";
 
         beforeEach(() => {
-            eslint.reset();
+            linter.reset();
         });
 
         afterEach(() => {
@@ -236,7 +236,7 @@ describe("SourceCode", () => {
              * @private
              */
             function assertJSDoc(node) {
-                const sourceCode = eslint.getSourceCode();
+                const sourceCode = linter.getSourceCode();
                 const jsdoc = sourceCode.getJSDocComment(node);
 
                 assert.equal(jsdoc, null);
@@ -244,8 +244,8 @@ describe("SourceCode", () => {
 
             const spy = sandbox.spy(assertJSDoc);
 
-            eslint.on("FunctionExpression", spy);
-            eslint.verify(code, { rules: {} }, filename, true);
+            linter.on("FunctionExpression", spy);
+            linter.verify(code, { rules: {} }, filename, true);
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
 
         });
@@ -264,7 +264,7 @@ describe("SourceCode", () => {
              * @private
              */
             function assertJSDoc(node) {
-                const sourceCode = eslint.getSourceCode();
+                const sourceCode = linter.getSourceCode();
                 const jsdoc = sourceCode.getJSDocComment(node);
 
                 assert.equal(jsdoc, null);
@@ -272,8 +272,8 @@ describe("SourceCode", () => {
 
             const spy = sandbox.spy(assertJSDoc);
 
-            eslint.on("FunctionExpression", spy);
-            eslint.verify(code, { rules: {} }, filename, true);
+            linter.on("FunctionExpression", spy);
+            linter.verify(code, { rules: {} }, filename, true);
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
 
         });
@@ -293,7 +293,7 @@ describe("SourceCode", () => {
              */
             function assertJSDoc(node) {
                 if (node.params.length === 1) {
-                    const sourceCode = eslint.getSourceCode();
+                    const sourceCode = linter.getSourceCode();
                     const jsdoc = sourceCode.getJSDocComment(node);
 
                     assert.equal(jsdoc, null);
@@ -302,8 +302,8 @@ describe("SourceCode", () => {
 
             const spy = sandbox.spy(assertJSDoc);
 
-            eslint.on("FunctionExpression", spy);
-            eslint.verify(code, { rules: {} }, filename, true);
+            linter.on("FunctionExpression", spy);
+            linter.verify(code, { rules: {} }, filename, true);
             assert.isTrue(spy.calledTwice, "Event handler should be called twice.");
 
         });
@@ -325,7 +325,7 @@ describe("SourceCode", () => {
              * @private
              */
             function assertJSDoc(node) {
-                const sourceCode = eslint.getSourceCode();
+                const sourceCode = linter.getSourceCode();
                 const jsdoc = sourceCode.getJSDocComment(node);
 
                 assert.equal(jsdoc.type, "Block");
@@ -334,8 +334,8 @@ describe("SourceCode", () => {
 
             const spy = sandbox.spy(assertJSDoc);
 
-            eslint.on("FunctionExpression", spy);
-            eslint.verify(code, { rules: {} }, filename, true);
+            linter.on("FunctionExpression", spy);
+            linter.verify(code, { rules: {} }, filename, true);
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
         });
 
@@ -353,7 +353,7 @@ describe("SourceCode", () => {
              * @private
              */
             function assertJSDoc(node) {
-                const sourceCode = eslint.getSourceCode();
+                const sourceCode = linter.getSourceCode();
                 const jsdoc = sourceCode.getJSDocComment(node);
 
                 assert.equal(jsdoc.type, "Block");
@@ -362,8 +362,8 @@ describe("SourceCode", () => {
 
             const spy = sandbox.spy(assertJSDoc);
 
-            eslint.on("FunctionDeclaration", spy);
-            eslint.verify(code, { rules: {} }, filename, true);
+            linter.on("FunctionDeclaration", spy);
+            linter.verify(code, { rules: {} }, filename, true);
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
 
         });
@@ -382,7 +382,7 @@ describe("SourceCode", () => {
              * @private
              */
             function assertJSDoc(node) {
-                const sourceCode = eslint.getSourceCode();
+                const sourceCode = linter.getSourceCode();
                 const jsdoc = sourceCode.getJSDocComment(node);
 
                 assert.equal(jsdoc.type, "Block");
@@ -391,8 +391,8 @@ describe("SourceCode", () => {
 
             const spy = sandbox.spy(assertJSDoc);
 
-            eslint.on("FunctionDeclaration", spy);
-            eslint.verify(code, { parserOptions: { sourceType: "module" }, rules: {} }, filename, true);
+            linter.on("FunctionDeclaration", spy);
+            linter.verify(code, { parserOptions: { sourceType: "module" }, rules: {} }, filename, true);
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
 
         });
@@ -413,7 +413,7 @@ describe("SourceCode", () => {
              * @private
              */
             function assertJSDoc(node) {
-                const sourceCode = eslint.getSourceCode();
+                const sourceCode = linter.getSourceCode();
                 const jsdoc = sourceCode.getJSDocComment(node);
 
                 assert.equal(jsdoc.type, "Block");
@@ -422,8 +422,8 @@ describe("SourceCode", () => {
 
             const spy = sandbox.spy(assertJSDoc);
 
-            eslint.on("FunctionDeclaration", spy);
-            eslint.verify(code, { rules: {} }, filename, true);
+            linter.on("FunctionDeclaration", spy);
+            linter.verify(code, { rules: {} }, filename, true);
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
 
         });
@@ -445,7 +445,7 @@ describe("SourceCode", () => {
              * @private
              */
             function assertJSDoc(node) {
-                const sourceCode = eslint.getSourceCode();
+                const sourceCode = linter.getSourceCode();
                 const jsdoc = sourceCode.getJSDocComment(node);
 
                 assert.isNull(jsdoc);
@@ -453,8 +453,8 @@ describe("SourceCode", () => {
 
             const spy = sandbox.spy(assertJSDoc);
 
-            eslint.on("FunctionDeclaration", spy);
-            eslint.verify(code, { rules: {} }, filename, true);
+            linter.on("FunctionDeclaration", spy);
+            linter.verify(code, { rules: {} }, filename, true);
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
 
         });
@@ -474,7 +474,7 @@ describe("SourceCode", () => {
              * @private
              */
             function assertJSDoc(node) {
-                const sourceCode = eslint.getSourceCode();
+                const sourceCode = linter.getSourceCode();
                 const jsdoc = sourceCode.getJSDocComment(node);
 
                 assert.equal(jsdoc.type, "Block");
@@ -483,8 +483,8 @@ describe("SourceCode", () => {
 
             const spy = sandbox.spy(assertJSDoc);
 
-            eslint.on("FunctionDeclaration", spy);
-            eslint.verify(code, { rules: {} }, filename, true);
+            linter.on("FunctionDeclaration", spy);
+            linter.verify(code, { rules: {} }, filename, true);
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
 
         });
@@ -506,7 +506,7 @@ describe("SourceCode", () => {
              * @private
              */
             function assertJSDoc(node) {
-                const sourceCode = eslint.getSourceCode();
+                const sourceCode = linter.getSourceCode();
                 const jsdoc = sourceCode.getJSDocComment(node);
 
                 assert.equal(jsdoc.type, "Block");
@@ -515,8 +515,8 @@ describe("SourceCode", () => {
 
             const spy = sandbox.spy(assertJSDoc);
 
-            eslint.on("FunctionDeclaration", spy);
-            eslint.verify(code, { rules: {} }, filename, true);
+            linter.on("FunctionDeclaration", spy);
+            linter.verify(code, { rules: {} }, filename, true);
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
         });
 
@@ -537,7 +537,7 @@ describe("SourceCode", () => {
              * @private
              */
             function assertJSDoc(node) {
-                const sourceCode = eslint.getSourceCode();
+                const sourceCode = linter.getSourceCode();
                 const jsdoc = sourceCode.getJSDocComment(node);
 
                 assert.equal(jsdoc.type, "Block");
@@ -546,8 +546,8 @@ describe("SourceCode", () => {
 
             const spy = sandbox.spy(assertJSDoc);
 
-            eslint.on("FunctionExpression", spy);
-            eslint.verify(code, { rules: {} }, filename, true);
+            linter.on("FunctionExpression", spy);
+            linter.verify(code, { rules: {} }, filename, true);
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
         });
 
@@ -568,7 +568,7 @@ describe("SourceCode", () => {
              * @private
              */
             function assertJSDoc(node) {
-                const sourceCode = eslint.getSourceCode();
+                const sourceCode = linter.getSourceCode();
                 const jsdoc = sourceCode.getJSDocComment(node);
 
                 assert.equal(jsdoc.type, "Block");
@@ -577,8 +577,8 @@ describe("SourceCode", () => {
 
             const spy = sandbox.spy(assertJSDoc);
 
-            eslint.on("ArrowFunctionExpression", spy);
-            eslint.verify(code, { parserOptions: { ecmaVersion: 6 }, rules: {} }, filename, true);
+            linter.on("ArrowFunctionExpression", spy);
+            linter.verify(code, { parserOptions: { ecmaVersion: 6 }, rules: {} }, filename, true);
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
         });
 
@@ -597,7 +597,7 @@ describe("SourceCode", () => {
              * @private
              */
             function assertJSDoc(node) {
-                const sourceCode = eslint.getSourceCode();
+                const sourceCode = linter.getSourceCode();
                 const jsdoc = sourceCode.getJSDocComment(node);
 
                 assert.equal(jsdoc.type, "Block");
@@ -606,8 +606,8 @@ describe("SourceCode", () => {
 
             const spy = sandbox.spy(assertJSDoc);
 
-            eslint.on("FunctionExpression", spy);
-            eslint.verify(code, { rules: {} }, filename, true);
+            linter.on("FunctionExpression", spy);
+            linter.verify(code, { rules: {} }, filename, true);
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
         });
 
@@ -629,7 +629,7 @@ describe("SourceCode", () => {
              */
             function assertJSDoc(node) {
                 if (!node.id) {
-                    const sourceCode = eslint.getSourceCode();
+                    const sourceCode = linter.getSourceCode();
                     const jsdoc = sourceCode.getJSDocComment(node);
 
                     assert.equal(jsdoc.type, "Block");
@@ -639,8 +639,8 @@ describe("SourceCode", () => {
 
             const spy = sandbox.spy(assertJSDoc);
 
-            eslint.on("FunctionExpression", spy);
-            eslint.verify(code, { rules: {} }, filename, true);
+            linter.on("FunctionExpression", spy);
+            linter.verify(code, { rules: {} }, filename, true);
             assert.isTrue(spy.calledTwice, "Event handler should be called.");
         });
 
@@ -662,7 +662,7 @@ describe("SourceCode", () => {
              */
             function assertJSDoc(node) {
                 if (!node.id) {
-                    const sourceCode = eslint.getSourceCode();
+                    const sourceCode = linter.getSourceCode();
                     const jsdoc = sourceCode.getJSDocComment(node);
 
                     assert.isNull(jsdoc);
@@ -671,8 +671,8 @@ describe("SourceCode", () => {
 
             const spy = sandbox.spy(assertJSDoc);
 
-            eslint.on("FunctionExpression", spy);
-            eslint.verify(code, { rules: {} }, filename, true);
+            linter.on("FunctionExpression", spy);
+            linter.verify(code, { rules: {} }, filename, true);
             assert.isTrue(spy.calledTwice, "Event handler should be called.");
         });
 
@@ -692,7 +692,7 @@ describe("SourceCode", () => {
              */
             function assertJSDoc(node) {
                 if (!node.id) {
-                    const sourceCode = eslint.getSourceCode();
+                    const sourceCode = linter.getSourceCode();
                     const jsdoc = sourceCode.getJSDocComment(node);
 
                     assert.isNull(jsdoc);
@@ -701,8 +701,8 @@ describe("SourceCode", () => {
 
             const spy = sandbox.spy(assertJSDoc);
 
-            eslint.on("FunctionExpression", spy);
-            eslint.verify(code, { rules: {} }, filename, true);
+            linter.on("FunctionExpression", spy);
+            linter.verify(code, { rules: {} }, filename, true);
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
         });
 
@@ -730,7 +730,7 @@ describe("SourceCode", () => {
              */
             function assertJSDoc(node) {
                 if (node.id) {
-                    const sourceCode = eslint.getSourceCode();
+                    const sourceCode = linter.getSourceCode();
                     const jsdoc = sourceCode.getJSDocComment(node);
 
                     assert.isNull(jsdoc);
@@ -739,8 +739,8 @@ describe("SourceCode", () => {
 
             const spy = sandbox.spy(assertJSDoc);
 
-            eslint.on("FunctionExpression", spy);
-            eslint.verify(code, { rules: {} }, filename, true);
+            linter.on("FunctionExpression", spy);
+            linter.verify(code, { rules: {} }, filename, true);
             assert.isTrue(spy.calledTwice, "Event handler should be called.");
         });
 
@@ -759,7 +759,7 @@ describe("SourceCode", () => {
              * @private
              */
             function assertJSDoc(node) {
-                const sourceCode = eslint.getSourceCode();
+                const sourceCode = linter.getSourceCode();
                 const jsdoc = sourceCode.getJSDocComment(node);
 
                 assert.equal(jsdoc.type, "Block");
@@ -768,8 +768,8 @@ describe("SourceCode", () => {
 
             const spy = sandbox.spy(assertJSDoc);
 
-            eslint.on("ClassExpression", spy);
-            eslint.verify(code, { rules: {}, parserOptions: { ecmaVersion: 6 } }, filename, true);
+            linter.on("ClassExpression", spy);
+            linter.verify(code, { rules: {}, parserOptions: { ecmaVersion: 6 } }, filename, true);
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
         });
 
@@ -788,7 +788,7 @@ describe("SourceCode", () => {
              * @private
              */
             function assertJSDoc(node) {
-                const sourceCode = eslint.getSourceCode();
+                const sourceCode = linter.getSourceCode();
                 const jsdoc = sourceCode.getJSDocComment(node);
 
                 assert.equal(jsdoc.type, "Block");
@@ -797,8 +797,8 @@ describe("SourceCode", () => {
 
             const spy = sandbox.spy(assertJSDoc);
 
-            eslint.on("ClassDeclaration", spy);
-            eslint.verify(code, { rules: {}, parserOptions: { ecmaVersion: 6 } }, filename, true);
+            linter.on("ClassDeclaration", spy);
+            linter.verify(code, { rules: {}, parserOptions: { ecmaVersion: 6 } }, filename, true);
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
         });
 
@@ -818,7 +818,7 @@ describe("SourceCode", () => {
              * @private
              */
             function assertJSDoc(node) {
-                const sourceCode = eslint.getSourceCode();
+                const sourceCode = linter.getSourceCode();
                 const jsdoc = sourceCode.getJSDocComment(node);
 
                 assert.isNull(jsdoc);
@@ -826,8 +826,8 @@ describe("SourceCode", () => {
 
             const spy = sandbox.spy(assertJSDoc);
 
-            eslint.on("FunctionExpression", spy);
-            eslint.verify(code, { rules: {}, parserOptions: { ecmaVersion: 6 } }, filename, true);
+            linter.on("FunctionExpression", spy);
+            linter.verify(code, { rules: {}, parserOptions: { ecmaVersion: 6 } }, filename, true);
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
         });
 
@@ -850,7 +850,7 @@ describe("SourceCode", () => {
              * @private
              */
             function assertJSDoc(node) {
-                const sourceCode = eslint.getSourceCode();
+                const sourceCode = linter.getSourceCode();
                 const jsdoc = sourceCode.getJSDocComment(node);
 
                 assert.equal(jsdoc.type, "Block");
@@ -859,8 +859,8 @@ describe("SourceCode", () => {
 
             const spy = sandbox.spy(assertJSDoc);
 
-            eslint.on("FunctionExpression", spy);
-            eslint.verify(code, { rules: {}, parserOptions: { ecmaVersion: 6 } }, filename, true);
+            linter.on("FunctionExpression", spy);
+            linter.verify(code, { rules: {}, parserOptions: { ecmaVersion: 6 } }, filename, true);
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
         });
 
@@ -882,7 +882,7 @@ describe("SourceCode", () => {
              * @private
              */
             function assertJSDoc(node) {
-                const sourceCode = eslint.getSourceCode();
+                const sourceCode = linter.getSourceCode();
                 const jsdoc = sourceCode.getJSDocComment(node);
 
                 assert.isNull(jsdoc);
@@ -890,8 +890,8 @@ describe("SourceCode", () => {
 
             const spy = sandbox.spy(assertJSDoc);
 
-            eslint.on("FunctionDeclaration", spy);
-            eslint.verify(code, { rules: {}, parserOptions: { ecmaVersion: 6 } }, filename, true);
+            linter.on("FunctionDeclaration", spy);
+            linter.verify(code, { rules: {}, parserOptions: { ecmaVersion: 6 } }, filename, true);
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
         });
 
@@ -909,7 +909,7 @@ describe("SourceCode", () => {
          */
         function assertCommentCount(leading, trailing) {
             return function(node) {
-                const sourceCode = eslint.getSourceCode();
+                const sourceCode = linter.getSourceCode();
                 const comments = sourceCode.getComments(node);
 
                 assert.equal(comments.leading.length, leading);
@@ -918,7 +918,7 @@ describe("SourceCode", () => {
         }
 
         beforeEach(() => {
-            eslint.reset();
+            linter.reset();
         });
 
         it("should return comments around nodes", () => {
@@ -928,13 +928,13 @@ describe("SourceCode", () => {
                 "/* Trailing comment for VariableDeclaration */"
             ].join("\n");
 
-            eslint.on("Program", assertCommentCount(0, 0));
-            eslint.on("VariableDeclaration", assertCommentCount(1, 1));
-            eslint.on("VariableDeclarator", assertCommentCount(0, 0));
-            eslint.on("Identifier", assertCommentCount(0, 0));
-            eslint.on("Literal", assertCommentCount(0, 0));
+            linter.on("Program", assertCommentCount(0, 0));
+            linter.on("VariableDeclaration", assertCommentCount(1, 1));
+            linter.on("VariableDeclarator", assertCommentCount(0, 0));
+            linter.on("Identifier", assertCommentCount(0, 0));
+            linter.on("Literal", assertCommentCount(0, 0));
 
-            eslint.verify(code, config, "", true);
+            linter.verify(code, config, "", true);
         });
 
         it("should return trailing comments inside a block", () => {
@@ -945,13 +945,13 @@ describe("SourceCode", () => {
                 "}"
             ].join("\n");
 
-            eslint.on("Program", assertCommentCount(0, 0));
-            eslint.on("BlockStatement", assertCommentCount(0, 0));
-            eslint.on("ExpressionStatement", assertCommentCount(0, 1));
-            eslint.on("CallExpression", assertCommentCount(0, 0));
-            eslint.on("Identifier", assertCommentCount(0, 0));
+            linter.on("Program", assertCommentCount(0, 0));
+            linter.on("BlockStatement", assertCommentCount(0, 0));
+            linter.on("ExpressionStatement", assertCommentCount(0, 1));
+            linter.on("CallExpression", assertCommentCount(0, 0));
+            linter.on("Identifier", assertCommentCount(0, 0));
 
-            eslint.verify(code, config, "", true);
+            linter.verify(code, config, "", true);
         });
 
         it("should return comments within a conditional", () => {
@@ -960,12 +960,12 @@ describe("SourceCode", () => {
                 "if (/* Leading comment for Identifier */ a) {}"
             ].join("\n");
 
-            eslint.on("Program", assertCommentCount(0, 0));
-            eslint.on("IfStatement", assertCommentCount(1, 0));
-            eslint.on("Identifier", assertCommentCount(1, 0));
-            eslint.on("BlockStatement", assertCommentCount(0, 0));
+            linter.on("Program", assertCommentCount(0, 0));
+            linter.on("IfStatement", assertCommentCount(1, 0));
+            linter.on("Identifier", assertCommentCount(1, 0));
+            linter.on("BlockStatement", assertCommentCount(0, 0));
 
-            eslint.verify(code, config, "", true);
+            linter.verify(code, config, "", true);
         });
 
         it("should not return comments within a previous node", () => {
@@ -978,15 +978,15 @@ describe("SourceCode", () => {
                 "}"
             ].join("\n");
 
-            eslint.on("Program", assertCommentCount(0, 0));
-            eslint.on("Identifier", assertCommentCount(0, 0));
-            eslint.on("BlockStatement", assertCommentCount(0, 0));
-            eslint.on("VariableDeclaration", assertCommentCount(0, 0));
-            eslint.on("VariableDeclarator", assertCommentCount(0, 0));
-            eslint.on("ObjectExpression", assertCommentCount(0, 1));
-            eslint.on("ReturnStatement", assertCommentCount(0, 0));
+            linter.on("Program", assertCommentCount(0, 0));
+            linter.on("Identifier", assertCommentCount(0, 0));
+            linter.on("BlockStatement", assertCommentCount(0, 0));
+            linter.on("VariableDeclaration", assertCommentCount(0, 0));
+            linter.on("VariableDeclarator", assertCommentCount(0, 0));
+            linter.on("ObjectExpression", assertCommentCount(0, 1));
+            linter.on("ReturnStatement", assertCommentCount(0, 0));
 
-            eslint.verify(code, config, "", true);
+            linter.verify(code, config, "", true);
         });
 
         it("should return comments only for children of parent node", () => {
@@ -998,15 +998,15 @@ describe("SourceCode", () => {
                 "var baz;"
             ].join("\n");
 
-            eslint.on("Program", assertCommentCount(0, 0));
-            eslint.on("VariableDeclaration", assertCommentCount(0, 0));
-            eslint.on("VariableDeclerator", assertCommentCount(0, 0));
-            eslint.on("Identifier", assertCommentCount(0, 0));
-            eslint.on("ObjectExpression", assertCommentCount(0, 0));
-            eslint.on("Property", assertCommentCount(0, 1));
-            eslint.on("Literal", assertCommentCount(0, 0));
+            linter.on("Program", assertCommentCount(0, 0));
+            linter.on("VariableDeclaration", assertCommentCount(0, 0));
+            linter.on("VariableDeclerator", assertCommentCount(0, 0));
+            linter.on("Identifier", assertCommentCount(0, 0));
+            linter.on("ObjectExpression", assertCommentCount(0, 0));
+            linter.on("Property", assertCommentCount(0, 1));
+            linter.on("Literal", assertCommentCount(0, 0));
 
-            eslint.verify(code, config, "", true);
+            linter.verify(code, config, "", true);
         });
 
         it("should return comments for an export default anonymous class", () => {
@@ -1023,16 +1023,16 @@ describe("SourceCode", () => {
                 "}"
             ].join("\n");
 
-            eslint.on("Program", assertCommentCount(0, 0));
-            eslint.on("ExportDefaultDeclaration", assertCommentCount(1, 0));
-            eslint.on("ClassDeclaration", assertCommentCount(0, 0));
-            eslint.on("ClassBody", assertCommentCount(0, 0));
-            eslint.on("MethodDefinition", assertCommentCount(1, 0));
-            eslint.on("Identifier", assertCommentCount(0, 0));
-            eslint.on("FunctionExpression", assertCommentCount(0, 0));
-            eslint.on("BlockStatement", assertCommentCount(0, 0));
+            linter.on("Program", assertCommentCount(0, 0));
+            linter.on("ExportDefaultDeclaration", assertCommentCount(1, 0));
+            linter.on("ClassDeclaration", assertCommentCount(0, 0));
+            linter.on("ClassBody", assertCommentCount(0, 0));
+            linter.on("MethodDefinition", assertCommentCount(1, 0));
+            linter.on("Identifier", assertCommentCount(0, 0));
+            linter.on("FunctionExpression", assertCommentCount(0, 0));
+            linter.on("BlockStatement", assertCommentCount(0, 0));
 
-            eslint.verify(code, config, "", true);
+            linter.verify(code, config, "", true);
         });
 
         it("should return leading comments", () => {
@@ -1044,8 +1044,8 @@ describe("SourceCode", () => {
             ].join("\n");
             let varDeclCount = 0;
 
-            eslint.on("Program", assertCommentCount(0, 0));
-            eslint.on("VariableDeclaration", node => {
+            linter.on("Program", assertCommentCount(0, 0));
+            linter.on("VariableDeclaration", node => {
                 if (varDeclCount === 0) {
                     assertCommentCount(1, 1)(node);
                 } else {
@@ -1053,10 +1053,10 @@ describe("SourceCode", () => {
                 }
                 varDeclCount++;
             });
-            eslint.on("VariableDeclarator", assertCommentCount(0, 0));
-            eslint.on("Identifier", assertCommentCount(0, 0));
+            linter.on("VariableDeclarator", assertCommentCount(0, 0));
+            linter.on("Identifier", assertCommentCount(0, 0));
 
-            eslint.verify(code, config, "", true);
+            linter.verify(code, config, "", true);
         });
 
         it("should return shebang comments", () => {
@@ -1068,8 +1068,8 @@ describe("SourceCode", () => {
             ].join("\n");
             let varDeclCount = 0;
 
-            eslint.on("Program", assertCommentCount(0, 0));
-            eslint.on("VariableDeclaration", node => {
+            linter.on("Program", assertCommentCount(0, 0));
+            linter.on("VariableDeclaration", node => {
                 if (varDeclCount === 0) {
                     assertCommentCount(1, 1)(node);
                 } else {
@@ -1077,17 +1077,17 @@ describe("SourceCode", () => {
                 }
                 varDeclCount++;
             });
-            eslint.on("VariableDeclarator", assertCommentCount(0, 0));
-            eslint.on("Identifier", assertCommentCount(0, 0));
+            linter.on("VariableDeclarator", assertCommentCount(0, 0));
+            linter.on("Identifier", assertCommentCount(0, 0));
 
-            eslint.verify(code, config, "", true);
+            linter.verify(code, config, "", true);
         });
 
         it("should include shebang comment when program only contains shebang", () => {
             const code = "#!/usr/bin/env node";
 
-            eslint.on("Program", assertCommentCount(1, 0));
-            eslint.verify(code, config, "", true);
+            linter.on("Program", assertCommentCount(1, 0));
+            linter.verify(code, config, "", true);
         });
 
         it("should return mixture of line and block comments", () => {
@@ -1097,13 +1097,13 @@ describe("SourceCode", () => {
                 "// Trailing comment for VariableDeclaration"
             ].join("\n");
 
-            eslint.on("Program", assertCommentCount(0, 0));
-            eslint.on("VariableDeclaration", assertCommentCount(1, 1));
-            eslint.on("VariableDeclarator", assertCommentCount(0, 0));
-            eslint.on("Identifier", assertCommentCount(0, 1));
-            eslint.on("Literal", assertCommentCount(0, 0));
+            linter.on("Program", assertCommentCount(0, 0));
+            linter.on("VariableDeclaration", assertCommentCount(1, 1));
+            linter.on("VariableDeclarator", assertCommentCount(0, 0));
+            linter.on("Identifier", assertCommentCount(0, 1));
+            linter.on("Literal", assertCommentCount(0, 0));
 
-            eslint.verify(code, config, "", true);
+            linter.verify(code, config, "", true);
         });
 
         it("should return comments surrounding a call expression", () => {
@@ -1115,14 +1115,14 @@ describe("SourceCode", () => {
                 "}"
             ].join("\n");
 
-            eslint.on("Program", assertCommentCount(0, 0));
-            eslint.on("FunctionDeclaration", assertCommentCount(0, 0));
-            eslint.on("Identifier", assertCommentCount(0, 0));
-            eslint.on("BlockStatement", assertCommentCount(0, 0));
-            eslint.on("ExpressionStatement", assertCommentCount(1, 1));
-            eslint.on("CallExpression", assertCommentCount(0, 0));
+            linter.on("Program", assertCommentCount(0, 0));
+            linter.on("FunctionDeclaration", assertCommentCount(0, 0));
+            linter.on("Identifier", assertCommentCount(0, 0));
+            linter.on("BlockStatement", assertCommentCount(0, 0));
+            linter.on("ExpressionStatement", assertCommentCount(1, 1));
+            linter.on("CallExpression", assertCommentCount(0, 0));
 
-            eslint.verify(code, config, "", true);
+            linter.verify(code, config, "", true);
         });
 
         it("should return comments surrounding a debugger statement", () => {
@@ -1134,13 +1134,13 @@ describe("SourceCode", () => {
                 "}"
             ].join("\n");
 
-            eslint.on("Program", assertCommentCount(0, 0));
-            eslint.on("FunctionDeclaration", assertCommentCount(0, 0));
-            eslint.on("Identifier", assertCommentCount(0, 0));
-            eslint.on("BlockStatement", assertCommentCount(0, 0));
-            eslint.on("DebuggerStatement", assertCommentCount(1, 1));
+            linter.on("Program", assertCommentCount(0, 0));
+            linter.on("FunctionDeclaration", assertCommentCount(0, 0));
+            linter.on("Identifier", assertCommentCount(0, 0));
+            linter.on("BlockStatement", assertCommentCount(0, 0));
+            linter.on("DebuggerStatement", assertCommentCount(1, 1));
 
-            eslint.verify(code, config, "", true);
+            linter.verify(code, config, "", true);
         });
 
         it("should return comments surrounding a return statement", () => {
@@ -1152,13 +1152,13 @@ describe("SourceCode", () => {
                 "}"
             ].join("\n");
 
-            eslint.on("Program", assertCommentCount(0, 0));
-            eslint.on("FunctionDeclaration", assertCommentCount(0, 0));
-            eslint.on("Identifier", assertCommentCount(0, 0));
-            eslint.on("BlockStatement", assertCommentCount(0, 0));
-            eslint.on("ReturnStatement", assertCommentCount(1, 1));
+            linter.on("Program", assertCommentCount(0, 0));
+            linter.on("FunctionDeclaration", assertCommentCount(0, 0));
+            linter.on("Identifier", assertCommentCount(0, 0));
+            linter.on("BlockStatement", assertCommentCount(0, 0));
+            linter.on("ReturnStatement", assertCommentCount(1, 1));
 
-            eslint.verify(code, config, "", true);
+            linter.verify(code, config, "", true);
         });
 
         it("should return comments surrounding a throw statement", () => {
@@ -1170,13 +1170,13 @@ describe("SourceCode", () => {
                 "}"
             ].join("\n");
 
-            eslint.on("Program", assertCommentCount(0, 0));
-            eslint.on("FunctionDeclaration", assertCommentCount(0, 0));
-            eslint.on("Identifier", assertCommentCount(0, 0));
-            eslint.on("BlockStatement", assertCommentCount(0, 0));
-            eslint.on("ThrowStatement", assertCommentCount(1, 1));
+            linter.on("Program", assertCommentCount(0, 0));
+            linter.on("FunctionDeclaration", assertCommentCount(0, 0));
+            linter.on("Identifier", assertCommentCount(0, 0));
+            linter.on("BlockStatement", assertCommentCount(0, 0));
+            linter.on("ThrowStatement", assertCommentCount(1, 1));
 
-            eslint.verify(code, config, "", true);
+            linter.verify(code, config, "", true);
         });
 
         it("should return comments surrounding a while loop", () => {
@@ -1189,16 +1189,16 @@ describe("SourceCode", () => {
                 "}"
             ].join("\n");
 
-            eslint.on("Program", assertCommentCount(0, 0));
-            eslint.on("FunctionDeclaration", assertCommentCount(0, 0));
-            eslint.on("Identifier", assertCommentCount(0, 0));
-            eslint.on("BlockStatement", assertCommentCount(0, 0));
-            eslint.on("WhileStatement", assertCommentCount(1, 1));
-            eslint.on("Literal", assertCommentCount(0, 0));
-            eslint.on("VariableDeclaration", assertCommentCount(1, 0));
-            eslint.on("VariableDeclarator", assertCommentCount(0, 0));
+            linter.on("Program", assertCommentCount(0, 0));
+            linter.on("FunctionDeclaration", assertCommentCount(0, 0));
+            linter.on("Identifier", assertCommentCount(0, 0));
+            linter.on("BlockStatement", assertCommentCount(0, 0));
+            linter.on("WhileStatement", assertCommentCount(1, 1));
+            linter.on("Literal", assertCommentCount(0, 0));
+            linter.on("VariableDeclaration", assertCommentCount(1, 0));
+            linter.on("VariableDeclarator", assertCommentCount(0, 0));
 
-            eslint.verify(code, config, "", true);
+            linter.verify(code, config, "", true);
         });
 
         it("should return switch case fallthrough comments in functions", () => {
@@ -1215,12 +1215,12 @@ describe("SourceCode", () => {
             ].join("\n");
             let switchCaseCount = 0;
 
-            eslint.on("Program", assertCommentCount(0, 0));
-            eslint.on("FunctionDeclaration", assertCommentCount(0, 0));
-            eslint.on("Identifier", assertCommentCount(0, 0));
-            eslint.on("BlockStatement", assertCommentCount(0, 0));
-            eslint.on("SwitchStatement", assertCommentCount(0, 0));
-            eslint.on("SwitchCase", node => {
+            linter.on("Program", assertCommentCount(0, 0));
+            linter.on("FunctionDeclaration", assertCommentCount(0, 0));
+            linter.on("Identifier", assertCommentCount(0, 0));
+            linter.on("BlockStatement", assertCommentCount(0, 0));
+            linter.on("SwitchStatement", assertCommentCount(0, 0));
+            linter.on("SwitchCase", node => {
                 if (switchCaseCount === 0) {
                     assertCommentCount(1, 1)(node);
                 } else {
@@ -1228,11 +1228,11 @@ describe("SourceCode", () => {
                 }
                 switchCaseCount++;
             });
-            eslint.on("Literal", assertCommentCount(0, 0));
-            eslint.on("ExpressionStatement", assertCommentCount(0, 0));
-            eslint.on("CallExpression", assertCommentCount(0, 0));
+            linter.on("Literal", assertCommentCount(0, 0));
+            linter.on("ExpressionStatement", assertCommentCount(0, 0));
+            linter.on("CallExpression", assertCommentCount(0, 0));
 
-            eslint.verify(code, config, "", true);
+            linter.verify(code, config, "", true);
         });
 
         it("should return switch case fallthrough comments", () => {
@@ -1247,9 +1247,9 @@ describe("SourceCode", () => {
             ].join("\n");
             let switchCaseCount = 0;
 
-            eslint.on("Program", assertCommentCount(0, 0));
-            eslint.on("SwitchStatement", assertCommentCount(0, 0));
-            eslint.on("SwitchCase", node => {
+            linter.on("Program", assertCommentCount(0, 0));
+            linter.on("SwitchStatement", assertCommentCount(0, 0));
+            linter.on("SwitchCase", node => {
                 if (switchCaseCount === 0) {
                     assertCommentCount(1, 1)(node);
                 } else {
@@ -1257,11 +1257,11 @@ describe("SourceCode", () => {
                 }
                 switchCaseCount++;
             });
-            eslint.on("Literal", assertCommentCount(0, 0));
-            eslint.on("ExpressionStatement", assertCommentCount(0, 0));
-            eslint.on("CallExpression", assertCommentCount(0, 0));
+            linter.on("Literal", assertCommentCount(0, 0));
+            linter.on("ExpressionStatement", assertCommentCount(0, 0));
+            linter.on("CallExpression", assertCommentCount(0, 0));
 
-            eslint.verify(code, config, "", true);
+            linter.verify(code, config, "", true);
         });
 
         it("should return switch case no-default comments in functions", () => {
@@ -1278,12 +1278,12 @@ describe("SourceCode", () => {
             ].join("\n");
             let breakStatementCount = 0;
 
-            eslint.on("Program", assertCommentCount(0, 0));
-            eslint.on("FunctionDeclaration", assertCommentCount(0, 0));
-            eslint.on("Identifier", assertCommentCount(0, 0));
-            eslint.on("BlockStatement", assertCommentCount(0, 0));
-            eslint.on("SwitchStatement", assertCommentCount(0, 0));
-            eslint.on("SwitchCase", node => {
+            linter.on("Program", assertCommentCount(0, 0));
+            linter.on("FunctionDeclaration", assertCommentCount(0, 0));
+            linter.on("Identifier", assertCommentCount(0, 0));
+            linter.on("BlockStatement", assertCommentCount(0, 0));
+            linter.on("SwitchStatement", assertCommentCount(0, 0));
+            linter.on("SwitchCase", node => {
                 if (breakStatementCount === 0) {
                     assertCommentCount(0, 0)(node);
                 } else {
@@ -1291,10 +1291,10 @@ describe("SourceCode", () => {
                 }
                 breakStatementCount++;
             });
-            eslint.on("BreakStatement", assertCommentCount(0, 0));
-            eslint.on("Literal", assertCommentCount(0, 0));
+            linter.on("BreakStatement", assertCommentCount(0, 0));
+            linter.on("Literal", assertCommentCount(0, 0));
 
-            eslint.verify(code, config, "", true);
+            linter.verify(code, config, "", true);
         });
 
         it("should return switch case no-default comments", () => {
@@ -1306,14 +1306,14 @@ describe("SourceCode", () => {
                 "}"
             ].join("\n");
 
-            eslint.on("Program", assertCommentCount(0, 0));
-            eslint.on("SwitchStatement", assertCommentCount(0, 0));
-            eslint.on("Identifier", assertCommentCount(0, 0));
-            eslint.on("SwitchCase", assertCommentCount(0, 1));
-            eslint.on("BreakStatement", assertCommentCount(0, 0));
-            eslint.on("Literal", assertCommentCount(0, 0));
+            linter.on("Program", assertCommentCount(0, 0));
+            linter.on("SwitchStatement", assertCommentCount(0, 0));
+            linter.on("Identifier", assertCommentCount(0, 0));
+            linter.on("SwitchCase", assertCommentCount(0, 1));
+            linter.on("BreakStatement", assertCommentCount(0, 0));
+            linter.on("Literal", assertCommentCount(0, 0));
 
-            eslint.verify(code, config, "", true);
+            linter.verify(code, config, "", true);
         });
 
         it("should return switch case no-default comments in nested functions", () => {
@@ -1330,22 +1330,22 @@ describe("SourceCode", () => {
                 "};"
             ].join("\n");
 
-            eslint.on("Program", assertCommentCount(0, 0));
-            eslint.on("ExpressionStatement", assertCommentCount(0, 0));
-            eslint.on("AssignmentExpression", assertCommentCount(0, 0));
-            eslint.on("MemberExpression", assertCommentCount(0, 0));
-            eslint.on("Identifier", assertCommentCount(0, 0));
-            eslint.on("FunctionExpression", assertCommentCount(0, 0));
-            eslint.on("BlockStatement", assertCommentCount(0, 0));
-            eslint.on("FunctionDeclaration", assertCommentCount(0, 0));
-            eslint.on("SwitchStatement", assertCommentCount(0, 0));
-            eslint.on("SwitchCase", assertCommentCount(0, 1));
-            eslint.on("ReturnStatement", assertCommentCount(0, 0));
-            eslint.on("CallExpression", assertCommentCount(0, 0));
-            eslint.on("BinaryExpression", assertCommentCount(0, 0));
-            eslint.on("Literal", assertCommentCount(0, 0));
+            linter.on("Program", assertCommentCount(0, 0));
+            linter.on("ExpressionStatement", assertCommentCount(0, 0));
+            linter.on("AssignmentExpression", assertCommentCount(0, 0));
+            linter.on("MemberExpression", assertCommentCount(0, 0));
+            linter.on("Identifier", assertCommentCount(0, 0));
+            linter.on("FunctionExpression", assertCommentCount(0, 0));
+            linter.on("BlockStatement", assertCommentCount(0, 0));
+            linter.on("FunctionDeclaration", assertCommentCount(0, 0));
+            linter.on("SwitchStatement", assertCommentCount(0, 0));
+            linter.on("SwitchCase", assertCommentCount(0, 1));
+            linter.on("ReturnStatement", assertCommentCount(0, 0));
+            linter.on("CallExpression", assertCommentCount(0, 0));
+            linter.on("BinaryExpression", assertCommentCount(0, 0));
+            linter.on("Literal", assertCommentCount(0, 0));
 
-            eslint.verify(code, config, "", true);
+            linter.verify(code, config, "", true);
         });
 
         it("should return leading comments if the code only contains comments", () => {
@@ -1354,9 +1354,9 @@ describe("SourceCode", () => {
                 "/*another comment*/"
             ].join("\n");
 
-            eslint.on("Program", assertCommentCount(2, 0));
+            linter.on("Program", assertCommentCount(2, 0));
 
-            eslint.verify(code, config, "", true);
+            linter.verify(code, config, "", true);
         });
 
         it("should return trailing comments if a block statement only contains comments", () => {
@@ -1367,10 +1367,10 @@ describe("SourceCode", () => {
                 "}"
             ].join("\n");
 
-            eslint.on("Program", assertCommentCount(0, 0));
-            eslint.on("BlockStatement", assertCommentCount(0, 2));
+            linter.on("Program", assertCommentCount(0, 0));
+            linter.on("BlockStatement", assertCommentCount(0, 2));
 
-            eslint.verify(code, config, "", true);
+            linter.verify(code, config, "", true);
         });
 
         it("should return trailing comments if a class body only contains comments", () => {
@@ -1381,11 +1381,11 @@ describe("SourceCode", () => {
                 "}"
             ].join("\n");
 
-            eslint.on("Program", assertCommentCount(0, 0));
-            eslint.on("ClassDeclaration", assertCommentCount(0, 0));
-            eslint.on("ClassBody", assertCommentCount(0, 2));
+            linter.on("Program", assertCommentCount(0, 0));
+            linter.on("ClassDeclaration", assertCommentCount(0, 0));
+            linter.on("ClassBody", assertCommentCount(0, 2));
 
-            eslint.verify(code, config, "", true);
+            linter.verify(code, config, "", true);
         });
 
         it("should return trailing comments if an object only contains comments", () => {
@@ -1396,11 +1396,11 @@ describe("SourceCode", () => {
                 "})"
             ].join("\n");
 
-            eslint.on("Program", assertCommentCount(0, 0));
-            eslint.on("ExpressionStatement", assertCommentCount(0, 0));
-            eslint.on("ObjectExpression", assertCommentCount(0, 2));
+            linter.on("Program", assertCommentCount(0, 0));
+            linter.on("ExpressionStatement", assertCommentCount(0, 0));
+            linter.on("ObjectExpression", assertCommentCount(0, 2));
 
-            eslint.verify(code, config, "", true);
+            linter.verify(code, config, "", true);
         });
 
         it("should return trailing comments if an array only contains comments", () => {
@@ -1411,11 +1411,11 @@ describe("SourceCode", () => {
                 "]"
             ].join("\n");
 
-            eslint.on("Program", assertCommentCount(0, 0));
-            eslint.on("ExpressionStatement", assertCommentCount(0, 0));
-            eslint.on("ArrayExpression", assertCommentCount(0, 2));
+            linter.on("Program", assertCommentCount(0, 0));
+            linter.on("ExpressionStatement", assertCommentCount(0, 0));
+            linter.on("ArrayExpression", assertCommentCount(0, 2));
 
-            eslint.verify(code, config, "", true);
+            linter.verify(code, config, "", true);
         });
 
         it("should return trailing comments if a switch statement only contains comments", () => {
@@ -1426,11 +1426,11 @@ describe("SourceCode", () => {
                 "}"
             ].join("\n");
 
-            eslint.on("Program", assertCommentCount(0, 0));
-            eslint.on("SwitchStatement", assertCommentCount(0, 2));
-            eslint.on("Identifier", assertCommentCount(0, 0));
+            linter.on("Program", assertCommentCount(0, 0));
+            linter.on("SwitchStatement", assertCommentCount(0, 2));
+            linter.on("Identifier", assertCommentCount(0, 0));
 
-            eslint.verify(code, config, "", true);
+            linter.verify(code, config, "", true);
         });
 
         it("should return comments for multiple declarations with a single variable", () => {
@@ -1443,9 +1443,9 @@ describe("SourceCode", () => {
             ].join("\n");
             let varDeclCount = 0;
 
-            eslint.on("Program", assertCommentCount(0, 0));
-            eslint.on("VariableDeclaration", assertCommentCount(1, 2));
-            eslint.on("VariableDeclarator", node => {
+            linter.on("Program", assertCommentCount(0, 0));
+            linter.on("VariableDeclaration", assertCommentCount(1, 2));
+            linter.on("VariableDeclarator", node => {
                 if (varDeclCount === 0) {
                     assertCommentCount(0, 0)(node);
                 } else if (varDeclCount === 1) {
@@ -1455,9 +1455,9 @@ describe("SourceCode", () => {
                 }
                 varDeclCount++;
             });
-            eslint.on("Identifier", assertCommentCount(0, 0));
+            linter.on("Identifier", assertCommentCount(0, 0));
 
-            eslint.verify(code, config, "", true);
+            linter.verify(code, config, "", true);
         });
 
         it("should return comments when comments exist between var keyword and VariableDeclarator", () => {
@@ -1467,32 +1467,32 @@ describe("SourceCode", () => {
                 "    a;"
             ].join("\n");
 
-            eslint.on("Program", assertCommentCount(0, 0));
-            eslint.on("VariableDeclaration", assertCommentCount(0, 0));
-            eslint.on("VariableDeclarator", assertCommentCount(2, 0));
-            eslint.on("Identifier", assertCommentCount(0, 0));
+            linter.on("Program", assertCommentCount(0, 0));
+            linter.on("VariableDeclaration", assertCommentCount(0, 0));
+            linter.on("VariableDeclarator", assertCommentCount(2, 0));
+            linter.on("Identifier", assertCommentCount(0, 0));
 
-            eslint.verify(code, config, "", true);
+            linter.verify(code, config, "", true);
         });
 
         it("should return attached comments between tokens to the correct nodes for empty function declarations", () => {
             const code = "/* 1 */ function /* 2 */ foo(/* 3 */) /* 4 */ { /* 5 */ } /* 6 */";
 
-            eslint.on("Program", assertCommentCount(0, 0));
-            eslint.on("FunctionDeclaration", assertCommentCount(1, 1));
-            eslint.on("Identifier", assertCommentCount(1, 0));
-            eslint.on("BlockStatement", assertCommentCount(1, 1));
+            linter.on("Program", assertCommentCount(0, 0));
+            linter.on("FunctionDeclaration", assertCommentCount(1, 1));
+            linter.on("Identifier", assertCommentCount(1, 0));
+            linter.on("BlockStatement", assertCommentCount(1, 1));
 
-            eslint.verify(code, config, "", true);
+            linter.verify(code, config, "", true);
         });
 
         it("should return attached comments between tokens to the correct nodes for empty class declarations", () => {
             const code = "/* 1 */ class /* 2 */ Foo /* 3 */ extends /* 4 */ Bar /* 5 */ { /* 6 */ } /* 7 */";
             let idCount = 0;
 
-            eslint.on("Program", assertCommentCount(0, 0));
-            eslint.on("ClassDeclaration", assertCommentCount(1, 1));
-            eslint.on("Identifier", node => {
+            linter.on("Program", assertCommentCount(0, 0));
+            linter.on("ClassDeclaration", assertCommentCount(1, 1));
+            linter.on("Identifier", node => {
                 if (idCount === 0) {
                     assertCommentCount(1, 1)(node);
                 } else {
@@ -1500,19 +1500,19 @@ describe("SourceCode", () => {
                 }
                 idCount++;
             });
-            eslint.on("ClassBody", assertCommentCount(1, 1));
+            linter.on("ClassBody", assertCommentCount(1, 1));
 
-            eslint.verify(code, config, "", true);
+            linter.verify(code, config, "", true);
         });
 
         it("should return attached comments between tokens to the correct nodes for empty switch statements", () => {
             const code = "/* 1 */ switch /* 2 */ (/* 3 */ foo /* 4 */) /* 5 */ { /* 6 */ } /* 7 */";
 
-            eslint.on("Program", assertCommentCount(0, 0));
-            eslint.on("SwitchStatement", assertCommentCount(1, 6));
-            eslint.on("Identifier", assertCommentCount(1, 1));
+            linter.on("Program", assertCommentCount(0, 0));
+            linter.on("SwitchStatement", assertCommentCount(1, 6));
+            linter.on("Identifier", assertCommentCount(1, 1));
 
-            eslint.verify(code, config, "", true);
+            linter.verify(code, config, "", true);
         });
     });
 
@@ -1751,9 +1751,9 @@ describe("SourceCode", () => {
         });
     });
 
-    // need to check that eslint.verify() works with SourceCode
+    // need to check that linter.verify() works with SourceCode
 
-    describe("eslint.verify()", () => {
+    describe("linter.verify()", () => {
 
         const CONFIG = {
             parserOptions: { ecmaVersion: 6 }
@@ -1763,21 +1763,21 @@ describe("SourceCode", () => {
             const ast = espree.parse(TEST_CODE, DEFAULT_CONFIG);
 
             const sourceCode = new SourceCode(TEST_CODE, ast),
-                messages = eslint.verify(sourceCode);
+                messages = linter.verify(sourceCode);
 
             assert.equal(messages.length, 0);
         });
 
         it("should work when passed a SourceCode object containing ES6 syntax and config", () => {
             const sourceCode = new SourceCode("let foo = bar;", AST),
-                messages = eslint.verify(sourceCode, CONFIG);
+                messages = linter.verify(sourceCode, CONFIG);
 
             assert.equal(messages.length, 0);
         });
 
         it("should report an error when using let and blockBindings is false", () => {
             const sourceCode = new SourceCode("let foo = bar;", AST),
-                messages = eslint.verify(sourceCode, {
+                messages = linter.verify(sourceCode, {
                     parserOptions: { ecmaVersion: 6 },
                     rules: { "no-unused-vars": 2 }
                 });


### PR DESCRIPTION
### Linked issues

* ~https://github.com/eslint/eslint.github.io/issues/322~
* https://github.com/eslint/eslint/issues/8454

### Linter class

* Moved all the logic from `eslint` file into a `class` form to `Linter`.
* ~Now `eslint` file exposes itself by using linter as `new Linter()`.~
* Nothing breaks right now.
* Since `CLIEngine` consumes `Linter` now then it makes `CLIEngine` immutable across different instances.

### TODO

- [x] Make `rules` module as a `class` then consume it in `Linter`.
- [x] Create `Linter` class
- [x] Fix existing Unit test
- [x] Remove `eslint` file and make `CLIEngine` consume `Linter`. That way every instance of CLIEngine gets its own linter.

**If accepted:**
- [x] Unit test
- [x] Docs