### PR TITLE
Update: Comments as blank lines in padding-line-between-statements rule

### DIFF
--- a/docs/rules/padding-line-between-statements.md
+++ b/docs/rules/padding-line-between-statements.md
@@ -1,81 +1,125 @@
 # Require or disallow padding lines between statements (padding-line-between-statements)
 
-This rule requires or disallows blank lines between the given 2 kinds of statements.
-Properly blank lines help developers to understand the code.
+The addition of blank padding lines can help to make code more readable by adding vertical space to visually separate out logical blocks of code.
 
-For example, the following configuration requires a blank line between a variable declaration and a `return` statement.
+## Rule Details
+
+This rule aims at improving code readability by either requiring or disallowing vertical space between different kinds of statements. For example, the following configuration requires at least one blank line between a `var` declaration and a `return` statement but disallows blank lines between pairs of `var` declarations.
 
 ```js
 /*eslint padding-line-between-statements: [
     "error",
-    { blankLine: "always", prev: "var", next: "return" }
+    { blankLine: "always", prev: "var", next: "return" },
+    { blankLine: "never", prev: "var", next: "var" }
 ]*/
 
 function foo() {
     var a = 1;
+    var b = 2
 
-    return a;
+    return a + b;
 }
 ```
 
-## Rule Details
+A "blank line" in this context is a line that may contain white space but does not contain any code or comments.
 
-This rule does nothing if no configuration.
+A single statement on its own within a block will be ignored by this rule (as it cannot form a "pair" with any previous statement) e.g. no blank line is required before the `return a + b` statement in the below code.
 
