### PR TITLE
Fix: 7451, Check existence of range

### DIFF
--- a/lib/rules/no-use-before-define.js
+++ b/lib/rules/no-use-before-define.js
@@ -203,6 +203,7 @@ module.exports = {
                 if (reference.init ||
                     !variable ||
                     variable.identifiers.length === 0 ||
+                    !reference.identifier.range ||
                     (variable.identifiers[0].range[1] < reference.identifier.range[1] && !isInInitializer(variable, reference)) ||
                     !isForbidden(variable, reference)
                 ) {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

fixes: https://github.com/eslint/eslint/issues/7451

With Flows new spread-syntax this rule failed to missing range.

**What changes did you make? (Give an overview)**
Added check for reference.range

**Is there anything you'd like reviewers to focus on?**

Some guidance for writing appropriate tests would be appreciated! I saw some has some custom ast files when no-use-before-define uses default so i'm not completely sure how this should be tested. I'm not very familiar with eslint&ast implementations, so lack of range might also be a symptom of something else. 
