### PR TITLE
Fix: Add class options for `lines-around-comment` (fixes #8564)

### DIFF
--- a/docs/rules/lines-around-comment.md
+++ b/docs/rules/lines-around-comment.md
@@ -172,6 +172,101 @@ function foo(){
 }
 ```
 
+### allowClassStart
+
+Examples of **incorrect** code for this rule with the `{ "beforeLineComment": true, "allowClassStart": false }` option:
+
+```js
+/*eslint lines-around-comment: ["error", { "beforeLineComment": true, "allowClassStart": false }]*/
+
+class foo {
+    // what a great and wonderful day
+    day() {}
+};
+```
+
+Examples of **correct** code for this rule with the `{ "beforeLineComment": true, "allowClassStart": false }` option:
+
+```js
+/*eslint lines-around-comment: ["error", { "beforeLineComment": true, "allowClassStart": false }]*/
+
+class foo {
+
+    // what a great and wonderful day
+    day() {}
+};
+```
+
+Examples of **correct** code for this rule with the `{ "beforeLineComment": true, "allowClassStart": true }` option:
+
+```js
+/*eslint lines-around-comment: ["error", { "beforeLineComment": true, "allowClassStart": true }]*/
+
+class foo {
+    // what a great and wonderful day
+    day() {}
+};
+```
+
+Examples of **incorrect** code for this rule with the `{ "beforeBlockComment": true, "allowClassStart": false }` option:
+
+```js
+/*eslint lines-around-comment: ["error", { "beforeBlockComment": true, "allowClassStart": false }]*/
+
+class foo {
+    /* what a great and wonderful day */
+    day() {}
+};
+```
+
+Examples of **correct** code for this rule with the `{ "beforeBlockComment": true, "allowClassStart": false }` option:
+
+```js
+/*eslint lines-around-comment: ["error", { "beforeBlockComment": true, "allowClassStart": false }]*/
+
+class foo {
+
+    /* what a great and wonderful day */
+    day() {}
+};
+```
+
+Examples of **correct** code for this rule with the `{ "beforeBlockComment": true, "allowClassStart": true }` option:
+
+```js
+/*eslint lines-around-comment: ["error", { "beforeBlockComment": true, "allowClassStart": true }]*/
+
+class foo {
+    /* what a great and wonderful day */
+    day() {}
+};
+```
+
+### allowClassEnd
+
+Examples of **correct** code for this rule with the `{ "afterLineComment": true, "allowClassEnd": true }` option:
+
+```js
+/*eslint lines-around-comment: ["error", { "afterLineComment": true, "allowClassEnd": true }]*/
+
+class foo {
+    day() {}
+    // what a great and wonderful day
+};
+```
+
+Examples of **correct** code for this rule with the `{ "afterBlockComment": true, "allowClassEnd": true }` option:
+
+```js
+/*eslint lines-around-comment: ["error", { "afterBlockComment": true, "allowClassEnd": true }]*/
+
+class foo {
+    day() {}
+
+    /* what a great and wonderful day */
+};
+```
+
 ### allowObjectStart
 
 Examples of **correct** code for this rule with the `{ "beforeLineComment": true, "allowObjectStart": true }` option:

--- a/lib/rules/lines-around-comment.js
+++ b/lib/rules/lines-around-comment.js
@@ -82,6 +82,12 @@ module.exports = {
                     allowBlockEnd: {
                         type: "boolean"
                     },
+                    allowClassStart: {
+                        type: "boolean"
+                    },
+                    allowClassEnd: {
+                        type: "boolean"
+                    },
                     allowObjectStart: {
                         type: "boolean"
                     },
@@ -225,6 +231,24 @@ module.exports = {
         }
 
         /**
+         * Returns whether or not comments are at the class start or not.
+         * @param {token} token The Comment token.
+         * @returns {boolean} True if the comment is at class start.
+         */
+        function isCommentAtClassStart(token) {
+            return isCommentAtParentStart(token, "ClassBody");
+        }
+
+        /**
+         * Returns whether or not comments are at the class end or not.
+         * @param {token} token The Comment token.
+         * @returns {boolean} True if the comment is at class end.
+         */
+        function isCommentAtClassEnd(token) {
+            return isCommentAtParentEnd(token, "ClassBody");
+        }
+
+        /**
          * Returns whether or not comments are at the object start or not.
          * @param {token} token The Comment token.
          * @returns {boolean} True if the comment is at object start.
@@ -284,15 +308,17 @@ module.exports = {
                 nextLineNum = token.loc.end.line + 1,
                 commentIsNotAlone = codeAroundComment(token);
 
-            const blockStartAllowed = options.allowBlockStart && isCommentAtBlockStart(token),
-                blockEndAllowed = options.allowBlockEnd && isCommentAtBlockEnd(token),
+            const blockStartAllowed = options.allowBlockStart && isCommentAtBlockStart(token) && !(options.allowClassStart === false && isCommentAtClassStart(token)),
+                blockEndAllowed = options.allowBlockEnd && isCommentAtBlockEnd(token) && !(options.allowClassEnd === false && isCommentAtClassEnd(token)),
+                classStartAllowed = options.allowClassStart && isCommentAtClassStart(token),
+                classEndAllowed = options.allowClassEnd && isCommentAtClassEnd(token),
                 objectStartAllowed = options.allowObjectStart && isCommentAtObjectStart(token),
                 objectEndAllowed = options.allowObjectEnd && isCommentAtObjectEnd(token),
                 arrayStartAllowed = options.allowArrayStart && isCommentAtArrayStart(token),
                 arrayEndAllowed = options.allowArrayEnd && isCommentAtArrayEnd(token);
 
-            const exceptionStartAllowed = blockStartAllowed || objectStartAllowed || arrayStartAllowed;
-            const exceptionEndAllowed = blockEndAllowed || objectEndAllowed || arrayEndAllowed;
+            const exceptionStartAllowed = blockStartAllowed || classStartAllowed || objectStartAllowed || arrayStartAllowed;
+            const exceptionEndAllowed = blockEndAllowed || classEndAllowed || objectEndAllowed || arrayEndAllowed;
 
             // ignore top of the file and bottom of the file
             if (prevLineNum < 1) {

--- a/tests/lib/rules/lines-around-comment.js
+++ b/tests/lib/rules/lines-around-comment.js
@@ -221,12 +221,24 @@ ruleTester.run("lines-around-comment", rule, {
         },
         {
             code: "class A {\n/**\n* hi\n */\nconstructor() {}\n}",
-            options: [{ allowBlockStart: true }],
+            options: [{
+                allowBlockStart: true
+            }],
             parserOptions: { ecmaVersion: 6 }
         },
         {
-            code: "class A {\nconstructor() {\n/**\n* hi\n */\n}\n}",
-            options: [{ allowBlockStart: true }],
+            code: "class A {\n/**\n* hi\n */\nconstructor() {}\n}",
+            options: [{
+                allowClassStart: true
+            }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "class A {\n/**\n* hi\n */\nconstructor() {}\n}",
+            options: [{
+                allowBlockStart: false,
+                allowClassStart: true
+            }],
             parserOptions: { ecmaVersion: 6 }
         },
         {
@@ -415,6 +427,23 @@ ruleTester.run("lines-around-comment", rule, {
             options: [{
                 afterBlockComment: true,
                 allowBlockEnd: true
+            }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "class B {\nconstructor() {}\n\n/**\n* hi\n */\n}",
+            options: [{
+                afterBlockComment: true,
+                allowClassEnd: true
+            }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "class B {\nconstructor() {}\n\n/**\n* hi\n */\n}",
+            options: [{
+                afterBlockComment: true,
+                allowBlockEnd: false,
+                allowClassEnd: true
             }],
             parserOptions: { ecmaVersion: 6 }
         },
@@ -966,6 +995,46 @@ ruleTester.run("lines-around-comment", rule, {
                 allowBlockEnd: true
             }],
             errors: [{ message: beforeMessage, type: "Line", line: 2 }]
+        },
+        {
+            code: "class A {\n// line at class start\nconstructor() {}\n}",
+            output: "class A {\n\n// line at class start\nconstructor() {}\n}",
+            options: [{
+                beforeLineComment: true
+            }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: beforeMessage, type: "Line", line: 2 }]
+        },
+        {
+            code: "class A {\n// line at class start\nconstructor() {}\n}",
+            output: "class A {\n\n// line at class start\nconstructor() {}\n}",
+            options: [{
+                allowBlockStart: true,
+                allowClassStart: false,
+                beforeLineComment: true
+            }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: beforeMessage, type: "Line", line: 2 }]
+        },
+        {
+            code: "class B {\nconstructor() {}\n\n// line at class end\n}",
+            output: "class B {\nconstructor() {}\n\n// line at class end\n\n}",
+            options: [{
+                afterLineComment: true
+            }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: afterMessage, type: "Line", line: 4 }]
+        },
+        {
+            code: "class B {\nconstructor() {}\n\n// line at class end\n}",
+            output: "class B {\nconstructor() {}\n\n// line at class end\n\n}",
+            options: [{
+                afterLineComment: true,
+                allowBlockEnd: true,
+                allowClassEnd: false
+            }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: afterMessage, type: "Line", line: 4 }]
         },
         {
             code: "switch ('foo'){\ncase 'foo':\nvar g = 1;\n\n// line at switch case end\n}",


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Fix #8564.

**What changes did you make? (Give an overview)**
~~Moved the "ClassBody" check from "Block" to "Object"~~ Added `allowClassStart` and `allowClassEnd` options, updated tests, and added docs.

**Is there anything you'd like reviewers to focus on?**
~~Should this be marked breaking?~~