### PR TITLE
Update: improve indent of `flatTernaryExpressions` (fixes #8481)

### DIFF
--- a/docs/rules/indent.md
+++ b/docs/rules/indent.md
@@ -530,11 +530,10 @@ Examples of **incorrect** code for this rule with the default `4, { "flatTernary
 ```js
 /*eslint indent: ["error", 4, { "flatTernaryExpressions": false }]*/
 
-foo
-    ? bar
-    : baz
-    ? qux
-    : boop;
+var a =
+    foo ? bar :
+    baz ? qux :
+    boop;
 ```
 
 Examples of **correct** code for this rule with the default `4, { "flatTernaryExpressions": false }` option:
@@ -542,11 +541,10 @@ Examples of **correct** code for this rule with the default `4, { "flatTernaryEx
 ```js
 /*eslint indent: ["error", 4, { "flatTernaryExpressions": false }]*/
 
-foo
-    ? bar
-    : baz
-        ? qux
-        : boop;
+var a =
+    foo ? bar :
+        baz ? qux :
+            boop;
 ```
 
 Examples of **incorrect** code for this rule with the `4, { "flatTernaryExpressions": true }` option:
@@ -554,11 +552,10 @@ Examples of **incorrect** code for this rule with the `4, { "flatTernaryExpressi
 ```js
 /*eslint indent: ["error", 4, { "flatTernaryExpressions": true }]*/
 
-foo
-    ? bar
-    : baz
-        ? qux
-        : boop;
+var a =
+    foo ? bar :
+        baz ? qux :
+            boop;
 ```
 
 Examples of **correct** code for this rule with the `4, { "flatTernaryExpressions": true }` option:
@@ -566,11 +563,10 @@ Examples of **correct** code for this rule with the `4, { "flatTernaryExpression
 ```js
 /*eslint indent: ["error", 4, { "flatTernaryExpressions": true }]*/
 
-foo
-    ? bar
-    : baz
-    ? qux
-    : boop;
+var a =
+    foo ? bar :
+    baz ? qux :
+    boop;
 ```
 
 

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -923,6 +923,23 @@ module.exports = {
             }
         }
 
+        /**
+         * Check whether the given token is the first token of a statement.
+         * @param {Token} token The token to check.
+         * @param {ASTNode} leafNode The expression node that the token belongs directly.
+         * @returns {boolean} `true` if the token is the first token of a statement.
+         */
+        function isFirstTokenOfStatement(token, leafNode) {
+            let node = leafNode;
+
+            while (node.parent && !node.parent.type.endsWith("Statement") && !node.parent.type.endsWith("Declaration")) {
+                node = node.parent;
+            }
+            node = node.parent;
+
+            return !node || node.range[0] === token.range[0];
+        }
+
         return {
             ArrayExpression: addArrayOrObjectIndent,
             ArrayPattern: addArrayOrObjectIndent,
@@ -966,7 +983,11 @@ module.exports = {
             ConditionalExpression(node) {
                 const tokens = getTokensAndComments(node);
 
-                if (!(node.parent.type === "ConditionalExpression" && options.flatTernaryExpressions)) {
+                if (options.flatTernaryExpressions && !isFirstTokenOfStatement(tokens[0], node)) {
+                    if (node.parent.type !== "ConditionalExpression") {
+                        offsets.increaseOffset(tokens[0], 1);
+                    }
+                } else {
                     offsets.setDesiredOffsets(tokens, tokens[0], 1);
                 }
             },

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -983,11 +983,15 @@ module.exports = {
             ConditionalExpression(node) {
                 const tokens = getTokensAndComments(node);
 
-                if (options.flatTernaryExpressions && !isFirstTokenOfStatement(tokens[0], node)) {
-                    if (node.parent.type !== "ConditionalExpression") {
-                        offsets.increaseOffset(tokens[0], 1);
-                    }
-                } else {
+                // `flatTernaryExpressions` option is for the following style:
+                // var a =
+                //     foo > 0 ? bar :
+                //     foo < 0 ? baz :
+                //     /*else*/ qiz ;
+                if (!options.flatTernaryExpressions ||
+                    !astUtils.isTokenOnSameLine(node.test, node.consequent) ||
+                    isFirstTokenOfStatement(tokens[0], node)
+                ) {
                     offsets.setDesiredOffsets(tokens, tokens[0], 1);
                 }
             },

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -2942,10 +2942,10 @@ ruleTester.run("indent", rule, {
                 foo
                     ? bar
                     : baz
-                    ? qux
-                    : foobar
-                    ? boop
-                    : beep
+                        ? qux
+                        : foobar
+                            ? boop
+                            : beep
             `,
             options: [4, { flatTernaryExpressions: true }]
         },
@@ -2954,10 +2954,10 @@ ruleTester.run("indent", rule, {
                 foo ?
                     bar :
                     baz ?
-                    qux :
-                    foobar ?
-                    boop :
-                    beep
+                        qux :
+                        foobar ?
+                            boop :
+                            beep
             `,
             options: [4, { flatTernaryExpressions: true }]
         },
@@ -2976,6 +2976,72 @@ ruleTester.run("indent", rule, {
                 var a = foo
                     ? bar
                     : baz
+            `,
+            options: [4, { flatTernaryExpressions: true }]
+        },
+        {
+            code: unIndent`
+                var a =
+                    foo
+                        ? bar
+                        : baz
+            `,
+            options: [4, { flatTernaryExpressions: true }]
+        },
+        {
+            code: unIndent`
+                a =
+                    foo ? bar :
+                    baz ? qux :
+                    foobar ? boop :
+                    /*else*/ beep
+            `,
+            options: [4, { flatTernaryExpressions: true }]
+        },
+        {
+            code: unIndent`
+                a = foo
+                    ? bar
+                    : baz
+            `,
+            options: [4, { flatTernaryExpressions: true }]
+        },
+        {
+            code: unIndent`
+                a =
+                    foo
+                        ? bar
+                        : baz
+            `,
+            options: [4, { flatTernaryExpressions: true }]
+        },
+        {
+            code: unIndent`
+                foo(
+                    foo ? bar :
+                    baz ? qux :
+                    foobar ? boop :
+                    /*else*/ beep
+                )
+            `,
+            options: [4, { flatTernaryExpressions: true }]
+        },
+        {
+            code: unIndent`
+                foo(
+                    foo
+                        ? bar
+                        : baz
+                )
+            `,
+            options: [4, { flatTernaryExpressions: true }]
+        },
+        {
+            code: unIndent`
+                foo(foo
+                    ? bar
+                    : baz
+                )
             `,
             options: [4, { flatTernaryExpressions: true }]
         },
@@ -6505,56 +6571,40 @@ ruleTester.run("indent", rule, {
         },
         {
             code: unIndent`
-                foo
-                    ? bar
-                    : baz
-                        ? qux
-                        : foobar
-                            ? boop
+                foo ? bar
+                    : baz ? qux
+                        : foobar ? boop
                             : beep
             `,
             output: unIndent`
-                foo
-                    ? bar
-                    : baz
-                    ? qux
-                    : foobar
-                    ? boop
+                foo ? bar
+                    : baz ? qux
+                    : foobar ? boop
                     : beep
             `,
             options: [4, { flatTernaryExpressions: true }],
             errors: expectedErrors([
-                [4, 4, 8, "Punctuator"],
-                [5, 4, 8, "Punctuator"],
-                [6, 4, 12, "Punctuator"],
-                [7, 4, 12, "Punctuator"]
+                [3, 4, 8, "Punctuator"],
+                [4, 4, 12, "Punctuator"]
             ])
         },
         {
             code: unIndent`
-                foo ?
-                    bar :
-                    baz ?
-                        qux :
-                        foobar ?
-                            boop :
+                foo ? bar :
+                    baz ? qux :
+                        foobar ? boop :
                             beep
             `,
             output: unIndent`
-                foo ?
-                    bar :
-                    baz ?
-                    qux :
-                    foobar ?
-                    boop :
+                foo ? bar :
+                    baz ? qux :
+                    foobar ? boop :
                     beep
             `,
             options: [4, { flatTernaryExpressions: true }],
             errors: expectedErrors([
-                [4, 4, 8, "Identifier"],
-                [5, 4, 8, "Identifier"],
-                [6, 4, 12, "Identifier"],
-                [7, 4, 12, "Identifier"]
+                [3, 4, 8, "Identifier"],
+                [4, 4, 12, "Identifier"]
             ])
         },
         {
@@ -6576,6 +6626,63 @@ ruleTester.run("indent", rule, {
             errors: expectedErrors([
                 [3, 4, 6, "Identifier"],
                 [4, 4, 2, "Identifier"]
+            ])
+        },
+        {
+            code: unIndent`
+                var a =
+                    foo
+                    ? bar
+                    : baz
+            `,
+            output: unIndent`
+                var a =
+                    foo
+                        ? bar
+                        : baz
+            `,
+            options: [4, { flatTernaryExpressions: true }],
+            errors: expectedErrors([
+                [3, 8, 4, "Punctuator"],
+                [4, 8, 4, "Punctuator"]
+            ])
+        },
+        {
+            code: unIndent`
+                foo ? bar
+                    : baz ? qux
+                    : foobar ? boop
+                    : beep
+            `,
+            output: unIndent`
+                foo ? bar
+                    : baz ? qux
+                        : foobar ? boop
+                            : beep
+            `,
+            options: [4, { flatTernaryExpressions: false }],
+            errors: expectedErrors([
+                [3, 8, 4, "Punctuator"],
+                [4, 12, 4, "Punctuator"]
+            ])
+        },
+        {
+            code: unIndent`
+                foo ? bar :
+                    baz ? qux :
+                    foobar ? boop :
+                    beep
+            `,
+            output: unIndent`
+                foo ? bar :
+                    baz ? qux :
+                        foobar ? boop :
+                            beep
+            `,
+            options: [4, { flatTernaryExpressions: false }],
+            errors: expectedErrors([
+                [3, 8, 4, "Identifier"],
+                [4, 12, 4, "Identifier"]
             ])
         },
         {

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -2963,6 +2963,24 @@ ruleTester.run("indent", rule, {
         },
         {
             code: unIndent`
+                var a =
+                    foo ? bar :
+                    baz ? qux :
+                    foobar ? boop :
+                    /*else*/ beep
+            `,
+            options: [4, { flatTernaryExpressions: true }]
+        },
+        {
+            code: unIndent`
+                var a = foo
+                    ? bar
+                    : baz
+            `,
+            options: [4, { flatTernaryExpressions: true }]
+        },
+        {
+            code: unIndent`
                 foo
                     ? bar
                     : baz
@@ -6537,6 +6555,27 @@ ruleTester.run("indent", rule, {
                 [5, 4, 8, "Identifier"],
                 [6, 4, 12, "Identifier"],
                 [7, 4, 12, "Identifier"]
+            ])
+        },
+        {
+            code: unIndent`
+                var a =
+                    foo ? bar :
+                      baz ? qux :
+                  foobar ? boop :
+                    /*else*/ beep
+            `,
+            output: unIndent`
+                var a =
+                    foo ? bar :
+                    baz ? qux :
+                    foobar ? boop :
+                    /*else*/ beep
+            `,
+            options: [4, { flatTernaryExpressions: true }],
+            errors: expectedErrors([
+                [3, 4, 6, "Identifier"],
+                [4, 4, 2, "Identifier"]
             ])
         },
         {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

Fixes #8481.

**What changes did you make? (Give an overview)**

This PR improves indentation when `{flatTernaryExpressions: true}`. See also #8481.

**Is there anything you'd like reviewers to focus on?**

Please check whether the usage of `offsets.increaseOffset` method is correct or not.
