### PR TITLE
Update: fix indentation of parenthesized MemberExpressions (fixes #8924)

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -1217,7 +1217,7 @@ module.exports = {
                 const firstNonObjectToken = sourceCode.getFirstTokenBetween(node.object, node.property, astUtils.isNotClosingParenToken);
                 const secondNonObjectToken = sourceCode.getTokenAfter(firstNonObjectToken);
 
-                const objectParenCount = sourceCode.getTokensBetween(node.object, node.property).findIndex(astUtils.isNotClosingParenToken);
+                const objectParenCount = sourceCode.getTokensBetween(node.object, node.property, { filter: astUtils.isClosingParenToken }).length;
                 const firstObjectToken = objectParenCount
                     ? sourceCode.getTokenBefore(node.object, { skip: objectParenCount - 1 })
                     : sourceCode.getFirstToken(node.object);

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -1217,8 +1217,10 @@ module.exports = {
                 const firstNonObjectToken = sourceCode.getFirstTokenBetween(node.object, node.property, astUtils.isNotClosingParenToken);
                 const secondNonObjectToken = sourceCode.getTokenAfter(firstNonObjectToken);
 
-                const tokenBeforeObject = sourceCode.getTokenBefore(node.object, token => astUtils.isNotOpeningParenToken(token) || parameterParens.has(token));
-                const firstObjectToken = tokenBeforeObject ? sourceCode.getTokenAfter(tokenBeforeObject) : sourceCode.ast.tokens[0];
+                const objectParenCount = sourceCode.getTokensBetween(node.object, node.property).findIndex(astUtils.isNotClosingParenToken);
+                const firstObjectToken = objectParenCount
+                    ? sourceCode.getTokenBefore(node.object, { skip: objectParenCount - 1 })
+                    : sourceCode.getFirstToken(node.object);
                 const lastObjectToken = sourceCode.getTokenBefore(firstNonObjectToken);
                 const firstPropertyToken = node.computed ? firstNonObjectToken : secondNonObjectToken;
 

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -1882,6 +1882,14 @@ ruleTester.run("indent", rule, {
         },
         {
             code: unIndent`
+                (
+                    (foo.bar)
+                )
+                    .baz
+            `
+        },
+        {
+            code: unIndent`
                 MemberExpression
                 .can
                   .be

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -1824,6 +1824,56 @@ ruleTester.run("indent", rule, {
         },
         {
             code: unIndent`
+                (
+                    foo
+                        .bar
+                )
+            `
+        },
+        {
+            code: unIndent`
+                (
+                    (
+                        foo
+                            .bar
+                    )
+                )
+            `
+        },
+        {
+            code: unIndent`
+                (
+                    foo
+                )
+                    .bar
+            `
+        },
+        {
+            code: unIndent`
+                (
+                    (
+                        foo
+                    )
+                        .bar
+                )
+            `
+        },
+        {
+            code: unIndent`
+                (
+                    (
+                        foo
+                    )
+                        [
+                            (
+                                bar
+                            )
+                        ]
+                )
+            `
+        },
+        {
+            code: unIndent`
                 MemberExpression
                 .can
                   .be
@@ -5199,6 +5249,21 @@ ruleTester.run("indent", rule, {
             errors: expectedErrors(
                 [3, 8, 10, "Punctuator"]
             )
+        },
+        {
+            code: unIndent`
+                (
+                    foo
+                    .bar
+                )
+            `,
+            output: unIndent`
+                (
+                    foo
+                        .bar
+                )
+            `,
+            errors: expectedErrors([3, 8, 4, "Punctuator"])
         },
         {
             code: unIndent`

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -1874,6 +1874,14 @@ ruleTester.run("indent", rule, {
         },
         {
             code: unIndent`
+                (
+                    foo[bar]
+                )
+                    .baz
+            `
+        },
+        {
+            code: unIndent`
                 MemberExpression
                 .can
                   .be


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (https://github.com/eslint/eslint/issues/8924)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

The MemberExpression listener in `indent` contains some logic to ensure that if the object of a MemberExpression is wrapped in parentheses, the property is offset from the opening paren, not the object itself. Due to a bug, this logic also caused the property to be offset from the opening paren if the entire MemberExpression was wrapped in parentheses, raather than just the object. This commit updates the MemberExpression listener to specifically check for parentheses around the object, not the entire MemberExpression.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
