### PR TITLE
Chore: Use `output: null` to assert that a test case is not autofixed.

### DIFF
--- a/tests/lib/rules/array-bracket-newline.js
+++ b/tests/lib/rules/array-bracket-newline.js
@@ -505,7 +505,7 @@ ruleTester.run("array-bracket-newline", rule, {
         {
             code: "var foo = [\n// any comment\n];",
             options: [{ multiline: true }],
-            output: "var foo = [\n// any comment\n];",
+            output: null,
             errors: [
                 {
                     message: ERR_NO_BREAK_AFTER,

--- a/tests/lib/rules/array-element-newline.js
+++ b/tests/lib/rules/array-element-newline.js
@@ -368,7 +368,7 @@ ruleTester.run("array-element-newline", rule, {
         {
             code: "var foo = [\n1 // any comment\n, 2\n];",
             options: ["never"],
-            output: "var foo = [\n1 // any comment\n, 2\n];",
+            output: null,
             errors: [
                 {
                     message: ERR_NO_BREAK_HERE,
@@ -380,7 +380,7 @@ ruleTester.run("array-element-newline", rule, {
         {
             code: "var foo = [\n1, // any comment\n2\n];",
             options: ["never"],
-            output: "var foo = [\n1, // any comment\n2\n];",
+            output: null,
             errors: [
                 {
                     message: ERR_NO_BREAK_HERE,
@@ -437,7 +437,7 @@ ruleTester.run("array-element-newline", rule, {
         {
             code: "var foo = [\nfunction foo() {\ndosomething();\n}, /* any comment */\nfunction bar() {\ndosomething();\n}\n];",
             options: ["never"],
-            output: "var foo = [\nfunction foo() {\ndosomething();\n}, /* any comment */\nfunction bar() {\ndosomething();\n}\n];",
+            output: null,
             errors: [
                 {
                     message: ERR_NO_BREAK_HERE,


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Use `output: null` to assert that a test case is not autofixed. it is detected by `eslint-plugin-eslint-plugin` rule prefer-output-null.

**Is there anything you'd like reviewers to focus on?**


