### PR TITLE
Chore: enable no-negated-condition on ESLint codebase

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -809,16 +809,16 @@ target.checkRuleFiles = function() {
         }
 
         // check for docs
-        if (!test("-f", docFilename)) {
-            console.error("Missing documentation for rule %s", basename);
-            errors++;
-        } else {
+        if (test("-f", docFilename)) {
 
             // check for proper doc format
             if (!hasIdInTitle(basename)) {
                 console.error("Missing id in the doc page's title of rule %s", basename);
                 errors++;
             }
+        } else {
+            console.error("Missing documentation for rule %s", basename);
+            errors++;
         }
 
         // check for recommended configuration

--- a/lib/code-path-analysis/code-path-segment.js
+++ b/lib/code-path-analysis/code-path-segment.js
@@ -34,7 +34,10 @@ function flattenUnusedSegments(segments) {
         }
 
         // Use previous segments if unused.
-        if (!segment.internal.used) {
+        if (segment.internal.used) {
+            done[segment.id] = true;
+            retv.push(segment);
+        } else {
             for (let j = 0; j < segment.allPrevSegments.length; ++j) {
                 const prevSegment = segment.allPrevSegments[j];
 
@@ -43,9 +46,6 @@ function flattenUnusedSegments(segments) {
                     retv.push(prevSegment);
                 }
             }
-        } else {
-            done[segment.id] = true;
-            retv.push(segment);
         }
     }
 

--- a/lib/code-path-analysis/code-path-state.js
+++ b/lib/code-path-analysis/code-path-state.js
@@ -407,15 +407,7 @@ class CodePathState {
                 break;
 
             case "test":
-                if (!context.processed) {
-
-                    /*
-                     * The head segments are the path of the `if` block here.
-                     * Updates the `true` path with the end of the `if` block.
-                     */
-                    context.trueForkContext.clear();
-                    context.trueForkContext.add(headSegments);
-                } else {
+                if (context.processed) {
 
                     /*
                      * The head segments are the path of the `else` block here.
@@ -424,6 +416,14 @@ class CodePathState {
                      */
                     context.falseForkContext.clear();
                     context.falseForkContext.add(headSegments);
+                } else {
+
+                    /*
+                     * The head segments are the path of the `if` block here.
+                     * Updates the `true` path with the end of the `if` block.
+                     */
+                    context.trueForkContext.clear();
+                    context.trueForkContext.add(headSegments);
                 }
 
                 break;

--- a/lib/code-path-analysis/debug-helpers.js
+++ b/lib/code-path-analysis/debug-helpers.js
@@ -53,7 +53,7 @@ module.exports = {
      * @param {boolean} leaving - A flag whether or not it's leaving
      * @returns {void}
      */
-    dumpState: !debug.enabled ? debug : /* istanbul ignore next */ function(node, state, leaving) {
+    dumpState: debug.enabled ? /* istanbul ignore next */ function(node, state, leaving) {
         for (let i = 0; i < state.currentSegments.length; ++i) {
             const segInternal = state.currentSegments[i].internal;
 
@@ -68,7 +68,7 @@ module.exports = {
             `${state.currentSegments.map(getId).join(",")})`,
             `${node.type}${leaving ? ":exit" : ""}`
         ].join(" "));
-    },
+    } : debug,
 
     /**
      * Dumps a DOT code of a given code path.
@@ -79,7 +79,7 @@ module.exports = {
      * @see http://www.graphviz.org
      * @see http://www.webgraphviz.com
      */
-    dumpDot: !debug.enabled ? debug : /* istanbul ignore next */ function(codePath) {
+    dumpDot: debug.enabled ? /* istanbul ignore next */ function(codePath) {
         let text =
             "\n" +
             "digraph {\n" +
@@ -134,7 +134,7 @@ module.exports = {
         text += `${arrows}\n`;
         text += "}";
         debug("DOT", text);
-    },
+    } : debug,
 
     /**
      * Makes a DOT code of a given code path.

--- a/lib/config/config-initializer.js
+++ b/lib/config/config-initializer.js
@@ -163,7 +163,7 @@ function configureRules(answers, config) {
     Object.keys(failingRegistry.rules).forEach(ruleId => {
 
         // If the rule is recommended, set it to error, otherwise disable it
-        disabledConfigs[ruleId] = (recRules.indexOf(ruleId) !== -1) ? 2 : 0;
+        disabledConfigs[ruleId] = (recRules.indexOf(ruleId) === -1) ? 0 : 2;
     });
 
     // Now that we know which rules to disable, strip out configs with errors

--- a/lib/config/config-ops.js
+++ b/lib/config/config-ops.js
@@ -158,12 +158,12 @@ module.exports = {
                         dst[i] = deepmerge(target[i], e, combine, isRule);
                     }
                 } else {
-                    if (!combine) {
-                        dst[i] = e;
-                    } else {
+                    if (combine) {
                         if (dst.indexOf(e) === -1) {
                             dst.push(e);
                         }
+                    } else {
+                        dst[i] = e;
                     }
                 }
             });

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -787,7 +787,10 @@ module.exports = (function() {
         config = prepareConfig(config);
 
         // only do this for text
-        if (text !== null) {
+        if (text === null) {
+            sourceCode = textOrSourceCode;
+            ast = sourceCode.ast;
+        } else {
 
             // there's no input, just exit here
             if (text.trim().length === 0) {
@@ -813,9 +816,6 @@ module.exports = (function() {
                 sourceCode = new SourceCode(text, ast);
             }
 
-        } else {
-            sourceCode = textOrSourceCode;
-            ast = sourceCode.ast;
         }
 
         // if espree failed to parse the file, there's no sense in setting up rules

--- a/lib/formatters/compact.js
+++ b/lib/formatters/compact.js
@@ -53,7 +53,7 @@ module.exports = function(results) {
     });
 
     if (total > 0) {
-        output += `\n${total} problem${total !== 1 ? "s" : ""}`;
+        output += `\n${total} problem${total === 1 ? "" : "s"}`;
     }
 
     return output;

--- a/lib/formatters/unix.js
+++ b/lib/formatters/unix.js
@@ -51,7 +51,7 @@ module.exports = function(results) {
     });
 
     if (total > 0) {
-        output += `\n${total} problem${total !== 1 ? "s" : ""}`;
+        output += `\n${total} problem${total === 1 ? "" : "s"}`;
     }
 
     return output;

--- a/lib/formatters/visualstudio.js
+++ b/lib/formatters/visualstudio.js
@@ -56,7 +56,7 @@ module.exports = function(results) {
     if (total === 0) {
         output += "no problems";
     } else {
-        output += `\n${total} problem${total !== 1 ? "s" : ""}`;
+        output += `\n${total} problem${total === 1 ? "" : "s"}`;
     }
 
     return output;

--- a/lib/load-rules.js
+++ b/lib/load-rules.js
@@ -23,10 +23,10 @@ const fs = require("fs"),
  * @returns {Object} Loaded rule modules by rule ids (file names).
  */
 module.exports = function(rulesDir, cwd) {
-    if (!rulesDir) {
-        rulesDir = path.join(__dirname, "rules");
-    } else {
+    if (rulesDir) {
         rulesDir = path.resolve(cwd, rulesDir);
+    } else {
+        rulesDir = path.join(__dirname, "rules");
     }
 
     const rules = Object.create(null);

--- a/lib/rules/constructor-super.js
+++ b/lib/rules/constructor-super.js
@@ -327,13 +327,13 @@ module.exports = {
                                 message: "Unexpected duplicate 'super()'.",
                                 node
                             });
-                        } else if (!funcInfo.superIsConstructor) {
+                        } else if (funcInfo.superIsConstructor) {
+                            info.validNodes.push(node);
+                        } else {
                             context.report({
                                 message: "Unexpected 'super()' because 'super' is not a constructor.",
                                 node
                             });
-                        } else {
-                            info.validNodes.push(node);
                         }
                     }
                 } else if (funcInfo.codePath.currentSegments.some(isReachable)) {

--- a/lib/rules/curly.js
+++ b/lib/rules/curly.js
@@ -153,7 +153,7 @@ module.exports = {
         function reportExpectedBraceError(node, bodyNode, name, suffix) {
             context.report({
                 node,
-                loc: (name !== "else" ? node : getElseKeyword(node)).loc.start,
+                loc: (name === "else" ? getElseKeyword(node) : node).loc.start,
                 message: "Expected { after '{{name}}'{{suffix}}.",
                 data: {
                     name,
@@ -227,7 +227,7 @@ module.exports = {
         function reportUnnecessaryBraceError(node, bodyNode, name, suffix) {
             context.report({
                 node,
-                loc: (name !== "else" ? node : getElseKeyword(node)).loc.start,
+                loc: (name === "else" ? getElseKeyword(node) : node).loc.start,
                 message: "Unnecessary { after '{{name}}'{{suffix}}.",
                 data: {
                     name,

--- a/lib/rules/id-length.js
+++ b/lib/rules/id-length.js
@@ -46,8 +46,8 @@ module.exports = {
 
     create(context) {
         const options = context.options[0] || {};
-        const minLength = typeof options.min !== "undefined" ? options.min : 2;
-        const maxLength = typeof options.max !== "undefined" ? options.max : Infinity;
+        const minLength = typeof options.min === "undefined" ? 2 : options.min;
+        const maxLength = typeof options.max === "undefined" ? Infinity : options.max;
         const properties = options.properties !== "never";
         const exceptions = (options.exceptions ? options.exceptions : [])
             .reduce((obj, item) => {

--- a/lib/rules/key-spacing.js
+++ b/lib/rules/key-spacing.js
@@ -52,17 +52,17 @@ function initOptionProperty(toOptions, fromOptions) {
     toOptions.mode = fromOptions.mode || "strict";
 
     // Set value of beforeColon
-    if (typeof fromOptions.beforeColon !== "undefined") {
-        toOptions.beforeColon = +fromOptions.beforeColon;
-    } else {
+    if (typeof fromOptions.beforeColon === "undefined") {
         toOptions.beforeColon = 0;
+    } else {
+        toOptions.beforeColon = +fromOptions.beforeColon;
     }
 
     // Set value of afterColon
-    if (typeof fromOptions.afterColon !== "undefined") {
-        toOptions.afterColon = +fromOptions.afterColon;
-    } else {
+    if (typeof fromOptions.afterColon === "undefined") {
         toOptions.afterColon = 1;
+    } else {
+        toOptions.afterColon = +fromOptions.afterColon;
     }
 
     // Set align if exists

--- a/lib/rules/lines-around-comment.js
+++ b/lib/rules/lines-around-comment.js
@@ -117,7 +117,7 @@ module.exports = {
 
         options.beforeLineComment = options.beforeLineComment || false;
         options.afterLineComment = options.afterLineComment || false;
-        options.beforeBlockComment = typeof options.beforeBlockComment !== "undefined" ? options.beforeBlockComment : true;
+        options.beforeBlockComment = typeof options.beforeBlockComment === "undefined" || options.beforeBlockComment;
         options.afterBlockComment = options.afterBlockComment || false;
         options.allowBlockStart = options.allowBlockStart || false;
         options.allowBlockEnd = options.allowBlockEnd || false;

--- a/lib/rules/max-statements-per-line.js
+++ b/lib/rules/max-statements-per-line.js
@@ -40,7 +40,7 @@ module.exports = {
 
         const sourceCode = context.getSourceCode(),
             options = context.options[0] || {},
-            maxStatementsPerLine = typeof options.max !== "undefined" ? options.max : 1,
+            maxStatementsPerLine = typeof options.max === "undefined" ? 1 : options.max,
             message = "This line has {{numberOfStatementsOnThisLine}} {{statements}}. Maximum allowed is {{maxStatementsPerLine}}.";
 
         let lastStatementLine = 0,

--- a/lib/rules/multiline-ternary.js
+++ b/lib/rules/multiline-ternary.js
@@ -60,21 +60,21 @@ module.exports = {
                 const areTestAndConsequentOnSameLine = astUtils.isTokenOnSameLine(node.test, node.consequent);
                 const areConsequentAndAlternateOnSameLine = astUtils.isTokenOnSameLine(node.consequent, node.alternate);
 
-                if (!multiline) {
-                    if (!areTestAndConsequentOnSameLine) {
-                        reportError(node.test, node, false);
-                    }
-
-                    if (!areConsequentAndAlternateOnSameLine) {
-                        reportError(node.consequent, node, false);
-                    }
-                } else {
+                if (multiline) {
                     if (areTestAndConsequentOnSameLine) {
                         reportError(node.test, node, true);
                     }
 
                     if (areConsequentAndAlternateOnSameLine) {
                         reportError(node.consequent, node, true);
+                    }
+                } else {
+                    if (!areTestAndConsequentOnSameLine) {
+                        reportError(node.test, node, false);
+                    }
+
+                    if (!areConsequentAndAlternateOnSameLine) {
+                        reportError(node.consequent, node, false);
                     }
                 }
             }

--- a/lib/rules/no-mixed-operators.js
+++ b/lib/rules/no-mixed-operators.js
@@ -163,7 +163,7 @@ module.exports = {
         function reportBothOperators(node) {
             const parent = node.parent;
             const left = (parent.left === node) ? node : parent;
-            const right = (parent.left !== node) ? node : parent;
+            const right = (parent.left === node) ? parent : node;
             const message =
                 "Unexpected mix of '{{leftOperator}}' and '{{rightOperator}}'.";
             const data = {

--- a/lib/rules/no-multiple-empty-lines.js
+++ b/lib/rules/no-multiple-empty-lines.js
@@ -51,8 +51,8 @@ module.exports = {
 
         if (context.options.length) {
             max = context.options[0].max;
-            maxEOF = typeof context.options[0].maxEOF !== "undefined" ? context.options[0].maxEOF : max;
-            maxBOF = typeof context.options[0].maxBOF !== "undefined" ? context.options[0].maxBOF : max;
+            maxEOF = typeof context.options[0].maxEOF === "undefined" ? max : context.options[0].maxEOF;
+            maxBOF = typeof context.options[0].maxBOF === "undefined" ? max : context.options[0].maxBOF;
         }
 
         const sourceCode = context.getSourceCode();

--- a/lib/rules/no-underscore-dangle.js
+++ b/lib/rules/no-underscore-dangle.js
@@ -43,8 +43,8 @@ module.exports = {
 
         const options = context.options[0] || {};
         const ALLOWED_VARIABLES = options.allow ? options.allow : [];
-        const allowAfterThis = typeof options.allowAfterThis !== "undefined" ? options.allowAfterThis : false;
-        const allowAfterSuper = typeof options.allowAfterSuper !== "undefined" ? options.allowAfterSuper : false;
+        const allowAfterThis = typeof options.allowAfterThis !== "undefined" && options.allowAfterThis;
+        const allowAfterSuper = typeof options.allowAfterSuper !== "undefined" && options.allowAfterSuper;
 
         //-------------------------------------------------------------------------
         // Helpers

--- a/lib/rules/operator-assignment.js
+++ b/lib/rules/operator-assignment.js
@@ -199,7 +199,7 @@ module.exports = {
         }
 
         return {
-            AssignmentExpression: context.options[0] !== "never" ? verify : prohibit
+            AssignmentExpression: context.options[0] === "never" ? prohibit : verify
         };
 
     }

--- a/lib/rules/semi.js
+++ b/lib/rules/semi.js
@@ -82,13 +82,7 @@ module.exports = {
                 fix,
                 loc = lastToken.loc;
 
-            if (!missing) {
-                message = "Missing semicolon.";
-                loc = loc.end;
-                fix = function(fixer) {
-                    return fixer.insertTextAfter(lastToken, ";");
-                };
-            } else {
+            if (missing) {
                 message = "Extra semicolon.";
                 loc = loc.start;
                 fix = function(fixer) {
@@ -99,6 +93,12 @@ module.exports = {
                     return new FixTracker(fixer, sourceCode)
                         .retainSurroundingTokens(lastToken)
                         .remove(lastToken);
+                };
+            } else {
+                message = "Missing semicolon.";
+                loc = loc.end;
+                fix = function(fixer) {
+                    return fixer.insertTextAfter(lastToken, ";");
                 };
             }
 
@@ -168,13 +168,13 @@ module.exports = {
                     report(node, true);
                 }
             } else {
-                if (!astUtils.isSemicolonToken(lastToken)) {
-                    if (!exceptOneLine || !isOneLinerBlock(node)) {
-                        report(node);
-                    }
-                } else {
+                if (astUtils.isSemicolonToken(lastToken)) {
                     if (exceptOneLine && isOneLinerBlock(node)) {
                         report(node, true);
+                    }
+                } else {
+                    if (!exceptOneLine || !isOneLinerBlock(node)) {
+                        report(node);
                     }
                 }
             }

--- a/lib/rules/sort-imports.js
+++ b/lib/rules/sort-imports.js
@@ -114,7 +114,17 @@ module.exports = {
                     // When the current declaration uses a different member syntax,
                     // then check if the ordering is correct.
                     // Otherwise, make a default string compare (like rule sort-vars to be consistent) of the first used local member name.
-                    if (currentMemberSyntaxGroupIndex !== previousMemberSyntaxGroupIndex) {
+                    if (currentMemberSyntaxGroupIndex === previousMemberSyntaxGroupIndex) {
+                        if (previousLocalMemberName &&
+                            currentLocalMemberName &&
+                            currentLocalMemberName < previousLocalMemberName
+                        ) {
+                            context.report({
+                                node,
+                                message: "Imports should be sorted alphabetically."
+                            });
+                        }
+                    } else {
                         if (currentMemberSyntaxGroupIndex < previousMemberSyntaxGroupIndex) {
                             context.report({
                                 node,
@@ -123,16 +133,6 @@ module.exports = {
                                     syntaxA: memberSyntaxSortOrder[currentMemberSyntaxGroupIndex],
                                     syntaxB: memberSyntaxSortOrder[previousMemberSyntaxGroupIndex]
                                 }
-                            });
-                        }
-                    } else {
-                        if (previousLocalMemberName &&
-                            currentLocalMemberName &&
-                            currentLocalMemberName < previousLocalMemberName
-                        ) {
-                            context.report({
-                                node,
-                                message: "Imports should be sorted alphabetically."
                             });
                         }
                     }

--- a/lib/rules/spaced-comment.js
+++ b/lib/rules/spaced-comment.js
@@ -351,10 +351,10 @@ module.exports = {
                 }
             } else {
                 if (beginMatch) {
-                    if (!beginMatch[1]) {
-                        reportBegin(node, "Unexpected space or tab after '{{refChar}}' in comment.", beginMatch, commentIdentifier);
-                    } else {
+                    if (beginMatch[1]) {
                         reportBegin(node, "Unexpected space or tab after marker ({{refChar}}) in comment.", beginMatch, beginMatch[1]);
+                    } else {
+                        reportBegin(node, "Unexpected space or tab after '{{refChar}}' in comment.", beginMatch, commentIdentifier);
                     }
                 }
 

--- a/packages/eslint-config-eslint/default.yml
+++ b/packages/eslint-config-eslint/default.yml
@@ -62,6 +62,7 @@ rules:
     no-multi-spaces: "error"
     no-multi-str: "error"
     no-native-reassign: "off"
+    no-negated-condition: "error"
     no-nested-ternary: "error"
     no-new: "error"
     no-new-func: "error"


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This enables the no-negated-condition rule on the ESLint codebase, and fixes existing linting errors.

Refs: https://github.com/eslint/eslint/pull/8504#discussion_r114015143

**Is there anything you'd like reviewers to focus on?**

The `no-negated-condition` rule doesn't have an autofixer, so these changes were made manually. It would be good to make sure I didn't mess anything up while copy-pasting.
