### PR TITLE
Fix: max-len does not allow comments longer than code when comment length is specified

### DIFF
--- a/lib/rules/max-len.js
+++ b/lib/rules/max-len.js
@@ -321,21 +321,24 @@ module.exports = {
                 }
 
                 const lineLength = computeLineLength(line, tabWidth);
+                const commentLengthApplies = lineIsComment && maxCommentLength;
 
                 if (lineIsComment && ignoreComments) {
                     return;
                 }
 
-                if (lineIsComment && lineLength > maxCommentLength) {
-                    context.report({
-                        node,
-                        loc: { line: lineNumber, column: 0 },
-                        message: "Line {{lineNumber}} exceeds the maximum comment line length of {{maxCommentLength}}.",
-                        data: {
-                            lineNumber: i + 1,
-                            maxCommentLength
-                        }
-                    });
+                if (commentLengthApplies) {
+                    if (lineLength > maxCommentLength) {
+                        context.report({
+                            node,
+                            loc: { line: lineNumber, column: 0 },
+                            message: "Line {{lineNumber}} exceeds the maximum comment line length of {{maxCommentLength}}.",
+                            data: {
+                                lineNumber: i + 1,
+                                maxCommentLength
+                            }
+                        });
+                    }
                 } else if (lineLength > maxLength) {
                     context.report({
                         node,

--- a/tests/lib/rules/max-len.js
+++ b/tests/lib/rules/max-len.js
@@ -314,7 +314,7 @@ ruleTester.run("max-len", rule, {
                 }
             ]
         }, {
-            code: "// A comment that exceeds the max comment length",
+            code: "// A comment that exceeds the max comment length and the max code length, but will fail for being too long of a comment",
             options: [40, 4, { comments: 80 }],
             errors: [
                 {

--- a/tests/lib/rules/max-len.js
+++ b/tests/lib/rules/max-len.js
@@ -314,7 +314,6 @@ ruleTester.run("max-len", rule, {
                 }
             ]
         }, {
-// A comment that exceeds the max comment length, but not the specified max length for code.
             code: "// A comment that exceeds the max comment length",
             options: [40, 4, { comments: 80 }],
             errors: [

--- a/tests/lib/rules/max-len.js
+++ b/tests/lib/rules/max-len.js
@@ -314,7 +314,8 @@ ruleTester.run("max-len", rule, {
                 }
             ]
         }, {
-            code: "// A comment that exceeds the max comment length, but not the specified max length for code.",
+// A comment that exceeds the max comment length, but not the specified max length for code.
+            code: "// A comment that exceeds the max comment length",
             options: [40, 4, { comments: 80 }],
             errors: [
                 {

--- a/tests/lib/rules/max-len.js
+++ b/tests/lib/rules/max-len.js
@@ -76,6 +76,11 @@ ruleTester.run("max-len", rule, {
             options: [80, { tabWidth: 4, comments: 30 }]
         }, {
             code:
+                "// I like longer comments and shorter code\n" +
+                "function see() { odd(eh()) }",
+            options: [30, { tabWidth: 4, comments: 80 }]
+        }, {
+            code:
                 "// Full line comment\n" +
                 "someCode(); // With a long trailing comment.",
             options: [{ code: 30, tabWidth: 4, comments: 20, ignoreTrailingComments: true }]
@@ -303,6 +308,17 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     message: "Line 1 exceeds the maximum comment line length of 20.",
+                    type: "Program",
+                    line: 1,
+                    column: 1
+                }
+            ]
+        }, {
+            code: "// A comment that exceeds the max comment length, but not the specified max length for code.",
+            options: [40, 4, { comments: 80 }],
+            errors: [
+                {
+                    message: "Line 1 exceeds the maximum comment line length of 80.",
                     type: "Program",
                     line: 1,
                     column: 1


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
**Tell us about your environment**

* **ESLint Version:** 3.19.0
* **Node Version:** 6.9.3
* **npm Version:** 3.10.10

**What parser (default, Babel-ESLint, etc.) are you using?**
babel-eslint

**Please show your full configuration:**
```
		"max-len": ["error", {
			"code": 80,
			"comments": 100,
			"tabWidth": 2,
			"ignoreUrls": true,
			"ignoreRegExpLiterals": true,
			"ignoreStrings": true,
			"ignoreTemplateLiterals": true
		}],
```
**What did you do? Please include the actual source code causing the issue.**
I wanted to allow comments up to 100 characters while limiting code to 80 characters.
In one of my modules, I have a comment longer than 80 characters, but less than the 100 characters specified for comments (see below):
```
 * - onLeftIconClick - optional click handler, invoked when icon is clicked (default: undefined)
```

**What did you expect to happen?**
That this 96 character comment would not result in a violation of max-len when configured to allow 100 character comments.

**What actually happened? Please include the actual, raw output from ESLint.**
Error reported indicates that the comment is in violation of the max code length: 
```
Line 61 exceeds the maximum line length of 80. (max-len)
```

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Prior to this PR, comment lines that were not in violation of the specified max comment length would be further validated using the max code length.  This works well for situations where the max comment length is less than the max length for code, but doesn't allow for longer comments.

Modified max-len to respect max comment length if it happens to be greater than max code length.  For situations where a max comment length is not defined, the max code length will be respected.

Added unit tests to validate this change for situations with long comments and short code.

**Is there anything you'd like reviewers to focus on?**

As a side note, I submitted this using the bug template because there was no indication in the documentation that comments must be less than the length specified for code.
