### PR TITLE
Fix: Ignore unknown nodes for Indent rule (fixes #8440)

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -927,9 +927,7 @@ module.exports = {
                     if (dependency && dependency.loc.start.line < startLine) {
                         const tokensOfLine = sourceCode.getTokensAfter(
                             firstTokenOfLine,
-                            (token) => {
-                                return token.loc.start.line === lineNumber;
-                            }
+                            token => token.loc.start.line === lineNumber
                         );
 
                         tokensOfLine.forEach(token => {

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -925,8 +925,12 @@ module.exports = {
                 if (!dependency || dependency.loc.start.line < startLine) {
                     offsets.ignoreToken(firstTokenOfLine);
                     if (dependency && dependency.loc.start.line < startLine) {
-                        const firstTokenOfNextLine = tokenInfo.firstTokensByLineNumber.get(lineNumber + 1);
-                        const tokensOfLine = sourceCode.getTokensBetween(firstTokenOfLine, firstTokenOfNextLine);
+                        const tokensOfLine = sourceCode.getTokensAfter(
+                            firstTokenOfLine,
+                            (token) => {
+                                return token.loc.start.line === lineNumber;
+                            }
+                        );
 
                         tokensOfLine.forEach(token => {
                             offsets.matchIndentOf(null, token);

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -886,11 +886,40 @@ module.exports = {
         }
 
         /**
+         * Iterate through the dependent tokens until we reach the last token
+         * dependency or the last token dependency that is within the unknown
+         * node. If the last token dependency is not the first token of the line
+         * make the last token dependcy depend on the first token of the line.
+         * This ensures the offset will be set correctly since only the first
+         * token of each line is ignored and not all tokens on a line.
+         * @param {Token} dependency First
+         * @param {number} startLineOfNode First line number of unknown node
+         * @returns {void}
+         */
+        function ignoreUnknownNodeLineWithDependency(dependency, startLineOfNode) {
+            let currDependency = dependency,
+                lastDependency = dependency;
+
+            while (
+                (currDependency = offsets.getFirstDependency(currDependency)) &&
+                currDependency.loc.start.line > startLineOfNode
+            ) {
+                lastDependency = currDependency;
+            }
+
+            const firstTokenOfDependentLine = tokenInfo.getFirstTokenOfLine(lastDependency);
+
+            if (lastDependency !== firstTokenOfDependentLine) {
+                offsets.matchIndentOf(firstTokenOfDependentLine, lastDependency);
+            }
+        }
+
+        /**
         * Ignore first token of each line within an unknown node if its
         * offset does not depend on another token's offset. If the first token
         * of a line's offset depends on the offset of another token, make the
-        * last dependent offset depend on the first token of its line.
-        * @param {ASTNode} node Node
+        * last dependent token's offset depend on the first token of its line.
+        * @param {ASTNode} node Unknown Node
         * @returns {void}
         */
         function ignoreUnknownNode(node) {
@@ -913,24 +942,8 @@ module.exports = {
 
                 const dependency = offsets.getFirstDependency(firstTokenOfLine);
 
-                if (dependency) {
-                    let currDependency = dependency,
-                        lastDependency = null;
-
-                    while (
-                        (currDependency = offsets.getFirstDependency(currDependency)) &&
-                        currDependency.loc.start.line > startLine
-                    ) {
-                        lastDependency = currDependency;
-                    }
-
-                    if (lastDependency) {
-                        const firstTokenOfDependentLine = tokenInfo.getFirstTokenOfLine(lastDependency);
-
-                        offsets.matchIndentOf(firstTokenOfDependentLine, lastDependency);
-                    } else if (dependency.loc.start.line < startLine) {
-                        offsets.ignoreToken(firstTokenOfLine);
-                    }
+                if (dependency && dependency.loc.start.line >= startLine) {
+                    ignoreUnknownNodeLineWithDependency(dependency, startLine);
                 } else {
                     offsets.ignoreToken(firstTokenOfLine);
                 }
@@ -943,11 +956,11 @@ module.exports = {
         * @returns {void}
         */
         function checkForUnknownNode(node) {
-            if (KNOWN_NODES.has(node.type)) {
-                return;
-            }
+            const isNodeUnknown = !(KNOWN_NODES.has(node.type));
 
-            ignoreUnknownNode(node);
+            if (isNodeUnknown) {
+                ignoreUnknownNode(node);
+            }
         }
 
         return {

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -298,8 +298,17 @@ class OffsetStorage {
                         (firstToken.loc.start.column - this.tokenInfo.getFirstTokenOfLine(firstToken).loc.start.column) / this.indentSize;
             } else {
                 const offsetInfo = this.desiredOffsets[token.range[0]];
+                let dependentToken = null;
+                let firstTokenOfLine = null;
 
-                this.desiredIndentCache[token.range[0]] = offsetInfo.offset + (offsetInfo.from ? this.getDesiredIndent(offsetInfo.from) : 0);
+                if (offsetInfo.from) {
+                    dependentToken = offsetInfo.from;
+                } else if ((firstTokenOfLine = this.tokenInfo.getFirstTokenOfLine(token)) !== token) {
+                    dependentToken = firstTokenOfLine;
+                }
+
+                this.desiredIndentCache[token.range[0]] = offsetInfo.offset +
+                    (dependentToken ? this.getDesiredIndent(dependentToken) : 0);
             }
         }
         return this.desiredIndentCache[token.range[0]];
@@ -886,39 +895,10 @@ module.exports = {
         }
 
         /**
-         * Iterate through the dependent tokens until we reach the last token
-         * dependency or the last token dependency that is within the unknown
-         * node. If the last token dependency is not the first token of the line
-         * make the last token dependcy depend on the first token of the line.
-         * This ensures the offset will be set correctly since only the first
-         * token of each line is ignored and not all tokens on a line.
-         * @param {Token} dependency First
-         * @param {number} startLineOfNode First line number of unknown node
-         * @returns {void}
-         */
-        function ignoreUnknownNodeLineWithDependency(dependency, startLineOfNode) {
-            let currDependency = dependency,
-                lastDependency = dependency;
-
-            while (
-                (currDependency = offsets.getFirstDependency(currDependency)) &&
-                currDependency.loc.start.line > startLineOfNode
-            ) {
-                lastDependency = currDependency;
-            }
-
-            const firstTokenOfDependentLine = tokenInfo.getFirstTokenOfLine(lastDependency);
-
-            if (lastDependency !== firstTokenOfDependentLine) {
-                offsets.matchIndentOf(firstTokenOfDependentLine, lastDependency);
-            }
-        }
-
-        /**
         * Ignore first token of each line within an unknown node if its
         * offset does not depend on another token's offset. If the first token
-        * of a line's offset depends on the offset of another token, make the
-        * last dependent token's offset depend on the first token of its line.
+        * of a line's offset depends on the offset of another token, that lies
+        * outside of the unknown node, then remove all its token dependecies.
         * @param {ASTNode} node Unknown Node
         * @returns {void}
         */
@@ -942,10 +922,16 @@ module.exports = {
 
                 const dependency = offsets.getFirstDependency(firstTokenOfLine);
 
-                if (dependency && dependency.loc.start.line >= startLine) {
-                    ignoreUnknownNodeLineWithDependency(dependency, startLine);
-                } else {
+                if (!dependency || dependency.loc.start.line < startLine) {
                     offsets.ignoreToken(firstTokenOfLine);
+                    if (dependency && dependency.loc.start.line < startLine) {
+                        const firstTokenOfNextLine = tokenInfo.firstTokensByLineNumber.get(lineNumber + 1);
+                        const tokensOfLine = sourceCode.getTokensBetween(firstTokenOfLine, firstTokenOfNextLine);
+
+                        tokensOfLine.forEach(token => {
+                            offsets.matchIndentOf(null, token);
+                        });
+                    }
                 }
             }
         }

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -19,86 +19,87 @@ const astUtils = require("../ast-utils");
 // Rule Definition
 //------------------------------------------------------------------------------
 
-const KNOWN_NODES = {
-    AssignmentExpression: "AssignmentExpression",
-    AssignmentPattern: "AssignmentPattern",
-    ArrayExpression: "ArrayExpression",
-    ArrayPattern: "ArrayPattern",
-    ArrowFunctionExpression: "ArrowFunctionExpression",
-    BlockStatement: "BlockStatement",
-    BinaryExpression: "BinaryExpression",
-    BreakStatement: "BreakStatement",
-    CallExpression: "CallExpression",
-    CatchClause: "CatchClause",
-    ClassBody: "ClassBody",
-    ClassDeclaration: "ClassDeclaration",
-    ClassExpression: "ClassExpression",
-    ConditionalExpression: "ConditionalExpression",
-    ContinueStatement: "ContinueStatement",
-    DoWhileStatement: "DoWhileStatement",
-    DebuggerStatement: "DebuggerStatement",
-    EmptyStatement: "EmptyStatement",
-    ExperimentalRestProperty: "ExperimentalRestProperty",
-    ExperimentalSpreadProperty: "ExperimentalSpreadProperty",
-    ExpressionStatement: "ExpressionStatement",
-    ForStatement: "ForStatement",
-    ForInStatement: "ForInStatement",
-    ForOfStatement: "ForOfStatement",
-    FunctionDeclaration: "FunctionDeclaration",
-    FunctionExpression: "FunctionExpression",
-    Identifier: "Identifier",
-    IfStatement: "IfStatement",
-    Literal: "Literal",
-    LabeledStatement: "LabeledStatement",
-    LogicalExpression: "LogicalExpression",
-    MemberExpression: "MemberExpression",
-    MetaProperty: "MetaProperty",
-    MethodDefinition: "MethodDefinition",
-    NewExpression: "NewExpression",
-    ObjectExpression: "ObjectExpression",
-    ObjectPattern: "ObjectPattern",
-    Program: "Program",
-    Property: "Property",
-    RestElement: "RestElement",
-    ReturnStatement: "ReturnStatement",
-    SequenceExpression: "SequenceExpression",
-    SpreadElement: "SpreadElement",
-    Super: "Super",
-    SwitchCase: "SwitchCase",
-    SwitchStatement: "SwitchStatement",
-    TaggedTemplateExpression: "TaggedTemplateExpression",
-    TemplateElement: "TemplateElement",
-    TemplateLiteral: "TemplateLiteral",
-    ThisExpression: "ThisExpression",
-    ThrowStatement: "ThrowStatement",
-    TryStatement: "TryStatement",
-    UnaryExpression: "UnaryExpression",
-    UpdateExpression: "UpdateExpression",
-    VariableDeclaration: "VariableDeclaration",
-    VariableDeclarator: "VariableDeclarator",
-    WhileStatement: "WhileStatement",
-    WithStatement: "WithStatement",
-    YieldExpression: "YieldExpression",
-    JSXIdentifier: "JSXIdentifier",
-    JSXNamespacedName: "JSXNamespacedName",
-    JSXMemberExpression: "JSXMemberExpression",
-    JSXEmptyExpression: "JSXEmptyExpression",
-    JSXExpressionContainer: "JSXExpressionContainer",
-    JSXElement: "JSXElement",
-    JSXClosingElement: "JSXClosingElement",
-    JSXOpeningElement: "JSXOpeningElement",
-    JSXAttribute: "JSXAttribute",
-    JSXSpreadAttribute: "JSXSpreadAttribute",
-    JSXText: "JSXText",
-    ExportDefaultDeclaration: "ExportDefaultDeclaration",
-    ExportNamedDeclaration: "ExportNamedDeclaration",
-    ExportAllDeclaration: "ExportAllDeclaration",
-    ExportSpecifier: "ExportSpecifier",
-    ImportDeclaration: "ImportDeclaration",
-    ImportSpecifier: "ImportSpecifier",
-    ImportDefaultSpecifier: "ImportDefaultSpecifier",
-    ImportNamespaceSpecifier: "ImportNamespaceSpecifier"
-};
+const KNOWN_NODES = new Set([
+    "AssignmentExpression",
+    "AssignmentPattern",
+    "ArrayExpression",
+    "ArrayPattern",
+    "ArrowFunctionExpression",
+    "AwaitExpression",
+    "BlockStatement",
+    "BinaryExpression",
+    "BreakStatement",
+    "CallExpression",
+    "CatchClause",
+    "ClassBody",
+    "ClassDeclaration",
+    "ClassExpression",
+    "ConditionalExpression",
+    "ContinueStatement",
+    "DoWhileStatement",
+    "DebuggerStatement",
+    "EmptyStatement",
+    "ExperimentalRestProperty",
+    "ExperimentalSpreadProperty",
+    "ExpressionStatement",
+    "ForStatement",
+    "ForInStatement",
+    "ForOfStatement",
+    "FunctionDeclaration",
+    "FunctionExpression",
+    "Identifier",
+    "IfStatement",
+    "Literal",
+    "LabeledStatement",
+    "LogicalExpression",
+    "MemberExpression",
+    "MetaProperty",
+    "MethodDefinition",
+    "NewExpression",
+    "ObjectExpression",
+    "ObjectPattern",
+    "Program",
+    "Property",
+    "RestElement",
+    "ReturnStatement",
+    "SequenceExpression",
+    "SpreadElement",
+    "Super",
+    "SwitchCase",
+    "SwitchStatement",
+    "TaggedTemplateExpression",
+    "TemplateElement",
+    "TemplateLiteral",
+    "ThisExpression",
+    "ThrowStatement",
+    "TryStatement",
+    "UnaryExpression",
+    "UpdateExpression",
+    "VariableDeclaration",
+    "VariableDeclarator",
+    "WhileStatement",
+    "WithStatement",
+    "YieldExpression",
+    "JSXIdentifier",
+    "JSXNamespacedName",
+    "JSXMemberExpression",
+    "JSXEmptyExpression",
+    "JSXExpressionContainer",
+    "JSXElement",
+    "JSXClosingElement",
+    "JSXOpeningElement",
+    "JSXAttribute",
+    "JSXSpreadAttribute",
+    "JSXText",
+    "ExportDefaultDeclaration",
+    "ExportNamedDeclaration",
+    "ExportAllDeclaration",
+    "ExportSpecifier",
+    "ImportDeclaration",
+    "ImportSpecifier",
+    "ImportDefaultSpecifier",
+    "ImportNamespaceSpecifier"
+]);
 
 /*
  * General rule strategy:
@@ -893,7 +894,7 @@ module.exports = {
         * @returns {void}
         */
         function setCurrentUnknownNode(node) {
-            if (node.type in KNOWN_NODES) {
+            if (KNOWN_NODES.has(node.type)) {
                 return;
             }
 
@@ -903,12 +904,12 @@ module.exports = {
         }
 
         /**
-        * On exit of unknown node append node to like of outer most nodes
+        * On exit of unknown node append it to list of outermost unknown nodes
         * @param {ASTNode} node Node
         * @returns {void}
         */
         function saveOutermostUnknownNode(node) {
-            if (node.type in KNOWN_NODES) {
+            if (KNOWN_NODES.has(node.type)) {
                 return;
             }
 
@@ -919,9 +920,10 @@ module.exports = {
         }
 
         /**
-        * Ignore each line of an unknown node if its offset has no dependencies.
-        * If the first token of the line's offset has a dependency make the last
-        * dependencies offset depend on the first token of its line.
+        * Ignore first token of each line of within an unknown node if its
+        * offset does not depend on another token's offset. If the first token
+        * of a line's offset depends on the offset of another token, make the
+        * last dependent offset depend on the first token of its line.
         * @param {ASTNode} node Node
         * @returns {void}
         */

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -1179,7 +1179,9 @@ module.exports = {
             },
 
             VariableDeclaration(node) {
-                offsets.setDesiredOffsets(getTokensAndComments(node), sourceCode.getFirstToken(node), options.VariableDeclarator[node.kind]);
+                const variableIndent = options.VariableDeclarator.hasOwnProperty(node.kind) ? options.VariableDeclarator[node.kind] : DEFAULT_VARIABLE_INDENT;
+
+                offsets.setDesiredOffsets(getTokensAndComments(node), sourceCode.getFirstToken(node), variableIndent);
                 const lastToken = sourceCode.getLastToken(node);
 
                 if (astUtils.isSemicolonToken(lastToken)) {

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -14,10 +14,92 @@
 
 const lodash = require("lodash");
 const astUtils = require("../ast-utils");
+const Traverser = require("../util/traverser");
 
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
+
+const KNOWN_NODES = {
+    AssignmentExpression: "AssignmentExpression",
+    AssignmentPattern: "AssignmentPattern",
+    ArrayExpression: "ArrayExpression",
+    ArrayPattern: "ArrayPattern",
+    ArrowFunctionExpression: "ArrowFunctionExpression",
+    BlockStatement: "BlockStatement",
+    BinaryExpression: "BinaryExpression",
+    BreakStatement: "BreakStatement",
+    CallExpression: "CallExpression",
+    CatchClause: "CatchClause",
+    ClassBody: "ClassBody",
+    ClassDeclaration: "ClassDeclaration",
+    ClassExpression: "ClassExpression",
+    ConditionalExpression: "ConditionalExpression",
+    ContinueStatement: "ContinueStatement",
+    DoWhileStatement: "DoWhileStatement",
+    DebuggerStatement: "DebuggerStatement",
+    EmptyStatement: "EmptyStatement",
+    ExperimentalRestProperty: "ExperimentalRestProperty",
+    ExperimentalSpreadProperty: "ExperimentalSpreadProperty",
+    ExpressionStatement: "ExpressionStatement",
+    ForStatement: "ForStatement",
+    ForInStatement: "ForInStatement",
+    ForOfStatement: "ForOfStatement",
+    FunctionDeclaration: "FunctionDeclaration",
+    FunctionExpression: "FunctionExpression",
+    Identifier: "Identifier",
+    IfStatement: "IfStatement",
+    Literal: "Literal",
+    LabeledStatement: "LabeledStatement",
+    LogicalExpression: "LogicalExpression",
+    MemberExpression: "MemberExpression",
+    MetaProperty: "MetaProperty",
+    MethodDefinition: "MethodDefinition",
+    NewExpression: "NewExpression",
+    ObjectExpression: "ObjectExpression",
+    ObjectPattern: "ObjectPattern",
+    Program: "Program",
+    Property: "Property",
+    RestElement: "RestElement",
+    ReturnStatement: "ReturnStatement",
+    SequenceExpression: "SequenceExpression",
+    SpreadElement: "SpreadElement",
+    Super: "Super",
+    SwitchCase: "SwitchCase",
+    SwitchStatement: "SwitchStatement",
+    TaggedTemplateExpression: "TaggedTemplateExpression",
+    TemplateElement: "TemplateElement",
+    TemplateLiteral: "TemplateLiteral",
+    ThisExpression: "ThisExpression",
+    ThrowStatement: "ThrowStatement",
+    TryStatement: "TryStatement",
+    UnaryExpression: "UnaryExpression",
+    UpdateExpression: "UpdateExpression",
+    VariableDeclaration: "VariableDeclaration",
+    VariableDeclarator: "VariableDeclarator",
+    WhileStatement: "WhileStatement",
+    WithStatement: "WithStatement",
+    YieldExpression: "YieldExpression",
+    JSXIdentifier: "JSXIdentifier",
+    JSXNamespacedName: "JSXNamespacedName",
+    JSXMemberExpression: "JSXMemberExpression",
+    JSXEmptyExpression: "JSXEmptyExpression",
+    JSXExpressionContainer: "JSXExpressionContainer",
+    JSXElement: "JSXElement",
+    JSXClosingElement: "JSXClosingElement",
+    JSXOpeningElement: "JSXOpeningElement",
+    JSXAttribute: "JSXAttribute",
+    JSXSpreadAttribute: "JSXSpreadAttribute",
+    JSXText: "JSXText",
+    ExportDefaultDeclaration: "ExportDefaultDeclaration",
+    ExportNamedDeclaration: "ExportNamedDeclaration",
+    ExportAllDeclaration: "ExportAllDeclaration",
+    ExportSpecifier: "ExportSpecifier",
+    ImportDeclaration: "ImportDeclaration",
+    ImportSpecifier: "ImportSpecifier",
+    ImportDefaultSpecifier: "ImportDefaultSpecifier",
+    ImportNamespaceSpecifier: "ImportNamespaceSpecifier"
+};
 
 /*
  * General rule strategy:
@@ -803,6 +885,59 @@ module.exports = {
             });
         }
 
+        /**
+        * Traverse AST and find all unkown nodes. Ignore first token of line
+        * if token is within node. If token offset has dependecy update the last
+        * dependecy to depend on first token of line.
+        * @param {AST} ast AST
+        * @returns {void}
+        */
+        function ignoreUnkownNodes(ast) {
+            const traverser = new Traverser();
+
+            traverser.traverse(ast, {
+                leave(node) {
+                    if (node.type in KNOWN_NODES) {
+                        return;
+                    }
+                    const startLine = node.loc.start.line;
+                    const endLine = node.loc.end.line;
+
+                    for (let x = startLine; x <= endLine; x++) {
+                        const firstTokenOfLine = tokenInfo.firstTokensByLineNumber.get(x);
+
+                        if (!firstTokenOfLine) {
+                            continue;
+                        }
+
+                        const tokenInNodeRange = (node.range[0] <= firstTokenOfLine.range[0]) &&
+                            (node.range[1] >= firstTokenOfLine.range[1]);
+
+                        if (!tokenInNodeRange) {
+                            continue;
+                        }
+
+                        const dependency = offsets.getFirstDependency(firstTokenOfLine);
+
+                        if (!dependency) {
+                            offsets.ignoreToken(firstTokenOfLine);
+                        } else {
+                            let currDependency = dependency,
+                                lastDependency = dependency;
+
+                            while ((currDependency = offsets.getFirstDependency(currDependency))) {
+                                lastDependency = currDependency;
+                            }
+
+                            const firstTokenOfDependentLine = tokenInfo.getFirstTokenOfLine(lastDependency);
+
+                            offsets.matchIndentOf(firstTokenOfDependentLine, lastDependency);
+                        }
+                    }
+                }
+            });
+        }
+
         return {
             ArrayExpression: addArrayOrObjectIndent,
             ArrayPattern: addArrayOrObjectIndent,
@@ -1081,6 +1216,7 @@ module.exports = {
 
             "Program:exit"() {
                 addParensIndent(sourceCode.ast.tokens);
+                ignoreUnkownNodes(sourceCode.ast);
 
                 /*
                  * Create a Map from (tokenOrComment) => (precedingToken).

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -299,8 +299,7 @@ class OffsetStorage {
             } else {
                 const offsetInfo = this.desiredOffsets[token.range[0]];
 
-                this.desiredIndentCache[token.range[0]] = offsetInfo.offset +
-                    (offsetInfo.from ? this.getDesiredIndent(offsetInfo.from) : 0);
+                this.desiredIndentCache[token.range[0]] = offsetInfo.offset + (offsetInfo.from ? this.getDesiredIndent(offsetInfo.from) : 0);
             }
         }
         return this.desiredIndentCache[token.range[0]];

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -14,7 +14,6 @@
 
 const lodash = require("lodash");
 const astUtils = require("../ast-utils");
-const Traverser = require("../util/traverser");
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -521,6 +520,9 @@ module.exports = {
         const offsets = new OffsetStorage(tokenInfo, indentType, indentSize);
         const parameterParens = new WeakSet();
 
+        let currentUnknownNode = null;
+        const unknownNodes = [];
+
         /**
          * Creates an error message for a line, given the expected/actual indentation.
          * @param {int} expectedAmount The expected amount of indentation characters for this line
@@ -886,56 +888,92 @@ module.exports = {
         }
 
         /**
-        * Traverse AST and find all unkown nodes. Ignore first token of line
-        * if token is within node. If token offset has dependecy update the last
-        * dependecy to depend on first token of line.
-        * @param {AST} ast AST
+        * Set the current unknown node if not set
+        * @param {ASTNode} node Node
         * @returns {void}
         */
-        function ignoreUnkownNodes(ast) {
-            const traverser = new Traverser();
+        function setCurrentUnknownNode(node) {
+            if (node.type in KNOWN_NODES) {
+                return;
+            }
 
-            traverser.traverse(ast, {
-                leave(node) {
-                    if (node.type in KNOWN_NODES) {
-                        return;
-                    }
-                    const startLine = node.loc.start.line;
-                    const endLine = node.loc.end.line;
+            if (currentUnknownNode === null) {
+                currentUnknownNode = node;
+            }
+        }
 
-                    for (let x = startLine; x <= endLine; x++) {
-                        const firstTokenOfLine = tokenInfo.firstTokensByLineNumber.get(x);
+        /**
+        * On exit of unknown node append node to like of outer most nodes
+        * @param {ASTNode} node Node
+        * @returns {void}
+        */
+        function saveOutermostUnknownNode(node) {
+            if (node.type in KNOWN_NODES) {
+                return;
+            }
 
-                        if (!firstTokenOfLine) {
-                            continue;
-                        }
+            if (currentUnknownNode === node) {
+                unknownNodes.push(node);
+                currentUnknownNode = null;
+            }
+        }
 
-                        const tokenInNodeRange = (node.range[0] <= firstTokenOfLine.range[0]) &&
-                            (node.range[1] >= firstTokenOfLine.range[1]);
+        /**
+        * Ignore each line of an unknown node if its offset has no dependencies.
+        * If the first token of the line's offset has a dependency make the last
+        * dependencies offset depend on the first token of its line.
+        * @param {ASTNode} node Node
+        * @returns {void}
+        */
+        function ignoreUnknownNode(node) {
+            const startLine = node.loc.start.line;
+            const endLine = node.loc.end.line;
 
-                        if (!tokenInNodeRange) {
-                            continue;
-                        }
+            for (let x = startLine; x <= endLine; x++) {
+                const firstTokenOfLine = tokenInfo.firstTokensByLineNumber.get(x);
 
-                        const dependency = offsets.getFirstDependency(firstTokenOfLine);
-
-                        if (!dependency) {
-                            offsets.ignoreToken(firstTokenOfLine);
-                        } else {
-                            let currDependency = dependency,
-                                lastDependency = dependency;
-
-                            while ((currDependency = offsets.getFirstDependency(currDependency))) {
-                                lastDependency = currDependency;
-                            }
-
-                            const firstTokenOfDependentLine = tokenInfo.getFirstTokenOfLine(lastDependency);
-
-                            offsets.matchIndentOf(firstTokenOfDependentLine, lastDependency);
-                        }
-                    }
+                if (!firstTokenOfLine) {
+                    continue;
                 }
-            });
+
+                const tokenInNodeRange = (node.range[0] <= firstTokenOfLine.range[0]) &&
+                    (node.range[1] >= firstTokenOfLine.range[1]);
+
+                if (!tokenInNodeRange) {
+                    continue;
+                }
+
+
+                const dependency = offsets.getFirstDependency(firstTokenOfLine);
+
+                if (!dependency) {
+                    offsets.ignoreToken(firstTokenOfLine);
+                } else {
+                    let currDependency = dependency,
+                        lastDependency = dependency;
+
+                    while ((currDependency = offsets.getFirstDependency(currDependency))) {
+                        lastDependency = currDependency;
+                    }
+
+                    const firstTokenOfDependentLine = tokenInfo.getFirstTokenOfLine(lastDependency);
+
+                    offsets.matchIndentOf(firstTokenOfDependentLine, lastDependency);
+                }
+            }
+        }
+
+        /**
+        * Ignore all lines of each outermost unknown node
+        * @returns {void}
+        */
+        function ignoreUnknownNodes() {
+            for (let x = 0; x < unknownNodes.length; x++) {
+                const unknownNode = unknownNodes[x];
+
+                ignoreUnknownNode(unknownNode);
+            }
+
         }
 
         return {
@@ -1214,9 +1252,13 @@ module.exports = {
 
             WhileStatement: node => addBlocklessNodeIndent(node.body),
 
+            "*": setCurrentUnknownNode,
+
+            "*:exit": saveOutermostUnknownNode,
+
             "Program:exit"() {
                 addParensIndent(sourceCode.ast.tokens);
-                ignoreUnkownNodes(sourceCode.ast);
+                ignoreUnknownNodes();
 
                 /*
                  * Create a Map from (tokenOrComment) => (precedingToken).

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -298,17 +298,9 @@ class OffsetStorage {
                         (firstToken.loc.start.column - this.tokenInfo.getFirstTokenOfLine(firstToken).loc.start.column) / this.indentSize;
             } else {
                 const offsetInfo = this.desiredOffsets[token.range[0]];
-                let dependentToken = null;
-                let firstTokenOfLine = null;
-
-                if (offsetInfo.from) {
-                    dependentToken = offsetInfo.from;
-                } else if ((firstTokenOfLine = this.tokenInfo.getFirstTokenOfLine(token)) !== token) {
-                    dependentToken = firstTokenOfLine;
-                }
 
                 this.desiredIndentCache[token.range[0]] = offsetInfo.offset +
-                    (dependentToken ? this.getDesiredIndent(dependentToken) : 0);
+                    (offsetInfo.from ? this.getDesiredIndent(offsetInfo.from) : 0);
             }
         }
         return this.desiredIndentCache[token.range[0]];

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -895,47 +895,25 @@ module.exports = {
         }
 
         /**
-        * Ignore first token of each line within an unknown node if its
-        * offset does not depend on another token's offset. If the first token
-        * of a line's offset depends on the offset of another token, that lies
-        * outside of the unknown node, then remove all its token dependecies.
+        * Ignore all tokens within an unknown node whose offset do not depend
+        * on another token's offset within the unknown node
         * @param {ASTNode} node Unknown Node
         * @returns {void}
         */
         function ignoreUnknownNode(node) {
-            const startLine = node.loc.start.line;
-            const endLine = node.loc.end.line;
+            const unknownNodeTokens = new Set(getTokensAndComments(node));
 
-            for (let lineNumber = startLine; lineNumber <= endLine; lineNumber++) {
-                const firstTokenOfLine = tokenInfo.firstTokensByLineNumber.get(lineNumber);
+            unknownNodeTokens.forEach(token => {
+                if (!unknownNodeTokens.has(offsets.getFirstDependency(token))) {
+                    const firstTokenOfLine = tokenInfo.getFirstTokenOfLine(token);
 
-                if (!firstTokenOfLine) {
-                    continue;
-                }
-
-                const tokenInNodeRange = (node.range[0] <= firstTokenOfLine.range[0]) &&
-                    (node.range[1] >= firstTokenOfLine.range[1]);
-
-                if (!tokenInNodeRange) {
-                    continue;
-                }
-
-                const dependency = offsets.getFirstDependency(firstTokenOfLine);
-
-                if (!dependency || dependency.loc.start.line < startLine) {
-                    offsets.ignoreToken(firstTokenOfLine);
-                    if (dependency && dependency.loc.start.line < startLine) {
-                        const tokensOfLine = sourceCode.getTokensAfter(
-                            firstTokenOfLine,
-                            token => token.loc.start.line === lineNumber
-                        );
-
-                        tokensOfLine.forEach(token => {
-                            offsets.matchIndentOf(null, token);
-                        });
+                    if (token === firstTokenOfLine) {
+                        offsets.ignoreToken(token);
+                    } else {
+                        offsets.matchIndentOf(firstTokenOfLine, token);
                     }
                 }
-            }
+            });
         }
 
         /**

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -521,9 +521,6 @@ module.exports = {
         const offsets = new OffsetStorage(tokenInfo, indentType, indentSize);
         const parameterParens = new WeakSet();
 
-        let currentUnknownNode = null;
-        const unknownNodes = [];
-
         /**
          * Creates an error message for a line, given the expected/actual indentation.
          * @param {int} expectedAmount The expected amount of indentation characters for this line
@@ -889,38 +886,7 @@ module.exports = {
         }
 
         /**
-        * Set the current unknown node if not set
-        * @param {ASTNode} node Node
-        * @returns {void}
-        */
-        function setCurrentUnknownNode(node) {
-            if (KNOWN_NODES.has(node.type)) {
-                return;
-            }
-
-            if (currentUnknownNode === null) {
-                currentUnknownNode = node;
-            }
-        }
-
-        /**
-        * On exit of unknown node append it to list of outermost unknown nodes
-        * @param {ASTNode} node Node
-        * @returns {void}
-        */
-        function saveOutermostUnknownNode(node) {
-            if (KNOWN_NODES.has(node.type)) {
-                return;
-            }
-
-            if (currentUnknownNode === node) {
-                unknownNodes.push(node);
-                currentUnknownNode = null;
-            }
-        }
-
-        /**
-        * Ignore first token of each line of within an unknown node if its
+        * Ignore first token of each line within an unknown node if its
         * offset does not depend on another token's offset. If the first token
         * of a line's offset depends on the offset of another token, make the
         * last dependent offset depend on the first token of its line.
@@ -931,8 +897,8 @@ module.exports = {
             const startLine = node.loc.start.line;
             const endLine = node.loc.end.line;
 
-            for (let x = startLine; x <= endLine; x++) {
-                const firstTokenOfLine = tokenInfo.firstTokensByLineNumber.get(x);
+            for (let lineNumber = startLine; lineNumber <= endLine; lineNumber++) {
+                const firstTokenOfLine = tokenInfo.firstTokensByLineNumber.get(lineNumber);
 
                 if (!firstTokenOfLine) {
                     continue;
@@ -945,37 +911,43 @@ module.exports = {
                     continue;
                 }
 
-
                 const dependency = offsets.getFirstDependency(firstTokenOfLine);
 
-                if (!dependency) {
-                    offsets.ignoreToken(firstTokenOfLine);
-                } else {
+                if (dependency) {
                     let currDependency = dependency,
-                        lastDependency = dependency;
+                        lastDependency = null;
 
-                    while ((currDependency = offsets.getFirstDependency(currDependency))) {
+                    while (
+                        (currDependency = offsets.getFirstDependency(currDependency)) &&
+                        currDependency.loc.start.line > startLine
+                    ) {
                         lastDependency = currDependency;
                     }
 
-                    const firstTokenOfDependentLine = tokenInfo.getFirstTokenOfLine(lastDependency);
+                    if (lastDependency) {
+                        const firstTokenOfDependentLine = tokenInfo.getFirstTokenOfLine(lastDependency);
 
-                    offsets.matchIndentOf(firstTokenOfDependentLine, lastDependency);
+                        offsets.matchIndentOf(firstTokenOfDependentLine, lastDependency);
+                    } else if (dependency.loc.start.line < startLine) {
+                        offsets.ignoreToken(firstTokenOfLine);
+                    }
+                } else {
+                    offsets.ignoreToken(firstTokenOfLine);
                 }
             }
         }
 
         /**
-        * Ignore all lines of each outermost unknown node
+        * Ignore node if it is unknown
+        * @param {ASTNode} node Node
         * @returns {void}
         */
-        function ignoreUnknownNodes() {
-            for (let x = 0; x < unknownNodes.length; x++) {
-                const unknownNode = unknownNodes[x];
-
-                ignoreUnknownNode(unknownNode);
+        function checkForUnknownNode(node) {
+            if (KNOWN_NODES.has(node.type)) {
+                return;
             }
 
+            ignoreUnknownNode(node);
         }
 
         return {
@@ -1254,13 +1226,10 @@ module.exports = {
 
             WhileStatement: node => addBlocklessNodeIndent(node.body),
 
-            "*": setCurrentUnknownNode,
-
-            "*:exit": saveOutermostUnknownNode,
+            "*:exit": checkForUnknownNode,
 
             "Program:exit"() {
                 addParensIndent(sourceCode.ast.tokens);
-                ignoreUnknownNodes();
 
                 /*
                  * Create a Map from (tokenOrComment) => (precedingToken).

--- a/tests/fixtures/parsers/unknown-nodes/abstract-class-invalid.js
+++ b/tests/fixtures/parsers/unknown-nodes/abstract-class-invalid.js
@@ -1,0 +1,1208 @@
+"use strict";
+
+/**
+ * Source code:
+ *  abstract class Foo {
+ *      public bar() {
+ *          let aaa = 4,
+ *          boo;
+ *
+ *          if (true) {
+ *          boo = 3;
+ *          }
+ *
+ *      boo = 3 + 2;
+ *      }
+ *  }
+ */
+
+
+exports.parse = () => ({
+    "type": "Program",
+    "range": [
+        0,
+        147
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 12,
+            "column": 1
+        }
+    },
+    "body": [
+        {
+            "type": "TSAbstractClassDeclaration",
+            "range": [
+                0,
+                147
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 12,
+                    "column": 1
+                }
+            },
+            "id": {
+                "type": "Identifier",
+                "range": [
+                    15,
+                    18
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 15
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 18
+                    }
+                },
+                "name": "Foo"
+            },
+            "body": {
+                "type": "ClassBody",
+                "body": [
+                    {
+                        "type": "MethodDefinition",
+                        "range": [
+                            25,
+                            145
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 2,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 11,
+                                "column": 5
+                            }
+                        },
+                        "key": {
+                            "type": "Identifier",
+                            "range": [
+                                32,
+                                35
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 2,
+                                    "column": 11
+                                },
+                                "end": {
+                                    "line": 2,
+                                    "column": 14
+                                }
+                            },
+                            "name": "bar"
+                        },
+                        "value": {
+                            "type": "FunctionExpression",
+                            "id": null,
+                            "generator": false,
+                            "expression": false,
+                            "async": false,
+                            "body": {
+                                "type": "BlockStatement",
+                                "range": [
+                                    38,
+                                    145
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 2,
+                                        "column": 17
+                                    },
+                                    "end": {
+                                        "line": 11,
+                                        "column": 5
+                                    }
+                                },
+                                "body": [
+                                    {
+                                        "type": "VariableDeclaration",
+                                        "range": [
+                                            48,
+                                            73
+                                        ],
+                                        "loc": {
+                                            "start": {
+                                                "line": 3,
+                                                "column": 8
+                                            },
+                                            "end": {
+                                                "line": 4,
+                                                "column": 12
+                                            }
+                                        },
+                                        "declarations": [
+                                            {
+                                                "type": "VariableDeclarator",
+                                                "range": [
+                                                    52,
+                                                    59
+                                                ],
+                                                "loc": {
+                                                    "start": {
+                                                        "line": 3,
+                                                        "column": 12
+                                                    },
+                                                    "end": {
+                                                        "line": 3,
+                                                        "column": 19
+                                                    }
+                                                },
+                                                "id": {
+                                                    "type": "Identifier",
+                                                    "range": [
+                                                        52,
+                                                        55
+                                                    ],
+                                                    "loc": {
+                                                        "start": {
+                                                            "line": 3,
+                                                            "column": 12
+                                                        },
+                                                        "end": {
+                                                            "line": 3,
+                                                            "column": 15
+                                                        }
+                                                    },
+                                                    "name": "aaa"
+                                                },
+                                                "init": {
+                                                    "type": "Literal",
+                                                    "range": [
+                                                        58,
+                                                        59
+                                                    ],
+                                                    "loc": {
+                                                        "start": {
+                                                            "line": 3,
+                                                            "column": 18
+                                                        },
+                                                        "end": {
+                                                            "line": 3,
+                                                            "column": 19
+                                                        }
+                                                    },
+                                                    "value": 4,
+                                                    "raw": "4"
+                                                }
+                                            },
+                                            {
+                                                "type": "VariableDeclarator",
+                                                "range": [
+                                                    69,
+                                                    72
+                                                ],
+                                                "loc": {
+                                                    "start": {
+                                                        "line": 4,
+                                                        "column": 8
+                                                    },
+                                                    "end": {
+                                                        "line": 4,
+                                                        "column": 11
+                                                    }
+                                                },
+                                                "id": {
+                                                    "type": "Identifier",
+                                                    "range": [
+                                                        69,
+                                                        72
+                                                    ],
+                                                    "loc": {
+                                                        "start": {
+                                                            "line": 4,
+                                                            "column": 8
+                                                        },
+                                                        "end": {
+                                                            "line": 4,
+                                                            "column": 11
+                                                        }
+                                                    },
+                                                    "name": "boo"
+                                                },
+                                                "init": null
+                                            }
+                                        ],
+                                        "kind": "let"
+                                    },
+                                    {
+                                        "type": "IfStatement",
+                                        "range": [
+                                            83,
+                                            121
+                                        ],
+                                        "loc": {
+                                            "start": {
+                                                "line": 6,
+                                                "column": 8
+                                            },
+                                            "end": {
+                                                "line": 8,
+                                                "column": 9
+                                            }
+                                        },
+                                        "test": {
+                                            "type": "Literal",
+                                            "range": [
+                                                87,
+                                                91
+                                            ],
+                                            "loc": {
+                                                "start": {
+                                                    "line": 6,
+                                                    "column": 12
+                                                },
+                                                "end": {
+                                                    "line": 6,
+                                                    "column": 16
+                                                }
+                                            },
+                                            "value": true,
+                                            "raw": "true"
+                                        },
+                                        "consequent": {
+                                            "type": "BlockStatement",
+                                            "range": [
+                                                93,
+                                                121
+                                            ],
+                                            "loc": {
+                                                "start": {
+                                                    "line": 6,
+                                                    "column": 18
+                                                },
+                                                "end": {
+                                                    "line": 8,
+                                                    "column": 9
+                                                }
+                                            },
+                                            "body": [
+                                                {
+                                                    "type": "ExpressionStatement",
+                                                    "range": [
+                                                        103,
+                                                        111
+                                                    ],
+                                                    "loc": {
+                                                        "start": {
+                                                            "line": 7,
+                                                            "column": 8
+                                                        },
+                                                        "end": {
+                                                            "line": 7,
+                                                            "column": 16
+                                                        }
+                                                    },
+                                                    "expression": {
+                                                        "type": "AssignmentExpression",
+                                                        "range": [
+                                                            103,
+                                                            110
+                                                        ],
+                                                        "loc": {
+                                                            "start": {
+                                                                "line": 7,
+                                                                "column": 8
+                                                            },
+                                                            "end": {
+                                                                "line": 7,
+                                                                "column": 15
+                                                            }
+                                                        },
+                                                        "operator": "=",
+                                                        "left": {
+                                                            "type": "Identifier",
+                                                            "range": [
+                                                                103,
+                                                                106
+                                                            ],
+                                                            "loc": {
+                                                                "start": {
+                                                                    "line": 7,
+                                                                    "column": 8
+                                                                },
+                                                                "end": {
+                                                                    "line": 7,
+                                                                    "column": 11
+                                                                }
+                                                            },
+                                                            "name": "boo"
+                                                        },
+                                                        "right": {
+                                                            "type": "Literal",
+                                                            "range": [
+                                                                109,
+                                                                110
+                                                            ],
+                                                            "loc": {
+                                                                "start": {
+                                                                    "line": 7,
+                                                                    "column": 14
+                                                                },
+                                                                "end": {
+                                                                    "line": 7,
+                                                                    "column": 15
+                                                                }
+                                                            },
+                                                            "value": 3,
+                                                            "raw": "3"
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "alternate": null
+                                    },
+                                    {
+                                        "type": "ExpressionStatement",
+                                        "range": [
+                                            127,
+                                            139
+                                        ],
+                                        "loc": {
+                                            "start": {
+                                                "line": 10,
+                                                "column": 4
+                                            },
+                                            "end": {
+                                                "line": 10,
+                                                "column": 16
+                                            }
+                                        },
+                                        "expression": {
+                                            "type": "AssignmentExpression",
+                                            "range": [
+                                                127,
+                                                138
+                                            ],
+                                            "loc": {
+                                                "start": {
+                                                    "line": 10,
+                                                    "column": 4
+                                                },
+                                                "end": {
+                                                    "line": 10,
+                                                    "column": 15
+                                                }
+                                            },
+                                            "operator": "=",
+                                            "left": {
+                                                "type": "Identifier",
+                                                "range": [
+                                                    127,
+                                                    130
+                                                ],
+                                                "loc": {
+                                                    "start": {
+                                                        "line": 10,
+                                                        "column": 4
+                                                    },
+                                                    "end": {
+                                                        "line": 10,
+                                                        "column": 7
+                                                    }
+                                                },
+                                                "name": "boo"
+                                            },
+                                            "right": {
+                                                "type": "BinaryExpression",
+                                                "range": [
+                                                    133,
+                                                    138
+                                                ],
+                                                "loc": {
+                                                    "start": {
+                                                        "line": 10,
+                                                        "column": 10
+                                                    },
+                                                    "end": {
+                                                        "line": 10,
+                                                        "column": 15
+                                                    }
+                                                },
+                                                "operator": "+",
+                                                "left": {
+                                                    "type": "Literal",
+                                                    "range": [
+                                                        133,
+                                                        134
+                                                    ],
+                                                    "loc": {
+                                                        "start": {
+                                                            "line": 10,
+                                                            "column": 10
+                                                        },
+                                                        "end": {
+                                                            "line": 10,
+                                                            "column": 11
+                                                        }
+                                                    },
+                                                    "value": 3,
+                                                    "raw": "3"
+                                                },
+                                                "right": {
+                                                    "type": "Literal",
+                                                    "range": [
+                                                        137,
+                                                        138
+                                                    ],
+                                                    "loc": {
+                                                        "start": {
+                                                            "line": 10,
+                                                            "column": 14
+                                                        },
+                                                        "end": {
+                                                            "line": 10,
+                                                            "column": 15
+                                                        }
+                                                    },
+                                                    "value": 2,
+                                                    "raw": "2"
+                                                }
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            "range": [
+                                35,
+                                145
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 2,
+                                    "column": 14
+                                },
+                                "end": {
+                                    "line": 11,
+                                    "column": 5
+                                }
+                            },
+                            "params": []
+                        },
+                        "computed": false,
+                        "static": false,
+                        "kind": "method",
+                        "accessibility": "public",
+                        "decorators": []
+                    }
+                ],
+                "range": [
+                    19,
+                    147
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 19
+                    },
+                    "end": {
+                        "line": 12,
+                        "column": 1
+                    }
+                }
+            },
+            "superClass": null,
+            "implements": [],
+            "decorators": []
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Identifier",
+            "value": "abstract",
+            "start": 0,
+            "end": 8,
+            "range": [
+                0,
+                8
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 8
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "class",
+            "start": 9,
+            "end": 14,
+            "range": [
+                9,
+                14
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 9
+                },
+                "end": {
+                    "line": 1,
+                    "column": 14
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "Foo",
+            "start": 15,
+            "end": 18,
+            "range": [
+                15,
+                18
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 15
+                },
+                "end": {
+                    "line": 1,
+                    "column": 18
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 19,
+            "end": 20,
+            "range": [
+                19,
+                20
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 19
+                },
+                "end": {
+                    "line": 1,
+                    "column": 20
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "public",
+            "start": 25,
+            "end": 31,
+            "range": [
+                25,
+                31
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 4
+                },
+                "end": {
+                    "line": 2,
+                    "column": 10
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "bar",
+            "start": 32,
+            "end": 35,
+            "range": [
+                32,
+                35
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 11
+                },
+                "end": {
+                    "line": 2,
+                    "column": 14
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "start": 35,
+            "end": 36,
+            "range": [
+                35,
+                36
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 14
+                },
+                "end": {
+                    "line": 2,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "start": 36,
+            "end": 37,
+            "range": [
+                36,
+                37
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 15
+                },
+                "end": {
+                    "line": 2,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 38,
+            "end": 39,
+            "range": [
+                38,
+                39
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 17
+                },
+                "end": {
+                    "line": 2,
+                    "column": 18
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "let",
+            "start": 48,
+            "end": 51,
+            "range": [
+                48,
+                51
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 8
+                },
+                "end": {
+                    "line": 3,
+                    "column": 11
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "aaa",
+            "start": 52,
+            "end": 55,
+            "range": [
+                52,
+                55
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 12
+                },
+                "end": {
+                    "line": 3,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "start": 56,
+            "end": 57,
+            "range": [
+                56,
+                57
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 16
+                },
+                "end": {
+                    "line": 3,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "Numeric",
+            "value": "4",
+            "start": 58,
+            "end": 59,
+            "range": [
+                58,
+                59
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 18
+                },
+                "end": {
+                    "line": 3,
+                    "column": 19
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ",",
+            "start": 59,
+            "end": 60,
+            "range": [
+                59,
+                60
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 19
+                },
+                "end": {
+                    "line": 3,
+                    "column": 20
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "boo",
+            "start": 69,
+            "end": 72,
+            "range": [
+                69,
+                72
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 8
+                },
+                "end": {
+                    "line": 4,
+                    "column": 11
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "start": 72,
+            "end": 73,
+            "range": [
+                72,
+                73
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 11
+                },
+                "end": {
+                    "line": 4,
+                    "column": 12
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "if",
+            "start": 83,
+            "end": 85,
+            "range": [
+                83,
+                85
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 8
+                },
+                "end": {
+                    "line": 6,
+                    "column": 10
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "start": 86,
+            "end": 87,
+            "range": [
+                86,
+                87
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 11
+                },
+                "end": {
+                    "line": 6,
+                    "column": 12
+                }
+            }
+        },
+        {
+            "type": "Boolean",
+            "value": "true",
+            "start": 87,
+            "end": 91,
+            "range": [
+                87,
+                91
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 12
+                },
+                "end": {
+                    "line": 6,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "start": 91,
+            "end": 92,
+            "range": [
+                91,
+                92
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 16
+                },
+                "end": {
+                    "line": 6,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 93,
+            "end": 94,
+            "range": [
+                93,
+                94
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 18
+                },
+                "end": {
+                    "line": 6,
+                    "column": 19
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "boo",
+            "start": 103,
+            "end": 106,
+            "range": [
+                103,
+                106
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 8
+                },
+                "end": {
+                    "line": 7,
+                    "column": 11
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "start": 107,
+            "end": 108,
+            "range": [
+                107,
+                108
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 12
+                },
+                "end": {
+                    "line": 7,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Numeric",
+            "value": "3",
+            "start": 109,
+            "end": 110,
+            "range": [
+                109,
+                110
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 14
+                },
+                "end": {
+                    "line": 7,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "start": 110,
+            "end": 111,
+            "range": [
+                110,
+                111
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 15
+                },
+                "end": {
+                    "line": 7,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 120,
+            "end": 121,
+            "range": [
+                120,
+                121
+            ],
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 8
+                },
+                "end": {
+                    "line": 8,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "boo",
+            "start": 127,
+            "end": 130,
+            "range": [
+                127,
+                130
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 4
+                },
+                "end": {
+                    "line": 10,
+                    "column": 7
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "start": 131,
+            "end": 132,
+            "range": [
+                131,
+                132
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 8
+                },
+                "end": {
+                    "line": 10,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Numeric",
+            "value": "3",
+            "start": 133,
+            "end": 134,
+            "range": [
+                133,
+                134
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 10
+                },
+                "end": {
+                    "line": 10,
+                    "column": 11
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "+",
+            "start": 135,
+            "end": 136,
+            "range": [
+                135,
+                136
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 12
+                },
+                "end": {
+                    "line": 10,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Numeric",
+            "value": "2",
+            "start": 137,
+            "end": 138,
+            "range": [
+                137,
+                138
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 14
+                },
+                "end": {
+                    "line": 10,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "start": 138,
+            "end": 139,
+            "range": [
+                138,
+                139
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 15
+                },
+                "end": {
+                    "line": 10,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 144,
+            "end": 145,
+            "range": [
+                144,
+                145
+            ],
+            "loc": {
+                "start": {
+                    "line": 11,
+                    "column": 4
+                },
+                "end": {
+                    "line": 11,
+                    "column": 5
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 146,
+            "end": 147,
+            "range": [
+                146,
+                147
+            ],
+            "loc": {
+                "start": {
+                    "line": 12,
+                    "column": 0
+                },
+                "end": {
+                    "line": 12,
+                    "column": 1
+                }
+            }
+        }
+    ],
+    "comments": []
+});
+

--- a/tests/fixtures/parsers/unknown-nodes/abstract-class-valid.js
+++ b/tests/fixtures/parsers/unknown-nodes/abstract-class-valid.js
@@ -1,0 +1,1207 @@
+"use strict";
+
+/**
+ * Source code:
+ *  abstract class Foo {
+ *      public bar() {
+ *          let aaa = 4,
+ *              boo;
+ *
+ *          if (true) {
+ *              boo = 3;
+ *          }
+ *
+ *          boo = 3 + 2;
+ *      }
+ *  }
+ */
+
+
+exports.parse = () => ({
+    "type": "Program",
+    "range": [
+        0,
+        159
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 12,
+            "column": 1
+        }
+    },
+    "body": [
+        {
+            "type": "TSAbstractClassDeclaration",
+            "range": [
+                0,
+                159
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 12,
+                    "column": 1
+                }
+            },
+            "id": {
+                "type": "Identifier",
+                "range": [
+                    15,
+                    18
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 15
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 18
+                    }
+                },
+                "name": "Foo"
+            },
+            "body": {
+                "type": "ClassBody",
+                "body": [
+                    {
+                        "type": "MethodDefinition",
+                        "range": [
+                            25,
+                            157
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 2,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 11,
+                                "column": 5
+                            }
+                        },
+                        "key": {
+                            "type": "Identifier",
+                            "range": [
+                                32,
+                                35
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 2,
+                                    "column": 11
+                                },
+                                "end": {
+                                    "line": 2,
+                                    "column": 14
+                                }
+                            },
+                            "name": "bar"
+                        },
+                        "value": {
+                            "type": "FunctionExpression",
+                            "id": null,
+                            "generator": false,
+                            "expression": false,
+                            "async": false,
+                            "body": {
+                                "type": "BlockStatement",
+                                "range": [
+                                    38,
+                                    157
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 2,
+                                        "column": 17
+                                    },
+                                    "end": {
+                                        "line": 11,
+                                        "column": 5
+                                    }
+                                },
+                                "body": [
+                                    {
+                                        "type": "VariableDeclaration",
+                                        "range": [
+                                            48,
+                                            77
+                                        ],
+                                        "loc": {
+                                            "start": {
+                                                "line": 3,
+                                                "column": 8
+                                            },
+                                            "end": {
+                                                "line": 4,
+                                                "column": 16
+                                            }
+                                        },
+                                        "declarations": [
+                                            {
+                                                "type": "VariableDeclarator",
+                                                "range": [
+                                                    52,
+                                                    59
+                                                ],
+                                                "loc": {
+                                                    "start": {
+                                                        "line": 3,
+                                                        "column": 12
+                                                    },
+                                                    "end": {
+                                                        "line": 3,
+                                                        "column": 19
+                                                    }
+                                                },
+                                                "id": {
+                                                    "type": "Identifier",
+                                                    "range": [
+                                                        52,
+                                                        55
+                                                    ],
+                                                    "loc": {
+                                                        "start": {
+                                                            "line": 3,
+                                                            "column": 12
+                                                        },
+                                                        "end": {
+                                                            "line": 3,
+                                                            "column": 15
+                                                        }
+                                                    },
+                                                    "name": "aaa"
+                                                },
+                                                "init": {
+                                                    "type": "Literal",
+                                                    "range": [
+                                                        58,
+                                                        59
+                                                    ],
+                                                    "loc": {
+                                                        "start": {
+                                                            "line": 3,
+                                                            "column": 18
+                                                        },
+                                                        "end": {
+                                                            "line": 3,
+                                                            "column": 19
+                                                        }
+                                                    },
+                                                    "value": 4,
+                                                    "raw": "4"
+                                                }
+                                            },
+                                            {
+                                                "type": "VariableDeclarator",
+                                                "range": [
+                                                    73,
+                                                    76
+                                                ],
+                                                "loc": {
+                                                    "start": {
+                                                        "line": 4,
+                                                        "column": 12
+                                                    },
+                                                    "end": {
+                                                        "line": 4,
+                                                        "column": 15
+                                                    }
+                                                },
+                                                "id": {
+                                                    "type": "Identifier",
+                                                    "range": [
+                                                        73,
+                                                        76
+                                                    ],
+                                                    "loc": {
+                                                        "start": {
+                                                            "line": 4,
+                                                            "column": 12
+                                                        },
+                                                        "end": {
+                                                            "line": 4,
+                                                            "column": 15
+                                                        }
+                                                    },
+                                                    "name": "boo"
+                                                },
+                                                "init": null
+                                            }
+                                        ],
+                                        "kind": "let"
+                                    },
+                                    {
+                                        "type": "IfStatement",
+                                        "range": [
+                                            87,
+                                            129
+                                        ],
+                                        "loc": {
+                                            "start": {
+                                                "line": 6,
+                                                "column": 8
+                                            },
+                                            "end": {
+                                                "line": 8,
+                                                "column": 9
+                                            }
+                                        },
+                                        "test": {
+                                            "type": "Literal",
+                                            "range": [
+                                                91,
+                                                95
+                                            ],
+                                            "loc": {
+                                                "start": {
+                                                    "line": 6,
+                                                    "column": 12
+                                                },
+                                                "end": {
+                                                    "line": 6,
+                                                    "column": 16
+                                                }
+                                            },
+                                            "value": true,
+                                            "raw": "true"
+                                        },
+                                        "consequent": {
+                                            "type": "BlockStatement",
+                                            "range": [
+                                                97,
+                                                129
+                                            ],
+                                            "loc": {
+                                                "start": {
+                                                    "line": 6,
+                                                    "column": 18
+                                                },
+                                                "end": {
+                                                    "line": 8,
+                                                    "column": 9
+                                                }
+                                            },
+                                            "body": [
+                                                {
+                                                    "type": "ExpressionStatement",
+                                                    "range": [
+                                                        111,
+                                                        119
+                                                    ],
+                                                    "loc": {
+                                                        "start": {
+                                                            "line": 7,
+                                                            "column": 12
+                                                        },
+                                                        "end": {
+                                                            "line": 7,
+                                                            "column": 20
+                                                        }
+                                                    },
+                                                    "expression": {
+                                                        "type": "AssignmentExpression",
+                                                        "range": [
+                                                            111,
+                                                            118
+                                                        ],
+                                                        "loc": {
+                                                            "start": {
+                                                                "line": 7,
+                                                                "column": 12
+                                                            },
+                                                            "end": {
+                                                                "line": 7,
+                                                                "column": 19
+                                                            }
+                                                        },
+                                                        "operator": "=",
+                                                        "left": {
+                                                            "type": "Identifier",
+                                                            "range": [
+                                                                111,
+                                                                114
+                                                            ],
+                                                            "loc": {
+                                                                "start": {
+                                                                    "line": 7,
+                                                                    "column": 12
+                                                                },
+                                                                "end": {
+                                                                    "line": 7,
+                                                                    "column": 15
+                                                                }
+                                                            },
+                                                            "name": "boo"
+                                                        },
+                                                        "right": {
+                                                            "type": "Literal",
+                                                            "range": [
+                                                                117,
+                                                                118
+                                                            ],
+                                                            "loc": {
+                                                                "start": {
+                                                                    "line": 7,
+                                                                    "column": 18
+                                                                },
+                                                                "end": {
+                                                                    "line": 7,
+                                                                    "column": 19
+                                                                }
+                                                            },
+                                                            "value": 3,
+                                                            "raw": "3"
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "alternate": null
+                                    },
+                                    {
+                                        "type": "ExpressionStatement",
+                                        "range": [
+                                            139,
+                                            151
+                                        ],
+                                        "loc": {
+                                            "start": {
+                                                "line": 10,
+                                                "column": 8
+                                            },
+                                            "end": {
+                                                "line": 10,
+                                                "column": 20
+                                            }
+                                        },
+                                        "expression": {
+                                            "type": "AssignmentExpression",
+                                            "range": [
+                                                139,
+                                                150
+                                            ],
+                                            "loc": {
+                                                "start": {
+                                                    "line": 10,
+                                                    "column": 8
+                                                },
+                                                "end": {
+                                                    "line": 10,
+                                                    "column": 19
+                                                }
+                                            },
+                                            "operator": "=",
+                                            "left": {
+                                                "type": "Identifier",
+                                                "range": [
+                                                    139,
+                                                    142
+                                                ],
+                                                "loc": {
+                                                    "start": {
+                                                        "line": 10,
+                                                        "column": 8
+                                                    },
+                                                    "end": {
+                                                        "line": 10,
+                                                        "column": 11
+                                                    }
+                                                },
+                                                "name": "boo"
+                                            },
+                                            "right": {
+                                                "type": "BinaryExpression",
+                                                "range": [
+                                                    145,
+                                                    150
+                                                ],
+                                                "loc": {
+                                                    "start": {
+                                                        "line": 10,
+                                                        "column": 14
+                                                    },
+                                                    "end": {
+                                                        "line": 10,
+                                                        "column": 19
+                                                    }
+                                                },
+                                                "operator": "+",
+                                                "left": {
+                                                    "type": "Literal",
+                                                    "range": [
+                                                        145,
+                                                        146
+                                                    ],
+                                                    "loc": {
+                                                        "start": {
+                                                            "line": 10,
+                                                            "column": 14
+                                                        },
+                                                        "end": {
+                                                            "line": 10,
+                                                            "column": 15
+                                                        }
+                                                    },
+                                                    "value": 3,
+                                                    "raw": "3"
+                                                },
+                                                "right": {
+                                                    "type": "Literal",
+                                                    "range": [
+                                                        149,
+                                                        150
+                                                    ],
+                                                    "loc": {
+                                                        "start": {
+                                                            "line": 10,
+                                                            "column": 18
+                                                        },
+                                                        "end": {
+                                                            "line": 10,
+                                                            "column": 19
+                                                        }
+                                                    },
+                                                    "value": 2,
+                                                    "raw": "2"
+                                                }
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            "range": [
+                                35,
+                                157
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 2,
+                                    "column": 14
+                                },
+                                "end": {
+                                    "line": 11,
+                                    "column": 5
+                                }
+                            },
+                            "params": []
+                        },
+                        "computed": false,
+                        "static": false,
+                        "kind": "method",
+                        "accessibility": "public",
+                        "decorators": []
+                    }
+                ],
+                "range": [
+                    19,
+                    159
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 19
+                    },
+                    "end": {
+                        "line": 12,
+                        "column": 1
+                    }
+                }
+            },
+            "superClass": null,
+            "implements": [],
+            "decorators": []
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Identifier",
+            "value": "abstract",
+            "start": 0,
+            "end": 8,
+            "range": [
+                0,
+                8
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 8
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "class",
+            "start": 9,
+            "end": 14,
+            "range": [
+                9,
+                14
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 9
+                },
+                "end": {
+                    "line": 1,
+                    "column": 14
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "Foo",
+            "start": 15,
+            "end": 18,
+            "range": [
+                15,
+                18
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 15
+                },
+                "end": {
+                    "line": 1,
+                    "column": 18
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 19,
+            "end": 20,
+            "range": [
+                19,
+                20
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 19
+                },
+                "end": {
+                    "line": 1,
+                    "column": 20
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "public",
+            "start": 25,
+            "end": 31,
+            "range": [
+                25,
+                31
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 4
+                },
+                "end": {
+                    "line": 2,
+                    "column": 10
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "bar",
+            "start": 32,
+            "end": 35,
+            "range": [
+                32,
+                35
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 11
+                },
+                "end": {
+                    "line": 2,
+                    "column": 14
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "start": 35,
+            "end": 36,
+            "range": [
+                35,
+                36
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 14
+                },
+                "end": {
+                    "line": 2,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "start": 36,
+            "end": 37,
+            "range": [
+                36,
+                37
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 15
+                },
+                "end": {
+                    "line": 2,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 38,
+            "end": 39,
+            "range": [
+                38,
+                39
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 17
+                },
+                "end": {
+                    "line": 2,
+                    "column": 18
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "let",
+            "start": 48,
+            "end": 51,
+            "range": [
+                48,
+                51
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 8
+                },
+                "end": {
+                    "line": 3,
+                    "column": 11
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "aaa",
+            "start": 52,
+            "end": 55,
+            "range": [
+                52,
+                55
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 12
+                },
+                "end": {
+                    "line": 3,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "start": 56,
+            "end": 57,
+            "range": [
+                56,
+                57
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 16
+                },
+                "end": {
+                    "line": 3,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "Numeric",
+            "value": "4",
+            "start": 58,
+            "end": 59,
+            "range": [
+                58,
+                59
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 18
+                },
+                "end": {
+                    "line": 3,
+                    "column": 19
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ",",
+            "start": 59,
+            "end": 60,
+            "range": [
+                59,
+                60
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 19
+                },
+                "end": {
+                    "line": 3,
+                    "column": 20
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "boo",
+            "start": 73,
+            "end": 76,
+            "range": [
+                73,
+                76
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 12
+                },
+                "end": {
+                    "line": 4,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "start": 76,
+            "end": 77,
+            "range": [
+                76,
+                77
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 15
+                },
+                "end": {
+                    "line": 4,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "if",
+            "start": 87,
+            "end": 89,
+            "range": [
+                87,
+                89
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 8
+                },
+                "end": {
+                    "line": 6,
+                    "column": 10
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "start": 90,
+            "end": 91,
+            "range": [
+                90,
+                91
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 11
+                },
+                "end": {
+                    "line": 6,
+                    "column": 12
+                }
+            }
+        },
+        {
+            "type": "Boolean",
+            "value": "true",
+            "start": 91,
+            "end": 95,
+            "range": [
+                91,
+                95
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 12
+                },
+                "end": {
+                    "line": 6,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "start": 95,
+            "end": 96,
+            "range": [
+                95,
+                96
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 16
+                },
+                "end": {
+                    "line": 6,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 97,
+            "end": 98,
+            "range": [
+                97,
+                98
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 18
+                },
+                "end": {
+                    "line": 6,
+                    "column": 19
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "boo",
+            "start": 111,
+            "end": 114,
+            "range": [
+                111,
+                114
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 12
+                },
+                "end": {
+                    "line": 7,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "start": 115,
+            "end": 116,
+            "range": [
+                115,
+                116
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 16
+                },
+                "end": {
+                    "line": 7,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "Numeric",
+            "value": "3",
+            "start": 117,
+            "end": 118,
+            "range": [
+                117,
+                118
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 18
+                },
+                "end": {
+                    "line": 7,
+                    "column": 19
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "start": 118,
+            "end": 119,
+            "range": [
+                118,
+                119
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 19
+                },
+                "end": {
+                    "line": 7,
+                    "column": 20
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 128,
+            "end": 129,
+            "range": [
+                128,
+                129
+            ],
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 8
+                },
+                "end": {
+                    "line": 8,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "boo",
+            "start": 139,
+            "end": 142,
+            "range": [
+                139,
+                142
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 8
+                },
+                "end": {
+                    "line": 10,
+                    "column": 11
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "start": 143,
+            "end": 144,
+            "range": [
+                143,
+                144
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 12
+                },
+                "end": {
+                    "line": 10,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Numeric",
+            "value": "3",
+            "start": 145,
+            "end": 146,
+            "range": [
+                145,
+                146
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 14
+                },
+                "end": {
+                    "line": 10,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "+",
+            "start": 147,
+            "end": 148,
+            "range": [
+                147,
+                148
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 16
+                },
+                "end": {
+                    "line": 10,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "Numeric",
+            "value": "2",
+            "start": 149,
+            "end": 150,
+            "range": [
+                149,
+                150
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 18
+                },
+                "end": {
+                    "line": 10,
+                    "column": 19
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "start": 150,
+            "end": 151,
+            "range": [
+                150,
+                151
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 19
+                },
+                "end": {
+                    "line": 10,
+                    "column": 20
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 156,
+            "end": 157,
+            "range": [
+                156,
+                157
+            ],
+            "loc": {
+                "start": {
+                    "line": 11,
+                    "column": 4
+                },
+                "end": {
+                    "line": 11,
+                    "column": 5
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 158,
+            "end": 159,
+            "range": [
+                158,
+                159
+            ],
+            "loc": {
+                "start": {
+                    "line": 12,
+                    "column": 0
+                },
+                "end": {
+                    "line": 12,
+                    "column": 1
+                }
+            }
+        }
+    ],
+    "comments": []
+});

--- a/tests/fixtures/parsers/unknown-nodes/functions-with-abstract-class-invalid.js
+++ b/tests/fixtures/parsers/unknown-nodes/functions-with-abstract-class-invalid.js
@@ -1,0 +1,1064 @@
+"use strict";
+
+/**
+ * Source code:
+ *  function foo() {
+ *      function bar() {
+ *          abstract class X {
+ *          public baz() {
+ *          if (true) {
+ *          qux();
+ *          }
+ *          }
+ *          }
+ *      }
+ *  }
+ */
+
+
+exports.parse = () => ({
+    "type": "Program",
+    "range": [
+        0,
+        160
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 11,
+            "column": 1
+        }
+    },
+    "body": [
+        {
+            "type": "FunctionDeclaration",
+            "range": [
+                0,
+                160
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 11,
+                    "column": 1
+                }
+            },
+            "id": {
+                "type": "Identifier",
+                "range": [
+                    9,
+                    12
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 9
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 12
+                    }
+                },
+                "name": "foo"
+            },
+            "generator": false,
+            "expression": false,
+            "async": false,
+            "params": [],
+            "body": {
+                "type": "BlockStatement",
+                "range": [
+                    15,
+                    160
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 15
+                    },
+                    "end": {
+                        "line": 11,
+                        "column": 1
+                    }
+                },
+                "body": [
+                    {
+                        "type": "FunctionDeclaration",
+                        "range": [
+                            21,
+                            158
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 2,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 10,
+                                "column": 5
+                            }
+                        },
+                        "id": {
+                            "type": "Identifier",
+                            "range": [
+                                30,
+                                33
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 2,
+                                    "column": 13
+                                },
+                                "end": {
+                                    "line": 2,
+                                    "column": 16
+                                }
+                            },
+                            "name": "bar"
+                        },
+                        "generator": false,
+                        "expression": false,
+                        "async": false,
+                        "params": [],
+                        "body": {
+                            "type": "BlockStatement",
+                            "range": [
+                                36,
+                                158
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 2,
+                                    "column": 19
+                                },
+                                "end": {
+                                    "line": 10,
+                                    "column": 5
+                                }
+                            },
+                            "body": [
+                                {
+                                    "type": "TSAbstractClassDeclaration",
+                                    "range": [
+                                        46,
+                                        152
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 3,
+                                            "column": 8
+                                        },
+                                        "end": {
+                                            "line": 9,
+                                            "column": 9
+                                        }
+                                    },
+                                    "id": {
+                                        "type": "Identifier",
+                                        "range": [
+                                            61,
+                                            62
+                                        ],
+                                        "loc": {
+                                            "start": {
+                                                "line": 3,
+                                                "column": 23
+                                            },
+                                            "end": {
+                                                "line": 3,
+                                                "column": 24
+                                            }
+                                        },
+                                        "name": "X"
+                                    },
+                                    "body": {
+                                        "type": "ClassBody",
+                                        "body": [
+                                            {
+                                                "type": "MethodDefinition",
+                                                "range": [
+                                                    73,
+                                                    142
+                                                ],
+                                                "loc": {
+                                                    "start": {
+                                                        "line": 4,
+                                                        "column": 8
+                                                    },
+                                                    "end": {
+                                                        "line": 8,
+                                                        "column": 9
+                                                    }
+                                                },
+                                                "key": {
+                                                    "type": "Identifier",
+                                                    "range": [
+                                                        80,
+                                                        83
+                                                    ],
+                                                    "loc": {
+                                                        "start": {
+                                                            "line": 4,
+                                                            "column": 15
+                                                        },
+                                                        "end": {
+                                                            "line": 4,
+                                                            "column": 18
+                                                        }
+                                                    },
+                                                    "name": "baz"
+                                                },
+                                                "value": {
+                                                    "type": "FunctionExpression",
+                                                    "id": null,
+                                                    "generator": false,
+                                                    "expression": false,
+                                                    "async": false,
+                                                    "body": {
+                                                        "type": "BlockStatement",
+                                                        "range": [
+                                                            86,
+                                                            142
+                                                        ],
+                                                        "loc": {
+                                                            "start": {
+                                                                "line": 4,
+                                                                "column": 21
+                                                            },
+                                                            "end": {
+                                                                "line": 8,
+                                                                "column": 9
+                                                            }
+                                                        },
+                                                        "body": [
+                                                            {
+                                                                "type": "IfStatement",
+                                                                "range": [
+                                                                    96,
+                                                                    132
+                                                                ],
+                                                                "loc": {
+                                                                    "start": {
+                                                                        "line": 5,
+                                                                        "column": 8
+                                                                    },
+                                                                    "end": {
+                                                                        "line": 7,
+                                                                        "column": 9
+                                                                    }
+                                                                },
+                                                                "test": {
+                                                                    "type": "Literal",
+                                                                    "range": [
+                                                                        100,
+                                                                        104
+                                                                    ],
+                                                                    "loc": {
+                                                                        "start": {
+                                                                            "line": 5,
+                                                                            "column": 12
+                                                                        },
+                                                                        "end": {
+                                                                            "line": 5,
+                                                                            "column": 16
+                                                                        }
+                                                                    },
+                                                                    "value": true,
+                                                                    "raw": "true"
+                                                                },
+                                                                "consequent": {
+                                                                    "type": "BlockStatement",
+                                                                    "range": [
+                                                                        106,
+                                                                        132
+                                                                    ],
+                                                                    "loc": {
+                                                                        "start": {
+                                                                            "line": 5,
+                                                                            "column": 18
+                                                                        },
+                                                                        "end": {
+                                                                            "line": 7,
+                                                                            "column": 9
+                                                                        }
+                                                                    },
+                                                                    "body": [
+                                                                        {
+                                                                            "type": "ExpressionStatement",
+                                                                            "range": [
+                                                                                116,
+                                                                                122
+                                                                            ],
+                                                                            "loc": {
+                                                                                "start": {
+                                                                                    "line": 6,
+                                                                                    "column": 8
+                                                                                },
+                                                                                "end": {
+                                                                                    "line": 6,
+                                                                                    "column": 14
+                                                                                }
+                                                                            },
+                                                                            "expression": {
+                                                                                "type": "CallExpression",
+                                                                                "range": [
+                                                                                    116,
+                                                                                    121
+                                                                                ],
+                                                                                "loc": {
+                                                                                    "start": {
+                                                                                        "line": 6,
+                                                                                        "column": 8
+                                                                                    },
+                                                                                    "end": {
+                                                                                        "line": 6,
+                                                                                        "column": 13
+                                                                                    }
+                                                                                },
+                                                                                "callee": {
+                                                                                    "type": "Identifier",
+                                                                                    "range": [
+                                                                                        116,
+                                                                                        119
+                                                                                    ],
+                                                                                    "loc": {
+                                                                                        "start": {
+                                                                                            "line": 6,
+                                                                                            "column": 8
+                                                                                        },
+                                                                                        "end": {
+                                                                                            "line": 6,
+                                                                                            "column": 11
+                                                                                        }
+                                                                                    },
+                                                                                    "name": "qux"
+                                                                                },
+                                                                                "arguments": []
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "alternate": null
+                                                            }
+                                                        ]
+                                                    },
+                                                    "range": [
+                                                        83,
+                                                        142
+                                                    ],
+                                                    "loc": {
+                                                        "start": {
+                                                            "line": 4,
+                                                            "column": 18
+                                                        },
+                                                        "end": {
+                                                            "line": 8,
+                                                            "column": 9
+                                                        }
+                                                    },
+                                                    "params": []
+                                                },
+                                                "computed": false,
+                                                "static": false,
+                                                "kind": "method",
+                                                "accessibility": "public",
+                                                "decorators": []
+                                            }
+                                        ],
+                                        "range": [
+                                            63,
+                                            152
+                                        ],
+                                        "loc": {
+                                            "start": {
+                                                "line": 3,
+                                                "column": 25
+                                            },
+                                            "end": {
+                                                "line": 9,
+                                                "column": 9
+                                            }
+                                        }
+                                    },
+                                    "superClass": null,
+                                    "implements": [],
+                                    "decorators": []
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "function",
+            "start": 0,
+            "end": 8,
+            "range": [
+                0,
+                8
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 8
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "foo",
+            "start": 9,
+            "end": 12,
+            "range": [
+                9,
+                12
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 9
+                },
+                "end": {
+                    "line": 1,
+                    "column": 12
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "start": 12,
+            "end": 13,
+            "range": [
+                12,
+                13
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 12
+                },
+                "end": {
+                    "line": 1,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "start": 13,
+            "end": 14,
+            "range": [
+                13,
+                14
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 13
+                },
+                "end": {
+                    "line": 1,
+                    "column": 14
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 15,
+            "end": 16,
+            "range": [
+                15,
+                16
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 15
+                },
+                "end": {
+                    "line": 1,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "function",
+            "start": 21,
+            "end": 29,
+            "range": [
+                21,
+                29
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 4
+                },
+                "end": {
+                    "line": 2,
+                    "column": 12
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "bar",
+            "start": 30,
+            "end": 33,
+            "range": [
+                30,
+                33
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 13
+                },
+                "end": {
+                    "line": 2,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "start": 33,
+            "end": 34,
+            "range": [
+                33,
+                34
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 16
+                },
+                "end": {
+                    "line": 2,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "start": 34,
+            "end": 35,
+            "range": [
+                34,
+                35
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 17
+                },
+                "end": {
+                    "line": 2,
+                    "column": 18
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 36,
+            "end": 37,
+            "range": [
+                36,
+                37
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 19
+                },
+                "end": {
+                    "line": 2,
+                    "column": 20
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "abstract",
+            "start": 46,
+            "end": 54,
+            "range": [
+                46,
+                54
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 8
+                },
+                "end": {
+                    "line": 3,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "class",
+            "start": 55,
+            "end": 60,
+            "range": [
+                55,
+                60
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 17
+                },
+                "end": {
+                    "line": 3,
+                    "column": 22
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "X",
+            "start": 61,
+            "end": 62,
+            "range": [
+                61,
+                62
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 23
+                },
+                "end": {
+                    "line": 3,
+                    "column": 24
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 63,
+            "end": 64,
+            "range": [
+                63,
+                64
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 25
+                },
+                "end": {
+                    "line": 3,
+                    "column": 26
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "public",
+            "start": 73,
+            "end": 79,
+            "range": [
+                73,
+                79
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 8
+                },
+                "end": {
+                    "line": 4,
+                    "column": 14
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "baz",
+            "start": 80,
+            "end": 83,
+            "range": [
+                80,
+                83
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 15
+                },
+                "end": {
+                    "line": 4,
+                    "column": 18
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "start": 83,
+            "end": 84,
+            "range": [
+                83,
+                84
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 18
+                },
+                "end": {
+                    "line": 4,
+                    "column": 19
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "start": 84,
+            "end": 85,
+            "range": [
+                84,
+                85
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 19
+                },
+                "end": {
+                    "line": 4,
+                    "column": 20
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 86,
+            "end": 87,
+            "range": [
+                86,
+                87
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 21
+                },
+                "end": {
+                    "line": 4,
+                    "column": 22
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "if",
+            "start": 96,
+            "end": 98,
+            "range": [
+                96,
+                98
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 8
+                },
+                "end": {
+                    "line": 5,
+                    "column": 10
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "start": 99,
+            "end": 100,
+            "range": [
+                99,
+                100
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 11
+                },
+                "end": {
+                    "line": 5,
+                    "column": 12
+                }
+            }
+        },
+        {
+            "type": "Boolean",
+            "value": "true",
+            "start": 100,
+            "end": 104,
+            "range": [
+                100,
+                104
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 12
+                },
+                "end": {
+                    "line": 5,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "start": 104,
+            "end": 105,
+            "range": [
+                104,
+                105
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 16
+                },
+                "end": {
+                    "line": 5,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 106,
+            "end": 107,
+            "range": [
+                106,
+                107
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 18
+                },
+                "end": {
+                    "line": 5,
+                    "column": 19
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "qux",
+            "start": 116,
+            "end": 119,
+            "range": [
+                116,
+                119
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 8
+                },
+                "end": {
+                    "line": 6,
+                    "column": 11
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "start": 119,
+            "end": 120,
+            "range": [
+                119,
+                120
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 11
+                },
+                "end": {
+                    "line": 6,
+                    "column": 12
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "start": 120,
+            "end": 121,
+            "range": [
+                120,
+                121
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 12
+                },
+                "end": {
+                    "line": 6,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "start": 121,
+            "end": 122,
+            "range": [
+                121,
+                122
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 13
+                },
+                "end": {
+                    "line": 6,
+                    "column": 14
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 131,
+            "end": 132,
+            "range": [
+                131,
+                132
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 8
+                },
+                "end": {
+                    "line": 7,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 141,
+            "end": 142,
+            "range": [
+                141,
+                142
+            ],
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 8
+                },
+                "end": {
+                    "line": 8,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 151,
+            "end": 152,
+            "range": [
+                151,
+                152
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 8
+                },
+                "end": {
+                    "line": 9,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 157,
+            "end": 158,
+            "range": [
+                157,
+                158
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 4
+                },
+                "end": {
+                    "line": 10,
+                    "column": 5
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 159,
+            "end": 160,
+            "range": [
+                159,
+                160
+            ],
+            "loc": {
+                "start": {
+                    "line": 11,
+                    "column": 0
+                },
+                "end": {
+                    "line": 11,
+                    "column": 1
+                }
+            }
+        }
+    ],
+    "comments": []
+});

--- a/tests/fixtures/parsers/unknown-nodes/functions-with-abstract-class-valid.js
+++ b/tests/fixtures/parsers/unknown-nodes/functions-with-abstract-class-valid.js
@@ -1,0 +1,1064 @@
+"use strict";
+
+/**
+ * Source code:
+ *  function foo() {
+ *      function bar() {
+ *          abstract class X {
+ *              public baz() {
+ *                  if (true) {
+ *                      qux();
+ *                  }
+ *              }
+ *          }
+ *      }
+ *  }
+ */
+
+
+exports.parse = () => ({
+    "type": "Program",
+    "range": [
+        0,
+        196
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 11,
+            "column": 1
+        }
+    },
+    "body": [
+        {
+            "type": "FunctionDeclaration",
+            "range": [
+                0,
+                196
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 11,
+                    "column": 1
+                }
+            },
+            "id": {
+                "type": "Identifier",
+                "range": [
+                    9,
+                    12
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 9
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 12
+                    }
+                },
+                "name": "foo"
+            },
+            "generator": false,
+            "expression": false,
+            "async": false,
+            "params": [],
+            "body": {
+                "type": "BlockStatement",
+                "range": [
+                    15,
+                    196
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 15
+                    },
+                    "end": {
+                        "line": 11,
+                        "column": 1
+                    }
+                },
+                "body": [
+                    {
+                        "type": "FunctionDeclaration",
+                        "range": [
+                            21,
+                            194
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 2,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 10,
+                                "column": 5
+                            }
+                        },
+                        "id": {
+                            "type": "Identifier",
+                            "range": [
+                                30,
+                                33
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 2,
+                                    "column": 13
+                                },
+                                "end": {
+                                    "line": 2,
+                                    "column": 16
+                                }
+                            },
+                            "name": "bar"
+                        },
+                        "generator": false,
+                        "expression": false,
+                        "async": false,
+                        "params": [],
+                        "body": {
+                            "type": "BlockStatement",
+                            "range": [
+                                36,
+                                194
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 2,
+                                    "column": 19
+                                },
+                                "end": {
+                                    "line": 10,
+                                    "column": 5
+                                }
+                            },
+                            "body": [
+                                {
+                                    "type": "TSAbstractClassDeclaration",
+                                    "range": [
+                                        46,
+                                        188
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 3,
+                                            "column": 8
+                                        },
+                                        "end": {
+                                            "line": 9,
+                                            "column": 9
+                                        }
+                                    },
+                                    "id": {
+                                        "type": "Identifier",
+                                        "range": [
+                                            61,
+                                            62
+                                        ],
+                                        "loc": {
+                                            "start": {
+                                                "line": 3,
+                                                "column": 23
+                                            },
+                                            "end": {
+                                                "line": 3,
+                                                "column": 24
+                                            }
+                                        },
+                                        "name": "X"
+                                    },
+                                    "body": {
+                                        "type": "ClassBody",
+                                        "body": [
+                                            {
+                                                "type": "MethodDefinition",
+                                                "range": [
+                                                    77,
+                                                    178
+                                                ],
+                                                "loc": {
+                                                    "start": {
+                                                        "line": 4,
+                                                        "column": 12
+                                                    },
+                                                    "end": {
+                                                        "line": 8,
+                                                        "column": 13
+                                                    }
+                                                },
+                                                "key": {
+                                                    "type": "Identifier",
+                                                    "range": [
+                                                        84,
+                                                        87
+                                                    ],
+                                                    "loc": {
+                                                        "start": {
+                                                            "line": 4,
+                                                            "column": 19
+                                                        },
+                                                        "end": {
+                                                            "line": 4,
+                                                            "column": 22
+                                                        }
+                                                    },
+                                                    "name": "baz"
+                                                },
+                                                "value": {
+                                                    "type": "FunctionExpression",
+                                                    "id": null,
+                                                    "generator": false,
+                                                    "expression": false,
+                                                    "async": false,
+                                                    "body": {
+                                                        "type": "BlockStatement",
+                                                        "range": [
+                                                            90,
+                                                            178
+                                                        ],
+                                                        "loc": {
+                                                            "start": {
+                                                                "line": 4,
+                                                                "column": 25
+                                                            },
+                                                            "end": {
+                                                                "line": 8,
+                                                                "column": 13
+                                                            }
+                                                        },
+                                                        "body": [
+                                                            {
+                                                                "type": "IfStatement",
+                                                                "range": [
+                                                                    108,
+                                                                    164
+                                                                ],
+                                                                "loc": {
+                                                                    "start": {
+                                                                        "line": 5,
+                                                                        "column": 16
+                                                                    },
+                                                                    "end": {
+                                                                        "line": 7,
+                                                                        "column": 17
+                                                                    }
+                                                                },
+                                                                "test": {
+                                                                    "type": "Literal",
+                                                                    "range": [
+                                                                        112,
+                                                                        116
+                                                                    ],
+                                                                    "loc": {
+                                                                        "start": {
+                                                                            "line": 5,
+                                                                            "column": 20
+                                                                        },
+                                                                        "end": {
+                                                                            "line": 5,
+                                                                            "column": 24
+                                                                        }
+                                                                    },
+                                                                    "value": true,
+                                                                    "raw": "true"
+                                                                },
+                                                                "consequent": {
+                                                                    "type": "BlockStatement",
+                                                                    "range": [
+                                                                        118,
+                                                                        164
+                                                                    ],
+                                                                    "loc": {
+                                                                        "start": {
+                                                                            "line": 5,
+                                                                            "column": 26
+                                                                        },
+                                                                        "end": {
+                                                                            "line": 7,
+                                                                            "column": 17
+                                                                        }
+                                                                    },
+                                                                    "body": [
+                                                                        {
+                                                                            "type": "ExpressionStatement",
+                                                                            "range": [
+                                                                                140,
+                                                                                146
+                                                                            ],
+                                                                            "loc": {
+                                                                                "start": {
+                                                                                    "line": 6,
+                                                                                    "column": 20
+                                                                                },
+                                                                                "end": {
+                                                                                    "line": 6,
+                                                                                    "column": 26
+                                                                                }
+                                                                            },
+                                                                            "expression": {
+                                                                                "type": "CallExpression",
+                                                                                "range": [
+                                                                                    140,
+                                                                                    145
+                                                                                ],
+                                                                                "loc": {
+                                                                                    "start": {
+                                                                                        "line": 6,
+                                                                                        "column": 20
+                                                                                    },
+                                                                                    "end": {
+                                                                                        "line": 6,
+                                                                                        "column": 25
+                                                                                    }
+                                                                                },
+                                                                                "callee": {
+                                                                                    "type": "Identifier",
+                                                                                    "range": [
+                                                                                        140,
+                                                                                        143
+                                                                                    ],
+                                                                                    "loc": {
+                                                                                        "start": {
+                                                                                            "line": 6,
+                                                                                            "column": 20
+                                                                                        },
+                                                                                        "end": {
+                                                                                            "line": 6,
+                                                                                            "column": 23
+                                                                                        }
+                                                                                    },
+                                                                                    "name": "qux"
+                                                                                },
+                                                                                "arguments": []
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "alternate": null
+                                                            }
+                                                        ]
+                                                    },
+                                                    "range": [
+                                                        87,
+                                                        178
+                                                    ],
+                                                    "loc": {
+                                                        "start": {
+                                                            "line": 4,
+                                                            "column": 22
+                                                        },
+                                                        "end": {
+                                                            "line": 8,
+                                                            "column": 13
+                                                        }
+                                                    },
+                                                    "params": []
+                                                },
+                                                "computed": false,
+                                                "static": false,
+                                                "kind": "method",
+                                                "accessibility": "public",
+                                                "decorators": []
+                                            }
+                                        ],
+                                        "range": [
+                                            63,
+                                            188
+                                        ],
+                                        "loc": {
+                                            "start": {
+                                                "line": 3,
+                                                "column": 25
+                                            },
+                                            "end": {
+                                                "line": 9,
+                                                "column": 9
+                                            }
+                                        }
+                                    },
+                                    "superClass": null,
+                                    "implements": [],
+                                    "decorators": []
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "function",
+            "start": 0,
+            "end": 8,
+            "range": [
+                0,
+                8
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 8
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "foo",
+            "start": 9,
+            "end": 12,
+            "range": [
+                9,
+                12
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 9
+                },
+                "end": {
+                    "line": 1,
+                    "column": 12
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "start": 12,
+            "end": 13,
+            "range": [
+                12,
+                13
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 12
+                },
+                "end": {
+                    "line": 1,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "start": 13,
+            "end": 14,
+            "range": [
+                13,
+                14
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 13
+                },
+                "end": {
+                    "line": 1,
+                    "column": 14
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 15,
+            "end": 16,
+            "range": [
+                15,
+                16
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 15
+                },
+                "end": {
+                    "line": 1,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "function",
+            "start": 21,
+            "end": 29,
+            "range": [
+                21,
+                29
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 4
+                },
+                "end": {
+                    "line": 2,
+                    "column": 12
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "bar",
+            "start": 30,
+            "end": 33,
+            "range": [
+                30,
+                33
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 13
+                },
+                "end": {
+                    "line": 2,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "start": 33,
+            "end": 34,
+            "range": [
+                33,
+                34
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 16
+                },
+                "end": {
+                    "line": 2,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "start": 34,
+            "end": 35,
+            "range": [
+                34,
+                35
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 17
+                },
+                "end": {
+                    "line": 2,
+                    "column": 18
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 36,
+            "end": 37,
+            "range": [
+                36,
+                37
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 19
+                },
+                "end": {
+                    "line": 2,
+                    "column": 20
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "abstract",
+            "start": 46,
+            "end": 54,
+            "range": [
+                46,
+                54
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 8
+                },
+                "end": {
+                    "line": 3,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "class",
+            "start": 55,
+            "end": 60,
+            "range": [
+                55,
+                60
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 17
+                },
+                "end": {
+                    "line": 3,
+                    "column": 22
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "X",
+            "start": 61,
+            "end": 62,
+            "range": [
+                61,
+                62
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 23
+                },
+                "end": {
+                    "line": 3,
+                    "column": 24
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 63,
+            "end": 64,
+            "range": [
+                63,
+                64
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 25
+                },
+                "end": {
+                    "line": 3,
+                    "column": 26
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "public",
+            "start": 77,
+            "end": 83,
+            "range": [
+                77,
+                83
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 12
+                },
+                "end": {
+                    "line": 4,
+                    "column": 18
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "baz",
+            "start": 84,
+            "end": 87,
+            "range": [
+                84,
+                87
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 19
+                },
+                "end": {
+                    "line": 4,
+                    "column": 22
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "start": 87,
+            "end": 88,
+            "range": [
+                87,
+                88
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 22
+                },
+                "end": {
+                    "line": 4,
+                    "column": 23
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "start": 88,
+            "end": 89,
+            "range": [
+                88,
+                89
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 23
+                },
+                "end": {
+                    "line": 4,
+                    "column": 24
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 90,
+            "end": 91,
+            "range": [
+                90,
+                91
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 25
+                },
+                "end": {
+                    "line": 4,
+                    "column": 26
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "if",
+            "start": 108,
+            "end": 110,
+            "range": [
+                108,
+                110
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 16
+                },
+                "end": {
+                    "line": 5,
+                    "column": 18
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "start": 111,
+            "end": 112,
+            "range": [
+                111,
+                112
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 19
+                },
+                "end": {
+                    "line": 5,
+                    "column": 20
+                }
+            }
+        },
+        {
+            "type": "Boolean",
+            "value": "true",
+            "start": 112,
+            "end": 116,
+            "range": [
+                112,
+                116
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 20
+                },
+                "end": {
+                    "line": 5,
+                    "column": 24
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "start": 116,
+            "end": 117,
+            "range": [
+                116,
+                117
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 24
+                },
+                "end": {
+                    "line": 5,
+                    "column": 25
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 118,
+            "end": 119,
+            "range": [
+                118,
+                119
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 26
+                },
+                "end": {
+                    "line": 5,
+                    "column": 27
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "qux",
+            "start": 140,
+            "end": 143,
+            "range": [
+                140,
+                143
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 20
+                },
+                "end": {
+                    "line": 6,
+                    "column": 23
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "start": 143,
+            "end": 144,
+            "range": [
+                143,
+                144
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 23
+                },
+                "end": {
+                    "line": 6,
+                    "column": 24
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "start": 144,
+            "end": 145,
+            "range": [
+                144,
+                145
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 24
+                },
+                "end": {
+                    "line": 6,
+                    "column": 25
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "start": 145,
+            "end": 146,
+            "range": [
+                145,
+                146
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 25
+                },
+                "end": {
+                    "line": 6,
+                    "column": 26
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 163,
+            "end": 164,
+            "range": [
+                163,
+                164
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 16
+                },
+                "end": {
+                    "line": 7,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 177,
+            "end": 178,
+            "range": [
+                177,
+                178
+            ],
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 12
+                },
+                "end": {
+                    "line": 8,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 187,
+            "end": 188,
+            "range": [
+                187,
+                188
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 8
+                },
+                "end": {
+                    "line": 9,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 193,
+            "end": 194,
+            "range": [
+                193,
+                194
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 4
+                },
+                "end": {
+                    "line": 10,
+                    "column": 5
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 195,
+            "end": 196,
+            "range": [
+                195,
+                196
+            ],
+            "loc": {
+                "start": {
+                    "line": 11,
+                    "column": 0
+                },
+                "end": {
+                    "line": 11,
+                    "column": 1
+                }
+            }
+        }
+    ],
+    "comments": []
+});

--- a/tests/fixtures/parsers/unknown-nodes/interface.js
+++ b/tests/fixtures/parsers/unknown-nodes/interface.js
@@ -1,0 +1,446 @@
+"use strict";
+
+/**
+ * Source code:
+ * interface Foo { bar: string; baz: number; }
+ */
+
+
+exports.parse = () => ({
+    "type": "Program",
+    "range": [
+        0,
+        51
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 4,
+            "column": 1
+        }
+    },
+    "body": [
+        {
+            "type": "TSInterfaceDeclaration",
+            "range": [
+                0,
+                51
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 4,
+                    "column": 1
+                }
+            },
+            "name": {
+                "type": "Identifier",
+                "range": [
+                    10,
+                    13
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 10
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 13
+                    }
+                },
+                "name": "Foo"
+            },
+            "members": [
+                {
+                    "type": "TSPropertySignature",
+                    "range": [
+                        20,
+                        32
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 2,
+                            "column": 4
+                        },
+                        "end": {
+                            "line": 2,
+                            "column": 16
+                        }
+                    },
+                    "name": {
+                        "type": "Identifier",
+                        "range": [
+                            20,
+                            23
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 2,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 2,
+                                "column": 7
+                            }
+                        },
+                        "name": "bar"
+                    },
+                    "typeAnnotation": {
+                        "type": "TypeAnnotation",
+                        "loc": {
+                            "start": {
+                                "line": 2,
+                                "column": 9
+                            },
+                            "end": {
+                                "line": 2,
+                                "column": 15
+                            }
+                        },
+                        "range": [
+                            25,
+                            31
+                        ],
+                        "typeAnnotation": {
+                            "type": "TSStringKeyword",
+                            "range": [
+                                25,
+                                31
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 2,
+                                    "column": 9
+                                },
+                                "end": {
+                                    "line": 2,
+                                    "column": 15
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "TSPropertySignature",
+                    "range": [
+                        37,
+                        49
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 3,
+                            "column": 4
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 16
+                        }
+                    },
+                    "name": {
+                        "type": "Identifier",
+                        "range": [
+                            37,
+                            40
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 3,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 3,
+                                "column": 7
+                            }
+                        },
+                        "name": "baz"
+                    },
+                    "typeAnnotation": {
+                        "type": "TypeAnnotation",
+                        "loc": {
+                            "start": {
+                                "line": 3,
+                                "column": 9
+                            },
+                            "end": {
+                                "line": 3,
+                                "column": 15
+                            }
+                        },
+                        "range": [
+                            42,
+                            48
+                        ],
+                        "typeAnnotation": {
+                            "type": "TSNumberKeyword",
+                            "range": [
+                                42,
+                                48
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 3,
+                                    "column": 9
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 15
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "interface",
+            "start": 0,
+            "end": 9,
+            "range": [
+                0,
+                9
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "Foo",
+            "start": 10,
+            "end": 13,
+            "range": [
+                10,
+                13
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 10
+                },
+                "end": {
+                    "line": 1,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 14,
+            "end": 15,
+            "range": [
+                14,
+                15
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 14
+                },
+                "end": {
+                    "line": 1,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "bar",
+            "start": 20,
+            "end": 23,
+            "range": [
+                20,
+                23
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 4
+                },
+                "end": {
+                    "line": 2,
+                    "column": 7
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "start": 23,
+            "end": 24,
+            "range": [
+                23,
+                24
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 7
+                },
+                "end": {
+                    "line": 2,
+                    "column": 8
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "string",
+            "start": 25,
+            "end": 31,
+            "range": [
+                25,
+                31
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 9
+                },
+                "end": {
+                    "line": 2,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "start": 31,
+            "end": 32,
+            "range": [
+                31,
+                32
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 15
+                },
+                "end": {
+                    "line": 2,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "baz",
+            "start": 37,
+            "end": 40,
+            "range": [
+                37,
+                40
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 4
+                },
+                "end": {
+                    "line": 3,
+                    "column": 7
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "start": 40,
+            "end": 41,
+            "range": [
+                40,
+                41
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 7
+                },
+                "end": {
+                    "line": 3,
+                    "column": 8
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "number",
+            "start": 42,
+            "end": 48,
+            "range": [
+                42,
+                48
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 9
+                },
+                "end": {
+                    "line": 3,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "start": 48,
+            "end": 49,
+            "range": [
+                48,
+                49
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 15
+                },
+                "end": {
+                    "line": 3,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 50,
+            "end": 51,
+            "range": [
+                50,
+                51
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 0
+                },
+                "end": {
+                    "line": 4,
+                    "column": 1
+                }
+            }
+        }
+    ],
+    "comments": []
+});

--- a/tests/fixtures/parsers/unknown-nodes/namespace-invalid.js
+++ b/tests/fixtures/parsers/unknown-nodes/namespace-invalid.js
@@ -1,0 +1,830 @@
+"use strict";
+
+/**
+ * Source code:
+ *  namespace Boo {
+ *      const bar = 3,
+ *      baz = 2;
+ *
+ *      if (true) {
+ *      const bax = 3;
+ *      }
+ *  }
+ */
+
+
+exports.parse = () => ({
+    "type": "Program",
+    "range": [
+        0,
+        91
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 8,
+            "column": 1
+        }
+    },
+    "body": [
+        {
+            "type": "TSModuleDeclaration",
+            "range": [
+                0,
+                91
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 8,
+                    "column": 1
+                }
+            },
+            "name": {
+                "type": "Identifier",
+                "range": [
+                    10,
+                    13
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 10
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 13
+                    }
+                },
+                "name": "Boo"
+            },
+            "body": {
+                "type": "TSModuleBlock",
+                "range": [
+                    14,
+                    91
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 14
+                    },
+                    "end": {
+                        "line": 8,
+                        "column": 1
+                    }
+                },
+                "statements": [
+                    {
+                        "type": "VariableDeclaration",
+                        "range": [
+                            20,
+                            47
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 2,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 3,
+                                "column": 12
+                            }
+                        },
+                        "declarations": [
+                            {
+                                "type": "VariableDeclarator",
+                                "range": [
+                                    26,
+                                    33
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 2,
+                                        "column": 10
+                                    },
+                                    "end": {
+                                        "line": 2,
+                                        "column": 17
+                                    }
+                                },
+                                "id": {
+                                    "type": "Identifier",
+                                    "range": [
+                                        26,
+                                        29
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 2,
+                                            "column": 10
+                                        },
+                                        "end": {
+                                            "line": 2,
+                                            "column": 13
+                                        }
+                                    },
+                                    "name": "bar"
+                                },
+                                "init": {
+                                    "type": "Literal",
+                                    "range": [
+                                        32,
+                                        33
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 2,
+                                            "column": 16
+                                        },
+                                        "end": {
+                                            "line": 2,
+                                            "column": 17
+                                        }
+                                    },
+                                    "value": 3,
+                                    "raw": "3"
+                                }
+                            },
+                            {
+                                "type": "VariableDeclarator",
+                                "range": [
+                                    39,
+                                    46
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 3,
+                                        "column": 4
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "column": 11
+                                    }
+                                },
+                                "id": {
+                                    "type": "Identifier",
+                                    "range": [
+                                        39,
+                                        42
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 3,
+                                            "column": 4
+                                        },
+                                        "end": {
+                                            "line": 3,
+                                            "column": 7
+                                        }
+                                    },
+                                    "name": "baz"
+                                },
+                                "init": {
+                                    "type": "Literal",
+                                    "range": [
+                                        45,
+                                        46
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 3,
+                                            "column": 10
+                                        },
+                                        "end": {
+                                            "line": 3,
+                                            "column": 11
+                                        }
+                                    },
+                                    "value": 2,
+                                    "raw": "2"
+                                }
+                            }
+                        ],
+                        "kind": "const"
+                    },
+                    {
+                        "type": "IfStatement",
+                        "range": [
+                            53,
+                            89
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 5,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 7,
+                                "column": 5
+                            }
+                        },
+                        "test": {
+                            "type": "Literal",
+                            "range": [
+                                57,
+                                61
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 5,
+                                    "column": 8
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 12
+                                }
+                            },
+                            "value": true,
+                            "raw": "true"
+                        },
+                        "consequent": {
+                            "type": "BlockStatement",
+                            "range": [
+                                63,
+                                89
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 5,
+                                    "column": 14
+                                },
+                                "end": {
+                                    "line": 7,
+                                    "column": 5
+                                }
+                            },
+                            "body": [
+                                {
+                                    "type": "VariableDeclaration",
+                                    "range": [
+                                        69,
+                                        83
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 6,
+                                            "column": 4
+                                        },
+                                        "end": {
+                                            "line": 6,
+                                            "column": 18
+                                        }
+                                    },
+                                    "declarations": [
+                                        {
+                                            "type": "VariableDeclarator",
+                                            "range": [
+                                                75,
+                                                82
+                                            ],
+                                            "loc": {
+                                                "start": {
+                                                    "line": 6,
+                                                    "column": 10
+                                                },
+                                                "end": {
+                                                    "line": 6,
+                                                    "column": 17
+                                                }
+                                            },
+                                            "id": {
+                                                "type": "Identifier",
+                                                "range": [
+                                                    75,
+                                                    78
+                                                ],
+                                                "loc": {
+                                                    "start": {
+                                                        "line": 6,
+                                                        "column": 10
+                                                    },
+                                                    "end": {
+                                                        "line": 6,
+                                                        "column": 13
+                                                    }
+                                                },
+                                                "name": "bax"
+                                            },
+                                            "init": {
+                                                "type": "Literal",
+                                                "range": [
+                                                    81,
+                                                    82
+                                                ],
+                                                "loc": {
+                                                    "start": {
+                                                        "line": 6,
+                                                        "column": 16
+                                                    },
+                                                    "end": {
+                                                        "line": 6,
+                                                        "column": 17
+                                                    }
+                                                },
+                                                "value": 3,
+                                                "raw": "3"
+                                            }
+                                        }
+                                    ],
+                                    "kind": "const"
+                                }
+                            ]
+                        },
+                        "alternate": null
+                    }
+                ]
+            }
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Identifier",
+            "value": "namespace",
+            "start": 0,
+            "end": 9,
+            "range": [
+                0,
+                9
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "Boo",
+            "start": 10,
+            "end": 13,
+            "range": [
+                10,
+                13
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 10
+                },
+                "end": {
+                    "line": 1,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 14,
+            "end": 15,
+            "range": [
+                14,
+                15
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 14
+                },
+                "end": {
+                    "line": 1,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "const",
+            "start": 20,
+            "end": 25,
+            "range": [
+                20,
+                25
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 4
+                },
+                "end": {
+                    "line": 2,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "bar",
+            "start": 26,
+            "end": 29,
+            "range": [
+                26,
+                29
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 10
+                },
+                "end": {
+                    "line": 2,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "start": 30,
+            "end": 31,
+            "range": [
+                30,
+                31
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 14
+                },
+                "end": {
+                    "line": 2,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Numeric",
+            "value": "3",
+            "start": 32,
+            "end": 33,
+            "range": [
+                32,
+                33
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 16
+                },
+                "end": {
+                    "line": 2,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ",",
+            "start": 33,
+            "end": 34,
+            "range": [
+                33,
+                34
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 17
+                },
+                "end": {
+                    "line": 2,
+                    "column": 18
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "baz",
+            "start": 39,
+            "end": 42,
+            "range": [
+                39,
+                42
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 4
+                },
+                "end": {
+                    "line": 3,
+                    "column": 7
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "start": 43,
+            "end": 44,
+            "range": [
+                43,
+                44
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 8
+                },
+                "end": {
+                    "line": 3,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Numeric",
+            "value": "2",
+            "start": 45,
+            "end": 46,
+            "range": [
+                45,
+                46
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 10
+                },
+                "end": {
+                    "line": 3,
+                    "column": 11
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "start": 46,
+            "end": 47,
+            "range": [
+                46,
+                47
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 11
+                },
+                "end": {
+                    "line": 3,
+                    "column": 12
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "if",
+            "start": 53,
+            "end": 55,
+            "range": [
+                53,
+                55
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 4
+                },
+                "end": {
+                    "line": 5,
+                    "column": 6
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "start": 56,
+            "end": 57,
+            "range": [
+                56,
+                57
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 7
+                },
+                "end": {
+                    "line": 5,
+                    "column": 8
+                }
+            }
+        },
+        {
+            "type": "Boolean",
+            "value": "true",
+            "start": 57,
+            "end": 61,
+            "range": [
+                57,
+                61
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 8
+                },
+                "end": {
+                    "line": 5,
+                    "column": 12
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "start": 61,
+            "end": 62,
+            "range": [
+                61,
+                62
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 12
+                },
+                "end": {
+                    "line": 5,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 63,
+            "end": 64,
+            "range": [
+                63,
+                64
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 14
+                },
+                "end": {
+                    "line": 5,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "const",
+            "start": 69,
+            "end": 74,
+            "range": [
+                69,
+                74
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 4
+                },
+                "end": {
+                    "line": 6,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "bax",
+            "start": 75,
+            "end": 78,
+            "range": [
+                75,
+                78
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 10
+                },
+                "end": {
+                    "line": 6,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "start": 79,
+            "end": 80,
+            "range": [
+                79,
+                80
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 14
+                },
+                "end": {
+                    "line": 6,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Numeric",
+            "value": "3",
+            "start": 81,
+            "end": 82,
+            "range": [
+                81,
+                82
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 16
+                },
+                "end": {
+                    "line": 6,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "start": 82,
+            "end": 83,
+            "range": [
+                82,
+                83
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 17
+                },
+                "end": {
+                    "line": 6,
+                    "column": 18
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 88,
+            "end": 89,
+            "range": [
+                88,
+                89
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 4
+                },
+                "end": {
+                    "line": 7,
+                    "column": 5
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 90,
+            "end": 91,
+            "range": [
+                90,
+                91
+            ],
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 0
+                },
+                "end": {
+                    "line": 8,
+                    "column": 1
+                }
+            }
+        }
+    ],
+    "comments": []
+});

--- a/tests/fixtures/parsers/unknown-nodes/namespace-valid.js
+++ b/tests/fixtures/parsers/unknown-nodes/namespace-valid.js
@@ -1,0 +1,830 @@
+"use strict";
+
+/**
+ * Source code:
+ *  namespace Boo {
+ *      const bar = 3,
+ *          baz = 2;
+ *
+ *      if (true) {
+ *          const bax = 3;
+ *      }
+ *  }
+ */
+
+
+exports.parse = () => ({
+    "type": "Program",
+    "range": [
+        0,
+        99
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 8,
+            "column": 1
+        }
+    },
+    "body": [
+        {
+            "type": "TSModuleDeclaration",
+            "range": [
+                0,
+                99
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 8,
+                    "column": 1
+                }
+            },
+            "name": {
+                "type": "Identifier",
+                "range": [
+                    10,
+                    13
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 10
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 13
+                    }
+                },
+                "name": "Boo"
+            },
+            "body": {
+                "type": "TSModuleBlock",
+                "range": [
+                    14,
+                    99
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 14
+                    },
+                    "end": {
+                        "line": 8,
+                        "column": 1
+                    }
+                },
+                "statements": [
+                    {
+                        "type": "VariableDeclaration",
+                        "range": [
+                            20,
+                            51
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 2,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 3,
+                                "column": 16
+                            }
+                        },
+                        "declarations": [
+                            {
+                                "type": "VariableDeclarator",
+                                "range": [
+                                    26,
+                                    33
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 2,
+                                        "column": 10
+                                    },
+                                    "end": {
+                                        "line": 2,
+                                        "column": 17
+                                    }
+                                },
+                                "id": {
+                                    "type": "Identifier",
+                                    "range": [
+                                        26,
+                                        29
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 2,
+                                            "column": 10
+                                        },
+                                        "end": {
+                                            "line": 2,
+                                            "column": 13
+                                        }
+                                    },
+                                    "name": "bar"
+                                },
+                                "init": {
+                                    "type": "Literal",
+                                    "range": [
+                                        32,
+                                        33
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 2,
+                                            "column": 16
+                                        },
+                                        "end": {
+                                            "line": 2,
+                                            "column": 17
+                                        }
+                                    },
+                                    "value": 3,
+                                    "raw": "3"
+                                }
+                            },
+                            {
+                                "type": "VariableDeclarator",
+                                "range": [
+                                    43,
+                                    50
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 3,
+                                        "column": 8
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "column": 15
+                                    }
+                                },
+                                "id": {
+                                    "type": "Identifier",
+                                    "range": [
+                                        43,
+                                        46
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 3,
+                                            "column": 8
+                                        },
+                                        "end": {
+                                            "line": 3,
+                                            "column": 11
+                                        }
+                                    },
+                                    "name": "baz"
+                                },
+                                "init": {
+                                    "type": "Literal",
+                                    "range": [
+                                        49,
+                                        50
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 3,
+                                            "column": 14
+                                        },
+                                        "end": {
+                                            "line": 3,
+                                            "column": 15
+                                        }
+                                    },
+                                    "value": 2,
+                                    "raw": "2"
+                                }
+                            }
+                        ],
+                        "kind": "const"
+                    },
+                    {
+                        "type": "IfStatement",
+                        "range": [
+                            57,
+                            97
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 5,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 7,
+                                "column": 5
+                            }
+                        },
+                        "test": {
+                            "type": "Literal",
+                            "range": [
+                                61,
+                                65
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 5,
+                                    "column": 8
+                                },
+                                "end": {
+                                    "line": 5,
+                                    "column": 12
+                                }
+                            },
+                            "value": true,
+                            "raw": "true"
+                        },
+                        "consequent": {
+                            "type": "BlockStatement",
+                            "range": [
+                                67,
+                                97
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 5,
+                                    "column": 14
+                                },
+                                "end": {
+                                    "line": 7,
+                                    "column": 5
+                                }
+                            },
+                            "body": [
+                                {
+                                    "type": "VariableDeclaration",
+                                    "range": [
+                                        77,
+                                        91
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 6,
+                                            "column": 8
+                                        },
+                                        "end": {
+                                            "line": 6,
+                                            "column": 22
+                                        }
+                                    },
+                                    "declarations": [
+                                        {
+                                            "type": "VariableDeclarator",
+                                            "range": [
+                                                83,
+                                                90
+                                            ],
+                                            "loc": {
+                                                "start": {
+                                                    "line": 6,
+                                                    "column": 14
+                                                },
+                                                "end": {
+                                                    "line": 6,
+                                                    "column": 21
+                                                }
+                                            },
+                                            "id": {
+                                                "type": "Identifier",
+                                                "range": [
+                                                    83,
+                                                    86
+                                                ],
+                                                "loc": {
+                                                    "start": {
+                                                        "line": 6,
+                                                        "column": 14
+                                                    },
+                                                    "end": {
+                                                        "line": 6,
+                                                        "column": 17
+                                                    }
+                                                },
+                                                "name": "bax"
+                                            },
+                                            "init": {
+                                                "type": "Literal",
+                                                "range": [
+                                                    89,
+                                                    90
+                                                ],
+                                                "loc": {
+                                                    "start": {
+                                                        "line": 6,
+                                                        "column": 20
+                                                    },
+                                                    "end": {
+                                                        "line": 6,
+                                                        "column": 21
+                                                    }
+                                                },
+                                                "value": 3,
+                                                "raw": "3"
+                                            }
+                                        }
+                                    ],
+                                    "kind": "const"
+                                }
+                            ]
+                        },
+                        "alternate": null
+                    }
+                ]
+            }
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Identifier",
+            "value": "namespace",
+            "start": 0,
+            "end": 9,
+            "range": [
+                0,
+                9
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "Boo",
+            "start": 10,
+            "end": 13,
+            "range": [
+                10,
+                13
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 10
+                },
+                "end": {
+                    "line": 1,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 14,
+            "end": 15,
+            "range": [
+                14,
+                15
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 14
+                },
+                "end": {
+                    "line": 1,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "const",
+            "start": 20,
+            "end": 25,
+            "range": [
+                20,
+                25
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 4
+                },
+                "end": {
+                    "line": 2,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "bar",
+            "start": 26,
+            "end": 29,
+            "range": [
+                26,
+                29
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 10
+                },
+                "end": {
+                    "line": 2,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "start": 30,
+            "end": 31,
+            "range": [
+                30,
+                31
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 14
+                },
+                "end": {
+                    "line": 2,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Numeric",
+            "value": "3",
+            "start": 32,
+            "end": 33,
+            "range": [
+                32,
+                33
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 16
+                },
+                "end": {
+                    "line": 2,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ",",
+            "start": 33,
+            "end": 34,
+            "range": [
+                33,
+                34
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 17
+                },
+                "end": {
+                    "line": 2,
+                    "column": 18
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "baz",
+            "start": 43,
+            "end": 46,
+            "range": [
+                43,
+                46
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 8
+                },
+                "end": {
+                    "line": 3,
+                    "column": 11
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "start": 47,
+            "end": 48,
+            "range": [
+                47,
+                48
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 12
+                },
+                "end": {
+                    "line": 3,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Numeric",
+            "value": "2",
+            "start": 49,
+            "end": 50,
+            "range": [
+                49,
+                50
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 14
+                },
+                "end": {
+                    "line": 3,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "start": 50,
+            "end": 51,
+            "range": [
+                50,
+                51
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 15
+                },
+                "end": {
+                    "line": 3,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "if",
+            "start": 57,
+            "end": 59,
+            "range": [
+                57,
+                59
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 4
+                },
+                "end": {
+                    "line": 5,
+                    "column": 6
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "start": 60,
+            "end": 61,
+            "range": [
+                60,
+                61
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 7
+                },
+                "end": {
+                    "line": 5,
+                    "column": 8
+                }
+            }
+        },
+        {
+            "type": "Boolean",
+            "value": "true",
+            "start": 61,
+            "end": 65,
+            "range": [
+                61,
+                65
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 8
+                },
+                "end": {
+                    "line": 5,
+                    "column": 12
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "start": 65,
+            "end": 66,
+            "range": [
+                65,
+                66
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 12
+                },
+                "end": {
+                    "line": 5,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 67,
+            "end": 68,
+            "range": [
+                67,
+                68
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 14
+                },
+                "end": {
+                    "line": 5,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "const",
+            "start": 77,
+            "end": 82,
+            "range": [
+                77,
+                82
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 8
+                },
+                "end": {
+                    "line": 6,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "bax",
+            "start": 83,
+            "end": 86,
+            "range": [
+                83,
+                86
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 14
+                },
+                "end": {
+                    "line": 6,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "start": 87,
+            "end": 88,
+            "range": [
+                87,
+                88
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 18
+                },
+                "end": {
+                    "line": 6,
+                    "column": 19
+                }
+            }
+        },
+        {
+            "type": "Numeric",
+            "value": "3",
+            "start": 89,
+            "end": 90,
+            "range": [
+                89,
+                90
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 20
+                },
+                "end": {
+                    "line": 6,
+                    "column": 21
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "start": 90,
+            "end": 91,
+            "range": [
+                90,
+                91
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 21
+                },
+                "end": {
+                    "line": 6,
+                    "column": 22
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 96,
+            "end": 97,
+            "range": [
+                96,
+                97
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 4
+                },
+                "end": {
+                    "line": 7,
+                    "column": 5
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 98,
+            "end": 99,
+            "range": [
+                98,
+                99
+            ],
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 0
+                },
+                "end": {
+                    "line": 8,
+                    "column": 1
+                }
+            }
+        }
+    ],
+    "comments": []
+});

--- a/tests/fixtures/parsers/unknown-nodes/namespace-with-functions-with-abstract-class-invalid.js
+++ b/tests/fixtures/parsers/unknown-nodes/namespace-with-functions-with-abstract-class-invalid.js
@@ -1,0 +1,1200 @@
+"use strict";
+
+/**
+ * Source code:
+ *  namespace Unknown {
+ *      function foo() {
+ *      function bar() {
+ *              abstract class X {
+ *                  public baz() {
+ *                      if (true) {
+ *                     qux();
+ *                      }
+ *                  }
+ *              }
+ *          }
+ *      }
+ *  }
+ */
+
+
+exports.parse = () => ({
+    "type": "Program",
+    "range": [
+        0,
+        254
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 13,
+            "column": 1
+        }
+    },
+    "body": [
+        {
+            "type": "TSModuleDeclaration",
+            "range": [
+                0,
+                254
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 13,
+                    "column": 1
+                }
+            },
+            "name": {
+                "type": "Identifier",
+                "range": [
+                    10,
+                    17
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 10
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 17
+                    }
+                },
+                "name": "Unknown"
+            },
+            "body": {
+                "type": "TSModuleBlock",
+                "range": [
+                    18,
+                    254
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 18
+                    },
+                    "end": {
+                        "line": 13,
+                        "column": 1
+                    }
+                },
+                "body": [
+                    {
+                        "type": "TSNamespaceFunctionDeclaration",
+                        "range": [
+                            24,
+                            252
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 2,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 12,
+                                "column": 5
+                            }
+                        },
+                        "id": {
+                            "type": "Identifier",
+                            "range": [
+                                33,
+                                36
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 2,
+                                    "column": 13
+                                },
+                                "end": {
+                                    "line": 2,
+                                    "column": 16
+                                }
+                            },
+                            "name": "foo"
+                        },
+                        "generator": false,
+                        "expression": false,
+                        "async": false,
+                        "params": [],
+                        "body": {
+                            "type": "BlockStatement",
+                            "range": [
+                                39,
+                                252
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 2,
+                                    "column": 19
+                                },
+                                "end": {
+                                    "line": 12,
+                                    "column": 5
+                                }
+                            },
+                            "body": [
+                                {
+                                    "type": "FunctionDeclaration",
+                                    "range": [
+                                        45,
+                                        246
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 3,
+                                            "column": 4
+                                        },
+                                        "end": {
+                                            "line": 11,
+                                            "column": 9
+                                        }
+                                    },
+                                    "id": {
+                                        "type": "Identifier",
+                                        "range": [
+                                            54,
+                                            57
+                                        ],
+                                        "loc": {
+                                            "start": {
+                                                "line": 3,
+                                                "column": 13
+                                            },
+                                            "end": {
+                                                "line": 3,
+                                                "column": 16
+                                            }
+                                        },
+                                        "name": "bar"
+                                    },
+                                    "generator": false,
+                                    "expression": false,
+                                    "async": false,
+                                    "params": [],
+                                    "body": {
+                                        "type": "BlockStatement",
+                                        "range": [
+                                            60,
+                                            246
+                                        ],
+                                        "loc": {
+                                            "start": {
+                                                "line": 3,
+                                                "column": 19
+                                            },
+                                            "end": {
+                                                "line": 11,
+                                                "column": 9
+                                            }
+                                        },
+                                        "body": [
+                                            {
+                                                "type": "TSAbstractClassDeclaration",
+                                                "range": [
+                                                    74,
+                                                    236
+                                                ],
+                                                "loc": {
+                                                    "start": {
+                                                        "line": 4,
+                                                        "column": 12
+                                                    },
+                                                    "end": {
+                                                        "line": 10,
+                                                        "column": 13
+                                                    }
+                                                },
+                                                "id": {
+                                                    "type": "Identifier",
+                                                    "range": [
+                                                        89,
+                                                        90
+                                                    ],
+                                                    "loc": {
+                                                        "start": {
+                                                            "line": 4,
+                                                            "column": 27
+                                                        },
+                                                        "end": {
+                                                            "line": 4,
+                                                            "column": 28
+                                                        }
+                                                    },
+                                                    "name": "X"
+                                                },
+                                                "body": {
+                                                    "type": "ClassBody",
+                                                    "body": [
+                                                        {
+                                                            "type": "MethodDefinition",
+                                                            "range": [
+                                                                109,
+                                                                222
+                                                            ],
+                                                            "loc": {
+                                                                "start": {
+                                                                    "line": 5,
+                                                                    "column": 16
+                                                                },
+                                                                "end": {
+                                                                    "line": 9,
+                                                                    "column": 17
+                                                                }
+                                                            },
+                                                            "key": {
+                                                                "type": "Identifier",
+                                                                "range": [
+                                                                    116,
+                                                                    119
+                                                                ],
+                                                                "loc": {
+                                                                    "start": {
+                                                                        "line": 5,
+                                                                        "column": 23
+                                                                    },
+                                                                    "end": {
+                                                                        "line": 5,
+                                                                        "column": 26
+                                                                    }
+                                                                },
+                                                                "name": "baz"
+                                                            },
+                                                            "value": {
+                                                                "type": "FunctionExpression",
+                                                                "id": null,
+                                                                "generator": false,
+                                                                "expression": false,
+                                                                "async": false,
+                                                                "body": {
+                                                                    "type": "BlockStatement",
+                                                                    "range": [
+                                                                        122,
+                                                                        222
+                                                                    ],
+                                                                    "loc": {
+                                                                        "start": {
+                                                                            "line": 5,
+                                                                            "column": 29
+                                                                        },
+                                                                        "end": {
+                                                                            "line": 9,
+                                                                            "column": 17
+                                                                        }
+                                                                    },
+                                                                    "body": [
+                                                                        {
+                                                                            "type": "IfStatement",
+                                                                            "range": [
+                                                                                144,
+                                                                                204
+                                                                            ],
+                                                                            "loc": {
+                                                                                "start": {
+                                                                                    "line": 6,
+                                                                                    "column": 20
+                                                                                },
+                                                                                "end": {
+                                                                                    "line": 8,
+                                                                                    "column": 21
+                                                                                }
+                                                                            },
+                                                                            "test": {
+                                                                                "type": "Literal",
+                                                                                "range": [
+                                                                                    148,
+                                                                                    152
+                                                                                ],
+                                                                                "loc": {
+                                                                                    "start": {
+                                                                                        "line": 6,
+                                                                                        "column": 24
+                                                                                    },
+                                                                                    "end": {
+                                                                                        "line": 6,
+                                                                                        "column": 28
+                                                                                    }
+                                                                                },
+                                                                                "value": true,
+                                                                                "raw": "true"
+                                                                            },
+                                                                            "consequent": {
+                                                                                "type": "BlockStatement",
+                                                                                "range": [
+                                                                                    154,
+                                                                                    204
+                                                                                ],
+                                                                                "loc": {
+                                                                                    "start": {
+                                                                                        "line": 6,
+                                                                                        "column": 30
+                                                                                    },
+                                                                                    "end": {
+                                                                                        "line": 8,
+                                                                                        "column": 21
+                                                                                    }
+                                                                                },
+                                                                                "body": [
+                                                                                    {
+                                                                                        "type": "ExpressionStatement",
+                                                                                        "range": [
+                                                                                            176,
+                                                                                            182
+                                                                                        ],
+                                                                                        "loc": {
+                                                                                            "start": {
+                                                                                                "line": 7,
+                                                                                                "column": 20
+                                                                                            },
+                                                                                            "end": {
+                                                                                                "line": 7,
+                                                                                                "column": 26
+                                                                                            }
+                                                                                        },
+                                                                                        "expression": {
+                                                                                            "type": "CallExpression",
+                                                                                            "range": [
+                                                                                                176,
+                                                                                                181
+                                                                                            ],
+                                                                                            "loc": {
+                                                                                                "start": {
+                                                                                                    "line": 7,
+                                                                                                    "column": 20
+                                                                                                },
+                                                                                                "end": {
+                                                                                                    "line": 7,
+                                                                                                    "column": 25
+                                                                                                }
+                                                                                            },
+                                                                                            "callee": {
+                                                                                                "type": "Identifier",
+                                                                                                "range": [
+                                                                                                    176,
+                                                                                                    179
+                                                                                                ],
+                                                                                                "loc": {
+                                                                                                    "start": {
+                                                                                                        "line": 7,
+                                                                                                        "column": 20
+                                                                                                    },
+                                                                                                    "end": {
+                                                                                                        "line": 7,
+                                                                                                        "column": 23
+                                                                                                    }
+                                                                                                },
+                                                                                                "name": "qux"
+                                                                                            },
+                                                                                            "arguments": []
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "alternate": null
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "range": [
+                                                                    119,
+                                                                    222
+                                                                ],
+                                                                "loc": {
+                                                                    "start": {
+                                                                        "line": 5,
+                                                                        "column": 26
+                                                                    },
+                                                                    "end": {
+                                                                        "line": 9,
+                                                                        "column": 17
+                                                                    }
+                                                                },
+                                                                "params": []
+                                                            },
+                                                            "computed": false,
+                                                            "static": false,
+                                                            "kind": "method",
+                                                            "accessibility": "public",
+                                                            "decorators": []
+                                                        }
+                                                    ],
+                                                    "range": [
+                                                        91,
+                                                        236
+                                                    ],
+                                                    "loc": {
+                                                        "start": {
+                                                            "line": 4,
+                                                            "column": 29
+                                                        },
+                                                        "end": {
+                                                            "line": 10,
+                                                            "column": 13
+                                                        }
+                                                    }
+                                                },
+                                                "superClass": null,
+                                                "implements": [],
+                                                "decorators": []
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Identifier",
+            "value": "namespace",
+            "start": 0,
+            "end": 9,
+            "range": [
+                0,
+                9
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "Unknown",
+            "start": 10,
+            "end": 17,
+            "range": [
+                10,
+                17
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 10
+                },
+                "end": {
+                    "line": 1,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 18,
+            "end": 19,
+            "range": [
+                18,
+                19
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 18
+                },
+                "end": {
+                    "line": 1,
+                    "column": 19
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "function",
+            "start": 24,
+            "end": 32,
+            "range": [
+                24,
+                32
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 4
+                },
+                "end": {
+                    "line": 2,
+                    "column": 12
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "foo",
+            "start": 33,
+            "end": 36,
+            "range": [
+                33,
+                36
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 13
+                },
+                "end": {
+                    "line": 2,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "start": 36,
+            "end": 37,
+            "range": [
+                36,
+                37
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 16
+                },
+                "end": {
+                    "line": 2,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "start": 37,
+            "end": 38,
+            "range": [
+                37,
+                38
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 17
+                },
+                "end": {
+                    "line": 2,
+                    "column": 18
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 39,
+            "end": 40,
+            "range": [
+                39,
+                40
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 19
+                },
+                "end": {
+                    "line": 2,
+                    "column": 20
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "function",
+            "start": 45,
+            "end": 53,
+            "range": [
+                45,
+                53
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 4
+                },
+                "end": {
+                    "line": 3,
+                    "column": 12
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "bar",
+            "start": 54,
+            "end": 57,
+            "range": [
+                54,
+                57
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 13
+                },
+                "end": {
+                    "line": 3,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "start": 57,
+            "end": 58,
+            "range": [
+                57,
+                58
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 16
+                },
+                "end": {
+                    "line": 3,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "start": 58,
+            "end": 59,
+            "range": [
+                58,
+                59
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 17
+                },
+                "end": {
+                    "line": 3,
+                    "column": 18
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 60,
+            "end": 61,
+            "range": [
+                60,
+                61
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 19
+                },
+                "end": {
+                    "line": 3,
+                    "column": 20
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "abstract",
+            "start": 74,
+            "end": 82,
+            "range": [
+                74,
+                82
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 12
+                },
+                "end": {
+                    "line": 4,
+                    "column": 20
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "class",
+            "start": 83,
+            "end": 88,
+            "range": [
+                83,
+                88
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 21
+                },
+                "end": {
+                    "line": 4,
+                    "column": 26
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "X",
+            "start": 89,
+            "end": 90,
+            "range": [
+                89,
+                90
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 27
+                },
+                "end": {
+                    "line": 4,
+                    "column": 28
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 91,
+            "end": 92,
+            "range": [
+                91,
+                92
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 29
+                },
+                "end": {
+                    "line": 4,
+                    "column": 30
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "public",
+            "start": 109,
+            "end": 115,
+            "range": [
+                109,
+                115
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 16
+                },
+                "end": {
+                    "line": 5,
+                    "column": 22
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "baz",
+            "start": 116,
+            "end": 119,
+            "range": [
+                116,
+                119
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 23
+                },
+                "end": {
+                    "line": 5,
+                    "column": 26
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "start": 119,
+            "end": 120,
+            "range": [
+                119,
+                120
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 26
+                },
+                "end": {
+                    "line": 5,
+                    "column": 27
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "start": 120,
+            "end": 121,
+            "range": [
+                120,
+                121
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 27
+                },
+                "end": {
+                    "line": 5,
+                    "column": 28
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 122,
+            "end": 123,
+            "range": [
+                122,
+                123
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 29
+                },
+                "end": {
+                    "line": 5,
+                    "column": 30
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "if",
+            "start": 144,
+            "end": 146,
+            "range": [
+                144,
+                146
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 20
+                },
+                "end": {
+                    "line": 6,
+                    "column": 22
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "start": 147,
+            "end": 148,
+            "range": [
+                147,
+                148
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 23
+                },
+                "end": {
+                    "line": 6,
+                    "column": 24
+                }
+            }
+        },
+        {
+            "type": "Boolean",
+            "value": "true",
+            "start": 148,
+            "end": 152,
+            "range": [
+                148,
+                152
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 24
+                },
+                "end": {
+                    "line": 6,
+                    "column": 28
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "start": 152,
+            "end": 153,
+            "range": [
+                152,
+                153
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 28
+                },
+                "end": {
+                    "line": 6,
+                    "column": 29
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 154,
+            "end": 155,
+            "range": [
+                154,
+                155
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 30
+                },
+                "end": {
+                    "line": 6,
+                    "column": 31
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "qux",
+            "start": 176,
+            "end": 179,
+            "range": [
+                176,
+                179
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 20
+                },
+                "end": {
+                    "line": 7,
+                    "column": 23
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "start": 179,
+            "end": 180,
+            "range": [
+                179,
+                180
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 23
+                },
+                "end": {
+                    "line": 7,
+                    "column": 24
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "start": 180,
+            "end": 181,
+            "range": [
+                180,
+                181
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 24
+                },
+                "end": {
+                    "line": 7,
+                    "column": 25
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "start": 181,
+            "end": 182,
+            "range": [
+                181,
+                182
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 25
+                },
+                "end": {
+                    "line": 7,
+                    "column": 26
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 203,
+            "end": 204,
+            "range": [
+                203,
+                204
+            ],
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 20
+                },
+                "end": {
+                    "line": 8,
+                    "column": 21
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 221,
+            "end": 222,
+            "range": [
+                221,
+                222
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 16
+                },
+                "end": {
+                    "line": 9,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 235,
+            "end": 236,
+            "range": [
+                235,
+                236
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 12
+                },
+                "end": {
+                    "line": 10,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 245,
+            "end": 246,
+            "range": [
+                245,
+                246
+            ],
+            "loc": {
+                "start": {
+                    "line": 11,
+                    "column": 8
+                },
+                "end": {
+                    "line": 11,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 251,
+            "end": 252,
+            "range": [
+                251,
+                252
+            ],
+            "loc": {
+                "start": {
+                    "line": 12,
+                    "column": 4
+                },
+                "end": {
+                    "line": 12,
+                    "column": 5
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 253,
+            "end": 254,
+            "range": [
+                253,
+                254
+            ],
+            "loc": {
+                "start": {
+                    "line": 13,
+                    "column": 0
+                },
+                "end": {
+                    "line": 13,
+                    "column": 1
+                }
+            }
+        }
+    ],
+    "comments": []
+});

--- a/tests/fixtures/parsers/unknown-nodes/namespace-with-functions-with-abstract-class-valid.js
+++ b/tests/fixtures/parsers/unknown-nodes/namespace-with-functions-with-abstract-class-valid.js
@@ -1,0 +1,1201 @@
+"use strict";
+
+/**
+ * Source code:
+ *  namespace Unknown {
+ *      function foo() {
+ *          function bar() {
+ *              abstract class X {
+ *                  public baz() {
+ *                      if (true) {
+ *                          qux();
+ *                      }
+ *                  }
+ *              }
+ *          }
+ *      }
+ *  }
+ */
+
+
+exports.parse = () => ({
+    "type": "Program",
+    "range": [
+        0,
+        262
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 13,
+            "column": 1
+        }
+    },
+    "body": [
+        {
+            "type": "TSModuleDeclaration",
+            "range": [
+                0,
+                262
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 13,
+                    "column": 1
+                }
+            },
+            "name": {
+                "type": "Identifier",
+                "range": [
+                    10,
+                    17
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 10
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 17
+                    }
+                },
+                "name": "Unknown"
+            },
+            "body": {
+                "type": "TSModuleBlock",
+                "range": [
+                    18,
+                    262
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 18
+                    },
+                    "end": {
+                        "line": 13,
+                        "column": 1
+                    }
+                },
+                "body": [
+                    {
+                        "type": "TSNamespaceFunctionDeclaration",
+                        "range": [
+                            24,
+                            260
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 2,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 12,
+                                "column": 5
+                            }
+                        },
+                        "id": {
+                            "type": "Identifier",
+                            "range": [
+                                33,
+                                36
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 2,
+                                    "column": 13
+                                },
+                                "end": {
+                                    "line": 2,
+                                    "column": 16
+                                }
+                            },
+                            "name": "foo"
+                        },
+                        "generator": false,
+                        "expression": false,
+                        "async": false,
+                        "params": [],
+                        "body": {
+                            "type": "BlockStatement",
+                            "range": [
+                                39,
+                                260
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 2,
+                                    "column": 19
+                                },
+                                "end": {
+                                    "line": 12,
+                                    "column": 5
+                                }
+                            },
+                            "body": [
+                                {
+                                    "type": "FunctionDeclaration",
+                                    "range": [
+                                        49,
+                                        254
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 3,
+                                            "column": 8
+                                        },
+                                        "end": {
+                                            "line": 11,
+                                            "column": 9
+                                        }
+                                    },
+                                    "id": {
+                                        "type": "Identifier",
+                                        "range": [
+                                            58,
+                                            61
+                                        ],
+                                        "loc": {
+                                            "start": {
+                                                "line": 3,
+                                                "column": 17
+                                            },
+                                            "end": {
+                                                "line": 3,
+                                                "column": 20
+                                            }
+                                        },
+                                        "name": "bar"
+                                    },
+                                    "generator": false,
+                                    "expression": false,
+                                    "async": false,
+                                    "params": [],
+                                    "body": {
+                                        "type": "BlockStatement",
+                                        "range": [
+                                            64,
+                                            254
+                                        ],
+                                        "loc": {
+                                            "start": {
+                                                "line": 3,
+                                                "column": 23
+                                            },
+                                            "end": {
+                                                "line": 11,
+                                                "column": 9
+                                            }
+                                        },
+                                        "body": [
+                                            {
+                                                "type": "TSAbstractClassDeclaration",
+                                                "range": [
+                                                    78,
+                                                    244
+                                                ],
+                                                "loc": {
+                                                    "start": {
+                                                        "line": 4,
+                                                        "column": 12
+                                                    },
+                                                    "end": {
+                                                        "line": 10,
+                                                        "column": 13
+                                                    }
+                                                },
+                                                "id": {
+                                                    "type": "Identifier",
+                                                    "range": [
+                                                        93,
+                                                        94
+                                                    ],
+                                                    "loc": {
+                                                        "start": {
+                                                            "line": 4,
+                                                            "column": 27
+                                                        },
+                                                        "end": {
+                                                            "line": 4,
+                                                            "column": 28
+                                                        }
+                                                    },
+                                                    "name": "X"
+                                                },
+                                                "body": {
+                                                    "type": "ClassBody",
+                                                    "body": [
+                                                        {
+                                                            "type": "MethodDefinition",
+                                                            "range": [
+                                                                113,
+                                                                230
+                                                            ],
+                                                            "loc": {
+                                                                "start": {
+                                                                    "line": 5,
+                                                                    "column": 16
+                                                                },
+                                                                "end": {
+                                                                    "line": 9,
+                                                                    "column": 17
+                                                                }
+                                                            },
+                                                            "key": {
+                                                                "type": "Identifier",
+                                                                "range": [
+                                                                    120,
+                                                                    123
+                                                                ],
+                                                                "loc": {
+                                                                    "start": {
+                                                                        "line": 5,
+                                                                        "column": 23
+                                                                    },
+                                                                    "end": {
+                                                                        "line": 5,
+                                                                        "column": 26
+                                                                    }
+                                                                },
+                                                                "name": "baz"
+                                                            },
+                                                            "value": {
+                                                                "type": "FunctionExpression",
+                                                                "id": null,
+                                                                "generator": false,
+                                                                "expression": false,
+                                                                "async": false,
+                                                                "body": {
+                                                                    "type": "BlockStatement",
+                                                                    "range": [
+                                                                        126,
+                                                                        230
+                                                                    ],
+                                                                    "loc": {
+                                                                        "start": {
+                                                                            "line": 5,
+                                                                            "column": 29
+                                                                        },
+                                                                        "end": {
+                                                                            "line": 9,
+                                                                            "column": 17
+                                                                        }
+                                                                    },
+                                                                    "body": [
+                                                                        {
+                                                                            "type": "IfStatement",
+                                                                            "range": [
+                                                                                148,
+                                                                                212
+                                                                            ],
+                                                                            "loc": {
+                                                                                "start": {
+                                                                                    "line": 6,
+                                                                                    "column": 20
+                                                                                },
+                                                                                "end": {
+                                                                                    "line": 8,
+                                                                                    "column": 21
+                                                                                }
+                                                                            },
+                                                                            "test": {
+                                                                                "type": "Literal",
+                                                                                "range": [
+                                                                                    152,
+                                                                                    156
+                                                                                ],
+                                                                                "loc": {
+                                                                                    "start": {
+                                                                                        "line": 6,
+                                                                                        "column": 24
+                                                                                    },
+                                                                                    "end": {
+                                                                                        "line": 6,
+                                                                                        "column": 28
+                                                                                    }
+                                                                                },
+                                                                                "value": true,
+                                                                                "raw": "true"
+                                                                            },
+                                                                            "consequent": {
+                                                                                "type": "BlockStatement",
+                                                                                "range": [
+                                                                                    158,
+                                                                                    212
+                                                                                ],
+                                                                                "loc": {
+                                                                                    "start": {
+                                                                                        "line": 6,
+                                                                                        "column": 30
+                                                                                    },
+                                                                                    "end": {
+                                                                                        "line": 8,
+                                                                                        "column": 21
+                                                                                    }
+                                                                                },
+                                                                                "body": [
+                                                                                    {
+                                                                                        "type": "ExpressionStatement",
+                                                                                        "range": [
+                                                                                            184,
+                                                                                            190
+                                                                                        ],
+                                                                                        "loc": {
+                                                                                            "start": {
+                                                                                                "line": 7,
+                                                                                                "column": 24
+                                                                                            },
+                                                                                            "end": {
+                                                                                                "line": 7,
+                                                                                                "column": 30
+                                                                                            }
+                                                                                        },
+                                                                                        "expression": {
+                                                                                            "type": "CallExpression",
+                                                                                            "range": [
+                                                                                                184,
+                                                                                                189
+                                                                                            ],
+                                                                                            "loc": {
+                                                                                                "start": {
+                                                                                                    "line": 7,
+                                                                                                    "column": 24
+                                                                                                },
+                                                                                                "end": {
+                                                                                                    "line": 7,
+                                                                                                    "column": 29
+                                                                                                }
+                                                                                            },
+                                                                                            "callee": {
+                                                                                                "type": "Identifier",
+                                                                                                "range": [
+                                                                                                    184,
+                                                                                                    187
+                                                                                                ],
+                                                                                                "loc": {
+                                                                                                    "start": {
+                                                                                                        "line": 7,
+                                                                                                        "column": 24
+                                                                                                    },
+                                                                                                    "end": {
+                                                                                                        "line": 7,
+                                                                                                        "column": 27
+                                                                                                    }
+                                                                                                },
+                                                                                                "name": "qux"
+                                                                                            },
+                                                                                            "arguments": []
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "alternate": null
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "range": [
+                                                                    123,
+                                                                    230
+                                                                ],
+                                                                "loc": {
+                                                                    "start": {
+                                                                        "line": 5,
+                                                                        "column": 26
+                                                                    },
+                                                                    "end": {
+                                                                        "line": 9,
+                                                                        "column": 17
+                                                                    }
+                                                                },
+                                                                "params": []
+                                                            },
+                                                            "computed": false,
+                                                            "static": false,
+                                                            "kind": "method",
+                                                            "accessibility": "public",
+                                                            "decorators": []
+                                                        }
+                                                    ],
+                                                    "range": [
+                                                        95,
+                                                        244
+                                                    ],
+                                                    "loc": {
+                                                        "start": {
+                                                            "line": 4,
+                                                            "column": 29
+                                                        },
+                                                        "end": {
+                                                            "line": 10,
+                                                            "column": 13
+                                                        }
+                                                    }
+                                                },
+                                                "superClass": null,
+                                                "implements": [],
+                                                "decorators": []
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Identifier",
+            "value": "namespace",
+            "start": 0,
+            "end": 9,
+            "range": [
+                0,
+                9
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "Unknown",
+            "start": 10,
+            "end": 17,
+            "range": [
+                10,
+                17
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 10
+                },
+                "end": {
+                    "line": 1,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 18,
+            "end": 19,
+            "range": [
+                18,
+                19
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 18
+                },
+                "end": {
+                    "line": 1,
+                    "column": 19
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "function",
+            "start": 24,
+            "end": 32,
+            "range": [
+                24,
+                32
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 4
+                },
+                "end": {
+                    "line": 2,
+                    "column": 12
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "foo",
+            "start": 33,
+            "end": 36,
+            "range": [
+                33,
+                36
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 13
+                },
+                "end": {
+                    "line": 2,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "start": 36,
+            "end": 37,
+            "range": [
+                36,
+                37
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 16
+                },
+                "end": {
+                    "line": 2,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "start": 37,
+            "end": 38,
+            "range": [
+                37,
+                38
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 17
+                },
+                "end": {
+                    "line": 2,
+                    "column": 18
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 39,
+            "end": 40,
+            "range": [
+                39,
+                40
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 19
+                },
+                "end": {
+                    "line": 2,
+                    "column": 20
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "function",
+            "start": 49,
+            "end": 57,
+            "range": [
+                49,
+                57
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 8
+                },
+                "end": {
+                    "line": 3,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "bar",
+            "start": 58,
+            "end": 61,
+            "range": [
+                58,
+                61
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 17
+                },
+                "end": {
+                    "line": 3,
+                    "column": 20
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "start": 61,
+            "end": 62,
+            "range": [
+                61,
+                62
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 20
+                },
+                "end": {
+                    "line": 3,
+                    "column": 21
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "start": 62,
+            "end": 63,
+            "range": [
+                62,
+                63
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 21
+                },
+                "end": {
+                    "line": 3,
+                    "column": 22
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 64,
+            "end": 65,
+            "range": [
+                64,
+                65
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 23
+                },
+                "end": {
+                    "line": 3,
+                    "column": 24
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "abstract",
+            "start": 78,
+            "end": 86,
+            "range": [
+                78,
+                86
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 12
+                },
+                "end": {
+                    "line": 4,
+                    "column": 20
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "class",
+            "start": 87,
+            "end": 92,
+            "range": [
+                87,
+                92
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 21
+                },
+                "end": {
+                    "line": 4,
+                    "column": 26
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "X",
+            "start": 93,
+            "end": 94,
+            "range": [
+                93,
+                94
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 27
+                },
+                "end": {
+                    "line": 4,
+                    "column": 28
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 95,
+            "end": 96,
+            "range": [
+                95,
+                96
+            ],
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 29
+                },
+                "end": {
+                    "line": 4,
+                    "column": 30
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "public",
+            "start": 113,
+            "end": 119,
+            "range": [
+                113,
+                119
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 16
+                },
+                "end": {
+                    "line": 5,
+                    "column": 22
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "baz",
+            "start": 120,
+            "end": 123,
+            "range": [
+                120,
+                123
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 23
+                },
+                "end": {
+                    "line": 5,
+                    "column": 26
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "start": 123,
+            "end": 124,
+            "range": [
+                123,
+                124
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 26
+                },
+                "end": {
+                    "line": 5,
+                    "column": 27
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "start": 124,
+            "end": 125,
+            "range": [
+                124,
+                125
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 27
+                },
+                "end": {
+                    "line": 5,
+                    "column": 28
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 126,
+            "end": 127,
+            "range": [
+                126,
+                127
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 29
+                },
+                "end": {
+                    "line": 5,
+                    "column": 30
+                }
+            }
+        },
+        {
+            "type": "Keyword",
+            "value": "if",
+            "start": 148,
+            "end": 150,
+            "range": [
+                148,
+                150
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 20
+                },
+                "end": {
+                    "line": 6,
+                    "column": 22
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "start": 151,
+            "end": 152,
+            "range": [
+                151,
+                152
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 23
+                },
+                "end": {
+                    "line": 6,
+                    "column": 24
+                }
+            }
+        },
+        {
+            "type": "Boolean",
+            "value": "true",
+            "start": 152,
+            "end": 156,
+            "range": [
+                152,
+                156
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 24
+                },
+                "end": {
+                    "line": 6,
+                    "column": 28
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "start": 156,
+            "end": 157,
+            "range": [
+                156,
+                157
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 28
+                },
+                "end": {
+                    "line": 6,
+                    "column": 29
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 158,
+            "end": 159,
+            "range": [
+                158,
+                159
+            ],
+            "loc": {
+                "start": {
+                    "line": 6,
+                    "column": 30
+                },
+                "end": {
+                    "line": 6,
+                    "column": 31
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "qux",
+            "start": 184,
+            "end": 187,
+            "range": [
+                184,
+                187
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 24
+                },
+                "end": {
+                    "line": 7,
+                    "column": 27
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "start": 187,
+            "end": 188,
+            "range": [
+                187,
+                188
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 27
+                },
+                "end": {
+                    "line": 7,
+                    "column": 28
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "start": 188,
+            "end": 189,
+            "range": [
+                188,
+                189
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 28
+                },
+                "end": {
+                    "line": 7,
+                    "column": 29
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "start": 189,
+            "end": 190,
+            "range": [
+                189,
+                190
+            ],
+            "loc": {
+                "start": {
+                    "line": 7,
+                    "column": 29
+                },
+                "end": {
+                    "line": 7,
+                    "column": 30
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 211,
+            "end": 212,
+            "range": [
+                211,
+                212
+            ],
+            "loc": {
+                "start": {
+                    "line": 8,
+                    "column": 20
+                },
+                "end": {
+                    "line": 8,
+                    "column": 21
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 229,
+            "end": 230,
+            "range": [
+                229,
+                230
+            ],
+            "loc": {
+                "start": {
+                    "line": 9,
+                    "column": 16
+                },
+                "end": {
+                    "line": 9,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 243,
+            "end": 244,
+            "range": [
+                243,
+                244
+            ],
+            "loc": {
+                "start": {
+                    "line": 10,
+                    "column": 12
+                },
+                "end": {
+                    "line": 10,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 253,
+            "end": 254,
+            "range": [
+                253,
+                254
+            ],
+            "loc": {
+                "start": {
+                    "line": 11,
+                    "column": 8
+                },
+                "end": {
+                    "line": 11,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 259,
+            "end": 260,
+            "range": [
+                259,
+                260
+            ],
+            "loc": {
+                "start": {
+                    "line": 12,
+                    "column": 4
+                },
+                "end": {
+                    "line": 12,
+                    "column": 5
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 261,
+            "end": 262,
+            "range": [
+                261,
+                262
+            ],
+            "loc": {
+                "start": {
+                    "line": 13,
+                    "column": 0
+                },
+                "end": {
+                    "line": 13,
+                    "column": 1
+                }
+            }
+        }
+    ],
+    "comments": []
+});
+

--- a/tests/fixtures/parsers/unknown-nodes/variable-declarator-type-indent-two-spaces.js
+++ b/tests/fixtures/parsers/unknown-nodes/variable-declarator-type-indent-two-spaces.js
@@ -1,0 +1,395 @@
+"use strict";
+
+/**
+ * Source code:
+ * type httpMethod = 'GET'
+ *   | 'POST'
+ *   | 'PUT';
+ */
+
+
+exports.parse = () => ({
+    "type": "Program",
+    "range": [
+        0,
+        45
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 3,
+            "column": 10
+        }
+    },
+    "body": [
+        {
+            "type": "VariableDeclaration",
+            "range": [
+                0,
+                45
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 3,
+                    "column": 10
+                }
+            },
+            "kind": "type",
+            "declarations": [
+                {
+                    "type": "VariableDeclarator",
+                    "id": {
+                        "type": "Identifier",
+                        "range": [
+                            5,
+                            15
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 5
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 15
+                            }
+                        },
+                        "name": "httpMethod"
+                    },
+                    "init": {
+                        "type": "TSUnionType",
+                        "range": [
+                            18,
+                            44
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 18
+                            },
+                            "end": {
+                                "line": 3,
+                                "column": 9
+                            }
+                        },
+                        "types": [
+                            {
+                                "type": "TSLastTypeNode",
+                                "range": [
+                                    18,
+                                    23
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 18
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 23
+                                    }
+                                },
+                                "literal": {
+                                    "type": "Literal",
+                                    "range": [
+                                        18,
+                                        23
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 1,
+                                            "column": 18
+                                        },
+                                        "end": {
+                                            "line": 1,
+                                            "column": 23
+                                        }
+                                    },
+                                    "value": "GET",
+                                    "raw": "'GET'"
+                                }
+                            },
+                            {
+                                "type": "TSLastTypeNode",
+                                "range": [
+                                    28,
+                                    34
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 2,
+                                        "column": 4
+                                    },
+                                    "end": {
+                                        "line": 2,
+                                        "column": 10
+                                    }
+                                },
+                                "literal": {
+                                    "type": "Literal",
+                                    "range": [
+                                        28,
+                                        34
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 2,
+                                            "column": 4
+                                        },
+                                        "end": {
+                                            "line": 2,
+                                            "column": 10
+                                        }
+                                    },
+                                    "value": "POST",
+                                    "raw": "'POST'"
+                                }
+                            },
+                            {
+                                "type": "TSLastTypeNode",
+                                "range": [
+                                    39,
+                                    44
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 3,
+                                        "column": 4
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "column": 9
+                                    }
+                                },
+                                "literal": {
+                                    "type": "Literal",
+                                    "range": [
+                                        39,
+                                        44
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 3,
+                                            "column": 4
+                                        },
+                                        "end": {
+                                            "line": 3,
+                                            "column": 9
+                                        }
+                                    },
+                                    "value": "PUT",
+                                    "raw": "'PUT'"
+                                }
+                            }
+                        ]
+                    },
+                    "range": [
+                        5,
+                        45
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 5
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 10
+                        }
+                    }
+                }
+            ]
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Identifier",
+            "value": "type",
+            "start": 0,
+            "end": 4,
+            "range": [
+                0,
+                4
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 4
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "httpMethod",
+            "start": 5,
+            "end": 15,
+            "range": [
+                5,
+                15
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 5
+                },
+                "end": {
+                    "line": 1,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "start": 16,
+            "end": 17,
+            "range": [
+                16,
+                17
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 16
+                },
+                "end": {
+                    "line": 1,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "String",
+            "value": "'GET'",
+            "start": 18,
+            "end": 23,
+            "range": [
+                18,
+                23
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 18
+                },
+                "end": {
+                    "line": 1,
+                    "column": 23
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "|",
+            "start": 26,
+            "end": 27,
+            "range": [
+                26,
+                27
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 2
+                },
+                "end": {
+                    "line": 2,
+                    "column": 3
+                }
+            }
+        },
+        {
+            "type": "String",
+            "value": "'POST'",
+            "start": 28,
+            "end": 34,
+            "range": [
+                28,
+                34
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 4
+                },
+                "end": {
+                    "line": 2,
+                    "column": 10
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "|",
+            "start": 37,
+            "end": 38,
+            "range": [
+                37,
+                38
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 2
+                },
+                "end": {
+                    "line": 3,
+                    "column": 3
+                }
+            }
+        },
+        {
+            "type": "String",
+            "value": "'PUT'",
+            "start": 39,
+            "end": 44,
+            "range": [
+                39,
+                44
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 4
+                },
+                "end": {
+                    "line": 3,
+                    "column": 9
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "start": 44,
+            "end": 45,
+            "range": [
+                44,
+                45
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 9
+                },
+                "end": {
+                    "line": 3,
+                    "column": 10
+                }
+            }
+        }
+    ],
+    "comments": []
+});

--- a/tests/fixtures/parsers/unknown-nodes/variable-declarator-type-no-indent.js
+++ b/tests/fixtures/parsers/unknown-nodes/variable-declarator-type-no-indent.js
@@ -1,0 +1,395 @@
+"use strict";
+
+/**
+ * Source code:
+ * type httpMethod = 'GET'
+ * | 'POST'
+ * | 'PUT';
+ */
+
+
+exports.parse = () => ({
+    "type": "Program",
+    "range": [
+        0,
+        41
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 3,
+            "column": 8
+        }
+    },
+    "body": [
+        {
+            "type": "VariableDeclaration",
+            "range": [
+                0,
+                41
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 3,
+                    "column": 8
+                }
+            },
+            "kind": "type",
+            "declarations": [
+                {
+                    "type": "VariableDeclarator",
+                    "id": {
+                        "type": "Identifier",
+                        "range": [
+                            5,
+                            15
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 5
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 15
+                            }
+                        },
+                        "name": "httpMethod"
+                    },
+                    "init": {
+                        "type": "TSUnionType",
+                        "range": [
+                            18,
+                            40
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 18
+                            },
+                            "end": {
+                                "line": 3,
+                                "column": 7
+                            }
+                        },
+                        "types": [
+                            {
+                                "type": "TSLastTypeNode",
+                                "range": [
+                                    18,
+                                    23
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 18
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 23
+                                    }
+                                },
+                                "literal": {
+                                    "type": "Literal",
+                                    "range": [
+                                        18,
+                                        23
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 1,
+                                            "column": 18
+                                        },
+                                        "end": {
+                                            "line": 1,
+                                            "column": 23
+                                        }
+                                    },
+                                    "value": "GET",
+                                    "raw": "'GET'"
+                                }
+                            },
+                            {
+                                "type": "TSLastTypeNode",
+                                "range": [
+                                    26,
+                                    32
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 2,
+                                        "column": 2
+                                    },
+                                    "end": {
+                                        "line": 2,
+                                        "column": 8
+                                    }
+                                },
+                                "literal": {
+                                    "type": "Literal",
+                                    "range": [
+                                        26,
+                                        32
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 2,
+                                            "column": 2
+                                        },
+                                        "end": {
+                                            "line": 2,
+                                            "column": 8
+                                        }
+                                    },
+                                    "value": "POST",
+                                    "raw": "'POST'"
+                                }
+                            },
+                            {
+                                "type": "TSLastTypeNode",
+                                "range": [
+                                    35,
+                                    40
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 3,
+                                        "column": 2
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "column": 7
+                                    }
+                                },
+                                "literal": {
+                                    "type": "Literal",
+                                    "range": [
+                                        35,
+                                        40
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 3,
+                                            "column": 2
+                                        },
+                                        "end": {
+                                            "line": 3,
+                                            "column": 7
+                                        }
+                                    },
+                                    "value": "PUT",
+                                    "raw": "'PUT'"
+                                }
+                            }
+                        ]
+                    },
+                    "range": [
+                        5,
+                        41
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 5
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 8
+                        }
+                    }
+                }
+            ]
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Identifier",
+            "value": "type",
+            "start": 0,
+            "end": 4,
+            "range": [
+                0,
+                4
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 4
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "httpMethod",
+            "start": 5,
+            "end": 15,
+            "range": [
+                5,
+                15
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 5
+                },
+                "end": {
+                    "line": 1,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "start": 16,
+            "end": 17,
+            "range": [
+                16,
+                17
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 16
+                },
+                "end": {
+                    "line": 1,
+                    "column": 17
+                }
+            }
+        },
+        {
+            "type": "String",
+            "value": "'GET'",
+            "start": 18,
+            "end": 23,
+            "range": [
+                18,
+                23
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 18
+                },
+                "end": {
+                    "line": 1,
+                    "column": 23
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "|",
+            "start": 24,
+            "end": 25,
+            "range": [
+                24,
+                25
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 0
+                },
+                "end": {
+                    "line": 2,
+                    "column": 1
+                }
+            }
+        },
+        {
+            "type": "String",
+            "value": "'POST'",
+            "start": 26,
+            "end": 32,
+            "range": [
+                26,
+                32
+            ],
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 2
+                },
+                "end": {
+                    "line": 2,
+                    "column": 8
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "|",
+            "start": 33,
+            "end": 34,
+            "range": [
+                33,
+                34
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 0
+                },
+                "end": {
+                    "line": 3,
+                    "column": 1
+                }
+            }
+        },
+        {
+            "type": "String",
+            "value": "'PUT'",
+            "start": 35,
+            "end": 40,
+            "range": [
+                35,
+                40
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 2
+                },
+                "end": {
+                    "line": 3,
+                    "column": 7
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "start": 40,
+            "end": 41,
+            "range": [
+                40,
+                41
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 7
+                },
+                "end": {
+                    "line": 3,
+                    "column": 8
+                }
+            }
+        }
+    ],
+    "comments": []
+});

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -3205,7 +3205,6 @@ ruleTester.run("indent", rule, {
             `,
             parserOptions: { ecmaVersion: 6 }
         },
-<<<<<<< de0b4ad7bd820ade41b1f606008bea68683dc11a
         {
             code: unIndent`
                 foo
@@ -6718,7 +6717,6 @@ ruleTester.run("indent", rule, {
             `,
             errors: expectedErrors([[4, 4, 8, "Identifier"], [5, 0, 4, "Punctuator"]])
         },
-<<<<<<< de0b4ad7bd820ade41b1f606008bea68683dc11a
         {
             code: unIndent`
                 foo.

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -3364,6 +3364,40 @@ ruleTester.run("indent", rule, {
                 }
             `,
             parser: parser("unknown-nodes/abstract-class-valid")
+        },
+        {
+            code: unIndent`
+                function foo() {
+                    function bar() {
+                        abstract class X {
+                            public baz() {
+                                if (true) {
+                                    qux();
+                                }
+                            }
+                        }
+                    }
+                }
+            `,
+            parser: parser("unknown-nodes/functions-with-abstract-class-valid")
+        },
+        {
+            code: unIndent`
+                namespace Unknown {
+                    function foo() {
+                        function bar() {
+                            abstract class X {
+                                public baz() {
+                                    if (true) {
+                                        qux();
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            `,
+            parser: parser("unknown-nodes/namespace-with-functions-with-abstract-class-valid")
         }
     ],
 
@@ -6740,6 +6774,77 @@ ruleTester.run("indent", rule, {
             `,
             parser: parser("unknown-nodes/abstract-class-invalid"),
             errors: expectedErrors([[4, 12, 8, "Identifier"], [7, 12, 8, "Identifier"], [10, 8, 4, "Identifier"]])
+        },
+        {
+            code: unIndent`
+                function foo() {
+                    function bar() {
+                        abstract class X {
+                        public baz() {
+                        if (true) {
+                        qux();
+                        }
+                        }
+                        }
+                    }
+                }
+            `,
+            output: unIndent`
+                function foo() {
+                    function bar() {
+                        abstract class X {
+                        public baz() {
+                            if (true) {
+                                qux();
+                            }
+                        }
+                        }
+                    }
+                }
+            `,
+            parser: parser("unknown-nodes/functions-with-abstract-class-invalid"),
+            errors: expectedErrors([
+                [5, 12, 8, "Keyword"],
+                [6, 16, 8, "Identifier"],
+                [7, 12, 8, "Punctuator"]
+            ])
+        },
+        {
+            code: unIndent`
+                namespace Unknown {
+                    function foo() {
+                    function bar() {
+                            abstract class X {
+                                public baz() {
+                                    if (true) {
+                                    qux();
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            `,
+            output: unIndent`
+                namespace Unknown {
+                    function foo() {
+                        function bar() {
+                            abstract class X {
+                                public baz() {
+                                    if (true) {
+                                        qux();
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            `,
+            parser: parser("unknown-nodes/namespace-with-functions-with-abstract-class-invalid"),
+            errors: expectedErrors([
+                [3, 8, 4, "Keyword"],
+                [7, 24, 20, "Identifier"]
+            ])
         }
     ]
 });

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -20,6 +20,7 @@ const path = require("path");
 
 const fixture = fs.readFileSync(path.join(__dirname, "../../fixtures/rules/indent/indent-invalid-fixture-1.js"), "utf8");
 const fixedFixture = fs.readFileSync(path.join(__dirname, "../../fixtures/rules/indent/indent-valid-fixture-1.js"), "utf8");
+const parser = require("../../fixtures/fixture-parser");
 
 /**
  * Create error message object for failure cases with a single 'found' indentation type
@@ -3204,6 +3205,7 @@ ruleTester.run("indent", rule, {
             `,
             parserOptions: { ecmaVersion: 6 }
         },
+<<<<<<< de0b4ad7bd820ade41b1f606008bea68683dc11a
         {
             code: unIndent`
                 foo
@@ -3318,6 +3320,50 @@ ruleTester.run("indent", rule, {
                         .qux
                 )
             `
+        },
+
+        //----------------------------------------------------------------------
+        // Ignore Unknown Nodes
+        //----------------------------------------------------------------------
+
+        {
+            code: unIndent`
+                interface Foo {
+                    bar: string;
+                    baz: number;
+                }
+            `,
+            parser: parser("unknown-nodes/interface")
+        },
+        {
+            code: unIndent`
+                namespace Foo {
+                    const bar = 3,
+                        baz = 2;
+
+                    if (true) {
+                        const bax = 3;
+                    }
+                }
+            `,
+            parser: parser("unknown-nodes/namespace-valid")
+        },
+        {
+            code: unIndent`
+                abstract class Foo {
+                    public bar() {
+                        let aaa = 4,
+                            boo;
+
+                        if (true) {
+                            boo = 3;
+                        }
+
+                        boo = 3 + 2;
+                    }
+                }
+            `,
+            parser: parser("unknown-nodes/abstract-class-valid")
         }
     ],
 
@@ -6620,6 +6666,7 @@ ruleTester.run("indent", rule, {
             `,
             errors: expectedErrors([[4, 4, 8, "Identifier"], [5, 0, 4, "Punctuator"]])
         },
+<<<<<<< de0b4ad7bd820ade41b1f606008bea68683dc11a
         {
             code: unIndent`
                 foo.
@@ -6632,6 +6679,67 @@ ruleTester.run("indent", rule, {
                     baz
             `,
             errors: expectedErrors([[2, 4, 2, "Identifier"], [3, 4, 6, "Identifier"]])
+        },
+
+        //----------------------------------------------------------------------
+        // Ignore Unknown Nodes
+        //----------------------------------------------------------------------
+
+        {
+            code: unIndent`
+                namespace Foo {
+                    const bar = 3,
+                    baz = 2;
+
+                    if (true) {
+                    const bax = 3;
+                    }
+                }
+            `,
+            output: unIndent`
+                namespace Foo {
+                    const bar = 3,
+                        baz = 2;
+
+                    if (true) {
+                        const bax = 3;
+                    }
+                }
+            `,
+            parser: parser("unknown-nodes/namespace-invalid"),
+            errors: expectedErrors([[3, 8, 4, "Identifier"], [6, 8, 4, "Keyword"]])
+        },
+        {
+            code: unIndent`
+                abstract class Foo {
+                    public bar() {
+                        let aaa = 4,
+                        boo;
+
+                        if (true) {
+                        boo = 3;
+                        }
+
+                    boo = 3 + 2;
+                    }
+                }
+            `,
+            output: unIndent`
+                abstract class Foo {
+                    public bar() {
+                        let aaa = 4,
+                            boo;
+
+                        if (true) {
+                            boo = 3;
+                        }
+
+                        boo = 3 + 2;
+                    }
+                }
+            `,
+            parser: parser("unknown-nodes/abstract-class-invalid"),
+            errors: expectedErrors([[4, 12, 8, "Identifier"], [7, 12, 8, "Identifier"], [10, 8, 4, "Identifier"]])
         }
     ]
 });

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -3398,6 +3398,24 @@ ruleTester.run("indent", rule, {
                 }
             `,
             parser: parser("unknown-nodes/namespace-with-functions-with-abstract-class-valid")
+        },
+        {
+            code: unIndent`
+              type httpMethod = 'GET'
+                | 'POST'
+                | 'PUT';
+            `,
+            options: [2, { VariableDeclarator: 0 }],
+            parser: parser("unknown-nodes/variable-declarator-type-indent-two-spaces")
+        },
+        {
+            code: unIndent`
+              type httpMethod = 'GET'
+              | 'POST'
+              | 'PUT';
+            `,
+            options: [2, { VariableDeclarator: 1 }],
+            parser: parser("unknown-nodes/variable-declarator-type-no-indent")
         }
     ],
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**
[ X ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Created a new function that is run after program exit. It traverses the entire AST searching for unknown nodes. If an unknown node exists it will ignore the first token of each line within the node. If the token has a dependency, used to calculate its offset, then we find the last dependency and set it's offset to match that of the first token on its line.


**Is there anything you'd like reviewers to focus on?**
This is my first attempt at a solution. There might be a cleaner one or more efficient one. I tried to keep it simple and readable. Not sure how we can avoid traversing the entire AST again. Maybe if we had a mapping for token to node that might work better. 

Is there any cases I missed of a token having an offset that this change will now ignore? I think by ensuring we do not ignore tokens that have dependencies should cover every case.

Is it safe to match the offset of the last dependency to that of the first token of the line. I assume it should be OK since that token will be ignored, since it should lie within the unknown node.

