### PR TITLE
New: rule no-greater-than

### DIFF
--- a/conf/eslint-recommended.js
+++ b/conf/eslint-recommended.js
@@ -120,6 +120,7 @@ module.exports = {
         "no-floating-decimal": "off",
         "no-func-assign": "error",
         "no-global-assign": "error",
+        "no-greater-than": "off",
         "no-implicit-coercion": "off",
         "no-implicit-globals": "off",
         "no-implied-eval": "off",

--- a/docs/rules/no-greater-than.md
+++ b/docs/rules/no-greater-than.md
@@ -1,0 +1,71 @@
+# Disallow `>` and `>=` operators (no-greater-than)
+
+One simple thing that comes up time and time again is the use of the greater than sign as part of a conditional while programming. Removing it cleans up code:
+
+- `(5 < x && x < 10)`: nicely expresses *"x is between 5 and 10"* because it is **literally between** 5 and 10,
+- `(x < 5 || 10 < x)`: nicely expresses *"x is outside the limits of 5 and 10"* because it is **literally outside** of 5 to 10.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```js
+/* eslint no-greater-than: "error" */
+
+if (2 > 1) {
+    // ...
+}
+
+if (2 >= 1) {
+    // ...
+}
+```
+
+Examples of **correct** code for this rule:
+
+```js
+/* eslint no-greater-than: "error" */
+
+if (1 < 2) {
+    // ...
+}
+
+if (1 <= 2) {
+    // ...
+}
+```
+
+## When Not To Use It
+
+This rule can conflict with the [`yoda`](http://eslint.org/docs/rules/yoda) one:
+
+```js
+/* eslint no-greater-than: "error" */
+/* eslint yoda: "error" */
+
+// this makes no-greater-then fail:
+if (0 > index) {
+    // ...
+}
+
+// but this makes yoda fail:
+if (index < 0) {
+    // ...
+}
+```
+
+If you want to use both, enable `yoda`'s [`"onlyEquality"` property](http://eslint.org/docs/rules/yoda#options):
+
+```js
+/* eslint no-greater-than: "error" */
+/* eslint yoda: ["error", "never", { "onlyEquality": true }] */
+
+// valid for both no-greater-than and yoda:
+if (index < 0) {
+    // ...
+}
+```
+
+## Further Reading
+
+- http://llewellynfalco.blogspot.co.uk/2016/02/dont-use-greater-than-sign-in.html

--- a/lib/rules/no-greater-than.js
+++ b/lib/rules/no-greater-than.js
@@ -1,0 +1,65 @@
+/**
+ * @fileoverview Rule to disallow > and >= operators.
+ * @author Christophe Maillard
+ */
+"use strict";
+
+module.exports = {
+
+    meta: {
+        docs: {
+            description: "disallow > and >= operators",
+            category: "Best Practices",
+            recommended: false
+        },
+        fixable: "code",
+        schema: []
+    },
+
+    create: context => {
+
+        const sourceCode = context.getSourceCode();
+
+        const OPERATOR_FLIP_MAP = {
+            ">": "<",
+            ">=": "<="
+        };
+
+        /**
+        * Returns a string representation of a BinaryExpression node with its sides/operator flipped around (credits to yoda rule).
+        * @param {ASTNode} node The BinaryExpression node.
+        * @returns {string} A string representation of the node with the sides and operator flipped.
+        */
+        function getFlippedString(node) {
+
+            const operatorToken = sourceCode.getFirstTokenBetween(node.left, node.right, token => token.value === node.operator);
+            const textBeforeOperator = sourceCode.getText().slice(sourceCode.getTokenBefore(operatorToken).range[1], operatorToken.range[0]);
+            const textAfterOperator = sourceCode.getText().slice(operatorToken.range[1], sourceCode.getTokenAfter(operatorToken).range[0]);
+            const leftText = sourceCode.getText().slice(node.range[0], sourceCode.getTokenBefore(operatorToken).range[1]);
+            const rightText = sourceCode.getText().slice(sourceCode.getTokenAfter(operatorToken).range[0], node.range[1]);
+
+            return rightText + textBeforeOperator + OPERATOR_FLIP_MAP[operatorToken.value] + textAfterOperator + leftText;
+
+        }
+
+        return {
+            BinaryExpression(node) {
+
+                if (OPERATOR_FLIP_MAP.hasOwnProperty(node.operator)) {
+                    context.report({
+                        node,
+                        message: "Expected {{expectedOperator}} instead of {{actualOperator}}.",
+                        data: {
+                            actualOperator: node.operator,
+                            expectedOperator: OPERATOR_FLIP_MAP[node.operator]
+                        },
+                        fix: fixer => fixer.replaceText(node, getFlippedString(node))
+                    });
+                }
+
+            }
+        };
+
+    }
+
+};

--- a/tests/lib/rules/no-greater-than.js
+++ b/tests/lib/rules/no-greater-than.js
@@ -1,0 +1,35 @@
+/**
+ * @fileoverview Tests for no-greater-than rule.
+ * @author Christophe Maillard
+ */
+"use strict";
+
+const rule = require("../../../lib/rules/no-greater-than");
+const RuleTester = require("../../../lib/testers/rule-tester");
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-greater-than", rule, {
+
+    valid: [
+        "if (1 < 2) {}",
+        "if (1 <= 2) {}"
+    ],
+
+    invalid: [{
+        code: "if (2 > 1) {}",
+        output: "if (1 < 2) {}",
+        errors: [{
+            message: "Expected < instead of >.",
+            type: "BinaryExpression"
+        }]
+    }, {
+        code: "if (2 >= 1) {}",
+        output: "if (1 <= 2) {}",
+        errors: [{
+            message: "Expected <= instead of >=.",
+            type: "BinaryExpression"
+        }]
+    }]
+
+});


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[X] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**Please describe what the rule should do:**

Disallow operators `>` and `>=`.

**What category of rule is this? (place an "X" next to just one item)**

[X] Enforces code style
[ ] Warns about a potential error
[ ] Suggests an alternate way of doing something
[ ] Other (please specify:)

**Provide 2-3 code examples that this rule will warn about:**

```js
if (2 > 1) {
    // ...
}

if (2 >= 1) {
    // ...
}
```

**Why should this rule be included in ESLint (instead of a plugin)?**

See [Llewellyn Falco explanation](http://llewellynfalco.blogspot.co.uk/2016/02/dont-use-greater-than-sign-in.html).