### PR TITLE
New: Override configFile entries by localConfigFile having "root": true

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -133,6 +133,7 @@ function getLocalConfig(thisConfig, directory) {
 
         // Check for root flag
         if (localConfig.root === true) {
+            thisConfig.hasRootConfigFile = true;
             break;
         }
     }
@@ -275,7 +276,15 @@ class Config {
         if (this.useSpecificConfig) {
             debug("Merging command line config file");
 
-            config = ConfigOps.merge(config, this.useSpecificConfig);
+            if (this.hasRootConfigFile) {
+
+                // Override or extend specific config settings with those found
+                // in a local file having "root": true.
+                config = ConfigOps.merge(this.useSpecificConfig, config);
+                this.hasRootConfigFile = false;
+            } else {
+                config = ConfigOps.merge(config, this.useSpecificConfig);
+            }
         }
 
         // Step 5: Merge in command line environments


### PR DESCRIPTION
I am new to the eslint so apologies if I've missed anything.

For now we can set specific [configFile](http://eslint.org/docs/developer-guide/nodejs-api#cliengine) to use and the **useEslintrc** option which is true by default. It allows us to use **configFile** as the base settings file for entire project and a local (.eslintrc, *.json, etc) file found in each of the project folders. The issue is that if any setting exists in both of the files then the local file setting will be overridden by the same setting in the base **configFile**. 

What I want to achieve is the other way round: the local **useEslintrc** file overrides the same settings in the **configFile**.

Read more: https://github.com/eslint/eslint/issues/8738
