### PR TITLE
Chore: avoid skipping test for env overrides (refs #8291)

### DIFF
--- a/tests/fixtures/config-hierarchy/overwrite-ecmaFeatures/.eslintrc
+++ b/tests/fixtures/config-hierarchy/overwrite-ecmaFeatures/.eslintrc
@@ -1,5 +1,7 @@
 {
-    "ecmaFeatures": {
-        "globalReturn": false
+    "parserOptions": {
+        "ecmaFeatures": {
+            "globalReturn": false
+        }
     }
 }

--- a/tests/lib/config.js
+++ b/tests/lib/config.js
@@ -773,13 +773,13 @@ describe("Config", () => {
         });
 
         describe("with env in a child configuration file", () => {
-            xit("should overwrite parserOptions of the parent with env of the child", () => {
+            it("should not overwrite parserOptions of the parent with env of the child", () => {
                 const config = new Config({ cwd: process.cwd() });
                 const targetPath = getFixturePath("overwrite-ecmaFeatures", "child", "foo.js");
                 const expected = {
                     rules: {},
                     env: { commonjs: true },
-                    parserOptions: { ecmaFeatures: { globalReturn: true } }
+                    parserOptions: { ecmaFeatures: { globalReturn: false } }
                 };
                 const actual = config.getConfig(targetPath);
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

When working on 734846b1557a45eb43286c4da2bdc1e13b89d1c6, it was discovered that the regression test for https://github.com/eslint/eslint/issues/3735 was broken and always passing. The test was broken by 1e600655b4da7134dbc9d0f909b1f7bc247e6cb0 over a year ago, and a regression occurred later on (possibly in 841086923b94de733a07d1a5851402311e84946e), which no one noticed because the regression test was broken.

The test was supposed to assert that an environment setting in a child config will override the corresponding setting in a parent config. Unfortunately, in the time since the regression occurred, people have started using things like `parserOptions: { ecmaVersion: 7 }` along with `env: { es6: true }`, Many projects rely on the fact that when these two options are combined, `ecmaVersion: 7` will be passed to the parser even though the `env` specifies `ecmaVersion: 6`. As a result, re-fixing the original bug would cause significant ecosystem breakage.

The solution in 734846b1557a45eb43286c4da2bdc1e13b89d1c6 was to skip the test and deal with the problem later. This commit modifies the test to assert the current behavior, which is the opposite of what the test was originally supposed to assert. If we decide to change the current behavior, we can always modify the test again, but I think it's important to verify that the current behavior doesn't change by mistake, because a lot of projects are relying on it.

Refs: https://github.com/eslint/eslint/issues/3735, https://github.com/eslint/eslint/pull/8291, https://github.com/eslint/eslint/pull/8295#discussion_r107003816

**Is there anything you'd like reviewers to focus on?**

Nothing in particular