### PR TITLE
Fix: avoid reporting the entire AST for missing rules

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -519,8 +519,11 @@ function createStubRule(message) {
      */
     function createRuleModule(context) {
         return {
-            Program(node) {
-                context.report(node, message);
+            Program() {
+                context.report({
+                    loc: { line: 1, column: 0 },
+                    message
+                });
             }
         };
     }

--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -2697,7 +2697,19 @@ describe("Linter", () => {
 
         it("should report multiple missing rules", () => {
             assert.isArray(resultsMultiple);
-            assert.equal(resultsMultiple[1].ruleId, "barfoo");
+
+            assert.deepEqual(
+                resultsMultiple[1],
+                {
+                    ruleId: "barfoo",
+                    message: "Definition for rule 'barfoo' was not found",
+                    line: 1,
+                    column: 1,
+                    severity: 1,
+                    source: "var answer = 6 * 7;",
+                    nodeType: void 0
+                }
+            );
         });
     });
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix

**Tell us about your environment**

* **ESLint Version:** master
* **Node Version:** 8.2.1
* **npm Version:** 5.3.0

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

```yml
rules:
  nonexistent-rule: error
```

**What did you do? Please include the actual source code causing the issue.**

```js
foo;
bar;
baz;
qux;
```

**What did you expect to happen?**

I expected an error to be reported at the top of the file due to the nonexistent rule.

**What actually happened? Please include the actual, raw output from ESLint.**

An error was reported, spanning the entire file.

<details>
<summary>Output of JSON formatter</summary>

```json
[{"filePath":"<text>","messages":[{"ruleId":"nonexistent-rule","severity":2,"message":"Definition for rule 'nonexistent-rule' was not found","line":1,"column":1,"nodeType":"Program","source":"foo;","endLine":4,"endColumn":5}],"errorCount":1,"warningCount":0,"fixableErrorCount":0,"fixableWarningCount":0,"source":"foo;\nbar;\nbaz;\nqux;"}]
```
</details>

This was an unintended side-effect of b0c63f0a928cceff7cf6f060262dd7ac4bc0f8dc.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Messages for missing rules are only intended to appear at the top of a file. However, the messages have always been implemented as `context.report` calls on the `Program` node, and due to b0c63f0a928cceff7cf6f060262dd7ac4bc0f8dc, this results in the entire AST range being reported. This commit updates the missing-rule messages to report issues at the top of the file.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular