### PR TITLE
Fix: handle destructuring with defaults in camelcase rule (fixes #8511)

### DIFF
--- a/lib/rules/camelcase.js
+++ b/lib/rules/camelcase.js
@@ -106,8 +106,10 @@ module.exports = {
                         report(node);
                     }
 
-                // Properties have their own rules
-                } else if (node.parent.type === "Property") {
+                // Properties have their own rules, and
+                // AssignmentPattern nodes can be treated like Properties:
+                // e.g.: const { no_camelcased = false } = bar;
+                } else if (node.parent.type === "Property" || node.parent.type === "AssignmentPattern") {
 
                     // "never" check properties
                     if (properties === "never") {

--- a/tests/lib/rules/camelcase.js
+++ b/tests/lib/rules/camelcase.js
@@ -79,6 +79,30 @@ ruleTester.run("camelcase", rule, {
         {
             code: "import { no_camelcased as camelCased, anoterCamelCased } from \"external-module\";",
             parserOptions: { ecmaVersion: 6, sourceType: "module" }
+        },
+        {
+            code: "const { no_camelcased } = bar;",
+            parserOptions: { ecmaVersion: 6 },
+            options: [{ properties: "never" }]
+        },
+        {
+            code: "const { no_camelcased = false } = bar;",
+            parserOptions: { ecmaVersion: 6 },
+            options: [{ properties: "never" }]
+        },
+        {
+            code: "function foo({ no_camelcased }) {};",
+            parserOptions: { ecmaVersion: 6 },
+            options: [{ properties: "never" }]
+        },
+        {
+            code: "function foo({ no_camelcased = 'default value' }) {};",
+            parserOptions: { ecmaVersion: 6 },
+            options: [{ properties: "never" }]
+        },
+        {
+            code: "function foo({ no_camelcased: camelCased }) {};",
+            parserOptions: { ecmaVersion: 6 }
         }
     ],
     invalid: [
@@ -223,6 +247,16 @@ ruleTester.run("camelcase", rule, {
             ]
         },
         {
+            code: "var { category_id = 1 } = query;",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    message: "Identifier 'category_id' is not in camel case.",
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
             code: "import no_camelcased from \"external-module\";",
             parserOptions: { ecmaVersion: 6, sourceType: "module" },
             errors: [
@@ -305,6 +339,26 @@ ruleTester.run("camelcase", rule, {
         {
             code: "import no_camelcased, { another_no_camelcased as camelCased } from \"external-module\";",
             parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [
+                {
+                    message: "Identifier 'no_camelcased' is not in camel case.",
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
+            code: "function foo({ no_camelcased }) {};",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    message: "Identifier 'no_camelcased' is not in camel case.",
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
+            code: "function foo({ no_camelcased = 'default value' }) {};",
+            parserOptions: { ecmaVersion: 6 },
             errors: [
                 {
                     message: "Identifier 'no_camelcased' is not in camel case.",


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Fixes the bug reported in #8511. I changed the logic of the `camelcase` rule to properly handle destructuring with defaults.

**Is there anything you'd like reviewers to focus on?**
I think not!

