### PR TITLE
Chore: indent bug proof to allow block relative disable [regression]

### DIFF
--- a/tests/lib/rules/indent-legacy.js
+++ b/tests/lib/rules/indent-legacy.js
@@ -3934,6 +3934,28 @@ ruleTester.run("indent-legacy", rule, {
             "             'baz']);",
             options: [2, { ArrayExpression: "first", CallExpression: { arguments: "first" } }],
             errors: expectedErrors([2, 13, 12, "ArrayExpression"])
+        },
+        {
+            code:
+            "function test1() {\n" +
+            "  function test2() {\n" +
+            "  // eslint-disable-next-line indent-legacy\n" +
+            "  function test3() {\n" +
+            "       var a = 1;\n" +
+            "  }\n" +
+            "  }\n" +
+            "}",
+            output:
+            "function test1() {\n" +
+            "  function test2() {\n" +
+            "  // eslint-disable-next-line indent-legacy\n" +
+            "  function test3() {\n" +
+            "    var a = 1;\n" +
+            "  }\n" +
+            "  }\n" +
+            "}",
+            options: [2],
+            errors: expectedErrors([5, 4, 7, "VariableDeclaration"])
         }
     ]
 });

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -8481,6 +8481,30 @@ ruleTester.run("indent", rule, {
                 )
             `,
             errors: expectedErrors([[5, 4, 8, "Punctuator"], [6, 4, 8, "Punctuator"], [7, 0, 4, "Punctuator"]])
+        },
+        {
+            code: unIndent`
+              function test1() {
+                function test2() {
+                // eslint-disable-next-line indent
+                function test3() {
+                     var a = 1;
+                }
+                }
+              }
+            `,
+            output: unIndent`
+              function test1() {
+                function test2() {
+                // eslint-disable-next-line indent
+                function test3() {
+                  var a = 1;
+                }
+                }
+              }
+            `,
+            options: [2],
+            errors: expectedErrors([5, 4, 7, "VariableDeclaration"])
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Other, please explain: bug proof

**What changes did you make? (Give an overview)**

This is a bug proof, I added the same test to both `indent-legacy` and `indent` to prove a regression was done on v4.0.0.

The build *intentionally* fails.

I have no idea on how to fix this bug, but hope the tests are clear enough for you to understand the issue.

**Is there anything you'd like reviewers to focus on?**

When writing for example a jQuery plugin it is common to wrap everything around a lambda. It is handy to **relativly** disable indentation check for the main inside block, in order to reduce indentation overhead:
```js
(function($){
// eslint-disable-next-line indent
$(function(){
  var a = 1;
  function test() {
    var b = 2;
  }
});
})(jQuery);
```
Here you can see that indentation check is mandatory and useful for internal code, but for the main `$(function(){});` it would just add 2 spaces everywere without benefits.

This behaviour was present in `indent-legacy`, but missing in new v4 `indent`