### PR TITLE
Fix: no-unreachable reporting EmptyStatements (fixes #9081)

### DIFF
--- a/lib/rules/no-unreachable.js
+++ b/lib/rules/no-unreachable.js
@@ -34,6 +34,7 @@ class ConsecutiveRange {
         this.sourceCode = sourceCode;
         this.startNode = null;
         this.endNode = null;
+        this.hasNonEmptyStatement = false;
     }
 
     /**
@@ -83,6 +84,10 @@ class ConsecutiveRange {
      */
     merge(node) {
         this.endNode = node;
+
+        if (node.type !== "EmptyStatement") {
+            this.hasNonEmptyStatement = true;
+        }
     }
 
     /**
@@ -92,6 +97,8 @@ class ConsecutiveRange {
      */
     reset(node) {
         this.startNode = this.endNode = node;
+
+        this.hasNonEmptyStatement = (node && node.type !== "EmptyStatement");
     }
 }
 
@@ -147,7 +154,7 @@ module.exports = {
 
             // Report the current range since this statement is reachable or is
             // not consecutive to the current range.
-            if (!range.isEmpty) {
+            if (!range.isEmpty && range.hasNonEmptyStatement) {
                 context.report({
                     message: "Unreachable code.",
                     loc: range.location,

--- a/tests/lib/rules/no-unreachable.js
+++ b/tests/lib/rules/no-unreachable.js
@@ -40,7 +40,16 @@ ruleTester.run("no-unreachable", rule, {
         "function foo() { var x = 1; for (x in {}) { return; } x = 2; }",
         "function foo() { var x = 1; try { return; } finally { x = 2; } }",
         "function foo() { var x = 1; for (;;) { if (x) break; } x = 2; }",
-        "A: { break A; } foo()"
+        "A: { break A; } foo()",
+
+        // EmptyStatements should not be reported (see rule "no-empty")
+        // https://github.com/eslint/eslint/issues/9081
+        "switch (foo) { default: throw new Error(); };",
+        "function a() { if (foo) { return; } else { return; }; }",
+        "function foo() { return x; ; }",
+        "switch (foo) { default: throw new Error(); };;;;",
+        "function a() { if (foo) { return; } else { return; };;;; }",
+        "function foo() { return x; ;;;; }"
     ],
     invalid: [
         { code: "function foo() { return x; var x = 1; }", errors: [{ message: "Unreachable code.", type: "VariableDeclaration" }] },
@@ -185,6 +194,53 @@ ruleTester.run("no-unreachable", rule, {
                     endColumn: 25
                 }
             ]
+        },
+
+        // EmptyStatements should not be reported (see rule "no-empty")
+        // https://github.com/eslint/eslint/issues/9081
+        {
+            code: "switch (foo) { default: throw new Error(); }; bar();",
+            errors: [{
+                message: "Unreachable code.",
+                type: "EmptyStatement",
+                line: 1,
+                column: 45,
+                endLine: 1,
+                endColumn: 53
+            }]
+        },
+        {
+            code: "function a() { if (foo) { return; } else { return; }; bar(); }",
+            errors: [{
+                message: "Unreachable code.",
+                type: "EmptyStatement",
+                line: 1,
+                column: 53,
+                endLine: 1,
+                endColumn: 61
+            }]
+        },
+        {
+            code: "function foo() { return x; ; bar(); }",
+            errors: [{
+                message: "Unreachable code.",
+                type: "EmptyStatement",
+                line: 1,
+                column: 28,
+                endLine: 1,
+                endColumn: 36
+            }]
+        },
+        {
+            code: "function foo() { return x; ;;;;; bar(); ;; }",
+            errors: [{
+                message: "Unreachable code.",
+                type: "EmptyStatement",
+                line: 1,
+                column: 28,
+                endLine: 1,
+                endColumn: 43
+            }]
         }
     ]
 });


### PR DESCRIPTION
no-unreachable will only report if there is at least one non-EmptyStatement node in the range

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

See #9081.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

no-unreachable now tracks whether non-EmptyStatement nodes have been included in an unreachable code range.

* If an unreachable code range only includes EmptyStatement nodes, the range is not reported. (Rule `no-empty` should be used instead.)
* However, if an unreachable code range has at least one EmptyStatement and at least one non-EmptyStatement, the entire range is reported, including the EmptyStatement(s).

**Is there anything you'd like reviewers to focus on?**

Is there a better way to track empty vs non-empty statements? My preference would have been to iterate on *nodes* (not tokens) between the start and end node of the reporting range and checking that all are EmptyStatements, but SourceCode doesn't have any methods for node iteration. I think what I have works for now, but will fall apart if the traversal order changes.