### PR TITLE
Fix: invalid syntax from prefer-arrow-callback autofixer (fixes #8541)

### DIFF
--- a/lib/rules/prefer-arrow-callback.js
+++ b/lib/rules/prefer-arrow-callback.js
@@ -277,15 +277,23 @@ module.exports = {
                             const paramsRightParen = sourceCode.getTokenBefore(node.body);
                             const asyncKeyword = node.async ? "async " : "";
                             const paramsFullText = sourceCode.text.slice(paramsLeftParen.range[0], paramsRightParen.range[1]);
+                            const arrowFunctionText = `${asyncKeyword}${paramsFullText} => ${sourceCode.getText(node.body)}`;
 
-                            if (callbackInfo.isLexicalThis) {
+                            /*
+                             * If the callback function has `.bind(this)`, replace it with an arrow function and remove the binding.
+                             * Otherwise, just replace the arrow function itself.
+                             */
+                            const replacedNode = callbackInfo.isLexicalThis ? node.parent.parent : node;
 
-                                // If the callback function has `.bind(this)`, replace it with an arrow function and remove the binding.
-                                return fixer.replaceText(node.parent.parent, `${asyncKeyword}${paramsFullText} => ${sourceCode.getText(node.body)}`);
-                            }
+                            /*
+                             * If the replaced node is part of a BinaryExpression, LogicalExpression, or MemberExpression, then
+                             * the arrow function needs to be parenthesized, because `foo || () => {}` is invalid syntax even
+                             * though `foo || function() {}` is valid.
+                             */
+                            const needsParens = replacedNode.parent.type !== "CallExpression" && replacedNode.parent.type !== "ConditionalExpression";
+                            const replacementText = needsParens ? `(${arrowFunctionText})` : arrowFunctionText;
 
-                            // Otherwise, only replace the `function` keyword and parameters with the arrow function parameters.
-                            return fixer.replaceTextRange([node.start, node.body.start], `${asyncKeyword}${paramsFullText} => `);
+                            return fixer.replaceText(replacedNode, replacementText);
                         }
                     });
                 }

--- a/tests/lib/rules/prefer-arrow-callback.js
+++ b/tests/lib/rules/prefer-arrow-callback.js
@@ -70,7 +70,7 @@ ruleTester.run("prefer-arrow-callback", rule, {
         {
             code: "foo(nativeCb || function() {});",
             errors,
-            output: "foo(nativeCb || () => {});"
+            output: "foo(nativeCb || (() => {}));"
         },
         {
             code: "foo(bar ? function() {} : function() {});",
@@ -86,6 +86,11 @@ ruleTester.run("prefer-arrow-callback", rule, {
             code: "foo(function() { this; }.bind(this));",
             errors,
             output: "foo(() => { this; });"
+        },
+        {
+            code: "foo(bar || function() { this; }.bind(this));",
+            errors,
+            output: "foo(bar || (() => { this; }));"
         },
         {
             code: "foo(function() { (() => this); }.bind(this));",
@@ -133,6 +138,11 @@ ruleTester.run("prefer-arrow-callback", rule, {
             code: "qux(function(foo, bar, baz) { return foo * this.qux; }.bind(this))",
             errors,
             output: "qux((foo, bar, baz) => { return foo * this.qux; })"
+        },
+        {
+            code: "foo(function() {}.bind(this, somethingElse))",
+            errors,
+            output: "foo((() => {}).bind(this, somethingElse))"
         },
         {
             code: "qux(function(foo = 1, [bar = 2] = [], {qux: baz = 3} = {foo: 'bar'}) { return foo + bar; });",


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (https://github.com/eslint/eslint/issues/8541)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Previously, the `prefer-arrow-callback` autofixer would simply replace a function expression with an arrow function. However, arrow functions have a different precedence than regular functions, so this was sometimes creating invalid syntax. This commit updates the fixer to parenthesize the arrow functions if necessary to avoid a syntax error.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular