### PR TITLE
Docs: suggest pushing new commits to a PR instead of amending

### DIFF
--- a/docs/developer-guide/contributing/pull-requests.md
+++ b/docs/developer-guide/contributing/pull-requests.md
@@ -160,11 +160,11 @@ If we ask you to make code changes, there's no need to close the pull request an
 
 ```
 $ git add -A
-$ git commit --amend --no-edit
-$ git push origin issue1234 -f
+$ git commit
+$ git push origin issue1234
 ```
 
-This snippets adds all your new changes, then amends the previous commit with them. The `--no-edit` means you don't want to edit the commit message; you can omit that option if you need to make commit message changes as well.
+When updating the code, it's usually better to add additional commits to your branch rather than amending the original commit, because reviewers can easily tell which changes were made in response to a particular review. When we merge pull requests, we will squash all the commits from your branch into a single commit on the `master` branch.
 
 ### Rebasing
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates the contribution guidelines to suggest adding new commits to a PR when changes are requested, rather than amending the original commit.

As a reviewer, adding additional commits makes it easier to tell what has changed. For example, if I suggest a very small change on a large PR, and a commit is added to address the change, I can easily look at the diff for that commit and make sure it looks okay. On the other hand, if the original commit is amended, it is harder to tell what was changed, so I might have to look through the entire PR again. 

I think the original guideline here was added before GitHub had the "squash and merge" feature, so we needed all PRs to contain a single commit.

**Is there anything you'd like reviewers to focus on?**

Do you agree with this suggestion?