### PR TITLE
Fix: Add `yarn` support to `eslint --init`

### DIFF
--- a/lib/util/npm-util.js
+++ b/lib/util/npm-util.js
@@ -68,7 +68,7 @@ function installSyncSaveDev(packages) {
 function fetchPeerDependencies(packageName) {
     const fetchedText = spawn.sync(
         packageManager,
-        [packageManager === "npm" ? "show" : "info", "--json", packageName, "peerDependencies"],
+        [packageManager === "npm" ? "info" : "show", "--json", packageName, "peerDependencies"],
         { encoding: "utf8" }
     ).stdout.trim();
 

--- a/lib/util/npm-util.js
+++ b/lib/util/npm-util.js
@@ -18,6 +18,8 @@ const fs = require("fs"),
 // Helpers
 //------------------------------------------------------------------------------
 
+let packageManager = "npm";
+
 /**
  * Find the closest package.json file, starting at process.cwd (by default),
  * and working up to root.
@@ -34,6 +36,8 @@ function findPackageJson(startDir) {
         if (!fs.existsSync(pkgFile) || !fs.statSync(pkgFile).isFile()) {
             dir = path.join(dir, "..");
             continue;
+        } else if (fs.existsSync(path.join(dir, "yarn.lock"))) {
+            packageManager = "yarn";
         }
         return pkgFile;
     } while (dir !== path.resolve(dir, ".."));
@@ -53,7 +57,7 @@ function installSyncSaveDev(packages) {
     if (!Array.isArray(packages)) {
         packages = [packages];
     }
-    spawn.sync("npm", ["i", "--save-dev"].concat(packages), { stdio: "inherit" });
+    spawn.sync(packageManager, (packageManager === "npm" ? ["i", "--save-dev"] : ["add", "--dev"]).concat(packages), { stdio: "inherit" });
 }
 
 /**
@@ -63,12 +67,19 @@ function installSyncSaveDev(packages) {
  */
 function fetchPeerDependencies(packageName) {
     const fetchedText = spawn.sync(
-        "npm",
-        ["show", "--json", packageName, "peerDependencies"],
+        packageManager,
+        [packageManager === "npm" ? "show" : "info", "--json", packageName, "peerDependencies"],
         { encoding: "utf8" }
     ).stdout.trim();
 
-    return JSON.parse(fetchedText || "{}");
+    try {
+        const deps = JSON.parse(fetchedText || "{}");
+
+        return packageManager === "npm" ? deps : deps.data || {};
+    } catch (e) {
+        log.info("Could not read devDependencies for package %s", packageName);
+        return {};
+    }
 }
 
 /**

--- a/lib/util/npm-util.js
+++ b/lib/util/npm-util.js
@@ -68,7 +68,7 @@ function installSyncSaveDev(packages) {
 function fetchPeerDependencies(packageName) {
     const fetchedText = spawn.sync(
         packageManager,
-        [packageManager === "npm" ? "info" : "show", "--json", packageName, "peerDependencies"],
+        [packageManager === "npm" ? "show" : "info", "--json", packageName, "peerDependencies"],
         { encoding: "utf8" }
     ).stdout.trim();
 


### PR DESCRIPTION
`aslant —init` always uses `NPM` even while packages was installed using `yarn`. This PR fixes that.