### PR TITLE
Fix: Avoid shell mangling during eslint --init

### DIFF
--- a/lib/util/npm-util.js
+++ b/lib/util/npm-util.js
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 const fs = require("fs"),
-    childProcess = require("child_process"),
+    spawn = require("cross-spawn"),
     path = require("path"),
     log = require("../logging");
 
@@ -50,10 +50,10 @@ function findPackageJson(startDir) {
  * @returns {void}
  */
 function installSyncSaveDev(packages) {
-    if (Array.isArray(packages)) {
-        packages = packages.join(" ");
+    if (!Array.isArray(packages)) {
+        packages = [packages];
     }
-    childProcess.execSync(`npm i --save-dev ${packages}`, { stdio: "inherit", encoding: "utf8" });
+    spawn.sync("npm", ["i", "--save-dev"].concat(packages), { stdio: "inherit" });
 }
 
 /**
@@ -62,10 +62,11 @@ function installSyncSaveDev(packages) {
  * @returns {string[]} Gotten peerDependencies.
  */
 function fetchPeerDependencies(packageName) {
-    const fetchedText = childProcess.execSync(
-        `npm show --json ${packageName} peerDependencies`,
+    const fetchedText = spawn.sync(
+        "npm",
+        ["show", "--json", packageName, "peerDependencies"],
         { encoding: "utf8" }
-    ).trim();
+    ).stdout.trim();
 
     return JSON.parse(fetchedText || "{}");
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "babel-code-frame": "^6.22.0",
     "chalk": "^1.1.3",
     "concat-stream": "^1.6.0",
+    "cross-spawn": "^5.1.0",
     "debug": "^2.6.8",
     "doctrine": "^2.0.0",
     "eslint-scope": "^3.7.1",

--- a/tests/lib/util/npm-util.js
+++ b/tests/lib/util/npm-util.js
@@ -9,7 +9,7 @@
 //------------------------------------------------------------------------------
 
 const assert = require("chai").assert,
-    childProcess = require("child_process"),
+    spawn = require("cross-spawn"),
     sinon = require("sinon"),
     npmUtil = require("../../../lib/util/npm-util"),
     log = require("../../../lib/logging"),
@@ -170,31 +170,34 @@ describe("npmUtil", () => {
 
     describe("installSyncSaveDev()", () => {
         it("should invoke npm to install a single desired package", () => {
-            const stub = sandbox.stub(childProcess, "execSync");
+            const stub = sandbox.stub(spawn, "sync");
 
             npmUtil.installSyncSaveDev("desired-package");
             assert(stub.calledOnce);
-            assert.equal(stub.firstCall.args[0], "npm i --save-dev desired-package");
+            assert.equal(stub.firstCall.args[0], "npm");
+            assert.deepEqual(stub.firstCall.args[1], ["i", "--save-dev", "desired-package"]);
             stub.restore();
         });
 
         it("should accept an array of packages to install", () => {
-            const stub = sandbox.stub(childProcess, "execSync");
+            const stub = sandbox.stub(spawn, "sync");
 
             npmUtil.installSyncSaveDev(["first-package", "second-package"]);
             assert(stub.calledOnce);
-            assert.equal(stub.firstCall.args[0], "npm i --save-dev first-package second-package");
+            assert.equal(stub.firstCall.args[0], "npm");
+            assert.deepEqual(stub.firstCall.args[1], ["i", "--save-dev", "first-package", "second-package"]);
             stub.restore();
         });
     });
 
     describe("fetchPeerDependencies()", () => {
         it("should execute 'npm show --json <packageName> peerDependencies' command", () => {
-            const stub = sandbox.stub(childProcess, "execSync").returns("");
+            const stub = sandbox.stub(spawn, "sync").returns({ stdout: "" });
 
             npmUtil.fetchPeerDependencies("desired-package");
             assert(stub.calledOnce);
-            assert.equal(stub.firstCall.args[0], "npm show --json desired-package peerDependencies");
+            assert.equal(stub.firstCall.args[0], "npm");
+            assert.deepEqual(stub.firstCall.args[1], ["show", "--json", "desired-package", "peerDependencies"]);
             stub.restore();
         });
     });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment**

* **ESLint Version:** 4.2.0
* **Node Version:** 4.8.3
* **npm Version:** 3.5.2

**What did you do? Please include the actual source code causing the issue.**

Ran `eslint --init` and selected the Google style guide.

**What actually happened? Please include the actual, raw output from ESLint.** See above.

This ended up calling `execSync("npm i --save-dev eslint>=4.1.1")`. Because `execSync` spawns the child through a shell, this had the effect of running `npm i --save-dev eslint` with its output redirected to a new file named `=4.1.1`, leaving the wrong version in `package.json`.

    $ npm init -y
    […]
    $ eslint --init
    ? How would you like to configure ESLint? Use a popular style guide
    ? Which style guide do you want to follow? Google
    ? What format do you want your config file to be in? JavaScript
    Checking peerDependencies of eslint-config-google
    Local ESLint installation not found.
    Installing eslint-config-google@latest, eslint@>=4.1.1
    npm WARN test@1.0.0 No description
    npm WARN test@1.0.0 No repository field.
    Successfully created .eslintrc.js file in /tmp/test
    ESLint was installed locally. We recommend using this local copy instead of your globally-installed copy.
    $ ls
    =4.1.1  node_modules  package.json
    $ cat package.json
    {
      "name": "test",
      "version": "1.0.0",
      "description": "",
      "main": ".eslintrc.js",
      "scripts": {
        "test": "echo \"Error: no test specified\" && exit 1"
      },
      "keywords": [],
      "author": "",
      "license": "ISC",
      "devDependencies": {
        "eslint": "^4.2.0",
        "eslint-config-google": "^0.9.1"
      }
    }

It’s always better to avoid spawning a shell when possible for correctness reasons, to say nothing of scary security reasons.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)** Replaced all uses of `execSync` with `execFileSync` to avoid spawning a shell, and updated the corresponding tests.

**Is there anything you'd like reviewers to focus on?** Nothing in particular.