### PR TITLE
Docs: State that functions option only applies in ES2017 (fixes #7809)

### DIFF
--- a/docs/rules/comma-dangle.md
+++ b/docs/rules/comma-dangle.md
@@ -68,8 +68,9 @@ The default for each option is `"never"` unless otherwise specified.
 * `objects` is for object literals and object patterns of destructuring. (e.g. `let {a,} = {a: 1};`)
 * `imports` is for import declarations of ES Modules. (e.g. `import {a,} from "foo";`)
 * `exports` is for export declarations of ES Modules. (e.g. `export {a,};`)
-* `functions` is for function declarations and function calls. (e.g. `(function(a,){ })(b,);`)<br>
-  `functions` is set to `"ignore"` by default for consistency with the string option.
+* `functions` is for function declarations and function calls. (e.g. `(function(a,){ })(b,);`)
+    * `functions` is set to `"ignore"` by default for consistency with the string option.
+    * `functions` should only be enabled when linting ECMAScript 2017 or higher.
 
 ### never
 


### PR DESCRIPTION
Add documentation for the comma-dangle rule that states that requiring
trailing commas in parameter lists may cause errors in pre-ES2017 code.

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Update the documentation for the `functions` option in the `comma-dangle` rule to make it clear that the `functions` options should only be used for ES2017 code.

**Is there anything you'd like reviewers to focus on?**