-A configuration is an object which has 3 properties; `blankLine`, `prev` and `next`. For example, `{ blankLine: "always", prev: "var", next: "return" }` is meaning "it requires one or more blank lines between a variable declaration and a `return` statement."
-You can supply any number of configurations. If an statement pair matches multiple configurations, the last matched configuration will be used.
+```js
+/*eslint padding-line-between-statements: [
+    "error",
+    { blankLine: "always", prev: "*", next: "return" },
+]*/
 
-```json
+function foo() {
+    return a + b;
+}
+```
+
+## Options
+
+This rule requires a set of configuration objects in order to work. Each configuration object specifies a pair of statement types to match and whether or not vertical space is required between those types. A wildcard `*` will match any type.
+
+```js
 {
     "padding-line-between-statements": [
         "error",
-        { "blankLine": LINEBREAK_TYPE, "prev": STATEMENT_TYPE, "next": STATEMENT_TYPE },
-        { "blankLine": LINEBREAK_TYPE, "prev": STATEMENT_TYPE, "next": STATEMENT_TYPE },
-        { "blankLine": LINEBREAK_TYPE, "prev": STATEMENT_TYPE, "next": STATEMENT_TYPE },
-        { "blankLine": LINEBREAK_TYPE, "prev": STATEMENT_TYPE, "next": STATEMENT_TYPE },
+        { "blankLine": "always", "prev": "*", "next": "return", "includeComments": true },
+        { "blankLine": "always", "prev": ["const", "let", "var"], "next": "*"},
+        { "blankLine": "any", "prev": ["const", "let", "var"], "next": ["const", "let", "var"] }
         ...
     ]
 }
 ```
 
-- `LINEBREAK_TYPE` is one of the following.
-    - `"any"` just ignores the statement pair.
-    - `"never"` disallows blank lines.
-    - `"always"` requires one or more blank lines. Note it does not count lines that comments exist as blank lines.
+You can supply any number of configuration objects. If a pair of consecutive statements matches multiple configuration objects, the last match will be used.
 
-- `STATEMENT_TYPE` is one of the following, or an array of the following.
-    - `"*"` is wildcard. This matches any statements.
-    - `"block"` is lonely blocks.
-    - `"block-like"` is block like statements. This matches statements that the last token is the closing brace of blocks; e.g. `{ }`, `if (a) { }`, and `while (a) { }`.
-    - `"break"` is `break` statements.
-    - `"case"` is `case` labels.
-    - `"cjs-export"` is `export` statements of CommonJS; e.g. `module.exports = 0`, `module.exports.foo = 1`, and `exports.foo = 2`. This is the special cases of assignment.
-    - `"cjs-import"` is `import` statements of CommonJS; e.g. `const foo = require("foo")`. This is the special cases of variable declarations.
-    - `"class"` is `class` declarations.
-    - `"const"` is `const` variable declarations.
-    - `"continue"` is `continue` statements.
-    - `"debugger"` is `debugger` statements.
-    - `"default"` is `default` labels.
-    - `"directive"` is directive prologues. This matches directives; e.g. `"use strict"`.
-    - `"do"` is `do-while` statements. This matches all statements that the first token is `do` keyword.
-    - `"empty"` is empty statements.
-    - `"export"` is `export` declarations.
-    - `"expression"` is expression statements.
-    - `"for"` is `for` loop families. This matches all statements that the first token is `for` keyword.
-    - `"function"` is function declarations.
-    - `"if"` is `if` statements.
-    - `"import"` is `import` declarations.
-    - `"let"` is `let` variable declarations.
-    - `"multiline-block-like"` is block like statements. This is the same as `block-like` type, but only the block is multiline.
-    - `"return"` is `return` statements.
-    - `"switch"` is `switch` statements.
-    - `"throw"` is `throw` statements.
-    - `"try"` is `try` statements.
-    - `"var"` is `var` variable declarations.
-    - `"while"` is `while` loop statements.
-    - `"with"` is `with` statements.
+### `blankLine`
+
+`blankLine` is a required string value that defines whether vertical space is required or disallowed. It can be one of the following:
+
+- `"any"` ignores the statement pair.
+- `"never"` disallows blank lines between `prev` and `next` statement pairs.
+- `"always"` requires one or more blank lines.
+
+### `prev`, `next`
+
+`prev` and `next` are required string or array values that define the statement pair to match. They can consist of one or more of the following:
+
+- `"*"` is wildcard. This matches any statements.
+- `"block"` is lonely blocks.
+- `"block-like"` is block like statements. This matches statements that the last token is the closing brace of blocks; e.g. `{ }`, `if (a) { }`, and `while (a) { }`.
+- `"break"` is `break` statements.
+- `"case"` is `case` labels.
+- `"cjs-export"` is `export` statements of CommonJS; e.g. `module.exports = 0`, `module.exports.foo = 1`, and `exports.foo = 2`. This is the special cases of assignment.
+- `"cjs-import"` is `import` statements of CommonJS; e.g. `const foo = require("foo")`. This is the special cases of variable declarations.
+- `"class"` is `class` declarations.
+- `"const"` is `const` variable declarations.
+- `"continue"` is `continue` statements.
+- `"debugger"` is `debugger` statements.
+- `"default"` is `default` labels.
+- `"directive"` is directive prologues. This matches directives; e.g. `"use strict"`.
+- `"do"` is `do-while` statements. This matches all statements that the first token is `do` keyword.
+- `"empty"` is empty statements.
+- `"export"` is `export` declarations.
+- `"expression"` is expression statements.
+- `"for"` is `for` loop families. This matches all statements that the first token is `for` keyword.
+- `"function"` is function declarations.
+- `"if"` is `if` statements.
+- `"import"` is `import` declarations.
+- `"let"` is `let` variable declarations.
+- `"multiline-block-like"` is the same as `block-like` but only matches statements of more than one line.
+- `"return"` is `return` statements.
+- `"switch"` is `switch` statements.
+- `"throw"` is `throw` statements.
+- `"try"` is `try` statements.
+- `"var"` is `var` variable declarations.
+- `"while"` is `while` loop statements.
+- `"with"` is `with` statements.
+
+### `includeComments`
+
+`includeComments` is an optional boolean value that defines whether to count comment lines between statements as vertical space, the same as blank lines. If unspecified, its value is `false`:
+
+- `false` - (default) don't count comment lines as vertical space
+- `true` - count comment lines as vertical space
+
+```js
+/*eslint padding-line-between-statements: [
+    "error",
+    { blankLine: "always", prev: "*", next: "return", includeComments: true }
+]*/
+
+function foo() {
+    bar();
+    // this comment counts as vertical space before the 'return' statement
+    return;
+}
+```
 
 ## Examples
+
+### Require blank lines before all `return` statements
 
 This configuration would require blank lines before all `return` statements, like the [newline-before-return] rule.
 
@@ -112,7 +156,7 @@ function foo() {
 }
 ```
 
