### PR TITLE
Docs: update instructions for adding TSC members

### DIFF
--- a/docs/maintainer-guide/governance.md
+++ b/docs/maintainer-guide/governance.md
@@ -92,13 +92,14 @@ A Committer is invited to become a TSC member by existing TSC members. A nominat
 #### Process for Adding TSC Members
 
 1. Add the GitHub user to the "ESLint TSC" team
-2. Set the GitHub user to be have the "Owner" role for the ESLint organization
-3. Send welcome email with link to maintainer guide
-4. Add TSC member to the README
-5. Invite to Gitter TSC chatroom
-6. Make TSC member an admin on the ESLint team mailing list
-7. Add TSC member as an admin to ESLint Twitter Account on Tweetdeck
-8. Tweet congratulations to the new TSC member from the ESLint Twitter account
+1. Set the GitHub user to be have the "Owner" role for the ESLint organization
+1. Send welcome email with link to maintainer guide
+1. Add the TSC member to the README
+1. Invite to the Gitter TSC chatroom
+1. Make the TSC member an admin on the ESLint team mailing list
+1. Add the TSC member to the recurring TSC meeting event on Google Calendar
+1. Add the TSC member as an admin to ESLint Twitter Account on Tweetdeck
+1. Tweet congratulations to the new TSC member from the ESLint Twitter account
 
 #### TSC Meetings
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

From [last month's TSC meeting](https://github.com/eslint/tsc-meetings/blob/4a238489c2f035711070e8beaa2ba11827bcc521/notes/2017/2017-07-06.md#difficulty-of-reaching-quorum), the TSC started using a calendar invite for meetings. When TSC members are added in the future, we should remember to add them to the calendar invite. This commit updates the guidelines for adding TSC members to include that reminder. 

**Is there anything you'd like reviewers to focus on?**

Nothing in particular