### PR TITLE
Fix: no-regex-spaces rule incorrectly fixes quantified spaces

### DIFF
--- a/lib/rules/no-regex-spaces.js
+++ b/lib/rules/no-regex-spaces.js
@@ -37,11 +37,11 @@ module.exports = {
          * @private
          */
         function checkRegex(node, value, valueStart) {
-            const multipleSpacesRegex = /( {2,})+?/,
+            const multipleSpacesRegex = /( {2,})+?( [+*{?]|[^+*{?])/,
                 regexResults = multipleSpacesRegex.exec(value);
 
             if (regexResults !== null) {
-                const count = regexResults[0].length;
+                const count = regexResults[1].length;
 
                 context.report({
                     node,

--- a/lib/rules/no-regex-spaces.js
+++ b/lib/rules/no-regex-spaces.js
@@ -37,7 +37,7 @@ module.exports = {
          * @private
          */
         function checkRegex(node, value, valueStart) {
-            const multipleSpacesRegex = /( {2,})+?( [+*{?]|[^+*{?])/,
+            const multipleSpacesRegex = /( {2,})( [+*{?]|[^+*{?]|$)/,
                 regexResults = multipleSpacesRegex.exec(value);
 
             if (regexResults !== null) {

--- a/tests/lib/rules/no-regex-spaces.js
+++ b/tests/lib/rules/no-regex-spaces.js
@@ -23,7 +23,8 @@ ruleTester.run("no-regex-spaces", rule, {
         "var foo = RegExp('bar\t\t\tbaz');",
         "var foo = new RegExp('bar\t\t\tbaz');",
         "var RegExp = function() {}; var foo = new RegExp('bar   baz');",
-        "var RegExp = function() {}; var foo = RegExp('bar   baz');"
+        "var RegExp = function() {}; var foo = RegExp('bar   baz');",
+        "var foo = /  +/;"
     ],
 
     invalid: [
@@ -67,6 +68,17 @@ ruleTester.run("no-regex-spaces", rule, {
                 {
                     message: "Spaces are hard to count. Use {4}.",
                     type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "var foo = /bar    ?baz/;",
+            output: "var foo = /bar {3} ?baz/;",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    message: "Spaces are hard to count. Use {3}.",
+                    type: "Literal"
                 }
             ]
         }

--- a/tests/lib/rules/no-regex-spaces.js
+++ b/tests/lib/rules/no-regex-spaces.js
@@ -74,11 +74,20 @@ ruleTester.run("no-regex-spaces", rule, {
         {
             code: "var foo = /bar    ?baz/;",
             output: "var foo = /bar {3} ?baz/;",
-            parserOptions: { ecmaVersion: 6 },
             errors: [
                 {
                     message: "Spaces are hard to count. Use {3}.",
                     type: "Literal"
+                }
+            ]
+        },
+        {
+            code: "var foo = new RegExp('bar    ');",
+            output: "var foo = new RegExp('bar {4}');",
+            errors: [
+                {
+                    message: "Spaces are hard to count. Use {4}.",
+                    type: "NewExpression"
                 }
             ]
         }


### PR DESCRIPTION
If the last space has a quantifer attached, that one should not be
considered.

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**Tell us about your environment**

* **ESLint Version:** latest
* **Node Version:** various
* **npm Version:** various

**What parser (default, Babel-ESLint, etc.) are you using?** default

**Please show your full configuration:**
```
{
  "rules": {
    "no-regex-spaces": "error"
  }
}
```

**What did you do? Please include the actual source code causing the issue.**
```
λ cat test.js
/  +/;

λ eslint --fix test.js
```


**What did you expect to happen?**

eslint to produce valid javascript

**What actually happened? Please include the actual, raw output from ESLint.**
```
λ eslint --fix test.js

/home/keri/projects/test/test.js
  1:2  error  Parsing error: Error parsing regular expression: Invalid regular expression: / {2}+/: Nothing to repeat

✖ 1 problem (1 error, 0 warnings)

λ cat test.js
/ {2}+/;

```

**What changes did you make? (Give an overview)**

I took the simplest option in this case: If there is a quantified space at the end of a string of spaces, ignore that space.
While it may have been better to analyse the quantifier and generate a new one accordingly, there are many cases that would need to be covered (see below) and I thought that would have been too complicated. Better to fix the bug first anyways.
`/  +/;` => `/ {2,}/;`
`/  */;` => `/ +/`;

Here's the original PR btw: https://github.com/eslint/eslint/pull/141/files

**Is there anything you'd like reviewers to focus on?**

no =]

