### PR TITLE
Fix: Config merge to correctly account for extends (fixes #8193)

### DIFF
--- a/lib/config/config-ops.js
+++ b/lib/config/config-ops.js
@@ -175,7 +175,7 @@ module.exports = {
             }
             Object.keys(src).forEach(key => {
                 if (Array.isArray(src[key]) || Array.isArray(target[key])) {
-                    dst[key] = deepmerge(target[key], src[key], key === "plugins", isRule);
+                    dst[key] = deepmerge(target[key], src[key], key === "plugins" || key === "extends", isRule);
                 } else if (typeof src[key] !== "object" || !src[key] || key === "exported" || key === "astGlobals") {
                     dst[key] = src[key];
                 } else {

--- a/tests/lib/config/config-ops.js
+++ b/tests/lib/config/config-ops.js
@@ -316,6 +316,18 @@ describe("ConfigOps", () => {
             assert.deepEqual(config[1], { rules: { "no-mixed-requires": "error" } });
         });
 
+        it("should combine extends correctly", () => {
+
+            const config = [
+                { extends: ["a", "b", "c", "d", "e"] },
+                { extends: ["f", "g", "h", "i"] }
+            ];
+
+            const result = ConfigOps.merge(config[0], config[1]);
+
+            assert.sameDeepMembers(result.extends, ["a", "b", "c", "d", "e", "f", "g", "h", "i"]);
+        });
+
         it("should combine configs correctly", () => {
 
             const config = [


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ X ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Config merge never took care of the extends that why it was overriding the array as mentioned in the issue. This has never caught because the rules for all those extended configs got picked up, it just the `extends` array inside `config` never got updated correctly due to merge issues.

**Is there anything you'd like reviewers to focus on?**


