### PR TITLE
Update: Add new regex matching rules for valid-jsdoc

### DIFF
--- a/docs/rules/valid-jsdoc.md
+++ b/docs/rules/valid-jsdoc.md
@@ -160,7 +160,9 @@ This rule has an object option:
     * `true` (default) **even if** the function or method does not have a `return` statement (this option value does not apply to constructors)
     * `false` **if and only if** the function or method has a `return` statement (this option value does apply to constructors)
 * `"requireReturnType": false` allows missing type in return tags
-* `"matchDescription"` specifies (as a string) a regular expression to match the description in each JSDoc comment (for example, `".+"` requires a description; this option does not apply to descriptions in parameter or return tags)
+* `"matchDescription"` specifies (as a string) a regular expression to match the description in each JSDoc comment (for example, `".+"` requires a description)
+* `"matchParamDescription"` specifies (as a string) a regular expression to match each parameter tag description
+* `"matchReturnDescription"` specifies (as a string) a regular expression to match each return tag description
 * `"requireParamDescription": false` allows missing description in parameter tags
 * `"requireReturnDescription": false` allows missing description in return tags
 
@@ -317,6 +319,38 @@ Example of additional **incorrect** code for this rule with a sample `"matchDesc
 /**
  * @param {string} name Whom to greet.
  * @returns {void}
+ */
+function greet(name) {
+    console.log("Hello " + name);
+}
+```
+
+### matchParamDescription
+
+Example of additional **correct** code for this rule with a sample `"matchParamDescription": "^[A-Z].*[.]$"` option:
+
+```js
+/*eslint valid-jsdoc: ["error", { "matchParamDescription": "^[A-Z].*[.]$" }]*/
+
+/**
+ * @param {string} name Whom to greet.
+ * @returns {void}
+ */
+function greet(name) {
+    console.log("Hello " + name);
+}
+```
+
+### matchReturnDescription
+
+Example of additional **incorrect** code for this rule with a sample `"matchReturnDescription": "^[A-Z].*[.]$"` option:
+
+```js
+/*eslint valid-jsdoc: ["error", { "matchReturnDescription": "^[A-Z].*[.]$" }]*/
+
+/**
+ * @param {string} name Whom to greet.
+ * @returns {void} returns nothing
  */
 function greet(name) {
     console.log("Hello " + name);

--- a/lib/rules/valid-jsdoc.js
+++ b/lib/rules/valid-jsdoc.js
@@ -50,6 +50,12 @@ module.exports = {
                     matchDescription: {
                         type: "string"
                     },
+                    matchParamDescription: {
+                        type: "string"
+                    },
+                    matchReturnDescription: {
+                        type: "string"
+                    },
                     requireReturnType: {
                         type: "boolean"
                     }
@@ -269,6 +275,16 @@ module.exports = {
                                 context.report({ node: jsdocNode, message: "Missing JSDoc parameter description for '{{name}}'.", data: { name: tag.name } });
                             }
 
+                            if (options.matchParamDescription) {
+                                const regex = new RegExp(options.matchParamDescription);
+
+                                if (!regex.test(tag.description)) {
+                                    context.report({ node: jsdocNode, message: "JSDoc parameter '{{name}}' does not satisfy the regex pattern.", data: {
+                                        name: tag.name
+                                    } });
+                                }
+                            }
+
                             if (params[tag.name]) {
                                 context.report({ node: jsdocNode, message: "Duplicate JSDoc parameter '{{name}}'.", data: { name: tag.name } });
                             } else if (tag.name.indexOf(".") === -1) {
@@ -295,6 +311,16 @@ module.exports = {
 
                                 if (!isValidReturnType(tag) && !tag.description && requireReturnDescription) {
                                     context.report({ node: jsdocNode, message: "Missing JSDoc return description." });
+                                }
+                            }
+
+                            if (options.matchReturnDescription) {
+                                const regex = new RegExp(options.matchReturnDescription);
+
+                                if (!regex.test(tag.description)) {
+                                    context.report({ node: jsdocNode, message: "JSDoc return description does not satisfy the regex pattern.", data: {
+                                        name: tag.name
+                                    } });
                                 }
                             }
 

--- a/tests/lib/rules/valid-jsdoc.js
+++ b/tests/lib/rules/valid-jsdoc.js
@@ -162,6 +162,18 @@ ruleTester.run("valid-jsdoc", rule, {
             }]
         },
         {
+            code: "/**\n* @param {string} a Start with caps and end with period.\n* @return {void} */\nfunction foo(a){}",
+            options: [{
+                matchParamDescription: "^[A-Z][A-Za-z0-9\\s]*[.]$"
+            }]
+        },
+        {
+            code: "/**\n* @return {void} Returns nothing. */\nfunction foo(){}",
+            options: [{
+                matchReturnDescription: "^[A-Z][A-Za-z0-9\\s]*[.]$"
+            }]
+        },
+        {
             code: "/** Foo \n@return {void} Foo\n */\nfunction foo(){}",
             options: [{ prefer: { return: "return" } }]
         },
@@ -952,6 +964,26 @@ ruleTester.run("valid-jsdoc", rule, {
             }],
             errors: [{
                 message: "JSDoc description does not satisfy the regex pattern.",
+                type: "Block"
+            }]
+        },
+        {
+            code: "/**\n* @param {string} arg Start with caps and end with period\n* @return {void} */\nfunction foo(arg){}",
+            options: [{
+                matchParamDescription: "^[A-Z][A-Za-z0-9\\s]*[.]$"
+            }],
+            errors: [{
+                message: "JSDoc parameter 'arg' does not satisfy the regex pattern.",
+                type: "Block"
+            }]
+        },
+        {
+            code: "/**\n* @return {void} Start with caps and end with period\n*/\nfunction foo(){}",
+            options: [{
+                matchReturnDescription: "^[A-Z][A-Za-z0-9\\s]*[.]$"
+            }],
+            errors: [{
+                message: "JSDoc return description does not satisfy the regex pattern.",
                 type: "Block"
             }]
         },


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

This PR adds new options to the `valid-jsdoc` rule enforcing parameter and return description formatting according to a regular expression.  It follows closely the existing `matchDescription` option.

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What rule do you want to change?**

`valid-jsdoc`

**Does this change cause the rule to produce more or fewer warnings?**

More warnings depending on the regex given.

**How will the change be implemented? (New option, new default behavior, etc.)?**

Two new options:
1. `matchParamDescription`: A regex matching all `param` descriptions
2. `matchReturnDescription`: A regex matching all `return` descriptions

**Please provide some example code that this change will affect:**

Given `{matchParamDescription: "^[A-Z].*[.]$"}`, the following fails
```js
/**
 * @param {string} arg this is an argument
 */
function foo(arg) {}
```
but the following passes
```js
/**
 * @param {string} arg This is an argument.
 */
function foo(arg) {}
```

**What does the rule currently do for this code?**

There is no mechanism for checking the style of parameter or return value descriptions.

**What will the rule do after it's changed?**

Allow users to enforce a uniform style for all jsdoc descriptions.

**What changes did you make? (Give an overview)**

I followed what was done in https://github.com/eslint/eslint/issues/2449 to add the options.

**Is there anything you'd like reviewers to focus on?**

In the current implementation, all parameter and return descriptions will be tested even if they are empty.  This means that if the description is optional, you may have to use a regex like `^([A-Z]+.*|)$` to allow the empty case as well.  Because there are separate options to check for empty descriptions, it might be better to only match non-empty descriptions.  I'm undecided on which is better.