### PR TITLE
Fix: Call expression consistency in variable declaration (fixes #8607)

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -1189,9 +1189,11 @@ module.exports = {
             VariableDeclarator(node) {
                 if (node.init) {
                     const equalOperator = sourceCode.getTokenBefore(node.init, astUtils.isNotOpeningParenToken);
+                    const tokenAfterOperator = sourceCode.getTokenAfter(equalOperator);
 
                     offsets.ignoreToken(equalOperator);
-                    offsets.ignoreToken(sourceCode.getFirstToken(node.init));
+                    offsets.ignoreToken(tokenAfterOperator);
+                    offsets.matchIndentOf(equalOperator, tokenAfterOperator);
                 }
             },
 

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -3424,6 +3424,133 @@ ruleTester.run("indent", rule, {
                 )
             `
         },
+        {
+            code: unIndent`
+                const foo = a.b(),
+                    longName =
+                        (memberFunction(
+                            'bar',
+                            'bar'
+                        ));
+            `
+        },
+        {
+            code: unIndent`
+                const foo = a.b(),
+                    longName =
+                    (memberFunction(
+                        'bar',
+                        'bar'
+                    ));
+            `
+        },
+        {
+            code: unIndent`
+                const foo = a.b(),
+                    longName =
+                        memberFunction(
+                            'bar',
+                            'bar'
+                        );
+            `
+        },
+        {
+            code: unIndent`
+                const foo = a.b(),
+                    longName =
+                    memberFunction(
+                        'bar',
+                        'bar'
+                    );
+            `
+        },
+        {
+            code: unIndent`
+                const foo = a.b(),
+                    longName
+                        = memberFunction(
+                            'bar',
+                            'bar'
+                        );
+            `
+        },
+        {
+            code: unIndent`
+                const foo = a.b(),
+                    longName
+                    = memberFunction(
+                        'bar',
+                        'bar'
+                    );
+            `
+        },
+        {
+            code: unIndent`
+                const foo = a.b(),
+                    longName =
+                        ('fff');
+            `
+        },
+        {
+            code: unIndent`
+                const foo = a.b(),
+                    longName =
+                    ('fff');
+            `
+        },
+        {
+            code: unIndent`
+                const foo = a.b(),
+                    longName
+                        = ('fff');
+
+            `
+        },
+        {
+            code: unIndent`
+                const foo = a.b(),
+                    longName
+                    = ('fff');
+
+            `
+        },
+        {
+            code: unIndent`
+                const foo = a.b(),
+                    longName =
+                        (
+                            'fff'
+                        );
+            `
+        },
+        {
+            code: unIndent`
+                const foo = a.b(),
+                    longName =
+                    (
+                        'fff'
+                    );
+            `
+        },
+        {
+            code: unIndent`
+                const foo = a.b(),
+                    longName
+                        =(
+                            'fff'
+                        );
+            `
+        },
+        {
+            code: unIndent`
+                const foo = a.b(),
+                    longName
+                    =(
+                        'fff'
+                    );
+            `
+        },
+
 
         //----------------------------------------------------------------------
         // Ignore Unknown Nodes
@@ -7632,6 +7759,80 @@ ruleTester.run("indent", rule, {
                     baz
             `,
             errors: expectedErrors([[2, 4, 2, "Identifier"], [3, 4, 6, "Identifier"]])
+        },
+        {
+            code: unIndent`
+                const foo = a.b(),
+                    longName
+                    = (memberFunction(
+                            'bar',
+                            'bar'
+                        ));
+            `,
+            output: unIndent`
+                const foo = a.b(),
+                    longName
+                    = (memberFunction(
+                        'bar',
+                        'bar'
+                    ));
+            `,
+            errors: expectedErrors([[4, 8, 12, "String"], [5, 8, 12, "String"], [6, 4, 8, "Punctuator"]])
+        },
+        {
+            code: unIndent`
+                const foo = a.b(),
+                    longName =
+                    (memberFunction(
+                            'bar',
+                            'bar'
+                        ));
+            `,
+            output: unIndent`
+                const foo = a.b(),
+                    longName =
+                    (memberFunction(
+                        'bar',
+                        'bar'
+                    ));
+            `,
+            errors: expectedErrors([[4, 8, 12, "String"], [5, 8, 12, "String"], [6, 4, 8, "Punctuator"]])
+        },
+        {
+            code: unIndent`
+                const foo = a.b(),
+                    longName
+                        =memberFunction(
+                            'bar',
+                            'bar'
+                    );
+            `,
+            output: unIndent`
+                const foo = a.b(),
+                    longName
+                        =memberFunction(
+                            'bar',
+                            'bar'
+                        );
+            `,
+            errors: expectedErrors([[6, 8, 4, "Punctuator"]])
+        },
+        {
+            code: unIndent`
+                const foo = a.b(),
+                    longName
+                        =(
+                        'fff'
+                        );
+            `,
+            output: unIndent`
+                const foo = a.b(),
+                    longName
+                        =(
+                            'fff'
+                        );
+            `,
+            errors: expectedErrors([[4, 12, 8, "String"]])
         },
 
         //----------------------------------------------------------------------

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -3428,7 +3428,7 @@ ruleTester.run("indent", rule, {
             code: unIndent`
                 const foo = a.b(),
                     longName =
-                        (memberFunction(
+                        (baz(
                             'bar',
                             'bar'
                         ));
@@ -3438,7 +3438,7 @@ ruleTester.run("indent", rule, {
             code: unIndent`
                 const foo = a.b(),
                     longName =
-                    (memberFunction(
+                    (baz(
                         'bar',
                         'bar'
                     ));
@@ -3448,7 +3448,7 @@ ruleTester.run("indent", rule, {
             code: unIndent`
                 const foo = a.b(),
                     longName =
-                        memberFunction(
+                        baz(
                             'bar',
                             'bar'
                         );
@@ -3458,7 +3458,7 @@ ruleTester.run("indent", rule, {
             code: unIndent`
                 const foo = a.b(),
                     longName =
-                    memberFunction(
+                    baz(
                         'bar',
                         'bar'
                     );
@@ -3468,7 +3468,7 @@ ruleTester.run("indent", rule, {
             code: unIndent`
                 const foo = a.b(),
                     longName
-                        = memberFunction(
+                        = baz(
                             'bar',
                             'bar'
                         );
@@ -3478,7 +3478,7 @@ ruleTester.run("indent", rule, {
             code: unIndent`
                 const foo = a.b(),
                     longName
-                    = memberFunction(
+                    = baz(
                         'bar',
                         'bar'
                     );
@@ -7764,7 +7764,7 @@ ruleTester.run("indent", rule, {
             code: unIndent`
                 const foo = a.b(),
                     longName
-                    = (memberFunction(
+                    = (baz(
                             'bar',
                             'bar'
                         ));
@@ -7772,7 +7772,7 @@ ruleTester.run("indent", rule, {
             output: unIndent`
                 const foo = a.b(),
                     longName
-                    = (memberFunction(
+                    = (baz(
                         'bar',
                         'bar'
                     ));
@@ -7783,7 +7783,7 @@ ruleTester.run("indent", rule, {
             code: unIndent`
                 const foo = a.b(),
                     longName =
-                    (memberFunction(
+                    (baz(
                             'bar',
                             'bar'
                         ));
@@ -7791,7 +7791,7 @@ ruleTester.run("indent", rule, {
             output: unIndent`
                 const foo = a.b(),
                     longName =
-                    (memberFunction(
+                    (baz(
                         'bar',
                         'bar'
                     ));
@@ -7802,7 +7802,7 @@ ruleTester.run("indent", rule, {
             code: unIndent`
                 const foo = a.b(),
                     longName
-                        =memberFunction(
+                        =baz(
                             'bar',
                             'bar'
                     );
@@ -7810,7 +7810,7 @@ ruleTester.run("indent", rule, {
             output: unIndent`
                 const foo = a.b(),
                     longName
-                        =memberFunction(
+                        =baz(
                             'bar',
                             'bar'
                         );


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

**What changes did you make? (Give an overview)**
Variable Declaration initial value should now be indented the same way as Assignment Expressions. We ignore the equal operator token and the token after it instead of just ignoring the initial value. By ignoring both of these token we can allow for an optional indent whether the equal operator is on a new line or not. Since a parenthesis token is not part of the initial value node it needs to be ignored in case it appears on a new line. We must also match indent of the first token after the equal since it might be a parenthesis that should have the same indentation of the equal when they are on the same line.


**Is there anything you'd like reviewers to focus on?**
Any test cases missing?


