### PR TITLE
Fix: clarify AST and don't use `node.start`/`node.end` (fixes #8956)

### DIFF
--- a/docs/developer-guide/working-with-plugins.md
+++ b/docs/developer-guide/working-with-plugins.md
@@ -248,26 +248,26 @@ exports.parseForESLint = function(code, options) {
 
 ### The AST specification
 
-The AST that custom parsers should create is based on [ESTree](https://github.com/estree/estree) basically. The AST requires some additional properties about detail information of the source code.
+The AST that custom parsers should create is based on [ESTree](https://github.com/estree/estree). The AST requires some additional properties about detail information of the source code.
 
 #### All nodes:
 
 All nodes must have `range` property.
 
-* `range` (`number[]`) is the array of two numbers. Both numbers are a 0-based index which is the position in the array of source code characters. The first is the start position of the node, the second is the end position of the node. `code.slice(node.range[0], node.range[1])` must be the text of the node. This range does not include spaces which are around the node.
+* `range` (`number[]`) is an array of two numbers. Both numbers are a 0-based index which is the position in the array of source code characters. The first is the start position of the node, the second is the end position of the node. `code.slice(node.range[0], node.range[1])` must be the text of the node. This range does not include spaces/parentheses which are around the node.
 * `loc` (`SourceLocation`) must not be `null`. [The `loc` property is defined as nullable by ESTree](https://github.com/estree/estree/blob/25834f7247d44d3156030f8e8a2d07644d771fdb/es5.md#node-objects), but ESLint requires this property. On the other hand, `SourceLocation#source` property can be `undefined`. ESLint does not use the `SourceLocation#source` property.
 
-The `parent` property of all nodes must be rewriteable. ESLint set their parent node to the `parent` properties while traversing.
+The `parent` property of all nodes must be rewriteable. ESLint sets each node's parent properties to its parent node while traversing.
 
 #### The `Program` node:
 
-The `Program` node must have `tokens` and `comments` properties. Both properties are the array of the below Token interface.
+The `Program` node must have `tokens` and `comments` properties. Both properties are an array of the below Token interface.
 
 ```ts
 interface Token {
     type: string;
     loc: SourceLocation;
-    range: [number, number];
+    range: [number, number]; // See "All nodes:" section for details of `range` property.
     value: string;
 }
 ```
@@ -275,7 +275,7 @@ interface Token {
 * `tokens` (`Token[]`) is the array of tokens which affect the behavior of programs. Arbitrary spaces can exist between tokens, so rules check the `Token#range` to detect spaces between tokens. This must be sorted by `Token#range[0]`.
 * `comments` (`Token[]`) is the array of comment tokens. This must be sorted by `Token#range[0]`.
 
-The `tokens` and the `comments` must not be overlapped themselves and each other.
+The range indexes of all tokens and comments must not overlap with the range of other tokens and comments.
 
 #### The `Literal` node:
 

--- a/docs/developer-guide/working-with-plugins.md
+++ b/docs/developer-guide/working-with-plugins.md
@@ -276,3 +276,9 @@ interface Token {
 * `comments` (`Token[]`) is the array of comment tokens. This must be sorted by `Token#range[0]`.
 
 The `tokens` and the `comments` must not be overlapped themselves and each other.
+
+#### The `Literal` node:
+
+The `Literal` node must have `raw` property.
+
+* `raw` (`string`) is the source code of this literal. This is the same as `code.slice(node.range[0], node.range[1])`.

--- a/docs/developer-guide/working-with-plugins.md
+++ b/docs/developer-guide/working-with-plugins.md
@@ -254,8 +254,8 @@ The AST that custom parsers should create is based on [ESTree](https://github.co
 
 All nodes must have `range` property.
 
-- `range` (`number[]`) is the array of two numbers. Both numbers are a 0-based index which is the position in the array of source code characters. The first is the start position of the node, the second is the end position of the node. `code.slice(node.range[0], node.range[1])` must be the text of the node. This range does not include spaces which are around the node.
-- `loc` (`SourceLocation`) must not be `null`. [The `loc` property is defined as nullable by ESTree](https://github.com/estree/estree/blob/25834f7247d44d3156030f8e8a2d07644d771fdb/es5.md#node-objects), but ESLint requires this property. On the other hand, `SourceLocation#source` property can be `undefined`. ESLint does not use the `SourceLocation#source` property.
+* `range` (`number[]`) is the array of two numbers. Both numbers are a 0-based index which is the position in the array of source code characters. The first is the start position of the node, the second is the end position of the node. `code.slice(node.range[0], node.range[1])` must be the text of the node. This range does not include spaces which are around the node.
+* `loc` (`SourceLocation`) must not be `null`. [The `loc` property is defined as nullable by ESTree](https://github.com/estree/estree/blob/25834f7247d44d3156030f8e8a2d07644d771fdb/es5.md#node-objects), but ESLint requires this property. On the other hand, `SourceLocation#source` property can be `undefined`. ESLint does not use the `SourceLocation#source` property.
 
 The `parent` property of all nodes must be rewriteable. ESLint set their parent node to the `parent` properties while traversing.
 
@@ -272,7 +272,7 @@ interface Token {
 }
 ```
 
-- `tokens` (`Token[]`) is the array of tokens which affect the behavior of programs. Arbitrary spaces can exist between tokens, so rules check the `Token#range` to detect spaces between tokens. This must be sorted by `Token#range[0]`.
-- `comments` (`Token[]`) is the array of comment tokens. This must be sorted by `Token#range[0]`.
+* `tokens` (`Token[]`) is the array of tokens which affect the behavior of programs. Arbitrary spaces can exist between tokens, so rules check the `Token#range` to detect spaces between tokens. This must be sorted by `Token#range[0]`.
+* `comments` (`Token[]`) is the array of comment tokens. This must be sorted by `Token#range[0]`.
 
 The `tokens` and the `comments` must not be overlapped themselves and each other.

--- a/lib/rules/arrow-parens.js
+++ b/lib/rules/arrow-parens.js
@@ -71,7 +71,7 @@ module.exports = {
                 // https://github.com/eslint/eslint/issues/8834
                 const closingParenToken = sourceCode.getTokenAfter(paramToken, astUtils.isClosingParenToken);
                 const asyncToken = isAsync ? sourceCode.getTokenBefore(firstTokenOfParam) : null;
-                const shouldAddSpaceForAsync = asyncToken && (asyncToken.end === firstTokenOfParam.start);
+                const shouldAddSpaceForAsync = asyncToken && (asyncToken.range[1] === firstTokenOfParam.range[0]);
 
                 return fixer.replaceTextRange([
                     firstTokenOfParam.range[0],

--- a/lib/rules/curly.js
+++ b/lib/rules/curly.js
@@ -238,7 +238,7 @@ module.exports = {
                     // `do while` expressions sometimes need a space to be inserted after `do`.
                     // e.g. `do{foo()} while (bar)` should be corrected to `do foo() while (bar)`
                     const needsPrecedingSpace = node.type === "DoWhileStatement" &&
-                        sourceCode.getTokenBefore(bodyNode).end === bodyNode.start &&
+                        sourceCode.getTokenBefore(bodyNode).range[1] === bodyNode.range[0] &&
                         !astUtils.canTokensBeAdjacent("do", sourceCode.getFirstToken(bodyNode, { skip: 1 }));
 
                     const openingBracket = sourceCode.getFirstToken(bodyNode);

--- a/lib/rules/key-spacing.js
+++ b/lib/rules/key-spacing.js
@@ -433,9 +433,9 @@ module.exports = {
 
                     // Remove whitespace
                     if (isKeySide) {
-                        range = [tokenBeforeColon.end, tokenBeforeColon.end + diffAbs];
+                        range = [tokenBeforeColon.range[1], tokenBeforeColon.range[1] + diffAbs];
                     } else {
-                        range = [tokenAfterColon.start - diffAbs, tokenAfterColon.start];
+                        range = [tokenAfterColon.range[0] - diffAbs, tokenAfterColon.range[0]];
                     }
                     fix = function(fixer) {
                         return fixer.removeRange(range);

--- a/lib/rules/no-else-return.js
+++ b/lib/rules/no-else-return.js
@@ -99,7 +99,7 @@ module.exports = {
                     // https://github.com/eslint/eslint/issues/8026
                     return new FixTracker(fixer, sourceCode)
                         .retainEnclosingFunction(node)
-                        .replaceTextRange([elseToken.start, node.end], fixedSource);
+                        .replaceTextRange([elseToken.range[0], node.range[1]], fixedSource);
                 }
             });
         }

--- a/lib/rules/no-regex-spaces.js
+++ b/lib/rules/no-regex-spaces.js
@@ -74,7 +74,7 @@ module.exports = {
                 nodeValue = token.value;
 
             if (nodeType === "RegularExpression") {
-                checkRegex(node, nodeValue, token.start);
+                checkRegex(node, nodeValue, token.range[0]);
             }
         }
 
@@ -100,7 +100,7 @@ module.exports = {
             const shadowed = regExpVar && regExpVar.defs.length > 0;
 
             if (node.callee.type === "Identifier" && node.callee.name === "RegExp" && isString(node.arguments[0]) && !shadowed) {
-                checkRegex(node, node.arguments[0].value, node.arguments[0].start + 1);
+                checkRegex(node, node.arguments[0].value, node.arguments[0].range[0] + 1);
             }
         }
 

--- a/lib/rules/object-curly-spacing.js
+++ b/lib/rules/object-curly-spacing.js
@@ -174,7 +174,7 @@ module.exports = {
                     options.arraysInObjectsException && astUtils.isClosingBracketToken(penultimate) ||
                     options.objectsInObjectsException && astUtils.isClosingBraceToken(penultimate)
                 );
-                const penultimateType = shouldCheckPenultimate && sourceCode.getNodeByRangeIndex(penultimate.start).type;
+                const penultimateType = shouldCheckPenultimate && sourceCode.getNodeByRangeIndex(penultimate.range[0]).type;
 
                 const closingCurlyBraceMustBeSpaced = (
                     options.arraysInObjectsException && penultimateType === "ArrayExpression" ||

--- a/lib/rules/padded-blocks.js
+++ b/lib/rules/padded-blocks.js
@@ -202,7 +202,7 @@ module.exports = {
                         node,
                         loc: { line: tokenBeforeFirst.loc.start.line, column: tokenBeforeFirst.loc.start.column },
                         fix(fixer) {
-                            return fixer.replaceTextRange([tokenBeforeFirst.end, firstBlockToken.start - firstBlockToken.loc.start.column], "\n");
+                            return fixer.replaceTextRange([tokenBeforeFirst.range[1], firstBlockToken.range[0] - firstBlockToken.loc.start.column], "\n");
                         },
                         message: NEVER_MESSAGE
                     });
@@ -215,7 +215,7 @@ module.exports = {
                         loc: { line: tokenAfterLast.loc.end.line, column: tokenAfterLast.loc.end.column - 1 },
                         message: NEVER_MESSAGE,
                         fix(fixer) {
-                            return fixer.replaceTextRange([lastBlockToken.end, tokenAfterLast.start - tokenAfterLast.loc.start.column], "\n");
+                            return fixer.replaceTextRange([lastBlockToken.range[1], tokenAfterLast.range[0] - tokenAfterLast.loc.start.column], "\n");
                         }
                     });
                 }

--- a/lib/rules/prefer-template.js
+++ b/lib/rules/prefer-template.js
@@ -74,7 +74,7 @@ function startsWithTemplateCurly(node) {
         return startsWithTemplateCurly(node.left);
     }
     if (node.type === "TemplateLiteral") {
-        return node.expressions.length && node.quasis.length && node.quasis[0].start === node.quasis[0].end;
+        return node.expressions.length && node.quasis.length && node.quasis[0].range[0] === node.quasis[0].range[1];
     }
     return node.type !== "Literal" || typeof node.value !== "string";
 }
@@ -89,7 +89,7 @@ function endsWithTemplateCurly(node) {
         return startsWithTemplateCurly(node.right);
     }
     if (node.type === "TemplateLiteral") {
-        return node.expressions.length && node.quasis.length && node.quasis[node.quasis.length - 1].start === node.quasis[node.quasis.length - 1].end;
+        return node.expressions.length && node.quasis.length && node.quasis[node.quasis.length - 1].range[0] === node.quasis[node.quasis.length - 1].range[1];
     }
     return node.type !== "Literal" || typeof node.value !== "string";
 }

--- a/lib/rules/spaced-comment.js
+++ b/lib/rules/spaced-comment.js
@@ -303,9 +303,9 @@ module.exports = {
                 node,
                 fix(fixer) {
                     if (requireSpace) {
-                        return fixer.insertTextAfterRange([node.start, node.end - 2], " ");
+                        return fixer.insertTextAfterRange([node.range[0], node.range[1] - 2], " ");
                     }
-                    const end = node.end - 2,
+                    const end = node.range[1] - 2,
                         start = end - match[0].length;
 
                     return fixer.replaceTextRange([start, end], "");

--- a/lib/testers/test-parser.js
+++ b/lib/testers/test-parser.js
@@ -1,0 +1,43 @@
+/**
+ * @author Toru Nagashima <https://github.com/mysticatea>
+ */
+"use strict";
+
+const espree = require("espree");
+const Traverser = require("../util/traverser");
+
+/**
+ * Remove `start`/`end` properties from the given node.
+ * @param {ASTNode} node The node to remove.
+ * @returns {void}
+ */
+function removeStartEnd(node) {
+    delete node.start;
+    delete node.end;
+}
+
+/**
+ * Remove `start`/`end` properties from all nodes of the given AST.
+ * @param {ASTNode} ast The root node to remove `start`/`end` properties.
+ * @returns {void}
+ */
+function removeStartEndInTree(ast) {
+    new Traverser().traverse(ast, {
+        enter: removeStartEnd
+    });
+
+    for (const token of ast.tokens) {
+        removeStartEnd(token);
+    }
+    for (const comment of ast.comments) {
+        removeStartEnd(comment);
+    }
+}
+
+module.exports.parse = (code, options) => {
+    const ret = espree.parse(code, options);
+
+    removeStartEndInTree(ret.ast || ret);
+
+    return ret;
+};

--- a/lib/testers/test-parser.js
+++ b/lib/testers/test-parser.js
@@ -12,8 +12,20 @@ const Traverser = require("../util/traverser");
  * @returns {void}
  */
 function removeStartEnd(node) {
-    delete node.start;
-    delete node.end;
+    Object.defineProperty(node, "start", {
+        get() {
+            throw new Error("Use node.range[0] instead of node.start");
+        },
+        configurable: true,
+        enumerable: false
+    });
+    Object.defineProperty(node, "end", {
+        get() {
+            throw new Error("Use node.range[1] instead of node.end");
+        },
+        configurable: true,
+        enumerable: false
+    });
 }
 
 /**

--- a/lib/testers/test-parser.js
+++ b/lib/testers/test-parser.js
@@ -7,11 +7,11 @@ const espree = require("espree");
 const Traverser = require("../util/traverser");
 
 /**
- * Remove `start`/`end` properties from the given node.
- * @param {ASTNode} node The node to remove.
+ * Define `start`/`end` properties as throwing error.
+ * @param {ASTNode} node The node to define.
  * @returns {void}
  */
-function removeStartEnd(node) {
+function defineStartEndAsError(node) {
     Object.defineProperty(node, "start", {
         get() {
             throw new Error("Use node.range[0] instead of node.start");
@@ -29,27 +29,20 @@ function removeStartEnd(node) {
 }
 
 /**
- * Remove `start`/`end` properties from all nodes of the given AST.
- * @param {ASTNode} ast The root node to remove `start`/`end` properties.
+ * Define `start`/`end` properties of all nodes of the given AST as throwing error.
+ * @param {ASTNode} ast The root node to errorize `start`/`end` properties.
  * @returns {void}
  */
-function removeStartEndInTree(ast) {
-    new Traverser().traverse(ast, {
-        enter: removeStartEnd
-    });
-
-    for (const token of ast.tokens) {
-        removeStartEnd(token);
-    }
-    for (const comment of ast.comments) {
-        removeStartEnd(comment);
-    }
+function defineStartEndAsErrorInTree(ast) {
+    new Traverser().traverse(ast, { enter: defineStartEndAsError });
+    ast.tokens.forEach(defineStartEndAsError);
+    ast.comments.forEach(defineStartEndAsError);
 }
 
 module.exports.parse = (code, options) => {
     const ret = espree.parse(code, options);
 
-    removeStartEndInTree(ret.ast || ret);
+    defineStartEndAsErrorInTree(ret.ast || ret);
 
     return ret;
 };

--- a/tests/lib/rules/_set-default-parser.js
+++ b/tests/lib/rules/_set-default-parser.js
@@ -1,0 +1,20 @@
+/**
+ * @author Toru Nagashima <https://github.com/mysticatea>
+ *
+ * This file must be loaded before rule files.
+ *
+ * This file configures the default config of RuleTester to use TestParser
+ * instead of espree. The TestParser parses the given source code by espree,
+ * then remove the `start` and `end` properties of nodes, tokens, and comments.
+ *
+ * We have not endorsed that the properties exist on the AST of custom parsers,
+ * so we should check that core rules don't use the properties.
+ */
+"use strict";
+
+const path = require("path");
+const RuleTester = require("../../../lib/testers/rule-tester");
+
+RuleTester.setDefaultConfig({
+    parser: path.resolve(__dirname, "../../../lib/testers/test-parser")
+});


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

Fixes #8956.

**What changes did you make? (Give an overview)**

This PR updates the document "Working with Custom Parsers" to clarify the specification of AST.
Also, this PR fixes 8 rules which are violating the spec.

It's hard that we catch the violations in review since `start` and `end` properties are legal on Location objects. So I added the custom parser which removes the properties from the result of `espree`. Tests of core rules use the custom parser by default. This does not affect to plugin developers.

**Is there anything you'd like reviewers to focus on?**

- Please correct my English.
- Check whether the added document is enough or not.