### PR TITLE
Chore: make eslintbot look at the PR title, not the first commit message

### DIFF
--- a/templates/pr-create.md.ejs
+++ b/templates/pr-create.md.ejs
@@ -10,22 +10,21 @@ function isValidCommitFlag(log) {
 
 var problems = [];
 
-if (!isValidCommitFlag(meta.title)) {
+if (!isValidCommitFlag(payload.pull_request.title)) {
     problems.push("The pull request title needs to begin with a tag (such as `Fix:` or `Update:`). Please check out our [guide](http://eslint.org/docs/developer-guide/contributing/pull-requests#step-2-make-your-changes) for how to properly format your commit summary and [update](http://eslint.org/docs/developer-guide/contributing/pull-requests#updating-the-commit-message) it on this pull request.")
 }
 
-if (meta.title.length > 72) {
+if (payload.pull_request.title.length > 72) {
     problems.push("The pull request title must be 72 characters or shorter. Please check out our [guide](http://eslint.org/docs/developer-guide/contributing/pull-requests#step-2-make-your-changes) for how to properly format your commit summary and [update](http://eslint.org/docs/developer-guide/contributing/pull-requests#updating-the-commit-message) it on this pull request.");
 }
 
 // It's only necessary to check the title when the PR is created or the title is edited.
 if (
-    problems.length &&
-    (
-        payload.action === "opened" ||
-        (payload.action === "edited" && payload.changes.title.from !== meta.title)
-    )
-) { %>
+    payload.action !== "opened" &&
+    !(payload.action === "edited" && payload.changes.title.from !== payload.pull_request.title)
+) {
+    // no response
+} else if (problems.length) { %>
 Thanks for the pull request, @<%= payload.sender.login %>! I took a look to make sure it's ready for merging and found some changes are needed:
 
 <% problems.forEach(function(problem) { %>

--- a/templates/pr-create.md.ejs
+++ b/templates/pr-create.md.ejs
@@ -10,30 +10,31 @@ function isValidCommitFlag(log) {
 
 var problems = [];
 
-// Check for one commit per pull request
-if (meta.commits) {
-    // get just the first line of the commit message
-    var log = meta.commits[0].commit.message.split(/\r?\n/g)[0];
-
-    if (!isValidCommitFlag(log)) {
-        problems.push("The commit summary needs to begin with a tag (such as `Fix:` or `Update:`). Please check out our [guide](http://eslint.org/docs/developer-guide/contributing/pull-requests#step-2-make-your-changes) for how to properly format your commit summary and [update](http://eslint.org/docs/developer-guide/contributing/pull-requests#updating-the-commit-message) it on this pull request.")
-    }
-
-    if (log.length > 72) {
-        problems.push("The commit summary must be 72 characters or shorter. Please check out our [guide](http://eslint.org/docs/developer-guide/contributing/pull-requests#step-2-make-your-changes) for how to properly format your commit summary and [update](http://eslint.org/docs/developer-guide/contributing/pull-requests#updating-the-commit-message) it on this pull request.");
-    }
+if (!isValidCommitFlag(meta.title)) {
+    problems.push("The pull request title needs to begin with a tag (such as `Fix:` or `Update:`). Please check out our [guide](http://eslint.org/docs/developer-guide/contributing/pull-requests#step-2-make-your-changes) for how to properly format your commit summary and [update](http://eslint.org/docs/developer-guide/contributing/pull-requests#updating-the-commit-message) it on this pull request.")
 }
 
-if (problems.length) { %>
+if (meta.title.length > 72) {
+    problems.push("The pull request title must be 72 characters or shorter. Please check out our [guide](http://eslint.org/docs/developer-guide/contributing/pull-requests#step-2-make-your-changes) for how to properly format your commit summary and [update](http://eslint.org/docs/developer-guide/contributing/pull-requests#updating-the-commit-message) it on this pull request.");
+}
+
+// It's only necessary to check the title when the PR is created or the title is edited.
+if ((payload.action === "opened" || payload.action === "edited") && problems.length) { %>
 Thanks for the pull request, @<%= payload.sender.login %>! I took a look to make sure it's ready for merging and found some changes are needed:
 
 <% problems.forEach(function(problem) { %>
 * <%- problem %>
 <% }); %>
 
-Can you please update the pull request to address these?
+Can you please edit the pull request title to address these?
 
 (More information can be found in our [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests).)
+
+<details>
+  <summary>Why is this required?</summary>
+
+  It's important that commit messages have a consistent format, because this allows us to use tooling to save time (e.g. autogenerating organized changelogs from commit messages). When a team member merges your pull request with GitHub's UI, the default commit message for the squashed commits is the title of the pull request. We want the title to have the correct format so that we can minimize errors when merging.
+</details>
 <% } else { %>
 LGTM
 <% } %>

--- a/templates/pr-create.md.ejs
+++ b/templates/pr-create.md.ejs
@@ -19,7 +19,13 @@ if (meta.title.length > 72) {
 }
 
 // It's only necessary to check the title when the PR is created or the title is edited.
-if ((payload.action === "opened" || payload.action === "edited") && problems.length) { %>
+if (
+    problems.length &&
+    (
+        payload.action === "opened" ||
+        (payload.action === "edited" && payload.changes.title.from !== meta.title)
+    )
+) { %>
 Thanks for the pull request, @<%= payload.sender.login %>! I took a look to make sure it's ready for merging and found some changes are needed:
 
 <% problems.forEach(function(problem) { %>


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Since we use GitHub's "squash and merge" feature, the default commit message of the squashed commit is the PR title, not the first commit message of the PR. As a result, it's not useful to validate the first commit message of a PR, because the eslintbot might incorrectly report a problem (or fail to notice a problem) if the commit message is different from the PR title.

This also means that eslintbot no longer needs to comment "LGTM" when someone pushes commits to a PR -- it only needs to make that comment when someone creates a PR or edits its title.

**Is there anything you'd like reviewers to focus on?**

I'm not very familiar with how eslintbot works, and I'm also not sure how to test that this is working. Is there a way to test this without merging it first?

edit: turns out there are already tests for this, and they're now failing 😃 