### PR TITLE
Docs: Fix always-multiline example in multiline-ternary docs

### DIFF
--- a/docs/rules/multiline-ternary.md
+++ b/docs/rules/multiline-ternary.md
@@ -68,7 +68,7 @@ foo > bar ?
 Examples of **incorrect** code for this rule with the `"always-multiline"` option:
 
 ```js
-/*eslint multiline-ternary: ["error", "always"]*/
+/*eslint multiline-ternary: ["error", "always-multiline"]*/
 
 foo > bar ? value1 :
     value2;
@@ -83,7 +83,7 @@ foo > bar &&
 Examples of **correct** code for this rule with the `"always-multiline"` option:
 
 ```js
-/*eslint multiline-ternary: ["error", "always"]*/
+/*eslint multiline-ternary: ["error", "always-multiline"]*/
 
 foo > bar ? value1 : value2;
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update

**What changes did you make? (Give an overview)**

The [`multiline-ternary`](http://eslint.org/docs/rules/multiline-ternary) docs had the wrong configuration in the `always-multiline` example (I copy-pasted and forgot to change it in #8841). This fixes the docs to use the right option in the example.