### PR TITLE
Docs: add description of no-sync `allowAtRootLevel` option (fixes #8902)

### DIFF
--- a/docs/rules/no-sync.md
+++ b/docs/rules/no-sync.md
@@ -6,17 +6,23 @@ In Node.js, most I/O is done through asynchronous methods. However, there are of
 
 This rule is aimed at preventing synchronous methods from being called in Node.js. It looks specifically for the method suffix "`Sync`" (as is the convention with Node.js operations).
 
-Examples of **incorrect** code for this rule:
+## Options
+
+This rule has an optional object option `{ allowAtRootLevel: <boolean> }`, which determines whether synchronous methods should be allowed at the top level of a file, outside of any functions. This option defaults to `false`.
+
+Examples of **incorrect** code for this rule with the default `{ allowAtRootLevel: false }` option:
 
 ```js
 /*eslint no-sync: "error"*/
 
 fs.existsSync(somePath);
 
-var contents = fs.readFileSync(somePath).toString();
+function foo() {
+  var contents = fs.readFileSync(somePath).toString();
+}
 ```
 
-Examples of **correct** code for this rule:
+Examples of **correct** code for this rule with the default `{ allowAtRootLevel: false }` option:
 
 ```js
 /*eslint no-sync: "error"*/
@@ -28,6 +34,26 @@ async(function() {
 });
 ```
 
+Examples of **incorrect** code for this rule with the `{ allowAtRootLevel: true }` option
+
+```js
+/*eslint no-sync: ["error", { allowAtRootLevel: true }]*/
+
+function foo() {
+  var contents = fs.readFileSync(somePath).toString();
+}
+
+var bar = baz => fs.readFileSync(qux);
+```
+
+Examples of **correct** code for this rule with the `{ allowAtRootLevel: true }` option
+
+```js
+/*eslint no-sync: ["error", { allowAtRootLevel: true }]*/
+
+fs.readFileSync(somePath).toString();
+```
+
 ## When Not To Use It
 
-If you want to allow synchronous operations in your script.
+If you want to allow synchronous operations in your script, do not enable this rule.


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update (https://github.com/eslint/eslint/issues/8902)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This adds documentation for the `allowAtRootLevel` option for `no-sync`, which was added in 3767cda2f58472ed3397ac188a71262a7b111c4b.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
