### PR TITLE
Update: emit a warning for ecmaFeatures rather than throwing an error

### DIFF
--- a/conf/config-schema.js
+++ b/conf/config-schema.js
@@ -12,7 +12,9 @@ const baseConfigProperties = {
     parserOptions: { type: "object" },
     plugins: { type: "array" },
     rules: { type: "object" },
-    settings: { type: "object" }
+    settings: { type: "object" },
+
+    ecmaFeatures: { type: "object" } // deprecated; logs a warning when used
 };
 
 const overrideProperties = Object.assign(

--- a/lib/config/config-validator.js
+++ b/lib/config/config-validator.js
@@ -10,6 +10,7 @@
 //------------------------------------------------------------------------------
 
 const ajv = require("../util/ajv"),
+    lodash = require("lodash"),
     configSchema = require("../../conf/config-schema.js"),
     util = require("util");
 
@@ -180,6 +181,25 @@ function formatErrors(errors) {
 }
 
 /**
+ * Emits a deprecation warning containing a given filepath. A new deprecation warning is emitted
+ * for each unique file path, but repeated invocations with the same file path have no effect.
+ * No warnings are emitted if the `--no-deprecation` or `--no-warnings` Node runtime flags are active.
+ * @param {string} source The name of the configuration source to report the warning for.
+ * @returns {void}
+ */
+const emitEcmaFeaturesWarning = lodash.memoize(source => {
+
+    /*
+     * util.deprecate seems to be the only way to emit a warning in Node 4.x while respecting the --no-warnings flag.
+     * (In Node 6+, process.emitWarning could be used instead.)
+     */
+    util.deprecate(
+        () => {},
+        `[eslint] The 'ecmaFeatures' config file property is deprecated, and has no effect. (found in ${source})`
+    )();
+});
+
+/**
  * Validates the top level properties of the config object.
  * @param {Object} config The config object to validate.
  * @param {string} source The name of the configuration source to report in any errors.
@@ -190,6 +210,10 @@ function validateConfigSchema(config, source) {
 
     if (!validateSchema(config)) {
         throw new Error(`${source}:\n\tESLint configuration is invalid:\n${formatErrors(validateSchema.errors)}`);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(config, "ecmaFeatures")) {
+        emitEcmaFeaturesWarning(source);
     }
 }
 

--- a/tests/bin/eslint.js
+++ b/tests/bin/eslint.js
@@ -280,6 +280,28 @@ describe("bin/eslint.js", () => {
         });
     });
 
+
+    describe("emitting a warning for ecmaFeatures", () => {
+        it("does not emit a warning when it does not find an ecmaFeatures option", () => {
+            const child = runESLint(["Makefile.js"]);
+
+            const exitCodePromise = assertExitCode(child, 0);
+            const outputPromise = getOutput(child).then(output => assert.strictEqual(output.stderr, ""));
+
+            return Promise.all([exitCodePromise, outputPromise]);
+        });
+        it("emits a warning when it finds an ecmaFeatures option", () => {
+            const child = runESLint(["-c", "tests/fixtures/config-file/ecma-features/.eslintrc.yml", "Makefile.js"]);
+
+            const exitCodePromise = assertExitCode(child, 0);
+            const outputPromise = getOutput(child).then(output => {
+                assert.include(output.stderr, "The 'ecmaFeatures' config file property is deprecated, and has no effect.");
+            });
+
+            return Promise.all([exitCodePromise, outputPromise]);
+        });
+    });
+
     afterEach(() => {
 
         // Clean up all the processes after every test.

--- a/tests/fixtures/config-file/ecma-features/.eslintrc.yml
+++ b/tests/fixtures/config-file/ecma-features/.eslintrc.yml
@@ -1,0 +1,1 @@
+ecmaFeatures: {}


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Add something to the core

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

(refs https://github.com/eslint/tsc-meetings/issues/51#issuecomment-315669556)

Starting in 4.0.0, ESLint has been throwing a fatal error when encountering unexpected config file properties, including `ecmaFeatures`. However, many old configs still have the top-level `ecmaFeatures` option, which has had no effect since ESLint 1.x. This commit updates ESLint to emit a warning when it encounters a config with `ecmaFeatures`, rather than throwing an error.

This was approved by the TSC in [today's meeting](https://github.com/eslint/tsc-meetings/blob/4a238489c2f035711070e8beaa2ba11827bcc521/notes/2017/2017-07-20.md#stop-throwing-for-ecmafeatures).

**Is there anything you'd like reviewers to focus on?**

Nothing in particular