### PR TITLE
Update: support more options in prefer-destructuring

### DIFF
--- a/docs/rules/prefer-destructuring.md
+++ b/docs/rules/prefer-destructuring.md
@@ -29,11 +29,15 @@ var foo = object.bar;
 
 ### Options
 
-This rule takes two sets of configuration objects; the first controls the types that the rule is applied to, and the second controls the way those objects are evaluated.
+This rule takes two sets of configuration objects. The first object parameter determines what types of destructuring the rule applies to.
 
-The first has two properties, `array` and `object`, which can be used to turn on or off the destructuring requirement for each of those types independently.  By default, both are `true`.
+The two properties, `array` and `object`, can be used to turn on or off the destructuring requirement for each of those types independently. By default, both are true.
 
-The second has a single property, `enforceForRenamedProperties`, that controls whether or not the `object` destructuring rules are applied in cases where the variable requires the property being access to be renamed.
+Alternatively, you can use separate configurations for different assignment types. It accepts 2 other keys instead of `array` and `object`.
+
+One key is `VariableDeclarator` and the other is `AssignmentExpression`, which can be used to control the destructuring requirement for each of those types independently. Each property accepts an object that accepts two properties, `array` and `object`, which can be used to control the destructuring requirement for each of `array` and `object` independently for variable declarations and assignment expressions.  By default, `array` and `object` are set to true for both `VariableDeclarator` and `AssignmentExpression`.
+
+The rule has a second object with a single key, `enforceForRenamedProperties`, which determines whether the `object` destructuring applies to renamed variables.
 
 Examples of **incorrect** code when `enforceForRenamedProperties` is enabled:
 
