### PR TITLE
Update: fix BinaryExpression indentation edge case (fixes #8914)

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -896,27 +896,6 @@ module.exports = {
         }
 
         /**
-        * Adds indentation for the right-hand side of binary/logical expressions.
-        * @param {ASTNode} node A BinaryExpression or LogicalExpression node
-        * @returns {void}
-        */
-        function addBinaryOrLogicalExpressionIndent(node) {
-            const operator = sourceCode.getFirstTokenBetween(node.left, node.right, token => token.value === node.operator);
-
-            /*
-             * For backwards compatibility, don't check BinaryExpression indents, e.g.
-             * var foo = bar &&
-             *                   baz;
-             */
-
-            const tokenAfterOperator = sourceCode.getTokenAfter(operator);
-
-            offsets.ignoreToken(operator);
-            offsets.ignoreToken(tokenAfterOperator);
-            offsets.setDesiredOffsets([operator.range[1], node.range[1]], tokenAfterOperator, 1);
-        }
-
-        /**
         * Checks the indentation for nodes that are like function calls (`CallExpression` and `NewExpression`)
         * @param {ASTNode} node A CallExpression or NewExpression node
         * @returns {void}
@@ -1077,7 +1056,22 @@ module.exports = {
                 offsets.ignoreToken(sourceCode.getTokenAfter(operator));
             },
 
-            BinaryExpression: addBinaryOrLogicalExpressionIndent,
+            "BinaryExpression, LogicalExpression"(node) {
+                const operator = sourceCode.getFirstTokenBetween(node.left, node.right, token => token.value === node.operator);
+
+                /*
+                * For backwards compatibility, don't check BinaryExpression indents, e.g.
+                * var foo = bar &&
+                *                   baz;
+                */
+
+                const tokenAfterOperator = sourceCode.getTokenAfter(operator);
+
+                offsets.ignoreToken(operator);
+                offsets.ignoreToken(tokenAfterOperator);
+                offsets.setDesiredOffset(tokenAfterOperator, operator, 0);
+                offsets.setDesiredOffsets([tokenAfterOperator.range[1], node.range[1]], tokenAfterOperator, 1);
+            },
 
             BlockStatement: addBlockIndent,
 
@@ -1210,8 +1204,6 @@ module.exports = {
                     offsets.setDesiredOffsets([fromToken.range[0], node.range[1]], sourceCode.getFirstToken(node), 1);
                 }
             },
-
-            LogicalExpression: addBinaryOrLogicalExpressionIndent,
 
             "MemberExpression, JSXMemberExpression"(node) {
                 const firstNonObjectToken = sourceCode.getFirstTokenBetween(node.object, node.property, astUtils.isNotClosingParenToken);

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -2753,6 +2753,22 @@ ruleTester.run("indent", rule, {
         },
         {
             code: unIndent`
+                foo
+                    || (
+                        bar
+                    )
+            `
+        },
+        {
+            code: unIndent`
+                foo
+                                || (
+                                    bar
+                                )
+            `
+        },
+        {
+            code: unIndent`
                 var foo =
                         1;
             `,
@@ -7423,6 +7439,21 @@ ruleTester.run("indent", rule, {
                 ]
             `,
             errors: expectedErrors([3, 0, 4, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                foo
+                        || (
+                                bar
+                            )
+            `,
+            output: unIndent`
+                foo
+                        || (
+                            bar
+                        )
+            `,
+            errors: expectedErrors([[3, 12, 16, "Identifier"], [4, 8, 12, "Punctuator"]])
         },
         {
             code: unIndent`


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (https://github.com/eslint/eslint/issues/8914)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This fixes an issue where the indentation of the right-hand side of a `BinaryExpression` did not depend on the indentation of the operator. This could result in a situation where the rule would verify the absolute indentation of a node within the BinaryExpression, rather than the relative indentation from the operator.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular