### PR TITLE
Fix: only run no-unexpected-multiline division operator if needed (fixes #8550)

### DIFF
--- a/lib/rules/no-unexpected-multiline.js
+++ b/lib/rules/no-unexpected-multiline.js
@@ -80,7 +80,7 @@ module.exports = {
                 checkForBreakAfter(node.callee, FUNCTION_MESSAGE);
             },
 
-            "BinaryExpression[operator='/'] > BinaryExpression[operator='/']"(node) {
+            "BinaryExpression[operator='/'] > BinaryExpression[operator='/'].left"(node) {
                 const secondSlash = sourceCode.getTokenAfter(node, token => token.value === "/");
                 const tokenAfterOperator = sourceCode.getTokenAfter(secondSlash);
 

--- a/tests/lib/rules/no-unexpected-multiline.js
+++ b/tests/lib/rules/no-unexpected-multiline.js
@@ -78,6 +78,10 @@ ruleTester.run("no-unexpected-multiline", rule, {
         `
             foo
             / /abc/
+        `,
+        `
+            5 / (5
+            / 5)
         `
     ],
     invalid: [


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
The rule should only execute if two division operators are found next to each other.

**Is there anything you'd like reviewers to focus on?**
I'm not sure if this is the best solution but it works as far as I see it.

