### PR TITLE
Added a way to not document return statement if it matches a pattern

### DIFF
--- a/lib/rules/valid-jsdoc.js
+++ b/lib/rules/valid-jsdoc.js
@@ -50,6 +50,9 @@ module.exports = {
                     matchDescription: {
                         type: "string"
                     },
+                    matchReturnOptional: {
+                        type: "string"
+                    },
                     requireReturnType: {
                         type: "boolean"
                     }
@@ -112,8 +115,12 @@ module.exports = {
         function addReturn(node) {
             const functionState = fns[fns.length - 1];
 
-            if (functionState && node.argument !== null) {
-                functionState.returnPresent = true;
+            if (functionState) {
+                if (node.argument !== null) {
+                    functionState.returnPresent = true;
+                }
+
+                functionState.returnExpression = sourceCode.getText(node);
             }
         }
 
@@ -337,7 +344,14 @@ module.exports = {
                 if (!isOverride && !hasReturns && !hasConstructor && !isInterface &&
                     node.parent.kind !== "get" && node.parent.kind !== "constructor" &&
                     node.parent.kind !== "set" && !isTypeClass(node)) {
-                    if (requireReturn || functionData.returnPresent) {
+                    let returnMatched = false;
+
+                    if (options.matchReturnOptional) {
+                        const regex = new RegExp(options.matchReturnOptional);
+
+                        returnMatched = regex.test(functionData.returnExpression);
+                    }
+                    if (requireReturn || (functionData.returnPresent && !returnMatched)) {
                         context.report({
                             node: jsdocNode,
                             message: "Missing JSDoc @{{returns}} for function.",

--- a/tests/lib/rules/valid-jsdoc.js
+++ b/tests/lib/rules/valid-jsdoc.js
@@ -124,6 +124,18 @@ ruleTester.run("valid-jsdoc", rule, {
             options: [{ requireReturn: false }]
         },
         {
+            code: "/**\n* Description\n* @param {function} callback mytest\n*/\nfunction asyncFunc(callback){if (false) {return callback(null);}};",
+            options: [{ requireReturn: false, matchReturnOptional: "return\\s+(?:callback|done|next)" }]
+        },
+        {
+            code: "/**\n* Description\n* @param {function} done mytest\n*/\nfunction asyncFunc(done){if (false) {return done(null);}};",
+            options: [{ requireReturn: false, matchReturnOptional: "return\\s+(?:callback|done|next)" }]
+        },
+        {
+            code: "/**\n* Description\n* @param {function} next mytest\n*/\nfunction asyncFunc(next){if (false) {return next(null);}};",
+            options: [{ requireReturn: false, matchReturnOptional: "return\\s+(?:callback|done|next)" }]
+        },
+        {
             code: "/**\n* Description\n* @param {string} p\n* @returns {void}*/\nFoo.bar = function(p){var t = function(){function name(){}; return name;}};",
             options: [{ requireParamDescription: false }]
         },
@@ -675,6 +687,16 @@ ruleTester.run("valid-jsdoc", rule, {
                 message: "Use @returns instead.",
                 type: "Block"
             }]
+        },
+        {
+            code: "/**\n* Description\n* @param {function} next mytest\n*/\nfunction asyncFunc(next){if (false) {return next(null);}};",
+            options: [{ requireReturn: false, matchReturnOptional: "return\\s+callback" }],
+            errors: [
+                {
+                    message: "Missing JSDoc @returns for function.",
+                    type: "Block"
+                }
+            ]
         },
         {
             code: "/** Foo \n@argument {int} bar baz\n */\nfunction foo(bar){}",


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**What rule do you want to change?**
`valid-jsdoc`

**Does this change cause the rule to produce more or fewer warnings?**
Fewer

**How will the change be implemented? (New option, new default behavior, etc.)?**
New option to allow the rule to be less restrictive if needed.

**Please provide some example code that this change will affect:**

```js
/**
 * Description
 * @param {function} callback mytest
 */
 function asyncFunc(callback){
    if (false) {
        return callback(null); // If this line matches the option, this snippet won't report.
    }
  };
```

**What does the rule currently do for this code?**
It always report if there is a non-documented `return` statement in a function.

**What will the rule do after it's changed?**
It will only report if the non-documented `return` statement **DOES NOT** match the pattern of the option `matchReturnOptional`

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Added an option to allow a rule to be less restrictive if needed.

**Is there anything you'd like reviewers to focus on?**
I'm not entirely sure about the name for the new option (`matchReturnOptional`)
