### PR TITLE
Fix: arrow-parens fixer gets tripped up with trailing comma in args

### DIFF
--- a/lib/rules/arrow-parens.js
+++ b/lib/rules/arrow-parens.js
@@ -66,13 +66,10 @@ module.exports = {
              */
             function fixParamsWithParenthesis(fixer) {
                 const paramToken = sourceCode.getTokenAfter(firstTokenOfParam);
-                let closingParenToken = sourceCode.getTokenAfter(paramToken);
 
                 // ES8 allows Trailing commas in function parameter lists and calls
                 // https://github.com/eslint/eslint/issues/8834
-                if (closingParenToken.value === ",") {
-                    closingParenToken = sourceCode.getTokenAfter(closingParenToken);
-                }
+                const closingParenToken = sourceCode.getTokenAfter(paramToken, astUtils.isClosingParenToken);
                 const asyncToken = isAsync ? sourceCode.getTokenBefore(firstTokenOfParam) : null;
                 const shouldAddSpaceForAsync = asyncToken && (asyncToken.end === firstTokenOfParam.start);
 

--- a/lib/rules/arrow-parens.js
+++ b/lib/rules/arrow-parens.js
@@ -66,7 +66,13 @@ module.exports = {
              */
             function fixParamsWithParenthesis(fixer) {
                 const paramToken = sourceCode.getTokenAfter(firstTokenOfParam);
-                const closingParenToken = sourceCode.getTokenAfter(paramToken);
+                let closingParenToken = sourceCode.getTokenAfter(paramToken);
+
+                // ES8 allows Trailing commas in function parameter lists and calls
+                // https://github.com/eslint/eslint/issues/8834
+                if (closingParenToken.value === ",") {
+                    closingParenToken = sourceCode.getTokenAfter(closingParenToken);
+                }
                 const asyncToken = isAsync ? sourceCode.getTokenBefore(firstTokenOfParam) : null;
                 const shouldAddSpaceForAsync = asyncToken && (asyncToken.end === firstTokenOfParam.start);
 

--- a/tests/lib/rules/arrow-parens.js
+++ b/tests/lib/rules/arrow-parens.js
@@ -165,6 +165,18 @@ const invalid = [
         }]
     },
     {
+        code: "(a,) => a",
+        output: "a => a",
+        options: ["as-needed"],
+        parserOptions: { ecmaVersion: 8 },
+        errors: [{
+            line: 1,
+            column: 1,
+            message: asNeededMessage,
+            type
+        }]
+    },
+    {
         code: "async (a) => a",
         output: "async a => a",
         options: ["as-needed"],


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
fixes #8834 

**Is there anything you'd like reviewers to focus on?**


