### PR TITLE
Fix: Indent Ignore Variable Declaration init operator (fixes #8546)

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -1039,10 +1039,10 @@ module.exports = {
 
             VariableDeclarator(node) {
                 if (node.init) {
-                    const operator = sourceCode.getTokenBefore(node.init);
+                    const equalOperator = sourceCode.getTokenBefore(node.init, astUtils.isNotOpeningParenToken);
 
-                    if (operator.type === "Punctuator" && operator.value === "=" && tokenInfo.isFirstTokenOfLine(operator)) {
-                        offsets.ignoreToken(operator);
+                    if (equalOperator) {
+                        offsets.ignoreToken(equalOperator);
                     }
                     offsets.ignoreToken(sourceCode.getFirstToken(node.init));
                 }

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -1039,6 +1039,11 @@ module.exports = {
 
             VariableDeclarator(node) {
                 if (node.init) {
+                    const operator = sourceCode.getTokenBefore(node.init);
+
+                    if (operator.type === "Punctuator" && operator.value === "=" && tokenInfo.isFirstTokenOfLine(operator)) {
+                        offsets.ignoreToken(operator);
+                    }
                     offsets.ignoreToken(sourceCode.getFirstToken(node.init));
                 }
             },

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -1041,9 +1041,7 @@ module.exports = {
                 if (node.init) {
                     const equalOperator = sourceCode.getTokenBefore(node.init, astUtils.isNotOpeningParenToken);
 
-                    if (equalOperator) {
-                        offsets.ignoreToken(equalOperator);
-                    }
+                    offsets.ignoreToken(equalOperator);
                     offsets.ignoreToken(sourceCode.getFirstToken(node.init));
                 }
             },

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -559,6 +559,15 @@ ruleTester.run("indent", rule, {
         },
         {
             code: unIndent`
+                var foo
+                  = (1),
+                  bar
+                    = (2)
+            `,
+            options: [2, { VariableDeclarator: 1 }]
+        },
+        {
+            code: unIndent`
                 var foo = 1,
                     bar = 2,
                     baz = 3

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -532,6 +532,34 @@ ruleTester.run("indent", rule, {
         {
             code: unIndent`
                 var foo = 1,
+                  bar
+                    = 2
+            `,
+            options: [2, { VariableDeclarator: 1 }]
+        },
+        {
+            code: unIndent`
+                var foo
+                  = 1,
+                  bar
+                    = 2
+            `,
+            options: [2, { VariableDeclarator: 1 }]
+        },
+        {
+            code: unIndent`
+                var foo
+                  =
+                  1,
+                  bar
+                    =
+                    2
+            `,
+            options: [2, { VariableDeclarator: 1 }]
+        },
+        {
+            code: unIndent`
+                var foo = 1,
                     bar = 2,
                     baz = 3
                 ;


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X ] Bug fix (fixes #8546 )

**What changes did you make? (Give an overview)**
Allow the VariableDeclarator node listener to ignore the operator as well as the initial value.


**Is there anything you'd like reviewers to focus on?**
I tried to match the behavior of variable assignment but might have missed something. The following are now all valid:
```js
const aLongName 
    = 1,
  bLongName
    = 2;
```
```js
const aLongName 
    =
  1,
  bLongName
     =
     2;
```



