### PR TITLE
Docs: Add missing documentation for scoped modules in sharable config developer-guide

### DIFF
--- a/docs/developer-guide/shareable-configs.md
+++ b/docs/developer-guide/shareable-configs.md
@@ -91,7 +91,7 @@ You can also omit the `eslint-config` and it will be automatically assumed by ES
 }
 ```
 
-The module name can also be customized, for example `@scope/eslint-config-myconfig`. Note that in this case there are no shortcuts:
+The module name can also be customized, just note that when using [scoped modules](https://docs.npmjs.com/misc/scope) is not possible to omit the `eslint-config-` prefix. Doing so would result in package naming conflicts, and thus in resolution errors in most of cases. For example a package named `@scope/eslint-config-myconfig` vs `@scope/my-config`, since both are valid scoped package names, the configuration should be specified as:
 
 ```json
 {
@@ -123,7 +123,7 @@ Then, assuming you're using the package name `eslint-config-myconfig`, you can a
 }
 ```
 
-When using [scoped modules](https://docs.npmjs.com/misc/scope) is not possible to omit the `eslint-config` prefix. Doing so would result in resolution errors since scoped modules can have such format by themselves. Assuming the package name is `@scope/eslint-config`:
+When using [scoped modules](https://docs.npmjs.com/misc/scope) is not possible to omit the `eslint-config` namespace. Doing so would result in resolution errors as explained above. Assuming the package name is `@scope/eslint-config`, the additional config can be accessed as:
 
 ```json
 {

--- a/docs/developer-guide/shareable-configs.md
+++ b/docs/developer-guide/shareable-configs.md
@@ -91,7 +91,7 @@ You can also omit the `eslint-config` and it will be automatically assumed by ES
 }
 ```
 
-The module name can also be customized, just note that when using [scoped modules](https://docs.npmjs.com/misc/scope) is not possible to omit the `eslint-config-` prefix. Doing so would result in package naming conflicts, and thus in resolution errors in most of cases. For example a package named `@scope/eslint-config-myconfig` vs `@scope/my-config`, since both are valid scoped package names, the configuration should be specified as:
+The module name can also be customized, just note that when using [scoped modules](https://docs.npmjs.com/misc/scope) it is not possible to omit the `eslint-config-` prefix. Doing so would result in package naming conflicts, and thus in resolution errors in most of cases. For example a package named `@scope/eslint-config-myconfig` vs `@scope/my-config`, since both are valid scoped package names, the configuration should be specified as:
 
 ```json
 {
@@ -123,7 +123,7 @@ Then, assuming you're using the package name `eslint-config-myconfig`, you can a
 }
 ```
 
-When using [scoped modules](https://docs.npmjs.com/misc/scope) is not possible to omit the `eslint-config` namespace. Doing so would result in resolution errors as explained above. Assuming the package name is `@scope/eslint-config`, the additional config can be accessed as:
+When using [scoped modules](https://docs.npmjs.com/misc/scope) it is not possible to omit the `eslint-config` namespace. Doing so would result in resolution errors as explained above. Assuming the package name is `@scope/eslint-config`, the additional config can be accessed as:
 
 ```json
 {

--- a/docs/developer-guide/shareable-configs.md
+++ b/docs/developer-guide/shareable-configs.md
@@ -4,7 +4,11 @@ The configuration that you have in your `.eslintrc` file is an important part of
 
 ## Creating a Shareable Config
 
-Shareable configs are simply npm packages that export a configuration object. To start, [create a Node.js module](https://docs.npmjs.com/getting-started/creating-node-modules) like you normally would. Make sure the module name begins with `eslint-config-`, such as `eslint-config-myconfig`. Create a new `index.js` file and export an object containing your settings:
+Shareable configs are simply npm packages that export a configuration object. To start, [create a Node.js module](https://docs.npmjs.com/getting-started/creating-node-modules) like you normally would. Make sure the module name begins with `eslint-config-`, such as `eslint-config-myconfig`.
+
+npm [scoped modules](https://docs.npmjs.com/misc/scope) are also supported, by naming or prefixing the module with `@scope/eslint-config`, such as `@scope/eslint-config` or `@scope/eslint-config-myconfig`.
+
+Create a new `index.js` file and export an object containing your settings:
 
 ```js
 module.exports = {
@@ -66,6 +70,35 @@ You can also omit the `eslint-config-` and it will be automatically assumed by E
 }
 ```
 
+### npm scoped modules
+
+npm [scoped modules](https://docs.npmjs.com/misc/scope) are also supported in a number of ways.
+
+
+By using the module name:
+
+```json
+{
+    "extends": "@scope/eslint-config"
+}
+```
+
+You can also omit the `eslint-config` and it will be automatically assumed by ESLint:
+
+```json
+{
+    "extends": "@scope"
+}
+```
+
+The module name can also be customized, for example `@scope/eslint-config-myconfig`. Note that in this case there are no shortcuts:
+
+```json
+{
+    "extends": "@scope/eslint-config-myconfig"
+}
+```
+
 You can override settings from the shareable config by adding them directly into your `.eslintrc` file.
 
 ## Sharing Multiple Configs
@@ -87,6 +120,14 @@ Then, assuming you're using the package name `eslint-config-myconfig`, you can a
 ```json
 {
     "extends": "myconfig/my-special-config"
+}
+```
+
+When using [scoped modules](https://docs.npmjs.com/misc/scope) is not possible to omit the `eslint-config` prefix. Doing so would result in resolution errors since scoped modules can have such format by themselves. Assuming the package name is `@scope/eslint-config`:
+
+```json
+{
+    "extends": "@scope/eslint-config/my-special-config"
 }
 ```
 


### PR DESCRIPTION
Docs: Add missing documentation for scoped modules in sharable config developer-guide (refs #3136) (#4800)

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Updated the documentation for sharable configurations developer guide, to add instructions on how to use scoped npm modules.

**Is there anything you'd like reviewers to focus on?**
The only references I could find on how to setup this, was in #3136 and #4800. I am not quite certain the options I am describing are still valid, or are the only ones.

