### PR TITLE
Build: Edit link in rule docs

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -707,8 +707,6 @@ target.gensite = function(prereleaseVersion) {
                 text = `${ruleHeading}${isRecommended ? RECOMMENDED_TEXT : ""}${isFixable ? FIXABLE_TEXT : ""}\n${ruleDocsContent}`;
 
                 title = `${ruleName} - Rules`;
-
-                editLink = `https://github.com/eslint/eslint/edit/master/docs/rules/${baseName}`;
             } else {
 
                 // extract the title from the file itself
@@ -718,14 +716,13 @@ target.gensite = function(prereleaseVersion) {
                 } else {
                     title = "Documentation";
                 }
-                editLink = `https://github.com/eslint/eslint/edit/master/${filePath}`;
             }
 
             text = [
                 "---",
                 `title: ${title}`,
                 "layout: doc",
-                editLink ? `edit_link: ${editLink}` : "",
+                `https://github.com/eslint/eslint/edit/master/${filePath}`,
                 "---",
                 "<!-- Note: No pull requests accepted for this file. See README.md in the root directory for details. -->",
                 "",

--- a/Makefile.js
+++ b/Makefile.js
@@ -708,7 +708,7 @@ target.gensite = function(prereleaseVersion) {
                     "---",
                     `title: ${ruleName} - Rules`,
                     "layout: doc",
-                    filename.indexOf("rules/") !== -1 && `edit_link: https://github.com/eslint/eslint/edit/master/docs/rules/${baseName}`
+                    filename.indexOf("rules/") !== -1 && `edit_link: https://github.com/eslint/eslint/edit/master/docs/rules/${baseName}`,
                     "---",
                     "<!-- Note: No pull requests accepted for this file. See README.md in the root directory for details. -->",
                     "",
@@ -800,7 +800,7 @@ target.gensite = function(prereleaseVersion) {
     }
 
     // 14. Create Example Formatter Output Page
-    echo("> Creating the formatter examples (Step 13)");
+    echo("> Creating the formatter examples (Step 14)");
     generateFormatterExamples(getFormatterResults(), prereleaseVersion);
 
     echo("Done generating eslint.org");

--- a/Makefile.js
+++ b/Makefile.js
@@ -708,7 +708,7 @@ target.gensite = function(prereleaseVersion) {
                     "---",
                     `title: ${ruleName} - Rules`,
                     "layout: doc",
-                    filename.indexOf("rules/") !== -1 && `edit_link: https://github.com/eslint/eslint/edit/master/docs/rules${baseName}`,
+                    filename.indexOf("rules/") !== -1 && `edit_link: https://github.com/eslint/eslint/edit/master/docs/rules/${baseName}`
                     "---",
                     "<!-- Note: No pull requests accepted for this file. See README.md in the root directory for details. -->",
                     "",
@@ -727,7 +727,7 @@ target.gensite = function(prereleaseVersion) {
                     "---",
                     `title: ${title}`,
                     "layout: doc",
-                    `edit_link: https://github.com/eslint/eslint/edit/master/${sourcePath}`,
+                    `edit_link: https://github.com/eslint/eslint/edit/master/${baseName}`,
                     "---",
                     "<!-- Note: No pull requests accepted for this file. See README.md in the root directory for details. -->",
                     "",

--- a/Makefile.js
+++ b/Makefile.js
@@ -686,8 +686,7 @@ target.gensite = function(prereleaseVersion) {
                 ruleName = path.basename(filename, ".md"),
                 filePath = path.join("docs", path.relative("tmp", filename));
             let text = cat(filename),
-                title,
-                editLink;
+                title;
 
             process.stdout.write(`> Updating files (Steps 4-9): ${i}/${length} - ${filePath + " ".repeat(30)}\r`);
 

--- a/Makefile.js
+++ b/Makefile.js
@@ -671,9 +671,9 @@ target.gensite = function(prereleaseVersion) {
     const FIXABLE_TEXT = "\n\n(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) can automatically fix some of the problems reported by this rule.";
 
     // 4. Loop through all files in temporary directory
-    process.stdout.write(`> Updating files (Steps 4-9): 0/... - ...\r`);
+    process.stdout.write("> Updating files (Steps 4-9): 0/... - ...\r");
     const tempFiles = find(TEMP_DIR);
-    const { length } = tempFiles;
+    const length = tempFiles.length;
 
     tempFiles.forEach((filename, i) => {
         if (test("-f", filename) && path.extname(filename) === ".md") {
@@ -687,7 +687,7 @@ target.gensite = function(prereleaseVersion) {
             let text = cat(filename),
                 title;
 
-            process.stdout.write(`> Updating files (Steps 4-9): ${i}/${length} - ${sourcePath + ' '.repeat(30)}\r`);
+            process.stdout.write(`> Updating files (Steps 4-9): ${i}/${length} - ${sourcePath + " ".repeat(30)}\r`);
 
             // 5. Prepend page title and layout variables at the top of rules
             if (path.dirname(filename).indexOf("rules") >= 0) {
@@ -705,15 +705,15 @@ target.gensite = function(prereleaseVersion) {
                 text = `${ruleHeading}${isRecommended ? RECOMMENDED_TEXT : ""}${isFixable ? FIXABLE_TEXT : ""}\n${ruleDocsContent}`;
 
                 text = [
-                    '---',
+                    "---",
                     `title: ${ruleName} - Rules`,
-                    'layout: doc',
+                    "layout: doc",
                     filename.indexOf("rules/") !== -1 && `edit_link: https://github.com/eslint/eslint/edit/master/docs/rules${baseName}`,
-                    '---',
-                    '<!-- Note: No pull requests accepted for this file. See README.md in the root directory for details. -->',
-                    '',
+                    "---",
+                    "<!-- Note: No pull requests accepted for this file. See README.md in the root directory for details. -->",
+                    "",
                     text
-                ].filter(x => x).join('\n');
+                ].filter(x => x).join("\n");
             } else {
 
                 // extract the title from the file itself
@@ -724,15 +724,15 @@ target.gensite = function(prereleaseVersion) {
                     title = "Documentation";
                 }
                 text = [
-                    '---',
+                    "---",
                     `title: ${title}`,
-                    'layout: doc',
+                    "layout: doc",
                     `edit_link: https://github.com/eslint/eslint/edit/master/${sourcePath}`,
-                    '---',
-                    '<!-- Note: No pull requests accepted for this file. See README.md in the root directory for details. -->',
-                    '',
+                    "---",
+                    "<!-- Note: No pull requests accepted for this file. See README.md in the root directory for details. -->",
+                    "",
                     text
-                ].filter(x => x).join('\n');
+                ].filter(x => x).join("\n");
             }
 
             // 6. Remove .md extension for relative links and change README to empty string
@@ -772,7 +772,7 @@ target.gensite = function(prereleaseVersion) {
         }
     });
     JSON.stringify(versions).to("./versions.json");
-    echo("> Updating files (Steps 4-9)" + " ".repeat(50));
+    echo(`> Updating files (Steps 4-9)${" ".repeat(50)}`);
 
     // 10. Copy temporary directory to site's docs folder
     echo("> Copying the temporary directory the site (Step 10)");

--- a/Makefile.js
+++ b/Makefile.js
@@ -685,7 +685,8 @@ target.gensite = function(prereleaseVersion) {
                 sourcePath = path.join("lib/rules", sourceBaseName),
                 ruleName = path.basename(filename, ".md");
             let text = cat(filename),
-                title;
+                title,
+                editLink;
 
             process.stdout.write(`> Updating files (Steps 4-9): ${i}/${length} - ${sourcePath + " ".repeat(30)}\r`);
 
@@ -704,16 +705,9 @@ target.gensite = function(prereleaseVersion) {
 
                 text = `${ruleHeading}${isRecommended ? RECOMMENDED_TEXT : ""}${isFixable ? FIXABLE_TEXT : ""}\n${ruleDocsContent}`;
 
-                text = [
-                    "---",
-                    `title: ${ruleName} - Rules`,
-                    "layout: doc",
-                    filename.indexOf("rules/") !== -1 && `edit_link: https://github.com/eslint/eslint/edit/master/docs/rules/${baseName}`,
-                    "---",
-                    "<!-- Note: No pull requests accepted for this file. See README.md in the root directory for details. -->",
-                    "",
-                    text
-                ].filter(x => x).join("\n");
+                title = `${ruleName} - Rules`;
+
+                editLink = `https://github.com/eslint/eslint/edit/master/docs/rules/${baseName}`;
             } else {
 
                 // extract the title from the file itself
@@ -723,17 +717,19 @@ target.gensite = function(prereleaseVersion) {
                 } else {
                     title = "Documentation";
                 }
-                text = [
-                    "---",
-                    `title: ${title}`,
-                    "layout: doc",
-                    `edit_link: https://github.com/eslint/eslint/edit/master/${baseName}`,
-                    "---",
-                    "<!-- Note: No pull requests accepted for this file. See README.md in the root directory for details. -->",
-                    "",
-                    text
-                ].filter(x => x).join("\n");
+                editLink = `https://github.com/eslint/eslint/edit/master/${filename}`;
             }
+
+            text = [
+                "---",
+                `title: ${title}`,
+                "layout: doc",
+                editLink ? `edit_link: ${editLink}` : "",
+                "---",
+                "<!-- Note: No pull requests accepted for this file. See README.md in the root directory for details. -->",
+                "",
+                text
+            ].join("\n");
 
             // 6. Remove .md extension for relative links and change README to empty string
             text = text.replace(/\((?!https?:\/\/)([^)]*?)\.md.*?\)/g, "($1)").replace("README.html", "");

--- a/Makefile.js
+++ b/Makefile.js
@@ -695,7 +695,16 @@ target.gensite = function(prereleaseVersion) {
 
                 text = `${ruleHeading}${isRecommended ? RECOMMENDED_TEXT : ""}${isFixable ? FIXABLE_TEXT : ""}\n${ruleDocsContent}`;
 
-                text = `---\ntitle: ${ruleName} - Rules\nlayout: doc\n---\n<!-- Note: No pull requests accepted for this file. See README.md in the root directory for details. -->\n\n${text}`;
+                text = [
+                    '---',
+                    `title: ${ruleName} - Rules`,
+                    'layout: doc',
+                    filename.indexOf("rules/") !== -1 && `edit_link: https://github.com/eslint/eslint/edit/master/docs/rules${baseName}`,
+                    '---',
+                    '<!-- Note: No pull requests accepted for this file. See README.md in the root directory for details. -->',
+                    '',
+                    text
+                ].filter(x => x).join('\n');
             } else {
 
                 // extract the title from the file itself
@@ -705,7 +714,16 @@ target.gensite = function(prereleaseVersion) {
                 } else {
                     title = "Documentation";
                 }
-                text = `---\ntitle: ${title}\nlayout: doc\n---\n<!-- Note: No pull requests accepted for this file. See README.md in the root directory for details. -->\n\n${text}`;
+                text = [
+                    '---',
+                    `title: ${title}`,
+                    'layout: doc',
+                    `edit_link: https://github.com/eslint/eslint/edit/master/${sourcePath}`,
+                    '---',
+                    '<!-- Note: No pull requests accepted for this file. See README.md in the root directory for details. -->',
+                    '',
+                    text
+                ].filter(x => x).join('\n');
             }
 
             // 6. Remove .md extension for relative links and change README to empty string

--- a/Makefile.js
+++ b/Makefile.js
@@ -683,12 +683,13 @@ target.gensite = function(prereleaseVersion) {
                 baseName = path.basename(filename),
                 sourceBaseName = `${path.basename(filename, ".md")}.js`,
                 sourcePath = path.join("lib/rules", sourceBaseName),
-                ruleName = path.basename(filename, ".md");
+                ruleName = path.basename(filename, ".md"),
+                filePath = path.join("docs", path.relative("tmp", filename));
             let text = cat(filename),
                 title,
                 editLink;
 
-            process.stdout.write(`> Updating files (Steps 4-9): ${i}/${length} - ${sourcePath + " ".repeat(30)}\r`);
+            process.stdout.write(`> Updating files (Steps 4-9): ${i}/${length} - ${filePath + " ".repeat(30)}\r`);
 
             // 5. Prepend page title and layout variables at the top of rules
             if (path.dirname(filename).indexOf("rules") >= 0) {
@@ -717,7 +718,7 @@ target.gensite = function(prereleaseVersion) {
                 } else {
                     title = "Documentation";
                 }
-                editLink = `https://github.com/eslint/eslint/edit/master/${filename}`;
+                editLink = `https://github.com/eslint/eslint/edit/master/${filePath}`;
             }
 
             text = [


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request?**
To add metadata to the rule docs, specifying the edit link for the rules

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

I added an `edit_link` key to the YAML front matter of the generated website docs. Additionally, I added progress logging to the `npm run gendocs` script.

Note: this is a dependency of eslint/eslint.github.io#367.

