### PR TITLE
Docs: add documentation for Linter methods (refs #6525)

### DIFF
--- a/docs/developer-guide/nodejs-api.md
+++ b/docs/developer-guide/nodejs-api.md
@@ -58,6 +58,8 @@ var Linter = require("eslint").Linter;
 var linter = new Linter();
 ```
 
+### Linter#verify
+
 The most important method on `Linter` is `verify()`, which initiates linting of the given text. This method accepts four arguments:
 
 * `code` - the source code to lint (a string or instance of `SourceCode`).
@@ -147,7 +149,7 @@ console.log(code.text);     // "var foo = bar;"
 
 In this way, you can retrieve the text and AST used for the last run of `linter.verify()`.
 
-### verifyAndFix()
+### Linter#verifyAndFix()
 
 This method is similar to verify except that it also runs autofixing logic, similar to the `--fix` flag on the command line. The result object will contain the autofixed code, along with any remaining linting messages for the code that were not autofixed.
 
@@ -177,6 +179,76 @@ The information available is:
 * `fixed` - True, if the code was fixed.
 * `output` - Fixed code text (might be the same as input if no fixes were applied).
 * `messages` - Collection of all messages for the given code (It has the same information as explained above under `verify` block).
+
+### Linter#defineRule
+
+Each `Linter` instance holds a map of rule names to loaded rule objects. By default, all ESLint core rules are loaded. If you want to use `Linter` with custom rules, you should use the `defineRule` method to register your rules by ID.
+
+```js
+const Linter = require("eslint").Linter;
+const linter = new Linter();
+
+linter.defineRule("my-custom-rule", {
+    // (an ESLint rule)
+
+    create(context) {
+        // ...
+    }
+});
+
+const results = linter.verify("// some source text", { rules: { "my-custom-rule": "error" } });
+```
+
+### Linter#defineRules
+
+This is a convenience method similar to `Linter#defineRule`, except that it allows you to define many rules at once using an object.
+
+```js
+const Linter = require("eslint").Linter;
+const linter = new Linter();
+
+linter.defineRules({
+    "my-custom-rule": { /* an ESLint rule */ create() {} },
+    "another-custom-rule": { /* an ESLint rule */ create() {} }
+});
+
+const results = linter.verify("// some source text", {
+    rules: {
+        "my-custom-rule": "error",
+        "another-custom-rule": "warn"
+    }
+});
+```
+
+### Linter#getRules
+
+This method returns a map of all loaded rules.
+
+```js
+const Linter = require("eslint").Linter;
+const linter = new Linter();
+
+linter.getRules();
+
+/*
+Map {
+  'accessor-pairs' => { meta: { docs: [Object], schema: [Array] }, create: [Function: create] },
+  'array-bracket-newline' => { meta: { docs: [Object], schema: [Array] }, create: [Function: create] },
+  ...
+}
+*/
+```
+
+### Linter#version
+
+Each instance of `Linter` has a `version` property containing the semantic version number of ESLint that the `Linter` instance is from.
+
+```js
+const Linter = require("eslint").Linter;
+const linter = new Linter();
+
+linter.version; // => '4.5.0'
+```
 
 ## linter
 
@@ -611,6 +683,14 @@ var report = cli.executeOnFiles(["myfile.js", "lib/"]);
 
 // output fixes to disk
 CLIEngine.outputFixes(report);
+```
+
+### CLIEngine.version
+
+`CLIEngine` has a static `version` property containing the semantic version number of ESLint that it comes from.
+
+```js
+require("eslint").CLIEngine.version; // '4.5.0'
 ```
 
 ## Deprecated APIs


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This adds documentation for the new APIs that were added in https://github.com/eslint/eslint/issues/6525, as well as a few other `Linter` methods that are undocumented.

The other methods on `Linter.prototype` (`reset`, `report`, `getSourceCode`, `getAncestors`, `getScope`, `markVariableAsUsed`, `getFilename`, `defaults`, `getDeclaredVariables`, the external methods [here](https://github.com/eslint/eslint/blob/ffa021e7696b24722cbbef306d494dd64d7b5215/lib/linter.js#L1256-L1277), and the methods on `EventEmitter.prototype`) are not intended to be used by Node.js API users, and are only exposed incidentally, so I didn't document them. Eventually I'd like to remove them and/or rename them to make it clear that they're private. It would also be nice to keep `linter.verify` as a pure function, but it currently modifies some internal state which is visible through those private methods.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
