### PR TITLE
Docs: clarify options descriptions (fixes #8875)

### DIFF
--- a/docs/rules/no-mixed-operators.md
+++ b/docs/rules/no-mixed-operators.md
@@ -60,11 +60,8 @@ var foo = (a + b) * c;
 
 This rule has 2 options.
 
-* `groups` (`string[][]`) - specifies groups to compare operators.
-  When this rule compares two operators, if both operators are included in a same group, this rule checks it. Otherwise, this rule ignores it.
-  This value is a list of groups. The group is a list of binary operators.
-  Default is the groups for each kind of operators.
-* `allowSamePrecedence` (`boolean`) - specifies to allow mix of 2 operators if those have the same precedence. Default is `true`.
+* `groups` (`string[][]`) - specifies operator groups to be checked. The `groups` option is a list of groups, and a group is a list of binary operators. Default operator groups are defined as arithmetic, bitwise, comparison, logical, and relational operators.
+* `allowSamePrecedence` (`boolean`) - specifies whether to allow mixed operators if they are of equal precedence. Default is `true`.
 
 ### groups
 
@@ -76,11 +73,10 @@ The following operators can be used in `groups` option:
 * Logical Operators: `"&&"`, `"||"`
 * Relational Operators: `"in"`, `"instanceof"`
 
-Now, considers about `{"groups": [["&", "|", "^", "~", "<<", ">>", ">>>"], ["&&", "||"]]}` configure.
-This configure has 2 groups: bitwise operators and logical operators.
-This rule checks only if both operators are included in a same group.
-So, in this case, this rule comes to check between bitwise operators and between logical operators.
-This rule ignores other operators.
+Now, consider the following group configuration: `{"groups": [["&", "|", "^", "~", "<<", ">>", ">>>"], ["&&", "||"]]}`.
+There are 2 groups specified in this configuration: bitwise operators and logical operators.
+This rule checks if the operators belong to the same group only.
+In this case, this rule checks if bitwise operators and logical operators are mixed, but ignores all other operators.
 
 Examples of **incorrect** code for this rule with `{"groups": [["&", "|", "^", "~", "<<", ">>", ">>>"], ["&&", "||"]]}` option:
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ X ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Rewrote some of the descriptions for the no-mixed-operators Options section.

**Is there anything you'd like reviewers to focus on?**
The original description for the `allowSamePrecedence` option stated that the option allows 2 operators to be mixed, though I believe it was intended to mean _at least_ 2 operators. 

