### PR TITLE
Fix: Add space between async and param on fix (fixes #8682)

### DIFF
--- a/lib/rules/arrow-parens.js
+++ b/lib/rules/arrow-parens.js
@@ -51,13 +51,32 @@ module.exports = {
         const sourceCode = context.getSourceCode();
 
 
+
         /**
          * Determines whether a arrow function argument end with `)`
          * @param {ASTNode} node The arrow function node.
          * @returns {void}
          */
         function parens(node) {
-            const token = sourceCode.getFirstToken(node, node.async ? 1 : 0);
+            const isAsync = node.async;
+            const token = sourceCode.getFirstToken(node, isAsync ? 1 : 0);
+
+            /**
+             * Remove the parenthesis around a parameter
+             * @param {Fixer} fixer Fixer
+             * @returns {string} fixed parameter
+             */
+            function fixParamsWithParenthesis(fixer) {
+                const paramToken = context.getTokenAfter(token);
+                const closingParenToken = context.getTokenAfter(paramToken);
+                const asyncToken = isAsync ? context.getTokenBefore(token) : null;
+                const shouldAddSpaceForAsync = asyncToken && (asyncToken.end === token.start);
+
+                return fixer.replaceTextRange([
+                    token.range[0],
+                    closingParenToken.range[1]
+                ], `${shouldAddSpaceForAsync ? " " : ""}${paramToken.value}`);
+            }
 
             // "as-needed", { "requireForBlockBody": true }: x => x
             if (
@@ -72,15 +91,7 @@ module.exports = {
                     context.report({
                         node,
                         message: requireForBlockBodyMessage,
-                        fix(fixer) {
-                            const paramToken = context.getTokenAfter(token);
-                            const closingParenToken = context.getTokenAfter(paramToken);
-
-                            return fixer.replaceTextRange([
-                                token.range[0],
-                                closingParenToken.range[1]
-                            ], paramToken.value);
-                        }
+                        fix: fixParamsWithParenthesis
                     });
                 }
                 return;
@@ -113,15 +124,7 @@ module.exports = {
                     context.report({
                         node,
                         message: asNeededMessage,
-                        fix(fixer) {
-                            const paramToken = context.getTokenAfter(token);
-                            const closingParenToken = context.getTokenAfter(paramToken);
-
-                            return fixer.replaceTextRange([
-                                token.range[0],
-                                closingParenToken.range[1]
-                            ], paramToken.value);
-                        }
+                        fix: fixParamsWithParenthesis
                     });
                 }
                 return;

--- a/lib/rules/arrow-parens.js
+++ b/lib/rules/arrow-parens.js
@@ -50,8 +50,6 @@ module.exports = {
 
         const sourceCode = context.getSourceCode();
 
-
-
         /**
          * Determines whether a arrow function argument end with `)`
          * @param {ASTNode} node The arrow function node.

--- a/lib/rules/arrow-parens.js
+++ b/lib/rules/arrow-parens.js
@@ -59,7 +59,7 @@ module.exports = {
          */
         function parens(node) {
             const isAsync = node.async;
-            const token = sourceCode.getFirstToken(node, isAsync ? 1 : 0);
+            const firstTokenOfParam = sourceCode.getFirstToken(node, isAsync ? 1 : 0);
 
             /**
              * Remove the parenthesis around a parameter
@@ -67,13 +67,13 @@ module.exports = {
              * @returns {string} fixed parameter
              */
             function fixParamsWithParenthesis(fixer) {
-                const paramToken = context.getTokenAfter(token);
-                const closingParenToken = context.getTokenAfter(paramToken);
-                const asyncToken = isAsync ? context.getTokenBefore(token) : null;
-                const shouldAddSpaceForAsync = asyncToken && (asyncToken.end === token.start);
+                const paramToken = sourceCode.getTokenAfter(firstTokenOfParam);
+                const closingParenToken = sourceCode.getTokenAfter(paramToken);
+                const asyncToken = isAsync ? sourceCode.getTokenBefore(firstTokenOfParam) : null;
+                const shouldAddSpaceForAsync = asyncToken && (asyncToken.end === firstTokenOfParam.start);
 
                 return fixer.replaceTextRange([
-                    token.range[0],
+                    firstTokenOfParam.range[0],
                     closingParenToken.range[1]
                 ], `${shouldAddSpaceForAsync ? " " : ""}${paramToken.value}`);
             }
@@ -87,7 +87,7 @@ module.exports = {
                 node.body.type !== "BlockStatement" &&
                 !node.returnType
             ) {
-                if (astUtils.isOpeningParenToken(token)) {
+                if (astUtils.isOpeningParenToken(firstTokenOfParam)) {
                     context.report({
                         node,
                         message: requireForBlockBodyMessage,
@@ -101,12 +101,12 @@ module.exports = {
                 requireForBlockBody &&
                 node.body.type === "BlockStatement"
             ) {
-                if (!astUtils.isOpeningParenToken(token)) {
+                if (!astUtils.isOpeningParenToken(firstTokenOfParam)) {
                     context.report({
                         node,
                         message: requireForBlockBodyNoParensMessage,
                         fix(fixer) {
-                            return fixer.replaceText(token, `(${token.value})`);
+                            return fixer.replaceText(firstTokenOfParam, `(${firstTokenOfParam.value})`);
                         }
                     });
                 }
@@ -120,7 +120,7 @@ module.exports = {
                 !node.params[0].typeAnnotation &&
                 !node.returnType
             ) {
-                if (astUtils.isOpeningParenToken(token)) {
+                if (astUtils.isOpeningParenToken(firstTokenOfParam)) {
                     context.report({
                         node,
                         message: asNeededMessage,
@@ -130,8 +130,8 @@ module.exports = {
                 return;
             }
 
-            if (token.type === "Identifier") {
-                const after = sourceCode.getTokenAfter(token);
+            if (firstTokenOfParam.type === "Identifier") {
+                const after = sourceCode.getTokenAfter(firstTokenOfParam);
 
                 // (x) => x
                 if (after.value !== ")") {
@@ -139,7 +139,7 @@ module.exports = {
                         node,
                         message,
                         fix(fixer) {
-                            return fixer.replaceText(token, `(${token.value})`);
+                            return fixer.replaceText(firstTokenOfParam, `(${firstTokenOfParam.value})`);
                         }
                     });
                 }

--- a/tests/lib/rules/arrow-parens.js
+++ b/tests/lib/rules/arrow-parens.js
@@ -176,6 +176,18 @@ const invalid = [
             type
         }]
     },
+    {
+        code: "async(a) => a",
+        output: "async a => a",
+        options: ["as-needed"],
+        parserOptions: { ecmaVersion: 8 },
+        errors: [{
+            line: 1,
+            column: 1,
+            message: asNeededMessage,
+            type
+        }]
+    },
 
     // "as-needed", { "requireForBlockBody": true }
     {
@@ -214,6 +226,18 @@ const invalid = [
     },
     {
         code: "async (a) => a",
+        output: "async a => a",
+        options: ["as-needed", { requireForBlockBody: true }],
+        parserOptions: { ecmaVersion: 8 },
+        errors: [{
+            line: 1,
+            column: 1,
+            message: requireForBlockBodyMessage,
+            type
+        }]
+    },
+    {
+        code: "async(a) => a",
         output: "async a => a",
         options: ["as-needed", { requireForBlockBody: true }],
         parserOptions: { ecmaVersion: 8 },


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**
[ X ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Update the fixer code to add space between async and the arrow function parameter when they are side by side.

**Is there anything you'd like reviewers to focus on?**
Nothing in particular


