### PR TITLE
Fix: Add lastToken check at padding-line-between-statements

### DIFF
--- a/lib/rules/padding-line-between-statements.js
+++ b/lib/rules/padding-line-between-statements.js
@@ -93,7 +93,7 @@ function isBlockLikeStatement(sourceCode, node) {
 
     // Checks the last token is a closing brace of blocks.
     const lastToken = sourceCode.getLastToken(node, astUtils.isNotSemicolonToken);
-    const belongingNode = astUtils.isClosingBraceToken(lastToken)
+    const belongingNode = lastToken && astUtils.isClosingBraceToken(lastToken)
         ? sourceCode.getNodeByRangeIndex(lastToken.range[0])
         : null;
 

--- a/tests/lib/rules/padding-line-between-statements.js
+++ b/tests/lib/rules/padding-line-between-statements.js
@@ -2387,6 +2387,12 @@ ruleTester.run("padding-line-between-statements", rule, {
             options: [
                 { blankLine: "always", prev: "*", next: ["if", "for", "return", "switch", "case", "break", "throw", "while", "default"] }
             ]
+        },
+        {
+            code: "function test() {};",
+            options: [
+                { blankLine: "always", prev: "block-like", next: "block-like" }
+            ]
         }
     ],
     invalid: [


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment**

* **ESLint Version:** v4.0.0
* **Node Version:** v8.1.0
* **npm Version:** 5.0.3

**What parser (default, Babel-ESLint, etc.) are you using?**
 babel-eslint

**Please show your full configuration:**
```yaml
---
  extends: airbnb-base
  parser: babel-eslint

  settings:
    import/resolver:
      node:
        extensions:
          - .js
          - .ios.js
          - .androis.js
        moduleDirectory:
          - node_modules
          - js

  plugins:
    - babel
    - react
    - import

  parserOptions:
    ecmaVersion: 7
    sourceType: module
    ecmaFeatures:
      jsx: true
      modules: true

  env:
    es6: true
    node: true
    jest: true

  globals:
    __DEV__: true
    fetch: true
    XMLHttpRequest: true

  rules:
    import/no-unresolved:
      - 2
      - { ignore: [ '^[app]' ] }
    import/extensions: 0
    import/no-extraneous-dependencies: 0
    import/prefer-default-export: 0

    strict: [2, 'never']
    no-debugger: 2
    arrow-body-style: 0
    no-return-assign: 0
    no-plusplus: 0
    class-methods-use-this: 0
    no-underscore-dangle: 0

    brace-style:
      - 2
      - stroustrup
      - { allowSingleLine: true }

    template-curly-spacing: [2, 'always']
    array-bracket-spacing: [2, 'always']

    array-element-newline: [2, { multiline: true }]

    key-spacing:
      - 2
      -
        align:
          afterColon: true
          on: value

    padding-line-between-statements:
        - 2
        - { blankLine: 'always', prev: 'block-like', next: '*' }
        - { blankLine: 'always', prev: '*', next: 'block-like' }

        - { blankLine: 'always', prev: '*', next: 'return' }

        - { blankLine: 'always', prev: '*', next: 'function' }
        - { blankLine: 'always', prev: 'function', next: '*' }

        - { blankLine: 'always', prev: ['const', 'let', 'var'], next: '*'}
        - { blankLine: 'any', prev: ['const', 'let', 'var'], next: ['const', 'let', 'var']}
        - { blankLine: 'always', prev: 'expression', next: ['const', 'let', 'var']}

        - { blankLine: 'always', prev: 'import', next: '*'}
        - { blankLine: 'any', prev: 'import', next: 'import'}

    id-length:
      - 2
      - { properties: 'never', exceptions: ['x', 'y', 'i', '_', 'e'] }

    jsx-quotes: [2, 'prefer-single']
    react/jsx-filename-extension: 0
    react/prefer-stateless-function: 0
    react/jsx-uses-react: 2
    react/jsx-uses-vars: 2
    react/jsx-first-prop-new-line: [2, 'multiline']
    react/jsx-indent-props: [2, 2]
    react/react-in-jsx-scope: 2
    react/jsx-curly-spacing: [2, 'always']
    react/jsx-equals-spacing: [2, 'always']
    react/forbid-prop-types:
      - 2
      - forbid: ['any', 'array']
    react/sort-comp:
      - 2
      -
        groups:
          lifecycle:
            - displayName
            - propTypes
            - contextTypes
            - childContextTypes
            - mixins
            - statics
            - defaultProps
            - state
            - constructor
            - getDefaultProps
            - getInitialState
            - getChildContext
            - componentWillMount
            - componentDidMount
            - componentWillReceiveProps
            - shouldComponentUpdate
            - componentWillUpdate
            - componentDidUpdate
            - componentWillLeave
            - componentWillUnmount
```

**What did you do? Please include the actual source code causing the issue.**

```js
import AppNavigator from './AppNavigator';

const initialState = AppNavigator.router.getStateForAction(
  AppNavigator.router.getActionForPathAndParams('Login'),
);

export function reducer(state = initialState, action) {
  const nextState = AppNavigator.router.getStateForAction(action, state);

  return nextState || state;
}
```

**What did you expect to happen?**
I expected eslint to lint my code

**What actually happened? Please include the actual, raw output from ESLint.**

```
$(yarn bin)/eslint js/**/*.js *.js
Cannot read property 'value' of null
TypeError: Cannot read property 'value' of null
    at Object.isClosingBraceToken (/Users/outpunk/Code/App/node_modules/eslint/lib/ast-utils.js:364:17)
    at isBlockLikeStatement (/Users/outpunk/Code/App/node_modules/eslint/lib/rules/padding-line-between-statements.js:96:36)
    at Object.test (/Users/outpunk/Code/App/node_modules/eslint/lib/rules/padding-line-between-statements.js:331:37)
    at match (/Users/outpunk/Code/App/node_modules/eslint/lib/rules/padding-line-between-statements.js:473:41)
    at getPaddingType (/Users/outpunk/Code/App/node_modules/eslint/lib/rules/padding-line-between-statements.js:489:21)
    at Linter.verify (/Users/outpunk/Code/App/node_modules/eslint/lib/rules/padding-line-between-statements.js:551:30)
    at emitOne (events.js:115:13)
    at Linter.emit (events.js:210:7)
    at NodeEventGenerator.applySelector (/Users/outpunk/Code/App/node_modules/eslint/lib/util/node-event-generator.js:265:26)
    at NodeEventGenerator.applySelectors (/Users/outpunk/Code/App/node_modules/eslint/lib/util/node-event-generator.js:292:22)
```


<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

I have added check for null value of `lastToken` at `isBlockLikeStatement` in `lib/rules/padding-line-between-statements.js`


**Is there anything you'd like reviewers to focus on?**
No