### PR TITLE
Fix: Semi-Style only check for comments when tokens exist (fixes #8696)

### DIFF
--- a/lib/rules/semi-style.js
+++ b/lib/rules/semi-style.js
@@ -79,7 +79,7 @@ module.exports = {
                             : "the beginning of the next line"
                     },
                     fix(fixer) {
-                        if (commentsExistBetween(prevToken, nextToken)) {
+                        if (prevToken && nextToken && commentsExistBetween(prevToken, nextToken)) {
                             return null;
                         }
 

--- a/tests/lib/rules/semi-style.js
+++ b/tests/lib/rules/semi-style.js
@@ -113,6 +113,12 @@ ruleTester.run("semi-style", rule, {
             options: ["last"],
             errors: ["Expected this semicolon to be at the end of the previous line."]
         },
+        {
+            code: "foo()\n;",
+            output: "foo();\n",
+            options: ["last"],
+            errors: ["Expected this semicolon to be at the end of the previous line."]
+        },
 
         {
             code: "foo;\nbar",


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**
[ X ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Ensure prevToken and nextToken are not null before checking for comments


**Is there anything you'd like reviewers to focus on?**
Nothing


