### PR TITLE
Fix: set indent level to return/throw argument (fixes #8710)

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -1173,6 +1173,16 @@ module.exports = {
                 }
             },
 
+            ReturnStatement(node) {
+                if (node.argument) {
+                    offsets.setDesiredOffsets(
+                        sourceCode.getTokens(node.argument),
+                        sourceCode.getFirstToken(node),
+                        1
+                    );
+                }
+            },
+
             SwitchStatement(node) {
                 const tokens = getTokensAndComments(node);
                 const openingCurlyIndex = tokens.findIndex(token => token.range[0] >= node.discriminant.range[1] && astUtils.isOpeningBraceToken(token));
@@ -1211,6 +1221,16 @@ module.exports = {
                     offsets.setDesiredOffsets(sourceCode.getTokensBetween(previousQuasi, nextQuasi), tokenToAlignFrom, 1);
                     offsets.setDesiredOffset(sourceCode.getFirstToken(nextQuasi), tokenToAlignFrom, 0);
                 });
+            },
+
+            ThrowStatement(node) {
+                if (node.argument) {
+                    offsets.setDesiredOffsets(
+                        sourceCode.getTokens(node.argument),
+                        sourceCode.getFirstToken(node),
+                        1
+                    );
+                }
             },
 
             VariableDeclaration(node) {

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -3004,6 +3004,41 @@ ruleTester.run("indent", rule, {
         },
         {
             code: unIndent`
+                function wrap() {
+                    return (
+                        foo ? bar :
+                        baz ? qux :
+                        foobar ? boop :
+                        /*else*/ beep
+                    )
+                }
+            `,
+            options: [4, { flatTernaryExpressions: true }]
+        },
+        {
+            code: unIndent`
+                function wrap() {
+                    return foo
+                        ? bar
+                        : baz
+                }
+            `,
+            options: [4, { flatTernaryExpressions: true }]
+        },
+        {
+            code: unIndent`
+                function wrap() {
+                    return (
+                        foo
+                            ? bar
+                            : baz
+                    )
+                }
+            `,
+            options: [4, { flatTernaryExpressions: true }]
+        },
+        {
+            code: unIndent`
                 foo
                     ? bar
                     : baz


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

Fixes #8710 .

**What changes did you make? (Give an overview)**

This PR make that `indent` rule set indent levels of `node.argument` property of `ReturnStatement`/`ThrowStatement`.

**Is there anything you'd like reviewers to focus on?**

Please check this direction is correct.
