### PR TITLE
Docs: fix examples for prefer-numeric-literals

### DIFF
--- a/docs/rules/prefer-numeric-literals.md
+++ b/docs/rules/prefer-numeric-literals.md
@@ -21,7 +21,7 @@ parseInt("767", 8) === 503;
 parseInt("1F7", 16) === 255;
 Number.parseInt("111110111", 2) === 503;
 Number.parseInt("767", 8) === 503;
-Number.parseInt("1F7", 16) === 255;
+Number.parseInt("1F7", 16) === 503;
 ```
 
 Examples of **correct** code for this rule:

--- a/docs/rules/prefer-numeric-literals.md
+++ b/docs/rules/prefer-numeric-literals.md
@@ -18,7 +18,7 @@ Examples of **incorrect** code for this rule:
 
 parseInt("111110111", 2) === 503;
 parseInt("767", 8) === 503;
-parseInt("1F7", 16) === 255;
+parseInt("1F7", 16) === 503;
 Number.parseInt("111110111", 2) === 503;
 Number.parseInt("767", 8) === 503;
 Number.parseInt("1F7", 16) === 503;


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

`Number.parseInt("1F7", 16)` -> `503`

**Is there anything you'd like reviewers to focus on?**

Just check it in the console. 😉 