-----
+### Require blank lines after every sequence of variable declarations
 
 This configuration would require blank lines after every sequence of variable declarations, like the [newline-after-var] rule.
 
@@ -172,9 +216,9 @@ function foo() {
 }
 ```
 
-----
+### Require blank lines after all directive prologues
 
-This configuration would require blank lines after all directive prologues, like the [lines-around-directive] rule.
+This configuration would require blank lines after all directive prologues (e.g. `"use-strict"`), like the [lines-around-directive] rule.
 
 Examples of **incorrect** code for the `[{ blankLine: "always", prev: "directive", next: "*" }, { blankLine: "any", prev: "directive", next: "directive" }]` configuration:
 
@@ -204,6 +248,45 @@ Examples of **correct** code for the `[{ blankLine: "always", prev: "directive",
 foo();
 ```
 
+### Prevent vertical space between `var` declarations
+
+Require that groups of consecutive `var` declarations cannot contain vertical space, including comments.
+
+Examples of **incorrect** code for the `[{ blankLine: "never", prev: "var", next: "var", includeComments: true }]` configuration:
+
+```js
+/*eslint padding-line-between-statements: [
+    "error",
+    { blankLine: "never", prev: "var", next: "var", includeComments: true }
+]*/
+
+function foo() {
+    var a = 42;
+
+    var b = 43;
+}
+
+function foo() {
+    var a = 42;
+    // comments between var declarations are not allowed
+    var b = 43;
+}
+```
+
+Examples of **correct** code for the `[{ blankLine: "never", prev: "var", next: "var", includeComments: true }]` configuration:
+
+```js
+/*eslint padding-line-between-statements: [
+    "error",
+    { blankLine: "never", prev: "var", next: "var", includeComments: true }
+]*/
+
+foo() {
+    var a = 42;
+    var b = 43;
+}
+```
+
 ## Compatibility
 
 - **JSCS:** [requirePaddingNewLineAfterVariableDeclaration]
@@ -218,8 +301,7 @@ foo();
 
 ## When Not To Use It
 
-If you don't want to notify warnings about linebreaks, then it's safe to disable this rule.
-
+If you don't want to notify warnings about vertical space, then it's safe to disable this rule.
 
 [lines-around-directive]: http://eslint.org/docs/rules/lines-around-directive
 [newline-after-var]: http://eslint.org/docs/rules/newline-after-var

--- a/lib/rules/padding-line-between-statements.js
+++ b/lib/rules/padding-line-between-statements.js
@@ -177,6 +177,79 @@ function getActualLastToken(sourceCode, node) {
 }
 
 /**
+ * Gets information about padding lines between the given 2 statements.
+ *
+ * @param {SourceCode} sourceCode Source code for the current context.
+ * @param {ASTNode} prevNode The previous statement to count.
+ * @param {ASTNode} nextNode The current statement to count.
+ * @returns {Object} Object containing padding information.
+ * @private
+ */
+function getPaddingLinesInfo(sourceCode, prevNode, nextNode) {
+    let token = getActualLastToken(sourceCode, prevNode);
+    const firstLine = token.loc.end.line;
+    const lastLine = nextNode.loc.start.line;
+    let prevLine = firstLine;
+    let commentLines = 0;
+
+    while (token.range[0] < nextNode.range[0]) {
+        if (astUtils.isCommentToken(token)) {
+            const startLine = Math.max(token.loc.start.line, prevLine + 1);
+            const endLine = Math.min(token.loc.end.line, lastLine - 1);
+
+            if (endLine >= startLine) {
+                commentLines += endLine - startLine + 1;
+                prevLine = endLine;
+            }
+        }
+
+        token = sourceCode.getTokenAfter(token, { includeComments: true });
+    }
+
+    const lineBreaks = lastLine - firstLine;
+    const blankLines = Math.max(lineBreaks - commentLines - 1, 0);
+
+    return {
+        lineBreaks,
+        blankLines,
+        commentLines
+    };
+}
+
+/**
+ * Gets pairs of tokens surrounding any blank lines between the given 2 statements.
+ * Comments are separators of the padding line sequences.
+ *
+ * @param {SourceCode} sourceCode Source code for the current context.
+ * @param {ASTNode} prevNode The previous statement to count.
+ * @param {ASTNode} nextNode The current statement to count.
+ * @returns {Array<Token[]>} Array of pairs of tokens surrounding blank lines.
+ * @private
+ */
+function getPaddingLineSequences(sourceCode, prevNode, nextNode) {
+    const pairs = [];
+
+    let prevToken = getActualLastToken(sourceCode, prevNode);
+
+    if (nextNode.loc.start.line - prevToken.loc.end.line >= 2) {
+        do {
+            const token = sourceCode.getTokenAfter(
+                prevToken,
+                { includeComments: true }
+            );
+
+            if (token.loc.start.line - prevToken.loc.end.line >= 2) {
+                pairs.push([prevToken, token]);
+            }
+            prevToken = token;
+
+        } while (prevToken.range[0] < nextNode.range[0]);
+    }
+
+    return pairs;
+}
+
+/**
  * This returns the concatenation of the first 2 captured strings.
  * @param {string} _ Unused. Whole matched string.
  * @param {string} trailingSpaces The trailing spaces of the first line.
@@ -207,13 +280,16 @@ function verifyForAny() {
  * @param {RuleContext} context The rule context to report.
  * @param {ASTNode} prevNode The previous node to check.
  * @param {ASTNode} nextNode The next node to check.
- * @param {Array<Token[]>} paddingLines The array of token pairs that blank
- * lines exist between the pair.
+ * @param {Object} config Config options for this node pair.
  * @returns {void}
  * @private
  */
-function verifyForNever(context, prevNode, nextNode, paddingLines) {
-    if (paddingLines.length === 0) {
+function verifyForNever(context, prevNode, nextNode, config) {
+    const sourceCode = context.getSourceCode();
+    const paddingInfo = getPaddingLinesInfo(sourceCode, prevNode, nextNode);
+    const totalLines = paddingInfo.blankLines + (config.includeComments ? paddingInfo.commentLines : 0);
+
+    if (totalLines === 0) {
         return;
     }
 
@@ -221,12 +297,18 @@ function verifyForNever(context, prevNode, nextNode, paddingLines) {
         node: nextNode,
         message: "Unexpected blank line before this statement.",
         fix(fixer) {
-            if (paddingLines.length >= 2) {
+            if (config.includeComments && paddingInfo.commentLines) {
                 return null;
             }
 
-            const prevToken = paddingLines[0][0];
-            const nextToken = paddingLines[0][1];
+            const tokenPairs = getPaddingLineSequences(sourceCode, prevNode, nextNode);
+
+            if (tokenPairs.length >= 2) {
+                return null;
+            }
+
+            const prevToken = tokenPairs[0][0];
+            const nextToken = tokenPairs[0][1];
             const start = prevToken.range[1];
             const end = nextToken.range[0];
             const text = context.getSourceCode().text
@@ -247,13 +329,16 @@ function verifyForNever(context, prevNode, nextNode, paddingLines) {
  * @param {RuleContext} context The rule context to report.
  * @param {ASTNode} prevNode The previous node to check.
  * @param {ASTNode} nextNode The next node to check.
- * @param {Array<Token[]>} paddingLines The array of token pairs that blank
- * lines exist between the pair.
+ * @param {Object} config Config options for this node pair.
  * @returns {void}
  * @private
  */
-function verifyForAlways(context, prevNode, nextNode, paddingLines) {
-    if (paddingLines.length > 0) {
+function verifyForAlways(context, prevNode, nextNode, config) {
+    const sourceCode = context.getSourceCode();
+    const paddingInfo = getPaddingLinesInfo(sourceCode, prevNode, nextNode);
+    const totalLines = paddingInfo.blankLines + (config.includeComments ? paddingInfo.commentLines : 0);
+
+    if (totalLines > 0) {
         return;
     }
 
@@ -261,8 +346,8 @@ function verifyForAlways(context, prevNode, nextNode, paddingLines) {
         node: nextNode,
         message: "Expected blank line before this statement.",
         fix(fixer) {
-            const sourceCode = context.getSourceCode();
-            let prevToken = getActualLastToken(sourceCode, prevNode);
+            const lastToken = getActualLastToken(sourceCode, prevNode);
+            let prevToken = lastToken;
             const nextToken = sourceCode.getFirstTokenBetween(
                 prevToken,
                 nextNode,
@@ -299,9 +384,14 @@ function verifyForAlways(context, prevNode, nextNode, paddingLines) {
                     }
                 }
             ) || nextNode;
-            const insertText = astUtils.isTokenOnSameLine(prevToken, nextToken)
-                ? "\n\n"
-                : "\n";
+
+            const isOnSameLine = astUtils.isTokenOnSameLine(prevToken, nextToken);
+            const insertText = isOnSameLine ? "\n\n" : "\n";
+
+            // Some edge-cases can't be fixed, e.g. "foo();/*multi-line\ncomment*/bar();"
+            if (isOnSameLine && config.includeComments && prevToken !== lastToken) {
+                return null;
+            }
 
             return fixer.insertTextAfter(prevToken, insertText);
         }
@@ -356,10 +446,8 @@ const StatementTypes = {
             node.loc.start.line !== node.loc.end.line &&
             isBlockLikeStatement(sourceCode, node)
     },
-
     block: newNodeTypeTester("BlockStatement"),
     empty: newNodeTypeTester("EmptyStatement"),
-
     break: newKeywordTester("break"),
     case: newKeywordTester("case"),
     class: newKeywordTester("class"),
@@ -419,7 +507,8 @@ module.exports = {
                 properties: {
                     blankLine: { $ref: "#/definitions/paddingType" },
                     prev: { $ref: "#/definitions/statementType" },
-                    next: { $ref: "#/definitions/statementType" }
+                    next: { $ref: "#/definitions/statementType" },
+                    includeComments: { type: "boolean" }
                 },
                 additionalProperties: false,
                 required: ["blankLine", "prev", "next"]
@@ -474,56 +563,25 @@ module.exports = {
         }
 
         /**
-         * Finds the last matched configure from configureList.
+         * Finds the last matching item in configureList, or null.
          *
          * @param {ASTNode} prevNode The previous statement to match.
          * @param {ASTNode} nextNode The current statement to match.
-         * @returns {Object} The tester of the last matched configure.
+         * @returns {Object} The last matching item, or null if no matches.
          * @private
          */
-        function getPaddingType(prevNode, nextNode) {
+        function getMatchingConfig(prevNode, nextNode) {
             for (let i = configureList.length - 1; i >= 0; --i) {
-                const configure = configureList[i];
+                const config = configureList[i];
                 const matched =
-                    match(prevNode, configure.prev) &&
-                    match(nextNode, configure.next);
+                    match(prevNode, config.prev) &&
+                    match(nextNode, config.next);
 
                 if (matched) {
-                    return PaddingTypes[configure.blankLine];
+                    return config;
                 }
             }
-            return PaddingTypes.any;
-        }
-
-        /**
-         * Gets padding line sequences between the given 2 statements.
-         * Comments are separators of the padding line sequences.
-         *
-         * @param {ASTNode} prevNode The previous statement to count.
-         * @param {ASTNode} nextNode The current statement to count.
-         * @returns {Array<Token[]>} The array of token pairs.
-         * @private
-         */
-        function getPaddingLineSequences(prevNode, nextNode) {
-            const pairs = [];
-            let prevToken = getActualLastToken(sourceCode, prevNode);
-
-            if (nextNode.loc.start.line - prevToken.loc.end.line >= 2) {
-                do {
-                    const token = sourceCode.getTokenAfter(
-                        prevToken,
-                        { includeComments: true }
-                    );
-
-                    if (token.loc.start.line - prevToken.loc.end.line >= 2) {
-                        pairs.push([prevToken, token]);
-                    }
-                    prevToken = token;
-
-                } while (prevToken.range[0] < nextNode.range[0]);
-            }
-
-            return pairs;
+            return null;
         }
 
         /**
@@ -548,10 +606,11 @@ module.exports = {
 
             // Verify.
             if (prevNode) {
-                const type = getPaddingType(prevNode, node);
-                const paddingLines = getPaddingLineSequences(prevNode, node);
+                const config = getMatchingConfig(prevNode, node);
+                const blankLine = config ? config.blankLine : "any";
+                const paddingType = PaddingTypes[blankLine];
 
-                type.verify(context, prevNode, node, paddingLines);
+                paddingType.verify(context, prevNode, node, config);
             }
 
             scopeInfo.prevNode = node;

--- a/tests/lib/rules/padding-line-between-statements.js
+++ b/tests/lib/rules/padding-line-between-statements.js
@@ -2387,6 +2387,72 @@ ruleTester.run("padding-line-between-statements", rule, {
             options: [
                 { blankLine: "always", prev: "*", next: ["if", "for", "return", "switch", "case", "break", "throw", "while", "default"] }
             ]
+        },
+
+        //----------------------------------------------------------------------
+        // { blankLine: "always", includeComments: true }
+        // Comment lines are treated the same as blank lines
+        //----------------------------------------------------------------------
+        {
+            code: "foo();\n\nbar();",
+            options: [{ blankLine: "always", prev: "*", next: "*", includeComments: true }]
+        },
+        {
+            code: "foo();\n//comment\nbar();",
+            options: [{ blankLine: "always", prev: "*", next: "*", includeComments: true }]
+        },
+        {
+            code: "foo();\n/*multi-line\ncomment*/\nbar();",
+            options: [{ blankLine: "always", prev: "*", next: "*", includeComments: true }]
+        },
+        {
+            code: "foo();\n/*comment1*/\n//comment2\nbar();",
+            options: [{ blankLine: "always", prev: "*", next: "*", includeComments: true }]
+        },
+        {
+            code: "foo();/*multi-line\ncomment*/\nbar();",
+            options: [{ blankLine: "always", prev: "*", next: "*", includeComments: true }]
+        },
+        {
+            code: "foo();\n/*multi-line\ncomment*/ bar();",
+            options: [{ blankLine: "always", prev: "*", next: "*", includeComments: true }]
+        },
+        {
+            code: "foo();/*multi\nline\ncomment*/bar();",
+            options: [{ blankLine: "always", prev: "*", next: "*", includeComments: true }]
+        },
+
+        //----------------------------------------------------------------------
+        // { blankLine: "never", includeComments: true }
+        // Comment lines are treated the same as blank lines
+        //----------------------------------------------------------------------
+        {
+            code: "foo();bar();",
+            options: [{ blankLine: "never", prev: "*", next: "*", includeComments: true }]
+        },
+        {
+            code: "foo();\nbar();",
+            options: [{ blankLine: "never", prev: "*", next: "*", includeComments: true }]
+        },
+        {
+            code: "foo();//comment\nbar();",
+            options: [{ blankLine: "never", prev: "*", next: "*", includeComments: true }]
+        },
+        {
+            code: "foo();\n/*comment*/bar();",
+            options: [{ blankLine: "never", prev: "*", next: "*", includeComments: true }]
+        },
+        {
+            code: "foo();/*comment*/\n/*comment*/bar();",
+            options: [{ blankLine: "never", prev: "*", next: "*", includeComments: true }]
+        },
+        {
+            code: "foo();/*comment*//*comment*/bar();",
+            options: [{ blankLine: "never", prev: "*", next: "*", includeComments: true }]
+        },
+        {
+            code: "foo();/*multi-line\ncomment*/bar();",
+            options: [{ blankLine: "never", prev: "*", next: "*", includeComments: true }]
         }
     ],
     invalid: [
@@ -4440,6 +4506,100 @@ ruleTester.run("padding-line-between-statements", rule, {
                 MESSAGE_ALWAYS,
                 MESSAGE_ALWAYS
             ]
+        },
+
+        //----------------------------------------------------------------------
+        // { blankLine: "never", includeComments: true }
+        // Comment lines are treated the same as blank lines
+        //----------------------------------------------------------------------
+        {
+            code: "foo();\n\nbar();",
+            output: "foo();\nbar();",
+            options: [{ blankLine: "never", prev: "*", next: "*", includeComments: true }],
+            errors: [MESSAGE_NEVER]
+        },
+        {
+            code: "foo();\n//comment\nbar();",
+            output: null,
+            options: [{ blankLine: "never", prev: "*", next: "*", includeComments: true }],
+            errors: [MESSAGE_NEVER]
+        },
+        {
+            code: "foo();\n/*multi-line\ncomment*/\nbar();",
+            output: null,
+            options: [{ blankLine: "never", prev: "*", next: "*", includeComments: true }],
+            errors: [MESSAGE_NEVER]
+        },
+        {
+            code: "foo();\n/*comment1*/\n//comment2\nbar();",
+            output: null,
+            options: [{ blankLine: "never", prev: "*", next: "*", includeComments: true }],
+            errors: [MESSAGE_NEVER]
+        },
+        {
+            code: "foo();/*multi-line\ncomment*/\nbar();",
+            output: null,
+            options: [{ blankLine: "never", prev: "*", next: "*", includeComments: true }],
+            errors: [MESSAGE_NEVER]
+        },
+        {
+            code: "foo();\n/*multi-line\ncomment*/ bar();",
+            output: null,
+            options: [{ blankLine: "never", prev: "*", next: "*", includeComments: true }],
+            errors: [MESSAGE_NEVER]
+        },
+        {
+            code: "foo();/*multi\nline\ncomment*/bar();",
+            output: null,
+            options: [{ blankLine: "never", prev: "*", next: "*", includeComments: true }],
+            errors: [MESSAGE_NEVER]
+        },
+
+        //----------------------------------------------------------------------
+        // { blankLine: "always", includeComments: true }
+        // Comment lines are treated the same as blank lines
+        //----------------------------------------------------------------------
+        {
+            code: "foo();bar();",
+            output: "foo();\n\nbar();",
+            options: [{ blankLine: "always", prev: "*", next: "*", includeComments: true }],
+            errors: [MESSAGE_ALWAYS]
+        },
+        {
+            code: "foo();\nbar();",
+            output: "foo();\n\nbar();",
+            options: [{ blankLine: "always", prev: "*", next: "*", includeComments: true }],
+            errors: [MESSAGE_ALWAYS]
+        },
+        {
+            code: "foo();//comment\nbar();",
+            output: "foo();//comment\n\nbar();",
+            options: [{ blankLine: "always", prev: "*", next: "*", includeComments: true }],
+            errors: [MESSAGE_ALWAYS]
+        },
+        {
+            code: "foo();\n/*comment*/bar();",
+            output: "foo();\n\n/*comment*/bar();",
+            options: [{ blankLine: "always", prev: "*", next: "*", includeComments: true }],
+            errors: [MESSAGE_ALWAYS]
+        },
+        {
+            code: "foo();/*comment*/\n/*comment*/bar();",
+            output: "foo();/*comment*/\n\n/*comment*/bar();",
+            options: [{ blankLine: "always", prev: "*", next: "*", includeComments: true }],
+            errors: [MESSAGE_ALWAYS]
+        },
+        {
+            code: "foo();/*comment*//*comment*/bar();",
+            output: null,
+            options: [{ blankLine: "always", prev: "*", next: "*", includeComments: true }],
+            errors: [MESSAGE_ALWAYS]
+        },
+        {
+            code: "foo();/*multi-line\ncomment*/bar();",
+            output: null,
+            options: [{ blankLine: "always", prev: "*", next: "*", includeComments: true }],
+            errors: [MESSAGE_ALWAYS]
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[**X**] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**What rule do you want to change?**
padding-line-between-statements

**Does this change cause the rule to produce more or fewer warnings?**
Fewer

**How will the change be implemented? (New option, new default behavior, etc.)?**
New field added to definition objects (`includeComments`)

**Please provide some example code that this change will affect:**
```js
/*eslint padding-line-between-statements: [
    "error",
    { blankLine: "always", prev: "*", next: "return", includeComments: true }
]*/

function foo(bar) {
    if (bar) {
        return a;
    }
    // else
    return b;
}
```

**What does the rule currently do for this code?**
The above function definition would currently be flagged as **incorrect** due to not having any vertical space before the `return b` statement

**What will the rule do after it's changed?**
Using `"includeComments": true` this would be flagged as **correct** due to the `\\ else` comment being seen the same as vertical space

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Added an (optional) `includeComments` field to `padding-line-between-statements` rule, to allow comments to be treated as vertical space, the same as blank lines

By default this field is effectively set to `false`, which gives identical behavior to the current code

This update allows developers to choose to use either comments or blank lines to visually separate code blocks

**Is there anything you'd like reviewers to focus on?**
This is my first contribution to `eslint` so I would appreciate comments on naming and style

I am not sure if the [`astUtils.isCommentToken(token)`](https://github.com/borilla/eslint/blob/3fa1f98e38870b75a3a6bed44048997208e46323/lib/rules/padding-line-between-statements.js#L196) test is strictly necessary. The existing code seems to assume any tokens in these positions are comments so it may be able to be safely removed
