### PR TITLE
Update: allow autofixing when using processors (fixes #7510)

### DIFF
--- a/docs/developer-guide/nodejs-api.md
+++ b/docs/developer-guide/nodejs-api.md
@@ -67,6 +67,8 @@ The most important method on `Linter` is `verify()`, which initiates linting of 
     * **Note**: If you want to lint text and have your configuration be read and processed, use CLIEngine's [`executeOnFiles`](#executeonfiles) or [`executeOnText`](#executeontext) instead.
 * `options` - (optional) Additional options for this run.
     * `filename` - (optional) the filename to associate with the source code.
+    * `preprocess` - (optional) A function that accepts a string containing source text, and returns an array of strings containing blocks of code to lint. Also see: [Processors in Plugins](/docs/developer-guide/working-with-plugins#processors-in-plugins)
+    * `postprocess` - (optional) A function that accepts an array of problem lists (one list of problems for each block of code from `preprocess`), and returns a one-dimensional array of problems containing problems for the original, unprocessed text. Also see: [Processors in Plugins](/docs/developer-guide/working-with-plugins#processors-in-plugins)
     * `allowInlineConfig` - (optional) set to `false` to disable inline comments from changing eslint rules.
 
 If the third argument is a string, it is interpreted as the `filename`.

--- a/docs/developer-guide/working-with-plugins.md
+++ b/docs/developer-guide/working-with-plugins.md
@@ -80,7 +80,7 @@ processors: {
 The `preprocess` method takes the file contents and filename as arguments, and returns an array of strings to lint. The strings will be linted separately but still be registered to the filename. It's up to the plugin to decide if it needs to return just one part, or multiple pieces. For example in the case of processing `.html` files, you might want to return just one item in the array by combining all scripts, but for `.md` file where each JavaScript block might be independent, you can return multiple items.
 
 The `postprocess` method takes a two-dimensional array of arrays of lint messages and the filename. Each item in the input
-array corresponds to the part that was returned from the `preprocess` method. The `postprocess` method must adjust the location of all errors and aggregate them into a single flat array and return it.
+array corresponds to the part that was returned from the `preprocess` method. The `postprocess` method must adjust the location of all errors, (including the range in the `fix` property, if present), and aggregate them into a single flat array and return it.
 
 You can have both rules and processors in a single plugin. You can also have multiple processors in one plugin.
 To support multiple extensions, add each one to the `processors` element and point them to the same object.

--- a/docs/user-guide/command-line-interface.md
+++ b/docs/user-guide/command-line-interface.md
@@ -356,10 +356,7 @@ The resulting configuration file will be created in the current directory.
 
 #### `--fix`
 
-This option instructs ESLint to try to fix as many issues as possible. The fixes are made to the actual files themselves and only the remaining unfixed issues are output. Not all problems are fixable using this option, and the option does not work in these situations:
-
-1. This option throws an error when code is piped to ESLint.
-1. This option has no effect on code that uses processors.
+This option instructs ESLint to try to fix as many issues as possible. The fixes are made to the actual files themselves and only the remaining unfixed issues are output. Not all problems are fixable using this option, and this option throws an error when code is piped to ESLint.
 
 #### `--debug`
 

--- a/docs/user-guide/command-line-interface.md
+++ b/docs/user-guide/command-line-interface.md
@@ -356,7 +356,10 @@ The resulting configuration file will be created in the current directory.
 
 #### `--fix`
 
-This option instructs ESLint to try to fix as many issues as possible. The fixes are made to the actual files themselves and only the remaining unfixed issues are output. Not all problems are fixable using this option, and this option throws an error when code is piped to ESLint.
+This option instructs ESLint to try to fix as many issues as possible. The fixes are made to the actual files themselves and only the remaining unfixed issues are output. Not all problems are fixable using this option, and the option does not work in these situations:
+
+1. This option throws an error when code is piped to ESLint.
+1. This option has no effect on code that uses a processor, unless the processor opts into allowing autofixes.
 
 #### `--debug`
 

--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -143,10 +143,8 @@ function calculateStatsPerRun(results) {
  */
 function processText(text, configHelper, filename, fix, allowInlineConfig, linter) {
     let filePath,
-        messages,
         fileExtension,
-        processor,
-        fixedResult;
+        processor;
 
     if (filename) {
         filePath = path.resolve(filename);
@@ -170,51 +168,26 @@ function processText(text, configHelper, filename, fix, allowInlineConfig, linte
         }
     }
 
-    if (processor) {
-        debug("Using processor");
-        const parsedBlocks = processor.preprocess(text, filename);
-        const unprocessedMessages = [];
+    const fixedResult = linter.verifyAndFix(text, config, {
+        filename,
+        allowInlineConfig,
+        fix: typeof fix !== "undefined" && fix,
+        preprocess: processor && processor.preprocess,
+        postprocess: processor && processor.postprocess
+    });
 
-        parsedBlocks.forEach(block => {
-            unprocessedMessages.push(linter.verify(block, config, {
-                filename,
-                allowInlineConfig
-            }));
-        });
-
-        // TODO(nzakas): Figure out how fixes might work for processors
-
-        messages = processor.postprocess(unprocessedMessages, filename);
-
-    } else {
-
-        if (fix) {
-            fixedResult = linter.verifyAndFix(text, config, {
-                filename,
-                allowInlineConfig,
-                fix
-            });
-            messages = fixedResult.messages;
-        } else {
-            messages = linter.verify(text, config, {
-                filename,
-                allowInlineConfig
-            });
-        }
-    }
-
-    const stats = calculateStatsPerFile(messages);
+    const stats = calculateStatsPerFile(fixedResult.messages);
 
     const result = {
         filePath: filename,
-        messages,
+        messages: fixedResult.messages,
         errorCount: stats.errorCount,
         warningCount: stats.warningCount,
         fixableErrorCount: stats.fixableErrorCount,
         fixableWarningCount: stats.fixableWarningCount
     };
 
-    if (fixedResult && fixedResult.fixed) {
+    if (fixedResult.fixed) {
         result.output = fixedResult.output;
     }
 

--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -172,8 +172,8 @@ function processText(text, configHelper, filename, fix, allowInlineConfig, linte
         filename,
         allowInlineConfig,
         fix: typeof fix !== "undefined" && fix,
-        preprocess: processor && processor.preprocess,
-        postprocess: processor && processor.postprocess
+        preprocess: processor && (rawText => processor.preprocess(rawText, filename)),
+        postprocess: processor && (problemLists => processor.postprocess(problemLists, filename))
     });
 
     const stats = calculateStatsPerFile(fixedResult.messages);

--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -168,10 +168,12 @@ function processText(text, configHelper, filename, fix, allowInlineConfig, linte
         }
     }
 
+    const autofixingEnabled = typeof fix !== "undefined" && (!processor || processor.supportsAutofix);
+
     const fixedResult = linter.verifyAndFix(text, config, {
         filename,
         allowInlineConfig,
-        fix: typeof fix !== "undefined" && fix,
+        fix: !!autofixingEnabled && fix,
         preprocess: processor && (rawText => processor.preprocess(rawText, filename)),
         postprocess: processor && (problemLists => processor.postprocess(problemLists, filename))
     });

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -1043,7 +1043,7 @@ module.exports = class Linter {
      *      should be allowed.
      * @param {boolean|Function} options.fix Determines whether fixes should be applied
      * @param {Function} options.preprocess preprocessor for source text. If provided, this should
-     *      this should accept a string of source text, and return an array of code blocks to lint.
+     *      accept a string of source text, and return an array of code blocks to lint.
      * @param {Function} options.postprocess postprocessor for report messages. If provided,
      *      this should accept an array of the message lists for each code block returned from the preprocessor,
      *      apply a mapping to the messages as appropriate, and return a one-dimensional array of messages

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -977,7 +977,7 @@ module.exports = class Linter {
      *      Mostly useful for testing purposes.
      * @param {boolean} [filenameOrOptions.allowInlineConfig] Allow/disallow inline comments' ability to change config once it is set. Defaults to true if not supplied.
      *      Useful if you want to validate JS without comments overriding rules.
-     * @param {function(string): string[]} [filenameOrOptions.preprocess] preprocessor for source text. If provided, this should
+     * @param {function(string): string[]} [filenameOrOptions.preprocess] preprocessor for source text. If provided,
      *      this should accept a string of source text, and return an array of code blocks to lint.
      * @param {function(Array<Object[]>): Object[]} [filenameOrOptions.postprocess] postprocessor for report messages. If provided,
      *      this should accept an array of the message lists for each code block returned from the preprocessor,

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -12,6 +12,7 @@
 const EventEmitter = require("events").EventEmitter,
     eslintScope = require("eslint-scope"),
     levn = require("levn"),
+    lodash = require("lodash"),
     blankScriptAST = require("../conf/blank-script.json"),
     defaultConfig = require("../conf/default-config-options.js"),
     CodePathAnalyzer = require("./code-path-analysis/code-path-analyzer"),
@@ -721,7 +722,7 @@ module.exports = class Linter {
      */
 
     /**
-     * Verifies the text against the rules specified by the second argument.
+     * Same as linter.verify, except without support for processors.
      * @param {string|SourceCode} textOrSourceCode The text to parse or a SourceCode object.
      * @param {ESLintConfig} config An ESLintConfig instance to configure everything.
      * @param {(string|Object)} [filenameOrOptions] The optional filename of the file being checked.
@@ -731,7 +732,7 @@ module.exports = class Linter {
      *      Useful if you want to validate JS without comments overriding rules.
      * @returns {Object[]} The results as an array of messages or null if no messages.
      */
-    verify(textOrSourceCode, config, filenameOrOptions) {
+    _verifyWithoutProcessors(textOrSourceCode, config, filenameOrOptions) {
         let text,
             parserServices,
             allowInlineConfig,
@@ -966,6 +967,37 @@ module.exports = class Linter {
     }
 
     /**
+     * Verifies the text against the rules specified by the second argument.
+     * @param {string|SourceCode} textOrSourceCode The text to parse or a SourceCode object.
+     * @param {ESLintConfig} config An ESLintConfig instance to configure everything.
+     * @param {(string|Object)} [filenameOrOptions] The optional filename of the file being checked.
+     *      If this is not set, the filename will default to '<input>' in the rule context. If
+     *      an object, then it has "filename", "saveState", and "allowInlineConfig" properties.
+     * @param {boolean} [saveState] Indicates if the state from the last run should be saved.
+     *      Mostly useful for testing purposes.
+     * @param {boolean} [filenameOrOptions.allowInlineConfig] Allow/disallow inline comments' ability to change config once it is set. Defaults to true if not supplied.
+     *      Useful if you want to validate JS without comments overriding rules.
+     * @param {function(string): string[]} [filenameOrOptions.preprocess] preprocessor for source text. If provided, this should
+     *      this should accept a string of source text, and return an array of code blocks to lint.
+     * @param {function(Array<Object[]>): Object[]} [filenameOrOptions.postprocess] postprocessor for report messages. If provided,
+     *      this should accept an array of the message lists for each code block returned from the preprocessor,
+     *      apply a mapping to the messages as appropriate, and return a one-dimensional array of messages
+     * @returns {Object[]} The results as an array of messages or null if no messages.
+     */
+    verify(textOrSourceCode, config, filenameOrOptions) {
+        const preprocess = filenameOrOptions && filenameOrOptions.preprocess || (rawText => [rawText]);
+        const postprocess = filenameOrOptions && filenameOrOptions.postprocess || lodash.flatten;
+        const filename = typeof filenameOrOptions === "object" ? filenameOrOptions.filename : filenameOrOptions;
+
+        return postprocess(
+            preprocess(textOrSourceCode, filename).map(
+                textBlock => this._verifyWithoutProcessors(textBlock, config, filenameOrOptions)
+            ),
+            filename
+        );
+    }
+
+    /**
      * Gets the SourceCode object representing the parsed source.
      * @returns {SourceCode} The SourceCode object.
      */
@@ -1012,6 +1044,8 @@ module.exports = class Linter {
      * @param {boolean} options.allowInlineConfig Flag indicating if inline comments
      *      should be allowed.
      * @param {boolean|Function} options.fix Determines whether fixes should be applied
+     * @param {Function} options.preprocess preprocessor
+     * @param {Function} options.postprocess postprocessor
      * @returns {Object} The result of the fix operation as returned from the
      *      SourceCodeFixer.
      */

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -1042,8 +1042,11 @@ module.exports = class Linter {
      * @param {boolean} options.allowInlineConfig Flag indicating if inline comments
      *      should be allowed.
      * @param {boolean|Function} options.fix Determines whether fixes should be applied
-     * @param {Function} options.preprocess preprocessor
-     * @param {Function} options.postprocess postprocessor
+     * @param {Function} options.preprocess preprocessor for source text. If provided, this should
+     *      this should accept a string of source text, and return an array of code blocks to lint.
+     * @param {Function} options.postprocess postprocessor for report messages. If provided,
+     *      this should accept an array of the message lists for each code block returned from the preprocessor,
+     *      apply a mapping to the messages as appropriate, and return a one-dimensional array of messages
      * @returns {Object} The result of the fix operation as returned from the
      *      SourceCodeFixer.
      */

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -987,13 +987,11 @@ module.exports = class Linter {
     verify(textOrSourceCode, config, filenameOrOptions) {
         const preprocess = filenameOrOptions && filenameOrOptions.preprocess || (rawText => [rawText]);
         const postprocess = filenameOrOptions && filenameOrOptions.postprocess || lodash.flatten;
-        const filename = typeof filenameOrOptions === "object" ? filenameOrOptions.filename : filenameOrOptions;
 
         return postprocess(
-            preprocess(textOrSourceCode, filename).map(
+            preprocess(textOrSourceCode).map(
                 textBlock => this._verifyWithoutProcessors(textBlock, config, filenameOrOptions)
-            ),
-            filename
+            )
         );
     }
 

--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -3705,8 +3705,7 @@ describe("Linter", () => {
                                                         rangeIndex => rangeIndex + blockIndex * 4
                                                     )
                                                 }
-                                            })
-                                        )
+                                            }))
                                     ),
                                 []
                             );

--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -3590,6 +3590,137 @@ describe("Linter", () => {
         });
     });
 
+    describe("processors", () => {
+        beforeEach(() => {
+
+            // A rule that always reports the AST with a message equal to the source text
+            linter.defineRule("report-original-text", context => ({
+                Program(ast) {
+                    context.report({ node: ast, message: context.getSourceCode().text });
+                }
+            }));
+        });
+
+        describe("preprocessors", () => {
+            it("should apply a preprocessor to the code, and lint each code sample separately", () => {
+                const code = "foo bar baz";
+                const problems = linter.verify(
+                    code,
+                    { rules: { "report-original-text": "error" } },
+                    {
+
+                        // Apply a preprocessor that splits the source text into spaces and lints each word individually
+                        preprocess(input) {
+                            assert.strictEqual(input, code);
+                            assert.strictEqual(arguments.length, 1);
+                            return input.split(" ");
+                        }
+                    }
+                );
+
+                assert.strictEqual(problems.length, 3);
+                assert.deepEqual(problems.map(problem => problem.message), ["foo", "bar", "baz"]);
+            });
+        });
+
+        describe("postprocessors", () => {
+            it("should apply a postprocessor to the reported messages", () => {
+                const code = "foo bar baz";
+
+                const problems = linter.verify(
+                    code,
+                    { rules: { "report-original-text": "error" } },
+                    {
+                        preprocess: input => input.split(" "),
+
+                        /*
+                         * Apply a postprocessor that updates the locations of the reported problems
+                         * to make sure they correspond to the locations in the original text.
+                         */
+                        postprocess(problemLists) {
+                            assert.strictEqual(problemLists.length, 3);
+                            assert.strictEqual(arguments.length, 1);
+
+                            problemLists.forEach(problemList => assert.strictEqual(problemList.length, 1));
+                            return problemLists.reduce(
+                                (combinedList, problemList, index) =>
+                                    combinedList.concat(
+                                        problemList.map(
+                                            problem =>
+                                                Object.assign(
+                                                    {},
+                                                    problem,
+                                                    {
+                                                        message: problem.message.toUpperCase(),
+                                                        column: problem.column + index * 4
+                                                    }
+                                                )
+                                        )
+                                    ),
+                                []
+                            );
+                        }
+                    }
+                );
+
+                assert.strictEqual(problems.length, 3);
+                assert.deepEqual(problems.map(problem => problem.message), ["FOO", "BAR", "BAZ"]);
+                assert.deepEqual(problems.map(problem => problem.column), [1, 5, 9]);
+            });
+
+            it("should use postprocessed problem ranges when applying autofixes", () => {
+                const code = "foo bar baz";
+
+                linter.defineRule("capitalize-identifiers", context => ({
+                    Identifier(node) {
+                        if (node.name !== node.name.toUpperCase()) {
+                            context.report({
+                                node,
+                                message: "Capitalize this identifier",
+                                fix: fixer => fixer.replaceText(node, node.name.toUpperCase())
+                            });
+                        }
+                    }
+                }));
+
+                const fixResult = linter.verifyAndFix(
+                    code,
+                    { rules: { "capitalize-identifiers": "error" } },
+                    {
+
+                        /*
+                         * Apply a postprocessor that updates the locations of autofixes
+                         * to make sure they correspond to locations in the original text.
+                         */
+                        preprocess: input => input.split(" "),
+                        postprocess(problemLists) {
+                            return problemLists.reduce(
+                                (combinedProblems, problemList, blockIndex) =>
+                                    combinedProblems.concat(
+                                        problemList.map(problem =>
+                                            Object.assign(problem, {
+                                                fix: {
+                                                    text: problem.fix.text,
+                                                    range: problem.fix.range.map(
+                                                        rangeIndex => rangeIndex + blockIndex * 4
+                                                    )
+                                                }
+                                            })
+                                        )
+                                    ),
+                                []
+                            );
+                        }
+                    }
+                );
+
+                assert.strictEqual(fixResult.fixed, true);
+                assert.strictEqual(fixResult.messages.length, 0);
+                assert.strictEqual(fixResult.output, "FOO BAR BAZ");
+            });
+        });
+    });
+
     describe("verifyAndFix", () => {
         it("Fixes the code", () => {
             const messages = linter.verifyAndFix("var a", {


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Add something to the core

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This implements the proposal from https://github.com/eslint/eslint/issues/7510#issuecomment-275947091 to allow autofixes to be applied when using processors.

The processor API basically remains the same. The only changes are:

* Processors can now export a `supportsAutofix: true` property, which opts a processor into autofixing.
* If a processor supports autofixing, the `postprocess` method is expected to also transform autofix ranges as necessary when it transforms the locations of reported problems. Afterwards, the transformed fixes are applied to the original, unprocessed text.

Multipass autofixing works by calling `preprocess` and `postprocess` for each pass.

(One alternative approach would be to run multipass autofixing on the processed text, and only return the fixed text to the postprocessor afterwards. As discussed in https://github.com/eslint/eslint/issues/7510, though, that would make it difficult for postprocessors because they would need to figure out how to split the fixed text into code blocks again, which would require some sort of imprecise diffing against the original text.)

Summary of changes:

* `linter.verify` and `linter.verifyAndFix`now accept optional `preprocess` and `postprocess` arguments for splitting up the text into code blocks and combining the messages from each code block. By default, the text is "preprocessed" into a single code block containing the code, and the problems are "postprocessed" by flattening the array. (This is the same as not applying a processor at all.)
* Applying processors is now is the responsibility of `Linter` rather than `CLIEngine`. (However, determining which processors need to be applied for a given file is still the responsibility of `CLIEngine`.)

TODO:

- [x] Add more tests
- [x] Add documentation
- [x] Get feedback on this API from people who have implemented processors (cc @BenoitZugmeyer, @btmills, others?)
- [x] Approve this API in a TSC meeting

**Is there anything you'd like reviewers to focus on?**

* Does the API seem reasonable?
* Does the API provide enough information to processors to allow them map autofix ranges correctly?
* ~~Is this a breaking change? (It seems like if a processor currently doesn't apply a transformation to fix ranges, then the original fix ranges will get used, which might be wildly incorrect and result in broken code.) One way to avoid this could be to have processors opt-in to allowing autofixes.~~
* Does it make sense to allow `postprocess` without `preprocess`? The default `postprocess` (flattening the array of problems) will almost always do the wrong thing if multiple code blocks are being linted, since some of the locations will probably be invalid. It might be better to just throw a validation error.
* This effectively allows plugins to remove or add any message to the user's reported problems list, with no opt-in. Are we sure we're okay with that? (Actually, that was already possible with processors before this change, but processors haven't gotten a lot of use because they prevent autofixing. Now that they don't have downsides, I can imagine that plugins could use them just for the purpose of modifying the problems list.)