### PR TITLE
New: Native linebreak-style option (fixes #8596)

### DIFF
--- a/docs/rules/linebreak-style.md
+++ b/docs/rules/linebreak-style.md
@@ -16,9 +16,29 @@ This rule enforces consistent line endings independent of operating system, VCS,
 
 This rule has a string option:
 
+* `"native"` enforces the usage of line endings appropriate for the current operating system.
 * `"unix"` (default) enforces the usage of Unix line endings: `\n` for LF.
 * `"windows"` enforces the usage of Windows line endings: `\r\n` for CRLF.
 
+### native
+
+Examples of **incorrect** code for this rule with the `"native"` option:
+
+```js
+/*eslint linebreak-style: ["error", "native"]*/
+
+var a = 'a'; // \r\n on Linux
+var b = 'b'; // \n on Windows
+```
+
+Examples of **correct** code for this rule with the `"native"` option:
+
+```js
+/*eslint linebreak-style: ["error", "native"]*/
+
+var a = 'a'; // \n on Linux
+var b = 'b'; // \r\n on Windows
+```
 
 ### unix
 
@@ -71,7 +91,7 @@ function foo(params) { // \r\n
 
 Version control systems sometimes have special behavior for linebreaks. To make it easy for developers to contribute to your codebase from different platforms, you may want to configure your VCS to handle linebreaks appropriately.
 
-For example, the default behavior of [git](https://git-scm.com/) on Windows systems is to convert LF linebreaks to CRLF when checking out files, but to store the linebreaks as LF when committing a change. This will cause the `linebreak-style` rule to report errors if configured with the `"unix"` setting, because the files that ESLint sees will have CRLF linebreaks. If you use git, you may want to add a line to your [`.gitattributes` file](https://git-scm.com/docs/gitattributes) to prevent git from converting linebreaks in `.js` files:
+For example, the default behavior of [git](https://git-scm.com/) on Windows systems is to convert LF linebreaks to CRLF when checking out files, but to store the linebreaks as LF when committing a change. This will cause the `linebreak-style` rule to report errors if configured with the `"unix"` setting, because the files that ESLint sees will have CRLF linebreaks. If you use git, you may want to set this to `"native"` or add a line to your [`.gitattributes` file](https://git-scm.com/docs/gitattributes) to prevent git from converting linebreaks in `.js` files:
 
 ```
 *.js text eol=lf

--- a/lib/rules/linebreak-style.js
+++ b/lib/rules/linebreak-style.js
@@ -9,7 +9,8 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const astUtils = require("../ast-utils");
+const os = require("os"),
+    astUtils = require("../ast-utils");
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -27,7 +28,7 @@ module.exports = {
 
         schema: [
             {
-                enum: ["unix", "windows"]
+                enum: ["native", "unix", "windows"]
             }
         ]
     },
@@ -63,7 +64,7 @@ module.exports = {
         return {
             Program: function checkForlinebreakStyle(node) {
                 const linebreakStyle = context.options[0] || "unix",
-                    expectedLF = linebreakStyle === "unix",
+                    expectedLF = linebreakStyle === "unix" || (linebreakStyle === "native" && os.EOL === "\n"),
                     expectedLFChars = expectedLF ? "\n" : "\r\n",
                     source = sourceCode.getText(),
                     pattern = astUtils.createGlobalLinebreakMatcher();

--- a/tests/lib/rules/linebreak-style.js
+++ b/tests/lib/rules/linebreak-style.js
@@ -8,11 +8,14 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const rule = require("../../../lib/rules/linebreak-style"),
+const os = require("os"),
+    rule = require("../../../lib/rules/linebreak-style"),
     RuleTester = require("../../../lib/testers/rule-tester");
 
 const EXPECTED_LF_MSG = "Expected linebreaks to be 'LF' but found 'CRLF'.",
-    EXPECTED_CRLF_MSG = "Expected linebreaks to be 'CRLF' but found 'LF'.";
+    EXPECTED_CRLF_MSG = "Expected linebreaks to be 'CRLF' but found 'LF'.",
+    EXPECTED_NATIVE_EOL_MSG = os.EOL === "\n" ? EXPECTED_LF_MSG : EXPECTED_CRLF_MSG,
+    badEOL = os.EOL === "\n" ? "\r\n" : "\n";
 
 //------------------------------------------------------------------------------
 // Tests
@@ -35,12 +38,20 @@ ruleTester.run("linebreak-style", rule, {
             options: ["windows"]
         },
         {
+            code: `var a = 'a',${os.EOL} b = 'b';${os.EOL}${os.EOL} function foo(params) {${os.EOL} /* do stuff */ ${os.EOL} }${os.EOL}`,
+            options: ["native"]
+        },
+        {
             code: "var b = 'b';",
             options: ["unix"]
         },
         {
             code: "var b = 'b';",
             options: ["windows"]
+        },
+        {
+            code: "var b = 'b';",
+            options: ["native"]
         }
     ],
 
@@ -75,6 +86,16 @@ ruleTester.run("linebreak-style", rule, {
             }]
         },
         {
+            code: `var a = 'a';${badEOL}`,
+            output: `var a = 'a';${os.EOL}`,
+            options: ["native"],
+            errors: [{
+                line: 1,
+                column: 13,
+                message: EXPECTED_NATIVE_EOL_MSG
+            }]
+        },
+        {
             code: "var a = 'a',\n b = 'b';\n\n function foo(params) {\r\n /* do stuff */ \n }\r\n",
             output: "var a = 'a',\n b = 'b';\n\n function foo(params) {\n /* do stuff */ \n }\n",
             errors: [{
@@ -106,6 +127,30 @@ ruleTester.run("linebreak-style", rule, {
                 line: 6,
                 column: 17,
                 message: EXPECTED_CRLF_MSG
+            }]
+        },
+
+
+
+
+        {
+            code: `var a = 'a',${os.EOL} b = 'b';${badEOL}${os.EOL} function foo(params) {${os.EOL}${badEOL} /* do stuff */ ${badEOL} }${os.EOL}`,
+            output: `var a = 'a',${os.EOL} b = 'b';${os.EOL}${os.EOL} function foo(params) {${os.EOL}${os.EOL} /* do stuff */ ${os.EOL} }${os.EOL}`,
+            options: ["native"],
+            errors: [{
+                line: 2,
+                column: 10,
+                message: EXPECTED_NATIVE_EOL_MSG
+            },
+            {
+                line: 5,
+                column: 1,
+                message: EXPECTED_NATIVE_EOL_MSG
+            },
+            {
+                line: 6,
+                column: 17,
+                message: EXPECTED_NATIVE_EOL_MSG
             }]
         }
     ]


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

https://github.com/eslint/eslint/issues/8596

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Added a `native` option to the `linebreak-style` rule. This new option enforces usage of line endings that match those expected by the host operating system that ESLint is running on. Using this is sensible for developers who want their code to be maximally compatible with tools and programs for the current machine. This also works well for git repositories, which automatically convert line endings to be OS specific by default. As a result, this option is the only way to make an ESLint config with `linebreak-style` that will pass on _both_ Windows and *nix when using git out of the box.

**Is there anything you'd like reviewers to focus on?**

Clearly describing this in the documentation is probably the most important. I personally feel that this option ought to be the default. Maybe that's worthy of some discussion, but I'm happy to address that in a separate PR,