### PR TITLE
Chore: Only instantiate fileEntryCache when cache flage set (perf)

### DIFF
--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -398,15 +398,17 @@ class CLIEngine {
         this.options = options;
         this.linter = new Linter();
 
-        const cacheFile = getCacheFile(this.options.cacheLocation || this.options.cacheFile, this.options.cwd);
+        if (options.cache) {
+            const cacheFile = getCacheFile(this.options.cacheLocation || this.options.cacheFile, this.options.cwd);
 
-        /**
-         * Cache used to avoid operating on files that haven't changed since the
-         * last successful execution (e.g., file passed linting with no errors and
-         * no warnings).
-         * @type {Object}
-         */
-        this._fileCache = fileEntryCache.create(cacheFile);
+            /**
+             * Cache used to avoid operating on files that haven't changed since the
+             * last successful execution (e.g., file passed linting with no errors and
+             * no warnings).
+             * @type {Object}
+             */
+            this._fileCache = fileEntryCache.create(cacheFile);
+        }
 
         // load in additional rules
         if (this.options.rulePaths) {
@@ -495,6 +497,11 @@ class CLIEngine {
             fileCache = this._fileCache,
             configHelper = this.config;
         let prevConfig; // the previous configuration used
+        const cacheFile = getCacheFile(this.options.cacheLocation || this.options.cacheFile, this.options.cwd);
+
+        if (!options.cache && fs.existsSync(cacheFile)) {
+            fs.unlinkSync(cacheFile);
+        }
 
         /**
          * Calculates the hash of the config file used to validate a given file
@@ -570,8 +577,6 @@ class CLIEngine {
                     // move to the next file
                     return;
                 }
-            } else {
-                fileCache.destroy();
             }
 
             debug(`Processing ${filename}`);

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -1324,6 +1324,8 @@ describe("CLIEngine", () => {
             fakeFS.realpathSync = function() {
                 throw new Error("this error should not happen");
             };
+            fakeFS.existsSync = fs.existsSync;
+            fakeFS.unlinkSync = fs.unlinkSync;
 
             engine = new LocalCLIEngine({
                 ignorePattern: "tests"


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ x ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

* Only instantiate `fileEntryCache` class when the  `cache` flag is set inside `CLIEngine` constructor
* We were calling `file.distroy` after every file runn when the `cache: false`. Move that to only run once per `executeOnFiles`.

<details>
  <summary>Perf: Before</summary>
  <p>

```sh
Loading:
  Load performance Run #1:  205.960476ms
  Load performance Run #2:  208.34978ms
  Load performance Run #3:  218.538645ms
  Load performance Run #4:  227.442409ms
  Load performance Run #5:  214.86766ms

  Load Performance median:  214.86766ms


Single File:
  CPU Speed is 2394 with multiplier 13000000
  Performance Run #1:  5697.026135ms
  Performance Run #2:  5858.647406ms
  Performance Run #3:  5737.508751ms
  Performance Run #4:  5771.058235ms
  Performance Run #5:  5696.607034ms

  Performance budget exceeded: 5737.508751ms (limit: 5430.242272347536ms)


Multi Files (0 files):
  CPU Speed is 2394 with multiplier 39000000
  Performance Run #1:  14013.649444ms
  Performance Run #2:  14370.318308ms
  Performance Run #3:  14275.008692ms
  Performance Run #4:  14162.922197ms
  Performance Run #5:  14093.300495ms

  Performance budget ok:  14162.922197ms (limit: 16290.726817042607ms)
```

</p>
</details>


<details>
  <summary>Perf: After</summary>
  <p>

```sh
Loading:
  Load performance Run #1:  221.480052ms
  Load performance Run #2:  209.718274ms
  Load performance Run #3:  228.439271ms
  Load performance Run #4:  254.376935ms
  Load performance Run #5:  223.951894ms

  Load Performance median:  223.951894ms


Single File:
  CPU Speed is 2394 with multiplier 13000000
  Performance Run #1:  5810.71505ms
  Performance Run #2:  5655.586ms
  Performance Run #3:  5657.586994ms
  Performance Run #4:  5686.535773ms
  Performance Run #5:  5680.692304ms

  Performance budget exceeded: 5680.692304ms (limit: 5430.242272347536ms)


Multi Files (0 files):
  CPU Speed is 2394 with multiplier 39000000
  Performance Run #1:  13652.665121ms
  Performance Run #2:  14079.418835ms
  Performance Run #3:  14312.056817ms
  Performance Run #4:  13719.907353ms
  Performance Run #5:  14058.561277ms

  Performance budget ok:  14058.561277ms (limit: 16290.726817042607ms)
```

</p>
</details>

* Not much difference in numbers.
* I found this while I was trying to learn how to profile nodejs project on chrome. so I used `eslint` as example. 😄 

**Is there anything you'd like reviewers to focus on?**

Nothing specific.
