### PR TITLE
Chore: update header info in `indent`

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -1,7 +1,7 @@
 /**
  * @fileoverview This option sets a specific tab width for your code
  *
- * This rule has been ported and modified from nodeca.
+ * @author Teddy Katz
  * @author Vitaly Puzrin
  * @author Gyandeep Singh
  */


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

The header of the `indent` rule says "ported from nodeca", but there isn't anything left in the rule that actually came from nodeca, so the line is probably more misleading than useful for people reading the file.

**Is there anything you'd like reviewers to focus on?**

No
