### PR TITLE
Update: no-extend-native checks global scope refs only (fixes #8461)

### DIFF
--- a/lib/rules/no-extend-native.js
+++ b/lib/rules/no-extend-native.js
@@ -74,44 +74,6 @@ module.exports = {
         }
 
         /**
-         * Checks that an identifier is an object of a prototype whose member
-         * is being assigned in an AssignmentExpression.
-         * Example: Object.prototype.foo = "bar"
-         * @param {ASTNode} identifierNode The identifier to check.
-         * @returns {boolean} True if the identifier's prototype is modified.
-         */
-        function isInPrototypePropertyAssignment(identifierNode) {
-            return Boolean(
-                identifierNode.parent.type === "MemberExpression" &&
-                identifierNode.parent.parent.type === "MemberExpression" &&
-                identifierNode.parent.parent.parent.type === "AssignmentExpression" &&
-                identifierNode.parent.parent.parent.left === identifierNode.parent.parent
-            );
-        }
-
-        /**
-         * Checks that an identifier is an object of a prototype whose member
-         * is being extended via the Object.defineProperty() or
-         * Object.defineProperties() methods.
-         * Example: Object.defineProperty(Array.prototype, "foo", ...)
-         * Example: Object.defineProperties(Array.prototype, ...)
-         * @param {ASTNode} identifierNode The identifier to check.
-         * @returns {boolean} True if the identifier's prototype is modified.
-         */
-        function isInDefinePropertyCall(identifierNode) {
-            return Boolean(
-                identifierNode.parent.type === "MemberExpression" &&
-                identifierNode.parent.parent.type === "CallExpression" &&
-                identifierNode.parent.parent.arguments[0] === identifierNode.parent &&
-                identifierNode.parent.parent.callee.type === "MemberExpression" &&
-                identifierNode.parent.parent.callee.object.type === "Identifier" &&
-                identifierNode.parent.parent.callee.object.name === "Object" &&
-                identifierNode.parent.parent.callee.property.type === "Identifier" &&
-                propertyDefinitionMethods.has(identifierNode.parent.parent.callee.property.name)
-            );
-        }
-
-        /**
          * Check to see if the `prototype` property of the given object
          * identifier node is being accessed.
          * @param {ASTNode} identifierNode The Identifier representing the object
@@ -131,6 +93,44 @@ module.exports = {
         }
 
         /**
+         * Checks that an identifier is an object of a prototype whose member
+         * is being assigned in an AssignmentExpression.
+         * Example: Object.prototype.foo = "bar"
+         * @param {ASTNode} identifierNode The identifier to check.
+         * @returns {boolean} True if the identifier's prototype is modified.
+         */
+        function isInPrototypePropertyAssignment(identifierNode) {
+            return Boolean(
+                isPrototypePropertyAccessed(identifierNode) &&
+                identifierNode.parent.parent.type === "MemberExpression" &&
+                identifierNode.parent.parent.parent.type === "AssignmentExpression" &&
+                identifierNode.parent.parent.parent.left === identifierNode.parent.parent
+            );
+        }
+
+        /**
+         * Checks that an identifier is an object of a prototype whose member
+         * is being extended via the Object.defineProperty() or
+         * Object.defineProperties() methods.
+         * Example: Object.defineProperty(Array.prototype, "foo", ...)
+         * Example: Object.defineProperties(Array.prototype, ...)
+         * @param {ASTNode} identifierNode The identifier to check.
+         * @returns {boolean} True if the identifier's prototype is modified.
+         */
+        function isInDefinePropertyCall(identifierNode) {
+            return Boolean(
+                isPrototypePropertyAccessed(identifierNode) &&
+                identifierNode.parent.parent.type === "CallExpression" &&
+                identifierNode.parent.parent.arguments[0] === identifierNode.parent &&
+                identifierNode.parent.parent.callee.type === "MemberExpression" &&
+                identifierNode.parent.parent.callee.object.type === "Identifier" &&
+                identifierNode.parent.parent.callee.object.name === "Object" &&
+                identifierNode.parent.parent.callee.property.type === "Identifier" &&
+                propertyDefinitionMethods.has(identifierNode.parent.parent.callee.property.name)
+            );
+        }
+
+        /**
          * Check to see if object prototype access is part of a prototype
          * extension. There are three ways a prototype can be extended:
          * 1. Assignment to prototype property (Object.prototype.foo = 1)
@@ -142,10 +142,6 @@ module.exports = {
          * @returns {void}
          */
         function checkAndReportPrototypeExtension(identifierNode) {
-            if (!isPrototypePropertyAccessed(identifierNode)) {
-                return;
-            }
-
             if (isInPrototypePropertyAssignment(identifierNode)) {
 
                 // Identifier --> MemberExpression --> MemberExpression --> AssignmentExpression

--- a/lib/rules/no-extend-native.js
+++ b/lib/rules/no-extend-native.js
@@ -9,7 +9,14 @@
 // Requirements
 //------------------------------------------------------------------------------
 
+const astUtils = require("../ast-utils");
 const globals = require("globals");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+const propertyDefinitionMethods = new Set(["defineProperty", "defineProperties"]);
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -43,73 +50,127 @@ module.exports = {
     create(context) {
 
         const config = context.options[0] || {};
-        const exceptions = config.exceptions || [];
-        let modifiedBuiltins = Object.keys(globals.builtin).filter(builtin => builtin[0].toUpperCase() === builtin[0]);
+        const exceptions = new Set(config.exceptions || []);
+        const modifiedBuiltins = new Set(
+            Object.keys(globals.builtin)
+                .filter(builtin => builtin[0].toUpperCase() === builtin[0])
+                .filter(builtin => !exceptions.has(builtin))
+        );
 
-        if (exceptions.length) {
-            modifiedBuiltins = modifiedBuiltins.filter(builtIn => exceptions.indexOf(builtIn) === -1);
+        /**
+         * Reports a lint error for the given node.
+         * @param {ASTNode} node The node to report.
+         * @param {string} builtin The name of the native builtin being extended.
+         * @returns {void}
+         */
+        function reportNode(node, builtin) {
+            context.report({
+                node,
+                message: "{{builtin}} prototype is read only, properties should not be added.",
+                data: {
+                    builtin
+                }
+            });
+        }
+
+        /**
+         * Checks that an identifier is an object of a prototype whose member
+         * is being assigned in an AssignmentExpression.
+         * Example: Object.prototype.foo = "bar"
+         * @param {ASTNode} identifierNode The identifier to check.
+         * @returns {boolean} True if the identifier's prototype is modified.
+         */
+        function isInPrototypePropertyAssignment(identifierNode) {
+            return Boolean(
+                identifierNode.parent.type === "MemberExpression" &&
+                identifierNode.parent.parent.type === "MemberExpression" &&
+                identifierNode.parent.parent.parent.type === "AssignmentExpression" &&
+                identifierNode.parent.parent.parent.left === identifierNode.parent.parent
+            );
+        }
+
+        /**
+         * Checks that an identifier is an object of a prototype whose member
+         * is being extended via the Object.defineProperty() or
+         * Object.defineProperties() methods.
+         * Example: Object.defineProperty(Array.prototype, "foo", ...)
+         * Example: Object.defineProperties(Array.prototype, ...)
+         * @param {ASTNode} identifierNode The identifier to check.
+         * @returns {boolean} True if the identifier's prototype is modified.
+         */
+        function isInDefinePropertyCall(identifierNode) {
+            return Boolean(
+                identifierNode.parent.type === "MemberExpression" &&
+                identifierNode.parent.parent.type === "CallExpression" &&
+                identifierNode.parent.parent.arguments[0] === identifierNode.parent &&
+                identifierNode.parent.parent.callee.type === "MemberExpression" &&
+                identifierNode.parent.parent.callee.object.type === "Identifier" &&
+                identifierNode.parent.parent.callee.object.name === "Object" &&
+                identifierNode.parent.parent.callee.property.type === "Identifier" &&
+                propertyDefinitionMethods.has(identifierNode.parent.parent.callee.property.name)
+            );
+        }
+
+        /**
+         * Check to see if the `prototype` property of the given object
+         * identifier node is being accessed.
+         * @param {ASTNode} identifierNode The Identifier representing the object
+         * to check.
+         * @returns {boolean} True if the identifier is the object of a
+         * MemberExpression and its `prototype` property is being accessed,
+         * false otherwise.
+         */
+        function isPrototypePropertyAccessed(identifierNode) {
+            return Boolean(
+                identifierNode &&
+                identifierNode.parent &&
+                identifierNode.parent.type === "MemberExpression" &&
+                identifierNode.parent.object === identifierNode &&
+                astUtils.getStaticPropertyName(identifierNode.parent) === "prototype"
+            );
+        }
+
+        /**
+         * Check to see if object prototype access is part of a prototype
+         * extension. There are three ways a prototype can be extended:
+         * 1. Assignment to prototype property (Object.prototype.foo = 1)
+         * 2. Object.defineProperty()/Object.defineProperties() on a prototype
+         * If prototype extension is detected, report the AssignmentExpression
+         * or CallExpression node.
+         * @param {ASTNode} identifierNode The Identifier representing the object
+         * which prototype is being accessed and possibly extended.
+         * @returns {void}
+         */
+        function checkAndReportPrototypeExtension(identifierNode) {
+            if (!isPrototypePropertyAccessed(identifierNode)) {
+                return;
+            }
+
+            if (isInPrototypePropertyAssignment(identifierNode)) {
+
+                // Identifier --> MemberExpression --> MemberExpression --> AssignmentExpression
+                reportNode(identifierNode.parent.parent.parent, identifierNode.name);
+            } else if (isInDefinePropertyCall(identifierNode)) {
+
+                // Identifier --> MemberExpression --> CallExpression
+                reportNode(identifierNode.parent.parent, identifierNode.name);
+            }
         }
 
         return {
 
-            // handle the Array.prototype.extra style case
-            AssignmentExpression(node) {
-                const lhs = node.left;
-
-                if (lhs.type !== "MemberExpression" || lhs.object.type !== "MemberExpression") {
-                    return;
-                }
-
-                const affectsProto = lhs.object.computed
-                    ? lhs.object.property.type === "Literal" && lhs.object.property.value === "prototype"
-                    : lhs.object.property.name === "prototype";
-
-                if (!affectsProto) {
-                    return;
-                }
+            "Program:exit"() {
+                const globalScope = context.getScope();
 
                 modifiedBuiltins.forEach(builtin => {
-                    if (lhs.object.object.name === builtin) {
-                        context.report({
-                            node,
-                            message: "{{builtin}} prototype is read only, properties should not be added.",
-                            data: {
-                                builtin
-                            }
-                        });
+                    const builtinVar = globalScope.set.get(builtin);
+
+                    if (builtinVar && builtinVar.references) {
+                        builtinVar.references
+                            .map(ref => ref.identifier)
+                            .forEach(checkAndReportPrototypeExtension);
                     }
                 });
-            },
-
-            // handle the Object.definePropert[y|ies](Array.prototype) case
-            CallExpression(node) {
-
-                const callee = node.callee;
-
-                // only worry about Object.definePropert[y|ies]
-                if (callee.type === "MemberExpression" &&
-                    callee.object.name === "Object" &&
-                    (callee.property.name === "defineProperty" || callee.property.name === "defineProperties")) {
-
-                    // verify the object being added to is a native prototype
-                    const subject = node.arguments[0];
-                    const object = subject && subject.object;
-
-                    if (object &&
-                        object.type === "Identifier" &&
-                        (modifiedBuiltins.indexOf(object.name) > -1) &&
-                        subject.property.name === "prototype") {
-
-                        context.report({
-                            node,
-                            message: "{{objectName}} prototype is read only, properties should not be added.",
-                            data: {
-                                objectName: object.name
-                            }
-                        });
-                    }
-                }
-
             }
         };
 

--- a/tests/lib/rules/no-extend-native.js
+++ b/tests/lib/rules/no-extend-native.js
@@ -40,7 +40,14 @@ ruleTester.run("no-extend-native", rule, {
 
         // https://github.com/eslint/eslint/issues/4438
         "Object.defineProperty()",
-        "Object.defineProperties()"
+        "Object.defineProperties()",
+
+        // https://github.com/eslint/eslint/issues/8461
+        "function foo() { var Object = function() {}; Object.prototype.p = 0 }",
+        {
+            code: "{ let Object = function() {}; Object.prototype.p = 0 }",
+            parserOptions: { ecmaVersion: 6 }
+        }
     ],
     invalid: [{
         code: "Object.prototype.p = 0",
@@ -78,12 +85,37 @@ ruleTester.run("no-extend-native", rule, {
             message: "Array prototype is read only, properties should not be added.",
             type: "CallExpression"
         }]
+    }, {
+        code: "Object.defineProperties(Array.prototype, {p: {value: 0}, q: {value: 0}})",
+        errors: [{
+            message: "Array prototype is read only, properties should not be added.",
+            type: "CallExpression"
+        }]
     },
     {
         code: "Number['prototype']['p'] = 0",
         options: [{ exceptions: ["Object"] }],
         errors: [{
             message: "Number prototype is read only, properties should not be added.",
+            type: "AssignmentExpression"
+        }]
+    },
+    {
+        code: "Object.prototype.p = 0; Object.prototype.q = 0",
+        errors: [{
+            message: "Object prototype is read only, properties should not be added.",
+            type: "AssignmentExpression",
+            column: 1
+        }, {
+            message: "Object prototype is read only, properties should not be added.",
+            type: "AssignmentExpression",
+            column: 25
+        }]
+    },
+    {
+        code: "function foo() { Object.prototype.p = 0 }",
+        errors: [{
+            message: "Object prototype is read only, properties should not be added.",
             type: "AssignmentExpression"
         }]
     }]


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

See issue #8461.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Rewrote the rule to use eslint-scope references to find violations of this rule. Previously, a prototype extension would be reported if the name of the owning object was the same as a builtin with uppercase first letter; now it only reports actual references to builtins with uppercase first letter.

**Is there anything you'd like reviewers to focus on?**

* I marked this as Update because I basically rewrote the rule.
* The rule relies on the fact that we add [the builtin environment's variables](https://github.com/eslint/eslint/blob/master/lib/eslint.js#L169) to the [eslint-scope global scope](https://github.com/eslint/eslint/blob/master/lib/eslint.js#L186-L196).
* Anything look funny? Are there other tests I should add?