### PR TITLE
Update: make indent handle custom syntax more reliably (fixes #8990)

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -960,11 +960,20 @@ module.exports = {
 
         return {
             "ArrayExpression, ArrayPattern"(node) {
-                addElementListIndent(node.elements, sourceCode.getFirstToken(node), sourceCode.getLastToken(node), options.ArrayExpression);
+                const openingBracket = sourceCode.getFirstToken(node);
+                const closingBracket = sourceCode.getTokenAfter(lodash.findLast(node.elements) || openingBracket, astUtils.isClosingBracketToken);
+
+                addElementListIndent(node.elements, openingBracket, closingBracket, options.ArrayExpression);
             },
 
             "ObjectExpression, ObjectPattern"(node) {
-                addElementListIndent(node.properties, sourceCode.getFirstToken(node), sourceCode.getLastToken(node), options.ObjectExpression);
+                const openingCurly = sourceCode.getFirstToken(node);
+                const closingCurly = sourceCode.getTokenAfter(
+                    node.properties.length ? node.properties[node.properties.length - 1] : openingCurly,
+                    astUtils.isClosingBraceToken
+                );
+
+                addElementListIndent(node.properties, openingCurly, closingCurly, options.ObjectExpression);
             },
 
             ArrowFunctionExpression(node) {

--- a/tests/fixtures/parsers/babel-eslint7/array-pattern-with-annotation.js
+++ b/tests/fixtures/parsers/babel-eslint7/array-pattern-with-annotation.js
@@ -1,0 +1,389 @@
+/**
+ * Parser: babel-eslint v7.2.3
+ * Source code:
+ * ([
+ *     foo
+ *     ]: bar) => baz
+ */
+
+exports.parse = () => ({
+    "type": "Program",
+    "start": 0,
+    "end": 29,
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 3,
+            "column": 18
+        }
+    },
+    "comments": [],
+    "tokens": [
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "start": 0,
+            "end": 1,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 1
+                }
+            },
+            "range": [
+                0,
+                1
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "[",
+            "start": 1,
+            "end": 2,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 1
+                },
+                "end": {
+                    "line": 1,
+                    "column": 2
+                }
+            },
+            "range": [
+                1,
+                2
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "foo",
+            "start": 7,
+            "end": 10,
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 4
+                },
+                "end": {
+                    "line": 2,
+                    "column": 7
+                }
+            },
+            "range": [
+                7,
+                10
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "]",
+            "start": 15,
+            "end": 16,
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 4
+                },
+                "end": {
+                    "line": 3,
+                    "column": 5
+                }
+            },
+            "range": [
+                15,
+                16
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "start": 16,
+            "end": 17,
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 5
+                },
+                "end": {
+                    "line": 3,
+                    "column": 6
+                }
+            },
+            "range": [
+                16,
+                17
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "bar",
+            "start": 18,
+            "end": 21,
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 7
+                },
+                "end": {
+                    "line": 3,
+                    "column": 10
+                }
+            },
+            "range": [
+                18,
+                21
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "start": 21,
+            "end": 22,
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 10
+                },
+                "end": {
+                    "line": 3,
+                    "column": 11
+                }
+            },
+            "range": [
+                21,
+                22
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "=>",
+            "start": 23,
+            "end": 25,
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 12
+                },
+                "end": {
+                    "line": 3,
+                    "column": 14
+                }
+            },
+            "range": [
+                23,
+                25
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "baz",
+            "start": 26,
+            "end": 29,
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 15
+                },
+                "end": {
+                    "line": 3,
+                    "column": 18
+                }
+            },
+            "range": [
+                26,
+                29
+            ]
+        }
+    ],
+    "range": [
+        0,
+        29
+    ],
+    "sourceType": "module",
+    "body": [
+        {
+            "type": "ExpressionStatement",
+            "start": 0,
+            "end": 29,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 3,
+                    "column": 18
+                }
+            },
+            "expression": {
+                "type": "ArrowFunctionExpression",
+                "start": 0,
+                "end": 29,
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 3,
+                        "column": 18
+                    }
+                },
+                "id": null,
+                "generator": false,
+                "expression": true,
+                "async": false,
+                "params": [
+                    {
+                        "type": "ArrayPattern",
+                        "start": 1,
+                        "end": 21,
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 1
+                            },
+                            "end": {
+                                "line": 3,
+                                "column": 10
+                            }
+                        },
+                        "elements": [
+                            {
+                                "type": "Identifier",
+                                "start": 7,
+                                "end": 10,
+                                "loc": {
+                                    "start": {
+                                        "line": 2,
+                                        "column": 4
+                                    },
+                                    "end": {
+                                        "line": 2,
+                                        "column": 7
+                                    },
+                                    "identifierName": "foo"
+                                },
+                                "name": "foo",
+                                "range": [
+                                    7,
+                                    10
+                                ],
+                                "_babelType": "Identifier"
+                            }
+                        ],
+                        "typeAnnotation": {
+                            "type": "TypeAnnotation",
+                            "start": 16,
+                            "end": 21,
+                            "loc": {
+                                "start": {
+                                    "line": 3,
+                                    "column": 5
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 10
+                                }
+                            },
+                            "typeAnnotation": {
+                                "type": "GenericTypeAnnotation",
+                                "start": 18,
+                                "end": 21,
+                                "loc": {
+                                    "start": {
+                                        "line": 3,
+                                        "column": 7
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "column": 10
+                                    }
+                                },
+                                "typeParameters": null,
+                                "id": {
+                                    "type": "Identifier",
+                                    "start": 18,
+                                    "end": 21,
+                                    "loc": {
+                                        "start": {
+                                            "line": 3,
+                                            "column": 7
+                                        },
+                                        "end": {
+                                            "line": 3,
+                                            "column": 10
+                                        },
+                                        "identifierName": "bar"
+                                    },
+                                    "name": "bar",
+                                    "range": [
+                                        18,
+                                        21
+                                    ],
+                                    "_babelType": "Identifier"
+                                },
+                                "range": [
+                                    18,
+                                    21
+                                ],
+                                "_babelType": "GenericTypeAnnotation"
+                            },
+                            "range": [
+                                16,
+                                21
+                            ],
+                            "_babelType": "TypeAnnotation"
+                        },
+                        "range": [
+                            1,
+                            21
+                        ],
+                        "_babelType": "ArrayPattern"
+                    }
+                ],
+                "body": {
+                    "type": "Identifier",
+                    "start": 26,
+                    "end": 29,
+                    "loc": {
+                        "start": {
+                            "line": 3,
+                            "column": 15
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 18
+                        },
+                        "identifierName": "baz"
+                    },
+                    "name": "baz",
+                    "range": [
+                        26,
+                        29
+                    ],
+                    "_babelType": "Identifier"
+                },
+                "range": [
+                    0,
+                    29
+                ],
+                "_babelType": "ArrowFunctionExpression",
+                "defaults": []
+            },
+            "range": [
+                0,
+                29
+            ],
+            "_babelType": "ExpressionStatement"
+        }
+    ]
+});

--- a/tests/fixtures/parsers/babel-eslint7/object-pattern-with-annotation.js
+++ b/tests/fixtures/parsers/babel-eslint7/object-pattern-with-annotation.js
@@ -1,0 +1,438 @@
+/**
+ * Parser: babel-eslint v7.2.3
+ * Source code:
+ * ({
+ *     foo
+ *     }: bar) => baz
+ */
+
+exports.parse = () => ({
+    type: "Program",
+    start: 0,
+    end: 29,
+    loc: {
+        start: {
+            line: 1,
+            column: 0
+        },
+        end: {
+            line: 3,
+            column: 18
+        }
+    },
+    comments: [],
+    tokens: [
+        {
+            type: "Punctuator",
+            value: "(",
+            start: 0,
+            end: 1,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 0
+                },
+                end: {
+                    line: 1,
+                    column: 1
+                }
+            },
+            range: [
+                0,
+                1
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: "{",
+            start: 1,
+            end: 2,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 1
+                },
+                end: {
+                    line: 1,
+                    column: 2
+                }
+            },
+            range: [
+                1,
+                2
+            ]
+        },
+        {
+            type: "Identifier",
+            value: "foo",
+            start: 7,
+            end: 10,
+            loc: {
+                start: {
+                    line: 2,
+                    column: 4
+                },
+                end: {
+                    line: 2,
+                    column: 7
+                }
+            },
+            range: [
+                7,
+                10
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: "}",
+            start: 15,
+            end: 16,
+            loc: {
+                start: {
+                    line: 3,
+                    column: 4
+                },
+                end: {
+                    line: 3,
+                    column: 5
+                }
+            },
+            range: [
+                15,
+                16
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: ":",
+            start: 16,
+            end: 17,
+            loc: {
+                start: {
+                    line: 3,
+                    column: 5
+                },
+                end: {
+                    line: 3,
+                    column: 6
+                }
+            },
+            range: [
+                16,
+                17
+            ]
+        },
+        {
+            type: "Identifier",
+            value: "bar",
+            start: 18,
+            end: 21,
+            loc: {
+                start: {
+                    line: 3,
+                    column: 7
+                },
+                end: {
+                    line: 3,
+                    column: 10
+                }
+            },
+            range: [
+                18,
+                21
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: ")",
+            start: 21,
+            end: 22,
+            loc: {
+                start: {
+                    line: 3,
+                    column: 10
+                },
+                end: {
+                    line: 3,
+                    column: 11
+                }
+            },
+            range: [
+                21,
+                22
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: "=>",
+            start: 23,
+            end: 25,
+            loc: {
+                start: {
+                    line: 3,
+                    column: 12
+                },
+                end: {
+                    line: 3,
+                    column: 14
+                }
+            },
+            range: [
+                23,
+                25
+            ]
+        },
+        {
+            type: "Identifier",
+            value: "baz",
+            start: 26,
+            end: 29,
+            loc: {
+                start: {
+                    line: 3,
+                    column: 15
+                },
+                end: {
+                    line: 3,
+                    column: 18
+                }
+            },
+            range: [
+                26,
+                29
+            ]
+        }
+    ],
+    range: [
+        0,
+        29
+    ],
+    sourceType: "module",
+    body: [
+        {
+            type: "ExpressionStatement",
+            start: 0,
+            end: 29,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 0
+                },
+                end: {
+                    line: 3,
+                    column: 18
+                }
+            },
+            expression: {
+                type: "ArrowFunctionExpression",
+                start: 0,
+                end: 29,
+                loc: {
+                    start: {
+                        line: 1,
+                        column: 0
+                    },
+                    end: {
+                        line: 3,
+                        column: 18
+                    }
+                },
+                id: null,
+                generator: false,
+                expression: true,
+                async: false,
+                params: [
+                    {
+                        type: "ObjectPattern",
+                        start: 1,
+                        end: 21,
+                        loc: {
+                            start: {
+                                line: 1,
+                                column: 1
+                            },
+                            end: {
+                                line: 3,
+                                column: 10
+                            }
+                        },
+                        properties: [
+                            {
+                                type: "Property",
+                                start: 7,
+                                end: 10,
+                                loc: {
+                                    start: {
+                                        line: 2,
+                                        column: 4
+                                    },
+                                    end: {
+                                        line: 2,
+                                        column: 7
+                                    }
+                                },
+                                method: false,
+                                shorthand: true,
+                                computed: false,
+                                key: {
+                                    type: "Identifier",
+                                    start: 7,
+                                    end: 10,
+                                    loc: {
+                                        start: {
+                                            line: 2,
+                                            column: 4
+                                        },
+                                        end: {
+                                            line: 2,
+                                            column: 7
+                                        },
+                                        identifierName: "foo"
+                                    },
+                                    name: "foo",
+                                    range: [
+                                        7,
+                                        10
+                                    ],
+                                    _babelType: "Identifier"
+                                },
+                                value: {
+                                    type: "Identifier",
+                                    start: 7,
+                                    end: 10,
+                                    loc: {
+                                        start: {
+                                            line: 2,
+                                            column: 4
+                                        },
+                                        end: {
+                                            line: 2,
+                                            column: 7
+                                        },
+                                        identifierName: "foo"
+                                    },
+                                    name: "foo",
+                                    range: [
+                                        7,
+                                        10
+                                    ],
+                                    _babelType: "Identifier"
+                                },
+                                extra: {
+                                    shorthand: true
+                                },
+                                range: [
+                                    7,
+                                    10
+                                ],
+                                _babelType: "ObjectProperty",
+                                kind: "init"
+                            }
+                        ],
+                        typeAnnotation: {
+                            type: "TypeAnnotation",
+                            start: 16,
+                            end: 21,
+                            loc: {
+                                start: {
+                                    line: 3,
+                                    column: 5
+                                },
+                                end: {
+                                    line: 3,
+                                    column: 10
+                                }
+                            },
+                            typeAnnotation: {
+                                type: "GenericTypeAnnotation",
+                                start: 18,
+                                end: 21,
+                                loc: {
+                                    start: {
+                                        line: 3,
+                                        column: 7
+                                    },
+                                    end: {
+                                        line: 3,
+                                        column: 10
+                                    }
+                                },
+                                typeParameters: null,
+                                id: {
+                                    type: "Identifier",
+                                    start: 18,
+                                    end: 21,
+                                    loc: {
+                                        start: {
+                                            line: 3,
+                                            column: 7
+                                        },
+                                        end: {
+                                            line: 3,
+                                            column: 10
+                                        },
+                                        identifierName: "bar"
+                                    },
+                                    name: "bar",
+                                    range: [
+                                        18,
+                                        21
+                                    ],
+                                    _babelType: "Identifier"
+                                },
+                                range: [
+                                    18,
+                                    21
+                                ],
+                                _babelType: "GenericTypeAnnotation"
+                            },
+                            range: [
+                                16,
+                                21
+                            ],
+                            _babelType: "TypeAnnotation"
+                        },
+                        range: [
+                            1,
+                            21
+                        ],
+                        _babelType: "ObjectPattern"
+                    }
+                ],
+                body: {
+                    type: "Identifier",
+                    start: 26,
+                    end: 29,
+                    loc: {
+                        start: {
+                            line: 3,
+                            column: 15
+                        },
+                        end: {
+                            line: 3,
+                            column: 18
+                        },
+                        identifierName: "baz"
+                    },
+                    name: "baz",
+                    range: [
+                        26,
+                        29
+                    ],
+                    _babelType: "Identifier"
+                },
+                range: [
+                    0,
+                    29
+                ],
+                _babelType: "ArrowFunctionExpression",
+                defaults: []
+            },
+            range: [
+                0,
+                29
+            ],
+            _babelType: "ExpressionStatement"
+        }
+    ]
+});

