### PR TITLE
Update: Add considerPropertyDescriptor option to func-name-matching

### DIFF
--- a/docs/rules/func-name-matching.md
+++ b/docs/rules/func-name-matching.md
@@ -4,10 +4,6 @@
 
 This rule requires function names to match the name of the variable or property to which they are assigned. The rule will ignore property assignments where the property name is a literal that is not a valid identifier in the ECMAScript version specified in your configuration (default ES5).
 
-## Options
-
-This rule takes an optional string of "always" or "never" (when omitted, it defaults to "always"), and an optional options object with one key, `includeCommonJSModuleExports`, and a boolean value. This option defaults to `false`, which means that `module.exports` and `module["exports"]` are ignored by this rule. If `includeCommonJSModuleExports` is set to true, `module.exports` and `module["exports"]` will be checked by this rule.
-
 Examples of **incorrect** code for this rule:
 
 ```js
@@ -19,14 +15,6 @@ obj.foo = function bar() {};
 obj['foo'] = function bar() {};
 var obj = {foo: function bar() {}};
 ({['foo']: function bar() {}});
-```
-
-```js
-/*eslint func-name-matching: ["error", { "includeCommonJSModuleExports": true }]*/
-/*eslint func-name-matching: ["error", "always", { "includeCommonJSModuleExports": true }]*/ // these are equivalent
-
-module.exports = function foo(name) {};
-module['exports'] = function foo(name) {};
 ```
 
 ```js
@@ -92,6 +80,50 @@ var obj = {foo: function() {}};
 obj['x' + 2] = function bar(){};
 var [ bar ] = [ function bar(){} ];
 ({[foo]: function bar() {}})
+
+module.exports = function foo(name) {};
+module['exports'] = function foo(name) {};
+```
+
+## Options
+
+This rule takes an optional string of "always" or "never" (when omitted, it defaults to "always"), and an optional options object with two properties `considerPropertyDescriptor` and `includeCommonJSModuleExports`.
+
+### considerPropertyDescriptor
+
+A boolean value that defaults to `false`. If `considerPropertyDescriptor` is set to true, the check will take into account the use `Object.create`, `Object.defineProperty`, and `Object.defineProperties`.
+
+Examples of **correct** code for the `{ considerPropertyDescriptor: true }` option:
+
+```js
+/*eslint func-name-matching: ["error", { "considerPropertyDescriptor": true }]*/
+/*eslint func-name-matching: ["error", "always", { "considerPropertyDescriptor": true }]*/ // these are equivalent
+var obj = {};
+Object.create(obj, {foo:{value: function foo() {}}});
+Object.defineProperty(obj, 'bar', {value: function bar() {}});
+Object.defineProperties(obj, {baz:{value: function baz() {} }});
+```
+
+Examples of **incorrect** code for the `{ considerPropertyDescriptor: true }` option:
+
+```js
+/*eslint func-name-matching: ["error", { "considerPropertyDescriptor": true }]*/
+/*eslint func-name-matching: ["error", "always", { "considerPropertyDescriptor": true }]*/ // these are equivalent
+var obj = {};
+Object.create(obj, {foo:{value: function bar() {}}});
+Object.defineProperty(obj, 'bar', {value: function baz() {}});
+Object.defineProperties(obj, {baz:{value: function foo() {} }});
+```
+
+### includeCommonJSModuleExports
+
+A boolean value that defaults to `false`. If `includeCommonJSModuleExports` is set to true, `module.exports` and `module["exports"]` will be checked by this rule.
+
+Examples of **incorrect** code for the `{ includeCommonJSModuleExports: true }` option:
+
+```js
+/*eslint func-name-matching: ["error", { "includeCommonJSModuleExports": true }]*/
+/*eslint func-name-matching: ["error", "always", { "includeCommonJSModuleExports": true }]*/ // these are equivalent
 
 module.exports = function foo(name) {};
 module['exports'] = function foo(name) {};

--- a/docs/rules/func-name-matching.md
+++ b/docs/rules/func-name-matching.md
@@ -91,7 +91,7 @@ This rule takes an optional string of "always" or "never" (when omitted, it defa
 
 ### considerPropertyDescriptor
 
-A boolean value that defaults to `false`. If `considerPropertyDescriptor` is set to true, the check will take into account the use `Object.create`, `Object.defineProperty`, and `Object.defineProperties`.
+A boolean value that defaults to `false`. If `considerPropertyDescriptor` is set to true, the check will take into account the use `Object.create`, `Object.defineProperty`, `Object.defineProperties`, and `Reflect.defineProperty`.
 
 Examples of **correct** code for the `{ considerPropertyDescriptor: true }` option:
 
@@ -102,6 +102,7 @@ var obj = {};
 Object.create(obj, {foo:{value: function foo() {}}});
 Object.defineProperty(obj, 'bar', {value: function bar() {}});
 Object.defineProperties(obj, {baz:{value: function baz() {} }});
+Reflect.defineProperty(obj, 'foo', {value: function foo() {}});
 ```
 
 Examples of **incorrect** code for the `{ considerPropertyDescriptor: true }` option:
