### PR TITLE
Chore: enable computed-property-spacing on ESLint codebase

### DIFF
--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -318,7 +318,7 @@ function getCacheFile(cacheFile, cwd) {
     cacheFile = path.normalize(cacheFile);
 
     const resolvedCacheFile = path.resolve(cwd, cacheFile);
-    const looksLikeADirectory = cacheFile[cacheFile.length - 1 ] === path.sep;
+    const looksLikeADirectory = cacheFile[cacheFile.length - 1] === path.sep;
 
     /**
      * return the name for the cache file in case the provided parameter is a directory

--- a/lib/code-path-analysis/code-path-state.js
+++ b/lib/code-path-analysis/code-path-state.js
@@ -240,7 +240,7 @@ class CodePathState {
         this.breakContext = null;
 
         this.currentSegments = [];
-        this.initialSegment = this.forkContext.head[ 0 ];
+        this.initialSegment = this.forkContext.head[0];
 
         // returnedSegments and thrownSegments push elements into finalSegments also.
         const final = this.finalSegments = [];

--- a/lib/config.js
+++ b/lib/config.js
@@ -198,7 +198,7 @@ class Config {
         this.useEslintrc = (options.useEslintrc !== false);
 
         this.env = (options.envs || []).reduce((envs, name) => {
-            envs[ name ] = true;
+            envs[name] = true;
             return envs;
         }, {});
 

--- a/packages/eslint-config-eslint/default.yml
+++ b/packages/eslint-config-eslint/default.yml
@@ -16,6 +16,7 @@ rules:
     comma-dangle: "error"
     comma-spacing: "error"
     comma-style: ["error", "last"]
+    computed-property-spacing: "error"
     consistent-return: "error"
     curly: ["error", "all"]
     default-case: "error"


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This enables `computed-property-spacing` on the ESLint codebase. We almost exclusively do not use spaces for computed properties, so I used the default `never` option.

**Is there anything you'd like reviewers to focus on?**

No