### PR TITLE
Fix: handle array-destructuring with obj assignment in prefer const

### DIFF
--- a/lib/rules/prefer-const.js
+++ b/lib/rules/prefer-const.js
@@ -199,6 +199,17 @@ function groupByDestructuring(variables, ignoreReadBeforeAssign) {
         }
     }
 
+    for (const key of identifierMap.keys()) {
+        const destructureGroup = identifierMap.get(key);
+        const destructureElement = destructureGroup[0];
+
+        if (destructureElement && destructureElement.parent && destructureElement.parent.elements) {
+            if (destructureElement.parent.elements.length !== destructureGroup.length) {
+                identifierMap.delete(key);
+            }
+        }
+    }
+
     return identifierMap;
 }
 

--- a/lib/rules/prefer-const.js
+++ b/lib/rules/prefer-const.js
@@ -204,11 +204,20 @@ function groupByDestructuring(variables, ignoreReadBeforeAssign, checkingMixedDe
         for (const key of identifierMap.keys()) {
             const destructureGroup = identifierMap.get(key);
             const destructureElement = destructureGroup[0];
+            let elementsInHost;
 
-            if (destructureElement && destructureElement.parent && destructureElement.parent.elements) {
-                if (destructureElement.parent.elements.length !== destructureGroup.length) {
-                    identifierMap.delete(key);
+            if (destructureElement && destructureElement.parent) {
+                if (destructureElement.parent.elements) {
+                    elementsInHost = destructureElement.parent.elements;
                 }
+
+                if (destructureElement.parent.parent.type === "ObjectPattern") {
+                    elementsInHost = destructureGroup[0].parent.parent.properties;
+                }
+            }
+
+            if (elementsInHost && elementsInHost.length && elementsInHost.length !== destructureGroup.length) {
+                identifierMap.delete(key);
             }
         }
     }

--- a/lib/rules/prefer-const.js
+++ b/lib/rules/prefer-const.js
@@ -126,6 +126,7 @@ function getIdentifierIfShouldBeConst(variable, ignoreReadBeforeAssign) {
     if (isReadBeforeInit) {
         return variable.defs[0].name;
     }
+
     return writer.identifier;
 }
 
@@ -164,16 +165,16 @@ function getDestructuringHost(reference) {
  * @param {eslint-scope.Variable[]} variables - Variables to group by destructuring.
  * @param {boolean} ignoreReadBeforeAssign -
  *      The value of `ignoreReadBeforeAssign` option.
- * @param {boolean} checkingMixedDestructuring - value on how to report destructuring (any/all)
  * @returns {Map<ASTNode, ASTNode[]>} Grouped identifier nodes.
  */
-function groupByDestructuring(variables, ignoreReadBeforeAssign, checkingMixedDestructuring) {
+function groupByDestructuring(variables, ignoreReadBeforeAssign) {
     const identifierMap = new Map();
 
     for (let i = 0; i < variables.length; ++i) {
         const variable = variables[i];
         const references = variable.references;
         const identifier = getIdentifierIfShouldBeConst(variable, ignoreReadBeforeAssign);
+
         let prevId = null;
 
         for (let j = 0; j < references.length; ++j) {
@@ -200,24 +201,124 @@ function groupByDestructuring(variables, ignoreReadBeforeAssign, checkingMixedDe
         }
     }
 
-    if (!checkingMixedDestructuring) {
+    return identifierMap;
+}
+
+/**
+ * Returns a list of nodes
+ * that have have the type Identifier.
+ * This will search for nested Identifiers.
+ *
+ * @param {ASTNode} node - node to search for children and nested identifiers.
+ * @returns {ASTNode[]} list Identifier nodes.
+ */
+function getIdentifiersInArrayDestructureGroup(node) {
+    const identifiers = [];
+
+    if (node.elements) {
+        const numberOfElements = node.elements.length;
+
+        for (let i = 0; i < numberOfElements; i++) {
+            if (!node.elements[i].elements && node.elements[i].type === "Identifier") {
+                identifiers.push(node.elements[i]);
+            } else {
+                const innerIdentifiers = getIdentifiersInArrayDestructureGroup(node.elements[i]);
+
+                innerIdentifiers.forEach(identifierNode => identifiers.push(identifierNode));
+            }
+        }
+    }
+    return identifiers;
+}
+
+/**
+ * Returns a count of nodes
+ * This will count nested nodes in nodes elements attribute.
+ *
+ * @param {ASTNode} node - node to count elements.
+ * @returns {integer} count nodes.
+ */
+function countElementsInArrayDestructureGroup(node) {
+    let count = 0;
+
+    if (node.elements) {
+        const numberOfElements = node.elements.length;
+
+        for (let i = 0; i < numberOfElements; i++) {
+            if (!node.elements[i].elements) {
+                count += 1;
+            } else {
+                count += countElementsInArrayDestructureGroup(node.elements[i]);
+            }
+        }
+    }
+    return count;
+}
+
+/**
+ * Returns a list of nodes
+ * that have have the value type Identifier.
+ * This will search for nested Identifiers.
+ *
+ * @param {ASTNode} node - node to search properties that have value Identifier.
+ * @returns {ASTNode[]} list Identifier nodes.
+ */
+function getIdentifiersInObjectDestructureGroup(node) {
+    const identifier = [];
+    const propertiesLength = node.properties.length;
+
+    for (let i = 0; i < propertiesLength; i++) {
+        if (node.properties[i].value.type === "Identifier") {
+            identifier.push(node.properties[i].value);
+        }
+    }
+    return identifier;
+}
+
+/**
+ * Returns a count of nodes
+ * This will count the node properties length
+ *
+ * @param {ASTNode} node - node to count properties.
+ * @returns {integer} count properties length.
+ */
+function countElementsInObjectDestructureGroup(node) {
+    return node.properties.length;
+}
+
+/**
+ * Checks to see if there are less identifier nodes in a destructure group
+ * than the number of terms in the group. It might mean that there
+ * is a term in the group that cannot be converted to const.
+ * We want to make sure all terms can be reported
+ * If not, we should remove the terms that would be reported in "any" case
+ *
+ * @param {Map<ASTNode, ASTNode[]>} identifierMap - Variables to group by destructuring.
+ * @param {boolean} checkingMixedDestructuring - boolean to check if any value in destructuring
+ *      should use const
+ * @param {integer|null} destructureCount count of destructure terms.
+ * @param {ASTNode[]|null} destructureIdentifier list of Identifier nodes to check 
+ *      in IdentifierMap
+ * @returns {Map<ASTNode, ASTNode[]>} Grouped identifier nodes.
+ */
+function verifyAllDestructuring(identifierMap, checkingMixedDestructuring, destructureCount, destructureIdentifier) {
+    if (checkingMixedDestructuring) {
+        return identifierMap;
+    }
+    if (destructureCount === null && destructureIdentifier === null) {
+        return identifierMap;
+    }
+    if (destructureIdentifier.length < destructureCount) {
         for (const key of identifierMap.keys()) {
             const destructureGroup = identifierMap.get(key);
             const destructureElement = destructureGroup[0];
-            let elementsInHost;
 
-            if (destructureElement && destructureElement.parent) {
-                if (destructureElement.parent.elements) {
-                    elementsInHost = destructureElement.parent.elements;
+            if (destructureIdentifier !== null) {
+                for (let i = 0; i < destructureIdentifier.length; i++) {
+                    if (destructureIdentifier[i] === destructureElement) {
+                        identifierMap.delete(key);
+                    }
                 }
-
-                if (destructureElement.parent.parent.type === "ObjectPattern") {
-                    elementsInHost = destructureGroup[0].parent.parent.properties;
-                }
-            }
-
-            if (elementsInHost && elementsInHost.length && elementsInHost.length !== destructureGroup.length) {
-                identifierMap.delete(key);
             }
         }
     }
@@ -275,6 +376,8 @@ module.exports = {
         const checkingMixedDestructuring = options.destructuring !== "all";
         const ignoreReadBeforeAssign = options.ignoreReadBeforeAssign === true;
         const variables = [];
+        let destructureCount = null;
+        let destructureIdentifier = null;
 
         /**
          * Reports given identifier nodes if all of the nodes should be declared
@@ -323,7 +426,18 @@ module.exports = {
 
         return {
             "Program:exit"() {
-                groupByDestructuring(variables, ignoreReadBeforeAssign, checkingMixedDestructuring).forEach(checkGroup);
+                const identifierMap = groupByDestructuring(variables, ignoreReadBeforeAssign);
+
+                verifyAllDestructuring(identifierMap, checkingMixedDestructuring, destructureCount, destructureIdentifier).forEach(checkGroup);
+            },
+            "ExpressionStatement[expression.left.type = /ArrayPattern|ObjectPattern/]"(node) {
+                if (node.expression.left.type === "ArrayPattern") {
+                    destructureIdentifier = getIdentifiersInArrayDestructureGroup(node.expression.left);
+                    destructureCount = countElementsInArrayDestructureGroup(node.expression.left);
+                } else {
+                    destructureIdentifier = getIdentifiersInObjectDestructureGroup(node.expression.left);
+                    destructureCount = countElementsInObjectDestructureGroup(node.expression.left);
+                }
             },
 
             VariableDeclaration(node) {

--- a/lib/rules/prefer-const.js
+++ b/lib/rules/prefer-const.js
@@ -164,9 +164,10 @@ function getDestructuringHost(reference) {
  * @param {eslint-scope.Variable[]} variables - Variables to group by destructuring.
  * @param {boolean} ignoreReadBeforeAssign -
  *      The value of `ignoreReadBeforeAssign` option.
+ * @param {boolean} checkingMixedDestructuring - value on how to report destructuring (any/all)
  * @returns {Map<ASTNode, ASTNode[]>} Grouped identifier nodes.
  */
-function groupByDestructuring(variables, ignoreReadBeforeAssign) {
+function groupByDestructuring(variables, ignoreReadBeforeAssign, checkingMixedDestructuring) {
     const identifierMap = new Map();
 
     for (let i = 0; i < variables.length; ++i) {
@@ -199,13 +200,15 @@ function groupByDestructuring(variables, ignoreReadBeforeAssign) {
         }
     }
 
-    for (const key of identifierMap.keys()) {
-        const destructureGroup = identifierMap.get(key);
-        const destructureElement = destructureGroup[0];
+    if (!checkingMixedDestructuring) {
+        for (const key of identifierMap.keys()) {
+            const destructureGroup = identifierMap.get(key);
+            const destructureElement = destructureGroup[0];
 
-        if (destructureElement && destructureElement.parent && destructureElement.parent.elements) {
-            if (destructureElement.parent.elements.length !== destructureGroup.length) {
-                identifierMap.delete(key);
+            if (destructureElement && destructureElement.parent && destructureElement.parent.elements) {
+                if (destructureElement.parent.elements.length !== destructureGroup.length) {
+                    identifierMap.delete(key);
+                }
             }
         }
     }
@@ -311,7 +314,7 @@ module.exports = {
 
         return {
             "Program:exit"() {
-                groupByDestructuring(variables, ignoreReadBeforeAssign).forEach(checkGroup);
+                groupByDestructuring(variables, ignoreReadBeforeAssign, checkingMixedDestructuring).forEach(checkGroup);
             },
 
             VariableDeclaration(node) {

--- a/tests/lib/rules/prefer-const.js
+++ b/tests/lib/rules/prefer-const.js
@@ -56,10 +56,20 @@ ruleTester.run("prefer-const", rule, {
         "let a; function foo() { if (a) {} a = bar(); }",
         "let a; function foo() { a = a || bar(); baz(a); }",
         "let a; function foo() { bar(++a); }",
-        "let predicate; [typeNode.returnType, predicate] = foo();",
-        "let predicate; let rest; [typeNode.returnType, predicate, ...rest] = foo();",
+        {
+            code: "let foo; ({ x: bar.baz, y: foo } = qux);",
+            options: [{ destructuring: "all" }]
+        },
+        {
+            code: "let foo; [foo, [bar.baz]] = qux;",
+            options: [{ destructuring: "all" }]
+        },
         {
             code: "let predicate; [typeNode.returnType, predicate] = foo();",
+            options: [{ destructuring: "all" }]
+        },
+        {
+            code: "let predicate; let rest; [typeNode.returnType, predicate, ...rest] = foo();",
             options: [{ destructuring: "all" }]
         },
         {
@@ -359,6 +369,36 @@ ruleTester.run("prefer-const", rule, {
                 { message: "'foo' is never reassigned. Use 'const' instead.", type: "Identifier" },
                 { message: "'bar' is never reassigned. Use 'const' instead.", type: "Identifier" }
             ]
+        },
+        {
+            code: "let predicate; [predicate, typeNode.returnType] = foo();",
+            output: null,
+            errors: [{ message: "'predicate' is never reassigned. Use 'const' instead.", type: "Identifier" }]
+        },
+        {
+            code: "let predicate; [typeNode.returnType, predicate] = foo();",
+            output: null,
+            errors: [{ message: "'predicate' is never reassigned. Use 'const' instead.", type: "Identifier" }]
+        },
+        {
+            code: "let predicate; let rest; [typeNode.returnType, predicate, ...rest] = foo();",
+            output: null,
+            errors: [
+                { message: "'predicate' is never reassigned. Use 'const' instead.", type: "Identifier" },
+                { message: "'rest' is never reassigned. Use 'const' instead.", type: "Identifier" }
+            ]
+        },
+        {
+            code: "let foo; [foo, [bar.baz]] = qux;",
+            output: null,
+            options: [{ destructuring: "any" }],
+            errors: [{ message: "'foo' is never reassigned. Use 'const' instead.", type: "Identifier" }]
+        },
+        {
+            code: "let foo; ({ x: bar.baz, y: foo } = qux);",
+            output: null,
+            options: [{ destructuring: "any" }],
+            errors: [{ message: "'foo' is never reassigned. Use 'const' instead.", type: "Identifier" }]
         }
     ]
 });

--- a/tests/lib/rules/prefer-const.js
+++ b/tests/lib/rules/prefer-const.js
@@ -61,7 +61,16 @@ ruleTester.run("prefer-const", rule, {
             options: [{ destructuring: "all" }]
         },
         {
+            code: "let foo; ({ x: bar.baz, y: foo, z: bar.bro.q } = qux);",
+            options: [{ destructuring: "all" }]
+        },
+        {
             code: "let foo; [foo, [bar.baz]] = qux;",
+            options: [{ destructuring: "all" }]
+        },
+        {
+            code: "let foo, bar; [foo, [bar, baz.qux]] = qux;",
+            output: null,
             options: [{ destructuring: "all" }]
         },
         {
@@ -72,18 +81,16 @@ ruleTester.run("prefer-const", rule, {
             code: "let predicate; let rest; [typeNode.returnType, predicate, ...rest] = foo();",
             options: [{ destructuring: "all" }]
         },
-        {
-            code: [
-                "let id;",
-                "function foo() {",
-                "    if (typeof id !== 'undefined') {",
-                "        return;",
-                "    }",
-                "    id = setInterval(() => {}, 250);",
-                "}",
-                "foo();"
-            ].join("\n")
-        },
+        [
+            "let id;",
+            "function foo() {",
+            "    if (typeof id !== 'undefined') {",
+            "        return;",
+            "    }",
+            "    id = setInterval(() => {}, 250);",
+            "}",
+            "foo();"
+        ].join("\n"),
         "/*exported a*/ let a; function init() { a = foo(); }",
         "/*exported a*/ let a = 1",
         "let a; if (true) a = 0; foo(a);",
@@ -124,6 +131,11 @@ ruleTester.run("prefer-const", rule, {
         }
     ],
     invalid: [
+        {
+            code: "let foo; [foo, []] = qux;",
+            output: null,
+            errors: [{ message: "'foo' is never reassigned. Use 'const' instead.", type: "Identifier" }]
+        },
         {
             code: "let x = 1; foo(x);",
             output: "const x = 1; foo(x);",

--- a/tests/lib/rules/prefer-const.js
+++ b/tests/lib/rules/prefer-const.js
@@ -95,6 +95,7 @@ ruleTester.run("prefer-const", rule, {
             options: [{ destructuring: "all" }]
         },
 
+        
         // https://github.com/eslint/eslint/issues/8187
         {
             code: "let { name, ...otherStuff } = obj; otherStuff = {};",

--- a/tests/lib/rules/prefer-const.js
+++ b/tests/lib/rules/prefer-const.js
@@ -56,16 +56,24 @@ ruleTester.run("prefer-const", rule, {
         "let a; function foo() { if (a) {} a = bar(); }",
         "let a; function foo() { a = a || bar(); baz(a); }",
         "let a; function foo() { bar(++a); }",
-        [
-            "let id;",
-            "function foo() {",
-            "    if (typeof id !== 'undefined') {",
-            "        return;",
-            "    }",
-            "    id = setInterval(() => {}, 250);",
-            "}",
-            "foo();"
-        ].join("\n"),
+        "let predicate; [typeNode.returnType, predicate] = foo();",
+        "let predicate; let rest; [typeNode.returnType, predicate, ...rest] = foo();",
+        {
+            code: "let predicate; [typeNode.returnType, predicate] = foo();",
+            options: [{ destructuring: "all" }]
+        },
+        {
+            code: [
+                "let id;",
+                "function foo() {",
+                "    if (typeof id !== 'undefined') {",
+                "        return;",
+                "    }",
+                "    id = setInterval(() => {}, 250);",
+                "}",
+                "foo();"
+            ].join("\n")
+        },
         "/*exported a*/ let a; function init() { a = foo(); }",
         "/*exported a*/ let a = 1",
         "let a; if (true) a = 0; foo(a);",
@@ -266,6 +274,14 @@ ruleTester.run("prefer-const", rule, {
             options: [],
             errors: [
                 { message: "'a' is never reassigned. Use 'const' instead.", type: "Identifier" }
+            ]
+        },
+        {
+            code: "let [ foo, bar ] = baz();",
+            output: "const [ foo, bar ] = baz();",
+            errors: [
+                { message: "'foo' is never reassigned. Use 'const' instead.", type: "Identifier" },
+                { message: "'bar' is never reassigned. Use 'const' instead.", type: "Identifier" }
             ]
         },
         {

--- a/tests/lib/rules/prefer-const.js
+++ b/tests/lib/rules/prefer-const.js
@@ -95,7 +95,6 @@ ruleTester.run("prefer-const", rule, {
             options: [{ destructuring: "all" }]
         },
 
-        
         // https://github.com/eslint/eslint/issues/8187
         {
             code: "let { name, ...otherStuff } = obj; otherStuff = {};",


### PR DESCRIPTION
(fixes #8308)

NPM version: 3.10.10
node: v6.9.5

**What parser (default, Babel-ESLint, etc.) are you using?**
default

**What is the purpose of this pull request? (put an "X" next to item)**
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

**What changes did you make? (Give an overview)**
Added a check in prefer_const where it counts the number of nodes in a destructure group and checks with the number of elements in the parent of the first element in the group. This is how I am checking if everything else in the group can be converted to `const`.

**Is there anything you'd like reviewers to focus on?**


