### PR TITLE
New: Allow passing a function as `fix` option (fixes #8039)

### DIFF
--- a/docs/developer-guide/nodejs-api.md
+++ b/docs/developer-guide/nodejs-api.md
@@ -215,7 +215,7 @@ The `CLIEngine` is a constructor, and you can create a new instance by passing i
 * `cwd` - Path to a directory that should be considered as the current working directory.
 * `envs` - An array of environments to load (default: empty array). Corresponds to `--env`.
 * `extensions` - An array of filename extensions that should be checked for code. The default is an array containing just `".js"`. Corresponds to `--ext`. It is only used in conjunction with directories, not with filenames or glob patterns.
-* `fix` - True indicates that fixes should be included with the output report, and that errors and warnings should not be listed if they can be fixed. However, the files on disk will not be changed. To persist changes to disk, call [`outputFixes()`](#outputfixes).
+* `fix` - This can be a boolean or a function which will be provided each linting message and should return a boolean. True indicates that fixes should be included with the output report, and that errors and warnings should not be listed if they can be fixed. However, the files on disk will not be changed. To persist changes to disk, call [`outputFixes()`](#outputfixes).
 * `globals` - An array of global variables to declare (default: empty array). Corresponds to `--global`.
 * `ignore` - False disables use of `.eslintignore`, `ignorePath` and `ignorePattern` (default: true). Corresponds to `--no-ignore`.
 * `ignorePath` - The ignore file to use instead of `.eslintignore` (default: null). Corresponds to `--ignore-path`.

--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -45,7 +45,7 @@ const debug = require("debug")("eslint:cli-engine");
  * @property {string} cwd The value to use for the current working directory.
  * @property {string[]} envs An array of environments to load.
  * @property {string[]} extensions An array of file extensions to check.
- * @property {boolean} fix Execute in autofix mode.
+ * @property {boolean|Function} fix Execute in autofix mode. If a function, should return a boolean.
  * @property {string[]} globals An array of global variables to declare.
  * @property {boolean} ignore False disables use of .eslintignore.
  * @property {string} ignorePath The ignore file to use instead of .eslintignore.
@@ -135,7 +135,7 @@ function calculateStatsPerRun(results) {
  * @param {string} text The source code to check.
  * @param {Object} configHelper The configuration options for ESLint.
  * @param {string} filename An optional string representing the texts filename.
- * @param {boolean} fix Indicates if fixes should be processed.
+ * @param {boolean|Function} fix Indicates if fixes should be processed.
  * @param {boolean} allowInlineConfig Allow/ignore comments that change config.
  * @param {Linter} linter Linter context
  * @returns {LintResult} The results for linting on this text.
@@ -196,7 +196,7 @@ function processText(text, configHelper, filename, fix, allowInlineConfig, linte
             fixedResult = linter.verifyAndFix(text, config, {
                 filename,
                 allowInlineConfig
-            });
+            }, fix);
             messages = fixedResult.messages;
         } else {
             messages = linter.verify(text, config, {

--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -195,8 +195,9 @@ function processText(text, configHelper, filename, fix, allowInlineConfig, linte
         if (fix) {
             fixedResult = linter.verifyAndFix(text, config, {
                 filename,
-                allowInlineConfig
-            }, fix);
+                allowInlineConfig,
+                fix
+            });
             messages = fixedResult.messages;
         } else {
             messages = linter.verify(text, config, {

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -1207,6 +1207,7 @@ class Linter extends EventEmitter {
             fixed = false,
             passNumber = 0;
         const debugTextDescription = options && options.filename || `${text.slice(0, 10)}...`;
+        const shouldFix = options && options.fix || true;
 
         /**
          * This loop continues until one of the following is true:
@@ -1224,7 +1225,7 @@ class Linter extends EventEmitter {
             messages = this.verify(text, config, options);
 
             debug(`Generating fixed text for ${debugTextDescription} (pass ${passNumber})`);
-            fixedResult = SourceCodeFixer.applyFixes(this.getSourceCode(), messages, options.fix);
+            fixedResult = SourceCodeFixer.applyFixes(this.getSourceCode(), messages, shouldFix);
 
             // stop if there are any syntax errors.
             // 'fixedResult.output' is a empty string.

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -1197,11 +1197,11 @@ class Linter extends EventEmitter {
      * @param {string} options.filename The filename from which the text was read.
      * @param {boolean} options.allowInlineConfig Flag indicating if inline comments
      *      should be allowed.
-     * @param {boolean|Function} shouldFix Determines whether fixes should be applied
+     * @param {boolean|Function} options.fix Determines whether fixes should be applied
      * @returns {Object} The result of the fix operation as returned from the
      *      SourceCodeFixer.
      */
-    verifyAndFix(text, config, options, shouldFix) {
+    verifyAndFix(text, config, options) {
         let messages = [],
             fixedResult,
             fixed = false,
@@ -1224,7 +1224,7 @@ class Linter extends EventEmitter {
             messages = this.verify(text, config, options);
 
             debug(`Generating fixed text for ${debugTextDescription} (pass ${passNumber})`);
-            fixedResult = SourceCodeFixer.applyFixes(this.getSourceCode(), messages, shouldFix);
+            fixedResult = SourceCodeFixer.applyFixes(this.getSourceCode(), messages, options.fix);
 
             // stop if there are any syntax errors.
             // 'fixedResult.output' is a empty string.

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -1197,10 +1197,11 @@ class Linter extends EventEmitter {
      * @param {string} options.filename The filename from which the text was read.
      * @param {boolean} options.allowInlineConfig Flag indicating if inline comments
      *      should be allowed.
+     * @param {boolean|Function} shouldFix Determines whether fixes should be applied
      * @returns {Object} The result of the fix operation as returned from the
      *      SourceCodeFixer.
      */
-    verifyAndFix(text, config, options) {
+    verifyAndFix(text, config, options, shouldFix) {
         let messages = [],
             fixedResult,
             fixed = false,
@@ -1223,7 +1224,7 @@ class Linter extends EventEmitter {
             messages = this.verify(text, config, options);
 
             debug(`Generating fixed text for ${debugTextDescription} (pass ${passNumber})`);
-            fixedResult = SourceCodeFixer.applyFixes(this.getSourceCode(), messages);
+            fixedResult = SourceCodeFixer.applyFixes(this.getSourceCode(), messages, shouldFix);
 
             // stop if there are any syntax errors.
             // 'fixedResult.output' is a empty string.

--- a/lib/util/source-code-fixer.js
+++ b/lib/util/source-code-fixer.js
@@ -55,14 +55,23 @@ function SourceCodeFixer() {
  * smart about the fixes and won't apply fixes over the same area in the text.
  * @param {SourceCode} sourceCode The source code to apply the changes to.
  * @param {Message[]} messages The array of messages reported by ESLint.
+ * @param {boolean|Function} [shouldFix=true] Determines whether each message should be fixed
  * @returns {Object} An object containing the fixed text and any unfixed messages.
  */
-SourceCodeFixer.applyFixes = function(sourceCode, messages) {
-
+SourceCodeFixer.applyFixes = function(sourceCode, messages, shouldFix) {
     debug("Applying fixes");
 
     if (!sourceCode) {
         debug("No source code to fix");
+        return {
+            fixed: false,
+            messages,
+            output: ""
+        };
+    }
+
+    if (shouldFix === false) {
+        debug("shouldFix parameter was false, not attempting fixes");
         return {
             fixed: false,
             messages,
@@ -78,6 +87,34 @@ SourceCodeFixer.applyFixes = function(sourceCode, messages) {
     let lastPos = Number.NEGATIVE_INFINITY,
         output = bom;
 
+    /**
+     * Try to use the 'fix' from a problem.
+     * @param   {Message} problem The message object to apply fixes from
+     * @returns {boolean}         Whether fix was successfully applied
+     */
+    function attemptFix(problem) {
+        const fix = problem.fix;
+        const start = fix.range[0];
+        const end = fix.range[1];
+
+        // Remain it as a problem if it's overlapped or it's a negative range
+        if (lastPos >= start || start > end) {
+            remainingMessages.push(problem);
+            return false;
+        }
+
+        // Remove BOM.
+        if ((start < 0 && end >= 0) || (start === 0 && fix.text.startsWith(BOM))) {
+            output = "";
+        }
+
+        // Make output to this fix.
+        output += text.slice(Math.max(0, lastPos), Math.max(0, start));
+        output += fix.text;
+        lastPos = end;
+        return true;
+    }
+
     messages.forEach(problem => {
         if (problem.hasOwnProperty("fix")) {
             fixes.push(problem);
@@ -88,32 +125,23 @@ SourceCodeFixer.applyFixes = function(sourceCode, messages) {
 
     if (fixes.length) {
         debug("Found fixes to apply");
+        let fixesWereApplied = false;
 
         for (const problem of fixes.sort(compareMessagesByFixRange)) {
-            const fix = problem.fix;
-            const start = fix.range[0];
-            const end = fix.range[1];
-
-            // Remain it as a problem if it's overlapped or it's a negative range
-            if (lastPos >= start || start > end) {
-                remainingMessages.push(problem);
-                continue;
+            if (typeof shouldFix === "function") {
+                if (shouldFix(problem)) {
+                    fixesWereApplied = attemptFix(problem) || fixesWereApplied;
+                } else {
+                    remainingMessages.push(problem);
+                }
+            } else {
+                fixesWereApplied = attemptFix(problem) || fixesWereApplied;
             }
-
-            // Remove BOM.
-            if ((start < 0 && end >= 0) || (start === 0 && fix.text.startsWith(BOM))) {
-                output = "";
-            }
-
-            // Make output to this fix.
-            output += text.slice(Math.max(0, lastPos), Math.max(0, start));
-            output += fix.text;
-            lastPos = end;
         }
         output += text.slice(Math.max(0, lastPos));
 
         return {
-            fixed: true,
+            fixed: fixesWereApplied,
             messages: remainingMessages.sort(compareMessagesByLocation),
             output
         };

--- a/lib/util/source-code-fixer.js
+++ b/lib/util/source-code-fixer.js
@@ -129,7 +129,11 @@ SourceCodeFixer.applyFixes = function(sourceCode, messages, shouldFix) {
 
         for (const problem of fixes.sort(compareMessagesByFixRange)) {
             if (typeof shouldFix !== "function" || shouldFix(problem)) {
-                fixesWereApplied = attemptFix(problem) || fixesWereApplied;
+                attemptFix(problem);
+
+                // The only time attemptFix will fail is if a previous fix was
+                // applied which conflicts with it.  So we can mark this as true.
+                fixesWereApplied = true;
             } else {
                 remainingMessages.push(problem);
             }

--- a/lib/util/source-code-fixer.js
+++ b/lib/util/source-code-fixer.js
@@ -128,14 +128,10 @@ SourceCodeFixer.applyFixes = function(sourceCode, messages, shouldFix) {
         let fixesWereApplied = false;
 
         for (const problem of fixes.sort(compareMessagesByFixRange)) {
-            if (typeof shouldFix === "function") {
-                if (shouldFix(problem)) {
-                    fixesWereApplied = attemptFix(problem) || fixesWereApplied;
-                } else {
-                    remainingMessages.push(problem);
-                }
-            } else {
+            if (typeof shouldFix !== "function" || shouldFix(problem)) {
                 fixesWereApplied = attemptFix(problem) || fixesWereApplied;
+            } else {
+                remainingMessages.push(problem);
             }
         }
         output += text.slice(Math.max(0, lastPos));

--- a/lib/util/source-code-fixer.js
+++ b/lib/util/source-code-fixer.js
@@ -75,7 +75,7 @@ SourceCodeFixer.applyFixes = function(sourceCode, messages, shouldFix) {
         return {
             fixed: false,
             messages,
-            output: ""
+            output: sourceCode.text
         };
     }
 

--- a/tests/lib/util/source-code-fixer.js
+++ b/tests/lib/util/source-code-fixer.js
@@ -204,6 +204,13 @@ describe("SourceCodeFixer", () => {
                 assert.equal(result.output, TEST_CODE);
             });
 
+            it("should only apply fixes for which the 'shouldFix' function returns true", () => {
+                const shouldFixSpy = sinon.spy(problem => problem.message === "foo");
+                const result = SourceCodeFixer.applyFixes(sourceCode, [INSERT_AT_START, REPLACE_ID], shouldFixSpy);
+
+                assert.equal(result.output, "var foo = 6 * 7;");
+            });
+
             it("is called without access to internal eslint state", () => {
                 const shouldFixSpy = sinon.spy();
 

--- a/tests/lib/util/source-code-fixer.js
+++ b/tests/lib/util/source-code-fixer.js
@@ -203,6 +203,14 @@ describe("SourceCodeFixer", () => {
 
                 assert.equal(result.output, TEST_CODE);
             });
+
+            it("is called without access to internal eslint state", () => {
+                const shouldFixSpy = sinon.spy();
+
+                SourceCodeFixer.applyFixes(sourceCode, [INSERT_AT_START], shouldFixSpy);
+
+                assert.isUndefined(shouldFixSpy.thisValues[0]);
+            });
         });
 
         describe("Text Insertion", () => {

--- a/tests/lib/util/source-code-fixer.js
+++ b/tests/lib/util/source-code-fixer.js
@@ -173,7 +173,7 @@ describe("SourceCodeFixer", () => {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [INSERT_AT_END], false);
 
                 assert.isFalse(result.fixed);
-                assert.equal(result.output.length, 0);
+                assert.equal(result.output, sourceCode.text);
             });
 
             it("should call a function provided as 'shouldFix' for each message", () => {

--- a/tests/lib/util/source-code-fixer.js
+++ b/tests/lib/util/source-code-fixer.js
@@ -176,6 +176,12 @@ describe("SourceCodeFixer", () => {
                 assert.equal(result.output, sourceCode.text);
             });
 
+            it("Should perform fixes if 'shouldFix' is not provided", () => {
+                const result = SourceCodeFixer.applyFixes(sourceCode, [INSERT_AT_END]);
+
+                assert.isTrue(result.fixed);
+            });
+
             it("should call a function provided as 'shouldFix' for each message", () => {
                 const shouldFixSpy = sinon.spy();
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[X] Add something to the core
[ ] Other, please explain:

Closes #8039 

**What changes did you make? (Give an overview)**
The main change here is to allow the `fix` option of the CLIEngine to be either a boolean or now also a function which is given each linting message and is expected to return a boolean.  This will give users greater control over what kind of fixes are applied by ESLint.

**Is there anything you'd like reviewers to focus on?**
This may be somewhat incomplete.  I worked on it a few months ago, and then put it aside.  I've rebased on latest master and believe the happy path works correctly, but there may need to be more safety added around executing the function that is provided as the `fix` option, as right now all it does is check for truthiness of the return value (which is maybe fine, but is worth some consideration).

I'm happy to continue working on this to get it across the finish line, based on feedback from reviewers.  Or alternatively if anyone wants to jump in and take it over, I'm happy to turn it over as well.
