### PR TITLE
Update: added node type based support to `space-before-function-paren`

### DIFF
--- a/docs/rules/space-before-function-paren.md
+++ b/docs/rules/space-before-function-paren.md
@@ -35,20 +35,39 @@ This rule has a string option or an object option:
         "named": "always",
         "asyncArrow": "always"
     }],
+    // or
+    "space-before-function-paren": ["error", {
+        "declaration": "always",
+        "expression": "always",
+        "arrowExpression": "always"
+    }],
 }
 ```
+
+String option:
 
 * `always` (default) requires a space followed by the `(` of arguments.
 * `never` disallows any space followed by the `(` of arguments.
 
 The string option does not check async arrow function expressions for backward compatibility.
 
-You can also use a separate option for each type of function.
+Object option:
+
+You can also use a separate option for how a function is named/not named.
 Each of the following options can be set to `"always"`, `"never"`, or `"ignore"`. The default is `"always"`.
 
 * `anonymous` is for anonymous function expressions (e.g. `function () {}`).
-* `named` is for named function expressions (e.g. `function foo () {}`).
+* `named` is for named function declarations/expressions (e.g. `function foo () {}`).
 * `asyncArrow` is for async arrow function expressions (e.g. `async () => {}`).
+
+Alternate object option:
+
+You can also use a separate option for each node type of function.
+Each of the following options can be set to `"always"`, `"never"`, or `"ignore"`. The default is `"always"`.
+
+* `declaration` is for function declarations (e.g. `function () {}`).
+* `expression` is for function expressions (e.g. `var foo = function bar () {}`).
+* `arrowExpression` is for arrow function expressions (e.g. `async () => {}`).
 
 ### "always"
 
@@ -358,6 +377,178 @@ var foo = {
 };
 ```
 
+### `{"declaration": "never", "expression": "always"", "arrowExpression": "always"}`
+
+Examples of **incorrect** code for this rule with the `{"declaration": "never", "expression": "always"", "arrowExpression": "always"}` option:
+
+```js
+/*eslint space-before-function-paren: ["error", {"declaration": "never", "expression": "always"", "arrowExpression": "always"}]*/
+/*eslint-env es6*/
+
+function foo () {
+    // ...
+}
+
+var bar = function() {
+    // ...
+};
+
+class Foo {
+    constructor () {
+        // ...
+    }
+}
+
+var foo = {
+    bar () {
+        // ...
+    }
+};
+
+var foo = async(a) => await a
+```
+
+Examples of **correct** code for this rule with the `{"declaration": "never", "expression": "always"", "arrowExpression": "always"}` option:
+
+```js
+/*eslint space-before-function-paren: ["error", {"declaration": "never", "expression": "always"", "arrowExpression": "always"}]*/
+/*eslint-env es6*/
+
+function foo() {
+    // ...
+}
+
+var bar = function () {
+    // ...
+};
+
+class Foo {
+    constructor() {
+        // ...
+    }
+}
+
+var foo = {
+    bar() {
+        // ...
+    }
+};
+
+var foo = async (a) => await a
+```
+
+### `{"declaration": "always", "expression": "never"}`
+
+Examples of **incorrect** code for this rule with the `{"declaration": "always", "expression": "never"}` option:
+
+```js
+/*eslint space-before-function-paren: ["error", { "declaration": "always", "expression": "never" }]*/
+/*eslint-env es6*/
+
+function foo() {
+    // ...
+}
+
+var bar = function () {
+    // ...
+};
+
+class Foo {
+    constructor() {
+        // ...
+    }
+}
+
+var foo = {
+    bar() {
+        // ...
+    }
+};
+```
+
+Examples of **correct** code for this rule with the `{"declaration": "always", "expression": "never"}` option:
+
+```js
+/*eslint space-before-function-paren: ["error", { "declaration": "always", "expression": "never" }]*/
+/*eslint-env es6*/
+
+function foo () {
+    // ...
+}
+
+var bar = function() {
+    // ...
+};
+
+class Foo {
+    constructor () {
+        // ...
+    }
+}
+
+var foo = {
+    bar () {
+        // ...
+    }
+};
+```
+
+### `{"declaration": "always", "expression": "ignore"}`
+
+Examples of **incorrect** code for this rule with the `{"declaration": "always", "expression": "ignore"}` option:
+
+```js
+/*eslint space-before-function-paren: ["error", { "declaration": "always", "expression": "ignore" }]*/
+/*eslint-env es6*/
+
+function foo() {
+    // ...
+}
+
+class Foo {
+    constructor() {
+        // ...
+    }
+}
+
+var foo = {
+    bar() {
+        // ...
+    }
+};
+```
+
+Examples of **correct** code for this rule with the `{"declaration": "always", "expression": "ignore"}` option:
+
+```js
+/*eslint space-before-function-paren: ["error", { "declaration": "always", "expression": "ignore" }]*/
+/*eslint-env es6*/
+
+var bar = function() {
+    // ...
+};
+
+var bar = function () {
+    // ...
+};
+
+function foo () {
+    // ...
+}
+
+class Foo {
+    constructor () {
+        // ...
+    }
+}
+
+var foo = {
+    bar () {
+        // ...
+    }
+};
+```
+
 ## When Not To Use It
 
 You can turn this rule off if you are not concerned with the consistency of spacing before function parenthesis.
@@ -366,3 +557,10 @@ You can turn this rule off if you are not concerned with the consistency of spac
 
 * [space-after-keywords](space-after-keywords.md)
 * [space-return-throw-case](space-return-throw-case.md)
+
+## Compatibility
+
+* **JSCS**: This rule roughly maps to [disallowSpacesInFunctionExpression](http://jscs.info/rule/disallowSpacesInFunctionExpression)
+* **JSCS**: This rule roughly maps to [requireSpacesInFunctionExpression](http://jscs.info/rule/requireSpacesInFunctionExpression)
+* **JSCS**: This rule roughly maps to [disallowSpacesInFunctionDeclaration](http://jscs.info/rule/disallowSpacesInFunctionDeclaration)
+* **JSCS**: This rule roughly maps to [requireSpacesInFunctionDeclaration](http://jscs.info/rule/requireSpacesInFunctionDeclaration)

--- a/lib/rules/space-before-function-paren.js
+++ b/lib/rules/space-before-function-paren.js
@@ -44,6 +44,21 @@ module.exports = {
                             }
                         },
                         additionalProperties: false
+                    },
+                    {
+                        type: "object",
+                        properties: {
+                            declaration: {
+                                enum: ["always", "never", "ignore"]
+                            },
+                            expression: {
+                                enum: ["always", "never", "ignore"]
+                            },
+                            arrowExpression: {
+                                enum: ["always", "never", "ignore"]
+                            }
+                        },
+                        additionalProperties: false
                     }
                 ]
             }
@@ -54,6 +69,7 @@ module.exports = {
         const sourceCode = context.getSourceCode();
         const baseConfig = typeof context.options[0] === "string" ? context.options[0] : "always";
         const overrideConfig = typeof context.options[0] === "object" ? context.options[0] : {};
+        const isUsingNodeType = overrideConfig.declaration || overrideConfig.expression || overrideConfig.arrowExpression;
 
         /**
          * Determines whether a function has a name.
@@ -78,15 +94,41 @@ module.exports = {
         }
 
         /**
+         * Determines if an arrow function is worth checking
+         * @param {ASTNode} node The function node
+         * @returns {boolean} `true` if the node should be checked
+         */
+        function shouldCheckArrowFunction(node) {
+
+            // Always ignore non-async functions and arrow functions without parens, e.g. async foo => bar
+            return node.async && astUtils.isOpeningParenToken(sourceCode.getFirstToken(node, { skip: 1 }));
+        }
+
+        /**
          * Gets the config for a given function
          * @param {ASTNode} node The function node
          * @returns {string} "always", "never", or "ignore"
          */
         function getConfigForFunction(node) {
-            if (node.type === "ArrowFunctionExpression") {
 
-                // Always ignore non-async functions and arrow functions without parens, e.g. async foo => bar
-                if (node.async && astUtils.isOpeningParenToken(sourceCode.getFirstToken(node, { skip: 1 }))) {
+            // If we are comparing against node types, then compare by their type
+            if (isUsingNodeType) {
+                if (node.type === "ArrowFunctionExpression") {
+                    if (shouldCheckArrowFunction(node)) {
+                        return overrideConfig.arrowExpression || baseConfig;
+                    }
+                    return "ignore";
+                } else if (node.type === "FunctionExpression") {
+                    return overrideConfig.expression || baseConfig;
+                } else if (node.type === "FunctionDeclaration") {
+                    return overrideConfig.declaration || baseConfig;
+                }
+                throw new Error(`Unexpected function type encountered: ${node.type}`);
+            }
+
+            // Otheriwse, compare against named/anonymous
+            if (node.type === "ArrowFunctionExpression") {
+                if (shouldCheckArrowFunction(node)) {
                     return overrideConfig.asyncArrow || baseConfig;
                 }
             } else if (isNamedFunction(node)) {

--- a/tests/lib/rules/space-before-function-paren.js
+++ b/tests/lib/rules/space-before-function-paren.js
@@ -112,7 +112,28 @@ ruleTester.run("space-before-function-paren", rule, {
         { code: "async() => 1", options: [{ asyncArrow: "ignore" }], parserOptions: { ecmaVersion: 8 } },
         { code: "async () => 1", parserOptions: { ecmaVersion: 8 } },
         { code: "async () => 1", options: ["always"], parserOptions: { ecmaVersion: 8 } },
-        { code: "async() => 1", options: ["never"], parserOptions: { ecmaVersion: 8 } }
+        { code: "async() => 1", options: ["never"], parserOptions: { ecmaVersion: 8 } },
+
+        // Alternative object syntax
+        { code: "function foo() {}", options: [{ declaration: "never" }] },
+        { code: "function foo () {}", options: [{ declaration: "always" }] },
+        { code: "function foo() {}", options: [{ declaration: "ignore" }] },
+        { code: "function foo () {}", options: [{ declaration: "ignore" }] },
+        { code: "var bar = function () {}", options: [{ expression: "always" }] },
+        { code: "var bar = function foo () {}", options: [{ expression: "always" }] },
+        { code: "var bar = function() {}", options: [{ expression: "never" }] },
+        { code: "var bar = function foo() {}", options: [{ expression: "never" }] },
+        { code: "var bar = function () {}", options: [{ expression: "ignore" }] },
+        { code: "var bar = function foo () {}", options: [{ expression: "ignore" }] },
+        { code: "var bar = function() {}", options: [{ expression: "ignore" }] },
+        { code: "var bar = function foo() {}", options: [{ expression: "ignore" }] },
+        { code: "async() => 1", options: [{ arrowExpression: "never" }], parserOptions: { ecmaVersion: 8 } },
+        { code: "async () => 1", options: [{ arrowExpression: "always" }], parserOptions: { ecmaVersion: 8 } },
+
+        // Trigger alternative syntax code path
+        { code: "() => 1", options: [{ arrowExpression: "ignore" }], parserOptions: { ecmaVersion: 6 } },
+        { code: "async() => 1", options: [{ arrowExpression: "ignore" }], parserOptions: { ecmaVersion: 8 } },
+        { code: "async () => 1", options: [{ arrowExpression: "ignore" }], parserOptions: { ecmaVersion: 8 } }
     ],
 
     invalid: [
@@ -507,6 +528,58 @@ ruleTester.run("space-before-function-paren", rule, {
             code: "async () => 1",
             output: "async() => 1",
             options: ["never"],
+            parserOptions: { ecmaVersion: 8 },
+            errors: [{ message: "Unexpected space before function parentheses.", type: "ArrowFunctionExpression" }]
+        },
+
+        // Alternative object syntax
+        {
+            code: "function foo() {}",
+            output: "function foo () {}",
+            options: [{ declaration: "always" }],
+            errors: [{ message: "Missing space before function parentheses.", type: "FunctionDeclaration" }]
+        },
+        {
+            code: "function foo () {}",
+            output: "function foo() {}",
+            options: [{ declaration: "never" }],
+            errors: [{ message: "Unexpected space before function parentheses.", type: "FunctionDeclaration" }]
+        },
+        {
+            code: "var bar = function () {}",
+            output: "var bar = function() {}",
+            options: [{ expression: "never" }],
+            errors: [{ message: "Unexpected space before function parentheses.", type: "FunctionExpression" }]
+        },
+        {
+            code: "var bar = function foo () {}",
+            output: "var bar = function foo() {}",
+            options: [{ expression: "never" }],
+            errors: [{ message: "Unexpected space before function parentheses.", type: "FunctionExpression" }]
+        },
+        {
+            code: "var bar = function() {}",
+            output: "var bar = function () {}",
+            options: [{ expression: "always" }],
+            errors: [{ message: "Missing space before function parentheses.", type: "FunctionExpression" }]
+        },
+        {
+            code: "var bar = function foo() {}",
+            output: "var bar = function foo () {}",
+            options: [{ expression: "always" }],
+            errors: [{ message: "Missing space before function parentheses.", type: "FunctionExpression" }]
+        },
+        {
+            code: "async() => 1",
+            output: "async () => 1",
+            options: [{ arrowExpression: "always" }],
+            parserOptions: { ecmaVersion: 8 },
+            errors: [{ message: "Missing space before function parentheses.", type: "ArrowFunctionExpression" }]
+        },
+        {
+            code: "async () => 1",
+            output: "async() => 1",
+            options: [{ arrowExpression: "never" }],
             parserOptions: { ecmaVersion: 8 },
             errors: [{ message: "Unexpected space before function parentheses.", type: "ArrowFunctionExpression" }]
         }


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**What rule do you want to change?**

[space-before-function-paren](http://eslint.org/docs/rules/space-before-function-paren)

**Does this change cause the rule to produce more or fewer warnings?**

Neither, alternative options object

**How will the change be implemented? (New option, new default behavior, etc.)?**

New options object

**Please provide some example code that this change will affect:**

```js
// Can't have independent spacing settings for these currently
// The new options allow setting specifically for FunctionDeclaration and FunctionExpression
function foo() {}
[].forEach(funciton foo () {});
```

**What does the rule currently do for this code?**

It doesn't support independent control for function declarations vs expressions

**What will the rule do after it's changed?**

It supports independent control for function declarations vs expressions

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

- Added alternative object syntax to rule (based on `one-var` alternative syntax)
- Added tests
- Added docs including links to corresponding JSCS rules

**Is there anything you'd like reviewers to focus on?**

I feel like I might have added too much new documentation. Let me know if you want me to cut it down