### PR TITLE
Chore: Cache fs reads in ignored-paths (fixes #8363)

### DIFF
--- a/lib/ignored-paths.js
+++ b/lib/ignored-paths.js
@@ -37,7 +37,6 @@ const DEFAULT_OPTIONS = {
     cwd: process.cwd()
 };
 
-
 //------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
@@ -80,6 +79,7 @@ class IgnoredPaths {
      */
     constructor(options) {
         options = mergeDefaultOptions(options);
+        this.cache = {};
 
         /**
          * add pattern to node-ignore instance
@@ -89,17 +89,6 @@ class IgnoredPaths {
          */
         function addPattern(ig, pattern) {
             return ig.addPattern(pattern);
-        }
-
-        /**
-         * add ignore file to node-ignore instance
-         * @param {Object} ig, instance of node-ignore
-         * @param {string} filepath, file to add to ig
-         * @returns {array} raw ignore rules
-         */
-        function addIgnoreFile(ig, filepath) {
-            ig.ignoreFiles.push(filepath);
-            return ig.add(fs.readFileSync(filepath, "utf8"));
         }
 
         this.defaultPatterns = [].concat(DEFAULT_IGNORE_DIRS, options.patterns || []);
@@ -155,8 +144,8 @@ class IgnoredPaths {
             if (ignorePath) {
                 debug(`Adding ${ignorePath}`);
                 this.baseDir = path.dirname(path.resolve(options.cwd, ignorePath));
-                addIgnoreFile(this.ig.custom, ignorePath);
-                addIgnoreFile(this.ig.default, ignorePath);
+                this.addIgnoreFile(this.ig.custom, ignorePath);
+                this.addIgnoreFile(this.ig.default, ignorePath);
             }
 
             if (options.ignorePattern) {
@@ -166,6 +155,29 @@ class IgnoredPaths {
         }
 
         this.options = options;
+    }
+
+    /**
+     * read ignore filepath
+     * @param {string} filePath, file to add to ig
+     * @returns {array} raw ignore rules
+     */
+    readIgnoreFile(filePath) {
+        if (!this.cache[filePath]) {
+            this.cache[filePath] = fs.readFileSync(filePath, "utf8");
+        }
+        return this.cache[filePath];
+    }
+
+    /**
+     * add ignore file to node-ignore instance
+     * @param {Object} ig, instance of node-ignore
+     * @param {string} filePath, file to add to ig
+     * @returns {array} raw ignore rules
+     */
+    addIgnoreFile(ig, filePath) {
+        ig.ignoreFiles.push(filePath);
+        return ig.add(this.readIgnoreFile(filePath));
     }
 
     /**

--- a/lib/ignored-paths.js
+++ b/lib/ignored-paths.js
@@ -163,7 +163,7 @@ class IgnoredPaths {
      * @returns {array} raw ignore rules
      */
     readIgnoreFile(filePath) {
-        if (!this.cache[filePath]) {
+        if (typeof this.cache[filePath] === "undefined") {
             this.cache[filePath] = fs.readFileSync(filePath, "utf8");
         }
         return this.cache[filePath];

--- a/tests/lib/ignored-paths.js
+++ b/tests/lib/ignored-paths.js
@@ -164,6 +164,30 @@ describe("IgnoredPaths", () => {
                 )
             );
         });
+
+
+    });
+
+    describe("caching file reads", () => {
+
+        let readFileSyncCount;
+
+        before(() => {
+            readFileSyncCount = sinon.spy(fs, "readFileSync");
+        });
+
+        after(() => {
+            readFileSyncCount.restore();
+        });
+
+        it("should cache readFileSync on same file paths", () => {
+            const ignoreFilePath = getFixturePath(".eslintignore");
+            const ignoredPaths = new IgnoredPaths({ ignore: true, cwd: getFixturePath() });
+
+            ignoredPaths.readIgnoreFile(ignoreFilePath);
+            assert.isTrue(ignoredPaths.contains(ignoreFilePath));
+            sinon.assert.calledOnce(readFileSyncCount);
+        });
     });
 
     describe("initialization with ignorePattern", () => {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] Other, please explain:
Per #8363 , this pr introduces caching fs reads to the ignored-paths.js file. This is to reduce the synchronous reads which would affect performance.


**What changes did you make? (Give an overview)**
Per #8363 , this pr introduces caching fs reads to the ignored-paths.js file. This is to reduce the synchronous reads which would affect performance.

**Is there anything you'd like reviewers to focus on?**
config-file.js - I am unclear on how to verify the additional reads since #8363 also mentions similar repeats in this file.

Also should there be any tests related to caching?

Any suggestions on on refactoring or any other approaches is appreciated.

Let me know what you think and how I can make better.

