### PR TITLE
Fix: refactor no-multi-spaces to avoid regex backtracking (fixes #9001)

### DIFF
--- a/lib/rules/no-multi-spaces.js
+++ b/lib/rules/no-multi-spaces.js
@@ -44,68 +44,11 @@ module.exports = {
     },
 
     create(context) {
-
-        // the index of the last comment that was checked
-        const sourceCode = context.getSourceCode(),
-            exceptions = { Property: true },
-            options = context.options[0] || {},
-            ignoreEOLComments = options.ignoreEOLComments;
-        let hasExceptions = true,
-            lastCommentIndex = 0;
-
-        if (options && options.exceptions) {
-            Object.keys(options.exceptions).forEach(key => {
-                if (options.exceptions[key]) {
-                    exceptions[key] = true;
-                } else {
-                    delete exceptions[key];
-                }
-            });
-            hasExceptions = Object.keys(exceptions).length > 0;
-        }
-
-        /**
-         * Checks if a given token is the last token of the line or not.
-         * @param {Token} token The token to check.
-         * @returns {boolean} Whether or not a token is at the end of the line it occurs in.
-         * @private
-         */
-        function isLastTokenOfLine(token) {
-            const nextToken = sourceCode.getTokenAfter(token, { includeComments: true });
-
-            // nextToken is null if the comment is the last token in the program.
-            if (!nextToken) {
-                return true;
-            }
-
-            return !astUtils.isTokenOnSameLine(token, nextToken);
-        }
-
-        /**
-         * Determines if a given source index is in a comment or not by checking
-         * the index against the comment range. Since the check goes straight
-         * through the file, once an index is passed a certain comment, we can
-         * go to the next comment to check that.
-         * @param {int} index The source index to check.
-         * @param {ASTNode[]} comments An array of comment nodes.
-         * @returns {boolean} True if the index is within a comment, false if not.
-         * @private
-         */
-        function isIndexInComment(index, comments) {
-            while (lastCommentIndex < comments.length) {
-                const comment = comments[lastCommentIndex];
-
-                if (comment.range[0] < index && index < comment.range[1]) {
-                    return true;
-                } else if (index > comment.range[1]) {
-                    lastCommentIndex++;
-                } else {
-                    break;
-                }
-            }
-
-            return false;
-        }
+        const sourceCode = context.getSourceCode();
+        const options = context.options[0] || {};
+        const ignoreEOLComments = options.ignoreEOLComments;
+        const exceptions = Object.assign({ Property: true }, options.exceptions);
+        const hasExceptions = Object.keys(exceptions).filter(key => exceptions[key]).length > 0;
 
         /**
          * Formats value of given comment token for error message by truncating its length.
@@ -121,70 +64,59 @@ module.exports = {
             return valueLines.length === 1 && value.length <= 12 ? value : formattedValue;
         }
 
-        /**
-         * Creates a fix function that removes the multiple spaces between the two tokens
-         * @param {Token} leftToken left token
-         * @param {Token} rightToken right token
-         * @returns {Function} fix function
-         * @private
-         */
-        function createFix(leftToken, rightToken) {
-            return function(fixer) {
-                return fixer.replaceTextRange([leftToken.range[1], rightToken.range[0]], " ");
-            };
-        }
-
         //--------------------------------------------------------------------------
         // Public
         //--------------------------------------------------------------------------
 
         return {
             Program() {
-
-                const source = sourceCode.getText(),
-                    allComments = sourceCode.getAllComments(),
-                    pattern = /[^\s].*? {2,}/g;
-                let parent;
-
-                while (pattern.test(source)) {
-
-                    // do not flag anything inside of comments
-                    if (!isIndexInComment(pattern.lastIndex, allComments)) {
-
-                        const token = sourceCode.getTokenByRangeStart(pattern.lastIndex, { includeComments: true });
-
-                        if (token) {
-                            if (ignoreEOLComments && astUtils.isCommentToken(token) && isLastTokenOfLine(token)) {
-                                return;
-                            }
-
-                            const previousToken = sourceCode.getTokenBefore(token, { includeComments: true });
-
-                            if (hasExceptions) {
-                                parent = sourceCode.getNodeByRangeIndex(pattern.lastIndex - 1);
-                            }
-
-                            if (!parent || !exceptions[parent.type]) {
-                                let value = token.value;
-
-                                if (token.type === "Block") {
-                                    value = `/*${formatReportedCommentValue(token)}*/`;
-                                } else if (token.type === "Line") {
-                                    value = `//${formatReportedCommentValue(token)}`;
-                                }
-
-                                context.report({
-                                    node: token,
-                                    loc: token.loc.start,
-                                    message: "Multiple spaces found before '{{value}}'.",
-                                    data: { value },
-                                    fix: createFix(previousToken, token)
-                                });
-                            }
-                        }
-
+                sourceCode.tokensAndComments.forEach((leftToken, leftIndex, tokensAndComments) => {
+                    if (leftIndex === tokensAndComments.length - 1) {
+                        return;
                     }
-                }
+                    const rightToken = tokensAndComments[leftIndex + 1];
+
+                    if (leftToken.range[1] + 1 >= rightToken.range[0] || leftToken.loc.end.line < rightToken.loc.start.line) {
+                        return;
+                    }
+
+                    if (
+                        ignoreEOLComments &&
+                        astUtils.isCommentToken(rightToken) &&
+                        (
+                            leftIndex === tokensAndComments.length - 2 ||
+                            rightToken.loc.end.line < tokensAndComments[leftIndex + 2].loc.start.line
+                        )
+                    ) {
+                        return;
+                    }
+
+                    if (hasExceptions) {
+                        const parentNode = sourceCode.getNodeByRangeIndex(rightToken.range[0] - 1);
+
+                        if (parentNode && exceptions[parentNode.type]) {
+                            return;
+                        }
+                    }
+
+                    let displayValue;
+
+                    if (rightToken.type === "Block") {
+                        displayValue = `/*${formatReportedCommentValue(rightToken)}*/`;
+                    } else if (rightToken.type === "Line") {
+                        displayValue = `//${formatReportedCommentValue(rightToken)}`;
+                    } else {
+                        displayValue = rightToken.value;
+                    }
+
+                    context.report({
+                        node: rightToken,
+                        loc: rightToken.loc.start,
+                        message: "Multiple spaces found before '{{displayValue}}'.",
+                        data: { displayValue },
+                        fix: fixer => fixer.replaceTextRange([leftToken.range[1], rightToken.range[0]], " ")
+                    });
+                });
             }
         };
 

--- a/lib/rules/no-multi-spaces.js
+++ b/lib/rules/no-multi-spaces.js
@@ -76,10 +76,12 @@ module.exports = {
                     }
                     const rightToken = tokensAndComments[leftIndex + 1];
 
-                    if (leftToken.range[1] + 1 >= rightToken.range[0] || leftToken.loc.end.line < rightToken.loc.start.line) {
+                    // Ignore tokens that have less than 2 spaces between them or are on different lines
+                    if (leftToken.range[1] + 2 > rightToken.range[0] || leftToken.loc.end.line < rightToken.loc.start.line) {
                         return;
                     }
 
+                    // Ignore comments that are the last token on their line if `ignoreEOLComments` is active.
                     if (
                         ignoreEOLComments &&
                         astUtils.isCommentToken(rightToken) &&
@@ -91,6 +93,7 @@ module.exports = {
                         return;
                     }
 
+                    // Ignore tokens that are in a node in the "exceptions" object
                     if (hasExceptions) {
                         const parentNode = sourceCode.getNodeByRangeIndex(rightToken.range[0] - 1);
 

--- a/tests/lib/rules/no-multi-spaces.js
+++ b/tests/lib/rules/no-multi-spaces.js
@@ -98,7 +98,10 @@ ruleTester.run("no-multi-spaces", rule, {
 
         "foo\n\f  bar",
         "foo\n\u2003  bar",
-        "foo\n \f  bar"
+        "foo\n \f  bar",
+
+        // https://github.com/eslint/eslint/issues/9001
+        "a".repeat(2e5)
     ],
 
     invalid: [


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (https://github.com/eslint/eslint/issues/9001)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This refactors the `no-multi-spaces` rule to compare spacing between tokens, rather than matching a regex against the source text. This prevents performance issues resulting from quadratic-time regex matching (https://github.com/eslint/eslint/issues/9001). This also allows the rule to be simpler because by only evaluating spacing between tokens, it no longer needs to specifically exclude spacing in comments.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular