### PR TITLE
Fix: EmptyStatements in padding-line-between-statements (fixes #8839)

### DIFF
--- a/lib/rules/padding-line-between-statements.js
+++ b/lib/rules/padding-line-between-statements.js
@@ -91,6 +91,11 @@ function isBlockLikeStatement(sourceCode, node) {
         return true;
     }
 
+    // https://github.com/eslint/eslint/issues/8839
+    if (node.type === "EmptyStatement") {
+        return false;
+    }
+
     // Checks the last token is a closing brace of blocks.
     const lastToken = sourceCode.getLastToken(node, astUtils.isNotSemicolonToken);
     const belongingNode = astUtils.isClosingBraceToken(lastToken)

--- a/tests/lib/rules/padding-line-between-statements.js
+++ b/tests/lib/rules/padding-line-between-statements.js
@@ -2387,6 +2387,50 @@ ruleTester.run("padding-line-between-statements", rule, {
             options: [
                 { blankLine: "always", prev: "*", next: ["if", "for", "return", "switch", "case", "break", "throw", "while", "default"] }
             ]
+        },
+
+        // https://github.com/eslint/eslint/issues/8839
+        {
+            code: "function test() {}",
+            options: [
+                { blankLine: "always", prev: "block-like", next: "block-like" }
+            ]
+        },
+        {
+            code: "function test() {};",
+            options: [
+                { blankLine: "always", prev: "block-like", next: "block-like" }
+            ]
+        },
+        {
+            code: "function test() {}\n\n;",
+            options: [
+                { blankLine: "always", prev: "block-like", next: "*" }
+            ]
+        },
+        {
+            code: "function test() {};",
+            options: [
+                { blankLine: "never", prev: "block-like", next: "*" }
+            ]
+        },
+        {
+            code: "function test() {};",
+            options: [
+                { blankLine: "always", prev: "empty", next: "*" }
+            ]
+        },
+        {
+            code: "function test() {}; {var test2;}",
+            options: [
+                { blankLine: "never", prev: "empty", next: "*" }
+            ]
+        },
+        {
+            code: "function test() {}; {var test2;}",
+            options: [
+                { blankLine: "never", prev: "empty", next: "block-like" }
+            ]
         }
     ],
     invalid: [
@@ -4438,6 +4482,68 @@ ruleTester.run("padding-line-between-statements", rule, {
             errors: [
                 MESSAGE_ALWAYS,
                 MESSAGE_ALWAYS,
+                MESSAGE_ALWAYS
+            ]
+        },
+
+        // https://github.com/eslint/eslint/issues/8839
+        {
+            code: "function test() {}\n\n;",
+            output: "function test() {}\n;",
+            options: [
+                { blankLine: "never", prev: "block-like", next: "*" }
+            ],
+            errors: [
+                MESSAGE_NEVER
+            ]
+        },
+        {
+            code: "function test() {}\n\n;",
+            output: "function test() {}\n;",
+            options: [
+                { blankLine: "never", prev: "block-like", next: "empty" }
+            ],
+            errors: [
+                MESSAGE_NEVER
+            ]
+        },
+        {
+            code: "function test() {};",
+            output: "function test() {}\n\n;",
+            options: [
+                { blankLine: "always", prev: "block-like", next: "*" }
+            ],
+            errors: [
+                MESSAGE_ALWAYS
+            ]
+        },
+        {
+            code: "function test() {};",
+            output: "function test() {}\n\n;",
+            options: [
+                { blankLine: "always", prev: "block-like", next: "empty" }
+            ],
+            errors: [
+                MESSAGE_ALWAYS
+            ]
+        },
+        {
+            code: "function test() {};{var test2;}",
+            output: "function test() {};\n\n{var test2;}",
+            options: [
+                { blankLine: "always", prev: "empty", next: "*" }
+            ],
+            errors: [
+                MESSAGE_ALWAYS
+            ]
+        },
+        {
+            code: "function test() {};{var test2;}",
+            output: "function test() {};\n\n{var test2;}",
+            options: [
+                { blankLine: "always", prev: "empty", next: "block-like" }
+            ],
+            errors: [
                 MESSAGE_ALWAYS
             ]
         }


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Handle `EmptyStatements` correctly - currently, the code will error while checking if it is a block-like statement.

**Is there anything you'd like reviewers to focus on?**
Nothing in particular.

