### PR TITLE
Update: Use sane defaults for JSX indentation (fixes #8425)

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -128,7 +128,7 @@ class TokenInfo {
             if (!map.has(token.loc.start.line)) {
                 map.set(token.loc.start.line, token);
             }
-            if (!map.has(token.loc.end.line)) {
+            if (!map.has(token.loc.end.line) && sourceCode.text.slice(token.range[1] - token.loc.end.column, token.range[1]).trim()) {
                 map.set(token.loc.end.line, token);
             }
             return map;
@@ -639,12 +639,13 @@ module.exports = {
 
         /**
         * Check indentation for lists of elements (arrays, objects, function params)
-        * @param {Token[]} tokens list of tokens
         * @param {ASTNode[]} elements List of elements that should be offset
+        * @param {Token} startToken The start token of the list that element should be aligned against, e.g. '['
+        * @param {Token} endToken The end token of the list, e.g. ']'
         * @param {number|string} offset The amount that the elements should be offset
         * @returns {void}
         */
-        function addElementListIndent(tokens, elements, offset) {
+        function addElementListIndent(elements, startToken, endToken, offset) {
 
             /**
             * Gets the first token of a given element, including surrounding parentheses.
@@ -654,7 +655,7 @@ module.exports = {
             function getFirstToken(element) {
                 let token = sourceCode.getTokenBefore(element);
 
-                while (astUtils.isOpeningParenToken(token) && token !== tokens[0]) {
+                while (astUtils.isOpeningParenToken(token) && token !== startToken) {
                     token = sourceCode.getTokenBefore(token);
                 }
 
@@ -663,8 +664,12 @@ module.exports = {
 
             // Run through all the tokens in the list, and offset them by one indent level (mainly for comments, other things will end up overridden)
             // FIXME: (not-an-aardvark) This isn't performant at all.
-            offsets.setDesiredOffsets(tokens, tokens[0], offset === "first" ? 1 : offset);
-            offsets.matchIndentOf(tokens[0], tokens[tokens.length - 1]);
+            offsets.setDesiredOffsets(
+                sourceCode.getTokensBetween(startToken, endToken, { includeComments: true }),
+                startToken,
+                offset === "first" ? 1 : offset
+            );
+            offsets.matchIndentOf(startToken, endToken);
 
             // If the preference is "first" but there is no first element (e.g. sparse arrays w/ empty first slot), fall back to 1 level.
             if (offset === "first" && elements.length && !elements[0]) {
@@ -684,7 +689,7 @@ module.exports = {
                     const previousElement = elements[index - 1];
                     const firstTokenOfPreviousElement = previousElement && getFirstToken(previousElement);
 
-                    if (previousElement && previousElement.loc.end.line > tokens[0].loc.end.line) {
+                    if (previousElement && sourceCode.getLastToken(previousElement).loc.start.line > startToken.loc.end.line) {
                         offsets.matchIndentOf(firstTokenOfPreviousElement, getFirstToken(elements[index]));
                     }
                 }
@@ -710,16 +715,14 @@ module.exports = {
                 blockIndentLevel = 1;
             }
 
-            const tokens = getTokensAndComments(node);
-
             /*
              * For blocks that aren't lone statements, ensure that the opening curly brace
              * is aligned with the parent.
              */
             if (!astUtils.STATEMENT_LIST_PARENTS.has(node.parent.type)) {
-                offsets.matchIndentOf(sourceCode.getFirstToken(node.parent), tokens[0]);
+                offsets.matchIndentOf(sourceCode.getFirstToken(node.parent), sourceCode.getFirstToken(node));
             }
-            addElementListIndent(tokens, node.body, blockIndentLevel);
+            addElementListIndent(node.body, sourceCode.getFirstToken(node), sourceCode.getLastToken(node), blockIndentLevel);
         }
 
         /**
@@ -730,7 +733,7 @@ module.exports = {
         function addArrayOrObjectIndent(node) {
             const tokens = getTokensAndComments(node);
 
-            addElementListIndent(tokens, node.elements || node.properties, options[node.type]);
+            addElementListIndent(node.elements || node.properties, tokens[0], tokens[tokens.length - 1], options[node.type]);
         }
 
         /**
@@ -787,12 +790,11 @@ module.exports = {
             const nodeTokens = getTokensAndComments(node);
             const openingParenIndex = lodash.sortedIndexBy(nodeTokens, openingParen, token => token.range[0]);
             const closingParenIndex = lodash.sortedIndexBy(nodeTokens, closingParen, token => token.range[0]);
-            const paramTokens = nodeTokens.slice(openingParenIndex, closingParenIndex + 1);
 
-            parameterParens.add(paramTokens[0]);
-            parameterParens.add(paramTokens[paramTokens.length - 1]);
+            parameterParens.add(nodeTokens[openingParenIndex]);
+            parameterParens.add(nodeTokens[closingParenIndex]);
 
-            addElementListIndent(paramTokens, node.params, paramsIndent);
+            addElementListIndent(node.params, nodeTokens[openingParenIndex], nodeTokens[closingParenIndex], paramsIndent);
         }
 
         /**
@@ -831,14 +833,13 @@ module.exports = {
             } else {
                 openingParen = sourceCode.getLastToken(node, 1);
             }
-            const callExpressionTokens = getTokensAndComments(node);
-            const tokens = callExpressionTokens.slice(lodash.sortedIndexBy(callExpressionTokens, openingParen, token => token.range[0]));
+            const closingParen = sourceCode.getLastToken(node);
 
-            parameterParens.add(tokens[0]);
-            parameterParens.add(tokens[tokens.length - 1]);
+            parameterParens.add(openingParen);
+            parameterParens.add(closingParen);
             offsets.matchIndentOf(sourceCode.getLastToken(node.callee), openingParen);
 
-            addElementListIndent(tokens, node.arguments, options.CallExpression.arguments);
+            addElementListIndent(node.arguments, openingParen, closingParen, options.CallExpression.arguments);
         }
 
         /**
@@ -980,7 +981,7 @@ module.exports = {
                     const closingCurlyIndex = lodash.sortedIndexBy(tokensInNode, closingCurly, token => token.range[0]);
 
                     // Indent the specifiers in `export {foo, bar, baz}`
-                    addElementListIndent(tokensInNode.slice(1, closingCurlyIndex + 1), node.specifiers, 1);
+                    addElementListIndent(node.specifiers, sourceCode.getFirstToken(node, { skip: 1 }), closingCurly, 1);
 
                     if (node.source) {
 
@@ -1028,9 +1029,8 @@ module.exports = {
                 if (node.specifiers.some(specifier => specifier.type === "ImportSpecifier")) {
                     const openingCurly = sourceCode.getFirstToken(node, astUtils.isOpeningBraceToken);
                     const closingCurly = sourceCode.getLastToken(node, astUtils.isClosingBraceToken);
-                    const specifierTokens = sourceCode.getTokensBetween(openingCurly, closingCurly, 1);
 
-                    addElementListIndent(specifierTokens, node.specifiers.filter(specifier => specifier.type === "ImportSpecifier"), 1);
+                    addElementListIndent(node.specifiers.filter(specifier => specifier.type === "ImportSpecifier"), openingCurly, closingCurly, 1);
                 }
 
                 const fromToken = sourceCode.getLastToken(node, token => token.type === "Identifier" && token.value === "from");
@@ -1044,7 +1044,7 @@ module.exports = {
 
             LogicalExpression: addBinaryOrLogicalExpressionIndent,
 
-            MemberExpression(node) {
+            "MemberExpression, JSXMemberExpression"(node) {
                 const firstNonObjectToken = sourceCode.getFirstTokenBetween(node.object, node.property, astUtils.isNotClosingParenToken);
                 const secondNonObjectToken = sourceCode.getTokenAfter(firstNonObjectToken);
 
@@ -1204,6 +1204,44 @@ module.exports = {
             WhileStatement: node => addBlocklessNodeIndent(node.body),
 
             "*:exit": checkForUnknownNode,
+
+            JSXElement(node) {
+                if (node.closingElement) {
+                    addElementListIndent(node.children, sourceCode.getFirstToken(node.openingElement), sourceCode.getFirstToken(node.closingElement), 1);
+                }
+            },
+
+            JSXOpeningElement(node) {
+                const firstToken = sourceCode.getFirstToken(node);
+                let closingToken;
+
+                if (node.selfClosing) {
+                    closingToken = sourceCode.getLastToken(node, { skip: 1 });
+                    offsets.matchIndentOf(closingToken, sourceCode.getLastToken(node));
+                } else {
+                    closingToken = sourceCode.getLastToken(node);
+                }
+                offsets.setDesiredOffsets(getTokensAndComments(node.name), sourceCode.getFirstToken(node));
+                addElementListIndent(node.attributes, firstToken, closingToken, 1);
+            },
+
+            JSXClosingElement(node) {
+                const firstToken = sourceCode.getFirstToken(node);
+
+                offsets.setDesiredOffsets(getTokensAndComments(node.name), firstToken, 1);
+                offsets.matchIndentOf(firstToken, sourceCode.getLastToken(node));
+            },
+
+            JSXExpressionContainer(node) {
+                const openingCurly = sourceCode.getFirstToken(node);
+                const firstExpressionToken = sourceCode.getFirstToken(node.expression);
+
+                if (firstExpressionToken) {
+                    offsets.setDesiredOffset(firstExpressionToken, openingCurly, 1);
+                }
+
+                offsets.matchIndentOf(openingCurly, sourceCode.getLastToken(node));
+            },
 
             "Program:exit"() {
                 addParensIndent(sourceCode.ast.tokens);

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -1205,6 +1205,14 @@ module.exports = {
 
             "*:exit": checkForUnknownNode,
 
+            "JSXAttribute[value]"(node) {
+                const equalsToken = sourceCode.getFirstTokenBetween(node.name, node.value, token => token.type === "Punctuator" && token.value === "=");
+                const firstNameToken = sourceCode.getFirstToken(node.name);
+
+                offsets.setDesiredOffset(equalsToken, firstNameToken, 1);
+                offsets.setDesiredOffset(sourceCode.getFirstToken(node.value), firstNameToken, 1);
+            },
+
             JSXElement(node) {
                 if (node.closingElement) {
                     addElementListIndent(node.children, sourceCode.getFirstToken(node.openingElement), sourceCode.getFirstToken(node.closingElement), 1);

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -67,7 +67,7 @@ function unIndent(strings) {
     return lines.map(line => line.slice(minLineIndent)).join("\n");
 }
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } });
 
 ruleTester.run("indent", rule, {
     valid: [
@@ -124,8 +124,7 @@ ruleTester.run("indent", rule, {
                     );
                 }
             `,
-            options: [4],
-            parserOptions: { ecmaVersion: 6 }
+            options: [4]
         },
         {
             code: unIndent`
@@ -147,8 +146,7 @@ ruleTester.run("indent", rule, {
                         return 100 * x;
                     });
             `,
-            options: [4],
-            parserOptions: { ecmaVersion: 6 }
+            options: [4]
         },
         {
             code: unIndent`
@@ -257,8 +255,7 @@ ruleTester.run("indent", rule, {
                   expect(true).toBe(true);
                 });
             `,
-            options: [2],
-            parserOptions: { ecmaVersion: 6 }
+            options: [2]
         },
         {
             code: unIndent`
@@ -326,8 +323,7 @@ ruleTester.run("indent", rule, {
                   console.log('hi');
                   return true;};
             `,
-            options: [2, { VariableDeclarator: 1, SwitchCase: 1 }],
-            parserOptions: { ecmaVersion: 6 }
+            options: [2, { VariableDeclarator: 1, SwitchCase: 1 }]
         },
         {
             code: unIndent`
@@ -766,16 +762,14 @@ ruleTester.run("indent", rule, {
                 let geometry,
                     rotate;
             `,
-            options: [2, { VariableDeclarator: 2 }],
-            parserOptions: { ecmaVersion: 6 }
+            options: [2, { VariableDeclarator: 2 }]
         },
         {
             code: unIndent`
                 const geometry = 2,
                     rotate = 3;
             `,
-            options: [2, { VariableDeclarator: 2 }],
-            parserOptions: { ecmaVersion: 6 }
+            options: [2, { VariableDeclarator: 2 }]
         },
         {
             code: unIndent`
@@ -816,8 +810,7 @@ ruleTester.run("indent", rule, {
                     index;
                 });
             `,
-            options: [4],
-            parserOptions: { ecmaVersion: 6 }
+            options: [4]
         },
         {
             code: unIndent`
@@ -826,8 +819,7 @@ ruleTester.run("indent", rule, {
                     return index;
                 });
             `,
-            options: [4],
-            parserOptions: { ecmaVersion: 6 }
+            options: [4]
         },
         {
             code: unIndent`
@@ -835,8 +827,7 @@ ruleTester.run("indent", rule, {
                     index;
                 });
             `,
-            options: [4],
-            parserOptions: { ecmaVersion: 6 }
+            options: [4]
         },
         {
             code: unIndent`
@@ -844,8 +835,7 @@ ruleTester.run("indent", rule, {
                     return index;
                 });
             `,
-            options: [4],
-            parserOptions: { ecmaVersion: 6 }
+            options: [4]
         },
         {
             code: unIndent`
@@ -854,8 +844,7 @@ ruleTester.run("indent", rule, {
                         baz
                     ]);
             `,
-            options: [4, { MemberExpression: 1 }],
-            parserOptions: { ecmaVersion: 6 }
+            options: [4, { MemberExpression: 1 }]
         },
         {
             code: unIndent`
@@ -1103,8 +1092,7 @@ ruleTester.run("indent", rule, {
                   }
                 );
             `,
-            options: [2, { VariableDeclarator: 3 }],
-            parserOptions: { ecmaVersion: 6 }
+            options: [2, { VariableDeclarator: 3 }]
 
         },
         {
@@ -1116,8 +1104,7 @@ ruleTester.run("indent", rule, {
                 let light = true,
                     shadow = false;
             `,
-            options: [2, { VariableDeclarator: { const: 3, let: 2 } }],
-            parserOptions: { ecmaVersion: 6 }
+            options: [2, { VariableDeclarator: { const: 3, let: 2 } }]
         },
         {
             code: unIndent`
@@ -1143,8 +1130,7 @@ ruleTester.run("indent", rule, {
                       b: 2
                     };
             `,
-            options: [2, { VariableDeclarator: { var: 2, const: 3 }, SwitchCase: 1 }],
-            parserOptions: { ecmaVersion: 6 }
+            options: [2, { VariableDeclarator: { var: 2, const: 3 }, SwitchCase: 1 }]
         },
         {
             code: unIndent`
@@ -1255,7 +1241,6 @@ ruleTester.run("indent", rule, {
                     a = 5,
                     b = 4
             `,
-            parserOptions: { ecmaVersion: 6 },
             options: [2, { VariableDeclarator: { var: 2, let: 2, const: 3 } }]
         },
         {
@@ -1269,7 +1254,6 @@ ruleTester.run("indent", rule, {
 
                 if (YO) console.log(TE)
             `,
-            parserOptions: { ecmaVersion: 6 },
             options: [2, { VariableDeclarator: { var: 2, let: 2, const: 3 } }]
         },
         {
@@ -1326,8 +1310,7 @@ ruleTester.run("indent", rule, {
                         console.log(argument);
                     },
                     someOtherValue = 'someOtherValue';
-            `,
-            parserOptions: { ecmaVersion: 6 }
+            `
         },
         {
             code: unIndent`
@@ -1350,8 +1333,7 @@ ruleTester.run("indent", rule, {
                       get b(){}
                     };
             `,
-            options: [2, { VariableDeclarator: 2, SwitchCase: 1 }],
-            parserOptions: { ecmaVersion: 6 }
+            options: [2, { VariableDeclarator: 2, SwitchCase: 1 }]
         },
         {
             code: unIndent`
@@ -1364,8 +1346,7 @@ ruleTester.run("indent", rule, {
                     },
                     c = 3;
             `,
-            options: [2, { VariableDeclarator: 2, SwitchCase: 1 }],
-            parserOptions: { ecmaVersion: 6 }
+            options: [2, { VariableDeclarator: 2, SwitchCase: 1 }]
         },
         {
             code: unIndent`
@@ -1375,8 +1356,7 @@ ruleTester.run("indent", rule, {
                     get b(){}
                 }
             `,
-            options: [4, { VariableDeclarator: 1, SwitchCase: 1 }],
-            parserOptions: { ecmaVersion: 6 }
+            options: [4, { VariableDeclarator: 1, SwitchCase: 1 }]
         },
         {
             code: unIndent`
@@ -1386,8 +1366,7 @@ ruleTester.run("indent", rule, {
                     get b(){}
                 }
             `,
-            options: [4, { VariableDeclarator: 1, SwitchCase: 1 }],
-            parserOptions: { ecmaVersion: 6 }
+            options: [4, { VariableDeclarator: 1, SwitchCase: 1 }]
         },
         {
             code: unIndent`
@@ -1448,7 +1427,6 @@ ruleTester.run("indent", rule, {
                     });
                 };
             `,
-            parserOptions: { ecmaVersion: 6 },
             options: [4, { MemberExpression: 0 }]
         },
         {
@@ -1462,7 +1440,6 @@ ruleTester.run("indent", rule, {
                         });
                 };
             `,
-            parserOptions: { ecmaVersion: 6 },
             options: [4]
         },
         {
@@ -1509,7 +1486,6 @@ ruleTester.run("indent", rule, {
                   }
                 };
             `,
-            parserOptions: { ecmaVersion: 6 },
             options: [2]
         },
         {
@@ -1531,7 +1507,6 @@ ruleTester.run("indent", rule, {
                   baz() {}
                 }
             `,
-            parserOptions: { ecmaVersion: 6 },
             options: [2]
         },
         {
@@ -1541,7 +1516,6 @@ ruleTester.run("indent", rule, {
                   baz() {}
                 }
             `,
-            parserOptions: { ecmaVersion: 6 },
             options: [2]
         },
         {
@@ -1553,7 +1527,6 @@ ruleTester.run("indent", rule, {
                   baz() {}
                 }
             `,
-            parserOptions: { ecmaVersion: 6 },
             options: [2]
         },
         {
@@ -1562,8 +1535,7 @@ ruleTester.run("indent", rule, {
                   files[name] = foo;
                 });
             `,
-            options: [2, { outerIIFEBody: 0 }],
-            parserOptions: { ecmaVersion: 6 }
+            options: [2, { outerIIFEBody: 0 }]
         },
         {
             code: unIndent`
@@ -1705,7 +1677,6 @@ ruleTester.run("indent", rule, {
                 }
                 })();
             `,
-            parserOptions: { ecmaVersion: 6 },
             options: [2, { outerIIFEBody: 0 }]
         },
         {
@@ -1723,7 +1694,6 @@ ruleTester.run("indent", rule, {
                 }
                 })();
             `,
-            parserOptions: { ecmaVersion: 6 },
             options: [2, { outerIIFEBody: 0 }]
         },
         {
@@ -2043,8 +2013,7 @@ ruleTester.run("indent", rule, {
                   foobar: baz = foobar
                 } = qux;
             `,
-            options: [2],
-            parserOptions: { ecmaVersion: 6 }
+            options: [2]
         },
         {
             code: unIndent`
@@ -2055,8 +2024,7 @@ ruleTester.run("indent", rule, {
                   foobar = baz
                 ] = qux;
             `,
-            options: [2],
-            parserOptions: { ecmaVersion: 6 }
+            options: [2]
         },
         {
 
@@ -2073,16 +2041,14 @@ ruleTester.run("indent", rule, {
                 for (const foo of bar)
                   baz();
             `,
-            options: [2],
-            parserOptions: { ecmaVersion: 6 }
+            options: [2]
         },
         {
             code: unIndent`
                 var x = () =>
                   5;
             `,
-            options: [2],
-            parserOptions: { ecmaVersion: 6 }
+            options: [2]
         },
         {
 
@@ -2534,8 +2500,7 @@ ruleTester.run("indent", rule, {
                   );
                 }
             `,
-            options: [2, { ObjectExpression: 1 }],
-            parserOptions: { ecmaVersion: 6 }
+            options: [2, { ObjectExpression: 1 }]
         },
         {
             code: unIndent`
@@ -2548,8 +2513,7 @@ ruleTester.run("indent", rule, {
                   );
                 }
             `,
-            options: [2, { ObjectExpression: "first" }],
-            parserOptions: { ecmaVersion: 6 }
+            options: [2, { ObjectExpression: "first" }]
         },
 
         // https://github.com/eslint/eslint/issues/7733
@@ -2632,8 +2596,7 @@ ruleTester.run("indent", rule, {
                 \`foo\${
                   bar}\`
             `,
-            options: [2],
-            parserOptions: { ecmaVersion: 6 }
+            options: [2]
         },
         {
             code: unIndent`
@@ -2641,8 +2604,7 @@ ruleTester.run("indent", rule, {
                   \`bar\${
                     baz}\`}\`
             `,
-            options: [2],
-            parserOptions: { ecmaVersion: 6 }
+            options: [2]
         },
         {
             code: unIndent`
@@ -2652,8 +2614,7 @@ ruleTester.run("indent", rule, {
                   }\`
                 }\`
             `,
-            options: [2],
-            parserOptions: { ecmaVersion: 6 }
+            options: [2]
         },
         {
             code: unIndent`
@@ -2663,8 +2624,7 @@ ruleTester.run("indent", rule, {
                   )
                 }\`
             `,
-            options: [2],
-            parserOptions: { ecmaVersion: 6 }
+            options: [2]
         },
         {
 
@@ -2674,8 +2634,7 @@ ruleTester.run("indent", rule, {
                         qux}foo\${
                         bar}baz\`
                 }
-            `,
-            parserOptions: { ecmaVersion: 6 }
+            `
         },
         {
 
@@ -2711,8 +2670,7 @@ ruleTester.run("indent", rule, {
                     const template = \`this indentation is not checked
                 because it's part of a template literal.\`;
                 }
-            `,
-            parserOptions: { ecmaVersion: 6 }
+            `
         },
         {
             code: unIndent`
@@ -2721,8 +2679,7 @@ ruleTester.run("indent", rule, {
                         node.type
                     } node is checked.\`;
                 }
-            `,
-            parserOptions: { ecmaVersion: 6 }
+            `
         },
         {
 
@@ -3039,8 +2996,7 @@ ruleTester.run("indent", rule, {
                   }
                 );
             `,
-            options: [2, { ObjectExpression: "first" }],
-            parserOptions: { ecmaVersion: 6 }
+            options: [2, { ObjectExpression: "first" }]
         },
         {
             code: unIndent`
@@ -3050,8 +3006,7 @@ ruleTester.run("indent", rule, {
                     baz;
                 })
             `,
-            options: [4, { CallExpression: { arguments: "first" } }],
-            parserOptions: { ecmaVersion: 6 }
+            options: [4, { CallExpression: { arguments: "first" } }]
         },
         {
             code: unIndent`
@@ -3103,8 +3058,7 @@ ruleTester.run("indent", rule, {
             `
         },
         {
-            code: "x => {}",
-            parserOptions: { ecmaVersion: 6 }
+            code: "x => {}"
         },
         {
             code: unIndent`
@@ -3126,8 +3080,7 @@ ruleTester.run("indent", rule, {
                 ) => b => {
                     c
                 }
-            `,
-            parserOptions: { ecmaVersion: 6 }
+            `
         },
         {
             code: unIndent`
@@ -3136,8 +3089,7 @@ ruleTester.run("indent", rule, {
                 ) => b => c => d => {
                     e
                 }
-            `,
-            parserOptions: { ecmaVersion: 6 }
+            `
         },
         {
             code: unIndent`
@@ -3149,8 +3101,7 @@ ruleTester.run("indent", rule, {
                     ) => {
                         c
                     }
-            `,
-            parserOptions: { ecmaVersion: 6 }
+            `
         },
         {
             code: unIndent`
@@ -3181,15 +3132,13 @@ ruleTester.run("indent", rule, {
             code: unIndent`
                 () =>
                     ({})
-            `,
-            parserOptions: { ecmaVersion: 6 }
+            `
         },
         {
             code: unIndent`
                 () =>
                     (({}))
-            `,
-            parserOptions: { ecmaVersion: 6 }
+            `
         },
         {
             code: unIndent`
@@ -3197,8 +3146,7 @@ ruleTester.run("indent", rule, {
                     () =>
                         ({})
                 )
-            `,
-            parserOptions: { ecmaVersion: 6 }
+            `
         },
         {
             code: unIndent`
@@ -3214,8 +3162,7 @@ ruleTester.run("indent", rule, {
                 {
                     baz();
                 }
-            `,
-            parserOptions: { ecmaVersion: 6 }
+            `
         },
         {
             code: unIndent`
@@ -3231,8 +3178,7 @@ ruleTester.run("indent", rule, {
                         baz();
                     }
                 }
-            `,
-            parserOptions: { ecmaVersion: 6 }
+            `
         },
         {
             code: unIndent`
@@ -3249,8 +3195,7 @@ ruleTester.run("indent", rule, {
                         baz();
                     }
                 }
-            `,
-            parserOptions: { ecmaVersion: 6 }
+            `
         },
         {
             code: unIndent`
@@ -3268,8 +3213,7 @@ ruleTester.run("indent", rule, {
                         }
                     }
                 )
-            `,
-            parserOptions: { ecmaVersion: 6 }
+            `
         },
         {
             code: unIndent`
@@ -3476,24 +3420,760 @@ ruleTester.run("indent", rule, {
         },
         {
             code: unIndent`
-              type httpMethod = 'GET'
-                | 'POST'
-                | 'PUT';
+                type httpMethod = 'GET'
+                  | 'POST'
+                  | 'PUT';
             `,
             options: [2, { VariableDeclarator: 0 }],
             parser: parser("unknown-nodes/variable-declarator-type-indent-two-spaces")
         },
         {
             code: unIndent`
-              type httpMethod = 'GET'
-              | 'POST'
-              | 'PUT';
+                type httpMethod = 'GET'
+                | 'POST'
+                | 'PUT';
             `,
             options: [2, { VariableDeclarator: 1 }],
             parser: parser("unknown-nodes/variable-declarator-type-no-indent")
+        },
+        {
+            code: unIndent`
+                foo(\`foo
+                        \`, {
+                        ok: true
+                    },
+                    {
+                        ok: false
+                    }
+                )
+            `
+        },
+        {
+            code: unIndent`
+                foo(tag\`foo
+                        \`, {
+                        ok: true
+                    },
+                    {
+                        ok: false
+                    }
+                )
+            `
+        },
+
+        //----------------------------------------------------------------------
+        // JSX tests
+        // https://github.com/eslint/eslint/issues/8425
+        // Some of the following tests are adapted from the the tests in eslint-plugin-react.
+        // License: https://github.com/yannickcr/eslint-plugin-react/blob/7ca9841f22d599f447a27ef5b2a97def9229d6c8/LICENSE
+        //----------------------------------------------------------------------
+
+        {
+            code: "<Foo a=\"b\" c=\"d\"/>;"
+        },
+        {
+            code: unIndent`
+                <Foo
+                    a="b"
+                    c="d"
+                />;
+            `
+        },
+        {
+            code: "var foo = <Bar a=\"b\" c=\"d\"/>;"
+        },
+        {
+            code: unIndent`
+                var foo = <Bar
+                    a="b"
+                    c="d"
+                />;
+            `
+        },
+        {
+            code: unIndent`
+                var foo = (<Bar
+                    a="b"
+                    c="d"
+                />);
+            `
+        },
+        {
+            code: unIndent`
+                var foo = (
+                    <Bar
+                        a="b"
+                        c="d"
+                    />
+                );
+            `
+        },
+        {
+            code: unIndent`
+                <
+                    Foo
+                    a="b"
+                    c="d"
+                />;
+            `
+        },
+        {
+            code: unIndent`
+                <Foo
+                    a="b"
+                    c="d"/>;
+            `
+        },
+        {
+            code: unIndent`
+                <
+                    Foo
+                    a="b"
+                    c="d"/>;
+            `
+        },
+        {
+            code: "<a href=\"foo\">bar</a>;"
+
+        },
+        {
+            code: unIndent`
+                <a href="foo">
+                    bar
+                </a>;
+            `
+        },
+        {
+            code: unIndent`
+                <a
+                    href="foo"
+                >
+                    bar
+                </a>;
+            `
+        },
+        {
+            code: unIndent`
+                <a
+                    href="foo">
+                    bar
+                </a>;
+            `
+        },
+        {
+            code: unIndent`
+                <
+                    a
+                    href="foo">
+                    bar
+                </a>;
+            `
+        },
+        {
+            code: unIndent`
+                <a
+                    href="foo">
+                    bar
+                </
+                    a>;
+            `
+        },
+        {
+            code: unIndent`
+                <a
+                    href="foo">
+                    bar
+                </a
+                >;
+            `
+        },
+        {
+            code: unIndent`
+                var foo = <a href="bar">
+                    baz
+                </a>;
+            `
+        },
+        {
+            code: unIndent`
+                var foo = <a
+                    href="bar"
+                >
+                    baz
+                </a>;
+            `
+        },
+        {
+            code: unIndent`
+                var foo = <a
+                    href="bar">
+                    baz
+                </a>;
+            `
+        },
+        {
+            code: unIndent`
+                var foo = <
+                    a
+                    href="bar">
+                    baz
+                </a>;
+            `
+        },
+        {
+            code: unIndent`
+                var foo = <a
+                    href="bar">
+                    baz
+                </
+                    a>;
+            `
+        },
+        {
+            code: unIndent`
+                var foo = <a
+                    href="bar">
+                    baz
+                </a
+                >
+            `
+        },
+        {
+            code: unIndent`
+                var foo = (<a
+                    href="bar">
+                    baz
+                </a>);
+            `
+        },
+        {
+            code: unIndent`
+                var foo = (
+                    <a href="bar">baz</a>
+                );
+            `
+        },
+        {
+            code: unIndent`
+                var foo = (
+                    <a href="bar">
+                        baz
+                    </a>
+                );
+            `
+        },
+        {
+            code: unIndent`
+                var foo = (
+                    <a
+                        href="bar">
+                        baz
+                    </a>
+                );
+            `
+        },
+        {
+            code: "var foo = <a href=\"bar\">baz</a>;"
+        },
+        {
+            code: unIndent`
+                <a>
+                    {
+                    }
+                </a>
+            `
+        },
+        {
+            code: unIndent`
+                <a>
+                    {
+                        foo
+                    }
+                </a>
+            `
+        },
+        {
+            code: unIndent`
+                function foo() {
+                    return (
+                        <a>
+                            {
+                                b.forEach(() => {
+                                    // comment
+                                    a = c
+                                        .d()
+                                        .e();
+                                })
+                            }
+                        </a>
+                    );
+                }
+            `
+        },
+        {
+            code: "<App></App>"
+        },
+        {
+            code: unIndent`
+                <App>
+                </App>
+            `
+        },
+        {
+            code: unIndent`
+                <App>
+                  <Foo />
+                </App>
+            `,
+            options: [2]
+        },
+        {
+            code: unIndent`
+                <App>
+                <Foo />
+                </App>
+            `,
+            options: [0]
+        },
+        {
+            code: unIndent`
+                <App>
+                \t<Foo />
+                </App>
+            `,
+            options: ["tab"]
+        },
+        {
+            code: unIndent`
+                function App() {
+                  return <App>
+                    <Foo />
+                  </App>;
+                }
+            `,
+            options: [2]
+        },
+        {
+            code: unIndent`
+                function App() {
+                  return (<App>
+                    <Foo />
+                  </App>);
+                }
+            `,
+            options: [2]
+        },
+        {
+            code: unIndent`
+                function App() {
+                  return (
+                    <App>
+                      <Foo />
+                    </App>
+                  );
+                }
+            `,
+            options: [2]
+        },
+        {
+            code: unIndent`
+                it(
+                  (
+                    <div>
+                      <span />
+                    </div>
+                  )
+                )
+            `,
+            options: [2]
+        },
+        {
+            code: unIndent`
+                it(
+                  (<div>
+                    <span />
+                    <span />
+                    <span />
+                  </div>)
+                )
+            `,
+            options: [2]
+        },
+        {
+            code: unIndent`
+                (
+                  <div>
+                    <span />
+                  </div>
+                )
+            `,
+            options: [2]
+        },
+        {
+            code: unIndent`
+                {
+                  head.title &&
+                  <h1>
+                    {head.title}
+                  </h1>
+                }
+            `,
+            options: [2]
+        },
+        {
+            code: unIndent`
+                {
+                  head.title &&
+                    <h1>
+                      {head.title}
+                    </h1>
+                }
+            `,
+            options: [2]
+        },
+        {
+            code: unIndent`
+                {
+                  head.title && (
+                    <h1>
+                      {head.title}
+                    </h1>)
+                }
+            `,
+            options: [2]
+        },
+        {
+            code: unIndent`
+                {
+                  head.title && (
+                    <h1>
+                      {head.title}
+                    </h1>
+                  )
+                }
+            `,
+            options: [2]
+        },
+        {
+            code: unIndent`
+                [
+                  <div />,
+                  <div />
+                ]
+            `,
+            options: [2]
+        },
+        {
+            code: unIndent`
+                <div>
+                    {
+                        [
+                            <Foo />,
+                            <Bar />
+                        ]
+                    }
+                </div>
+            `
+        },
+        {
+            code: unIndent`
+                <div>
+                    {foo &&
+                        [
+                            <Foo />,
+                            <Bar />
+                        ]
+                    }
+                </div>
+            `
+        },
+        {
+
+            // Literals indentation is not touched
+            code: unIndent`
+                <div>
+                bar <div>
+                   bar
+                   bar {foo}
+                bar </div>
+                </div>
+            `
+        },
+        {
+
+            // Multiline ternary
+            // (colon at the end of the first expression)
+            code: unIndent`
+                foo ?
+                    <Foo /> :
+                    <Bar />
+            `
+        },
+        {
+
+            // Multiline ternary
+            // (colon at the start of the second expression)
+            code: unIndent`
+                foo ?
+                    <Foo />
+                    : <Bar />
+            `
+        },
+        {
+
+            // Multiline ternary
+            // (colon on its own line)
+            code: unIndent`
+                foo ?
+                    <Foo />
+                    :
+                    <Bar />
+            `
+        },
+        {
+
+            // Multiline ternary
+            // (multiline JSX, colon on its own line)
+            code: unIndent`
+                {!foo ?
+                    <Foo
+                        onClick={this.onClick}
+                    />
+                    :
+                    <Bar
+                        onClick={this.onClick}
+                    />
+                }
+            `
+        },
+        {
+            code: unIndent`
+                <span>
+                  {condition ?
+                    <Thing
+                      foo={\`bar\`}
+                    /> :
+                    <Thing/>
+                  }
+                </span>
+            `,
+            options: [2]
+        },
+        {
+            code: unIndent`
+                <span>
+                  {condition ?
+                    <Thing
+                      foo={"bar"}
+                    /> :
+                    <Thing/>
+                  }
+                </span>
+            `,
+            options: [2]
+        },
+        {
+            code: unIndent`
+                function foo() {
+                  <span>
+                    {condition ?
+                      <Thing
+                        foo={super}
+                      /> :
+                      <Thing/>
+                    }
+                  </span>
+                }
+            `,
+            options: [2]
+        },
+        {
+            code: unIndent`
+              <App foo
+              />
+            `
+        },
+        {
+            code: unIndent`
+              <App
+                foo
+              />
+            `,
+            options: [2]
+        },
+        {
+            code: unIndent`
+              <App
+              foo
+              />
+            `,
+            options: [0]
+        },
+        {
+            code: unIndent`
+              <App
+              \tfoo
+              />
+            `,
+            options: ["tab"]
+        },
+        {
+            code: unIndent`
+                <App
+                    foo
+                />
+            `
+        },
+        {
+            code: unIndent`
+                <App
+                    foo
+                ></App>
+            `
+        },
+        {
+            code: unIndent`
+                <App
+                  foo={function() {
+                    console.log('bar');
+                  }}
+                />
+            `,
+            options: [2]
+        },
+        {
+            code: unIndent`
+                <App foo={function() {
+                  console.log('bar');
+                }}
+                />
+            `,
+            options: [2]
+        },
+        {
+            code: unIndent`
+                var x = function() {
+                  return <App
+                    foo={function() {
+                      console.log('bar');
+                    }}
+                  />
+                }
+            `,
+            options: [2]
+        },
+        {
+            code: unIndent`
+                var x = <App
+                  foo={function() {
+                    console.log('bar');
+                  }}
+                />
+            `,
+            options: [2]
+        },
+        {
+            code: unIndent`
+                <Provider
+                  store
+                >
+                  <App
+                    foo={function() {
+                      console.log('bar');
+                    }}
+                  />
+                </Provider>
+            `,
+            options: [2]
+        },
+        {
+            code: unIndent`
+                <Provider
+                  store
+                >
+                  {baz && <App
+                    foo={function() {
+                      console.log('bar');
+                    }}
+                  />}
+                </Provider>
+            `,
+            options: [2]
+        },
+        {
+            code: unIndent`
+                <App
+                \tfoo
+                />
+            `,
+            options: ["tab"]
+        },
+        {
+            code: unIndent`
+                <App
+                \tfoo
+                ></App>
+            `,
+            options: ["tab"]
+        },
+        {
+            code: unIndent`
+                <App foo={function() {
+                \tconsole.log('bar');
+                }}
+                />
+            `,
+            options: ["tab"]
+        },
+        {
+            code: unIndent`
+                var x = <App
+                \tfoo={function() {
+                \t\tconsole.log('bar');
+                \t}}
+                />
+            `,
+            options: ["tab"]
+        },
+        {
+            code: unIndent`
+                <App
+                    foo />
+            `
+        },
+        {
+            code: unIndent`
+                <div>
+                   unrelated{
+                        foo
+                    }
+                </div>
+            `
+        },
+        {
+            code: unIndent`
+                <div>unrelated{
+                    foo
+                }
+                </div>
+            `
+        },
+        {
+            code: unIndent`
+                <
+                    foo
+                        .bar
+                        .baz
+                >
+                    foo
+                </
+                    foo.
+                        bar.
+                        baz
+                >
+            `
         }
     ],
-
 
     invalid: [
         {
@@ -3949,7 +4629,6 @@ ruleTester.run("indent", rule, {
                 }
             `,
             options: [4, { MemberExpression: 2 }],
-            parserOptions: { ecmaVersion: 6 },
             errors: expectedErrors(
                 [3, 12, 13, "Punctuator"]
             )
@@ -3972,7 +4651,6 @@ ruleTester.run("indent", rule, {
                 };
             `,
             options: [2, { MemberExpression: 1 }],
-            parserOptions: { ecmaVersion: 6 },
             errors: expectedErrors([3, 4, 6, "Punctuator"])
         },
         {
@@ -4185,7 +4863,6 @@ ruleTester.run("indent", rule, {
                 });
             `,
             options: [4],
-            parserOptions: { ecmaVersion: 6 },
             errors: expectedErrors([
                 [3, 4, 8, "Identifier"],
                 [4, 0, 4, "Punctuator"]
@@ -4205,7 +4882,6 @@ ruleTester.run("indent", rule, {
                 });
             `,
             options: [4],
-            parserOptions: { ecmaVersion: 6 },
             errors: expectedErrors([
                 [2, 4, 0, "Identifier"],
                 [3, 4, 2, "Keyword"]
@@ -4223,7 +4899,6 @@ ruleTester.run("indent", rule, {
                 });
             `,
             options: [4],
-            parserOptions: { ecmaVersion: 6 },
             errors: expectedErrors([
                 [2, 4, 2, "Keyword"]
             ])
@@ -4242,7 +4917,6 @@ ruleTester.run("indent", rule, {
                     ]);
             `,
             options: [4, { MemberExpression: 1 }],
-            parserOptions: { ecmaVersion: 6 },
             errors: expectedErrors([[3, 8, 4, "Identifier"], [4, 4, 0, "Punctuator"]])
         },
         {
@@ -4325,7 +4999,6 @@ ruleTester.run("indent", rule, {
                 ];
             `,
             options: [4],
-            parserOptions: { ecmaVersion: 6 },
             errors: expectedErrors([
                 [2, 4, 9, "String"],
                 [3, 4, 9, "String"],
@@ -4469,7 +5142,6 @@ ruleTester.run("indent", rule, {
                     rotate;
             `,
             options: [2, { VariableDeclarator: 2 }],
-            parserOptions: { ecmaVersion: 6 },
             errors: expectedErrors([
                 [2, 4, 2, "Identifier"]
             ])
@@ -4544,7 +5216,6 @@ ruleTester.run("indent", rule, {
                 ]
             `,
             options: [2, { VariableDeclarator: { let: 2 }, SwitchCase: 1 }],
-            parserOptions: { ecmaVersion: 6 },
             errors: expectedErrors([
                 [2, 2, 4, "Identifier"],
                 [3, 2, 4, "Identifier"]
@@ -4591,7 +5262,6 @@ ruleTester.run("indent", rule, {
                   d = 4;
             `,
             options: [2, { VariableDeclarator: { var: 2 } }],
-            parserOptions: { ecmaVersion: 6 },
             errors: expectedErrors([
                 [6, 4, 6, "Identifier"],
                 [7, 2, 4, "Punctuator"],
@@ -4707,7 +5377,6 @@ ruleTester.run("indent", rule, {
                 }
             `,
             options: [4, { VariableDeclarator: 1, SwitchCase: 1 }],
-            parserOptions: { ecmaVersion: 6 },
             errors: expectedErrors([[2, 4, 2, "Identifier"]])
         },
         {
@@ -4726,7 +5395,6 @@ ruleTester.run("indent", rule, {
                 };
             `,
             options: [4, { VariableDeclarator: 1, SwitchCase: 1 }],
-            parserOptions: { ecmaVersion: 6 },
             errors: expectedErrors([[2, 4, 2, "Identifier"], [4, 4, 2, "Identifier"]])
         },
         {
@@ -4747,7 +5415,6 @@ ruleTester.run("indent", rule, {
                     };
             `,
             options: [2, { VariableDeclarator: 2, SwitchCase: 1 }],
-            parserOptions: { ecmaVersion: 6 },
             errors: expectedErrors([[3, 6, 4, "Identifier"]])
         },
         {
@@ -5821,7 +6488,6 @@ ruleTester.run("indent", rule, {
                 } = qux;
             `,
             options: [2],
-            parserOptions: { ecmaVersion: 6 },
             errors: expectedErrors([[2, 2, 0, "Identifier"], [4, 2, 4, "Identifier"], [5, 2, 6, "Identifier"], [6, 0, 2, "Punctuator"]])
         },
         {
@@ -6000,7 +6666,6 @@ ruleTester.run("indent", rule, {
                 ] = qux;
             `,
             options: [2],
-            parserOptions: { ecmaVersion: 6 },
             errors: expectedErrors([[2, 2, 0, "Identifier"], [4, 2, 4, "Identifier"], [5, 2, 6, "Identifier"], [6, 0, 2, "Punctuator"]])
         },
         {
@@ -6083,7 +6748,6 @@ ruleTester.run("indent", rule, {
                   baz();
             `,
             options: [2],
-            parserOptions: { ecmaVersion: 6 },
             errors: expectedErrors([2, 2, 4, "Identifier"])
         },
         {
@@ -6096,7 +6760,6 @@ ruleTester.run("indent", rule, {
                   5;
             `,
             options: [2],
-            parserOptions: { ecmaVersion: 6 },
             errors: expectedErrors([2, 2, 4, "Numeric"])
         },
         {
@@ -6127,7 +6790,6 @@ ruleTester.run("indent", rule, {
                   bar}\`
             `,
             options: [2],
-            parserOptions: { ecmaVersion: 6 },
             errors: expectedErrors([2, 2, 0, "Identifier"])
         },
         {
@@ -6142,7 +6804,6 @@ ruleTester.run("indent", rule, {
                     baz}\`}\`
             `,
             options: [2],
-            parserOptions: { ecmaVersion: 6 },
             errors: expectedErrors([[2, 2, 4, "Template"], [3, 4, 0, "Identifier"]])
         },
         {
@@ -6161,7 +6822,6 @@ ruleTester.run("indent", rule, {
                 }\`
             `,
             options: [2],
-            parserOptions: { ecmaVersion: 6 },
             errors: expectedErrors([[2, 2, 4, "Template"], [3, 4, 2, "Identifier"], [4, 2, 4, "Template"], [5, 0, 2, "Template"]])
         },
         {
@@ -6180,7 +6840,6 @@ ruleTester.run("indent", rule, {
                 }\`
             `,
             options: [2],
-            parserOptions: { ecmaVersion: 6 },
             errors: expectedErrors([[2, 2, 0, "Punctuator"], [3, 4, 2, "Identifier"], [4, 2, 0, "Punctuator"]])
         },
         {
@@ -6198,7 +6857,6 @@ ruleTester.run("indent", rule, {
                         bar}baz\`
                 }
             `,
-            parserOptions: { ecmaVersion: 6 },
             errors: expectedErrors([[3, 8, 0, "Identifier"], [4, 8, 2, "Identifier"]])
         },
         {
@@ -6218,8 +6876,7 @@ ruleTester.run("indent", rule, {
                 } node is checked.\`;
                 }
             `,
-            errors: expectedErrors([[4, 4, 8, "Identifier"], [5, 0, 4, "Template"]]),
-            parserOptions: { ecmaVersion: 6 }
+            errors: expectedErrors([[4, 4, 8, "Identifier"], [5, 0, 4, "Template"]])
         },
         {
             code: unIndent`
@@ -6238,8 +6895,7 @@ ruleTester.run("indent", rule, {
                         so the spaces before this line aren't removed.\`;
                 }
             `,
-            errors: expectedErrors([4, 4, 12, "Identifier"]),
-            parserOptions: { ecmaVersion: 6 }
+            errors: expectedErrors([4, 4, 12, "Identifier"])
         },
         {
 
@@ -6755,7 +7411,6 @@ ruleTester.run("indent", rule, {
                     c
                 }
             `,
-            parserOptions: { ecmaVersion: 6 },
             errors: expectedErrors([[4, 4, 8, "Identifier"], [5, 0, 4, "Punctuator"]])
         },
         {
@@ -6773,7 +7428,6 @@ ruleTester.run("indent", rule, {
                     e
                 }
             `,
-            parserOptions: { ecmaVersion: 6 },
             errors: expectedErrors([[4, 4, 8, "Identifier"], [5, 0, 4, "Punctuator"]])
         },
         {
@@ -6938,6 +7592,411 @@ ruleTester.run("indent", rule, {
             errors: expectedErrors([
                 [3, 8, 4, "Keyword"],
                 [7, 24, 20, "Identifier"]
+            ])
+        },
+
+        //----------------------------------------------------------------------
+        // JSX tests
+        // Some of the following tests are adapted from the the tests in eslint-plugin-react.
+        // License: https://github.com/yannickcr/eslint-plugin-react/blob/7ca9841f22d599f447a27ef5b2a97def9229d6c8/LICENSE
+        //----------------------------------------------------------------------
+
+        {
+            code: unIndent`
+                <App>
+                  <Foo />
+                </App>
+            `,
+            output: unIndent`
+                <App>
+                    <Foo />
+                </App>
+            `,
+            errors: expectedErrors([2, 4, 2, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                <App>
+                    <Foo />
+                </App>
+            `,
+            output: unIndent`
+                <App>
+                  <Foo />
+                </App>
+            `,
+            options: [2],
+            errors: expectedErrors([2, 2, 4, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                <App>
+                    <Foo />
+                </App>
+            `,
+            output: unIndent`
+                <App>
+                \t<Foo />
+                </App>
+            `,
+            options: ["tab"],
+            errors: expectedErrors([2, "1 tab", "4 spaces", "Punctuator"])
+        },
+        {
+            code: unIndent`
+                function App() {
+                  return <App>
+                    <Foo />
+                         </App>;
+                }
+            `,
+            output: unIndent`
+                function App() {
+                  return <App>
+                    <Foo />
+                  </App>;
+                }
+            `,
+            options: [2],
+            errors: expectedErrors([4, 2, 9, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                function App() {
+                  return (<App>
+                    <Foo />
+                    </App>);
+                }
+            `,
+            output: unIndent`
+                function App() {
+                  return (<App>
+                    <Foo />
+                  </App>);
+                }
+            `,
+            options: [2],
+            errors: expectedErrors([4, 2, 4, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                function App() {
+                  return (
+                <App>
+                  <Foo />
+                </App>
+                  );
+                }
+            `,
+            output: unIndent`
+                function App() {
+                  return (
+                    <App>
+                      <Foo />
+                    </App>
+                  );
+                }
+            `,
+            options: [2],
+            errors: expectedErrors([[3, 4, 0, "Punctuator"], [4, 6, 2, "Punctuator"], [5, 4, 0, "Punctuator"]])
+        },
+        {
+            code: unIndent`
+                <App>
+                 {test}
+                </App>
+            `,
+            output: unIndent`
+                <App>
+                    {test}
+                </App>
+            `,
+            errors: expectedErrors([2, 4, 1, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                <App>
+                    {options.map((option, index) => (
+                        <option key={index} value={option.key}>
+                           {option.name}
+                        </option>
+                    ))}
+                </App>
+            `,
+            output: unIndent`
+                <App>
+                    {options.map((option, index) => (
+                        <option key={index} value={option.key}>
+                            {option.name}
+                        </option>
+                    ))}
+                </App>
+            `,
+            errors: expectedErrors([4, 12, 11, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                [
+                  <div />,
+                    <div />
+                ]
+            `,
+            output: unIndent`
+                [
+                  <div />,
+                  <div />
+                ]
+            `,
+            options: [2],
+            errors: expectedErrors([3, 2, 4, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                <App>
+
+                 <Foo />
+
+                </App>
+            `,
+            output: unIndent`
+                <App>
+
+                \t<Foo />
+
+                </App>
+            `,
+            options: ["tab"],
+            errors: expectedErrors([3, "1 tab", "1 space", "Punctuator"])
+        },
+        {
+
+            // Multiline ternary
+            // (colon at the end of the first expression)
+            code: unIndent`
+                foo ?
+                    <Foo /> :
+                <Bar />
+            `,
+            output: unIndent`
+                foo ?
+                    <Foo /> :
+                    <Bar />
+            `,
+            errors: expectedErrors([3, 4, 0, "Punctuator"])
+        },
+        {
+
+            // Multiline ternary
+            // (colon on its own line)
+            code: unIndent`
+                foo ?
+                    <Foo />
+                :
+                <Bar />
+            `,
+            output: unIndent`
+                foo ?
+                    <Foo />
+                    :
+                    <Bar />
+            `,
+            errors: expectedErrors([[3, 4, 0, "Punctuator"], [4, 4, 0, "Punctuator"]])
+        },
+        {
+
+            // Multiline ternary
+            // (colon at the end of the first expression, parenthesized first expression)
+            code: unIndent`
+                foo ? (
+                    <Foo />
+                ) :
+                <Bar />
+            `,
+            output: unIndent`
+                foo ? (
+                    <Foo />
+                ) :
+                    <Bar />
+            `,
+            errors: expectedErrors([4, 4, 0, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                <App
+                  foo
+                />
+            `,
+            output: unIndent`
+                <App
+                    foo
+                />
+            `,
+            errors: expectedErrors([2, 4, 2, "JSXIdentifier"])
+        },
+        {
+            code: unIndent`
+                <App
+                  foo
+                  />
+            `,
+            output: unIndent`
+                <App
+                  foo
+                />
+            `,
+            options: [2],
+            errors: expectedErrors([3, 0, 2, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                <App
+                  foo
+                  ></App>
+            `,
+            output: unIndent`
+                <App
+                  foo
+                ></App>
+            `,
+            options: [2],
+            errors: expectedErrors([3, 0, 2, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                const Button = function(props) {
+                  return (
+                    <Button
+                      size={size}
+                      onClick={onClick}
+                                                    >
+                      Button Text
+                    </Button>
+                  );
+                };
+            `,
+            output: unIndent`
+                const Button = function(props) {
+                  return (
+                    <Button
+                      size={size}
+                      onClick={onClick}
+                    >
+                      Button Text
+                    </Button>
+                  );
+                };
+            `,
+            options: [2],
+            errors: expectedErrors([6, 4, 36, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                var x = function() {
+                  return <App
+                    foo
+                         />
+                }
+            `,
+            output: unIndent`
+                var x = function() {
+                  return <App
+                    foo
+                  />
+                }
+            `,
+            options: [2],
+            errors: expectedErrors([4, 2, 9, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                var x = <App
+                  foo
+                        />
+            `,
+            output: unIndent`
+                var x = <App
+                  foo
+                />
+            `,
+            options: [2],
+            errors: expectedErrors([3, 0, 8, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                var x = (
+                  <Something
+                    />
+                )
+            `,
+            output: unIndent`
+                var x = (
+                  <Something
+                  />
+                )
+            `,
+            options: [2],
+            errors: expectedErrors([3, 2, 4, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                <App
+                \tfoo
+                \t/>
+            `,
+            output: unIndent`
+                <App
+                \tfoo
+                />
+            `,
+            options: ["tab"],
+            errors: expectedErrors("tab", [3, 0, 1, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                <App
+                \tfoo
+                \t></App>
+            `,
+            output: unIndent`
+                <App
+                \tfoo
+                ></App>
+            `,
+            options: ["tab"],
+            errors: expectedErrors("tab", [3, 0, 1, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                <
+                    foo
+                    .bar
+                    .baz
+                >
+                    foo
+                </
+                    foo.
+                    bar.
+                    baz
+                >
+            `,
+            output: unIndent`
+                <
+                    foo
+                        .bar
+                        .baz
+                >
+                    foo
+                </
+                    foo.
+                        bar.
+                        baz
+                >
+            `,
+            errors: expectedErrors([
+                [3, 8, 4, "Punctuator"],
+                [4, 8, 4, "Punctuator"],
+                [9, 8, 4, "JSXIdentifier"],
+                [10, 8, 4, "JSXIdentifier"]
             ])
         }
     ]

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -4172,6 +4172,33 @@ ruleTester.run("indent", rule, {
                         baz
                 >
             `
+        },
+        {
+            code: unIndent`
+                <
+                    input
+                    type=
+                        "number"
+                />
+            `
+        },
+        {
+            code: unIndent`
+                <
+                    input
+                    type=
+                        {'number'}
+                />
+            `
+        },
+        {
+            code: unIndent`
+                <
+                    input
+                    type
+                        ="number"
+                />
+            `
         }
     ],
 
@@ -7998,6 +8025,57 @@ ruleTester.run("indent", rule, {
                 [9, 8, 4, "JSXIdentifier"],
                 [10, 8, 4, "JSXIdentifier"]
             ])
+        },
+        {
+            code: unIndent`
+                <
+                    input
+                    type=
+                    "number"
+                />
+            `,
+            output: unIndent`
+                <
+                    input
+                    type=
+                        "number"
+                />
+            `,
+            errors: expectedErrors([4, 8, 4, "JSXText"])
+        },
+        {
+            code: unIndent`
+                <
+                    input
+                    type=
+                    {'number'}
+                />
+            `,
+            output: unIndent`
+                <
+                    input
+                    type=
+                        {'number'}
+                />
+            `,
+            errors: expectedErrors([4, 8, 4, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                <
+                    input
+                    type
+                    ="number"
+                />
+            `,
+            output: unIndent`
+                <
+                    input
+                    type
+                        ="number"
+                />
+            `,
+            errors: expectedErrors([4, 8, 4, "Punctuator"])
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates the `indent` rule to enforce reasonable defaults for JSX nodes. Previously, it always enforced that their indentation was zero, which was usually undesirable.

For some users, this might make it so that the `jsx-indent` rule from `eslint-plugin-react` is no longer necessary. However, `indent` is not aiming for full compatibility with the `jsx-indent` rule. In the future it should be possible to ignore specified nodes with the `indent` rule (e.g. JSX elements), which will allow users to continue to use `indent` and `jsx-indent` simultaneously.

**Is there anything you'd like reviewers to focus on?**

This does not implement the `ignoreJSX` option described in https://github.com/eslint/eslint/issues/8425. I'm going to make another issue (edit: https://github.com/eslint/eslint/issues/8594) to propose ignoring custom node types or selectors, which should make `ignoreJSX` unnecessary. (This will also make it easier for people to use the `indent` rule along with a custom rule if they don't agree with every decision the rule makes.)