### PR TITLE
Update: fix indentation of nested function parameters (fixes #8892)

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -750,7 +750,7 @@ module.exports = {
                     const firstTokenOfPreviousElement = previousElement && getFirstToken(previousElement);
 
                     if (previousElement && sourceCode.getLastToken(previousElement).loc.start.line > startToken.loc.end.line) {
-                        offsets.matchIndentOf(firstTokenOfPreviousElement, getFirstToken(element));
+                        offsets.setDesiredOffsets(getTokensAndComments(element), firstTokenOfPreviousElement, 0);
                     }
                 }
             });

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -1472,6 +1472,27 @@ ruleTester.run("indent", rule, {
         },
         {
             code: unIndent`
+                [[
+                ], function(
+                    foo
+                ) {}
+                ]
+            `
+        },
+        {
+            code: unIndent`
+                define([
+                    'foo'
+                ], function(
+                    bar
+                ) {
+                    baz;
+                }
+                )
+            `
+        },
+        {
+            code: unIndent`
                 const func = function (opts) {
                     return Promise.resolve()
                     .then(() => {
@@ -5587,6 +5608,46 @@ ruleTester.run("indent", rule, {
                 [4, 4, 9, "String"],
                 [5, 0, 2, "Punctuator"]
             ])
+        },
+        {
+            code: unIndent`
+                [[
+                ], function(
+                        foo
+                    ) {}
+                ]
+            `,
+            output: unIndent`
+                [[
+                ], function(
+                    foo
+                ) {}
+                ]
+            `,
+            errors: expectedErrors([[3, 4, 8, "Identifier"], [4, 0, 4, "Punctuator"]])
+        },
+        {
+            code: unIndent`
+                define([
+                    'foo'
+                ], function(
+                        bar
+                    ) {
+                    baz;
+                }
+                )
+            `,
+            output: unIndent`
+                define([
+                    'foo'
+                ], function(
+                    bar
+                ) {
+                    baz;
+                }
+                )
+            `,
+            errors: expectedErrors([[4, 4, 8, "Identifier"], [5, 0, 4, "Punctuator"]])
         },
         {
             code: unIndent`


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (https://github.com/eslint/eslint/issues/8892)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Previously, the `indent` rule would only offset the first token of an element in a list (e.g. an array). However, this was incorrect because the other tokens of the element might not depend on the indentation of the first token. For example, in a function expression, the indentation of the parens does not depend on the indentation of the `function` token. This commit updates the `indent` rule to correctly offset all of the tokens in the element.


**Is there anything you'd like reviewers to focus on?**

Nothing in particular