### PR TITLE
Update: Allow comments to be treated as empty lines in newline-before-return rule

### DIFF
--- a/docs/rules/newline-before-return.md
+++ b/docs/rules/newline-before-return.md
@@ -107,6 +107,36 @@ function foo() {
 }
 ```
 
+## Options
+
+### includeComments
+
+Set to `false` by default. Setting this option to `true` treats comment lines the same as empty lines.
+
+Examples of **correct** code when `includeComments` is `true`:
+
+```js
+/*eslint newline-before-return: ["error", { "includeComments": true }]*/
+
+function foo(bar) {
+    if (bar) {
+        return a;
+    }
+    // else
+    return b;
+}
+
+function foo(bar) {
+    if (bar) {
+        return a;
+    }
+    /* multi-line
+    comment */
+    return b;
+}
+
+```
+
 ## When Not To Use It
 
 You can safely disable this rule if you do not have any strict conventions about whitespace before `return` statements.

--- a/lib/rules/newline-before-return.js
+++ b/lib/rules/newline-before-return.js
@@ -18,12 +18,24 @@ module.exports = {
             replacedBy: ["padding-line-between-statements"]
         },
         fixable: "whitespace",
-        schema: [],
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    includeComments: {
+                        type: "boolean"
+                    }
+                },
+                additionalProperties: false
+            }
+        ],
         deprecated: true
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
+        const sourceCode = context.getSourceCode(),
+            options = context.options[0] || {},
+            includeComments = !!options.includeComments;
 
         //--------------------------------------------------------------------------
         // Helpers
@@ -140,6 +152,10 @@ module.exports = {
             const lineNumNode = node.loc.start.line;
             const lineNumTokenBefore = getLineNumberOfTokenBefore(node);
             const commentLines = calcCommentLines(node, lineNumTokenBefore);
+
+            if (includeComments) {
+                return commentLines > 0;
+            }
 
             return (lineNumNode - lineNumTokenBefore - commentLines) > 1;
         }

--- a/tests/lib/rules/newline-before-return.js
+++ b/tests/lib/rules/newline-before-return.js
@@ -107,6 +107,30 @@ ruleTester.run("newline-before-return", rule, {
         {
             code: "/* multi-line\ncomment */\nreturn;",
             parserOptions: { ecmaFeatures: { globalReturn: true } }
+        },
+
+        // { includeComments: true }
+        {
+            code: "function a() {\nif (b) { return; }\n//comment\nreturn c;\n}",
+            options: [{ includeComments: true }]
+        },
+        {
+            code: "function a() {\nif (b) { return; }\n/* comment */\nreturn c;\n}",
+            options: [{ includeComments: true }]
+        },
+        {
+            code: "function a() {\nif (b) { return; } /* multi-line\ncomment */\nreturn c;\n}",
+            options: [{ includeComments: true }]
+        },
+
+        // unlikely edge-cases for { includeComments: true }
+        {
+            code: "function a() {\nif (b) { return; } /* multi-line\ncomment\nsharing line */ return c;\n}",
+            options: [{ includeComments: true }]
+        },
+        {
+            code: "function a() {\nif (b) { return; }\n/* multi-line comment\nsharing line */ return c;\n}",
+            options: [{ includeComments: true }]
         }
     ],
 
@@ -276,6 +300,34 @@ ruleTester.run("newline-before-return", rule, {
             code: "function a() {\nvar b; return; //comment\n}",
             errors: ["Expected newline before return statement."],
             output: "function a() {\nvar b; \n\nreturn; //comment\n}"
+        },
+
+        // { includeComments: true }
+        {
+            code: "function a() {\nif (b) { return; } //comment\nreturn c;\n}",
+            options: [{ includeComments: true }],
+            errors: ["Expected newline before return statement."],
+            output: "function a() {\nif (b) { return; } //comment\n\nreturn c;\n}"
+        },
+        {
+            code: "function a() {\nif (b) { return; } /* comment */\nreturn c;\n}",
+            options: [{ includeComments: true }],
+            errors: ["Expected newline before return statement."],
+            output: "function a() {\nif (b) { return; } /* comment */\n\nreturn c;\n}"
+        },
+
+        // unlikely edge cases for { includeComments: true }
+        {
+            code: "function a() {\nif (b) { return; }\n/* comment sharing line */ return c;\n}",
+            options: [{ includeComments: true }],
+            errors: ["Expected newline before return statement."],
+            output: null
+        },
+        {
+            code: "function a() {\nif (b) { return; } /* multi-line comment\nsharing line */ return c;\n}",
+            options: [{ includeComments: true }],
+            errors: ["Expected newline before return statement."],
+            output: null
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[**X**] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**What rule do you want to change?**
newline-before-spaces

**Does this change cause the rule to produce more or fewer warnings?**
Fewer

**How will the change be implemented? (New option, new default behavior, etc.)?**
New option (`includeComments`)

**Please provide some example code that this change will affect:**

```js
/*eslint newline-before-return: ["error", { "includeComments": true }]*/

function foo(bar) {
    if (bar) {
        return a;
    }
    // else
    return b;
}

function foo(bar) {
    if (bar) {
        return a;
    }
    /* multi-line
    comment */
    return b;
}
```

**What does the rule currently do for this code?**
Both of the above function definitions would currently be flagged as **incorrect**

**What will the rule do after it's changed?**
Using the `{ "includeComments": true }` option, they would be flagged as **correct**

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Added a `includeComments` option to `newline-before-spaces` rule, to allow comments to be treated as blank lines

**Is there anything you'd like reviewers to focus on?**
This is my first contribution to `eslint` so I would appreciate comments on naming and style