@@ -113,6 +114,7 @@ var obj = {};
 Object.create(obj, {foo:{value: function bar() {}}});
 Object.defineProperty(obj, 'bar', {value: function baz() {}});
 Object.defineProperties(obj, {baz:{value: function foo() {} }});
+Reflect.defineProperty(obj, 'foo', {value: function value() {}});
 ```
 
 ### includeCommonJSModuleExports

--- a/lib/rules/func-name-matching.js
+++ b/lib/rules/func-name-matching.js
@@ -98,18 +98,19 @@ module.exports = {
         const ecmaVersion = context.parserOptions && context.parserOptions.ecmaVersion ? context.parserOptions.ecmaVersion : 5;
 
         /**
-         * Check whether node is a CallExpression on Object.
+         * Check whether node is a certain CallExpression.
+         * @param {string} objName object name
+         * @param {string} funcName function name
          * @param {ASTNode} node The node to check
-         * @param {string} func function name
-         * @returns {boolean} `true` if node is correct CallExpression
+         * @returns {boolean} `true` if node matches CallExpression
          */
-        function isObjectCall(node, func) {
+        function isPropertyCall(objName, funcName, node) {
             if (!node) {
                 return false;
             }
             return node.type === "CallExpression" &&
-                node.callee.object.name === "Object" &&
-                node.callee.property.name === func;
+                node.callee.object.name === objName &&
+                node.callee.property.name === funcName;
         }
 
         /**
@@ -203,18 +204,18 @@ module.exports = {
                     let propertyName = node.key.name;
 
                     if (considerPropertyDescriptor && propertyName === "value") {
-                        if (isObjectCall(node.parent.parent, "defineProperty")) {
+                        if (isPropertyCall("Object", "defineProperty", node.parent.parent) || isPropertyCall("Reflect", "defineProperty", node.parent.parent)) {
                             const property = node.parent.parent.arguments[1];
 
                             if (isStringLiteral(property) && shouldWarn(property.value, functionName)) {
                                 report(node, property.value, functionName, true);
                             }
-                        } else if (isObjectCall(node.parent.parent.parent.parent, "defineProperties")) {
+                        } else if (isPropertyCall("Object", "defineProperties", node.parent.parent.parent.parent)) {
                             propertyName = node.parent.parent.key.name;
                             if (!node.parent.parent.computed && shouldWarn(propertyName, functionName)) {
                                 report(node, propertyName, functionName, true);
                             }
-                        } else if (isObjectCall(node.parent.parent.parent.parent, "create")) {
+                        } else if (isPropertyCall("Object", "create", node.parent.parent.parent.parent)) {
                             propertyName = node.parent.parent.key.name;
                             if (!node.parent.parent.computed && shouldWarn(propertyName, functionName)) {
                                 report(node, propertyName, functionName, true);

--- a/lib/rules/func-name-matching.js
+++ b/lib/rules/func-name-matching.js
@@ -58,6 +58,9 @@ const alwaysOrNever = { enum: ["always", "never"] };
 const optionsObject = {
     type: "object",
     properties: {
+        considerPropertyDescriptor: {
+            type: "boolean"
+        },
         includeCommonJSModuleExports: {
             type: "boolean"
         }
@@ -90,8 +93,24 @@ module.exports = {
     create(context) {
         const options = (typeof context.options[0] === "object" ? context.options[0] : context.options[1]) || {};
         const nameMatches = typeof context.options[0] === "string" ? context.options[0] : "always";
+        const considerPropertyDescriptor = options.considerPropertyDescriptor;
         const includeModuleExports = options.includeCommonJSModuleExports;
         const ecmaVersion = context.parserOptions && context.parserOptions.ecmaVersion ? context.parserOptions.ecmaVersion : 5;
+
+        /**
+         * Check whether node is a CallExpression on Object.
+         * @param {ASTNode} node The node to check
+         * @param {string} func function name
+         * @returns {boolean} `true` if node is correct CallExpression
+         */
+        function isObjectCall(node, func) {
+            if (!node) {
+                return false;
+            }
+            return node.type === "CallExpression" &&
+                node.callee.object.name === "Object" &&
+                node.callee.property.name === func;
+        }
 
         /**
          * Compares identifiers based on the nameMatches option
@@ -147,7 +166,6 @@ module.exports = {
         //--------------------------------------------------------------------------
 
         return {
-
             VariableDeclarator(node) {
                 if (!node.init || node.init.type !== "FunctionExpression" || node.id.type !== "Identifier") {
                     return;
@@ -179,9 +197,38 @@ module.exports = {
                 if (node.value.type !== "FunctionExpression" || !node.value.id || node.computed && !isStringLiteral(node.key)) {
                     return;
                 }
-                if (node.key.type === "Identifier" && shouldWarn(node.key.name, node.value.id.name)) {
-                    report(node, node.key.name, node.value.id.name, true);
-                } else if (
+
+                if (node.key.type === "Identifier") {
+                    const functionName = node.value.id.name;
+                    let propertyName = node.key.name;
+
+                    if (considerPropertyDescriptor && propertyName === "value") {
+                        if (isObjectCall(node.parent.parent, "defineProperty")) {
+                            const property = node.parent.parent.arguments[1];
+
+                            if (isStringLiteral(property) && shouldWarn(property.value, functionName)) {
+                                report(node, property.value, functionName, true);
+                            }
+                        } else if (isObjectCall(node.parent.parent.parent.parent, "defineProperties")) {
+                            propertyName = node.parent.parent.key.name;
+                            if (!node.parent.parent.computed && shouldWarn(propertyName, functionName)) {
+                                report(node, propertyName, functionName, true);
+                            }
+                        } else if (isObjectCall(node.parent.parent.parent.parent, "create")) {
+                            propertyName = node.parent.parent.key.name;
+                            if (!node.parent.parent.computed && shouldWarn(propertyName, functionName)) {
+                                report(node, propertyName, functionName, true);
+                            }
+                        } else if (shouldWarn(propertyName, functionName)) {
+                            report(node, propertyName, functionName, true);
+                        }
+                    } else if (shouldWarn(propertyName, functionName)) {
+                        report(node, propertyName, functionName, true);
+                    }
+                    return;
+                }
+
+                if (
                     isStringLiteral(node.key) &&
                     isIdentifier(node.key.value, ecmaVersion) &&
                     shouldWarn(node.key.value, node.value.id.name)

--- a/tests/lib/rules/func-name-matching.js
+++ b/tests/lib/rules/func-name-matching.js
@@ -242,6 +242,19 @@ ruleTester.run("func-name-matching", rule, {
             code: "Object.create(proto, { bar: { value() {} } })",
             options: ["never", { considerPropertyDescriptor: true }],
             parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "Reflect.defineProperty(foo, 'bar', { value: function bar() {} })",
+            options: ["always", { considerPropertyDescriptor: true }]
+        },
+        {
+            code: "Reflect.defineProperty(foo, 'b' + 'ar', { value: function baz() {} })",
+            options: ["always", { considerPropertyDescriptor: true }]
+        },
+        {
+            code: "Reflect.defineProperty(foo, 'bar', { value() {} })",
+            options: ["never", { considerPropertyDescriptor: true }],
+            parserOptions: { ecmaVersion: 6 }
         }
     ],
     invalid: [
@@ -415,6 +428,20 @@ ruleTester.run("func-name-matching", rule, {
         },
         {
             code: "Object.create(proto, { bar: { value: function bar() {} } })",
+            options: ["never", { considerPropertyDescriptor: true }],
+            errors: [
+                { message: "Function name `bar` should not match property name `bar`" }
+            ]
+        },
+        {
+            code: "Reflect.defineProperty(foo, 'bar', { value: function baz() {} })",
+            options: ["always", { considerPropertyDescriptor: true }],
+            errors: [
+                { message: "Function name `baz` should match property name `bar`" }
+            ]
+        },
+        {
+            code: "Reflect.defineProperty(foo, 'bar', { value: function bar() {} })",
             options: ["never", { considerPropertyDescriptor: true }],
             errors: [
                 { message: "Function name `bar` should not match property name `bar`" }

--- a/tests/lib/rules/func-name-matching.js
+++ b/tests/lib/rules/func-name-matching.js
@@ -177,6 +177,71 @@ ruleTester.run("func-name-matching", rule, {
         {
             code: "var {a} = function foo() {}",
             parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "({ value: function value() {} })",
+            options: [{ considerPropertyDescriptor: true }]
+        },
+        {
+            code: "obj.foo = function foo() {};",
+            options: ["always", { considerPropertyDescriptor: true }]
+        },
+        {
+            code: "obj.bar.foo = function foo() {};",
+            options: ["always", { considerPropertyDescriptor: true }]
+        },
+        {
+            code: "var obj = {foo: function foo() {}};",
+            options: ["always", { considerPropertyDescriptor: true }]
+        },
+        {
+            code: "var obj = {foo: function() {}};",
+            options: ["always", { considerPropertyDescriptor: true }]
+        },
+        {
+            code: "var obj = { value: function value() {} }",
+            options: ["always", { considerPropertyDescriptor: true }]
+        },
+        {
+            code: "Object.defineProperty(foo, 'bar', { value: function bar() {} })",
+            options: ["always", { considerPropertyDescriptor: true }]
+        },
+        {
+            code: "Object.defineProperties(foo, { bar: { value: function bar() {} } })",
+            options: ["always", { considerPropertyDescriptor: true }]
+        },
+        {
+            code: "Object.create(proto, { bar: { value: function bar() {} } })",
+            options: ["always", { considerPropertyDescriptor: true }]
+        },
+        {
+            code: "Object.defineProperty(foo, 'b' + 'ar', { value: function bar() {} })",
+            options: ["always", { considerPropertyDescriptor: true }]
+        },
+        {
+            code: "Object.defineProperties(foo, { ['bar']: { value: function bar() {} } })",
+            options: ["always", { considerPropertyDescriptor: true }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "Object.create(proto, { ['bar']: { value: function bar() {} } })",
+            options: ["always", { considerPropertyDescriptor: true }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "Object.defineProperty(foo, 'bar', { value() {} })",
+            options: ["never", { considerPropertyDescriptor: true }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "Object.defineProperties(foo, { bar: { value() {} } })",
+            options: ["never", { considerPropertyDescriptor: true }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "Object.create(proto, { bar: { value() {} } })",
+            options: ["never", { considerPropertyDescriptor: true }],
+            parserOptions: { ecmaVersion: 6 }
         }
     ],
     invalid: [
@@ -304,6 +369,55 @@ ruleTester.run("func-name-matching", rule, {
             options: ["never"],
             errors: [
                 { message: "Function name `foo` should not match property name `foo`" }
+            ]
+        },
+        {
+            code: "Object.defineProperty(foo, 'bar', { value: function baz() {} })",
+            options: ["always", { considerPropertyDescriptor: true }],
+            errors: [
+                { message: "Function name `baz` should match property name `bar`" }
+            ]
+        },
+        {
+            code: "Object.defineProperties(foo, { bar: { value: function baz() {} } })",
+            options: ["always", { considerPropertyDescriptor: true }],
+            errors: [
+                { message: "Function name `baz` should match property name `bar`" }
+            ]
+        },
+        {
+            code: "Object.create(proto, { bar: { value: function baz() {} } })",
+            options: ["always", { considerPropertyDescriptor: true }],
+            errors: [
+                { message: "Function name `baz` should match property name `bar`" }
+            ]
+        },
+        {
+            code: "var obj = { value: function foo(name) {} }",
+            options: ["always", { considerPropertyDescriptor: true }],
+            errors: [
+                { message: "Function name `foo` should match property name `value`" }
+            ]
+        },
+        {
+            code: "Object.defineProperty(foo, 'bar', { value: function bar() {} })",
+            options: ["never", { considerPropertyDescriptor: true }],
+            errors: [
+                { message: "Function name `bar` should not match property name `bar`" }
+            ]
+        },
+        {
+            code: "Object.defineProperties(foo, { bar: { value: function bar() {} } })",
+            options: ["never", { considerPropertyDescriptor: true }],
+            errors: [
+                { message: "Function name `bar` should not match property name `bar`" }
+            ]
+        },
+        {
+            code: "Object.create(proto, { bar: { value: function bar() {} } })",
+            options: ["never", { considerPropertyDescriptor: true }],
+            errors: [
+                { message: "Function name `bar` should not match property name `bar`" }
             ]
         }
     ]


### PR DESCRIPTION
Fixes #9926.

**What is the purpose of this pull request?**

Change an existing rule.

**What rule do you want to change?**

`func-name-matching`

**Does this change cause the rule to produce more or fewer warnings?**

Fewer.

**How will the change be implemented?**

Add option `{ considerPropertyDescriptor: true }` to have rule do some additional checks on what the function name should be.

Previously only property key was checked. With this option enabled it will check if the property is within `Object.defineProperty`, `Object.defineProperties`, or `Object.create`.

**Please provide some example code that this change will affect:**

```js
/** eslint func-name-matching: ["always", { "considerPropertyDescriptor": true }] */
Object.defineProperty(foo, 'bar', {
  value: function baz() {}
})
```

**What does the rule currently do for this code?**

    Function name `baz` should match property name `value`

**What will the rule do after it's changed?**

    Function name `baz` should match property name `bar`
