### PR TITLE
Update: make indent MemberExpression handling more robust (fixes #8552)

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -924,21 +924,49 @@ module.exports = {
 
             MemberExpression(node) {
                 const firstNonObjectToken = sourceCode.getFirstTokenBetween(node.object, node.property, astUtils.isNotClosingParenToken);
-                const tokensToIndent = node.computed ? [sourceCode.getTokenAfter(firstNonObjectToken)] : [firstNonObjectToken, sourceCode.getTokenAfter(firstNonObjectToken)];
+                const secondNonObjectToken = sourceCode.getTokenAfter(firstNonObjectToken);
+
+                const tokenBeforeObject = sourceCode.getTokenBefore(node.object, astUtils.isNotOpeningParenToken);
+                const firstObjectToken = tokenBeforeObject ? sourceCode.getTokenAfter(tokenBeforeObject) : sourceCode.ast.tokens[0];
+                const lastObjectToken = sourceCode.getTokenBefore(firstNonObjectToken);
 
                 if (node.computed) {
+
+                    // For computed MemberExpressions, match the closing bracket with the opening bracket.
                     offsets.matchIndentOf(firstNonObjectToken, sourceCode.getLastToken(node));
                 }
 
-                if (typeof options.MemberExpression !== "number") {
-                    tokensToIndent.forEach(token => offsets.ignoreToken(token));
+                if (typeof options.MemberExpression === "number") {
+                    const firstPropertyToken = node.computed ? firstNonObjectToken : secondNonObjectToken;
+
+                    /*
+                     * If the object ends on the same line that the property starts, match against the last token
+                     * of the object, to ensure that the MemberExpression is not indented.
+                     *
+                     * Otherwise, match against the first token of the object, e.g.
+                     * foo
+                     *   .bar
+                     *   .baz // <-- offset by 1 from `foo`
+                     */
+                    const offsetBase = lastObjectToken.loc.end.line === firstPropertyToken.loc.start.line
+                        ? lastObjectToken
+                        : firstObjectToken;
+
+                    // Match the dot (for non-computed properties) or the opening bracket (for computed properties) against the object.
+                    offsets.setDesiredOffset(firstNonObjectToken, offsetBase, options.MemberExpression);
+
+                    /*
+                     * For computed MemberExpressions, match the first token of the property against the opening bracket.
+                     * Otherwise, match the first token of the property against the object.
+                     */
+                    offsets.setDesiredOffset(secondNonObjectToken, node.computed ? firstNonObjectToken : offsetBase, options.MemberExpression);
+                } else {
+
+                    // If the MemberExpression option is off, ignore the dot and the first token of the property.
+                    offsets.ignoreToken(firstNonObjectToken);
+                    offsets.ignoreToken(secondNonObjectToken);
+                    offsets.matchIndentOf(firstNonObjectToken, secondNonObjectToken);
                 }
-
-                const offsetBase = node.object.loc.end.line === node.property.loc.start.line
-                    ? sourceCode.getLastToken(node.object)
-                    : sourceCode.getFirstToken(node.object);
-
-                offsets.setDesiredOffsets(tokensToIndent, offsetBase, options.MemberExpression);
             },
 
             NewExpression(node) {

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -926,7 +926,7 @@ module.exports = {
                 const firstNonObjectToken = sourceCode.getFirstTokenBetween(node.object, node.property, astUtils.isNotClosingParenToken);
                 const secondNonObjectToken = sourceCode.getTokenAfter(firstNonObjectToken);
 
-                const tokenBeforeObject = sourceCode.getTokenBefore(node.object, astUtils.isNotOpeningParenToken);
+                const tokenBeforeObject = sourceCode.getTokenBefore(node.object, token => astUtils.isNotOpeningParenToken(token) || parameterParens.has(token));
                 const firstObjectToken = tokenBeforeObject ? sourceCode.getTokenAfter(tokenBeforeObject) : sourceCode.ast.tokens[0];
                 const lastObjectToken = sourceCode.getTokenBefore(firstNonObjectToken);
 

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -3272,6 +3272,15 @@ ruleTester.run("indent", rule, {
                     baz();
                 })
             `
+        },
+        {
+            code: unIndent`
+                new Foo(
+                    bar
+                        .baz
+                        .qux
+                )
+            `
         }
     ],
 

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -3166,6 +3166,112 @@ ruleTester.run("indent", rule, {
                 }
             `,
             parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: unIndent`
+                foo
+                    .bar(function() {
+                        baz
+                    })
+            `
+        },
+        {
+            code: unIndent`
+                foo
+                        .bar(function() {
+                            baz
+                        })
+            `,
+            options: [4, { MemberExpression: 2 }]
+        },
+        {
+            code: unIndent`
+                foo
+                    [bar](function() {
+                        baz
+                    })
+            `
+        },
+        {
+            code: unIndent`
+                foo.
+                    bar.
+                    baz
+            `
+        },
+        {
+            code: unIndent`
+                foo
+                    .bar(function() {
+                        baz
+                    })
+            `,
+            options: [4, { MemberExpression: "off" }]
+        },
+        {
+            code: unIndent`
+                foo
+                                .bar(function() {
+                                    baz
+                                })
+            `,
+            options: [4, { MemberExpression: "off" }]
+        },
+        {
+            code: unIndent`
+                foo
+                                [bar](function() {
+                                    baz
+                                })
+            `,
+            options: [4, { MemberExpression: "off" }]
+        },
+        {
+            code: unIndent`
+                  foo.
+                          bar.
+                                      baz
+            `,
+            options: [4, { MemberExpression: "off" }]
+        },
+        {
+            code: unIndent`
+                  foo
+                      [
+                          bar
+                      ]
+                      .baz(function() {
+                          quz();
+                      })
+            `
+        },
+        {
+            code: unIndent`
+                  [
+                      foo
+                  ][
+                      "map"](function() {
+                      qux();
+                  })
+            `
+        },
+        {
+            code: unIndent`
+                (
+                    a.b(function() {
+                        c;
+                    })
+                )
+            `
+        },
+        {
+            code: unIndent`
+                (
+                    foo
+                ).bar(function() {
+                    baz();
+                })
+            `
         }
     ],
 
@@ -6467,6 +6573,19 @@ ruleTester.run("indent", rule, {
                 );
             `,
             errors: expectedErrors([[4, 4, 8, "Identifier"], [5, 0, 4, "Punctuator"]])
+        },
+        {
+            code: unIndent`
+                foo.
+                  bar.
+                      baz
+            `,
+            output: unIndent`
+                foo.
+                    bar.
+                    baz
+            `,
+            errors: expectedErrors([[2, 4, 2, "Identifier"], [3, 4, 6, "Identifier"]])
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (https://github.com/eslint/eslint/issues/8552)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This commit updates the indent rule's MemberExpression handler to avoid expecting NaN indentation when the MemberExpression option is set to "off". It also fixes a related bug with indenting MemberExpressions with parenthesized objects, and adds a few comments to clarify why particular pieces of the MemberExpression logic are necessary.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular