### PR TITLE
Fix: getter-return marking method named 'get' as an issue (fixes #8919)

### DIFF
--- a/tests/lib/rules/getter-return.js
+++ b/tests/lib/rules/getter-return.js
@@ -67,7 +67,9 @@ ruleTester.run("getter-return", rule, {
         { code: "var foo = { bar(){ return true; } };" },
         { code: "var foo = { bar: function(){} };" },
         { code: "var foo = { bar: function(){return;} };" },
-        { code: "var foo = { bar: function(){return true;} };" }
+        { code: "var foo = { bar: function(){return true;} };" },
+        { code: "var foo = { get: function () {} }" },
+        { code: "var foo = { get: () => {}};" }
     ],
 
     invalid: [
@@ -95,6 +97,7 @@ ruleTester.run("getter-return", rule, {
         // test object.defineProperty(s)
         // option: {allowImplicit: false}
         { code: "Object.defineProperty(foo, \"bar\", { get: function (){}});", errors: [{ noReturnMessage }] },
+        { code: "Object.defineProperty(foo, \"bar\", { get: () => {}});", errors: [{ noReturnMessage }] },
         { code: "Object.defineProperty(foo, \"bar\", { get: function (){if(bar) {return true;}}});", errors: [{ message: "Expected method 'get' to always return a value." }] },
         { code: "Object.defineProperty(foo, \"bar\", { get: function (){ ~function () { return true; }()}});", errors: [{ noReturnMessage }] },
         { code: "Object.defineProperties(foo, { bar: { get: function () {}} });", options, errors: [{ noReturnMessage }] },


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))


<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
fixes #8919 https://github.com/eslint/eslint/issues/8919#issuecomment-315467793

**Is there anything you'd like reviewers to focus on?**

the currently fix is not decent. I think there should be an easier way to check the AST node structure that I didn't know (like selector).
