### PR TITLE
chore: Update `chalk` to 2.x release

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -458,7 +458,7 @@ function hasBranch(branchName) {
  */
 function getFormatterResults() {
     const CLIEngine = require("./lib/cli-engine"),
-        chalk = require("chalk");
+        stripAnsi = require("strip-ansi");
 
     const formatterFiles = fs.readdirSync("./lib/formatters/"),
         cli = new CLIEngine({
@@ -489,7 +489,7 @@ function getFormatterResults() {
 
         if (fileExt === ".js") {
             data.formatterResults[name] = {
-                result: chalk.stripColor(cli.getFormatter(name)(rawMessages.results))
+                result: stripAnsi(cli.getFormatter(name)(rawMessages.results))
             };
         }
         return data;

--- a/lib/formatters/stylish.js
+++ b/lib/formatters/stylish.js
@@ -5,6 +5,7 @@
 "use strict";
 
 const chalk = require("chalk"),
+    stripAnsi = require("strip-ansi"),
     table = require("text-table");
 
 //------------------------------------------------------------------------------
@@ -71,7 +72,7 @@ module.exports = function(results) {
             {
                 align: ["", "r", "l"],
                 stringLength(str) {
-                    return chalk.stripColor(str).length;
+                    return stripAnsi(str).length;
                 }
             }
         ).split("\n").map(el => el.replace(/(\d+)\s+(\d+)/, (m, p1, p2) => chalk.dim(`${p1}:${p2}`))).join("\n")}\n\n`;

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "ajv": "^5.2.0",
     "babel-code-frame": "^6.22.0",
-    "chalk": "^1.1.3",
+    "chalk": "^2.1.0",
     "concat-stream": "^1.6.0",
     "cross-spawn": "^5.1.0",
     "debug": "^2.6.8",
@@ -68,6 +68,7 @@
     "progress": "^2.0.0",
     "require-uncached": "^1.0.3",
     "semver": "^5.3.0",
+    "strip-ansi": "^4.0.0",
     "strip-json-comments": "~2.0.1",
     "table": "^4.0.1",
     "text-table": "~0.2.0"

--- a/tests/lib/formatters/codeframe.js
+++ b/tests/lib/formatters/codeframe.js
@@ -14,6 +14,7 @@ const sinon = require("sinon");
 const proxyquire = require("proxyquire");
 const chalk = require("chalk");
 const path = require("path");
+const stripAnsi = require("strip-ansi");
 
 // Chalk protects its methods so we need to inherit from it for Sinon to work.
 const chalkStub = Object.create(chalk, {
@@ -86,7 +87,7 @@ describe("formatter:codeframe", () => {
         it("should return a string in the correct format for warnings", () => {
             const result = formatter(code);
 
-            assert.equal(chalk.stripColor(result), [
+            assert.equal(stripAnsi(result), [
                 `warning: Unexpected foo (foo) at ${path.join("lib", "foo.js")}:1:5:`,
                 "> 1 | var foo = 1;",
                 "    |     ^",
@@ -115,7 +116,7 @@ describe("formatter:codeframe", () => {
             it("should return a string in the correct format", () => {
                 const result = formatter(code);
 
-                assert.equal(chalk.stripColor(result), [
+                assert.equal(stripAnsi(result), [
                     `warning: Unexpected foo (foo) at ${path.join("lib", "foo.js")}:1:5:`,
                     "> 1 | var foo = 1;",
                     "    |     ^",
@@ -147,7 +148,7 @@ describe("formatter:codeframe", () => {
         it("should return a string in the correct format for errors", () => {
             const result = formatter(code);
 
-            assert.equal(chalk.stripColor(result), [
+            assert.equal(stripAnsi(result), [
                 `error: Unexpected foo (foo) at ${path.join("lib", "foo.js")}:1:5:`,
                 "> 1 | var foo = 1;",
                 "    |     ^",
@@ -193,7 +194,7 @@ describe("formatter:codeframe", () => {
         it("should return a string with multiple entries", () => {
             const result = formatter(code);
 
-            assert.equal(chalk.stripColor(result), [
+            assert.equal(stripAnsi(result), [
                 "error: Missing semicolon (semi) at foo.js:1:14:",
                 "> 1 | const foo = 1",
                 "    |              ^",
@@ -241,7 +242,7 @@ describe("formatter:codeframe", () => {
         it("should return a string with code preview pointing to the correct location after fixes", () => {
             const result = formatter(code);
 
-            assert.equal(chalk.stripColor(result), [
+            assert.equal(stripAnsi(result), [
                 "error: 'foo' is assigned a value but never used (no-unused-vars) at foo.js:4:11:",
                 "  2 | ",
                 "  3 |     // a comment",
@@ -286,7 +287,7 @@ describe("formatter:codeframe", () => {
         it("should return a string with multiple entries", () => {
             const result = formatter(code);
 
-            assert.equal(chalk.stripColor(result), [
+            assert.equal(stripAnsi(result), [
                 "error: Missing semicolon (semi) at foo.js:1:14:",
                 "> 1 | const foo = 1",
                 "    |              ^",
@@ -322,7 +323,7 @@ describe("formatter:codeframe", () => {
         it("should return a string in the correct format", () => {
             const result = formatter(code);
 
-            assert.equal(chalk.stripColor(result), [
+            assert.equal(stripAnsi(result), [
                 "error: Parsing error: Unexpected token { at foo.js:1:2:",
                 "> 1 | e{}",
                 "    |  ^",
@@ -347,7 +348,7 @@ describe("formatter:codeframe", () => {
         it("should return a string without code preview (codeframe)", () => {
             const result = formatter(code);
 
-            assert.equal(chalk.stripColor(result), "error: Couldn't find foo.js at foo.js\n\n\n1 error found.");
+            assert.equal(stripAnsi(result), "error: Couldn't find foo.js at foo.js\n\n\n1 error found.");
         });
     });
 
@@ -367,13 +368,13 @@ describe("formatter:codeframe", () => {
         it("should return a string without code preview (codeframe)", () => {
             const result = formatter(code);
 
-            assert.equal(chalk.stripColor(result), "error: Unexpected foo (foo) at foo.js\n\n\n1 error found.");
+            assert.equal(stripAnsi(result), "error: Unexpected foo (foo) at foo.js\n\n\n1 error found.");
         });
 
         it("should output filepath but without 'line:column' appended", () => {
             const result = formatter(code);
 
-            assert.equal(chalk.stripColor(result), "error: Unexpected foo (foo) at foo.js\n\n\n1 error found.");
+            assert.equal(stripAnsi(result), "error: Unexpected foo (foo) at foo.js\n\n\n1 error found.");
         });
     });
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Update `chalk` to the latest _major_ 2.x branch from 1.x
• Release notes: https://github.com/chalk/chalk/releases/tag/v2.0.0
• Changelog for chalk 1.1.3 to 2.0.0 changes https://github.com/chalk/chalk/compare/v1.1.3...v2.0.0

chalk 2.0.0 breaking change (via release notes)
• Removed `chalk.stripColor()`. Use the `strip-ansi` package directly instead.

This PR adds the `strip-ansi` package replacing instances of `chalk.stripColor()` with `strip-ansi`

**Is there anything you'd like reviewers to focus on?**

The new package `strip-ansi` was added to `dependencies` as it's required by the `stylish` formatter which is shipped as part of the build, I think this is what is required just as `chalk` is and was previously in the same regard.