### PR TITLE
Update: fix multiline binary operator/parentheses indentation

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -816,7 +816,6 @@ module.exports = {
 
             offsets.ignoreToken(operator);
             offsets.ignoreToken(tokensAfterOperator[0]);
-            offsets.setDesiredOffset(tokensAfterOperator[0], sourceCode.getFirstToken(node), 1);
             offsets.setDesiredOffsets(tokensAfterOperator, tokensAfterOperator[0], 1);
         }
 
@@ -882,6 +881,13 @@ module.exports = {
 
                 // We only want to handle parens around expressions, so exclude parentheses that are in function parameters and function call arguments.
                 if (!parameterParens.has(leftParen) && !parameterParens.has(rightParen)) {
+                    const parenthesizedTokens = new Set(sourceCode.getTokensBetween(leftParen, rightParen));
+
+                    parenthesizedTokens.forEach(token => {
+                        if (!parenthesizedTokens.has(offsets.getFirstDependency(token))) {
+                            offsets.setDesiredOffset(token, leftParen, 1);
+                        }
+                    });
                     offsets.setDesiredOffset(sourceCode.getTokenAfter(leftParen), leftParen, 1);
                 }
 

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -2565,6 +2565,40 @@ ruleTester.run("indent", rule, {
         },
         {
             code: unIndent`
+                [
+                ] || [
+                ]
+            `
+        },
+        {
+            code: unIndent`
+                (
+                    [
+                    ] || [
+                    ]
+                )
+            `
+        },
+        {
+            code: unIndent`
+                1
+                + (
+                    1
+                )
+            `
+        },
+        {
+            code: unIndent`
+                (
+                    foo && (
+                        bar ||
+                        baz
+                    )
+                )
+            `
+        },
+        {
+            code: unIndent`
                 var foo =
                         1;
             `,
@@ -2980,6 +3014,41 @@ ruleTester.run("indent", rule, {
                     foobar ? boop :
                     /*else*/ beep
                 )
+            `,
+            options: [4, { flatTernaryExpressions: true }]
+        },
+        {
+            code: unIndent`
+                function wrap() {
+                    return (
+                        foo ? bar :
+                        baz ? qux :
+                        foobar ? boop :
+                        /*else*/ beep
+                    )
+                }
+            `,
+            options: [4, { flatTernaryExpressions: true }]
+        },
+        {
+            code: unIndent`
+                function wrap() {
+                    return foo
+                        ? bar
+                        : baz
+                }
+            `,
+            options: [4, { flatTernaryExpressions: true }]
+        },
+        {
+            code: unIndent`
+                function wrap() {
+                    return (
+                        foo
+                            ? bar
+                            : baz
+                    )
+                }
             `,
             options: [4, { flatTernaryExpressions: true }]
         },
@@ -7035,6 +7104,34 @@ ruleTester.run("indent", rule, {
             `,
             options: [4],
             errors: expectedErrors([2, 4, 8, "Identifier"])
+        },
+        {
+            code: unIndent`
+                [
+                ] || [
+                    ]
+            `,
+            output: unIndent`
+                [
+                ] || [
+                ]
+            `,
+            errors: expectedErrors([3, 0, 4, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                1
+                + (
+                        1
+                    )
+            `,
+            output: unIndent`
+                1
+                + (
+                    1
+                )
+            `,
+            errors: expectedErrors([[3, 4, 8, "Numeric"], [4, 0, 4, "Punctuator"]])
         },
 
         // Template curlies


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (https://github.com/eslint/eslint/issues/8666, https://github.com/eslint/eslint/issues/8717, https://github.com/eslint/eslint/issues/8710)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Fixes #8666, fixes #8717, fixes #8710

Previously, the logic for indenting multiline parenthesized expressions assumed that the indentation of every token in the expression other than the first was dependent on the first token. However, this assumption is not always correct. This led to bugs with multiline parenthesized expressions (#8710). Additionally, the BinaryExpression listener attempted to account for this assumption by always linking its tokens' indentation to the first token's indentation, even when it didn't make sense to do so. This led to other bugs (#8666, #8717). This commit updates the parenthesis logic to avoid making that assumption and check the indentation of all the tokens properly.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular