### PR TITLE
Update: fix indentation of multiline `new.target` expressions

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -1178,14 +1178,15 @@ module.exports = {
                 }
             },
 
-            "MemberExpression, JSXMemberExpression"(node) {
-                const firstNonObjectToken = sourceCode.getFirstTokenBetween(node.object, node.property, astUtils.isNotClosingParenToken);
+            "MemberExpression, JSXMemberExpression, MetaProperty"(node) {
+                const object = node.type === "MetaProperty" ? node.meta : node.object;
+                const firstNonObjectToken = sourceCode.getFirstTokenBetween(object, node.property, astUtils.isNotClosingParenToken);
                 const secondNonObjectToken = sourceCode.getTokenAfter(firstNonObjectToken);
 
-                const objectParenCount = sourceCode.getTokensBetween(node.object, node.property, { filter: astUtils.isClosingParenToken }).length;
+                const objectParenCount = sourceCode.getTokensBetween(object, node.property, { filter: astUtils.isClosingParenToken }).length;
                 const firstObjectToken = objectParenCount
-                    ? sourceCode.getTokenBefore(node.object, { skip: objectParenCount - 1 })
-                    : sourceCode.getFirstToken(node.object);
+                    ? sourceCode.getTokenBefore(object, { skip: objectParenCount - 1 })
+                    : sourceCode.getFirstToken(object);
                 const lastObjectToken = sourceCode.getTokenBefore(firstNonObjectToken);
                 const firstPropertyToken = node.computed ? firstNonObjectToken : secondNonObjectToken;
 

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -1843,6 +1843,18 @@ ruleTester.run("indent", rule, {
             `,
             options: [4, { MemberExpression: 1 }]
         },
+        unIndent`
+            function foo() {
+                new
+                    .target
+            }
+        `,
+        unIndent`
+            function foo() {
+                new.
+                    target
+            }
+        `,
         {
             code: unIndent`
                 if (foo) {
@@ -6126,6 +6138,36 @@ ruleTester.run("indent", rule, {
             `,
             options: [2, { MemberExpression: 2 }],
             errors: expectedErrors([[2, 4, 2, "Punctuator"], [3, 4, 2, "Punctuator"]])
+        },
+        {
+            code: unIndent`
+                function foo() {
+                    new
+                    .target
+                }
+            `,
+            output: unIndent`
+                function foo() {
+                    new
+                        .target
+                }
+            `,
+            errors: expectedErrors([3, 8, 4, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                function foo() {
+                    new.
+                    target
+                }
+            `,
+            output: unIndent`
+                function foo() {
+                    new.
+                        target
+                }
+            `,
+            errors: expectedErrors([3, 8, 4, "Identifier"])
         },
         {
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment**

* **ESLint Version:** master
* **Node Version:** 8.4.0
* **npm Version:** 5.3.0

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

```yml
rules:
  indent: error
```

**What did you do? Please include the actual source code causing the issue.**

```js
function foo() {
    foo
        .bar;

    new
        .target;
}
```

**What did you expect to happen?**

I expected no errors to be reported.

**What actually happened? Please include the actual, raw output from ESLint.**

```
<text>
  6:1  error  Expected indentation of 4 spaces but found 8  indent

✖ 1 problem (1 error, 0 warnings)
  1 error, 0 warnings potentially fixable with the `--fix` option.
```

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates the `indent` rule to handle `MetaProperty` nodes in the same manner as `MemberExpression` nodes.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
