### PR TITLE
Fix: object-shorthand crash on some computed keys (fixes #8576)

### DIFF
--- a/lib/rules/object-shorthand.js
+++ b/lib/rules/object-shorthand.js
@@ -392,7 +392,7 @@ module.exports = {
                         });
                     }
                 } else if (APPLY_TO_METHODS && !node.value.id && (node.value.type === "FunctionExpression" || node.value.type === "ArrowFunctionExpression")) {
-                    if (IGNORE_CONSTRUCTORS && isConstructor(node.key.name)) {
+                    if (IGNORE_CONSTRUCTORS && node.key.type === "Identifier" && isConstructor(node.key.name)) {
                         return;
                     }
                     if (AVOID_QUOTES && isStringLiteral(node.key)) {

--- a/tests/lib/rules/object-shorthand.js
+++ b/tests/lib/rules/object-shorthand.js
@@ -374,6 +374,10 @@ ruleTester.run("object-shorthand", rule, {
                 }
             `,
             options: ["always", { avoidExplicitReturnArrows: true }]
+        },
+        {
+            code: "({ [foo.bar]: () => {} })",
+            options: ["always", { ignoreConstructors: true }]
         }
     ],
     invalid: [


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (https://github.com/eslint/eslint/issues/8576)

**What changes did you make? (Give an overview)**

This commit adds a missing node type check to fix the crash described in https://github.com/eslint/eslint/issues/8576.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
