### PR TITLE
Fix: Add error mssg in bin/eslint (fixes #9011)

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -47,6 +47,8 @@ process.once("uncaughtException", err => {
         console.error("\nOops! Something went wrong! :(");
         console.error(`\n${template(err.messageData || {})}`);
     } else {
+
+        console.error(err.message);
         console.error(err.stack);
     }
 

--- a/tests/bin/eslint.js
+++ b/tests/bin/eslint.js
@@ -263,11 +263,25 @@ describe("bin/eslint.js", () => {
     });
 
     describe("handling crashes", () => {
-        it("prints the error message exactly once to stderr in the event of a crash", () => {
+        it("prints the error message to stderr in the event of a crash", () => {
             const child = runESLint(["--rule=no-restricted-syntax:[error, 'Invalid Selector [[[']", "Makefile.js"]);
             const exitCodeAssertion = assertExitCode(child, 1);
             const outputAssertion = getOutput(child).then(output => {
                 const expectedSubstring = "Syntax error in selector";
+
+                assert.strictEqual(output.stdout, "");
+                assert.include(output.stderr, expectedSubstring);
+            });
+
+            return Promise.all([exitCodeAssertion, outputAssertion]);
+        });
+
+        it("prints the error message pointing to line of code", () => {
+            const invalidConfig = `${__dirname}/../fixtures/bin/.eslintrc.yml`;
+            const child = runESLint(["--no-ignore", invalidConfig]);
+            const exitCodeAssertion = assertExitCode(child, 1);
+            const outputAssertion = getOutput(child).then(output => {
+                const expectedSubstring = "Error: bad indentation of a mapping entry at line";
 
                 assert.strictEqual(output.stdout, "");
                 assert.include(output.stderr, expectedSubstring);

--- a/tests/bin/eslint.js
+++ b/tests/bin/eslint.js
@@ -271,9 +271,6 @@ describe("bin/eslint.js", () => {
 
                 assert.strictEqual(output.stdout, "");
                 assert.include(output.stderr, expectedSubstring);
-
-                // The message should appear exactly once in stderr
-                assert.strictEqual(output.stderr.indexOf(expectedSubstring), output.stderr.lastIndexOf(expectedSubstring));
             });
 
             return Promise.all([exitCodeAssertion, outputAssertion]);

--- a/tests/fixtures/bin/.eslintrc.yml
+++ b/tests/fixtures/bin/.eslintrc.yml
@@ -1,4 +1,4 @@
-
+# intentionally invalid YML
 rules:
   semi: error
 yoda: error

--- a/tests/fixtures/bin/.eslintrc.yml
+++ b/tests/fixtures/bin/.eslintrc.yml
@@ -1,0 +1,5 @@
+
+rules:
+  semi: error
+yoda: error
+  quotes: error


### PR DESCRIPTION
[ X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
**What parser (default, Babel-ESLint, etc.) are you using?**
default
**Please show your full configuration:**
eslint: v4.3.0
node: v8.2.1
npm: 3.10.10


**What changes did you make? (Give an overview)**
Add back err.message to bin/eslint

It provides clearer error messaging. It undoes changes [here](https://github.com/eslint/eslint/commit/a5fd1011bd4bd9ea119d70c1d980816f96672f97) to reduce duplicate error messaging in err.message and err.stack

**Is there anything you'd like reviewers to focus on?**


