### PR TITLE
Update default.yml, turn off comma-dangle

### DIFF
--- a/packages/eslint-config-eslint/default.yml
+++ b/packages/eslint-config-eslint/default.yml
@@ -13,6 +13,7 @@ rules:
     camelcase: ["error", { properties: "never" }]
     callback-return: ["error", ["cb", "callback", "next"]]
     class-methods-use-this: "error"
+    comma-dangle: "off"
     comma-spacing: "error"
     comma-style: ["error", "last"]
     consistent-return: "error"

--- a/packages/eslint-config-eslint/default.yml
+++ b/packages/eslint-config-eslint/default.yml
@@ -13,7 +13,6 @@ rules:
     camelcase: ["error", { properties: "never" }]
     callback-return: ["error", ["cb", "callback", "next"]]
     class-methods-use-this: "error"
-    comma-dangle: "error"
     comma-spacing: "error"
     comma-style: ["error", "last"]
     consistent-return: "error"


### PR DESCRIPTION
**What changes did you make? (Give an overview)**
turn off the rule comma-dangle.

**What is the purpose of this pull request?**
>Trailing commas simplify adding and removing items to objects and arrays, since only the lines you are modifying must be touched. Another argument in favor of trailing commas is that it improves the clarity of diffs when an item is added or removed from an object or array:
```js
//Less clear:
 var foo = {
-    bar: "baz",
-    qux: "quux"
+    bar: "baz"
 };
//More clear:
 var foo = {
     bar: "baz",
-    qux: "quux",
 };
```
I think the rule is mainly for IE8 and below, for it will throw an error when it encounters trailing commas in JavaScript. But ESLint not run on it, so it's better to turn this rule off.
