### PR TITLE
Docs: Access parseInt property correctly

### DIFF
--- a/docs/rules/prefer-numeric-literals.md
+++ b/docs/rules/prefer-numeric-literals.md
@@ -39,7 +39,7 @@ Number.parseInt(1, 3);
 0o767 === 503;
 0x1F7 === 503;
 
-a[parseInt](1,2);
+a["parseInt"](1,2);
 
 parseInt(foo);
 parseInt(foo, 2);


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Fixed documentation of the `prefer-numeric-literals` rule to correctly access `a`'s `parseInt` property.