### PR TITLE
Fix: max-len and eslint-disable

### DIFF
--- a/lib/rules/max-len.js
+++ b/lib/rules/max-len.js
@@ -331,7 +331,7 @@ module.exports = {
                     if (lineLength > maxCommentLength) {
                         context.report({
                             node,
-                            loc: { line: lineNumber, column: 0 },
+                            loc: { line: lineNumber, column: line.match(/^\s*/)[0].length },
                             message: "Line {{lineNumber}} exceeds the maximum comment line length of {{maxCommentLength}}.",
                             data: {
                                 lineNumber: i + 1,
@@ -342,7 +342,7 @@ module.exports = {
                 } else if (lineLength > maxLength) {
                     context.report({
                         node,
-                        loc: { line: lineNumber, column: 0 },
+                        loc: { line: lineNumber, column: line.match(/^\s*/)[0].length },
                         message: "Line {{lineNumber}} exceeds the maximum line length of {{maxLength}}.",
                         data: {
                             lineNumber: i + 1,

--- a/tests/lib/rules/max-len.js
+++ b/tests/lib/rules/max-len.js
@@ -173,6 +173,15 @@ ruleTester.run("max-len", rule, {
         {
             code: "'🙂😀😆😎😊😜😉👍'",
             options: [10]
+        },
+
+        // eslint-enable edge cases
+        {
+            code: "/* eslint-disable */var x = y/* eslint-enable*/;",
+            options: [20]
+        }, {
+            code: "    /* eslint-disable */var x = y/* eslint-enable*/;",
+            options: [20]
         }
     ],
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**Tell us about your environment**

* **ESLint Version:** master (any)
* **Node Version:** v4.5.0 (doesn't matter)
* **npm Version:** v2.15.11 (doesn't matter)

**What parser (default, Babel-ESLint, etc.) are you using?** default (any)

**Please show your full configuration:**
```json
{ "rules": { "max-len": ["error", 20] } }
```

**What did you do? Please include the actual source code causing the issue.**
```js
    /* eslint-disable */var o123456789 = 'o123456789';
```

**What did you expect to happen?**

No error.

**What actually happened? Please include the actual, raw output from ESLint.**

Error reported.

Fixes #8778 