--- a/tests/fixtures/parsers/babel-eslint7/object-pattern-with-object-annotation.js
+++ b/tests/fixtures/parsers/babel-eslint7/object-pattern-with-object-annotation.js
@@ -1,0 +1,439 @@
+/**
+ * Parser: babel-eslint v7.2.3
+ * Source code:
+ * ({
+ *     foo
+ *     }: {}) => baz
+ */
+
+exports.parse = () => ({
+    type: "Program",
+    start: 0,
+    end: 28,
+    loc: {
+        start: {
+            line: 1,
+            column: 0
+        },
+        end: {
+            line: 3,
+            column: 17
+        }
+    },
+    comments: [],
+    tokens: [
+        {
+            type: "Punctuator",
+            value: "(",
+            start: 0,
+            end: 1,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 0
+                },
+                end: {
+                    line: 1,
+                    column: 1
+                }
+            },
+            range: [
+                0,
+                1
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: "{",
+            start: 1,
+            end: 2,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 1
+                },
+                end: {
+                    line: 1,
+                    column: 2
+                }
+            },
+            range: [
+                1,
+                2
+            ]
+        },
+        {
+            type: "Identifier",
+            value: "foo",
+            start: 7,
+            end: 10,
+            loc: {
+                start: {
+                    line: 2,
+                    column: 4
+                },
+                end: {
+                    line: 2,
+                    column: 7
+                }
+            },
+            range: [
+                7,
+                10
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: "}",
+            start: 15,
+            end: 16,
+            loc: {
+                start: {
+                    line: 3,
+                    column: 4
+                },
+                end: {
+                    line: 3,
+                    column: 5
+                }
+            },
+            range: [
+                15,
+                16
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: ":",
+            start: 16,
+            end: 17,
+            loc: {
+                start: {
+                    line: 3,
+                    column: 5
+                },
+                end: {
+                    line: 3,
+                    column: 6
+                }
+            },
+            range: [
+                16,
+                17
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: "{",
+            start: 18,
+            end: 19,
+            loc: {
+                start: {
+                    line: 3,
+                    column: 7
+                },
+                end: {
+                    line: 3,
+                    column: 8
+                }
+            },
+            range: [
+                18,
+                19
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: "}",
+            start: 19,
+            end: 20,
+            loc: {
+                start: {
+                    line: 3,
+                    column: 8
+                },
+                end: {
+                    line: 3,
+                    column: 9
+                }
+            },
+            range: [
+                19,
+                20
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: ")",
+            start: 20,
+            end: 21,
+            loc: {
+                start: {
+                    line: 3,
+                    column: 9
+                },
+                end: {
+                    line: 3,
+                    column: 10
+                }
+            },
+            range: [
+                20,
+                21
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: "=>",
+            start: 22,
+            end: 24,
+            loc: {
+                start: {
+                    line: 3,
+                    column: 11
+                },
+                end: {
+                    line: 3,
+                    column: 13
+                }
+            },
+            range: [
+                22,
+                24
+            ]
+        },
+        {
+            type: "Identifier",
+            value: "baz",
+            start: 25,
+            end: 28,
+            loc: {
+                start: {
+                    line: 3,
+                    column: 14
+                },
+                end: {
+                    line: 3,
+                    column: 17
+                }
+            },
+            range: [
+                25,
+                28
+            ]
+        }
+    ],
+    range: [
+        0,
+        28
+    ],
+    sourceType: "module",
+    body: [
+        {
+            type: "ExpressionStatement",
+            start: 0,
+            end: 28,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 0
+                },
+                end: {
+                    line: 3,
+                    column: 17
+                }
+            },
+            expression: {
+                type: "ArrowFunctionExpression",
+                start: 0,
+                end: 28,
+                loc: {
+                    start: {
+                        line: 1,
+                        column: 0
+                    },
+                    end: {
+                        line: 3,
+                        column: 17
+                    }
+                },
+                id: null,
+                generator: false,
+                expression: true,
+                async: false,
+                params: [
+                    {
+                        type: "ObjectPattern",
+                        start: 1,
+                        end: 20,
+                        loc: {
+                            start: {
+                                line: 1,
+                                column: 1
+                            },
+                            end: {
+                                line: 3,
+                                column: 9
+                            }
+                        },
+                        properties: [
+                            {
+                                type: "Property",
+                                start: 7,
+                                end: 10,
+                                loc: {
+                                    start: {
+                                        line: 2,
+                                        column: 4
+                                    },
+                                    end: {
+                                        line: 2,
+                                        column: 7
+                                    }
+                                },
+                                method: false,
+                                shorthand: true,
+                                computed: false,
+                                key: {
+                                    type: "Identifier",
+                                    start: 7,
+                                    end: 10,
+                                    loc: {
+                                        start: {
+                                            line: 2,
+                                            column: 4
+                                        },
+                                        end: {
+                                            line: 2,
+                                            column: 7
+                                        },
+                                        identifierName: "foo"
+                                    },
+                                    name: "foo",
+                                    range: [
+                                        7,
+                                        10
+                                    ],
+                                    _babelType: "Identifier"
+                                },
+                                value: {
+                                    type: "Identifier",
+                                    start: 7,
+                                    end: 10,
+                                    loc: {
+                                        start: {
+                                            line: 2,
+                                            column: 4
+                                        },
+                                        end: {
+                                            line: 2,
+                                            column: 7
+                                        },
+                                        identifierName: "foo"
+                                    },
+                                    name: "foo",
+                                    range: [
+                                        7,
+                                        10
+                                    ],
+                                    _babelType: "Identifier"
+                                },
+                                extra: {
+                                    shorthand: true
+                                },
+                                range: [
+                                    7,
+                                    10
+                                ],
+                                _babelType: "ObjectProperty",
+                                kind: "init"
+                            }
+                        ],
+                        typeAnnotation: {
+                            type: "TypeAnnotation",
+                            start: 16,
+                            end: 20,
+                            loc: {
+                                start: {
+                                    line: 3,
+                                    column: 5
+                                },
+                                end: {
+                                    line: 3,
+                                    column: 9
+                                }
+                            },
+                            typeAnnotation: {
+                                type: "ObjectTypeAnnotation",
+                                start: 18,
+                                end: 20,
+                                loc: {
+                                    start: {
+                                        line: 3,
+                                        column: 7
+                                    },
+                                    end: {
+                                        line: 3,
+                                        column: 9
+                                    }
+                                },
+                                callProperties: [],
+                                properties: [],
+                                indexers: [],
+                                exact: false,
+                                range: [
+                                    18,
+                                    20
+                                ],
+                                _babelType: "ObjectTypeAnnotation"
+                            },
+                            range: [
+                                16,
+                                20
+                            ],
+                            _babelType: "TypeAnnotation"
+                        },
+                        range: [
+                            1,
+                            20
+                        ],
+                        _babelType: "ObjectPattern"
+                    }
+                ],
+                body: {
+                    type: "Identifier",
+                    start: 25,
+                    end: 28,
+                    loc: {
+                        start: {
+                            line: 3,
+                            column: 14
+                        },
+                        end: {
+                            line: 3,
+                            column: 17
+                        },
+                        identifierName: "baz"
+                    },
+                    name: "baz",
+                    range: [
+                        25,
+                        28
+                    ],
+                    _babelType: "Identifier"
+                },
+                range: [
+                    0,
+                    28
+                ],
+                _babelType: "ArrowFunctionExpression",
+                defaults: []
+            },
+            range: [
+                0,
+                28
+            ],
+            _babelType: "ExpressionStatement"
+        }
+    ]
+});

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -9114,6 +9114,48 @@ ruleTester.run("indent", rule, {
                 </div>
             `,
             errors: expectedErrors([3, 8, 6, "Block"])
+        },
+        {
+            code: unIndent`
+                ({
+                    foo
+                    }: bar) => baz
+            `,
+            output: unIndent`
+                ({
+                    foo
+                }: bar) => baz
+            `,
+            errors: expectedErrors([3, 0, 4, "Punctuator"]),
+            parser: require.resolve("../../fixtures/parsers/babel-eslint7/object-pattern-with-annotation")
+        },
+        {
+            code: unIndent`
+                ([
+                    foo
+                    ]: bar) => baz
+            `,
+            output: unIndent`
+                ([
+                    foo
+                ]: bar) => baz
+            `,
+            errors: expectedErrors([3, 0, 4, "Punctuator"]),
+            parser: require.resolve("../../fixtures/parsers/babel-eslint7/array-pattern-with-annotation")
+        },
+        {
+            code: unIndent`
+                ({
+                    foo
+                    }: {}) => baz
+            `,
+            output: unIndent`
+                ({
+                    foo
+                }: {}) => baz
+            `,
+            errors: expectedErrors([3, 0, 4, "Punctuator"]),
+            parser: require.resolve("../../fixtures/parsers/babel-eslint7/object-pattern-with-object-annotation")
         }
     ]
 });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (https://github.com/eslint/eslint/issues/8990)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates the `indent` rule to select tokens in destructuring patterns more precisely, which makes it more robust when handling custom syntax.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.

As a separate note, I think we should really address https://github.com/eslint/eslint/issues/8991 soon -- having to copy-paste ASTs when dealing with custom parsers is kind of tedious.
