### PR TITLE
Docs: fix badge in eslint-config-eslint readme

### DIFF
--- a/packages/eslint-config-eslint/README.md
+++ b/packages/eslint-config-eslint/README.md
@@ -31,5 +31,5 @@ In your `.eslintrc` file, add:
 
 Join our [Mailing List](https://groups.google.com/group/eslint) or [Chatroom](https://gitter.im/eslint/eslint)
 
-[npm-image]: https://img.shields.io/npm/v/eslint.svg?style=flat-square
+[npm-image]: https://img.shields.io/npm/v/eslint-config-eslint.svg?style=flat-square
 [npm-url]: https://www.npmjs.com/package/eslint-config-eslint


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

The badge in the `eslint-config-eslint` readme correctly links to the `eslint-config-eslint` package, but it displays the image for `eslint`. As a result, the displayed version number is incorrect (it displays the version of the latest `eslint` release, not the latest `eslint-config-eslint` release).

**Is there anything you'd like reviewers to focus on?**

No