### PR TITLE
Update: allow sync operation at root level (fixes: #7985)

### DIFF
--- a/lib/rules/no-sync.js
+++ b/lib/rules/no-sync.js
@@ -58,15 +58,16 @@ module.exports = {
         function reportIfSyncInFunction(node) {
             if (allowAtRootLevel) {
                 if (setOfSyncExpressions.size > 0) {
-                    const syncExpression = setOfSyncExpressions.values().next().value;
-
-                    context.report({
-                        node,
-                        message: "Unexpected sync method: '{{propertyName}}'.",
-                        data: {
-                            propertyName: syncExpression.property.name
-                        }
+                    setOfSyncExpressions.forEach(syncExpression => {
+                        context.report({
+                            node,
+                            message: "Unexpected sync method: '{{propertyName}}'.",
+                            data: {
+                                propertyName: syncExpression.property.name
+                            }
+                        });
                     });
+
                 }
                 setOfSyncExpressions.clear();
                 setOfSyncExpressions = stackOfSyncExpressions.pop();

--- a/lib/rules/no-sync.js
+++ b/lib/rules/no-sync.js
@@ -19,22 +19,78 @@ module.exports = {
             recommended: false
         },
 
-        schema: []
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    allowAtRootLevel: {
+                        type: "boolean"
+                    }
+                },
+                additionalProperties: false
+            }
+        ]
     },
 
     create(context) {
+        const allowAtRootLevel = context.options[0] ? context.options[0].allowAtRootLevel : false;
+        const stackOfSyncExpressions = [];
+        let setOfSyncExpressions = new Set();
+
+        /**
+         * push Sync Expression sets and track Sync Expressions in a new set
+         *
+         * @returns {void}
+         */
+        function trackSyncExpression() {
+            if (allowAtRootLevel) {
+                stackOfSyncExpressions.push(setOfSyncExpressions);
+                setOfSyncExpressions = new Set();
+            }
+        }
+
+        /**
+         * Report if the Sync Expression is not in the root level
+         *
+         * @param {ASTNode} node the FunctionDeclaration/Expression node
+         * @returns {void}
+         */
+        function reportIfSyncInFunction(node) {
+            if (allowAtRootLevel) {
+                if (setOfSyncExpressions.size > 0) {
+                    const syncExpression = setOfSyncExpressions.values().next().value;
+
+                    context.report({
+                        node,
+                        message: "Unexpected sync method: '{{propertyName}}'.",
+                        data: {
+                            propertyName: syncExpression.property.name
+                        }
+                    });
+                }
+                setOfSyncExpressions.clear();
+                setOfSyncExpressions = stackOfSyncExpressions.pop();
+            }
+        }
 
         return {
-
             "MemberExpression[property.name=/.*Sync$/]"(node) {
-                context.report({
-                    node,
-                    message: "Unexpected sync method: '{{propertyName}}'.",
-                    data: {
-                        propertyName: node.property.name
-                    }
-                });
-            }
+                if (allowAtRootLevel) {
+                    setOfSyncExpressions.add(node);
+                } else {
+                    context.report({
+                        node,
+                        message: "Unexpected sync method: '{{propertyName}}'.",
+                        data: {
+                            propertyName: node.property.name
+                        }
+                    });
+                }
+            },
+            FunctionDeclaration: trackSyncExpression,
+            "FunctionDeclaration:exit": reportIfSyncInFunction,
+            FunctionExpression: trackSyncExpression,
+            "FunctionExpression:exit": reportIfSyncInFunction
         };
 
     }

--- a/lib/rules/no-sync.js
+++ b/lib/rules/no-sync.js
@@ -33,65 +33,20 @@ module.exports = {
     },
 
     create(context) {
-        const allowAtRootLevel = context.options[0] ? context.options[0].allowAtRootLevel : false;
-        const stackOfSyncExpressions = [];
-        let setOfSyncExpressions = new Set();
-
-        /**
-         * push Sync Expression sets and track Sync Expressions in a new set
-         *
-         * @returns {void}
-         */
-        function trackSyncExpression() {
-            if (allowAtRootLevel) {
-                stackOfSyncExpressions.push(setOfSyncExpressions);
-                setOfSyncExpressions = new Set();
-            }
-        }
-
-        /**
-         * Report if the Sync Expression is not in the root level
-         *
-         * @param {ASTNode} node the FunctionDeclaration/Expression node
-         * @returns {void}
-         */
-        function reportIfSyncInFunction(node) {
-            if (allowAtRootLevel) {
-                if (setOfSyncExpressions.size > 0) {
-                    setOfSyncExpressions.forEach(syncExpression => {
-                        context.report({
-                            node,
-                            message: "Unexpected sync method: '{{propertyName}}'.",
-                            data: {
-                                propertyName: syncExpression.property.name
-                            }
-                        });
-                    });
-
-                }
-                setOfSyncExpressions.clear();
-                setOfSyncExpressions = stackOfSyncExpressions.pop();
-            }
-        }
+        const selector = context.options[0] && context.options[0].allowAtRootLevel
+            ? ":function MemberExpression[property.name=/.*Sync$/]"
+            : "MemberExpression[property.name=/.*Sync$/]";
 
         return {
-            "MemberExpression[property.name=/.*Sync$/]"(node) {
-                if (allowAtRootLevel) {
-                    setOfSyncExpressions.add(node);
-                } else {
-                    context.report({
-                        node,
-                        message: "Unexpected sync method: '{{propertyName}}'.",
-                        data: {
-                            propertyName: node.property.name
-                        }
-                    });
-                }
-            },
-            FunctionDeclaration: trackSyncExpression,
-            "FunctionDeclaration:exit": reportIfSyncInFunction,
-            FunctionExpression: trackSyncExpression,
-            "FunctionExpression:exit": reportIfSyncInFunction
+            [selector](node) {
+                context.report({
+                    node,
+                    message: "Unexpected sync method: '{{propertyName}}'.",
+                    data: {
+                        propertyName: node.property.name
+                    }
+                });
+            }
         };
 
     }

--- a/tests/lib/rules/no-sync.js
+++ b/tests/lib/rules/no-sync.js
@@ -30,8 +30,8 @@ ruleTester.run("no-sync", rule, {
         { code: "if (true) {fs.fooSync();}", errors: [{ message: "Unexpected sync method: 'fooSync'.", type: "MemberExpression" }] },
         { code: "var foo = fs.fooSync;", errors: [{ message: "Unexpected sync method: 'fooSync'.", type: "MemberExpression" }] },
         { code: "function someFunction() {fs.fooSync();}", errors: [{ message: "Unexpected sync method: 'fooSync'.", type: "MemberExpression" }] },
-        { code: "function someFunction() {fs.fooSync();}", options: [{ allowAtRootLevel: true }], errors: [{ message: "Unexpected sync method: 'fooSync'.", type: "FunctionDeclaration" }] },
-        { code: "var a = function someFunction() {fs.fooSync();}", options: [{ allowAtRootLevel: true }], errors: [{ message: "Unexpected sync method: 'fooSync'.", type: "FunctionExpression" }] }
+        { code: "function someFunction() {fs.fooSync();}", options: [{ allowAtRootLevel: true }], errors: [{ message: "Unexpected sync method: 'fooSync'.", type: "MemberExpression" }] },
+        { code: "var a = function someFunction() {fs.fooSync();}", options: [{ allowAtRootLevel: true }], errors: [{ message: "Unexpected sync method: 'fooSync'.", type: "MemberExpression" }] }
 
     ]
 });

