### PR TITLE
Update: Ability to load plugins by path

### DIFF
--- a/lib/config/plugins.js
+++ b/lib/config/plugins.js
@@ -8,7 +8,10 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const Environments = require("./environments"),
+const path = require("path"),
+    fs = require("fs"),
+    readPkgUp = require("read-pkg-up"),
+    Environments = require("./environments"),
     Rules = require("../rules");
 
 const debug = require("debug")("eslint:plugins");
@@ -21,6 +24,20 @@ let plugins = Object.create(null);
 
 const PLUGIN_NAME_PREFIX = "eslint-plugin-",
     NAMESPACE_REGEX = /^@.*\//i;
+
+/**
+ * Checks if the given file path is a regular file or a symbolic link.
+ * @param {string} filepath The file path of a plugin.
+ * @returns {boolean} True if the given string is a filepath.
+ */
+function isFilePath(filepath) {
+    try {
+        return fs.statSync(filepath).isFile() ||
+            fs.lstatSync(filepath).isSymbolicLink();
+    } catch (err) {
+        return false;
+    }
+}
 
 /**
  * Removes the prefix `eslint-plugin-` from a plugin name.
@@ -95,12 +112,28 @@ module.exports = {
     },
 
     /**
-     * Loads a plugin with the given name.
-     * @param {string} pluginName The name of the plugin to load.
+     * Loads a plugin with the given name or file path.
+     * @param {string} pluginName The name or file path of the plugin to load.
      * @returns {void}
      * @throws {Error} If the plugin cannot be loaded.
      */
     load(pluginName) {
+        let absPath;
+
+        if (isFilePath(pluginName)) {
+            absPath = path.isAbsolute(pluginName)
+                ? pluginName
+                : path.join(process.cwd(), pluginName);
+            try {
+                pluginName = readPkgUp.sync({ cwd: absPath }).pkg.name;
+            } catch (err) {
+                debug(`Failed to resolve name of plugin ${absPath}.`);
+                const invalidPluginError = new Error(`Failed to resolve name of plugin ${pluginName}`);
+
+                throw invalidPluginError;
+            }
+        }
+
         const pluginNamespace = getNamespace(pluginName),
             pluginNameWithoutNamespace = removeNamespace(pluginName),
             pluginNameWithoutPrefix = removePrefix(pluginNameWithoutNamespace),
@@ -120,12 +153,12 @@ module.exports = {
 
         if (!plugins[shortName]) {
             try {
-                plugin = require(longName);
+                plugin = require(absPath || longName);
             } catch (pluginLoadErr) {
                 try {
 
                     // Check whether the plugin exists
-                    require.resolve(longName);
+                    require.resolve(absPath || longName);
                 } catch (missingPluginErr) {
 
                     // If the plugin can't be resolved, display the missing plugin error (usually a config or install error)

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "path-is-inside": "^1.0.2",
     "pluralize": "^4.0.0",
     "progress": "^1.1.8",
+    "read-pkg-up": "^2.0.0",
     "require-uncached": "^1.0.3",
     "shelljs": "^0.7.7",
     "strip-bom": "^3.0.0",


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[X] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
See #6237 
Problem in PR #6016 with long plugin names on rule definitions, error messages and eslint comments solved

Example shareable config:
```json
{
  "name": "eslint-config-shareable",
  "version": "0.0.1",
  "dependencies": {
    "babel-eslint": "7.2.0",
    "eslint": "4.0.0-alpha.2",
    "eslint-plugin-fp": "2.3.0"
  }
}
```

```js
'use strict'

module.exports = {
  parser: require.resolve('babel-eslint'),

  plugins: [
    require.resolve('eslint-plugin-fp'),
  ],

  rules: {
    'fp/no-mutation': 'error',
  },
}
```

**Is there anything you'd like reviewers to focus on?**


