### PR TITLE
Revert "Breaking: Traverse into type annotations (fixes #7129) (#8365)"

### DIFF
--- a/docs/user-guide/migrating-to-4.0.0.md
+++ b/docs/user-guide/migrating-to-4.0.0.md
@@ -20,7 +20,6 @@ The lists below are ordered roughly by the number of users each change is expect
 1. [`RuleTester` now validates properties of test cases](#rule-tester-validation)
 1. [AST nodes no longer have comment properties](#comment-attachment)
 1. [Shebangs are now returned from comment APIs](#shebangs)
-1. [Type annotation nodes in an AST are now traversed](#type-annotation-traversal)
 
 ### Breaking changes for integration developers
 
@@ -202,12 +201,6 @@ In 4.0, shebang comments are treated as comment tokens of type `Shebang` and wil
 ```
 sourceCode.getAllComments().filter(comment => comment.type !== "Shebang");
 ```
-
-## <a name="type-annotation-traversal"/> Type annotation nodes in an AST are now traversed
-
-Starting in 4.0, if a parser produces type annotation nodes, they will be traversed as part of ESLint's AST traversal.
-
-**To address:** If you have a custom rule that relies on having a particular traversal depth, and your rule is run on code with type annotations, you should update the rule logic to account for the new traversal.
 
 ---
 

--- a/lib/util/traverser.js
+++ b/lib/util/traverser.js
@@ -21,18 +21,6 @@ const KEY_BLACKLIST = new Set([
 ]);
 
 /**
- * Modify estraverse's visitor keys to traverse type annotations.
- */
-estraverse.VisitorKeys.Identifier.push("typeAnnotation");
-estraverse.VisitorKeys.FunctionDeclaration.push("returnType");
-estraverse.VisitorKeys.FunctionExpression.push("returnType");
-estraverse.VisitorKeys.ArrowFunctionExpression.push("returnType");
-estraverse.VisitorKeys.MethodDefinition.push("returnType");
-estraverse.VisitorKeys.ObjectPattern.push("typeAnnotation");
-estraverse.VisitorKeys.ArrayPattern.push("typeAnnotation");
-estraverse.VisitorKeys.RestElement.push("typeAnnotation");
-
-/**
  * Wrapper around an estraverse controller that ensures the correct keys
  * are visited.
  * @constructor
@@ -53,9 +41,5 @@ class Traverser extends estraverse.Controller {
         return Object.keys(node).filter(key => !KEY_BLACKLIST.has(key));
     }
 }
-
-//------------------------------------------------------------------------------
-// Public Interface
-//------------------------------------------------------------------------------
 
 module.exports = Traverser;

--- a/tests/lib/util/traverser.js
+++ b/tests/lib/util/traverser.js
@@ -3,30 +3,9 @@
 const assert = require("chai").assert;
 const Traverser = require("../../../lib/util/traverser");
 
-/**
- * Traverses an AST and returns the traversal order (both for entering and leaving nodes).
- * @param {ASTNode} ast The Program node of the AST to check.
- * @returns {Object} An object containing an enteredNodes and exitedNodes array.
- * @private
- */
-function traverseAst(ast) {
-    const traverser = new Traverser();
-    const enteredNodes = [];
-    const exitedNodes = [];
-
-    traverser.traverse(ast, {
-        enter: node => enteredNodes.push(node),
-        leave: node => exitedNodes.push(node)
-    });
-
-    return {
-        enteredNodes,
-        exitedNodes
-    };
-}
-
 describe("Traverser", () => {
     it("traverses all keys except 'parent', 'leadingComments', and 'trailingComments'", () => {
+        const traverser = new Traverser();
         const fakeAst = {
             type: "Program",
             body: [
@@ -50,155 +29,15 @@ describe("Traverser", () => {
 
         fakeAst.body[0].parent = fakeAst;
 
-        const traversalResults = traverseAst(fakeAst);
+        const enteredNodes = [];
+        const exitedNodes = [];
 
-        assert.deepEqual(traversalResults.enteredNodes, [fakeAst, fakeAst.body[0], fakeAst.body[1], fakeAst.body[1].foo]);
-        assert.deepEqual(traversalResults.exitedNodes, [fakeAst.body[0], fakeAst.body[1].foo, fakeAst.body[1], fakeAst]);
-    });
-
-    describe("type annotations", () => {
-        it("traverses type annotations in Identifiers", () => {
-            const fakeAst = {
-                type: "Program",
-                body: [
-                    {
-                        type: "Identifier",
-                        typeAnnotation: {
-                            type: "foo"
-                        }
-                    }
-                ]
-            };
-            const traversalResults = traverseAst(fakeAst);
-
-            assert.deepEqual(traversalResults.enteredNodes, [fakeAst, fakeAst.body[0], fakeAst.body[0].typeAnnotation]);
-            assert.deepEqual(traversalResults.exitedNodes, [fakeAst.body[0].typeAnnotation, fakeAst.body[0], fakeAst]);
+        traverser.traverse(fakeAst, {
+            enter: node => enteredNodes.push(node),
+            leave: node => exitedNodes.push(node)
         });
 
-        it("traverses return types in FunctionDeclarations", () => {
-            const fakeAst = {
-                type: "Program",
-                body: [
-                    {
-                        type: "FunctionDeclaration",
-                        returnType: {
-                            type: "foo"
-                        }
-                    }
-                ]
-            };
-            const traversalResults = traverseAst(fakeAst);
-
-            assert.deepEqual(traversalResults.enteredNodes, [fakeAst, fakeAst.body[0], fakeAst.body[0].returnType]);
-            assert.deepEqual(traversalResults.exitedNodes, [fakeAst.body[0].returnType, fakeAst.body[0], fakeAst]);
-        });
-
-        it("traverses return types in FunctionExpressions", () => {
-            const fakeAst = {
-                type: "Program",
-                body: [
-                    {
-                        type: "FunctionExpression",
-                        returnType: {
-                            type: "foo"
-                        }
-                    }
-                ]
-            };
-            const traversalResults = traverseAst(fakeAst);
-
-            assert.deepEqual(traversalResults.enteredNodes, [fakeAst, fakeAst.body[0], fakeAst.body[0].returnType]);
-            assert.deepEqual(traversalResults.exitedNodes, [fakeAst.body[0].returnType, fakeAst.body[0], fakeAst]);
-        });
-
-        it("traverses return types in ArrowFunctionExpressions", () => {
-            const fakeAst = {
-                type: "Program",
-                body: [
-                    {
-                        type: "ArrowFunctionExpression",
-                        returnType: {
-                            type: "foo"
-                        }
-                    }
-                ]
-            };
-            const traversalResults = traverseAst(fakeAst);
-
-            assert.deepEqual(traversalResults.enteredNodes, [fakeAst, fakeAst.body[0], fakeAst.body[0].returnType]);
-            assert.deepEqual(traversalResults.exitedNodes, [fakeAst.body[0].returnType, fakeAst.body[0], fakeAst]);
-        });
-
-        it("traverses return types in MethodDefinitions", () => {
-            const fakeAst = {
-                type: "Program",
-                body: [
-                    {
-                        type: "MethodDefinition",
-                        returnType: {
-                            type: "foo"
-                        }
-                    }
-                ]
-            };
-            const traversalResults = traverseAst(fakeAst);
-
-            assert.deepEqual(traversalResults.enteredNodes, [fakeAst, fakeAst.body[0], fakeAst.body[0].returnType]);
-            assert.deepEqual(traversalResults.exitedNodes, [fakeAst.body[0].returnType, fakeAst.body[0], fakeAst]);
-        });
-
-        it("traverses type annotations in ObjectPatterns", () => {
-            const fakeAst = {
-                type: "Program",
-                body: [
-                    {
-                        type: "ObjectPattern",
-                        typeAnnotation: {
-                            type: "foo"
-                        }
-                    }
-                ]
-            };
-            const traversalResults = traverseAst(fakeAst);
-
-            assert.deepEqual(traversalResults.enteredNodes, [fakeAst, fakeAst.body[0], fakeAst.body[0].typeAnnotation]);
-            assert.deepEqual(traversalResults.exitedNodes, [fakeAst.body[0].typeAnnotation, fakeAst.body[0], fakeAst]);
-        });
-
-        it("traverses type annotations in ArrayPatterns", () => {
-            const fakeAst = {
-                type: "Program",
-                body: [
-                    {
-                        type: "ArrayPattern",
-                        typeAnnotation: {
-                            type: "foo"
-                        }
-                    }
-                ]
-            };
-            const traversalResults = traverseAst(fakeAst);
-
-            assert.deepEqual(traversalResults.enteredNodes, [fakeAst, fakeAst.body[0], fakeAst.body[0].typeAnnotation]);
-            assert.deepEqual(traversalResults.exitedNodes, [fakeAst.body[0].typeAnnotation, fakeAst.body[0], fakeAst]);
-        });
-
-        it("traverses type annotations in RestElements", () => {
-            const fakeAst = {
-                type: "Program",
-                body: [
-                    {
-                        type: "RestElement",
-                        typeAnnotation: {
-                            type: "foo"
-                        }
-                    }
-                ]
-            };
-            const traversalResults = traverseAst(fakeAst);
-
-            assert.deepEqual(traversalResults.enteredNodes, [fakeAst, fakeAst.body[0], fakeAst.body[0].typeAnnotation]);
-            assert.deepEqual(traversalResults.exitedNodes, [fakeAst.body[0].typeAnnotation, fakeAst.body[0], fakeAst]);
-        });
+        assert.deepEqual(enteredNodes, [fakeAst, fakeAst.body[0], fakeAst.body[1], fakeAst.body[1].foo]);
+        assert.deepEqual(exitedNodes, [fakeAst.body[0], fakeAst.body[1].foo, fakeAst.body[1], fakeAst]);
     });
 });


### PR DESCRIPTION
This reverts commit 66af53e86ae2640981ed06b48c07cd2d7af261d5.

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[X] Add something to the core
[ ] Other, please explain:
 
<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
In light of the discussion surrounding adding a `VisitorKeys` option to `parseForESLint()` ([PR here](https://github.com/eslint/eslint/pull/8582)),  I think we should revert the monkeypatching of `estraverse.VisitorKeys` I added for v4. The monkeypatching made sense in a world where parsers could not provide their own visitor keys, but I think make a lot less sense now.

Quoting @soda0289 because I think this sums it up clearly:
> Type annotations are not defined as a node by ESTree only where they should be and each parser may do things differently. So it makes sense for a parser to define its own visitor keys for type annotations. A parser may also have type annotations in places that ESLint would never traverse anyway.

I know this is a breaking change, but considering we added in the type traversal for v4.0 and we're still doing alpha releases, I think it's safe to revert this now. I made this PR so that we can discuss.

**Is there anything you'd like reviewers to focus on?**
@eslint/eslint-tsc Yes - let's discuss!