--- a/tests/lib/rules/no-sync.js
+++ b/tests/lib/rules/no-sync.js
@@ -20,10 +20,16 @@ const ruleTester = new RuleTester();
 
 ruleTester.run("no-sync", rule, {
     valid: [
-        "var foo = fs.foo.foo();"
+        "var foo = fs.foo.foo();",
+        { code: "var foo = fs.fooSync;", options: [{ allowAtRootLevel: true }] }
     ],
     invalid: [
         { code: "var foo = fs.fooSync();", errors: [{ message: "Unexpected sync method: 'fooSync'.", type: "MemberExpression" }] },
-        { code: "var foo = fs.fooSync;", errors: [{ message: "Unexpected sync method: 'fooSync'.", type: "MemberExpression" }] }
+        { code: "var foo = fs.fooSync();", options: [{ allowAtRootLevel: false }], errors: [{ message: "Unexpected sync method: 'fooSync'.", type: "MemberExpression" }] },
+        { code: "var foo = fs.fooSync;", errors: [{ message: "Unexpected sync method: 'fooSync'.", type: "MemberExpression" }] },
+        { code: "function someFunction() {fs.fooSync();}", errors: [{ message: "Unexpected sync method: 'fooSync'.", type: "MemberExpression" }] },
+        { code: "function someFunction() {fs.fooSync();}", options: [{ allowAtRootLevel: true }], errors: [{ message: "Unexpected sync method: 'fooSync'.", type: "FunctionDeclaration" }] },
+        { code: "var a = function someFunction() {fs.fooSync();}", options: [{ allowAtRootLevel: true }], errors: [{ message: "Unexpected sync method: 'fooSync'.", type: "FunctionExpression" }] }
+
     ]
 });

