### PR TITLE
Docs: fix verifyAndFix result property name

### DIFF
--- a/docs/developer-guide/nodejs-api.md
+++ b/docs/developer-guide/nodejs-api.md
@@ -167,7 +167,7 @@ Output object from this method:
 ```js
 {
     fixed: true,
-    text: "var foo;",
+    output: "var foo;",
     messages: []
 }
 ```
@@ -175,7 +175,7 @@ Output object from this method:
 The information available is:
 
 * `fixed` - True, if the code was fixed.
-* `text` - Fixed code text (might be the same as input if no fixes were applied).
+* `output` - Fixed code text (might be the same as input if no fixes were applied).
 * `messages` - Collection of all messages for the given code (It has the same information as explained above under `verify` block).
 
 ## linter


### PR DESCRIPTION

<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X ] Documentation update

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Not sure whether it's a docs error or API error, but `verifyAndFix` in `eslint 4.2` returns fixed code in `output` property, not in the `text`.

**Is there anything you'd like reviewers to focus on?**


