### PR TITLE
Docs: Remove wrong descriptions in `padded-block` rule

### DIFF
--- a/docs/rules/padded-blocks.md
+++ b/docs/rules/padded-blocks.md
@@ -24,8 +24,8 @@ This rule has one option, which can be a string option or an object option.
 
 String option:
 
-* `"always"` (default) requires empty lines at the beginning and ending of block statements (except `switch` statements and classes)
-* `"never"` disallows empty lines at the beginning and ending of block statements (except `switch` statements and classes)
+* `"always"` (default) requires empty lines at the beginning and ending of block statements
+* `"never"` disallows empty lines at the beginning and ending of block statements
 
 Object option:
 

--- a/docs/rules/padded-blocks.md
+++ b/docs/rules/padded-blocks.md
@@ -24,8 +24,8 @@ This rule has one option, which can be a string option or an object option.
 
 String option:
 
-* `"always"` (default) requires empty lines at the beginning and ending of block statements
-* `"never"` disallows empty lines at the beginning and ending of block statements
+* `"always"` (default) requires empty lines at the beginning and ending of block statements and classes
+* `"never"` disallows empty lines at the beginning and ending of block statements and classes
 
 Object option:
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Remove wrong descriptions from `padded-blocks.md`.

**Is there anything you'd like reviewers to focus on?**

Rule `padded-blocks` now enforces padding in class bodies and switch statements.

See: https://github.com/eslint/eslint/pull/8134


