### PR TITLE
Fix: don't autofix with linter.verifyAndFix when `fix: false` is used

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -1210,7 +1210,7 @@ class Linter extends EventEmitter {
             fixed = false,
             passNumber = 0;
         const debugTextDescription = options && options.filename || `${text.slice(0, 10)}...`;
-        const shouldFix = options && options.fix || true;
+        const shouldFix = options && typeof options.fix !== "undefined" ? options.fix : true;
 
         /**
          * This loop continues until one of the following is true:

--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -3819,6 +3819,16 @@ describe("Linter", () => {
                 output: "var a;"
             });
         });
+
+        it("does not apply autofixes when fix argument is `false`", () => {
+            const fixResult = linter.verifyAndFix("var a", {
+                rules: {
+                    semi: 2
+                }
+            }, { fix: false });
+
+            assert.strictEqual(fixResult.fixed, false);
+        });
     });
 
     describe("Edge cases", () => {


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**Tell us about your environment**

* **ESLint Version:** master
* **Node Version:** 8.3.0
* **npm Version:** 5.3.0

**What parser (default, Babel-ESLint, etc.) are you using?**

N/A

**Please show your full configuration:**

N/A

**What did you do? Please include the actual source code causing the issue.**

```js
const eslint = require("eslint");
const linter = new eslint.Linter();

linter.verifyAndFix("foo", { rules: { semi: 2 } }, { fix: false });
```

**What did you expect to happen?**

I expected no autofixes to be applied. The `fix` property specifies a filter function for fixes, and can also be set to a boolean (where `true` implies that all problems are fixed, and `false` implies that no problems are fixed). However, `false` currently behaves the same as `true`.

**What actually happened? Please include the actual, raw output from ESLint.**

```
{ fixed: true, messages: [], output: 'foo;' }
```

**What changes did you make? (Give an overview)**

Due to a bug, `linter.verifyAndFix` previously applied all autofixes when the `fix` option was set to `false`, even though the documented behavior was to apply no autofixes. This commit fixes the bug.

This fix was also included as part of https://github.com/eslint/eslint/pull/9090 because the bug was affecting the updated behavior of `CLIEngine`. However, I decided to separate it out into a different fix because it's an independent bug.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
