### PR TITLE
Update: Add support for parens on left side for-loops (fixes: #8393) 

### DIFF
--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -256,6 +256,22 @@ module.exports = {
         }
 
         /**
+         * Determines whether a node should be followed by an additional space when removing parens
+         * @param {ASTNode} node node to evaluate; must be surrounded by parentheses
+         * @returns {boolean} `true` if a space should be inserted after the node
+         * @private
+         */
+        function requiresAfterSpace(node) {
+            const nextTwoTokens = sourceCode.getTokensAfter(node, { count: 2 });
+            const rightParenToken = nextTwoTokens[0];
+            const tokenAfterRightParen = nextTwoTokens[1];
+
+            return rightParenToken && tokenAfterRightParen &&
+                !sourceCode.isSpaceBetweenTokens(rightParenToken, tokenAfterRightParen) &&
+                tokenAfterRightParen.type === "Keyword";
+        }
+
+        /**
          * Report the node
          * @param {ASTNode} node node to evaluate
          * @returns {void}
@@ -279,7 +295,7 @@ module.exports = {
                     return fixer.replaceTextRange([
                         leftParenToken.range[0],
                         rightParenToken.range[1]
-                    ], (requiresLeadingSpace(node) ? " " : "") + parenthesizedSource);
+                    ], (requiresLeadingSpace(node) ? " " : "") + parenthesizedSource + (requiresAfterSpace(node) ? " " : ""));
                 }
             });
         }
@@ -488,11 +504,17 @@ module.exports = {
                 if (hasExcessParens(node.right)) {
                     report(node.right);
                 }
+                if (hasExcessParens(node.left)) {
+                    report(node.left);
+                }
             },
 
             ForOfStatement(node) {
                 if (hasExcessParens(node.right)) {
                     report(node.right);
+                }
+                if (hasExcessParens(node.left)) {
+                    report(node.left);
                 }
             },
 

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -261,7 +261,7 @@ module.exports = {
          * @returns {boolean} `true` if a space should be inserted after the node
          * @private
          */
-        function requiresAfterSpace(node) {
+        function requiresTrailingSpace(node) {
             const nextTwoTokens = sourceCode.getTokensAfter(node, { count: 2 });
             const rightParenToken = nextTwoTokens[0];
             const tokenAfterRightParen = nextTwoTokens[1];
@@ -296,7 +296,7 @@ module.exports = {
                     return fixer.replaceTextRange([
                         leftParenToken.range[0],
                         rightParenToken.range[1]
-                    ], (requiresLeadingSpace(node) ? " " : "") + parenthesizedSource + (requiresAfterSpace(node) ? " " : ""));
+                    ], (requiresLeadingSpace(node) ? " " : "") + parenthesizedSource + (requiresTrailingSpace(node) ? " " : ""));
                 }
             });
         }

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -265,10 +265,11 @@ module.exports = {
             const nextTwoTokens = sourceCode.getTokensAfter(node, { count: 2 });
             const rightParenToken = nextTwoTokens[0];
             const tokenAfterRightParen = nextTwoTokens[1];
+            const tokenBeforeRightParen = sourceCode.getLastToken(node);
 
             return rightParenToken && tokenAfterRightParen &&
                 !sourceCode.isSpaceBetweenTokens(rightParenToken, tokenAfterRightParen) &&
-                tokenAfterRightParen.type === "Keyword";
+                !astUtils.canTokensBeAdjacent(tokenBeforeRightParen, tokenAfterRightParen);
         }
 
         /**

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -1010,6 +1010,13 @@ ruleTester.run("no-extra-parens", rule, {
             { parserOptions: { ecmaVersion: 2015 } }
         ),
         invalid(
+            "for ((foo['bar'])of baz);",
+            "for (foo['bar']of baz);",
+            "MemberExpression",
+            1,
+            { parserOptions: { ecmaVersion: 2015 } }
+        ),
+        invalid(
             "() => (({ foo: 1 }).foo)",
             "() => ({ foo: 1 }).foo",
             "MemberExpression",
@@ -1018,3 +1025,5 @@ ruleTester.run("no-extra-parens", rule, {
         )
     ]
 });
+
+

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -41,7 +41,6 @@ function invalid(code, output, type, line, config) {
     if (line) {
         result.errors[0].line = line;
     }
-
     return result;
 }
 
@@ -992,6 +991,20 @@ ruleTester.run("no-extra-parens", rule, {
         invalid(
             "for (foo of(bar));",
             "for (foo of bar);",
+            "Identifier",
+            1,
+            { parserOptions: { ecmaVersion: 2015 } }
+        ),
+        invalid(
+            "for ((foo) of bar);",
+            "for (foo of bar);",
+            "Identifier",
+            1,
+            { parserOptions: { ecmaVersion: 2015 } }
+        ),
+        invalid(
+            "for ((foo)in bar);",
+            "for (foo in bar);",
             "Identifier",
             1,
             { parserOptions: { ecmaVersion: 2015 } }

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -1025,5 +1025,3 @@ ruleTester.run("no-extra-parens", rule, {
         )
     ]
 });
-
-


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Added a fix around supporting parens support for for-in and for-of loops which weren't giving off warnings. I updated no-extra-parens.js with supporting tests.

**Is there anything you'd like reviewers to focus on?**
I wrote a function requiresAfterSpace to determine if a space is required after a node. I didn't know a good way to test this and wasn't sure if what I have is optimal (not sure what I don't know). If you could provide some tips on what a good approach would be to fixing these issues, that would be great. I followed the docs from http://eslint.org/docs/developer-guide/working-with-rules and 

