### PR TITLE
Docs: describe how to use formatters on the formatter demo page

### DIFF
--- a/templates/formatter-examples.md.ejs
+++ b/templates/formatter-examples.md.ejs
@@ -6,6 +6,8 @@ layout: doc
 
 ESLint comes with several built-in formatters to control the appearance of the linting results, and supports third-party formatters as well.
 
+You can specify a formatter using the `--format` or `-f` flag on the command line. For example, `--format codeframe` uses the `codeframe` formatter.
+
 The built-in formatter options are:
 
 <% Object.keys(formatterResults).forEach(function(formatterName) { -%>


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates the autogenerated formatters page to describe how to use a formatter. Previously this could only be found in the CLI docs page, and was easy to miss.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
