### PR TITLE
Fix: Preserve comment tokens in object-curly-newline fix().

### DIFF
--- a/lib/rules/object-curly-newline.js
+++ b/lib/rules/object-curly-newline.js
@@ -128,14 +128,14 @@ module.exports = {
             const options = normalizedOptions[node.type];
             const openBrace = sourceCode.getFirstToken(node);
             const closeBrace = sourceCode.getLastToken(node);
-            let first = sourceCode.getTokenAfter(openBrace, { includeComments: true });
-            let last = sourceCode.getTokenBefore(closeBrace, { includeComments: true });
+            const firstTokenOrComment = sourceCode.getTokenAfter(openBrace, { includeComments: true });
+            const lastTokenOrComment = sourceCode.getTokenBefore(closeBrace, { includeComments: true });
             const needsLinebreaks = (
                 node.properties.length >= options.minProperties ||
                 (
                     options.multiline &&
                     node.properties.length > 0 &&
-                    first.loc.start.line !== last.loc.end.line
+                    firstTokenOrComment.loc.start.line !== lastTokenOrComment.loc.end.line
                 )
             );
 
@@ -147,8 +147,8 @@ module.exports = {
              *         a: 1
              *     }
              */
-            first = sourceCode.getTokenAfter(openBrace);
-            last = sourceCode.getTokenBefore(closeBrace);
+            const first = sourceCode.getTokenAfter(openBrace);
+            const last = sourceCode.getTokenBefore(closeBrace);
 
             if (needsLinebreaks) {
                 if (astUtils.isTokenOnSameLine(openBrace, first)) {
@@ -180,7 +180,7 @@ module.exports = {
                         fix(fixer) {
                             return fixer.removeRange([
                                 openBrace.range[1],
-                                first.range[0]
+                                firstTokenOrComment.range[0]
                             ]);
                         }
                     });
@@ -192,7 +192,7 @@ module.exports = {
                         loc: closeBrace.loc.start,
                         fix(fixer) {
                             return fixer.removeRange([
-                                last.range[1],
+                                lastTokenOrComment.range[1],
                                 closeBrace.range[0]
                             ]);
                         }

--- a/tests/lib/rules/object-curly-newline.js
+++ b/tests/lib/rules/object-curly-newline.js
@@ -430,12 +430,57 @@ ruleTester.run("object-curly-newline", rule, {
         },
         {
             code: [
+                "var a = {",
+                "  /* comment */ ",
+                "};"
+            ].join("\n"),
+            output: [
+                "var a = {/* comment */};"
+            ].join("\n"),
+            options: [{ multiline: true }],
+            errors: [
+                { line: 1, column: 9, message: "Unexpected line break after this opening brace." },
+                { line: 3, column: 1, message: "Unexpected line break before this closing brace." }
+            ]
+        },
+        {
+            code: [
                 "var b = {",
                 "    a: 1",
                 "};"
             ].join("\n"),
             output: [
                 "var b = {a: 1};"
+            ].join("\n"),
+            options: [{ multiline: true }],
+            errors: [
+                { line: 1, column: 9, message: "Unexpected line break after this opening brace." },
+                { line: 3, column: 1, message: "Unexpected line break before this closing brace." }
+            ]
+        },
+        {
+            code: [
+                "var a = {",
+                "  /* comment */ b: 1",
+                "};"
+            ].join("\n"),
+            output: [
+                "var a = {/* comment */ b: 1};"
+            ].join("\n"),
+            options: [{ multiline: true }],
+            errors: [
+                { line: 1, column: 9, message: "Unexpected line break after this opening brace." },
+                { line: 3, column: 1, message: "Unexpected line break before this closing brace." }
+            ]
+        },
+        {
+            code: [
+                "var a = {",
+                "  b: 1 /* comment */ ",
+                "};"
+            ].join("\n"),
+            output: [
+                "var a = {b: 1 /* comment */};"
             ].join("\n"),
             options: [{ multiline: true }],
             errors: [


### PR DESCRIPTION
Fixes #8484.

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Tweaked object-curly-newline fix() logic to not accidentally remove comment tokens.