### PR TITLE
Update: no-unexpected-multiline to flag confusing division (fixes #8469)

### DIFF
--- a/docs/rules/no-unexpected-multiline.md
+++ b/docs/rules/no-unexpected-multiline.md
@@ -32,6 +32,9 @@ let x = function() {}
 let x = function() {}
 x
 `hello`
+
+let x = foo
+/regex/g.test(bar)
 ```
 
 Examples of **correct** code for this rule:

--- a/lib/rules/no-unexpected-multiline.js
+++ b/lib/rules/no-unexpected-multiline.js
@@ -30,6 +30,9 @@ module.exports = {
         const FUNCTION_MESSAGE = "Unexpected newline between function and ( of function call.";
         const PROPERTY_MESSAGE = "Unexpected newline between object and [ of property access.";
         const TAGGED_TEMPLATE_MESSAGE = "Unexpected newline between template tag and template literal.";
+        const DIVISION_MESSAGE = "Unexpected newline between numerator and division operator.";
+
+        const REGEX_FLAG_MATCHER = /^[gimuy]+$/;
 
         const sourceCode = context.getSourceCode();
 
@@ -75,6 +78,19 @@ module.exports = {
                     return;
                 }
                 checkForBreakAfter(node.callee, FUNCTION_MESSAGE);
+            },
+
+            "BinaryExpression[operator='/'] > BinaryExpression[operator='/']"(node) {
+                const secondSlash = sourceCode.getTokenAfter(node, token => token.value === "/");
+                const tokenAfterOperator = sourceCode.getTokenAfter(secondSlash);
+
+                if (
+                    tokenAfterOperator.type === "Identifier" &&
+                    REGEX_FLAG_MATCHER.test(tokenAfterOperator.value) &&
+                    secondSlash.range[1] === tokenAfterOperator.range[0]
+                ) {
+                    checkForBreakAfter(node.left, DIVISION_MESSAGE);
+                }
             }
         };
 

--- a/tests/lib/rules/no-unexpected-multiline.js
+++ b/tests/lib/rules/no-unexpected-multiline.js
@@ -200,17 +200,6 @@ ruleTester.run("no-unexpected-multiline", rule, {
                 column: 17,
                 message: "Unexpected newline between numerator and division operator."
             }]
-        },
-        {
-            code: `
-                foo
-                /bar/gimuygimuygimuy.test(baz)
-            `,
-            errors: [{
-                line: 3,
-                column: 17,
-                message: "Unexpected newline between numerator and division operator."
-            }]
         }
     ]
 });

--- a/tests/lib/rules/no-unexpected-multiline.js
+++ b/tests/lib/rules/no-unexpected-multiline.js
@@ -42,7 +42,43 @@ ruleTester.run("no-unexpected-multiline", rule, {
         {
             code: "x\n.y\nz `Valid Test Case`",
             parserOptions: { ecmaVersion: 6 }
-        }
+        },
+        `
+            foo
+            / bar /2
+        `,
+        `
+            foo
+            / bar / mgy
+        `,
+        `
+            foo
+            / bar /
+            gym
+        `,
+        `
+            foo
+            / bar
+            / ygm
+        `,
+        `
+            foo
+            / bar /GYM
+        `,
+        `
+            foo
+            / bar / baz
+        `,
+        "foo /bar/g",
+        `
+            foo
+            /denominator/
+            2
+        `,
+        `
+            foo
+            / /abc/
+        `
     ],
     invalid: [
         {
@@ -119,6 +155,61 @@ ruleTester.run("no-unexpected-multiline", rule, {
                 line: 3,
                 column: 1,
                 message: "Unexpected newline between template tag and template literal."
+            }]
+        },
+        {
+            code: `
+                foo
+                / bar /gym
+            `,
+            errors: [{
+                line: 3,
+                column: 17,
+                message: "Unexpected newline between numerator and division operator."
+            }]
+        },
+        {
+            code: `
+                foo
+                / bar /g
+            `,
+            errors: [{
+                line: 3,
+                column: 17,
+                message: "Unexpected newline between numerator and division operator."
+            }]
+        },
+        {
+            code: `
+                foo
+                / bar /g.test(baz)
+            `,
+            errors: [{
+                line: 3,
+                column: 17,
+                message: "Unexpected newline between numerator and division operator."
+            }]
+        },
+        {
+            code: `
+                foo
+                /bar/gimuygimuygimuy.test(baz)
+            `,
+            errors: [{
+                line: 3,
+                column: 17,
+                message: "Unexpected newline between numerator and division operator."
+            }]
+        },
+        {
+            code: `
+                foo
+                /bar/gimuygimuygimuy.test(baz)
+            `,
+            errors: [{
+                line: 3,
+                column: 17,
+                message: "Unexpected newline between numerator and division operator."
             }]
         }
     ]


### PR DESCRIPTION
**What is the purpose of this pull request?**

Bug fix (https://github.com/eslint/eslint/issues/8469)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Previously, the no-unexpected-multiline docs mentioned that the division operator could prevent semicolon insertion, but it did not report an error for cases where this happens. This commit updates the rule to report an error when a multiline division operation looks like it was intended to be a regular expression with flags.

Fixes https://github.com/eslint/eslint/issues/8469

**Is there anything you'd like reviewers to focus on?**

Do you have any suggestions for improving the method used to detect "confusing" division?

Also see: https://github.com/eslint/eslint/issues/8469#issuecomment-294953414