@@ -47,7 +51,7 @@ Examples of **correct** code when `enforceForRenamedProperties` is enabled:
 var { bar: foo } = object;
 ```
 
-An example configuration, with the defaults filled in, looks like this:
+An example configuration, with the defaults `array` and `object` filled in, looks like this:
 
 ```json
 {
@@ -55,6 +59,27 @@ An example configuration, with the defaults filled in, looks like this:
     "prefer-destructuring": ["error", {
       "array": true,
       "object": true
+    }, {
+      "enforceForRenamedProperties": false
+    }]
+  }
+}
+```
+
+An example configuration, with the defaults `VariableDeclarator` and `AssignmentExpression` filled in, looks like this:
+
+```json
+{
+  "rules": {
+    "prefer-destructuring": ["error", {
+      "VariableDeclarator": {
+        "array": false,
+        "object": true
+      },
+      "AssignmentExpression": {
+        "array": true,
+        "object": true
+      }
     }, {
       "enforceForRenamedProperties": false
     }]

--- a/docs/rules/prefer-destructuring.md
+++ b/docs/rules/prefer-destructuring.md
@@ -126,12 +126,14 @@ For example, the following configuration enforces object destructuring in variab
 Examples of **correct** code when object destructuring in `VariableDeclarator` is enforced:
 
 ```javascript
+/* eslint prefer-destructuring: ["error", {VariableDeclarator: {object: true}}] */
 var {bar: foo} = object;
 ```
 
 Examples of **correct** code when array destructuring in `AssignmentExpression` is enforced:
 
 ```javascript
+/* eslint prefer-destructuring: ["error", {AssignmentExpression: {array: true}}] */
 [bar] = array;
 ```
 

--- a/docs/rules/prefer-destructuring.md
+++ b/docs/rules/prefer-destructuring.md
@@ -4,6 +4,18 @@ With JavaScript ES6, a new syntax was added for creating variables from an array
 
 ## Rule Details
 
+### Options
+
+This rule takes two sets of configuration objects. The first object parameter determines what types of destructuring the rule applies to.
+
+The two properties, `array` and `object`, can be used to turn on or off the destructuring requirement for each of those types independently. By default, both are true.
+
+Alternatively, you can use separate configurations for different assignment types. It accepts 2 other keys instead of `array` and `object`.
+
+One key is `VariableDeclarator` and the other is `AssignmentExpression`, which can be used to control the destructuring requirement for each of those types independently. Each property accepts an object that accepts two properties, `array` and `object`, which can be used to control the destructuring requirement for each of `array` and `object` independently for variable declarations and assignment expressions.  By default, `array` and `object` are set to true for both `VariableDeclarator` and `AssignmentExpression`.
+
+The rule has a second object with a single key, `enforceForRenamedProperties`, which determines whether the `object` destructuring applies to renamed variables.
+
 Examples of **incorrect** code for this rule:
 
 ```javascript
@@ -26,18 +38,6 @@ var foo = array[someIndex];
 var { foo } = object;
 var foo = object.bar;
 ```
-
-### Options
-
-This rule takes two sets of configuration objects. The first object parameter determines what types of destructuring the rule applies to.
-
-The two properties, `array` and `object`, can be used to turn on or off the destructuring requirement for each of those types independently. By default, both are true.
-
-Alternatively, you can use separate configurations for different assignment types. It accepts 2 other keys instead of `array` and `object`.
-
-One key is `VariableDeclarator` and the other is `AssignmentExpression`, which can be used to control the destructuring requirement for each of those types independently. Each property accepts an object that accepts two properties, `array` and `object`, which can be used to control the destructuring requirement for each of `array` and `object` independently for variable declarations and assignment expressions.  By default, `array` and `object` are set to true for both `VariableDeclarator` and `AssignmentExpression`.
-
-The rule has a second object with a single key, `enforceForRenamedProperties`, which determines whether the `object` destructuring applies to renamed variables.
 
 Examples of **incorrect** code when `enforceForRenamedProperties` is enabled:
 
@@ -66,6 +66,18 @@ An example configuration, with the defaults `array` and `object` filled in, look
 }
 ```
 
+The two properties, `array` and `object`, which can be used to turn on or off the destructuring requirement for each of those types independently. By default, both are true.
+
+For example, the following configuration enforces only object destructuring, but not array destructuring:
+
+```json
+{
+  "rules": {
+    "prefer-destructuring": ["error", {"object": true, "array": false}]
+  }
+}
+```
+
 An example configuration, with the defaults `VariableDeclarator` and `AssignmentExpression` filled in, looks like this:
 
 ```json
@@ -85,6 +97,42 @@ An example configuration, with the defaults `VariableDeclarator` and `Assignment
     }]
   }
 }
+```
+
+The two properties, `VariableDeclarator` and `AssignmentExpression`, which can be used to turn on or off the destructuring requirement for `array` and `object`. By default, all values are true.
+
+For example, the following configuration enforces object destructuring in variable declarations and enforces array destructuring in assignment expressions.
+
+```json
+{
+  "rules": {
+    "prefer-destructuring": ["error", {
+      "VariableDeclarator": {
+        "array": false,
+        "object": true
+      },
+      "AssignmentExpression": {
+        "array": true,
+        "object": false
+      }
+    }, {
+      "enforceForRenamedProperties": false
+    }]
+  }
+}
+
+```
+
+Examples of **correct** code when object destructuring in `VariableDeclarator` is enforced:
+
+```javascript
+var {bar: foo} = object;
+```
+
+Examples of **correct** code when array destructuring in `AssignmentExpression` is enforced:
+
+```javascript
+[bar] = array;
 ```
 
 ## When Not To Use It

--- a/lib/rules/prefer-destructuring.js
+++ b/lib/rules/prefer-destructuring.js
@@ -15,19 +15,59 @@ module.exports = {
             category: "ECMAScript 6",
             recommended: false
         },
-
         schema: [
             {
-                type: "object",
-                properties: {
-                    array: {
-                        type: "boolean"
+
+                // old support {array: Boolean, object: Boolean}
+                // new support {VariableDeclarator: {}, AssignmentExpression: {}}
+                oneOf: [
+                    {
+                        type: "object",
+                        properties: {
+                            VariableDeclarator: {
+                                type: "object",
+                                properties: {
+                                    array: {
+                                        type: "boolean",
+                                        default: true
+                                    },
+                                    object: {
+                                        type: "boolean",
+                                        default: true
+                                    }
+                                },
+                                additionalProperties: false
+                            },
+                            AssignmentExpression: {
+                                type: "object",
+                                properties: {
+                                    array: {
+                                        type: "boolean",
+                                        default: true
+                                    },
+                                    object: {
+                                        type: "boolean",
+                                        default: true
+                                    }
+                                },
+                                additionalProperties: false
+                            }
+                        },
+                        additionalProperties: false
                     },
-                    object: {
-                        type: "boolean"
+                    {
+                        type: "object",
+                        properties: {
+                            array: {
+                                type: "boolean"
+                            },
+                            object: {
+                                type: "boolean"
+                            }
+                        },
+                        additionalProperties: false
                     }
-                },
-                additionalProperties: false
+                ]
             },
             {
                 type: "object",
@@ -42,20 +82,18 @@ module.exports = {
     },
     create(context) {
 
-        let checkArrays = true;
-        let checkObjects = true;
-        let enforceForRenamedProperties = false;
         const enabledTypes = context.options[0];
         const additionalOptions = context.options[1];
+        let enforceForRenamedProperties = false;
+        let normalizedOptions = {
+            VariableDeclarator: { array: true, object: true },
+            AssignmentExpression: { array: true, object: true }
+        };
 
         if (enabledTypes) {
-            if (typeof enabledTypes.array !== "undefined") {
-                checkArrays = enabledTypes.array;
-            }
-
-            if (typeof enabledTypes.object !== "undefined") {
-                checkObjects = enabledTypes.object;
-            }
+            normalizedOptions = typeof enabledTypes.array !== "undefined" || typeof enabledTypes.object !== "undefined"
+                ? { VariableDeclarator: enabledTypes, AssignmentExpression: enabledTypes }
+                : enabledTypes;
         }
 
         if (additionalOptions) {
@@ -69,7 +107,18 @@ module.exports = {
         //--------------------------------------------------------------------------
 
         /**
-         * Determines if the given node node is accessing an array index
+         * @param {string} nodeType "AssignmentExpression" or "VariableDeclarator"
+         * @param {string} destructuringType "array" or "object"
+         * @returns {boolean} `true` if the destructuring type should be checked for the given node
+         */
+        function shouldCheck(nodeType, destructuringType) {
+            return normalizedOptions &&
+                normalizedOptions[nodeType] &&
+                normalizedOptions[nodeType][destructuringType];
+        }
+
+        /**
+         * Determines if the given node is accessing an array index
          *
          * This is used to differentiate array index access from object property
          * access.
@@ -110,22 +159,26 @@ module.exports = {
             }
 
             if (isArrayIndexAccess(rightNode)) {
-                if (checkArrays) {
+                if ((shouldCheck("VariableDeclarator", "array") && reportNode.type === "VariableDeclarator") ||
+                    (shouldCheck("AssignmentExpression", "array") && reportNode.type === "AssignmentExpression")) {
                     report(reportNode, "array");
                 }
                 return;
             }
 
-            if (checkObjects && enforceForRenamedProperties) {
+            if (((shouldCheck("VariableDeclarator", "object") && reportNode.type === "VariableDeclarator") ||
+                (shouldCheck("AssignmentExpression", "object") && reportNode.type === "AssignmentExpression")) &&
+                enforceForRenamedProperties) {
                 report(reportNode, "object");
                 return;
             }
 
-            if (checkObjects) {
+            if ((shouldCheck("VariableDeclarator", "object") && reportNode.type === "VariableDeclarator") ||
+                (shouldCheck("AssignmentExpression", "object") && reportNode.type === "AssignmentExpression")) {
                 const property = rightNode.property;
 
-                if ((property.type === "Literal" && leftNode.name === property.value) ||
-                    (property.type === "Identifier" && leftNode.name === property.name)) {
+                if ((property.type === "Literal" && leftNode.name === property.value) || (property.type === "Identifier" &&
+                    leftNode.name === property.name)) {
                     report(reportNode, "object");
                 }
             }

--- a/lib/rules/prefer-destructuring.js
+++ b/lib/rules/prefer-destructuring.js
@@ -28,12 +28,10 @@ module.exports = {
                                 type: "object",
                                 properties: {
                                     array: {
-                                        type: "boolean",
-                                        default: true
+                                        type: "boolean"
                                     },
                                     object: {
-                                        type: "boolean",
-                                        default: true
+                                        type: "boolean"
                                     }
                                 },
                                 additionalProperties: false
@@ -42,12 +40,10 @@ module.exports = {
                                 type: "object",
                                 properties: {
                                     array: {
-                                        type: "boolean",
-                                        default: true
+                                        type: "boolean"
                                     },
                                     object: {
-                                        type: "boolean",
-                                        default: true
+                                        type: "boolean"
                                     }
                                 },
                                 additionalProperties: false
@@ -83,8 +79,7 @@ module.exports = {
     create(context) {
 
         const enabledTypes = context.options[0];
-        const additionalOptions = context.options[1];
-        let enforceForRenamedProperties = false;
+        const enforceForRenamedProperties = context.options[1] && context.options[1].enforceForRenamedProperties;
         let normalizedOptions = {
             VariableDeclarator: { array: true, object: true },
             AssignmentExpression: { array: true, object: true }
@@ -94,12 +89,6 @@ module.exports = {
             normalizedOptions = typeof enabledTypes.array !== "undefined" || typeof enabledTypes.object !== "undefined"
                 ? { VariableDeclarator: enabledTypes, AssignmentExpression: enabledTypes }
                 : enabledTypes;
-        }
-
-        if (additionalOptions) {
-            if (typeof additionalOptions.enforceForRenamedProperties !== "undefined") {
-                enforceForRenamedProperties = additionalOptions.enforceForRenamedProperties;
-            }
         }
 
         //--------------------------------------------------------------------------
@@ -159,22 +148,18 @@ module.exports = {
             }
 
             if (isArrayIndexAccess(rightNode)) {
-                if ((shouldCheck("VariableDeclarator", "array") && reportNode.type === "VariableDeclarator") ||
-                    (shouldCheck("AssignmentExpression", "array") && reportNode.type === "AssignmentExpression")) {
+                if (shouldCheck(reportNode.type, "array")) {
                     report(reportNode, "array");
                 }
                 return;
             }
 
-            if (((shouldCheck("VariableDeclarator", "object") && reportNode.type === "VariableDeclarator") ||
-                (shouldCheck("AssignmentExpression", "object") && reportNode.type === "AssignmentExpression")) &&
-                enforceForRenamedProperties) {
+            if (shouldCheck(reportNode.type, "object") && enforceForRenamedProperties) {
                 report(reportNode, "object");
                 return;
             }
 
-            if ((shouldCheck("VariableDeclarator", "object") && reportNode.type === "VariableDeclarator") ||
-                (shouldCheck("AssignmentExpression", "object") && reportNode.type === "AssignmentExpression")) {
+            if (shouldCheck(reportNode.type, "object")) {
                 const property = rightNode.property;
 
                 if ((property.type === "Literal" && leftNode.name === property.value) || (property.type === "Identifier" &&

--- a/tests/lib/rules/prefer-destructuring.js
+++ b/tests/lib/rules/prefer-destructuring.js
@@ -35,7 +35,17 @@ ruleTester.run("prefer-destructuring", rule, {
 
             // Ensure that the default behavior does not require desturcturing when renaming
             code: "var foo = object.bar;",
+            options: [{ VariableDeclarator: { object: true } }]
+        },
+        {
+
+            // Ensure that the default behavior does not require desturcturing when renaming
+            code: "var foo = object.bar;",
             options: [{ object: true }]
+        },
+        {
+            code: "var foo = object.bar;",
+            options: [{ VariableDeclarator: { object: true } }, { enforceForRenamedProperties: false }]
         },
         {
             code: "var foo = object.bar;",
@@ -43,7 +53,7 @@ ruleTester.run("prefer-destructuring", rule, {
         },
         {
             code: "var foo = object['bar'];",
-            options: [{ object: true }, { enforceForRenamedProperties: false }]
+            options: [{ VariableDeclarator: { object: true } }, { enforceForRenamedProperties: false }]
         },
         {
             code: "var foo = object[bar];",
@@ -51,7 +61,15 @@ ruleTester.run("prefer-destructuring", rule, {
         },
         {
             code: "var { bar: foo } = object;",
+            options: [{ VariableDeclarator: { object: true } }, { enforceForRenamedProperties: true }]
+        },
+        {
+            code: "var { bar: foo } = object;",
             options: [{ object: true }, { enforceForRenamedProperties: true }]
+        },
+        {
+            code: "var { [bar]: foo } = object;",
+            options: [{ VariableDeclarator: { object: true } }, { enforceForRenamedProperties: true }]
         },
         {
             code: "var { [bar]: foo } = object;",
@@ -59,18 +77,28 @@ ruleTester.run("prefer-destructuring", rule, {
         },
         {
             code: "var foo = array[0];",
+            options: [{ VariableDeclarator: { array: false } }]
+        },
+        {
+            code: "var foo = array[0];",
             options: [{ array: false }]
         },
         {
             code: "var foo = object.foo;",
-            options: [{ object: false }]
+            options: [{ VariableDeclarator: { object: false } }]
         },
         {
             code: "var foo = object['foo'];",
-            options: [{ object: false }]
+            options: [{ VariableDeclarator: { object: false } }]
         },
         {
             code: "({ foo } = object);"
+        },
+        {
+
+            // Fix #8654
+            code: "var foo = array[0];",
+            options: [{ VariableDeclarator: { array: false } }, { enforceForRenamedProperties: true }]
         },
         {
 
@@ -80,7 +108,39 @@ ruleTester.run("prefer-destructuring", rule, {
         },
         "[foo] = array;",
         "foo += array[0]",
-        "foo += bar.foo"
+        "foo += bar.foo",
+        {
+            code: "foo = object.foo;",
+            options: [{ AssignmentExpression: { object: false } }, { enforceForRenamedProperties: true }]
+        },
+        {
+            code: "foo = object.foo;",
+            options: [{ AssignmentExpression: { object: false } }, { enforceForRenamedProperties: false }]
+        },
+        {
+            code: "foo = array[0];",
+            options: [{ AssignmentExpression: { array: false } }, { enforceForRenamedProperties: true }]
+        },
+        {
+            code: "foo = array[0];",
+            options: [{ AssignmentExpression: { array: false } }, { enforceForRenamedProperties: false }]
+        },
+        {
+            code: "foo = array[0];",
+            options: [{ VariableDeclarator: { array: true }, AssignmentExpression: { array: false } }, { enforceForRenamedProperties: false }]
+        },
+        {
+            code: "var foo = array[0];",
+            options: [{ VariableDeclarator: { array: false }, AssignmentExpression: { array: true } }, { enforceForRenamedProperties: false }]
+        },
+        {
+            code: "foo = object.foo;",
+            options: [{ VariableDeclarator: { object: true }, AssignmentExpression: { object: false } }]
+        },
+        {
+            code: "var foo = object.foo;",
+            options: [{ VariableDeclarator: { object: false }, AssignmentExpression: { object: true } }]
+        }
     ],
 
     invalid: [
@@ -107,7 +167,23 @@ ruleTester.run("prefer-destructuring", rule, {
         },
         {
             code: "var foobar = object.bar;",
+            options: [{ VariableDeclarator: { object: true } }, { enforceForRenamedProperties: true }],
+            errors: [{
+                message: "Use object destructuring.",
+                type: "VariableDeclarator"
+            }]
+        },
+        {
+            code: "var foobar = object.bar;",
             options: [{ object: true }, { enforceForRenamedProperties: true }],
+            errors: [{
+                message: "Use object destructuring.",
+                type: "VariableDeclarator"
+            }]
+        },
+        {
+            code: "var foo = object[bar];",
+            options: [{ VariableDeclarator: { object: true } }, { enforceForRenamedProperties: true }],
             errors: [{
                 message: "Use object destructuring.",
                 type: "VariableDeclarator"
@@ -122,21 +198,90 @@ ruleTester.run("prefer-destructuring", rule, {
             }]
         },
         {
-            code: "var foo = array['foo'];",
+            code: "var foo = object['foo'];",
             errors: [{
                 message: "Use object destructuring.",
                 type: "VariableDeclarator"
             }]
         },
         {
-            code: "foo = array.foo;",
+            code: "foo = object.foo;",
             errors: [{
                 message: "Use object destructuring.",
                 type: "AssignmentExpression"
             }]
         },
         {
-            code: "foo = array['foo'];",
+            code: "foo = object['foo'];",
+            errors: [{
+                message: "Use object destructuring.",
+                type: "AssignmentExpression"
+            }]
+        },
+        {
+            code: "var foo = array[0];",
+            options: [{ VariableDeclarator: { array: true } }, { enforceForRenamedProperties: true }],
+            errors: [{
+                message: "Use array destructuring.",
+                type: "VariableDeclarator"
+            }]
+        },
+        {
+            code: "foo = array[0];",
+            options: [{ AssignmentExpression: { array: true } }],
+            errors: [{
+                message: "Use array destructuring.",
+                type: "AssignmentExpression"
+            }]
+        },
+        {
+            code: "var foo = array[0];",
+            options: [
+                {
+                    VariableDeclarator: { array: true },
+                    AssignmentExpression: { array: false }
+                },
+                { enforceForRenamedProperties: true }
+            ],
+            errors: [{
+                message: "Use array destructuring.",
+                type: "VariableDeclarator"
+            }]
+        },
+        {
+            code: "var foo = array[0];",
+            options: [
+                {
+                    VariableDeclarator: { array: true },
+                    AssignmentExpression: { array: false }
+                }
+            ],
+            errors: [{
+                message: "Use array destructuring.",
+                type: "VariableDeclarator"
+            }]
+        },
+        {
+            code: "foo = array[0];",
+            options: [
+                {
+                    VariableDeclarator: { array: false },
+                    AssignmentExpression: { array: true }
+                }
+            ],
+            errors: [{
+                message: "Use array destructuring.",
+                type: "AssignmentExpression"
+            }]
+        },
+        {
+            code: "foo = object.foo;",
+            options: [
+                {
+                    VariableDeclarator: { array: true, object: false },
+                    AssignmentExpression: { object: true }
+                }
+            ],
             errors: [{
                 message: "Use object destructuring.",
                 type: "AssignmentExpression"


### PR DESCRIPTION
[X ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))


**What rule do you want to change?**
prefer-destructuring.js
This pr is in reference to the issue #7886 

**Does this change cause the rule to produce more or fewer warnings?**
less warnings since you have more flexibility to control destructuring errors.

**How will the change be implemented? (New option, new default behavior, etc.)?**
The first parameter of destructuring has been updated to also take a VariableDeclarator value or an AssignmentExpression value. Each value takes an object that takes an object of optional keys array and/or object.

The old parameters of  {object: Boolean, array: Boolean} is still supported

**Please provide some example code that this change will affect:**

```json
{
  "rules": {
    "prefer-destructuring": ["error", {
      "VariableDeclaration": {
        "array": false,
        "object": true
      },
     "AssignmentExpression": {
        "array": true,
        "object": true
      }
    }, {
      "enforceForRenamedProperties": false
    }]
  }
}
```

**What does the rule currently do for this code?**
In the above example, prefer-destructuring will be enforced for variable declarations from objects but not from arrays. Prefer-destructuring will be enforced for assignment expressions for both arrays and objects

**What will the rule do after it's changed?**
It will let users have more flexibility and control over when prefer-destructuring should be enforced.

