### PR TITLE
Fix: eslint --quiet no longer fixes warnings (fixes #8675)

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -169,14 +169,14 @@ const cli = {
 
             const report = text ? engine.executeOnText(text, currentOptions.stdinFilename, true) : engine.executeOnFiles(files);
 
-            if (currentOptions.fix) {
-                debug("Fix mode enabled - applying fixes");
-                CLIEngine.outputFixes(report);
-            }
-
             if (currentOptions.quiet) {
                 debug("Quiet mode enabled - filtering out warnings");
                 report.results = CLIEngine.getErrorResults(report.results);
+            }
+
+            if (currentOptions.fix) {
+                debug("Fix mode enabled - applying fixes");
+                CLIEngine.outputFixes(report);
             }
 
             if (printResults(engine, report.results, currentOptions.format, currentOptions.outputFile)) {

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -804,7 +804,7 @@ describe("cli", () => {
 
         });
 
-        it("should rewrite files when in fix mode and quiet mode", () => {
+        it("should not rewrite files when in fix mode and quiet mode", () => {
 
             const report = {
                 errorCount: 0,
@@ -828,7 +828,9 @@ describe("cli", () => {
             sandbox.stub(fakeCLIEngine.prototype, "executeOnFiles").returns(report);
             sandbox.stub(fakeCLIEngine.prototype, "getFormatter").returns(() => "done");
             fakeCLIEngine.getErrorResults = sandbox.stub().returns([]);
-            fakeCLIEngine.outputFixes = sandbox.mock().withExactArgs(report);
+            fakeCLIEngine.outputFixes = sandbox.mock()
+                .once()
+                .withExactArgs(sinon.match({ results: [] }));
 
             localCLI = proxyquire("../../lib/cli", {
                 "./cli-engine": fakeCLIEngine,
@@ -837,6 +839,7 @@ describe("cli", () => {
 
             const exitCode = localCLI.execute("--fix --quiet .");
 
+            fakeCLIEngine.outputFixes.verify();
             assert.equal(exitCode, 0);
 
         });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

See #8675.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

`eslint --quiet --fix` no longer fixes the warnings that are not reported.

**Is there anything you'd like reviewers to focus on?**

Please do not merge until we have agreed that #8675 represents a bug, rather than an enhancement request.