### PR TITLE
Add framework option in the config initializer

### DIFF
--- a/lib/config/config-initializer.js
+++ b/lib/config/config-initializer.js
@@ -263,12 +263,14 @@ function processAnswers(answers) {
         config.parserOptions = config.parserOptions || {};
         config.parserOptions.ecmaFeatures = config.parserOptions.ecmaFeatures || {};
         config.parserOptions.ecmaFeatures.jsx = true;
-        if (answers.react) {
-            config.plugins = ["react"];
+    }
+
+    if (answers.framework) {
+        config.plugins = [answers.framework];
+        if (answers.framework === "react") {
             config.parserOptions.ecmaFeatures.experimentalObjectRestSpread = true;
         }
     }
-
     if (answers.source === "prompt") {
         config.extends = "eslint:recommended";
         config.rules.indent = ["error", answers.indent];
@@ -276,7 +278,6 @@ function processAnswers(answers) {
         config.rules["linebreak-style"] = ["error", answers.linebreak];
         config.rules.semi = ["error", answers.semi ? "always" : "never"];
     }
-
     installModules(config);
 
     if (answers.source === "auto") {
@@ -513,13 +514,20 @@ function promptUser() {
                 default: false
             },
             {
-                type: "confirm",
-                name: "react",
-                message: "Do you use React?",
-                default: false,
-                when(answers) {
-                    return answers.jsx;
-                }
+                type: "list",
+                name: "framework",
+                message: "Which framework do you use?",
+                choices(answers) {
+                    const frameworks = [{ name: "None", value: "" }];
+
+                    if (answers.jsx) {
+                        frameworks.push({ name: "React", value: "react" });
+                    } else {
+                        frameworks.push({ name: "AngularJS", value: "angular" });
+                    }
+                    return frameworks;
+                },
+                default: 0
             }
         ]).then(secondAnswers => {
 

--- a/tests/lib/config/config-initializer.js
+++ b/tests/lib/config/config-initializer.js
@@ -131,7 +131,7 @@ describe("configInitializer", () => {
                     modules: true,
                     env: ["browser"],
                     jsx: false,
-                    react: false,
+                    framework: "",
                     format: "JSON",
                     commonjs: false
                 };
@@ -166,12 +166,20 @@ describe("configInitializer", () => {
 
             it("should enable react plugin", () => {
                 answers.jsx = true;
-                answers.react = true;
+                answers.framework = "react";
                 const config = init.processAnswers(answers);
 
                 assert.equal(config.parserOptions.ecmaFeatures.jsx, true);
                 assert.equal(config.parserOptions.ecmaFeatures.experimentalObjectRestSpread, true);
                 assert.deepEqual(config.plugins, ["react"]);
+            });
+
+            it("should enable angular plugin", () => {
+                answers.jsx = false;
+                answers.framework = "angular";
+                const config = init.processAnswers(answers);
+
+                assert.deepEqual(config.plugins, ["angular"]);
             });
 
             it("should not enable es6", () => {


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ x ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
The first time I have tested the config initializer, I saw the possibility to install react plugin. In this PR, I propose to add a framework option in order to select the web framework you use in your application. For the moment, I only support React and AngularJS (I have created few years ago the AngularJS plugin for eslint)

**Is there anything you'd like reviewers to focus on?**


