### PR TITLE
Upgrade: espree@^3.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "debug": "^2.6.3",
     "doctrine": "^2.0.0",
     "eslint-scope": "^3.6.0",
-    "espree": "^3.4.0",
+    "espree": "^3.4.2",
     "esquery": "^1.0.0",
     "estraverse": "^4.2.0",
     "esutils": "^2.0.2",


### PR DESCRIPTION
Since I had espree@>=3.4.0 <3.4.2 on my system, `npm install` never updated the package. With ESLint freezing the parser options/config object, seems we are relying on 3.4.2's bugfix not to set ecmaFeatures.impliedStrict. So this dependency really should be at 3.4.2.

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain: Upgrade espree since we are depending on a particular bugfix, see above.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Upgrade espree to 3.4.2. Rationale is above.

**Is there anything you'd like reviewers to focus on?**
Not really.