### PR TITLE
Chore: remove concat-stream dependency

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -27,8 +27,7 @@ if (debug) {
 //------------------------------------------------------------------------------
 
 // now we can safely include the other modules that use debug
-const concat = require("concat-stream"),
-    cli = require("../lib/cli"),
+const cli = require("../lib/cli"),
     path = require("path"),
     fs = require("fs");
 
@@ -55,9 +54,7 @@ process.once("uncaughtException", err => {
 });
 
 if (useStdIn) {
-    process.stdin.pipe(concat({ encoding: "string" }, text => {
-        process.exitCode = cli.execute(process.argv, text);
-    }));
+    process.exitCode = cli.execute(process.argv, fs.readFileSync(process.stdin.fd, "utf8"));
 } else if (init) {
     const configInit = require("../lib/config/config-initializer");
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   "dependencies": {
     "babel-code-frame": "^6.22.0",
     "chalk": "^1.1.3",
-    "concat-stream": "^1.6.0",
     "debug": "^2.6.3",
     "doctrine": "^2.0.0",
     "eslint-scope": "^3.6.0",


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

**What changes did you make? (Give an overview)**

We use the `concat-stream` module to get source text from stdin when the `--stdin` flag is used. However, getting text from stdin is a one-liner without `concat-stream`, so it's not necessary to keep it as a dependency. This commit removes the dependency.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
