### PR TITLE
Update: Include files with no messages in junit results (#9093)

### DIFF
--- a/lib/formatters/junit.js
+++ b/lib/formatters/junit.js
@@ -39,10 +39,7 @@ module.exports = function(results) {
 
         const messages = result.messages;
 
-        if (messages.length) {
-            output += `<testsuite package="org.eslint" time="0" tests="${messages.length}" errors="${messages.length}" name="${result.filePath}">\n`;
-        }
-
+        output += `<testsuite package="org.eslint" time="0" tests="${messages.length}" errors="${messages.length}" name="${result.filePath}">\n`;
         messages.forEach(message => {
             const type = message.fatal ? "error" : "failure";
 
@@ -57,10 +54,7 @@ module.exports = function(results) {
             output += `</${type}>`;
             output += "</testcase>\n";
         });
-
-        if (messages.length) {
-            output += "</testsuite>\n";
-        }
+        output += "</testsuite>\n";
 
     });
 

--- a/tests/lib/formatters/junit.js
+++ b/tests/lib/formatters/junit.js
@@ -177,7 +177,7 @@ describe("formatter:junit", () => {
         });
     });
 
-    describe("when passed multiple files with total 1 failure", () => {
+    describe("when passed multiple files should print even if no errors", () => {
         const code = [{
             filePath: "foo.js",
             messages: [{
@@ -192,10 +192,10 @@ describe("formatter:junit", () => {
             messages: []
         }];
 
-        it("should return 1 <testsuite>", () => {
+        it("should return 2 <testsuite>", () => {
             const result = formatter(code);
 
-            assert.equal(result.replace(/\n/g, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><failure message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Warning - Unexpected foo. (foo)]]></failure></testcase></testsuite></testsuites>");
+            assert.equal(result.replace(/\n/g, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><failure message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Warning - Unexpected foo. (foo)]]></failure></testcase></testsuite><testsuite package=\"org.eslint\" time=\"0\" tests=\"0\" errors=\"0\" name=\"bar.js\"></testsuite></testsuites>");
         });
     });
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**
[X] Bug fix https://github.com/eslint/eslint/issues/9093

**What changes did you make? (Give an overview)**
Currently when a file has no errors there isn't an entry in the junit results. This breaks some junit parsers as they expect at least one result. It also provides more data since now you know how many files have actually been parsed.

**Is there anything you'd like reviewers to focus on?**