### PR TITLE
Update: check semicolons in ClassProperty nodes, too

### DIFF
--- a/lib/rules/semi.js
+++ b/lib/rules/semi.js
@@ -210,6 +210,7 @@ module.exports = {
             DebuggerStatement: checkForSemicolon,
             BreakStatement: checkForSemicolon,
             ContinueStatement: checkForSemicolon,
+            ClassProperty: checkForSemicolon,
             ImportDeclaration: checkForSemicolon,
             ExportAllDeclaration: checkForSemicolon,
             ExportNamedDeclaration(node) {

--- a/tests/lib/rules/semi.js
+++ b/tests/lib/rules/semi.js
@@ -142,6 +142,7 @@ ruleTester.run("semi", rule, {
         { code: "if (foo) {\n bar() }", output: "if (foo) {\n bar(); }", options: ["always", { omitLastInOneLineBlock: true }], errors: [{ message: "Missing semicolon." }] },
         { code: "if (foo) {\n bar(); baz() }", output: "if (foo) {\n bar(); baz(); }", options: ["always", { omitLastInOneLineBlock: true }], errors: [{ message: "Missing semicolon." }] },
         { code: "if (foo) { bar(); }", output: "if (foo) { bar() }", options: ["always", { omitLastInOneLineBlock: true }], errors: [{ message: "Extra semicolon." }] },
+        { code: "class Foo { bar = 1 }", output: "class Foo { bar = 1; }", parserOptions: { ecmaVersion: 6 }, parser: "babel-eslint", errors: [{ message: "Missing semicolon.", type: "ClassProperty" }] },
 
 
         // exports, "always"


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**What rule do you want to change?**
`semi`

**Does this change cause the rule to produce more or fewer warnings?**
more

**How will the change be implemented? (New option, new default behavior, etc.)?**
new default behaviour

**Please provide some example code that this change will affect:**
```js
class Foo { bar = 1 }
```

**What does the rule currently do for this code?**
It ignores ClassProperty nodes in the AST

**What will the rule do after it's changed?**
It will complain on missing semicolons after ClassProperty nodes

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Added ClassProperty into the list of nodes to test; added the corresponding test case.

**Is there anything you'd like reviewers to focus on?**
Nope, it's just a two lines change.
