### PR TITLE
Fix: confusing RuleTester error message when options is not an array

### DIFF
--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -304,11 +304,9 @@ class RuleTester {
                 filename = item.filename;
             }
 
-            if (item.options) {
-                const options = item.options.concat();
-
-                options.unshift(1);
-                config.rules[ruleName] = options;
+            if (Object.prototype.hasOwnProperty.call(item, "options")) {
+                assert(Array.isArray(item.options), "options must be an array");
+                config.rules[ruleName] = [1].concat(item.options);
             } else {
                 config.rules[ruleName] = 1;
             }

--- a/tests/lib/testers/rule-tester.js
+++ b/tests/lib/testers/rule-tester.js
@@ -557,6 +557,34 @@ describe("RuleTester", () => {
         });
     });
 
+    it("should throw an error if the options an object", () => {
+        assert.throws(() => {
+            ruleTester.run("no-invalid-args", require("../../fixtures/testers/rule-tester/no-invalid-args"), {
+                valid: [
+                    {
+                        code: "foo",
+                        options: { ok: true }
+                    }
+                ],
+                invalid: []
+            });
+        }, /options must be an array/);
+    });
+
+    it("should throw an error if the options a number", () => {
+        assert.throws(() => {
+            ruleTester.run("no-invalid-args", require("../../fixtures/testers/rule-tester/no-invalid-args"), {
+                valid: [
+                    {
+                        code: "foo",
+                        options: 0
+                    }
+                ],
+                invalid: []
+            });
+        }, /options must be an array/);
+    });
+
     it("should pass-through the parser to the rule", () => {
 
         assert.doesNotThrow(() => {

--- a/tests/lib/testers/rule-tester.js
+++ b/tests/lib/testers/rule-tester.js
@@ -557,7 +557,7 @@ describe("RuleTester", () => {
         });
     });
 
-    it("should throw an error if the options an object", () => {
+    it("should throw an error if the options are an object", () => {
         assert.throws(() => {
             ruleTester.run("no-invalid-args", require("../../fixtures/testers/rule-tester/no-invalid-args"), {
                 valid: [
@@ -571,7 +571,7 @@ describe("RuleTester", () => {
         }, /options must be an array/);
     });
 
-    it("should throw an error if the options a number", () => {
+    it("should throw an error if the options are a number", () => {
         assert.throws(() => {
             ruleTester.run("no-invalid-args", require("../../fixtures/testers/rule-tester/no-invalid-args"), {
                 valid: [


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix

**Tell us about your environment**

* **ESLint Version:** master
* **Node Version:** 7.10.0
* **npm Version:** 4.2.0

**What did you do? Please include the actual source code causing the issue.**

```js
const RuleTester = require("eslint").RuleTester;
const ruleTester = new RuleTester();

ruleTester.run("foo", require("eslint/lib/rules/new-parens"), {
    valid: [
        {
            code: "foo",
            options: { ok: true } // <-- not an array
        }
    ],
    invalid: []
});
```

**What did you expect to happen?**

I expected `RuleTester` to either run to completion or give a clear error message.

**What actually happened? Please include the actual, raw output from ESLint.**

`RuleTester` produced a confusing error message:

```
TypeError: item.options.concat is not a function
      at runRuleForItem (lib/testers/rule-tester.js:308:46)
      at testInvalidTemplate (lib/testers/rule-tester.js:455:28)
      at Context.RuleTester.it (lib/testers/rule-tester.js:553:25)
```

**What changes did you make? (Give an overview)**

This updates `RuleTester` to output a clear error message when `options` for a test is not an array.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
