### PR TITLE
Chore: enable linebreak-style on ESLint codebase

### DIFF
--- a/packages/eslint-config-eslint/default.yml
+++ b/packages/eslint-config-eslint/default.yml
@@ -28,7 +28,7 @@ rules:
     guard-for-in: "error"
     key-spacing: ["error", { beforeColon: false, afterColon: true }]
     keyword-spacing: "error"
-    linebreak-style: "error"
+    linebreak-style: ["error", "unix"]
     lines-around-comment: ["error", {
         beforeBlockComment: true,
         afterBlockComment: false,

--- a/packages/eslint-config-eslint/default.yml
+++ b/packages/eslint-config-eslint/default.yml
@@ -28,6 +28,7 @@ rules:
     guard-for-in: "error"
     key-spacing: ["error", { beforeColon: false, afterColon: true }]
     keyword-spacing: "error"
+    linebreak-style: "error"
     lines-around-comment: ["error", {
         beforeBlockComment: true,
         afterBlockComment: false,


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This enables linebreak-style on the ESLint codebase. As a result, it should no longer be necessary to convert linebreaks as part of the release process.

Refs: https://github.com/eslint/eslint-release/issues/17

**Is there anything you'd like reviewers to focus on?**

Nothing in particular