### PR TITLE
Update: fix no-self-compare false negative on non-literals (fixes #7677)

### DIFF
--- a/lib/rules/no-self-compare.js
+++ b/lib/rules/no-self-compare.js
@@ -22,15 +22,28 @@ module.exports = {
     },
 
     create(context) {
+        const sourceCode = context.getSourceCode();
+
+        /**
+         * Determines whether two nodes are composed of the same tokens.
+         * @param {ASTNode} nodeA The first node
+         * @param {ASTNode} nodeB The second node
+         * @returns {boolean} true if the nodes have identical token representations
+         */
+        function hasSameTokens(nodeA, nodeB) {
+            const tokensA = sourceCode.getTokens(nodeA);
+            const tokensB = sourceCode.getTokens(nodeB);
+
+            return tokensA.length === tokensB.length &&
+                tokensA.every((token, index) => token.type === tokensB[index].type && token.value === tokensB[index].value);
+        }
 
         return {
 
             BinaryExpression(node) {
-                const operators = ["===", "==", "!==", "!=", ">", "<", ">=", "<="];
+                const operators = new Set(["===", "==", "!==", "!=", ">", "<", ">=", "<="]);
 
-                if (operators.indexOf(node.operator) > -1 &&
-                    (node.left.type === "Identifier" && node.right.type === "Identifier" && node.left.name === node.right.name ||
-                    node.left.type === "Literal" && node.right.type === "Literal" && node.left.value === node.right.value)) {
+                if (operators.has(node.operator) && hasSameTokens(node.left, node.right)) {
                     context.report({ node, message: "Comparing to itself is potentially pointless." });
                 }
             }

--- a/tests/lib/rules/no-self-compare.js
+++ b/tests/lib/rules/no-self-compare.js
@@ -21,10 +21,9 @@ const ruleTester = new RuleTester();
 ruleTester.run("no-self-compare", rule, {
     valid: [
         "if (x === y) { }",
-        "if (f() === f()) { }",
-        "if (a[1] === a[1]) { }",
         "if (1 === 2) { }",
-        "y=x*x"
+        "y=x*x",
+        "foo.bar.baz === foo.bar.qux"
     ],
     invalid: [
         { code: "if (x === x) { }", errors: [{ message: "Comparing to itself is potentially pointless.", type: "BinaryExpression" }] },
@@ -39,6 +38,7 @@ ruleTester.run("no-self-compare", rule, {
         { code: "x > x", errors: [{ message: "Comparing to itself is potentially pointless.", type: "BinaryExpression" }] },
         { code: "x < x", errors: [{ message: "Comparing to itself is potentially pointless.", type: "BinaryExpression" }] },
         { code: "x >= x", errors: [{ message: "Comparing to itself is potentially pointless.", type: "BinaryExpression" }] },
-        { code: "x <= x", errors: [{ message: "Comparing to itself is potentially pointless.", type: "BinaryExpression" }] }
+        { code: "x <= x", errors: [{ message: "Comparing to itself is potentially pointless.", type: "BinaryExpression" }] },
+        { code: "foo.bar().baz.qux >= foo.bar ().baz .qux", errors: [{ message: "Comparing to itself is potentially pointless.", type: "BinaryExpression" }] }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (https://github.com/eslint/eslint/issues/7677)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Previously, the `no-self-compare` rule would only check comparisons between identifiers and did not check comparisons between more complex expressions. (I assume this is because the APIs that would allow comparing complex expressions didn't exist yet at the time the rule was implemented.) The rule is still applicable to non-literals, so this commit updates the rule to check comparisons that aren't between literals.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular