### PR TITLE
Update: curly-spacing replaces object-curly-spacing (refs #7361)

### DIFF
--- a/docs/rules/object-curly-spacing.md
+++ b/docs/rules/object-curly-spacing.md
@@ -37,6 +37,12 @@ Object option:
 * `"arraysInObjects": false` disallows spacing inside of braces of objects beginning and/or ending with an array element (applies when the first option is set to `always`)
 * `"objectsInObjects": true` requires spacing inside of braces of objects beginning and/or ending with an object element (applies when the first option is set to `never`)
 * `"objectsInObjects": false` disallows spacing inside of braces of objects beginning and/or ending with an object element (applies when the first option is set to `always`)
+* `"import": true` requires spacing inside of braces of ES6 import statements (applies when the first option is set to `never`)
+* `"import": false` disallows spacing inside of braces of ES6 import statements (applies when the first option is set to `always`)
+* `"export": true` requires spacing inside of braces of ES6 export statements (applies when the first option is set to `never`)
+* `"export": false` disallows spacing inside of braces of ES6 export statements (applies when the first option is set to `always`)
+* `"destructuringAssignment": true` requires spacing inside of braces of ES6 destructuring assignment results (applies when the first option is set to `never`)
+* `"destructuringAssignment": false` disallows spacing inside of braces of ES6 destructuring assignment results (applies when the first option is set to `always`)
 
 ### never
 
@@ -51,6 +57,7 @@ var obj = { baz: {'foo': 'qux'}, bar};
 var obj = {baz: { 'foo': 'qux'}, bar};
 var {x } = y;
 import { foo } from 'bar';
+export { bar };
 ```
 
 Examples of **correct** code for this rule with the default `"never"` option:
@@ -70,6 +77,7 @@ var obj = {
 var obj = {};
 var {x} = y;
 import {foo} from 'bar';
+export {bar};
 ```
 
 ### always
@@ -89,6 +97,7 @@ var obj = {
   'foo':'bar'};
 var {x} = y;
 import {foo } from 'bar';
+export {bar };
 ```
 
 Examples of **correct** code for this rule with the `"always"` option:
@@ -104,6 +113,7 @@ var obj = {
 };
 var { x } = y;
 import { foo } from 'bar';
+export { bar };
 ```
 
 #### arraysInObjects
@@ -143,6 +153,60 @@ Examples of additional **correct** code for this rule with the `"always", { "obj
 /*eslint object-curly-spacing: ["error", "always", { "objectsInObjects": false }]*/
 
 var obj = { "foo": { "baz": 1, "bar": 2 }};
+```
+
+#### import
+
+Examples of additional **correct** code for this rule with the `"never", { "import": true }` options:
+
+```js
+/*eslint object-curly-spacing: ["error", "never", { "import": true }]*/
+
+import {foo} from 'bar';
+```
+
+Examples of additional **correct** code for this rule with the `"always", { "import": false }` options:
+
+```js
+/*eslint object-curly-spacing: ["error", "always", { "import": false }]*/
+
+import { foo } from 'bar';
+```
+
+#### export
+
+Examples of additional **correct** code for this rule with the `"never", { "export": true }` options:
+
+```js
+/*eslint object-curly-spacing: ["error", "never", { "export": true }]*/
+
+export {bar};
+```
+
+Examples of additional **correct** code for this rule with the `"always", { "export": false }` options:
+
+```js
+/*eslint object-curly-spacing: ["error", "always", { "export": false }]*/
+
+export { bar };
+```
+
+#### destructuringAssignment
+
+Examples of additional **correct** code for this rule with the `"never", { "destructuringAssignment": true }` options:
+
+```js
+/*eslint object-curly-spacing: ["error", "never", { "destructuringAssignment": true }]*/
+
+var {x} = y;
+```
+
+Examples of additional **correct** code for this rule with the `"always", { "destructuringAssignment": false }` options:
+
+```js
+/*eslint object-curly-spacing: ["error", "always", { "destructuringAssignment": false }]*/
+
+var { x } = y;
 ```
 
 ## When Not To Use It

--- a/lib/rules/object-curly-spacing.js
+++ b/lib/rules/object-curly-spacing.js
@@ -32,6 +32,15 @@ module.exports = {
                     },
                     objectsInObjects: {
                         type: "boolean"
+                    },
+                    import: {
+                        type: "boolean"
+                    },
+                    export: {
+                        type: "boolean"
+                    },
+                    destructuringAssignment: {
+                        type: "boolean"
                     }
                 },
                 additionalProperties: false
@@ -57,7 +66,10 @@ module.exports = {
         const options = {
             spaced,
             arraysInObjectsException: isOptionSet("arraysInObjects"),
-            objectsInObjectsException: isOptionSet("objectsInObjects")
+            objectsInObjectsException: isOptionSet("objectsInObjects"),
+            importException: isOptionSet("import"),
+            exportException: isOptionSet("export"),
+            destructuringAssignmentException: isOptionSet("destructuringAssignment")
         };
 
         //--------------------------------------------------------------------------
@@ -155,38 +167,49 @@ module.exports = {
          * @param {Token} second The second token to check (should be first after the opening brace)
          * @param {Token} penultimate The penultimate token to check (should be last before closing brace)
          * @param {Token} last The last token to check (should be closing brace)
+         * @param {string} expressionType The type of the current expression
          * @returns {void}
          */
-        function validateBraceSpacing(node, first, second, penultimate, last) {
+        function validateBraceSpacing(node, first, second, penultimate, last, expressionType) {
+            const curlyBraceMustBeSpaced = (
+                options.importException && expressionType === "ImportDeclaration" ||
+                options.exportException && expressionType === "ExportNamedDeclaration" ||
+                options.destructuringAssignmentException && expressionType === "ObjectPattern"
+            ) ? !options.spaced : options.spaced;
+
             if (astUtils.isTokenOnSameLine(first, second)) {
                 const firstSpaced = sourceCode.isSpaceBetweenTokens(first, second);
 
-                if (options.spaced && !firstSpaced) {
+                if (curlyBraceMustBeSpaced && !firstSpaced) {
                     reportRequiredBeginningSpace(node, first);
                 }
-                if (!options.spaced && firstSpaced) {
+                if (!curlyBraceMustBeSpaced && firstSpaced) {
                     reportNoBeginningSpace(node, first);
                 }
             }
 
             if (astUtils.isTokenOnSameLine(penultimate, last)) {
-                const shouldCheckPenultimate = (
-                    options.arraysInObjectsException && astUtils.isClosingBracketToken(penultimate) ||
-                    options.objectsInObjectsException && astUtils.isClosingBraceToken(penultimate)
-                );
-                const penultimateType = shouldCheckPenultimate && sourceCode.getNodeByRangeIndex(penultimate.start).type;
-
-                const closingCurlyBraceMustBeSpaced = (
-                    options.arraysInObjectsException && penultimateType === "ArrayExpression" ||
-                    options.objectsInObjectsException && (penultimateType === "ObjectExpression" || penultimateType === "ObjectPattern")
-                ) ? !options.spaced : options.spaced;
-
                 const lastSpaced = sourceCode.isSpaceBetweenTokens(penultimate, last);
 
-                if (closingCurlyBraceMustBeSpaced && !lastSpaced) {
+                let endCurlyBraceMustBeSpaced = curlyBraceMustBeSpaced;
+
+                if (expressionType === "ObjectExpression") {
+                    const shouldCheckPenultimate = (
+                        options.arraysInObjectsException && astUtils.isClosingBracketToken(penultimate) ||
+                        options.objectsInObjectsException && astUtils.isClosingBraceToken(penultimate)
+                    );
+                    const penultimateType = shouldCheckPenultimate && sourceCode.getNodeByRangeIndex(penultimate.start).type;
+
+                    endCurlyBraceMustBeSpaced = (
+                        options.arraysInObjectsException && penultimateType === "ArrayExpression" ||
+                        options.objectsInObjectsException && penultimateType === "ObjectExpression"
+                    ) ? !endCurlyBraceMustBeSpaced : endCurlyBraceMustBeSpaced;
+                }
+
+                if (endCurlyBraceMustBeSpaced && !lastSpaced) {
                     reportRequiredEndingSpace(node, last);
                 }
-                if (!closingCurlyBraceMustBeSpaced && lastSpaced) {
+                if (!endCurlyBraceMustBeSpaced && lastSpaced) {
                     reportNoEndingSpace(node, last);
                 }
             }
@@ -211,8 +234,26 @@ module.exports = {
         }
 
         /**
+         * Reports a given destructuring node if spacing in curly braces is invalid.
+         * @param {ASTNode} node - An ObjectPattern node to check.
+         * @returns {void}
+         */
+        function checkForDestructuringAssignement(node) {
+            if (node.properties.length === 0) {
+                return;
+            }
+
+            const first = sourceCode.getFirstToken(node),
+                last = getClosingBraceOfObject(node),
+                second = sourceCode.getTokenAfter(first),
+                penultimate = sourceCode.getTokenBefore(last);
+
+            validateBraceSpacing(node, first, second, penultimate, last, "ObjectPattern");
+        }
+
+        /**
          * Reports a given object node if spacing in curly braces is invalid.
-         * @param {ASTNode} node - An ObjectExpression or ObjectPattern node to check.
+         * @param {ASTNode} node - An ObjectExpression node to check.
          * @returns {void}
          */
         function checkForObject(node) {
@@ -225,7 +266,7 @@ module.exports = {
                 second = sourceCode.getTokenAfter(first),
                 penultimate = sourceCode.getTokenBefore(last);
 
-            validateBraceSpacing(node, first, second, penultimate, last);
+            validateBraceSpacing(node, first, second, penultimate, last, "ObjectExpression");
         }
 
         /**
@@ -253,7 +294,7 @@ module.exports = {
                 second = sourceCode.getTokenAfter(first),
                 penultimate = sourceCode.getTokenBefore(last);
 
-            validateBraceSpacing(node, first, second, penultimate, last);
+            validateBraceSpacing(node, first, second, penultimate, last, "ImportDeclaration");
         }
 
         /**
@@ -273,7 +314,7 @@ module.exports = {
                 second = sourceCode.getTokenAfter(first),
                 penultimate = sourceCode.getTokenBefore(last);
 
-            validateBraceSpacing(node, first, second, penultimate, last);
+            validateBraceSpacing(node, first, second, penultimate, last, "ExportNamedDeclaration");
         }
 
         //--------------------------------------------------------------------------
@@ -283,7 +324,7 @@ module.exports = {
         return {
 
             // var {x} = y;
-            ObjectPattern: checkForObject,
+            ObjectPattern: checkForDestructuringAssignement,
 
             // var y = {x: 'y'}
             ObjectExpression: checkForObject,

--- a/tests/lib/rules/object-curly-spacing.js
+++ b/tests/lib/rules/object-curly-spacing.js
@@ -62,7 +62,8 @@ ruleTester.run("object-curly-spacing", rule, {
         // always - objectsInObjects
         { code: "var obj = { 'foo': { 'bar': 1, 'baz': 2 }};", options: ["always", { objectsInObjects: false }] },
         { code: "var a = { noop: function () {} };", options: ["always", { objectsInObjects: false }] },
-        { code: "var { y: { z }} = x", options: ["always", { objectsInObjects: false }], parserOptions: { ecmaVersion: 6 } },
+        { code: "var { y: { z } } = x;", options: ["always", { objectsInObjects: false }], parserOptions: { ecmaVersion: 6 } },
+        { code: "var { y: { z } } = { x: {}};", options: ["always", { objectsInObjects: false }], parserOptions: { ecmaVersion: 6 } },
 
         // always - arraysInObjects
         { code: "var obj = { 'foo': [ 1, 2 ]};", options: ["always", { arraysInObjects: false }] },
@@ -73,6 +74,20 @@ ruleTester.run("object-curly-spacing", rule, {
 
         // always - arraysInObjects, objectsInObjects (reverse)
         { code: "var obj = { 'foo': { 'bar': 1, 'baz': 2 }, 'qux': [ 1, 2 ]};", options: ["always", { arraysInObjects: false, objectsInObjects: false }] },
+
+        // always - import
+        { code: "import {x} from 'foo';", options: ["always", { import: false }], parserOptions: { sourceType: "module" } },
+        { code: "import {x, y} from 'foo';", options: ["always", { import: false }], parserOptions: { sourceType: "module" } },
+
+        // always - export
+        { code: "export {door};", options: ["always", { export: false }], parserOptions: { sourceType: "module" } },
+        { code: "export {house, mouse} from 'caravan';", options: ["always", { export: false }], parserOptions: { sourceType: "module" } },
+
+        // always - destructuringAssignment
+        { code: "var {y, z} = x;", options: ["always", { destructuringAssignment: false }], parserOptions: { ecmaVersion: 6 } },
+        { code: "var {y: {z}} = x;", options: ["always", { destructuringAssignment: false }], parserOptions: { ecmaVersion: 6 } },
+        { code: "var {y = 10, z} = x;", options: ["always", { destructuringAssignment: false }], parserOptions: { ecmaVersion: 6 } },
+        { code: "var {y = 10, z} = { x };", options: ["always", { destructuringAssignment: false }], parserOptions: { ecmaVersion: 6 } },
 
         // never
         { code: "var obj = {foo: bar,\nbaz: qux\n};", options: ["never"] },
@@ -123,6 +138,21 @@ ruleTester.run("object-curly-spacing", rule, {
 
         // never - objectsInObjects
         { code: "var obj = {'foo': {'bar': 1, 'baz': 2} };", options: ["never", { objectsInObjects: true }] },
+        { code: "var {y: {z}} = {x: {} };", options: ["never", { objectsInObjects: true }], parserOptions: { ecmaVersion: 6 } },
+
+        // never - import
+        { code: "import { x } from 'foo';", options: ["never", { import: true }], parserOptions: { sourceType: "module" } },
+        { code: "import { x, y } from 'foo';", options: ["never", { import: true }], parserOptions: { sourceType: "module" } },
+
+        // always - export
+        { code: "export { door };", options: ["never", { export: true }], parserOptions: { sourceType: "module" } },
+        { code: "export { house, mouse } from 'caravan';", options: ["never", { export: true }], parserOptions: { sourceType: "module" } },
+
+        // never - destructuringAssignment
+        { code: "var { y, z } = x;", options: ["never", { destructuringAssignment: true }], parserOptions: { ecmaVersion: 6 } },
+        { code: "var { y: { z } } = x;", options: ["never", { destructuringAssignment: true }], parserOptions: { ecmaVersion: 6 } },
+        { code: "var { y = 10, z } = x;", options: ["never", { destructuringAssignment: true }], parserOptions: { ecmaVersion: 6 } },
+        { code: "var { y = 10, z } = {x};", options: ["never", { destructuringAssignment: true }], parserOptions: { ecmaVersion: 6 } },
 
         // https://github.com/eslint/eslint/issues/3658
         // Empty cases.


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[X] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Changes made according to #7361. Credit to @almirfilho.

**Please describe what the rule should do:**
This rule is a copy of `object-curly-spacing` with extra options (ES6 features) and a more appropriate name.

**What category of rule is this? (place an "X" next to just one item)**

[X] Enforces code style
[ ] Warns about a potential error
[ ] Suggests an alternate way of doing something
[ ] Other (please specify:)

**Provide 2-3 code examples that this rule will warn about:**

```js
/* eslint curly-spacing: ["error", "never", {import: true, destructuringAssignment: true}] */

import { foo } from 'bar'; // Valid
let obj = {bar: 'foo'};    // Valid
const { bar } = obj;       // Valid
export { obj };              // Invalid
```

```js
/* eslint curly-spacing: ["error", "always", {import: false}] */

import {foo} from 'bar'; // Valid
let obj = {bar: 'foo'};    // Invalid
const { bar } = obj;       // Valid
export { obj };              // Valid
```

**Why should this rule be included in ESLint (instead of a plugin)?**
It is an extension of an existing rule, the new rule is just to have a more suitable name.

**What changes did you make? (Give an overview)**
The pull request doesn't change the existing rule (some people may be relying on its quirks) but forks the existing `object-curly-spacing` and adds three new options: `import`, `export`, `destructuringAssignment`. These options allow to more finely define the spacing around curly braces for new ES6 features.
The tests are included, copied from `object-curly-spacing` with a few extra ones.
The documentation was updated, copied from `curly-spacing` with all usage of `object-curly-spacing` marked as deprecated (not sure if justified or correct) and replaced by `curly-spacing`.

**Is there anything you'd like reviewers to focus on?**
I took the freedom of deprecating the previous `object-curly-spacing` rule, this process is probably incomplete (and not my call to make). `object-curly-spacing` documentation doesn't include the proper version where it was deprecated, just `XXX` (see `docs/rules/object-curly-spacing.md`).