### PR TITLE
Fix: don't pass default parserOptions to custom parsers (fixes #8744)

### DIFF
--- a/conf/default-config-options.js
+++ b/conf/default-config-options.js
@@ -25,9 +25,5 @@ module.exports = deepFreeze({
     rules: {},
     settings: {},
     parser: "espree",
-    parserOptions: {
-        ecmaVersion: 5,
-        sourceType: "script",
-        ecmaFeatures: {}
-    }
+    parserOptions: {}
 });

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -455,8 +455,8 @@ function normalizeEcmaVersion(ecmaVersion, isModule) {
  */
 function prepareConfig(config, envContext) {
     config.globals = config.globals || {};
-    const copiedRules = Object.assign({}, defaultConfig.rules);
-    let parserOptions = Object.assign({}, defaultConfig.parserOptions);
+    const copiedRules = {};
+    let parserOptions = {};
 
     if (typeof config.rules === "object") {
         Object.keys(config.rules).forEach(k => {

--- a/tests/fixtures/parsers/throws-with-options.js
+++ b/tests/fixtures/parsers/throws-with-options.js
@@ -1,0 +1,10 @@
+"use strict";
+
+const espree = require("espree");
+
+exports.parse = (sourceText, options) => {
+    if (options.ecmaVersion) {
+        throw new Error("Expected no parserOptions to be used");
+    }
+    return espree.parse(sourceText, options);
+};

--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -3905,6 +3905,13 @@ describe("eslint", () => {
                 assert.equal(messages[0].message, errorPrefix + require(parser).expectedError);
             });
 
+            it("should not pass any default parserOptions to the parser", () => {
+                const parser = path.join(parserFixtures, "throws-with-options.js");
+
+                const messages = linter.verify(";", { parser }, "filename");
+
+                assert.strictEqual(messages.length, 0);
+            });
         });
     }
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix (#8744)
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

afbea78d4b94839ec6d59d2c98321901aeb76313 accidentally introduced a regression where parsers would get passed additional "default" options even when the user did not specify them. This updates the default parserOptions to prevent any unexpected options from getting passed to parsers.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
