### PR TITLE
Fix: avoid creating extra whitespace in brace-style fixer (fixes #7621)

### DIFF
--- a/lib/rules/brace-style.js
+++ b/lib/rules/brace-style.js
@@ -62,10 +62,12 @@ module.exports = {
         function removeNewlineBetween(firstToken, secondToken) {
             const textRange = [firstToken.range[1], secondToken.range[0]];
             const textBetween = sourceCode.text.slice(textRange[0], textRange[1]);
-            const NEWLINE_REGEX = astUtils.createGlobalLinebreakMatcher();
 
             // Don't do a fix if there is a comment between the tokens
-            return fixer => fixer.replaceTextRange(textRange, textBetween.trim() ? null : textBetween.replace(NEWLINE_REGEX, ""));
+            if (textBetween.trim()) {
+                return null;
+            }
+            return fixer => fixer.replaceTextRange(textRange, " ");
         }
 
         /**

--- a/tests/lib/rules/brace-style.js
+++ b/tests/lib/rules/brace-style.js
@@ -200,7 +200,7 @@ ruleTester.run("brace-style", rule, {
     invalid: [
         {
             code: "if (f) {\nbar;\n}\nelse\nbaz;",
-            output: "if (f) {\nbar;\n}else\nbaz;",
+            output: "if (f) {\nbar;\n} else\nbaz;",
             errors: [{ message: CLOSE_MESSAGE, type: "Punctuator" }]
         },
         {
@@ -216,83 +216,83 @@ ruleTester.run("brace-style", rule, {
         },
         {
             code: "function foo() \n { \n return; }",
-            output: "function foo()  { \n return; \n}",
+            output: "function foo() { \n return; \n}",
             errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }, { message: CLOSE_MESSAGE_SINGLE, type: "Punctuator" }]
         },
         {
             code: "!function foo() \n { \n return; }",
-            output: "!function foo()  { \n return; \n}",
+            output: "!function foo() { \n return; \n}",
             errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }, { message: CLOSE_MESSAGE_SINGLE, type: "Punctuator" }]
         },
         {
             code: "if (foo) \n { \n bar(); }",
-            output: "if (foo)  { \n bar(); \n}",
+            output: "if (foo) { \n bar(); \n}",
             errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }, { message: CLOSE_MESSAGE_SINGLE, type: "Punctuator" }]
         },
         {
             code: "if (foo) \n { \n bar(); }",
-            output: "if (foo)  { \n bar(); \n}",
+            output: "if (foo) { \n bar(); \n}",
             errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }, { message: CLOSE_MESSAGE_SINGLE, type: "Punctuator" }]
         },
         {
             code: "if (a) { \nb();\n } else \n { c(); }",
-            output: "if (a) { \nb();\n } else  {\n c(); \n}",
+            output: "if (a) { \nb();\n } else {\n c(); \n}",
             errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }, { message: BODY_MESSAGE, type: "Punctuator" }, { message: CLOSE_MESSAGE_SINGLE, type: "Punctuator" }]
         },
         {
             code: "while (foo) \n { \n bar(); }",
-            output: "while (foo)  { \n bar(); \n}",
+            output: "while (foo) { \n bar(); \n}",
             errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }, { message: CLOSE_MESSAGE_SINGLE, type: "Punctuator" }]
         },
         {
             code: "for (;;) \n { \n bar(); }",
-            output: "for (;;)  { \n bar(); \n}",
+            output: "for (;;) { \n bar(); \n}",
             errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }, { message: CLOSE_MESSAGE_SINGLE, type: "Punctuator" }]
         },
         {
             code: "with (foo) \n { \n bar(); }",
-            output: "with (foo)  { \n bar(); \n}",
+            output: "with (foo) { \n bar(); \n}",
             errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }, { message: CLOSE_MESSAGE_SINGLE, type: "Punctuator" }]
         },
         {
             code: "switch (foo) \n { \n case \"bar\": break; }",
-            output: "switch (foo)  { \n case \"bar\": break; \n}",
+            output: "switch (foo) { \n case \"bar\": break; \n}",
             errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }, { message: CLOSE_MESSAGE_SINGLE, type: "Punctuator" }]
         },
         {
             code: "switch (foo) \n { }",
-            output: "switch (foo)  { }",
+            output: "switch (foo) { }",
             errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }]
         },
         {
             code: "try \n { \n bar(); \n } catch (e) {}",
-            output: "try  { \n bar(); \n } catch (e) {}",
+            output: "try { \n bar(); \n } catch (e) {}",
             errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }]
         },
         {
             code: "try { \n bar(); \n } catch (e) \n {}",
-            output: "try { \n bar(); \n } catch (e)  {}",
+            output: "try { \n bar(); \n } catch (e) {}",
             errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }]
         },
         {
             code: "do \n { \n bar(); \n} while (true)",
-            output: "do  { \n bar(); \n} while (true)",
+            output: "do { \n bar(); \n} while (true)",
             errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }]
         },
         {
             code: "for (foo in bar) \n { \n baz(); \n }",
-            output: "for (foo in bar)  { \n baz(); \n }",
+            output: "for (foo in bar) { \n baz(); \n }",
             errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }]
         },
         {
             code: "for (foo of bar) \n { \n baz(); \n }",
-            output: "for (foo of bar)  { \n baz(); \n }",
+            output: "for (foo of bar) { \n baz(); \n }",
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }]
         },
         {
             code: "try { \n bar(); \n }\ncatch (e) {\n}",
-            output: "try { \n bar(); \n }catch (e) {\n}",
+            output: "try { \n bar(); \n } catch (e) {\n}",
             errors: [{ message: CLOSE_MESSAGE, type: "Punctuator" }]
         },
         {
@@ -302,7 +302,7 @@ ruleTester.run("brace-style", rule, {
         },
         {
             code: "if (a) { \nb();\n } \n else { \nc();\n }",
-            output: "if (a) { \nb();\n }  else { \nc();\n }",
+            output: "if (a) { \nb();\n } else { \nc();\n }",
             errors: [{ message: CLOSE_MESSAGE, type: "Punctuator" }]
         },
         {
@@ -443,7 +443,7 @@ ruleTester.run("brace-style", rule, {
         },
         {
             code: "if (a) { b(); }\nelse { c(); }",
-            output: "if (a) { b(); }else { c(); }",
+            output: "if (a) { b(); } else { c(); }",
             options: ["1tbs", { allowSingleLine: true }],
             errors: [{ message: CLOSE_MESSAGE, type: "Punctuator" }]
         },
@@ -467,49 +467,49 @@ ruleTester.run("brace-style", rule, {
         },
         {
             code: "switch (foo) \n { \n case \"bar\": break; }",
-            output: "switch (foo)  { \n case \"bar\": break; \n}",
+            output: "switch (foo) { \n case \"bar\": break; \n}",
             options: ["1tbs", { allowSingleLine: true }],
             errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }, { message: CLOSE_MESSAGE_SINGLE, type: "Punctuator" }]
         },
         {
             code: "switch (foo) \n { }",
-            output: "switch (foo)  { }",
+            output: "switch (foo) { }",
             options: ["1tbs", { allowSingleLine: true }],
             errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }]
         },
         {
             code: "try {  bar(); }\ncatch (e) { baz();  }",
-            output: "try {  bar(); }catch (e) { baz();  }",
+            output: "try {  bar(); } catch (e) { baz();  }",
             options: ["1tbs", { allowSingleLine: true }],
             errors: [{ message: CLOSE_MESSAGE, type: "Punctuator" }]
         },
         {
             code: "try \n { \n bar(); \n } catch (e) {}",
-            output: "try  { \n bar(); \n } catch (e) {}",
+            output: "try { \n bar(); \n } catch (e) {}",
             options: ["1tbs", { allowSingleLine: true }],
             errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }]
         },
         {
             code: "try { \n bar(); \n } catch (e) \n {}",
-            output: "try { \n bar(); \n } catch (e)  {}",
+            output: "try { \n bar(); \n } catch (e) {}",
             options: ["1tbs", { allowSingleLine: true }],
             errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }]
         },
         {
             code: "do \n { \n bar(); \n} while (true)",
-            output: "do  { \n bar(); \n} while (true)",
+            output: "do { \n bar(); \n} while (true)",
             options: ["1tbs", { allowSingleLine: true }],
             errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }]
         },
         {
             code: "for (foo in bar) \n { \n baz(); \n }",
-            output: "for (foo in bar)  { \n baz(); \n }",
+            output: "for (foo in bar) { \n baz(); \n }",
             options: ["1tbs", { allowSingleLine: true }],
             errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }]
         },
         {
             code: "try { \n bar(); \n }\ncatch (e) {\n}",
-            output: "try { \n bar(); \n }catch (e) {\n}",
+            output: "try { \n bar(); \n } catch (e) {\n}",
             options: ["1tbs", { allowSingleLine: true }],
             errors: [{ message: CLOSE_MESSAGE, type: "Punctuator" }]
         },
@@ -521,7 +521,7 @@ ruleTester.run("brace-style", rule, {
         },
         {
             code: "if (a) { \nb();\n } \n else { \nc();\n }",
-            output: "if (a) { \nb();\n }  else { \nc();\n }",
+            output: "if (a) { \nb();\n } else { \nc();\n }",
             options: ["1tbs", { allowSingleLine: true }],
             errors: [{ message: CLOSE_MESSAGE, type: "Punctuator" }]
         },
@@ -599,12 +599,12 @@ ruleTester.run("brace-style", rule, {
         },
         {
             code: "class Foo\n{\n}",
-            output: "class Foo{\n}",
+            output: "class Foo {\n}",
             errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }]
         },
         {
             code: "(class\n{\n})",
-            output: "(class{\n})",
+            output: "(class {\n})",
             errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }]
         },
         {
@@ -634,6 +634,30 @@ ruleTester.run("brace-style", rule, {
             output: "class\nFoo\n{}",
             options: ["allman"],
             errors: [{ message: OPEN_MESSAGE_ALLMAN, type: "Punctuator" }]
+        },
+
+        // https://github.com/eslint/eslint/issues/7621
+        {
+            code: `
+                if (foo)
+                {
+                    bar
+                }
+                else {
+                    baz
+                }
+            `,
+            output: `
+                if (foo) {
+                    bar
+                } else {
+                    baz
+                }
+            `,
+            errors: [
+                { message: OPEN_MESSAGE, type: "Punctuator" },
+                { message: CLOSE_MESSAGE, type: "Punctuator" }
+            ]
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (https://github.com/eslint/eslint/issues/7621)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Previously, the brace-style autofixer would leave any existing whitespace between tokens when removing newlines. This would result in a large amount of extra whitespace on a line when fixing indented code. Users generally don't expect indentation whitespace to be preserved inline when fixing brace styling, so this commit updates the fixer to always output a single space between tokens when removing newlines.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular