### PR TITLE
Update: check allman-style blocks correctly in indent rule (fixes #8493)

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -628,24 +628,12 @@ module.exports = {
                 blockIndentLevel = 1;
             }
 
-            /*
-             * If the block starts on its own line, then match the tokens in the block against the opening curly of the block.
-             * Otherwise, match the token in the block against the tokens in the block's parent.
-             *
-             * For example:
-             * function foo() {
-             *   {
-             *      // (random block, tokens should get matched against the { that opens the block)
-             *      foo;
-             *   }
-             *
-             * if (foo &&
-             *     bar) {
-             *     baz(); // Tokens in the block should get matched against the `if` statement, even though the opening curly is indented.
-             * }
-             */
             const tokens = getTokensAndComments(node);
 
+            /*
+             * For blocks that aren't lone statements, ensure that the opening curly brace
+             * is aligned with the parent.
+             */
             if (!astUtils.STATEMENT_LIST_PARENTS.has(node.parent.type)) {
                 offsets.matchIndentOf(sourceCode.getFirstToken(node.parent), tokens[0]);
             }

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -556,49 +556,6 @@ module.exports = {
         }
 
         /**
-         * Check indentation for blocks
-         * @param {ASTNode} node node to check
-         * @returns {void}
-         */
-        function addBlockIndent(node) {
-
-            let blockIndentLevel;
-
-            if (node.parent && isOuterIIFE(node.parent)) {
-                blockIndentLevel = options.outerIIFEBody;
-            } else if (node.parent && (node.parent.type === "FunctionExpression" || node.parent.type === "ArrowFunctionExpression")) {
-                blockIndentLevel = options.FunctionExpression.body;
-            } else if (node.parent && node.parent.type === "FunctionDeclaration") {
-                blockIndentLevel = options.FunctionDeclaration.body;
-            } else {
-                blockIndentLevel = 1;
-            }
-
-            /*
-             * If the block starts on its own line, then match the tokens in the block against the opening curly of the block.
-             * Otherwise, match the token in the block against the tokens in the block's parent.
-             *
-             * For example:
-             * function foo() {
-             *   {
-             *      // (random block, tokens should get matched against the { that opens the block)
-             *      foo;
-             *   }
-             *
-             * if (foo &&
-             *     bar) {
-             *     baz(); // Tokens in the block should get matched against the `if` statement, even though the opening curly is indented.
-             * }
-             */
-            const tokens = getTokensAndComments(node);
-            const tokenToMatchAgainst = tokenInfo.isFirstTokenOfLine(tokens[0]) ? tokens[0] : sourceCode.getFirstToken(node.parent);
-
-            offsets.matchIndentOf(tokenToMatchAgainst, tokens[0]);
-            offsets.setDesiredOffsets(tokens, tokens[0], blockIndentLevel);
-            offsets.matchIndentOf(tokenToMatchAgainst, tokens[tokens.length - 1]);
-        }
-
-        /**
         * Check indentation for lists of elements (arrays, objects, function params)
         * @param {Token[]} tokens list of tokens
         * @param {ASTNode[]} elements List of elements that should be offset
@@ -650,6 +607,49 @@ module.exports = {
                     }
                 }
             });
+        }
+
+        /**
+         * Check indentation for blocks
+         * @param {ASTNode} node node to check
+         * @returns {void}
+         */
+        function addBlockIndent(node) {
+
+            let blockIndentLevel;
+
+            if (node.parent && isOuterIIFE(node.parent)) {
+                blockIndentLevel = options.outerIIFEBody;
+            } else if (node.parent && (node.parent.type === "FunctionExpression" || node.parent.type === "ArrowFunctionExpression")) {
+                blockIndentLevel = options.FunctionExpression.body;
+            } else if (node.parent && node.parent.type === "FunctionDeclaration") {
+                blockIndentLevel = options.FunctionDeclaration.body;
+            } else {
+                blockIndentLevel = 1;
+            }
+
+            /*
+             * If the block starts on its own line, then match the tokens in the block against the opening curly of the block.
+             * Otherwise, match the token in the block against the tokens in the block's parent.
+             *
+             * For example:
+             * function foo() {
+             *   {
+             *      // (random block, tokens should get matched against the { that opens the block)
+             *      foo;
+             *   }
+             *
+             * if (foo &&
+             *     bar) {
+             *     baz(); // Tokens in the block should get matched against the `if` statement, even though the opening curly is indented.
+             * }
+             */
+            const tokens = getTokensAndComments(node);
+
+            if (!astUtils.STATEMENT_LIST_PARENTS.has(node.parent.type)) {
+                offsets.matchIndentOf(sourceCode.getFirstToken(node.parent), tokens[0]);
+            }
+            addElementListIndent(tokens, node.body, blockIndentLevel);
         }
 
         /**

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -3113,6 +3113,22 @@ ruleTester.run("indent", rule, {
         },
         {
             code: unIndent`
+                if (foo)
+                {
+                    bar();
+                }
+            `
+        },
+        {
+            code: unIndent`
+                function foo(bar)
+                {
+                    baz();
+                }
+            `
+        },
+        {
+            code: unIndent`
                 () =>
                     ({})
             `,
@@ -3131,6 +3147,23 @@ ruleTester.run("indent", rule, {
                     () =>
                         ({})
                 )
+            `,
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: unIndent`
+                var x = function foop(bar)
+                {
+                    baz();
+                }
+            `
+        },
+        {
+            code: unIndent`
+                var x = (bar) =>
+                {
+                    baz();
+                }
             `,
             parserOptions: { ecmaVersion: 6 }
         }


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (https://github.com/eslint/eslint/issues/8493)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Previously, there was a bug in the indent rule where allman-style blocks with function bodies would be indented by one too many levels. This commit fixes the issue and updates the BlockStatement indentation handler to use the same logic as other lists of nodes (e.g. arrays).

**Is there anything you'd like reviewers to focus on?**

Nothing in particular