### PR TITLE
no-undef: don't flag guarded variable uses

### DIFF
--- a/lib/rules/no-undef.js
+++ b/lib/rules/no-undef.js
@@ -19,6 +19,93 @@ function hasTypeOfOperator(node) {
     return parent.type === "UnaryExpression" && parent.operator === "typeof";
 }
 
+/**
+ * Checks if the expression represented by the provided node asserts that
+ * the provided identifier is or isn't defined before using the identifier.
+ *
+ * @param {ASTNode} node The AST node being checked.
+ * @param {string} identifierName The name of the identifier whose (lack of)
+ *                                existence may be being asserted.
+ * @param {boolearn} shouldBeDefined Whether to check that the expression asserts
+ *                                   that the variable exists, or to check that
+ *                                   it asserts that the variable does not exist.
+ * @returns {boolean} Whether or not the expression asserts whether the
+ *                               identifier is defined.
+ */
+function assertsOnExistence(node, identifierName, shouldBeDefined) {
+    if (node.type === "LogicalExpression") {
+        return node.operator === "&&"
+            ? (assertsOnExistence(node.left, identifierName, shouldBeDefined) ||
+                assertsOnExistence(node.right, identifierName, shouldBeDefined))
+            : false;
+    }
+
+    const isBinaryExpression = node.type === "BinaryExpression";
+    const checksTypeofIdentifierAgainstLiteral =
+        node.left.type === "UnaryExpression" &&
+        node.left.operator === "typeof" &&
+        node.left.argument.type === "Identifier" &&
+        node.left.argument.name === identifierName &&
+        node.right.type === "Literal";
+
+    const operator = node.operator;
+    const value = node.right.value;
+
+    return isBinaryExpression && checksTypeofIdentifierAgainstLiteral &&
+        (shouldBeDefined
+            ? (((operator === "==" || operator === "===") && value !== "undefined") ||
+                ((operator === "!=" || operator === "!==") && value === "undefined"))
+            : (operator === "==" || operator === "===") && value === "undefined");
+}
+
+/**
+ * @param {ASTNode} node The AST node being checked, representing an indentifier.
+ * @returns {boolean} Whether or not the code checks earlier in the expression that the identifier is defined.
+ */
+function isGuardedUsage(node) {
+    const origIdentifierName = node.name;
+    const expressionContainers = [
+        "ExpressionStatement",
+        "WithStatement",
+        "ReturnStatement",
+        "IfStatement",
+        "SwitchStatement",
+        "SwitchCase",
+        "ThrowStatement",
+        "WhileStatement",
+        "DoWhileStatement",
+        "ForStatement",
+        "ForInStatement",
+        "ForOfStatement",
+        "VariableDeclarator"
+    ];
+
+    let prevNode = null;
+
+    while (node.parent && expressionContainers.indexOf(node.parent.type) === -1) {
+        prevNode = node;
+        node = node.parent;
+
+        if (node.type === "LogicalExpression") {
+            const mayBeGuarded = node.operator === "&&" && node.right === prevNode;
+            if (mayBeGuarded && assertsOnExistence(node.left, origIdentifierName, true)) {
+                return true;
+            }
+        }
+
+        if (node.type === "ConditionalExpression") {
+            const assertsExists = assertsOnExistence(node.test, origIdentifierName, true);
+            const assertsDoesntExist = assertsOnExistence(node.test, origIdentifierName, false);
+
+            if ((assertsExists && node.consequent === prevNode) || (assertsDoesntExist && node.alternate === prevNode)) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -58,6 +145,11 @@ module.exports = {
                     if (!considerTypeOf && hasTypeOfOperator(identifier)) {
                         return;
                     }
+
+                    if (!considerTypeOf && isGuardedUsage(identifier)) {
+                        return;
+                    }
+
 
                     context.report({
                         node: identifier,

--- a/lib/rules/no-undef.js
+++ b/lib/rules/no-undef.js
@@ -88,6 +88,7 @@ function isGuardedUsage(node) {
 
         if (node.type === "LogicalExpression") {
             const mayBeGuarded = node.operator === "&&" && node.right === prevNode;
+
             if (mayBeGuarded && assertsOnExistence(node.left, origIdentifierName, true)) {
                 return true;
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint",
-  "version": "4.0.0-alpha.1",
+  "version": "4.0.0-alpha.2",
   "author": "Nicholas C. Zakas <nicholas+npm@nczconsulting.com>",
   "description": "An AST-based pattern checker for JavaScript.",
   "bin": {

--- a/tests/lib/rules/no-undef.js
+++ b/tests/lib/rules/no-undef.js
@@ -41,6 +41,7 @@ ruleTester.run("no-undef", rule, {
         "var b = typeof a",
         "typeof a === 'undefined'",
         "if (typeof a === 'undefined') {}",
+        "if (typeof a === 'string') {}",
         { code: "function foo() { var [a, b=4] = [1, 2]; return {a, b}; }", parserOptions: { ecmaVersion: 6 } },
         { code: "var toString = 1;", parserOptions: { ecmaVersion: 6 } },
         { code: "function myFunc(...foo) {  return foo;}", parserOptions: { ecmaVersion: 6 } },
@@ -82,7 +83,18 @@ ruleTester.run("no-undef", rule, {
                 }
             },
             globals: { stuff: false, foo: false }
-        }
+        },
+
+        // Guarded usage aware:
+        "var x = typeof $ !== 'undefined' && true && $();",
+        "var x = typeof $ === 'function' ? $(1) : (typeof $ !== 'undefined' ? (true, $) : false)",
+        "{b: typeof $ === 'undefined' ? false : new $(1)}",
+        "Object[typeof $ === 'undefined' ? '' : $]",
+        "typeof $ === 'undefined' ? Object : Object[$]",
+        "typeof $ === 'undefined' ? {b: false} : { b: new $(1)}",
+        "typeof $ !== 'undefined' && (true || false) && $();",
+        { code: "typeof $ === 'undefined' ? [false] : [...new $(1)]", parserOptions: { ecmaVersion: 6 } },
+        { code: "for(var x of typeof window === 'undefined' ? ['node'] : ['browser']) {}", parserOptions: { ecmaVersion: 6 } }
     ],
     invalid: [
         { code: "a = 1;", errors: [{ message: "'a' is not defined.", type: "Identifier" }] },
@@ -108,6 +120,12 @@ ruleTester.run("no-undef", rule, {
                 }
             },
             errors: [{ message: "'b' is not defined." }]
-        }
+        },
+
+        // Guarded usage aware
+        { code: "typeof $ === 'undefined' ? $() : false", errors: [{ message: "'$' is not defined.", type: "Identifier" }] },
+        { code: "(typeof $ === 'undefined' || false) && $()", errors: [{ message: "'$' is not defined.", type: "Identifier" }] },
+        { code: "typeof $ === 'function' ? $(1) : (typeof $ === 'undefined' ? (true, $) : false)", errors: [{ message: "'$' is not defined.", type: "Identifier" }] },
+        { code: "!$ ? false : $()", errors: [{ message: "'$' is not defined.", type: "Identifier" }, { message: "'$' is not defined.", type: "Identifier" }] }
     ]
 });


### PR DESCRIPTION
# This is just a proof-of-concept for the proposal in #8549. It's not ready to merge.

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What rule do you want to change?**
no-undef

**Does this change cause the rule to produce more or fewer warnings?**
Fewer

**How will the change be implemented? (New option, new default behavior, etc.)?**
TBD

**Please provide some example code that this change will affect:**

```js
var x = typeof PossiblyUndefinedGlobal === 'function' ? PossiblyUndefinedGlobal : fallback;
```

**What does the rule currently do for this code?**
Errors, saying that the second use of `PossiblyUndefinedGlobal` represents using an undefined variable.

**What will the rule do after it's changed?**
Not error, because the typeof check ensures that the variable is, in fact, defined.

**What changes did you make? (Give an overview)**
See #8549

**Is there anything you'd like reviewers to focus on?**


