### PR TITLE
Update: check allman-style classes correctly in indent (fixes #8493)

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -610,8 +610,8 @@ module.exports = {
         }
 
         /**
-         * Check indentation for blocks
-         * @param {ASTNode} node node to check
+         * Check indentation for blocks and class bodies
+         * @param {ASTNode} node The BlockStatement or ClassBody node to indent
          * @returns {void}
          */
         function addBlockIndent(node) {
@@ -765,10 +765,13 @@ module.exports = {
         * @returns {void}
         */
         function addClassIndent(node) {
-            const tokens = getTokensAndComments(node);
+            if (node.superClass) {
+                const classToken = sourceCode.getFirstToken(node);
+                const extendsToken = sourceCode.getTokenBefore(node.superClass, astUtils.isNotOpeningParenToken);
 
-            offsets.setDesiredOffsets(tokens, tokens[0], 1);
-            offsets.matchIndentOf(tokens[0], tokens[tokens.length - 1]);
+                offsets.setDesiredOffset(extendsToken, classToken, 1);
+                offsets.setDesiredOffsets(sourceCode.getTokensBetween(extendsToken, node.body, { includeComments: true }), classToken, 1);
+            }
         }
 
         /**
@@ -836,6 +839,8 @@ module.exports = {
             BlockStatement: addBlockIndent,
 
             CallExpression: addFunctionCallIndent,
+
+            ClassBody: addBlockIndent,
 
             ClassDeclaration: addClassIndent,
 

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -3198,6 +3198,24 @@ ruleTester.run("indent", rule, {
         },
         {
             code: unIndent`
+                class Foo
+                    extends Bar
+                {
+                    constructor()
+                    {
+                        foo();
+                    }
+
+                    bar()
+                    {
+                        baz();
+                    }
+                }
+            `,
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: unIndent`
                 (
                     class Foo
                     {

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -1508,6 +1508,18 @@ ruleTester.run("indent", rule, {
         },
         {
             code: unIndent`
+                class Foo extends
+                  (
+                    Bar
+                  ) {
+                  baz() {}
+                }
+            `,
+            parserOptions: { ecmaVersion: 6 },
+            options: [2]
+        },
+        {
+            code: unIndent`
                 fs.readdirSync(path.join(__dirname, '../rules')).forEach(name => {
                   files[name] = foo;
                 });
@@ -3166,6 +3178,52 @@ ruleTester.run("indent", rule, {
                 }
             `,
             parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: unIndent`
+                class Foo
+                {
+                    constructor()
+                    {
+                        foo();
+                    }
+
+                    bar()
+                    {
+                        baz();
+                    }
+                }
+            `,
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: unIndent`
+                (
+                    class Foo
+                    {
+                        constructor()
+                        {
+                            foo();
+                        }
+
+                        bar()
+                        {
+                            baz();
+                        }
+                    }
+                )
+            `,
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: unIndent`
+                switch (foo)
+                {
+                    case 1:
+                        bar();
+                }
+            `,
+            options: [4, { SwitchCase: 1 }]
         }
     ],
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (https://github.com/eslint/eslint/issues/8493#issuecomment-299860602)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Previously, the logic in the `indent` for handling classes was separate from the logic for handling block statements, and there was a bug where the opening curly brace in a class was incorrectly offset from the start of the class. This commit updates the rule to use the same logic for handling block statements and class bodies.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
