### PR TITLE
Support an "eslint" property for package.json configuration

### DIFF
--- a/docs/user-guide/configuring.md
+++ b/docs/user-guide/configuring.md
@@ -3,7 +3,7 @@
 ESLint is designed to be completely configurable, meaning you can turn off every rule and run only with basic syntax validation, or mix and match the bundled rules and your custom rules to make ESLint perfect for your project. There are two primary ways to configure ESLint:
 
 1. **Configuration Comments** - use JavaScript comments to embed configuration information directly into a file.
-1. **Configuration Files** - use a JavaScript, JSON or YAML file to specify configuration information for an entire directory and all of its subdirectories. This can be in the form of an [.eslintrc.*](#configuration-file-formats) file or an `eslintConfig` field in a [`package.json`](https://docs.npmjs.com/files/package.json) file, both of which ESLint will look for and read automatically, or you can specify a configuration file on the [command line](command-line-interface).
+1. **Configuration Files** - use a JavaScript, JSON or YAML file to specify configuration information for an entire directory and all of its subdirectories. This can be in the form of an [.eslintrc.*](#configuration-file-formats) file or either an `eslint` or `eslintConfig` field in a [`package.json`](https://docs.npmjs.com/files/package.json) file, both of which ESLint will look for and read automatically, or you can specify a configuration file on the [command line](command-line-interface).
 
 There are several pieces of information that can be configured:
 
@@ -467,7 +467,7 @@ ESLint supports configuration files in several formats:
 * **YAML** - use `.eslintrc.yaml` or `.eslintrc.yml` to define the configuration structure.
 * **JSON** - use `.eslintrc.json` to define the configuration structure. ESLint's JSON files also allow JavaScript-style comments.
 * **Deprecated** - use `.eslintrc`, which can be either JSON or YAML.
-* **package.json** - create an `eslintConfig` property in your `package.json` file and define your configuration there.
+* **package.json** - create an `eslint` or `eslintConfig` property in your `package.json` file and define your configuration there.
 
 If there are multiple configuration files in the same directory, ESLint will only use one. The priority order is:
 

--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -174,7 +174,9 @@ function loadJSConfigFile(filePath) {
 function loadPackageJSONConfigFile(filePath) {
     debug(`Loading package.json config file: ${filePath}`);
     try {
-        return loadJSONConfigFile(filePath).eslintConfig || null;
+        const packageConfig = loadJSONConfigFile(filePath);
+
+        return packageConfig.eslint || packageConfig.eslintConfig || null;
     } catch (e) {
         debug(`Error reading package.json file: ${filePath}`);
         e.message = `Cannot read config file: ${filePath}\nError: ${e.message}`;

--- a/tests/lib/config/config-file.js
+++ b/tests/lib/config/config-file.js
@@ -574,7 +574,38 @@ describe("ConfigFile", () => {
             });
         });
 
-        it("should load fresh information from a package.json file", () => {
+        it("should load fresh information from a package.json file using `eslint`", () => {
+            const initialConfig = {
+                    eslint: {
+                        parserOptions: {},
+                        env: {},
+                        globals: {},
+                        rules: {
+                            quotes: [2, "double"]
+                        }
+                    }
+                },
+                updatedConfig = {
+                    eslint: {
+                        parserOptions: {},
+                        env: {},
+                        globals: {},
+                        rules: {
+                            quotes: 0
+                        }
+                    }
+                },
+                tmpFilename = "package.json",
+                tmpFilePath = writeTempConfigFile(initialConfig, tmpFilename);
+            let config = ConfigFile.load(tmpFilePath);
+
+            assert.deepEqual(config, initialConfig.eslint);
+            writeTempConfigFile(updatedConfig, tmpFilename, path.dirname(tmpFilePath));
+            config = ConfigFile.load(tmpFilePath);
+            assert.deepEqual(config, updatedConfig.eslint);
+        });
+
+        it("should load fresh information from a package.json file using `eslintConfig`", () => {
             const initialConfig = {
                     eslintConfig: {
                         parserOptions: {},


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Support `eslint` alongside `eslintConfig` as a configuration property in package.json.

A large majority of build tools that allow configuration through package.json simply use the project name as the property name, like `babel`, `ava`, `jest`, instead of `babelConfig`, etc. 

This PR simply adds a bit of consistency with other build tools, and removes any confusion when `eslint` is used (instead of `eslintConfig`).

**Is there anything you'd like reviewers to focus on?**

Not really. Consumer choice is always nice.
