### PR TITLE
Update: Add desc for valid/invalid in RuleTester

### DIFF
--- a/docs/developer-guide/working-with-rules.md
+++ b/docs/developer-guide/working-with-rules.md
@@ -665,6 +665,21 @@ valid: [
 
 The options available and the expected syntax for `parserOptions` is the same as those used in [configuration](../user-guide/configuring#specifying-parser-options).
 
+## Specifying Description Of Code
+
+By default the code in the case will be printed on running test. If the code is too long to be displayed, you may provide a message as replacement by using the `desc` property.
+
+For example:
+
+```js
+valid: [
+    {
+        code: "/* something too long to be displayed on screen ... */",
+        desc: "code about ..."
+    }
+]
+```
+
 ## Performance Testing
 
 To keep the linting process efficient and unobtrusive, it is useful to verify the performance impact of new rules or modifications to existing rules.

--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -537,7 +537,12 @@ class RuleTester {
         RuleTester.describe(ruleName, () => {
             RuleTester.describe("valid", () => {
                 test.valid.forEach(valid => {
-                    RuleTester.it(typeof valid === "object" ? valid.code : valid, () => {
+                    let desc = valid;
+
+                    if (typeof valid === "object") {
+                        desc = valid.desc ? valid.desc : valid.code;
+                    }
+                    RuleTester.it(desc, () => {
                         eslint.defineRules(this.rules);
                         testValidTemplate(ruleName, valid);
                     });
@@ -546,7 +551,7 @@ class RuleTester {
 
             RuleTester.describe("invalid", () => {
                 test.invalid.forEach(invalid => {
-                    RuleTester.it(invalid.code, () => {
+                    RuleTester.it(invalid.desc ? invalid.desc : invalid.code, () => {
                         eslint.defineRules(this.rules);
                         testInvalidTemplate(ruleName, invalid);
                     });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:
_By default the code in the case will be printed on running test. However, sometimes the code is too long to be displayed. So I wanna allow unit-test writers to provide a message as replacement by using the `desc` property._

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
RuleTesters changed to receive property `desc` of valid/invalid.

**Is there anything you'd like reviewers to focus on?**

