### PR TITLE
Fix: handle es6 class extensions in new-parens.

### DIFF
--- a/docs/rules/new-parens.md
+++ b/docs/rules/new-parens.md
@@ -26,4 +26,5 @@ Examples of **correct** code for this rule:
 
 var person = new Person();
 var person = new (Person)();
+var foo = new class extends Map {};
 ```

--- a/lib/rules/new-parens.js
+++ b/lib/rules/new-parens.js
@@ -37,8 +37,12 @@ module.exports = {
 
         return {
             NewExpression(node) {
-                if (node.arguments.length !== 0) {
-                    return; // shortcut: if there are arguments, there have to be parens
+                if (node.arguments.length !== 0 || node.callee.type === "ClassExpression") {
+
+                    // shortcut:
+                    //   if there are arguments, there have to be parens
+                    //   or if the callee is a ClassExpression, we don't need parens
+                    return;
                 }
 
                 const lastToken = sourceCode.getLastToken(node);

--- a/tests/lib/rules/new-parens.js
+++ b/tests/lib/rules/new-parens.js
@@ -28,7 +28,8 @@ ruleTester.run("new-parens", rule, {
         "var a = (new Date());",
         "var a = new foo.Bar();",
         "var a = (new Foo()).bar;",
-        { code: "new Storage<RootState>('state');", parser: parser("typescript-parsers/new-parens") }
+        { code: "new Storage<RootState>('state');", parser: parser("typescript-parsers/new-parens") },
+        { code: "var a = new class extends Map {};", parserOptions: { ecmaVersion: 6 } }
     ],
     invalid: [
         {


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))

**What rule do you want to change?** new-parens

**Does this change cause the rule to produce more or fewer warnings?** Fewer when in es6 mode.

**How will the change be implemented? (New option, new default behavior, etc.)?** New default behaviour


**Please provide some example code that this change will affect:**

```js
var foo = new class extends Map {};
```

**What does the rule currently do for this code?**

Reports `Missing '()' invoking a constructor.`

**What will the rule do after it's changed?**

No errors.

This is changing the rule to support a part of the es6 syntax for classes.