### PR TITLE
New: Allow parsers to supply Visitor Keys/Fallback (fixes #8392)

### DIFF
--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -41,6 +41,8 @@ const assert = require("assert"),
  * @property {ASTNode} ast The ESTree AST Program node.
  * @property {Object} services An object containing additional services related
  *      to the parser.
+ * @property {VisitorKeys} visitorKeys Visitor Keys
+ * @property {VisitorFallback} visitorFallback Visitor Fallback function
  */
 
 //------------------------------------------------------------------------------
@@ -873,7 +875,14 @@ module.exports = (function() {
 
             // save config so rules can access as necessary
             currentConfig = config;
-            traverser = new Traverser();
+
+            const visitorKeys = (parseResult) ? parseResult.visitorKeys : null;
+            const visitorFallback = (parseResult) ? parseResult.visitorFallback : null;
+
+            traverser = new Traverser(
+                visitorKeys,
+                visitorFallback
+            );
 
             const ecmaFeatures = currentConfig.parserOptions.ecmaFeatures;
             const ecmaVersion = currentConfig.parserOptions.ecmaVersion;
@@ -885,7 +894,8 @@ module.exports = (function() {
                 impliedStrict: ecmaFeatures.impliedStrict,
                 ecmaVersion,
                 sourceType: currentConfig.parserOptions.sourceType,
-                fallback: Traverser.getKeys
+                childVisitorKeys: traverser.getVisitorKeys(),
+                fallback: traverser.getVisitorFallback()
             });
 
             currentScopes = scopeManager.scopes;

--- a/lib/util/traverser.js
+++ b/lib/util/traverser.js
@@ -38,9 +38,25 @@ estraverse.VisitorKeys.RestElement.push("typeAnnotation");
  * @constructor
  */
 class Traverser extends estraverse.Controller {
+    constructor(visitorKeys, visitorFallback) {
+        super();
+
+        this.visitorKeys = visitorKeys || estraverse.VisitorKeys;
+        this.visitorFallback = visitorFallback || Traverser.getKeys;
+    }
+
     traverse(node, visitor) {
-        visitor.fallback = Traverser.getKeys;
+        visitor.keys = this.visitorKeys;
+        visitor.fallback = this.visitorFallback;
         return super.traverse(node, visitor);
+    }
+
+    getVisitorKeys() {
+        return this.visitorKeys;
+    }
+
+    getVisitorFallback() {
+        return this.visitorFallback;
     }
 
     /**


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**
[ X ] Add something to the core

Still need to write tests just need feedback on implementation. This would allow for typescript-eslint-parser to fix issues with the `no-undef` rule and allow rules to traverse decorators and type parameters.

**What changes did you make? (Give an overview)**
Modified the Traverser class to accept an optional VisitorKey object and VisitorFallback function. These are then passed into eslint-scope and estravese.

Updated the parseForESLint function to have two extra options:
 - visitorKeys
 - visitorFallback

These values are passed into the Traverser constructor.

**Is there anything you'd like reviewers to focus on?**
Currently the visitorKeys passed into eslint, with the `parseForESLint()`, modifies the VisitorKeys by replacing a key. This is the default behavior  of both estraverse and eslint-scope. I think this should be fine as it allows parsers to both add and delete visitor properties but maybe there is better way.

Both VisitorKeys and VisitorFallback are passed into Traverser but it could be its own class that wraps them both.

