### PR TITLE
Test-Case: no-unused-vars broken for isHidden function.

### DIFF
--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -142,6 +142,7 @@ ruleTester.run("no-unused-vars", rule, {
         { code: "var x = 1; function foo({y = x} = {}) { bar(y); } foo();", parserOptions: { ecmaVersion: 6 } },
         { code: "var x = 1; function foo(y = function(z = x) { bar(z); }) { y(); } foo();", parserOptions: { ecmaVersion: 6 } },
         { code: "var x = 1; function foo(y = function() { bar(x); }) { y(); } foo();", parserOptions: { ecmaVersion: 6 } },
+        { code: "function isHidden(something) {return !something;}function doSomething(map) {const isHidden = isHidden(map['something']);} doSomething();\n", parserOptions: { ecmaVersion: 6 } },
 
         // exported variables should work
         "/*exported toaster*/ var toaster = 'great'",


### PR DESCRIPTION
The rules no-used-vars and no-use-before-defined show an error where non should be reported. 

I attached a Test-Case for no-used-vars.

If you rename the isHidden function or remove the return value it works as expected.

<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**
[x] Bug Test-Case without fix
**Tell us about your environment**

* **ESLint Version:**
4.4.1

* **Node Version:**
6.11.1 and 6.11.2

* **npm Version:**
3.10.10

**What parser (default, Babel-ESLint, etc.) are you using?**
default

**Please show your full configuration:**
```
{
  "parserOptions": {
    "sourceType": "module",
    "ecmaVersion": 6,
    "ecmaFeatures": {
      "modules": true,
      "arrowFunctions": true,
      "blockBindings": true,
      "destructuring": true,
      "classes": true
    }
  },
  "extends": [
    "eslint:recommended"
  ],
  "env": {
    "browser": true,
    "es6": true
  },
  "plugins": [
  ],
  "rules": {
    "no-use-before-define": "error",
    "no-unused-vars": "error"
  }
}
```

**What did you do? Please include the actual source code causing the issue.**

```
function isHidden(something) {
    return !something;
}

function doSomething(map) {
    const isHidden = isHidden(map['something']);
}

doSomething();
```

**What did you expect to happen?**
I expected just a warning that isHidden is unused.

**What actually happened? Please include the actual, raw output from ESLint.**
I got an error that isHidden is used before defined and unused.
```
  1:10  error  'isHidden' is defined but never used       no-unused-vars
  6:22  error  'isHidden' was used before it was defined  no-use-before-define

✖ 2 problems (2 errors, 0 warnings)

```
**What changes did you make? (Give an overview)**
I added a Test-Case that shows the error but **does not fix it**.

**Is there anything you'd like reviewers to focus on?**
Maybe this should only be committed together with a fix?

