### PR TITLE
Build: fix race condition in demo

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -758,13 +758,12 @@ target.browserify = function() {
 
     // 5. browserify the temp directory
     nodeCLI.exec("browserify", "-x espree", `${TEMP_DIR}linter.js`, "-o", `${BUILD_DIR}eslint.js`, "-s eslint", "--global-transform [ babelify --presets [ es2015 ] ]");
-    nodeCLI.exec("browserify", "-x espree", `${TEMP_DIR}rules.js`, "-o", `${TEMP_DIR}rules.js`, "-s rules", "--global-transform [ babelify --presets [ es2015 ] ]");
 
     // 6. Browserify espree
     nodeCLI.exec("browserify", "-r espree", "-o", `${TEMP_DIR}espree.js`);
 
     // 7. Concatenate Babel polyfill, Espree, and ESLint files together
-    cat("./node_modules/babel-polyfill/dist/polyfill.js", `${TEMP_DIR}espree.js`, `${BUILD_DIR}eslint.js`, `${TEMP_DIR}rules.js`).to(`${BUILD_DIR}eslint.js`);
+    cat("./node_modules/babel-polyfill/dist/polyfill.js", `${TEMP_DIR}espree.js`, `${BUILD_DIR}eslint.js`).to(`${BUILD_DIR}eslint.js`);
 
     // 8. remove temp directory
     rm("-r", TEMP_DIR);


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (fixes https://github.com/eslint/eslint.github.io/issues/363)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Since 3ec436eeed0b0271e2ed0d0cb22e4246eb15f137 was committed, the demo at http://eslint.org/demo has occasionally failed to load properly -- see https://github.com/eslint/eslint.github.io/issues/363 for more details. It appears that the issue was caused by a change to the build process in that commit which involved placing two browserified modules in the same bundle file. Based on https://github.com/eslint/eslint/pull/8465#discussion_r117091971 this was changed in order to pass the tests in karma, but the tests seem to pass without the change.

I'm not exactly sure what the root cause of the issue is. It only occurs when an unrelated file is loaded by requirejs after the eslint bundle, and that unrelated load files. My best guess at the moment is that requirejs was only able to infer the module name of the eslint bundle correctly when it contained a single anonymous module. When it contained two anonymous modules, requirejs couldn't infer their names, so it threw an error if there were no more modules to load after that. Depending on the state of the browser cache and the network, there would only sometimes be another module left to load after loading the eslint bundle, so this led to seemingly random errors in the demo.

**Is there anything you'd like reviewers to focus on?**

If anyone knows the root cause of the issue, I'd be interested to hear it.

Also cc @gyandeeps to make sure I'm not breaking anything from https://github.com/eslint/eslint/pull/8465#discussion_r117091971.