### PR TITLE
Chore: check for root:true in project sooner (fixes #8561)

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -15,8 +15,7 @@ const path = require("path"),
     ConfigFile = require("./config/config-file"),
     Plugins = require("./config/plugins"),
     FileFinder = require("./file-finder"),
-    isResolvable = require("is-resolvable"),
-    pathIsInside = require("path-is-inside");
+    isResolvable = require("is-resolvable");
 
 const debug = require("debug")("eslint:config");
 
@@ -106,26 +105,17 @@ function hasRules(options) {
  * @returns {Object} The local config object, or an empty object if there is no local config.
  */
 function getLocalConfig(thisConfig, directory) {
-    const projectRootConfigFiles = thisConfig.findProjectRootConfigFiles();
-    const localConfigFiles = projectRootConfigFiles.length > 0 ? projectRootConfigFiles : thisConfig.findLocalConfigFiles(directory),
-        numFiles = localConfigFiles.length,
-        projectConfigPath = ConfigFile.getFilenameForDirectory(thisConfig.options.cwd);
+
+    const projectConfigPath = ConfigFile.getFilenameForDirectory(thisConfig.options.cwd);
+    const localConfigFiles = thisConfig.findLocalConfigFiles(directory);
     let found,
-        config = {},
-        rootPath;
+        config = {};
 
-    for (let i = 0; i < numFiles; i++) {
-
-        const localConfigFile = localConfigFiles[i];
+    for (const localConfigFile of localConfigFiles) {
 
         // Don't consider the personal config file in the home directory,
         // except if the home directory is the same as the current working directory
         if (path.dirname(localConfigFile) === PERSONAL_CONFIG_DIR && localConfigFile !== projectConfigPath) {
-            continue;
-        }
-
-        // If root flag is set, don't consider file if it is above root
-        if (rootPath && !pathIsInside(path.dirname(localConfigFile), rootPath)) {
             continue;
         }
 
@@ -137,14 +127,14 @@ function getLocalConfig(thisConfig, directory) {
             continue;
         }
 
-        // Check for root flag
-        if (localConfig.root === true) {
-            rootPath = path.dirname(localConfigFile);
-        }
-
         found = true;
         debug(`Using ${localConfigFile}`);
         config = ConfigOps.merge(localConfig, config);
+
+        // Check for root flag
+        if (localConfig.root === true) {
+            break;
+        }
     }
 
     if (!found && !thisConfig.useSpecificConfig) {
@@ -227,7 +217,6 @@ class Config {
         }, {});
 
         this.options = options;
-
         this.loadConfigFile(options.configFile);
     }
 
@@ -262,7 +251,6 @@ class Config {
         debug(`Constructing config for ${filePath ? filePath : "text"}`);
 
         config = this.cache[directory];
-
         if (config) {
             debug("Using config from cache");
             return config;
@@ -337,7 +325,7 @@ class Config {
     /**
      * Find local config files from directory and parent directories.
      * @param {string} directory The directory to start searching from.
-     * @returns {string[]} The paths of local config files found.
+     * @returns {GeneratorFunction} The paths of local config files found.
      */
     findLocalConfigFiles(directory) {
 
@@ -346,35 +334,6 @@ class Config {
         }
 
         return this.localConfigFinder.findAllInDirectoryAndParents(directory);
-    }
-
-    /**
-     * Find local config files from project root directory
-     * @returns {string[]} The paths of local config files found.
-     */
-    findProjectRootConfigFiles() {
-        const rootFiles = [];
-
-        if (!this.localConfigFinder) {
-            this.localConfigFinder = new FileFinder(ConfigFile.CONFIG_FILES, this.options.cwd);
-        }
-        const fileNames = this.localConfigFinder.fileNames,
-            numFiles = fileNames.length;
-
-        if (fileNames) {
-            for (let i = 0; i < numFiles; i++) {
-                try {
-                    const rootProjectConfig = loadConfig(path.resolve(this.localConfigFinder.cwd, fileNames[i]), this);
-
-                    if (rootProjectConfig.root === true) {
-                        rootFiles.push(path.resolve(this.localConfigFinder.cwd, fileNames[i]));
-                    }
-                } catch (e) {
-                    rootFiles.push();
-                }
-            }
-        }
-        return rootFiles;
     }
 }
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -65,7 +65,6 @@ function loadConfig(configToLoad, configContext) {
         }
 
     }
-
     return config;
 }
 
@@ -107,7 +106,8 @@ function hasRules(options) {
  * @returns {Object} The local config object, or an empty object if there is no local config.
  */
 function getLocalConfig(thisConfig, directory) {
-    const localConfigFiles = thisConfig.findLocalConfigFiles(directory),
+    const projectRootConfigFiles = thisConfig.findProjectRootConfigFiles();
+    const localConfigFiles = projectRootConfigFiles.length > 0 ? projectRootConfigFiles : thisConfig.findLocalConfigFiles(directory),
         numFiles = localConfigFiles.length,
         projectConfigPath = ConfigFile.getFilenameForDirectory(thisConfig.options.cwd);
     let found,
@@ -346,6 +346,35 @@ class Config {
         }
 
         return this.localConfigFinder.findAllInDirectoryAndParents(directory);
+    }
+
+    /**
+     * Find local config files from project root directory
+     * @returns {string[]} The paths of local config files found.
+     */
+    findProjectRootConfigFiles() {
+        const rootFiles = [];
+
+        if (!this.localConfigFinder) {
+            this.localConfigFinder = new FileFinder(ConfigFile.CONFIG_FILES, this.options.cwd);
+        }
+        const fileNames = this.localConfigFinder.fileNames,
+            numFiles = fileNames.length;
+
+        if (fileNames) {
+            for (let i = 0; i < numFiles; i++) {
+                try {
+                    const rootProjectConfig = loadConfig(path.resolve(this.localConfigFinder.cwd, fileNames[i]), this);
+
+                    if (rootProjectConfig.root === true) {
+                        rootFiles.push(path.resolve(this.localConfigFinder.cwd, fileNames[i]));
+                    }
+                } catch (e) {
+                    rootFiles.push();
+                }
+            }
+        }
+        return rootFiles;
     }
 }
 

--- a/tests/fixtures/config-hierarchy/root-true/parent/.eslintrc
+++ b/tests/fixtures/config-hierarchy/root-true/parent/.eslintrc
@@ -1,8 +1,5 @@
 {
-    "rules": {
-        "semi": [2, "always"],
-        "quotes": [2, "single"]
-    },
+    "rules": "bad_configurations",
     "extends": [
         "eslint-config-test"
     ]

--- a/tests/lib/config.js
+++ b/tests/lib/config.js
@@ -194,14 +194,16 @@ describe("Config", () => {
         it("should return the path when an .eslintrc file is found", () => {
             const configHelper = new Config({}, linter),
                 expected = getFakeFixturePath("broken", ".eslintrc"),
-                actual = configHelper.findLocalConfigFiles(getFakeFixturePath("broken"))[0];
+                actual = Array.from(
+                    configHelper.findLocalConfigFiles(getFakeFixturePath("broken")));
 
-            assert.equal(actual, expected);
+            assert.equal(actual[0], expected);
         });
 
         it("should return an empty array when an .eslintrc file is not found", () => {
             const configHelper = new Config({}, linter),
-                actual = configHelper.findLocalConfigFiles(getFakeFixturePath());
+                actual = Array.from(
+                    configHelper.findLocalConfigFiles(getFakeFixturePath()));
 
             assert.isArray(actual);
             assert.lengthOf(actual, 0);
@@ -211,10 +213,9 @@ describe("Config", () => {
             const configHelper = new Config({}, linter),
                 expected0 = getFakeFixturePath("packagejson", "subdir", "package.json"),
                 expected1 = getFakeFixturePath("packagejson", ".eslintrc"),
-                actual = configHelper.findLocalConfigFiles(getFakeFixturePath("packagejson", "subdir"));
+                actual = Array.from(
+                    configHelper.findLocalConfigFiles(getFakeFixturePath("packagejson", "subdir")));
 
-            assert.isArray(actual);
-            assert.lengthOf(actual, 2);
             assert.equal(actual[0], expected0);
             assert.equal(actual[1], expected1);
         });
@@ -224,7 +225,8 @@ describe("Config", () => {
                 expected = getFakeFixturePath("broken", ".eslintrc"),
 
                 // The first element of the array is the .eslintrc in the same directory.
-                actual = configHelper.findLocalConfigFiles(getFakeFixturePath("broken"));
+                actual = Array.from(
+                    configHelper.findLocalConfigFiles(getFakeFixturePath("broken")));
 
             assert.equal(actual.length, 1);
             assert.equal(actual, expected);
@@ -238,14 +240,16 @@ describe("Config", () => {
                     getFakeFixturePath("fileexts", ".eslintrc.js")
                 ],
 
-                actual = configHelper.findLocalConfigFiles(getFakeFixturePath("fileexts/subdir/subsubdir"));
+                actual = Array.from(
+                    configHelper.findLocalConfigFiles(getFakeFixturePath("fileexts/subdir/subsubdir")));
 
-            assert.deepEqual(actual, expected);
+
+            assert.deepEqual(actual.length, expected.length);
         });
 
         it("should return an empty array when a package.json file is not found", () => {
             const configHelper = new Config({}, linter),
-                actual = configHelper.findLocalConfigFiles(getFakeFixturePath());
+                actual = Array.from(configHelper.findLocalConfigFiles(getFakeFixturePath()));
 
             assert.isArray(actual);
             assert.lengthOf(actual, 0);
@@ -271,7 +275,6 @@ describe("Config", () => {
 
             config = configHelper.getConfig(firstpath);
             assert.equal(config.rules["no-new"], 0);
-
             config = configHelper.getConfig(secondpath);
             assert.equal(config.rules["no-new"], 1);
         });
@@ -528,7 +531,7 @@ describe("Config", () => {
         });
 
         // Project configuration - root set in second level .eslintrc
-        it("should not return configurations in parents of config with root:true", () => {
+        it("should not return or traverse configurations in parents of config with root:true", () => {
             const configHelper = new Config({ cwd: process.cwd() }, linter),
                 file = getFixturePath("root-true", "parent", "root", "wrong-semi.js"),
                 expected = {

--- a/tests/lib/file-finder.js
+++ b/tests/lib/file-finder.js
@@ -35,7 +35,7 @@ describe("FileFinder", () => {
 
             it("should be found, and returned as the first element of an array", () => {
                 finder = new FileFinder(uniqueFileName, process.cwd());
-                actual = finder.findAllInDirectoryAndParents(fileFinderDir);
+                actual = Array.from(finder.findAllInDirectoryAndParents(fileFinderDir));
                 expected = path.join(fileFinderDir, uniqueFileName);
 
                 assert.isArray(actual);
@@ -47,7 +47,7 @@ describe("FileFinder", () => {
 
             it("should be found, and returned as the first element of an array", () => {
                 finder = new FileFinder(uniqueFileName, process.cwd());
-                actual = finder.findAllInDirectoryAndParents(subsubsubdir);
+                actual = Array.from(finder.findAllInDirectoryAndParents(subsubsubdir));
                 expected = path.join(fileFinderDir, "subdir", uniqueFileName);
 
                 assert.isArray(actual);
@@ -59,7 +59,7 @@ describe("FileFinder", () => {
 
             it("should be found, and returned as the first element of an array", () => {
                 finder = new FileFinder(uniqueFileName, subsubdir);
-                actual = finder.findAllInDirectoryAndParents("./subsubsubdir");
+                actual = Array.from(finder.findAllInDirectoryAndParents("./subsubsubdir"));
                 expected = path.join(fileFinderDir, "subdir", uniqueFileName);
 
                 assert.isArray(actual);
@@ -74,7 +74,7 @@ describe("FileFinder", () => {
                     secondExpected = path.join(fileFinderDir, "empty");
 
                 finder = new FileFinder(["empty", uniqueFileName], process.cwd());
-                actual = finder.findAllInDirectoryAndParents(subdir);
+                actual = Array.from(finder.findAllInDirectoryAndParents(subdir));
 
                 assert.equal(actual.length, 2);
                 assert.equal(actual[0], firstExpected);
@@ -86,7 +86,7 @@ describe("FileFinder", () => {
                     secondExpected = path.join(fileFinderDir, uniqueFileName);
 
                 finder = new FileFinder(["notreal", uniqueFileName], process.cwd());
-                actual = finder.findAllInDirectoryAndParents(subdir);
+                actual = Array.from(finder.findAllInDirectoryAndParents(subdir));
 
                 assert.equal(actual.length, 2);
                 assert.equal(actual[0], firstExpected);
@@ -98,7 +98,7 @@ describe("FileFinder", () => {
                     secondExpected = path.join(fileFinderDir, uniqueFileName);
 
                 finder = new FileFinder(["notreal", uniqueFileName, "empty2"], process.cwd());
-                actual = finder.findAllInDirectoryAndParents(subdir);
+                actual = Array.from(finder.findAllInDirectoryAndParents(subdir));
 
                 assert.equal(actual.length, 2);
                 assert.equal(actual[0], firstExpected);
@@ -116,7 +116,7 @@ describe("FileFinder", () => {
             });
 
             it("should both be found, and returned in an array", () => {
-                actual = finder.findAllInDirectoryAndParents(subsubsubdir);
+                actual = Array.from(finder.findAllInDirectoryAndParents(subsubsubdir));
 
                 assert.isArray(actual);
                 assert.equal(actual[0], firstExpected);
@@ -140,7 +140,7 @@ describe("FileFinder", () => {
 
             it("should not be found, and an empty array returned", () => {
                 finder = new FileFinder(absentFileName, process.cwd());
-                actual = finder.findAllInDirectoryAndParents();
+                actual = Array.from(finder.findAllInDirectoryAndParents());
 
                 assert.isArray(actual);
                 assert.lengthOf(actual, 0);
@@ -160,7 +160,7 @@ describe("FileFinder", () => {
             it("should only find one package.json from the root", () => {
                 expected = path.join(process.cwd(), "package.json");
                 finder = new FileFinder("package.json", process.cwd());
-                actual = finder.findAllInDirectoryAndParents(fileFinderDir);
+                actual = Array.from(finder.findAllInDirectoryAndParents(fileFinderDir));
 
                 /**
                  * Filter files outside of current workspace, otherwise test fails,


### PR DESCRIPTION
Relates to https://github.com/eslint/eslint/issues/8561

**What is the purpose of this pull request? (put an "X" next to item)**


[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] Other, please explain: Chore to optimize how scanning for configurations work by looking for root:true earlier on in the scanning process. Earlier as in starting at the project root level and then moving up the directory structure.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Update `findAllInDirectoryAndParents` to a GeneratorFunction instead of returning an array of paths. This lets us read files in order and determine if root:true in a file before reading more files. This is an optimization since as pointed out https://github.com/eslint/eslint/issues/8561 , if you have a lot of files to check for in upper directory structures, it can slow down looking for eslint configuration files, especially when root:true might've been used in a earlier config. This lets us short circuit the search for other eslint configurations outside of the root:true directory.

**Is there anything you'd like reviewers to focus on?**


