### PR TITLE
Fix: eslint --init installs wrong dependencies of popular styles (fixes #7338)

### DIFF
--- a/lib/config/config-initializer.js
+++ b/lib/config/config-initializer.js
@@ -62,42 +62,46 @@ function writeFile(config, format) {
  * @returns {void}
  */
 function installModules(config) {
-    let modules = [];
+    const modules = {};
 
     // Create a list of modules which should be installed based on config
     if (config.plugins) {
-        modules = modules.concat(config.plugins.map(name => `eslint-plugin-${name}`));
+        for (const plugin of config.plugins) {
+            modules[`eslint-plugin-${plugin}`] = "latest";
+        }
     }
     if (config.extends && config.extends.indexOf("eslint:") === -1) {
-        modules.push(`eslint-config-${config.extends}`);
+        const moduleName = `eslint-config-${config.extends}`;
+
+        log.info(`Checking peerDependencies of ${moduleName}`);
+        modules[moduleName] = "latest";
+        Object.assign(
+            modules,
+            npmUtil.fetchPeerDependencies(`${moduleName}@latest`)
+        );
     }
 
     // Determine which modules are already installed
-    if (modules.length === 0) {
+    if (Object.keys(modules).length === 0) {
         return;
     }
 
     // Add eslint to list in case user does not have it installed locally
-    modules.unshift("eslint");
+    modules.eslint = modules.eslint || "latest";
 
-    const installStatus = npmUtil.checkDevDeps(modules);
+    const installStatus = npmUtil.checkDevDeps(["eslint"]);
 
-    // Install packages which aren't already installed
-    const modulesToInstall = Object.keys(installStatus).filter(module => {
-        const notInstalled = installStatus[module] === false;
-
-        if (module === "eslint" && notInstalled) {
-            log.info("Local ESLint installation not found.");
-            config.installedESLint = true;
-        }
-
-        return notInstalled;
-    });
-
-    if (modulesToInstall.length > 0) {
-        log.info(`Installing ${modulesToInstall.join(", ")}`);
-        npmUtil.installSyncSaveDev(modulesToInstall);
+    if (installStatus.eslint === false) {
+        log.info("Local ESLint installation not found.");
+        config.installedESLint = true;
     }
+
+    // Install packages
+    const modulesToInstall = Object.keys(modules).map(name => `${name}@${modules[name]}`);
+
+    log.info(`Installing ${modulesToInstall.join(", ")}`);
+
+    npmUtil.installSyncSaveDev(modulesToInstall);
 }
 
 /**
@@ -265,9 +269,9 @@ function processAnswers(answers) {
 function getConfigForStyleGuide(guide) {
     const guides = {
         google: { extends: "google" },
-        airbnb: { extends: "airbnb", plugins: ["react", "jsx-a11y", "import"] },
-        "airbnb-base": { extends: "airbnb-base", plugins: ["import"] },
-        standard: { extends: "standard", plugins: ["standard", "promise"] }
+        airbnb: { extends: "airbnb" },
+        "airbnb-base": { extends: "airbnb-base" },
+        standard: { extends: "standard" }
     };
 
     if (!guides[guide]) {

--- a/lib/config/config-initializer.js
+++ b/lib/config/config-initializer.js
@@ -81,7 +81,7 @@ function installModules(config) {
         );
     }
 
-    // Determine which modules are already installed
+    // If no modules, do nothing.
     if (Object.keys(modules).length === 0) {
         return;
     }
@@ -89,6 +89,7 @@ function installModules(config) {
     // Add eslint to list in case user does not have it installed locally
     modules.eslint = modules.eslint || "latest";
 
+    // Mark to show messages if it's new installation of eslint.
     const installStatus = npmUtil.checkDevDeps(["eslint"]);
 
     if (installStatus.eslint === false) {

--- a/lib/util/npm-util.js
+++ b/lib/util/npm-util.js
@@ -57,6 +57,20 @@ function installSyncSaveDev(packages) {
 }
 
 /**
+ * Fetch `peerDependencies` of the given package by `npm show` command.
+ * @param {string} packageName The package name to fetch peerDependencies.
+ * @returns {string[]} Gotten peerDependencies.
+ */
+function fetchPeerDependencies(packageName) {
+    const fetchedText = childProcess.execSync(
+        `npm show --json ${packageName} peerDependencies`,
+        { encoding: "utf8" }
+    ).trim();
+
+    return JSON.parse(fetchedText || "{}");
+}
+
+/**
  * Check whether node modules are include in a project's package.json.
  *
  * @param   {string[]} packages           Array of node module names
@@ -140,6 +154,7 @@ function checkPackageJson(startDir) {
 
 module.exports = {
     installSyncSaveDev,
+    fetchPeerDependencies,
     checkDeps,
     checkDevDeps,
     checkPackageJson

--- a/tests/lib/config/config-initializer.js
+++ b/tests/lib/config/config-initializer.js
@@ -185,19 +185,19 @@ describe("configInitializer", () => {
             it("should support the airbnb style guide", () => {
                 const config = init.getConfigForStyleGuide("airbnb");
 
-                assert.deepEqual(config, { extends: "airbnb", installedESLint: true, plugins: ["react", "jsx-a11y", "import"] });
+                assert.deepEqual(config, { extends: "airbnb", installedESLint: true });
             });
 
             it("should support the airbnb base style guide", () => {
                 const config = init.getConfigForStyleGuide("airbnb-base");
 
-                assert.deepEqual(config, { extends: "airbnb-base", installedESLint: true, plugins: ["import"] });
+                assert.deepEqual(config, { extends: "airbnb-base", installedESLint: true });
             });
 
             it("should support the standard style guide", () => {
                 const config = init.getConfigForStyleGuide("standard");
 
-                assert.deepEqual(config, { extends: "standard", installedESLint: true, plugins: ["standard", "promise"] });
+                assert.deepEqual(config, { extends: "standard", installedESLint: true });
             });
 
             it("should throw when encountering an unsupported style guide", () => {
@@ -209,13 +209,13 @@ describe("configInitializer", () => {
             it("should install required sharable config", () => {
                 init.getConfigForStyleGuide("google");
                 assert(npmInstallStub.calledOnce);
-                assert.deepEqual(npmInstallStub.firstCall.args[0][1], "eslint-config-google");
+                assert(npmInstallStub.firstCall.args[0].some(name => name.startsWith("eslint-config-google@")));
             });
 
             it("should install ESLint if not installed locally", () => {
                 init.getConfigForStyleGuide("google");
                 assert(npmInstallStub.calledOnce);
-                assert.deepEqual(npmInstallStub.firstCall.args[0][0], "eslint");
+                assert(npmInstallStub.firstCall.args[0].some(name => name.startsWith("eslint@")));
             });
         });
 

--- a/tests/lib/util/npm-util.js
+++ b/tests/lib/util/npm-util.js
@@ -187,4 +187,15 @@ describe("npmUtil", () => {
             stub.restore();
         });
     });
+
+    describe("fetchPeerDependencies()", () => {
+        it("should execute 'npm show --json <packageName> peerDependencies' command", () => {
+            const stub = sandbox.stub(childProcess, "execSync").returns("");
+
+            npmUtil.fetchPeerDependencies("desired-package");
+            assert(stub.calledOnce);
+            assert.equal(stub.firstCall.args[0], "npm show --json desired-package peerDependencies");
+            stub.restore();
+        });
+    });
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

Fixes #7338.

In `eslint --init`, if people select a popular style guide, it installs wrong versions of eslint and plugins.

- `airbnb` and `airbnb-base` requires ESLint 3 but it installs ESLint 4.
- `standard` requires `eslint-plugin-standard` and `eslint-plugin-node` but it does not install those plugins.

**What changes did you make? (Give an overview)**

This PR improve `eslint --init`.
If people select a popular style guide, it checks the `peerDependencies` of the shareable config, then installs the correct dependencies.

To install correct versions, this PR's `eslint --init` installs all dependencies even if those have been installed already. This behavior is different to the current master branch.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.
