### PR TITLE
Fix: Throw error if plugins from config is not an array.

### DIFF
--- a/lib/config/plugins.js
+++ b/lib/config/plugins.js
@@ -156,8 +156,20 @@ class Plugins {
      * @param {string[]} pluginNames An array of plugins names.
      * @returns {void}
      * @throws {Error} If a plugin cannot be loaded.
+     * @throws {Error} If "plugins" in config is not an array
      */
     loadAll(pluginNames) {
+
+        // if "plugins" in config is not an array, throw an error so user can fix their config.
+        if (!Array.isArray(pluginNames)) {
+            const pluginNotArrayMessage = "ESLint configuration error: \"plugins\" value must be an array";
+
+            debug(`${pluginNotArrayMessage}: ${JSON.stringify(pluginNames)}`);
+
+            throw new Error(pluginNotArrayMessage);
+        }
+
+        // load each plugin by name
         pluginNames.forEach(this.load, this);
     }
 }

--- a/tests/lib/config/plugins.js
+++ b/tests/lib/config/plugins.js
@@ -236,6 +236,10 @@ describe("Plugins", () => {
             assert.equal(rules.get("example2/bar"), plugin2.rules.bar);
         });
 
+        it("should throw an error if plugins is not an array", () => {
+            assert.throws(() => StubbedPlugins.loadAll("example1"), "\"plugins\" value must be an array");
+        });
+
     });
 
     describe("removePrefix()", () => {


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] Other, please explain:

I'm throwing an Error if the plugins set doesn't match expected input type.  This isn't a bug necessarily, but it's something I've ran into multiple times on multiple projects where I initially tried to pass in a string (with one plugin name) instead of an array.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

I'm throwing an Error with a detailed error message if the user has a config with `plugins` as anything other than an array (which is expected).

**Is there anything you'd like reviewers to focus on?**

I have both a `debug(/* ... */)` statement and throwing an error.  I'm not sure if that's the expected convention, but I tried to do similar to what's happening in other parts of the same `plugins.js` file.  Build passes and tests pass.