### PR TITLE
Update: fix indentation of EmptyStatements (fixes #8882)

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -825,7 +825,7 @@ module.exports = {
                  */
                 const lastToken = sourceCode.getLastToken(node);
 
-                if (astUtils.isSemicolonToken(lastToken)) {
+                if (node.type !== "EmptyStatement" && astUtils.isSemicolonToken(lastToken)) {
                     offsets.matchIndentOf(lastParentToken, lastToken);
                 }
             }

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -3344,6 +3344,12 @@ ruleTester.run("indent", rule, {
             `
         },
         {
+            code: unIndent`
+                if (foo)
+                    ;
+            `
+        },
+        {
             code: "x => {}"
         },
         {
@@ -8027,6 +8033,17 @@ ruleTester.run("indent", rule, {
                 ; [1, 2, 3].map(baz)
             `,
             errors: expectedErrors([3, 0, 4, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                if (foo)
+                ;
+            `,
+            output: unIndent`
+                if (foo)
+                    ;
+            `,
+            errors: expectedErrors([2, 4, 0, "Punctuator"])
         },
         {
             code: unIndent`


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (https://github.com/eslint/eslint/issues/8882)

**What changes did you make? (Give an overview)**

The `indent` rule contains some logic to ensure that semicolons at the start of a line are indented correctly when using semicolon-free style. For example, in the following code the semicolon on the second line is not indented, even though it's part of the `bar()` statement.

```js
if (foo) bar()
; [1, 2, 3].map(foo)
```

Due to a bug, this logic also applied to semicolons in `EmptyStatement` nodes, resulting in an incorrect indentation for those semicolons. This commit fixes that bug.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular