### PR TITLE
Chore: fix title of linter test suite

### DIFF
--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -71,7 +71,7 @@ function getVariable(scope, name) {
 // Tests
 //------------------------------------------------------------------------------
 
-describe("linter", () => {
+describe("Linter", () => {
     const filename = "filename.js";
     let sandbox, linter;
 

--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -71,7 +71,7 @@ function getVariable(scope, name) {
 // Tests
 //------------------------------------------------------------------------------
 
-describe("eslint", () => {
+describe("linter", () => {
     const filename = "filename.js";
     let sandbox, linter;
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

The `linter` test suite was mistakenly still called "eslint" from when lib/linter.js was called lib/eslint.js. This renames the test suite to call it "linter" instead.

**Is there anything you'd like reviewers to focus on?**

No
