### PR TITLE
Chore: remove unused helper method from `indent`

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -386,18 +386,6 @@ class OffsetStorage {
     getFirstDependency(token) {
         return this.desiredOffsets[token.range[0]].from;
     }
-
-    /**
-     * Increases the offset for a token from its parent by the given amount
-     * @param {Token} token The token whose offset should be increased
-     * @param {number} amount The number of indent levels that the offset should increase by
-     * @returns {void}
-     */
-    increaseOffset(token, amount) {
-        const currentOffsetInfo = this.desiredOffsets[token.range[0]];
-
-        this.desiredOffsets[token.range[0]] = { offset: currentOffsetInfo.offset + amount, from: currentOffsetInfo.from };
-    }
 }
 
 const ELEMENT_LIST_SCHEMA = {


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

The `OffsetStorage#increaseOffset` method for the `indent` rule is no longer used anywhere. This commit removes it.

**Is there anything you'd like reviewers to focus on?**

No