### PR TITLE
Update: Add multiline-expression statement type

### DIFF
--- a/docs/rules/padding-line-between-statements.md
+++ b/docs/rules/padding-line-between-statements.md
@@ -22,8 +22,8 @@ function foo() {
 
 This rule does nothing if no configuration.
 
-A configuration is an object which has 3 properties; `blankLine`, `prev` and `next`. For example, `{ blankLine: "always", prev: "var", next: "return" }` is meaning "it requires one or more blank lines between a variable declaration and a `return` statement."
-You can supply any number of configurations. If an statement pair matches multiple configurations, the last matched configuration will be used.
+A configuration is an object which has 3 properties; `blankLine`, `prev` and `next`. For example, `{ blankLine: "always", prev: "var", next: "return" }` means "it requires one or more blank lines between a variable declaration and a `return` statement."
+You can supply any number of configurations. If a statement pair matches multiple configurations, the last matched configuration will be used.
 
 ```json
 {
@@ -66,7 +66,8 @@ You can supply any number of configurations. If an statement pair matches multip
     - `"if"` is `if` statements.
     - `"import"` is `import` declarations.
     - `"let"` is `let` variable declarations.
-    - `"multiline-block-like"` is block like statements. This is the same as `block-like` type, but only the block is multiline.
+    - `"multiline-block-like"` is block like statements. This is the same as `block-like` type, but only if the block is multiline.
+    - `"multiline-expression"` is expression statements. This is the same as `expression` type, but only if the statement is multiline.
     - `"return"` is `return` statements.
     - `"switch"` is `switch` statements.
     - `"throw"` is `throw` statements.

--- a/lib/rules/padding-line-between-statements.js
+++ b/lib/rules/padding-line-between-statements.js
@@ -356,6 +356,12 @@ const StatementTypes = {
             node.loc.start.line !== node.loc.end.line &&
             isBlockLikeStatement(sourceCode, node)
     },
+    "multiline-expression": {
+        test: (node, sourceCode) =>
+            node.loc.start.line !== node.loc.end.line &&
+            node.type === "ExpressionStatement" &&
+            !isDirectivePrologue(node, sourceCode)
+    },
 
     block: newNodeTypeTester("BlockStatement"),
     empty: newNodeTypeTester("EmptyStatement"),

--- a/tests/lib/rules/padding-line-between-statements.js
+++ b/tests/lib/rules/padding-line-between-statements.js
@@ -535,6 +535,23 @@ ruleTester.run("padding-line-between-statements", rule, {
         },
 
         //----------------------------------------------------------------------
+        // multiline-expression
+        //----------------------------------------------------------------------
+
+        {
+            code: "foo()\n\nfoo(\n\tx,\n\ty\n)",
+            options: [
+                { blankLine: "always", prev: "*", next: "multiline-expression" }
+            ]
+        },
+        {
+            code: "foo()\nfoo()",
+            options: [
+                { blankLine: "always", prev: "*", next: "multiline-expression" }
+            ]
+        },
+
+        //----------------------------------------------------------------------
         // break
         //----------------------------------------------------------------------
 
@@ -2984,6 +3001,27 @@ ruleTester.run("padding-line-between-statements", rule, {
             output: "foo()\n\nfoo()",
             options: [
                 { blankLine: "always", prev: "expression", next: "*" }
+            ],
+            errors: [MESSAGE_ALWAYS]
+        },
+
+        //----------------------------------------------------------------------
+        // multiline-expression
+        //----------------------------------------------------------------------
+
+        {
+            code: "foo()\n\nfoo(\n\tx,\n\ty\n)",
+            output: "foo()\nfoo(\n\tx,\n\ty\n)",
+            options: [
+                { blankLine: "never", prev: "*", next: "multiline-expression" }
+            ],
+            errors: [MESSAGE_NEVER]
+        },
+        {
+            code: "foo()\nfoo(\n\tx,\n\ty\n)",
+            output: "foo()\n\nfoo(\n\tx,\n\ty\n)",
+            options: [
+                { blankLine: "always", prev: "*", next: "multiline-expression" }
             ],
             errors: [MESSAGE_ALWAYS]
         },


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Added `multiline-expression` statement type to existing `padding-line-between-statements` rule.

**Is there anything you'd like reviewers to focus on?**

n/a

**What rule do you want to change?**

`padding-line-between-statements`

**Does this change cause the rule to produce more or fewer warnings?**

More (or at least never fewer)

**How will the change be implemented? (New option, new default behavior, etc.)?**

Adds `multiline-expression` property to existing `StatementTypes` object (basically a copy/paste of the existing `expression` property and a copy/paste of the line numbers check from existing `multiline-block-like` property).

**Please provide some example code that this change will affect:**

Given the following rule:

```js
"padding-line-between-statements": [
  "error",
  { "blankLine": "always", "prev": "*", "next": "multiline-expression" }
]
```

The following code (single-line expression without padding line) is **correct**:

```js
const promise = fetch();
promise.then(console.dir);
```

The following code (multi-line expression with padding line) is **correct**:

```js
const promise = fetch();

promise.then(data => {
  console.dir(data);
});
```

The following code (multi-line expression without padding line) is **incorrect**:

```js
const promise = fetch();
promise.then(data => {
  console.dir(data));
});
```

**What does the rule currently do for this code?**

Currently, no warnings/errors emitted for any of the samples above.

**What will the rule do after it's changed?**

No warnings/errors will be produced for the **correct** samples. An error will be produced for the **incorrect** sample.