--- a/tests/lib/rules/no-sync.js
+++ b/tests/lib/rules/no-sync.js
@@ -21,11 +21,13 @@ const ruleTester = new RuleTester();
 ruleTester.run("no-sync", rule, {
     valid: [
         "var foo = fs.foo.foo();",
-        { code: "var foo = fs.fooSync;", options: [{ allowAtRootLevel: true }] }
+        { code: "var foo = fs.fooSync;", options: [{ allowAtRootLevel: true }] },
+        { code: "if (true) {fs.fooSync();}", options: [{ allowAtRootLevel: true }] },
     ],
     invalid: [
         { code: "var foo = fs.fooSync();", errors: [{ message: "Unexpected sync method: 'fooSync'.", type: "MemberExpression" }] },
         { code: "var foo = fs.fooSync();", options: [{ allowAtRootLevel: false }], errors: [{ message: "Unexpected sync method: 'fooSync'.", type: "MemberExpression" }] },
+        { code: "if (true) {fs.fooSync();}", errors: [{ message: "Unexpected sync method: 'fooSync'.", type: "MemberExpression" }] },
         { code: "var foo = fs.fooSync;", errors: [{ message: "Unexpected sync method: 'fooSync'.", type: "MemberExpression" }] },
         { code: "function someFunction() {fs.fooSync();}", errors: [{ message: "Unexpected sync method: 'fooSync'.", type: "MemberExpression" }] },
         { code: "function someFunction() {fs.fooSync();}", options: [{ allowAtRootLevel: true }], errors: [{ message: "Unexpected sync method: 'fooSync'.", type: "FunctionDeclaration" }] },

--- a/tests/lib/rules/no-sync.js
+++ b/tests/lib/rules/no-sync.js
@@ -22,7 +22,7 @@ ruleTester.run("no-sync", rule, {
     valid: [
         "var foo = fs.foo.foo();",
         { code: "var foo = fs.fooSync;", options: [{ allowAtRootLevel: true }] },
-        { code: "if (true) {fs.fooSync();}", options: [{ allowAtRootLevel: true }] },
+        { code: "if (true) {fs.fooSync();}", options: [{ allowAtRootLevel: true }] }
     ],
     invalid: [
         { code: "var foo = fs.fooSync();", errors: [{ message: "Unexpected sync method: 'fooSync'.", type: "MemberExpression" }] },


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))

**What rule do you want to change?**
This address issues #7985 
This update lets the no-sync rule take an option parameter allowAtRootLevel: boolean that will allow sync operations at the root level.

**Does this change cause the rule to produce more or fewer warnings?**
less errors since it is making the rule more lenient.

**How will the change be implemented? (New option, new default behavior, etc.)?**
New option

**Please provide some example code that this change will affect:**

```js
<!-- example code here -->
//no-sync: [1, { allowAtRootLevel: true }]

// good
const contents = fs.readFileSync('/super/important.txt')

// bad
function someFunction() {
    fs.readFileSync('file.txt'); // very clearly not root of module
}

```

**What does the rule currently do for this code?**
If sync operations are found, it reports

**What will the rule do after it's changed?**
if allowAtRootLevel:true is used, no errors will be reported for sync operations at the root level. If functions are at in function declaration/ function expressions and sync operations are inside, it will be reported