### PR TITLE
Chore: fix misleading `indent` test

### DIFF
--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -4453,15 +4453,17 @@ ruleTester.run("indent", rule, {
             // Multiline ternary
             // (multiline JSX, colon on its own line)
             code: unIndent`
-                {!foo ?
-                    <Foo
-                        onClick={this.onClick}
-                    />
-                    :
-                    <Bar
-                        onClick={this.onClick}
-                    />
-                }
+                <div>
+                    {!foo ?
+                        <Foo
+                            onClick={this.onClick}
+                        />
+                        :
+                        <Bar
+                            onClick={this.onClick}
+                        />
+                    }
+                </div>
             `
         },
         {


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This fixes an `indent` test that was intended to contain a `JSXExpressionContainer`, but actually contained a `BlockStatement`.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
