### PR TITLE
Breaking: Add .jsx to the default --ext file extensions (fixes #8399)

### DIFF
--- a/conf/default-cli-options.js
+++ b/conf/default-cli-options.js
@@ -12,7 +12,7 @@ module.exports = {
     useEslintrc: true,
     envs: [],
     globals: [],
-    extensions: [".js"],
+    extensions: [".js", ".jsx"],
     ignore: true,
     ignorePath: null,
     cache: false,

--- a/docs/user-guide/command-line-interface.md
+++ b/docs/user-guide/command-line-interface.md
@@ -33,7 +33,7 @@ Basic configuration:
   -c, --config path::String    Use configuration from this file or shareable config
   --no-eslintrc                Disable use of configuration from .eslintrc
   --env [String]               Specify environments
-  --ext [String]               Specify JavaScript file extensions - default: .js
+  --ext [String]               Specify JavaScript file extensions - default: .js,.jsx
   --global [String]            Define global variables
   --parser String              Specify the parser to be used
   --parser-options Object      Specify parser options

--- a/docs/user-guide/migrating-to-4.0.0.md
+++ b/docs/user-guide/migrating-to-4.0.0.md
@@ -14,6 +14,7 @@ The lists below are ordered roughly by the number of users each change is expect
 1. [The `space-before-function-paren` rule is more strict by default](#space-before-function-paren-defaults)
 1. [The `no-multi-spaces` rule is more strict by default](#no-multi-spaces-eol-comments)
 1. [References to scoped plugins in config files are now required to include the scope](#scoped-plugin-resolution)
+1. [The `--ext` file extensions default now includes `.jsx`](#file-extensions-default)
 
 ### Breaking changes for plugin/custom rule developers
 
@@ -152,6 +153,12 @@ To avoid this ambiguity, in 4.0 references to scoped plugins must include the sc
 ```
 
 **To address:** If you reference a scoped NPM package as a plugin in a config file, be sure to include the scope wherever you reference it.
+
+## <a name="file-extensions-default"/> The `--ext` file extensions default now includes `.jsx`
+
+The CLI now defaults to including files with the extension `.jsx` in addition to `.js`.
+
+**To address:** To restore the 3.x behaviour, pass `--ext .js` on the command line. Alternatively, add `*.jsx` to `.eslintignore` to suppress any new lint errors.
 
 ---
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -46,7 +46,7 @@ module.exports = optionator({
         {
             option: "ext",
             type: "[String]",
-            default: ".js",
+            default: ".js,.jsx",
             description: "Specify JavaScript file extensions"
         },
         {

--- a/tests/fixtures/.eslintignore
+++ b/tests/fixtures/.eslintignore
@@ -1,2 +1,3 @@
 *.json
 *.js
+*.jsx

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -2794,9 +2794,9 @@ describe("CLIEngine", () => {
     describe("resolveFileGlobPatterns", () => {
 
         leche.withData([
-            [".", "**/*.js"],
-            ["./", "**/*.js"],
-            ["../", "../**/*.js"]
+            [".", "**/*.{js,jsx}"],
+            ["./", "**/*.{js,jsx}"],
+            ["../", "../**/*.{js,jsx}"]
         ], (input, expected) => {
 
             it(`should correctly resolve ${input} to ${expected}`, () => {

--- a/tests/lib/options.js
+++ b/tests/lib/options.js
@@ -82,12 +82,13 @@ describe("options", () => {
             assert.equal(currentOptions.ext[1], ".js");
         });
 
-        it("should return an array one item when not passed", () => {
+        it("should return an array with two items when not passed", () => {
             const currentOptions = options.parse("");
 
             assert.isArray(currentOptions.ext);
-            assert.equal(currentOptions.ext.length, 1);
+            assert.equal(currentOptions.ext.length, 2);
             assert.equal(currentOptions.ext[0], ".js");
+            assert.equal(currentOptions.ext[1], ".jsx");
         });
     });
 

--- a/tests/lib/options.js
+++ b/tests/lib/options.js
@@ -60,6 +60,7 @@ describe("options", () => {
             const currentOptions = options.parse("--ext .jsx");
 
             assert.isArray(currentOptions.ext);
+            assert.equal(currentOptions.ext.length, 1);
             assert.equal(currentOptions.ext[0], ".jsx");
         });
 
@@ -67,6 +68,7 @@ describe("options", () => {
             const currentOptions = options.parse("--ext .jsx --ext .js");
 
             assert.isArray(currentOptions.ext);
+            assert.equal(currentOptions.ext.length, 2);
             assert.equal(currentOptions.ext[0], ".jsx");
             assert.equal(currentOptions.ext[1], ".js");
         });
@@ -75,6 +77,7 @@ describe("options", () => {
             const currentOptions = options.parse("--ext .jsx,.js");
 
             assert.isArray(currentOptions.ext);
+            assert.equal(currentOptions.ext.length, 2);
             assert.equal(currentOptions.ext[0], ".jsx");
             assert.equal(currentOptions.ext[1], ".js");
         });
@@ -83,6 +86,7 @@ describe("options", () => {
             const currentOptions = options.parse("");
 
             assert.isArray(currentOptions.ext);
+            assert.equal(currentOptions.ext.length, 1);
             assert.equal(currentOptions.ext[0], ".js");
         });
     });

--- a/tests/lib/util/source-code-util.js
+++ b/tests/lib/util/source-code-util.js
@@ -146,7 +146,7 @@ describe("SourceCodeUtil", () => {
 
             getSourceCodeOfFiles(filename);
             assert(spy.called);
-            assert.deepEqual(spy.firstCall.args[1].extensions, [".js"]);
+            assert.deepEqual(spy.firstCall.args[1].extensions, [".js", ".jsx"]);
         });
 
         it("should create an object with located filenames as keys", () => {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**
[X] Other, please explain:
Change default value for existing CLI option.

**What changes did you make? (Give an overview)**
The default file extensions list used by the CLI has been updated to now include `.jsx` in addition to the existing `.js` entry.

This is necessary since:
* file traversal occurs before `.eslintrc` is read, so file extensions cannot be specified via the config file, only on the command line (see #3469)
* specifying via the command line is a pain/error prone when invoking eslint by hand (not everyone uses package.json scripts)
* even for people who do use wrapper/package.json scripts, it's not obvious that JSX files aren't included by default and can lead to JSX files being inadvertently omitted from eg the CI run (as happened in our team's project recently)

The change is breaking in that there might be users who unknowingly have lint errors in their `.jsx` files due to not realising ESLint didn't include them by default previously. They can either:
* fix the lint errors in their JSX files (and will probably be glad this pointed them out)
* revert to the previous default, by passing `--ext .js` on the command line
* add `*.jsx` to `.eslintignore`

Fixes #8399.