### PR TITLE
Update: avoid requiring NaN spaces of indentation (fixes #9083)

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -783,7 +783,7 @@ module.exports = {
             offsets.setDesiredOffsets(
                 [startToken.range[1], endToken.range[0]],
                 startToken,
-                offset === "first" ? 1 : offset
+                typeof offset === "number" ? offset : 1
             );
             offsets.setDesiredOffset(endToken, startToken, 0);
 

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -4915,6 +4915,24 @@ ruleTester.run("indent", rule, {
                     );
                 }
             `
+        },
+        {
+            code: unIndent`
+                a(b
+                  , c
+                )
+            `,
+            options: [2, { CallExpression: { arguments: "off" } }]
+        },
+        {
+            code: unIndent`
+                a(
+                  new B({
+                    c,
+                  })
+                );
+            `,
+            options: [2, { CallExpression: { arguments: "off" } }]
         }
     ],
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (https://github.com/eslint/eslint/issues/9083)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This fixes an issue where the `indent` rule would sometimes expect "NaN spaces" of indentation when an `"off"` option was used. The value `"off"` was incorrectly getting used as a numeric offset, so it was cast to a number, resulting in `NaN`.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
