### PR TITLE
Update: indent `from` tokens in import statements (fixes #8438)

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -850,7 +850,18 @@ module.exports = {
 
             ExportNamedDeclaration(node) {
                 if (node.declaration === null) {
-                    addElementListIndent(getTokensAndComments(node).slice(1), node.specifiers, 1);
+                    const tokensInNode = getTokensAndComments(node);
+                    const closingCurly = sourceCode.getLastToken(node, astUtils.isClosingBraceToken);
+                    const closingCurlyIndex = lodash.sortedIndexBy(tokensInNode, closingCurly, token => token.range[0]);
+
+                    // Indent the specifiers in `export {foo, bar, baz}`
+                    addElementListIndent(tokensInNode.slice(1, closingCurlyIndex + 1), node.specifiers, 1);
+
+                    if (node.source) {
+
+                        // Indent everything after the `from` token in `export {foo, bar, baz} from 'qux'`
+                        offsets.setDesiredOffsets(tokensInNode.slice(closingCurlyIndex + 1), sourceCode.getFirstToken(node), 1);
+                    }
                 }
             },
 

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -859,7 +859,7 @@ module.exports = {
 
                     if (node.source) {
 
-                        // Indent everything after the `from` token in `export {foo, bar, baz} from 'qux'`
+                        // Indent everything after and including the `from` token in `export {foo, bar, baz} from 'qux'`
                         offsets.setDesiredOffsets(tokensInNode.slice(closingCurlyIndex + 1), sourceCode.getFirstToken(node), 1);
                     }
                 }

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -896,6 +896,14 @@ module.exports = {
 
                     addElementListIndent(specifierTokens, node.specifiers.filter(specifier => specifier.type === "ImportSpecifier"), 1);
                 }
+
+                const fromToken = sourceCode.getLastToken(node, token => token.type === "Identifier" && token.value === "from");
+
+                if (fromToken) {
+                    const tokensToOffset = sourceCode.getTokensBetween(fromToken, sourceCode.getLastToken(node), 1);
+
+                    offsets.setDesiredOffsets(tokensToOffset, sourceCode.getFirstToken(node), 1);
+                }
             },
 
             LogicalExpression: addBinaryOrLogicalExpressionIndent,

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -1001,6 +1001,16 @@ ruleTester.run("indent", rule, {
         },
         {
             code: unIndent`
+                export {
+                    foo,
+                    bar,
+                    baz
+                } from 'qux';
+            `,
+            parserOptions: { sourceType: "module" }
+        },
+        {
+            code: unIndent`
                 var a = 1,
                     b = 2,
                     c = 3;
@@ -5589,6 +5599,42 @@ ruleTester.run("indent", rule, {
             errors: expectedErrors([[2, 4, 0, "Identifier"], [3, 4, 2, "Identifier"]])
         },
         {
+            code: unIndent`
+                export {
+                foo,
+                  bar,
+                    baz
+                };
+            `,
+            output: unIndent`
+                export {
+                    foo,
+                    bar,
+                    baz
+                };
+            `,
+            parserOptions: { sourceType: "module" },
+            errors: expectedErrors([[2, 4, 0, "Identifier"], [3, 4, 2, "Identifier"]])
+        },
+        {
+            code: unIndent`
+                export {
+                foo,
+                  bar,
+                    baz
+                } from 'qux';
+            `,
+            output: unIndent`
+                export {
+                    foo,
+                    bar,
+                    baz
+                } from 'qux';
+            `,
+            parserOptions: { sourceType: "module" },
+            errors: expectedErrors([[2, 4, 0, "Identifier"], [3, 4, 2, "Identifier"]])
+        },
+        {
 
             // https://github.com/eslint/eslint/issues/7233
             code: unIndent`
@@ -6254,6 +6300,18 @@ ruleTester.run("indent", rule, {
             `,
             output: unIndent`
                 import {foo}
+                    from 'bar';
+            `,
+            parserOptions: { sourceType: "module" },
+            errors: expectedErrors([2, 4, 0, "Identifier"])
+        },
+        {
+            code: unIndent`
+                export {foo}
+                from 'bar';
+            `,
+            output: unIndent`
+                export {foo}
                     from 'bar';
             `,
             parserOptions: { sourceType: "module" },

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -3045,6 +3045,17 @@ ruleTester.run("indent", rule, {
         {
             code: "x => {}",
             parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: unIndent`
+                import {foo}
+                    from 'bar';
+            `,
+            parserOptions: { sourceType: "module" }
+        },
+        {
+            code: "import 'foo'",
+            parserOptions: { sourceType: "module" }
         }
     ],
 
@@ -6235,6 +6246,18 @@ ruleTester.run("indent", rule, {
                 ; [1, 2, 3].map(baz)
             `,
             errors: expectedErrors([3, 0, 4, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                import {foo}
+                from 'bar';
+            `,
+            output: unIndent`
+                import {foo}
+                    from 'bar';
+            `,
+            parserOptions: { sourceType: "module" },
+            errors: expectedErrors([2, 4, 0, "Identifier"])
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (see https://github.com/eslint/eslint/issues/8438)

**What changes did you make? (Give an overview)**

This updates the `indent` rule to ensure that `from` tokens are indented in `import a from 'b'` statements.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
