### PR TITLE
Chore: Remove dependency to user-home (fixes #8604)

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -10,11 +10,11 @@
 //------------------------------------------------------------------------------
 
 const path = require("path"),
+    os = require("os"),
     ConfigOps = require("./config/config-ops"),
     ConfigFile = require("./config/config-file"),
     Plugins = require("./config/plugins"),
     FileFinder = require("./file-finder"),
-    userHome = require("user-home"),
     isResolvable = require("is-resolvable"),
     pathIsInside = require("path-is-inside");
 
@@ -24,7 +24,7 @@ const debug = require("debug")("eslint:config");
 // Constants
 //------------------------------------------------------------------------------
 
-const PERSONAL_CONFIG_DIR = userHome || null;
+const PERSONAL_CONFIG_DIR = os.homedir() || null;
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -79,6 +79,7 @@ function getPersonalConfig(configContext) {
     let config;
 
     if (PERSONAL_CONFIG_DIR) {
+
         const filename = ConfigFile.getFilenameForDirectory(PERSONAL_CONFIG_DIR);
 
         if (filename) {

--- a/package.json
+++ b/package.json
@@ -65,8 +65,7 @@
     "require-uncached": "^1.0.3",
     "strip-json-comments": "~2.0.1",
     "table": "^4.0.1",
-    "text-table": "~0.2.0",
-    "user-home": "^2.0.0"
+    "text-table": "~0.2.0"
   },
   "devDependencies": {
     "babel-polyfill": "^6.23.0",

--- a/tests/lib/config.js
+++ b/tests/lib/config.js
@@ -117,6 +117,17 @@ describe("Config", () => {
             .returns(fakeCWDPath);
     }
 
+    /**
+     * Mocks the current user's home path
+     * @param {string} fakeUserHomePath - fake user's home path
+     * @returns {void}
+     * @private
+     */
+    function mockOsHomedir(fakeUserHomePath) {
+        sandbox.stub(os, "homedir")
+            .returns(fakeUserHomePath);
+    }
+
     // copy into clean area so as not to get "infected" by this project's .eslintrc files
     before(() => {
         fixtureDir = `${os.tmpdir()}/eslint/fixtures`;
@@ -269,7 +280,8 @@ describe("Config", () => {
             const configPath = path.resolve(__dirname, "..", "fixtures", "configurations", "foobaz", ".eslintrc");
             const homePath = "does-not-exist";
 
-            const StubbedConfig = proxyquire("../../lib/config", { "user-home": homePath });
+            mockOsHomedir(homePath);
+            const StubbedConfig = proxyquire("../../lib/config", {});
 
             const configHelper = new StubbedConfig({ cwd: process.cwd() }, linter);
 
@@ -831,7 +843,8 @@ describe("Config", () => {
                     homePath = getFakeFixturePath("personal-config", "home-folder"),
                     filePath = getFakeFixturePath("personal-config", "project-without-config", "foo.js");
 
-                const StubbedConfig = proxyquire("../../lib/config", { "user-home": homePath });
+                mockOsHomedir(homePath);
+                const StubbedConfig = proxyquire("../../lib/config", {});
 
                 mockPersonalConfigFileSystem();
                 mockCWDResponse(projectPath);
@@ -856,7 +869,8 @@ describe("Config", () => {
                     homePath = getFakeFixturePath("personal-config", "home-folder"),
                     filePath = getFakeFixturePath("personal-config", "home-folder", "project", "foo.js");
 
-                const StubbedConfig = proxyquire("../../lib/config", { "user-home": homePath });
+                mockOsHomedir(homePath);
+                const StubbedConfig = proxyquire("../../lib/config", {});
 
                 mockPersonalConfigFileSystem();
                 mockCWDResponse(projectPath);
@@ -882,7 +896,8 @@ describe("Config", () => {
                     homePath = getFakeFixturePath("personal-config", "home-folder"),
                     filePath = getFakeFixturePath("personal-config", "project-without-config", "foo.js");
 
-                const StubbedConfig = proxyquire("../../lib/config", { "user-home": homePath });
+                mockOsHomedir(homePath);
+                const StubbedConfig = proxyquire("../../lib/config", {});
 
                 mockPersonalConfigFileSystem();
                 mockCWDResponse(projectPath);
@@ -906,7 +921,8 @@ describe("Config", () => {
                 const projectPath = getFakeFixturePath("personal-config", "project-with-config"),
                     filePath = getFakeFixturePath("personal-config", "project-with-config", "subfolder", "foo.js");
 
-                const StubbedConfig = proxyquire("../../lib/config", { "user-home": projectPath });
+                mockOsHomedir(projectPath);
+                const StubbedConfig = proxyquire("../../lib/config", {});
 
                 mockPersonalConfigFileSystem();
                 mockCWDResponse(projectPath);
@@ -969,7 +985,8 @@ describe("Config", () => {
                     homePath = getFakeFixturePath("personal-config", "folder-does-not-exist"),
                     filePath = getFakeFixturePath("personal-config", "project-without-config", "foo.js");
 
-                const StubbedConfig = proxyquire("../../lib/config", { "user-home": homePath });
+                mockOsHomedir(homePath);
+                const StubbedConfig = proxyquire("../../lib/config", {});
 
                 mockPersonalConfigFileSystem();
                 mockCWDResponse(projectPath);
@@ -986,7 +1003,8 @@ describe("Config", () => {
                     homePath = getFakeFixturePath("personal-config", "home-folder-with-packagejson"),
                     filePath = getFakeFixturePath("personal-config", "project-without-config", "foo.js");
 
-                const StubbedConfig = proxyquire("../../lib/config", { "user-home": homePath });
+                mockOsHomedir(homePath);
+                const StubbedConfig = proxyquire("../../lib/config", {});
 
                 mockPersonalConfigFileSystem();
                 mockCWDResponse(projectPath);
@@ -1003,7 +1021,8 @@ describe("Config", () => {
                     homePath = getFakeFixturePath("personal-config", "folder-does-not-exist"),
                     filePath = getFakeFixturePath("personal-config", "project-without-config", "foo.js");
 
-                const StubbedConfig = proxyquire("../../lib/config", { "user-home": homePath });
+                mockOsHomedir(homePath);
+                const StubbedConfig = proxyquire("../../lib/config", {});
 
                 mockPersonalConfigFileSystem();
                 mockCWDResponse(projectPath);
@@ -1023,7 +1042,8 @@ describe("Config", () => {
                     homePath = getFakeFixturePath("personal-config", "folder-does-not-exist"),
                     filePath = getFakeFixturePath("personal-config", "project-without-config", "foo.js");
 
-                const StubbedConfig = proxyquire("../../lib/config", { "user-home": homePath });
+                mockOsHomedir(homePath);
+                const StubbedConfig = proxyquire("../../lib/config", {});
 
                 mockPersonalConfigFileSystem();
                 mockCWDResponse(projectPath);
@@ -1043,7 +1063,8 @@ describe("Config", () => {
                     homePath = getFakeFixturePath("personal-config", "folder-does-not-exist"),
                     filePath = getFakeFixturePath("personal-config", "project-without-config", "foo.js");
 
-                const StubbedConfig = proxyquire("../../lib/config", { "user-home": homePath });
+                mockOsHomedir(homePath);
+                const StubbedConfig = proxyquire("../../lib/config", {});
 
                 mockPersonalConfigFileSystem();
                 mockCWDResponse(projectPath);

--- a/tests/lib/config/config-file.js
+++ b/tests/lib/config/config-file.js
@@ -13,14 +13,15 @@ const assert = require("chai").assert,
     sinon = require("sinon"),
     path = require("path"),
     fs = require("fs"),
+    os = require("os"),
     yaml = require("js-yaml"),
-    userHome = require("user-home"),
     shell = require("shelljs"),
     environments = require("../../../conf/environments"),
     ConfigFile = require("../../../lib/config/config-file"),
     Linter = require("../../../lib/linter"),
     Config = require("../../../lib/config");
 
+const userHome = os.homedir();
 const temp = require("temp").track();
 const proxyquire = require("proxyquire").noCallThru().noPreserveCache();
 const configContext = new Config({}, new Linter());


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Module user-home dependency replaced with core module os.homedir().

**Is there anything you'd like reviewers to focus on?**
I had little trouble with mocking os.pathname(), can you check if is it correct, please?

