### PR TITLE
Fix: no-multi-spaces to avoid reporting consecutive tabs (fixes #9079)

### DIFF
--- a/lib/rules/no-multi-spaces.js
+++ b/lib/rules/no-multi-spaces.js
@@ -76,8 +76,11 @@ module.exports = {
                     }
                     const rightToken = tokensAndComments[leftIndex + 1];
 
-                    // Ignore tokens that have less than 2 spaces between them or are on different lines
-                    if (leftToken.range[1] + 2 > rightToken.range[0] || leftToken.loc.end.line < rightToken.loc.start.line) {
+                    // Ignore tokens that don't have 2 spaces between them or are on different lines
+                    if (
+                        !sourceCode.text.slice(leftToken.range[1], rightToken.range[0]).includes("  ") ||
+                        leftToken.loc.end.line < rightToken.loc.start.line
+                    ) {
                         return;
                     }
 

--- a/tests/lib/rules/no-multi-spaces.js
+++ b/tests/lib/rules/no-multi-spaces.js
@@ -101,7 +101,9 @@ ruleTester.run("no-multi-spaces", rule, {
         "foo\n \f  bar",
 
         // https://github.com/eslint/eslint/issues/9001
-        "a".repeat(2e5)
+        "a".repeat(2e5),
+
+        "foo\t\t+bar"
     ],
 
     invalid: [


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (https://github.com/eslint/eslint/issues/9079)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

An unintended side-effect of the refactor in 0f9727902fce753c87f45d439c521c93850d7dd8 caused `no-multi-spaces` to start reporting any consecutive whitespace characters between tokens, rather than just reporting consecutive spaces. This commit fixes the rule to only report consecutive spaces.

To be honest, reporting any consecutive whitespace seems like it would also be a reasonable behavior -- I'm not really convinced that it's better for the rule to only report spaces. But that would be a semver-major change.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular