### PR TITLE
Fix: fix indent errors on multiline destructure

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -945,36 +945,6 @@ module.exports = {
             return !node || node.range[0] === token.range[0];
         }
 
-        /**
-         * Check whether the given tokens are pairs of "{" and "}"
-         * @param {Token} openBraceToken is "[".
-         * @param {Token} closeBraceToken is "]".
-         * @returns {boolean} `true` if the two tokens are complementary pair
-         */
-        function isComplementBrace(openBraceToken, closeBraceToken) {
-            return astUtils.isOpeningBraceToken(openBraceToken) && astUtils.isClosingBraceToken(closeBraceToken);
-        }
-
-        /**
-         * Check whether the given tokens are pairs of "]" and "[", in reverse
-         * @param {Token} openBracketToken is "{".
-         * @param {Token} closeBracketToken is "}".
-         * @returns {boolean} `true` if the two tokens are complementary pair
-         */
-        function isComplementBracket(openBracketToken, closeBracketToken) {
-            return astUtils.isOpeningBracketToken(openBracketToken) && astUtils.isClosingBracketToken(closeBracketToken);
-        }
-
-        /**
-         * Check whether the given tokens are pairs of "{" and "}" or "]" and "["
-         * @param {Token} openToken is "{" or "[".
-         * @param {Token} closeToken is "}" or "]".
-         * @returns {boolean} `true` if the two tokens are complementary pair
-         */
-        function isComplementBraceOrBracket(openToken, closeToken) {
-            return isComplementBrace(openToken, closeToken) || isComplementBracket(openToken, closeToken);
-        }
-
         return {
             ArrayExpression: addArrayOrObjectIndent,
             ArrayPattern: addArrayOrObjectIndent,
@@ -1265,27 +1235,12 @@ module.exports = {
             VariableDeclarator(node) {
                 if (node.init) {
                     const equalOperator = sourceCode.getTokenBefore(node.init, astUtils.isNotOpeningParenToken);
-                    const tokenBeforeOperator = sourceCode.getTokenBefore(equalOperator);
                     const tokenAfterOperator = sourceCode.getTokenAfter(equalOperator);
 
-                    /**
-                    * For object and array destructuring that is used across lines
-                    * align the right side elements of the object or array with the equal sign
-                    */
-                    if (isComplementBraceOrBracket(tokenAfterOperator, tokenBeforeOperator)) {
-                        const closingToken = sourceCode.getLastToken(node);
-                        const inBetweenTokens = sourceCode.getTokensBetween(equalOperator, closingToken);
-
-                        inBetweenTokens.forEach(token => {
-                            offsets.matchIndentOf(equalOperator, token);
-                            offsets.ignoreToken(token);
-                        });
-                        offsets.matchIndentOf(tokenBeforeOperator, closingToken);
-                        offsets.ignoreToken(closingToken);
-                    }
                     offsets.ignoreToken(equalOperator);
                     offsets.ignoreToken(tokenAfterOperator);
                     offsets.matchIndentOf(equalOperator, tokenAfterOperator);
+                    offsets.matchIndentOf(sourceCode.getFirstToken(node), equalOperator);
                 }
             },
 

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -946,23 +946,33 @@ module.exports = {
         }
 
         /**
-         * Check whether the given tokens are pairs of "}" and "{", in reverse
-         * @param {Token} tokenBeforeOperator is "[".
-         * @param {Token} tokenAfterOperator is "]".
-         * @returns {boolean} `true` if the token is the first token of a statement.
+         * Check whether the given tokens are pairs of "{" and "}"
+         * @param {Token} openBraceToken is "[".
+         * @param {Token} closeBraceToken is "]".
+         * @returns {boolean} `true` if the two tokens are complementary pair
          */
-        function isReversedPairBrace(tokenBeforeOperator, tokenAfterOperator) {
-            return astUtils.isClosingBraceToken(tokenBeforeOperator) && astUtils.isOpeningBraceToken(tokenAfterOperator);
+        function isComplementBrace(openBraceToken, closeBraceToken) {
+            return astUtils.isOpeningBraceToken(openBraceToken) && astUtils.isClosingBraceToken(closeBraceToken);
         }
 
         /**
          * Check whether the given tokens are pairs of "]" and "[", in reverse
-         * @param {Token} tokenBeforeOperator is "{".
-         * @param {Token} tokenAfterOperator is "{".
-         * @returns {boolean} `true` if the token is the first token of a statement.
+         * @param {Token} openBracketToken is "{".
+         * @param {Token} closeBracketToken is "}".
+         * @returns {boolean} `true` if the two tokens are complementary pair
          */
-        function isReversedPairBracket(tokenBeforeOperator, tokenAfterOperator) {
-            return astUtils.isClosingBracketToken(tokenBeforeOperator) && astUtils.isOpeningBracketToken(tokenAfterOperator);
+        function isComplementBracket(openBracketToken, closeBracketToken) {
+            return astUtils.isOpeningBracketToken(openBracketToken) && astUtils.isClosingBracketToken(closeBracketToken);
+        }
+
+        /**
+         * Check whether the given tokens are pairs of "{" and "}" or "]" and "["
+         * @param {Token} openToken is "{" or "[".
+         * @param {Token} closeToken is "}" or "]".
+         * @returns {boolean} `true` if the two tokens are complementary pair
+         */
+        function isComplementBraceOrBracket(openToken, closeToken) {
+            return isComplementBrace(openToken, closeToken) || isComplementBracket(openToken, closeToken);
         }
 
         return {
@@ -1262,8 +1272,7 @@ module.exports = {
                     * For object and array destructuring that is used across lines
                     * align the right side elements of the object or array with the equal sign
                     */
-                    if (isReversedPairBrace(tokenBeforeOperator, tokenAfterOperator) ||
-                        isReversedPairBracket(tokenBeforeOperator, tokenAfterOperator)) {
+                    if (isComplementBraceOrBracket(tokenAfterOperator, tokenBeforeOperator)) {
                         const closingToken = sourceCode.getLastToken(node);
                         const inBetweenTokens = sourceCode.getTokensBetween(equalOperator, closingToken);
 

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -658,7 +658,6 @@ module.exports = {
                 while (astUtils.isOpeningParenToken(token) && token !== startToken) {
                     token = sourceCode.getTokenBefore(token);
                 }
-
                 return sourceCode.getTokenAfter(token);
             }
 
@@ -675,7 +674,6 @@ module.exports = {
             if (offset === "first" && elements.length && !elements[0]) {
                 return;
             }
-
             elements.forEach((element, index) => {
                 if (offset === "off") {
                     offsets.ignoreToken(getFirstToken(element));
@@ -945,6 +943,26 @@ module.exports = {
             node = node.parent;
 
             return !node || node.range[0] === token.range[0];
+        }
+
+        /**
+         * Check whether the given tokens are pairs of "}" and "{", in reverse
+         * @param {Token} tokenBeforeOperator is "[".
+         * @param {Token} tokenAfterOperator is "]".
+         * @returns {boolean} `true` if the token is the first token of a statement.
+         */
+        function isReversedPairBrace(tokenBeforeOperator, tokenAfterOperator) {
+            return astUtils.isClosingBraceToken(tokenBeforeOperator) && astUtils.isOpeningBraceToken(tokenAfterOperator);
+        }
+
+        /**
+         * Check whether the given tokens are pairs of "]" and "[", in reverse
+         * @param {Token} tokenBeforeOperator is "{".
+         * @param {Token} tokenAfterOperator is "{".
+         * @returns {boolean} `true` if the token is the first token of a statement.
+         */
+        function isReversedPairBracket(tokenBeforeOperator, tokenAfterOperator) {
+            return astUtils.isClosingBracketToken(tokenBeforeOperator) && astUtils.isOpeningBracketToken(tokenAfterOperator);
         }
 
         return {
@@ -1237,8 +1255,25 @@ module.exports = {
             VariableDeclarator(node) {
                 if (node.init) {
                     const equalOperator = sourceCode.getTokenBefore(node.init, astUtils.isNotOpeningParenToken);
+                    const tokenBeforeOperator = sourceCode.getTokenBefore(equalOperator);
                     const tokenAfterOperator = sourceCode.getTokenAfter(equalOperator);
 
+                    /**
+                    * For object and array destructuring that is used across lines
+                    * align the right side elements of the object or array with the equal sign
+                    */
+                    if (isReversedPairBrace(tokenBeforeOperator, tokenAfterOperator) ||
+                        isReversedPairBracket(tokenBeforeOperator, tokenAfterOperator)) {
+                        const closingToken = sourceCode.getLastToken(node);
+                        const inBetweenTokens = sourceCode.getTokensBetween(equalOperator, closingToken);
+
+                        inBetweenTokens.forEach(token => {
+                            offsets.matchIndentOf(equalOperator, token);
+                            offsets.ignoreToken(token);
+                        });
+                        offsets.matchIndentOf(tokenBeforeOperator, closingToken);
+                        offsets.ignoreToken(closingToken);
+                    }
                     offsets.ignoreToken(equalOperator);
                     offsets.ignoreToken(tokenAfterOperator);
                     offsets.matchIndentOf(equalOperator, tokenAfterOperator);

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -2043,16 +2043,6 @@ ruleTester.run("indent", rule, {
                 const {
                   a
                 } = {
-                    a: 1
-                  }
-            `,
-            options: [2]
-        },
-        {
-            code: unIndent`
-                const {
-                  a
-                } = {
                   a: 1
                 }
             `,
@@ -6875,6 +6865,24 @@ ruleTester.run("indent", rule, {
             `,
             options: [2],
             errors: expectedErrors([[2, 2, 0, "Identifier"], [4, 2, 4, "Identifier"], [5, 2, 6, "Identifier"], [6, 0, 2, "Punctuator"]])
+        },
+        {
+            code: unIndent`
+                const {
+                  a
+                } = {
+                    a: 1
+                  }
+            `,
+            output: unIndent`
+                const {
+                  a
+                } = {
+                  a: 1
+                }
+            `,
+            options: [2],
+            errors: expectedErrors([[4, 2, 4, "Identifier"], [5, 0, 2, "Punctuator"]])
         },
         {
             code: unIndent`

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -2026,7 +2026,18 @@ ruleTester.run("indent", rule, {
             `,
             options: [2]
         },
-        // VICTOR passes
+        {
+            code: unIndent`
+                const {
+                  a
+                }
+                =
+                {
+                  a: 1
+                }
+            `,
+            options: [2]
+        },
         {
             code: unIndent`
                 const {
@@ -2037,7 +2048,6 @@ ruleTester.run("indent", rule, {
             `,
             options: [2]
         },
-        // VICTOR fails
         {
             code: unIndent`
                 const {
@@ -2045,6 +2055,16 @@ ruleTester.run("indent", rule, {
                 } = {
                   a: 1
                 }
+            `,
+            options: [2]
+        },
+        {
+            code: unIndent`
+                const [
+                  a
+                ] = [
+                  1
+                ]
             `,
             options: [2]
         },

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -2050,6 +2050,26 @@ ruleTester.run("indent", rule, {
         },
         {
             code: unIndent`
+                const
+                  {
+                    a
+                  } = {
+                    a: 1
+                  };
+            `,
+            options: [2]
+        },
+        {
+            code: unIndent`
+                const
+                  foo = {
+                    bar: 1
+                  }
+            `,
+            options: [2]
+        },
+        {
+            code: unIndent`
                 const [
                   a
                 ] = [

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -2026,6 +2026,28 @@ ruleTester.run("indent", rule, {
             `,
             options: [2]
         },
+        // VICTOR passes
+        {
+            code: unIndent`
+                const {
+                  a
+                } = {
+                    a: 1
+                  }
+            `,
+            options: [2]
+        },
+        // VICTOR fails
+        {
+            code: unIndent`
+                const {
+                  a
+                } = {
+                  a: 1
+                }
+            `,
+            options: [2]
+        },
         {
 
             // https://github.com/eslint/eslint/issues/7233


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

**Tell us about your environment**

* **ESLint Version:4.0.0**
* **Node Version:6.9.5**
* **npm Version:3.10.10**

**What parser (default, Babel-ESLint, etc.) are you using?**
default
**Please show your full configuration:**

**What did you do? Please include the actual source code causing the issue.**
I have a fix for errors that were being reported on multiline destructure as reported in #8729 
I Added test cases for a bug where errors were reported on indentation on multiline destructure


**Is there anything you'd like reviewers to focus on?**
Not sure if my approach is correct. Any feedback is welcome.

