### PR TITLE
Chore: remove unnecessary eslint-disable comments in codebase

### DIFF
--- a/conf/eslint-recommended.js
+++ b/conf/eslint-recommended.js
@@ -6,13 +6,10 @@
 
 "use strict";
 
-/* eslint sort-keys: ["error", "asc"], quote-props: ["error", "consistent"] */
-/* eslint-disable sort-keys */
+/* eslint sort-keys: ["error", "asc"] */
 
 module.exports = {
     rules: {
-
-        /* eslint-enable sort-keys */
         "accessor-pairs": "off",
         "array-bracket-newline": "off",
         "array-bracket-spacing": "off",
@@ -25,23 +22,23 @@ module.exports = {
         "block-spacing": "off",
         "brace-style": "off",
         "callback-return": "off",
-        "camelcase": "off",
+        camelcase: "off",
         "capitalized-comments": "off",
         "class-methods-use-this": "off",
         "comma-dangle": "off",
         "comma-spacing": "off",
         "comma-style": "off",
-        "complexity": "off",
+        complexity: "off",
         "computed-property-spacing": "off",
         "consistent-return": "off",
         "consistent-this": "off",
         "constructor-super": "error",
-        "curly": "off",
+        curly: "off",
         "default-case": "off",
         "dot-location": "off",
         "dot-notation": "off",
         "eol-last": "off",
-        "eqeqeq": "off",
+        eqeqeq: "off",
         "for-direction": "off",
         "func-call-spacing": "off",
         "func-name-matching": "off",
@@ -55,7 +52,7 @@ module.exports = {
         "id-blacklist": "off",
         "id-length": "off",
         "id-match": "off",
-        "indent": "off",
+        indent: "off",
         "indent-legacy": "off",
         "init-declarations": "off",
         "jsx-quotes": "off",
@@ -234,13 +231,13 @@ module.exports = {
         "prefer-spread": "off",
         "prefer-template": "off",
         "quote-props": "off",
-        "quotes": "off",
-        "radix": "off",
+        quotes: "off",
+        radix: "off",
         "require-await": "off",
         "require-jsdoc": "off",
         "require-yield": "error",
         "rest-spread-spacing": "off",
-        "semi": "off",
+        semi: "off",
         "semi-spacing": "off",
         "semi-style": "off",
         "sort-imports": "off",
@@ -252,7 +249,7 @@ module.exports = {
         "space-infix-ops": "off",
         "space-unary-ops": "off",
         "spaced-comment": "off",
-        "strict": "off",
+        strict: "off",
         "switch-colon-spacing": "off",
         "symbol-description": "off",
         "template-curly-spacing": "off",
@@ -265,6 +262,6 @@ module.exports = {
         "wrap-iife": "off",
         "wrap-regex": "off",
         "yield-star-spacing": "off",
-        "yoda": "off"
+        yoda: "off"
     }
 };

--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -3,8 +3,6 @@
  * @author Nicholas C. Zakas
  */
 
-/* eslint no-use-before-define: 0 */
-
 "use strict";
 
 //------------------------------------------------------------------------------
@@ -418,6 +416,8 @@ function applyExtends(config, configContext, filePath, relativeTo) {
                 );
             }
             debug(`Loading ${parentPath}`);
+
+            // eslint-disable-next-line no-use-before-define
             return ConfigOps.merge(load(parentPath, configContext, relativeTo), previousValue);
         } catch (e) {
 

--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -250,7 +250,6 @@ class RuleTester {
         const testerConfig = this.testerConfig,
             requiredScenarios = ["valid", "invalid"],
             scenarioErrors = [],
-            result = {},
             linter = this.linter;
 
         if (lodash.isNil(test) || typeof test !== "object") {
@@ -269,16 +268,13 @@ class RuleTester {
             ].concat(scenarioErrors).join("\n"));
         }
 
-        /* eslint-disable no-shadow */
-
         /**
          * Run the rule for the given item
-         * @param {string} ruleName name of the rule
          * @param {string|Object} item Item to run the rule against
          * @returns {Object} Eslint run result
          * @private
          */
-        function runRuleForItem(ruleName, item) {
+        function runRuleForItem(item) {
             let config = lodash.cloneDeep(testerConfig),
                 code, filename, beforeAST, afterAST;
 
@@ -350,27 +346,27 @@ class RuleTester {
 
             try {
                 linter.rules.get = function(ruleId) {
-                    const rule = originalGet.call(linter.rules, ruleId);
+                    const originalRule = originalGet.call(linter.rules, ruleId);
 
-                    if (typeof rule === "function") {
+                    if (typeof originalRule === "function") {
                         return function(context) {
                             Object.freeze(context);
                             freezeDeeply(context.options);
                             freezeDeeply(context.settings);
                             freezeDeeply(context.parserOptions);
 
-                            return rule(context);
+                            return originalRule(context);
                         };
                     }
                     return {
-                        meta: rule.meta,
+                        meta: originalRule.meta,
                         create(context) {
                             Object.freeze(context);
                             freezeDeeply(context.options);
                             freezeDeeply(context.settings);
                             freezeDeeply(context.parserOptions);
 
-                            return rule.create(context);
+                            return originalRule.create(context);
                         }
                     };
 
@@ -404,13 +400,12 @@ class RuleTester {
         /**
          * Check if the template is valid or not
          * all valid cases go through this
-         * @param {string} ruleName name of the rule
          * @param {string|Object} item Item to run the rule against
          * @returns {void}
          * @private
          */
-        function testValidTemplate(ruleName, item) {
-            const result = runRuleForItem(ruleName, item);
+        function testValidTemplate(item) {
+            const result = runRuleForItem(item);
             const messages = result.messages;
 
             assert.equal(messages.length, 0, util.format("Should have no errors but had %d: %s",
@@ -444,16 +439,15 @@ class RuleTester {
         /**
          * Check if the template is invalid or not
          * all invalid cases go through this.
-         * @param {string} ruleName name of the rule
          * @param {string|Object} item Item to run the rule against
          * @returns {void}
          * @private
          */
-        function testInvalidTemplate(ruleName, item) {
+        function testInvalidTemplate(item) {
             assert.ok(item.errors || item.errors === 0,
                 `Did not specify errors for an invalid test of ${ruleName}`);
 
-            const result = runRuleForItem(ruleName, item);
+            const result = runRuleForItem(item);
             const messages = result.messages;
 
 
@@ -543,7 +537,7 @@ class RuleTester {
                 test.valid.forEach(valid => {
                     RuleTester.it(typeof valid === "object" ? valid.code : valid, () => {
                         linter.defineRules(this.rules);
-                        testValidTemplate(ruleName, valid);
+                        testValidTemplate(valid);
                     });
                 });
             });
@@ -552,13 +546,11 @@ class RuleTester {
                 test.invalid.forEach(invalid => {
                     RuleTester.it(invalid.code, () => {
                         linter.defineRules(this.rules);
-                        testInvalidTemplate(ruleName, invalid);
+                        testInvalidTemplate(invalid);
                     });
                 });
             });
         });
-
-        return result.suite;
     }
 }
 

--- a/tests/lib/config.js
+++ b/tests/lib/config.js
@@ -2,7 +2,6 @@
  * @fileoverview Tests for config object.
  * @author Seth McLaughlin
  */
-/* eslint no-undefined: "off" */
 "use strict";
 
 //------------------------------------------------------------------------------
@@ -875,7 +874,7 @@ describe("Config", () => {
                         parserOptions: {},
                         env: {},
                         globals: {},
-                        parser: undefined,
+                        parser: void 0,
                         rules: {
                             "home-folder-rule": 2
                         }
@@ -901,7 +900,7 @@ describe("Config", () => {
                         parserOptions: {},
                         env: {},
                         globals: {},
-                        parser: undefined,
+                        parser: void 0,
                         rules: {
                             "project-level-rule": 2
                         }
@@ -928,7 +927,7 @@ describe("Config", () => {
                         parserOptions: {},
                         env: {},
                         globals: {},
-                        parser: undefined,
+                        parser: void 0,
                         rules: {
                             quotes: [2, "double"]
                         }
@@ -953,7 +952,7 @@ describe("Config", () => {
                         parserOptions: {},
                         env: {},
                         globals: {},
-                        parser: undefined,
+                        parser: void 0,
                         rules: {
                             "project-level-rule": 2,
                             "subfolder-level-rule": 2

--- a/tests/lib/config/config-file.js
+++ b/tests/lib/config/config-file.js
@@ -16,6 +16,7 @@ const assert = require("chai").assert,
     os = require("os"),
     yaml = require("js-yaml"),
     shell = require("shelljs"),
+    espree = require("espree"),
     ConfigFile = require("../../../lib/config/config-file"),
     Linter = require("../../../lib/linter"),
     Config = require("../../../lib/config");
@@ -46,17 +47,6 @@ const PROJECT_PATH = path.resolve(__dirname, "../../../../"),
  */
 function getFixturePath(filepath) {
     return path.resolve(__dirname, "../../fixtures/config-file", filepath);
-}
-
-/**
- * Reads a JS configuration object from a string to ensure that it parses.
- * Used for testing configuration file output.
- * @param {string} code The code to eval.
- * @returns {*} The result of the evaluation.
- * @private
- */
-function readJSModule(code) {
-    return eval(`var module = {};\n${code}`); // eslint-disable-line no-eval
 }
 
 /**
@@ -1229,7 +1219,7 @@ describe("ConfigFile", () => {
         });
 
         leche.withData([
-            ["JavaScript", "foo.js", readJSModule],
+            ["JavaScript", "foo.js", espree.parse],
             ["JSON", "bar.json", JSON.parse],
             ["YAML", "foo.yaml", yaml.safeLoad],
             ["YML", "foo.yml", yaml.safeLoad]

--- a/tests/lib/util/source-code.js
+++ b/tests/lib/util/source-code.js
@@ -61,37 +61,39 @@ describe("SourceCode", () => {
             assert.equal(sourceCode.lines[1], "bar;");
         });
 
-        /* eslint-disable no-new */
-
         it("should throw an error when called with an AST that's missing tokens", () => {
 
-            assert.throws(() => {
-                new SourceCode("foo;", { comments: [], loc: {}, range: [] });
-            }, /missing the tokens array/);
+            assert.throws(
+                () => new SourceCode("foo;", { comments: [], loc: {}, range: [] }),
+                /missing the tokens array/
+            );
 
         });
 
         it("should throw an error when called with an AST that's missing comments", () => {
 
-            assert.throws(() => {
-                new SourceCode("foo;", { tokens: [], loc: {}, range: [] });
-            }, /missing the comments array/);
+            assert.throws(
+                () => new SourceCode("foo;", { tokens: [], loc: {}, range: [] }),
+                /missing the comments array/
+            );
 
         });
 
         it("should throw an error when called with an AST that's missing location", () => {
 
-            assert.throws(() => {
-                new SourceCode("foo;", { comments: [], tokens: [], range: [] });
-            }, /missing location information/);
+            assert.throws(
+                () => new SourceCode("foo;", { comments: [], tokens: [], range: [] }),
+                /missing location information/
+            );
 
         });
 
         it("should throw an error when called with an AST that's missing range", () => {
 
-            assert.throws(() => {
-                new SourceCode("foo;", { comments: [], tokens: [], loc: {} });
-            }, /missing range information/);
+            assert.throws(
+                () => new SourceCode("foo;", { comments: [], tokens: [], loc: {} }),
+                /missing range information/
+            );
         });
 
         it("should store all tokens and comments sorted by range", () => {


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This removes or decreases the scope of some unneeded `eslint-disable` comments in the codebase.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular