### PR TITLE
Fix: inconsistent `indent` behavior on computed properties (fixes #8989)

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -1229,7 +1229,7 @@ module.exports = {
             },
 
             Property(node) {
-                if (!node.computed && !node.shorthand && !node.method && node.kind === "init") {
+                if (!node.shorthand && !node.method && node.kind === "init") {
                     const colon = sourceCode.getFirstTokenBetween(node.key, node.value, astUtils.isColonToken);
 
                     offsets.ignoreToken(sourceCode.getTokenAfter(colon));

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -2289,6 +2289,22 @@ ruleTester.run("indent", rule, {
             options: [2]
         },
         {
+            code: unIndent`
+                ({
+                    foo:
+                        bar
+                })
+            `
+        },
+        {
+            code: unIndent`
+                ({
+                    [foo]:
+                        bar
+                })
+            `
+        },
+        {
 
             // Comments in switch cases
             code: unIndent`


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (https://github.com/eslint/eslint/issues/8989)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This removes an incorrect exception in the `indent` rule for computed `Property` nodes.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
