### PR TITLE
Fix: indent crash on arrow functions without parens at start of line

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -698,6 +698,13 @@ module.exports = {
         */
         function addFunctionParamsIndent(node, paramsIndent) {
             const openingParen = node.params.length ? sourceCode.getTokenBefore(node.params[0]) : sourceCode.getTokenBefore(node.body, 1);
+
+            if (!openingParen) {
+
+                // If there is no opening paren (e.g. for an arrow function with a single parameter), don't indent anything.
+                return;
+            }
+
             const closingParen = sourceCode.getTokenBefore(node.body);
             const nodeTokens = getTokensAndComments(node);
             const openingParenIndex = lodash.sortedIndexBy(nodeTokens, openingParen, token => token.range[0]);

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -3041,6 +3041,10 @@ ruleTester.run("indent", rule, {
 
                 ; [1, 2, 3].map(baz)
             `
+        },
+        {
+            code: "x => {}",
+            parserOptions: { ecmaVersion: 6 }
         }
     ],
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix

**Tell us about your environment**

* **ESLint Version:**
* **Node Version:**
* **npm Version:**

**What parser (default, Babel-ESLint, etc.) are you using?**

**Please show your full configuration:**

```yml
rules:
  indent: error
parserOptions:
  ecmaVersion: 6
```

**What did you do? Please include the actual source code causing the issue.**

```js
x => {}
```

**What did you expect to happen?**

I expected ESLint to not crash.

**What actually happened? Please include the actual, raw output from ESLint.**

ESLint crashed.

```
TypeError: Cannot read property 'range' of null
    at lodash.sortedIndexBy.token (path/to/lib/rules/indent.js:703:100)
    at baseSortedIndexBy (path/to/node_modules/lodash/lodash.js:4143:15)
    at Function.sortedIndexBy (path/to/node_modules/lodash/lodash.js:7991:14)
    at addFunctionParamsIndent (path/to/lib/rules/indent.js:703:46)
    at EventEmitter.ArrowFunctionExpression (path/to/lib/rules/indent.js:808:17)
    at emitOne (events.js:96:13)
    at EventEmitter.emit (events.js:191:7)
    at NodeEventGenerator.applySelector (path/to/lib/util/node-event-generator.js:265:26)
    at NodeEventGenerator.applySelectors (path/to/lib/util/node-event-generator.js:294:22)
    at NodeEventGenerator.enterNode (path/to/lib/util/node-event-generator.js:308:14)
```

**What changes did you make? (Give an overview)**

Previously, an arrow function without parentheses around the parameters at the start of a line would cause the `indent` rule to crash. This commit fixes the crash.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
