### PR TITLE
Update: Allow eslint-disable-line to be wrapper in BlockComment

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -311,6 +311,19 @@ function enableReporting(reportingConfig, start, rulesToEnable) {
 }
 
 /**
+ * Add data to reporting configuration to disable reporting for list of rules
+ * for specific line
+ * @param  {Object[]} reportingConfig Current reporting configuration
+ * @param  {number} line Line number to disable
+ * @param  {string[]} rulesToDisable List of rules
+ * @returns {void}
+ */
+function disableReportingAtLine(reportingConfig, line, rulesToDisable) {
+    disableReporting(reportingConfig, { line, column: 0 }, rulesToDisable);
+    enableReporting(reportingConfig, { line, column: Infinity }, rulesToDisable);
+}
+
+/**
  * Parses comments in file to extract file-specific config of rules, globals
  * and environments and merges them with global config; also code blocks
  * where reporting is disabled or enabled and merges them with reporting config.
@@ -363,6 +376,10 @@ function modifyConfigsFromComments(filename, ast, config, linterContext) {
                         enableReporting(reportingConfig, comment.loc.start, Object.keys(parseListConfig(value)));
                         break;
 
+                    case "eslint-disable-line":
+                        disableReportingAtLine(reportingConfig, comment.loc.start.line, Object.keys(parseListConfig(value)));
+                        break;
+
                     case "eslint": {
                         const items = parseJsonConfig(value, comment.loc, messages);
 
@@ -379,11 +396,9 @@ function modifyConfigsFromComments(filename, ast, config, linterContext) {
                 }
             } else { // comment.type === "Line"
                 if (match[1] === "eslint-disable-line") {
-                    disableReporting(reportingConfig, { line: comment.loc.start.line, column: 0 }, Object.keys(parseListConfig(value)));
-                    enableReporting(reportingConfig, comment.loc.end, Object.keys(parseListConfig(value)));
+                    disableReportingAtLine(reportingConfig, comment.loc.start.line, Object.keys(parseListConfig(value)));
                 } else if (match[1] === "eslint-disable-next-line") {
-                    disableReporting(reportingConfig, comment.loc.start, Object.keys(parseListConfig(value)));
-                    enableReporting(reportingConfig, { line: comment.loc.start.line + 2 }, Object.keys(parseListConfig(value)));
+                    disableReportingAtLine(reportingConfig, comment.loc.start.line + 1, Object.keys(parseListConfig(value)));
                 }
             }
         }

--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -2105,10 +2105,10 @@ describe("eslint", () => {
                 assert.equal(messages[0].ruleId, "no-alert");
             });
 
-            it("should report a violation", () => {
+            it("should not report a violation", () => {
                 const code = [
-                    "alert('test'); // eslint-disable-line no-alert",
-                    "alert('test'); /*eslint-disable-line no-alert*/" // here
+                    "alert('test'); /* eslint-disable-line no-alert */",
+                    "/*eslint-disable-line no-alert*/ alert('test');"
                 ].join("\n");
                 const config = {
                     rules: {
@@ -2118,9 +2118,7 @@ describe("eslint", () => {
 
                 const messages = linter.verify(code, config, filename);
 
-                assert.equal(messages.length, 1);
-
-                assert.equal(messages[0].ruleId, "no-alert");
+                assert.equal(messages.length, 0);
             });
 
             it("should not report a violation", () => {


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Allow to use `eslint-disable-line` in block-comment as it was in JSCS: `/* jscs:ignore */`.

**Is there anything you'd like reviewers to focus on?**

I've moved out a function for disabling line and feels like there were a bug in `eslint-disable-next-line` because it skipped errors for rules that reporting `column: 0` (like max-len or valid-jsdoc, etc.).

Fixes #8781