### PR TITLE
Fix: no-extra-parens reported some parenthesized IIFEs (fixes #9140)

### DIFF
--- a/lib/ast-utils.js
+++ b/lib/ast-utils.js
@@ -808,19 +808,14 @@ module.exports = {
                 return 17;
 
             case "CallExpression":
-
-                // IIFE is allowed to have parens in any position (#655)
-                if (node.callee.type === "FunctionExpression") {
-                    return -1;
-                }
                 return 18;
 
             case "NewExpression":
                 return 19;
 
-            // no default
+            default:
+                return 20;
         }
-        return 20;
     },
 
     /**

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -277,6 +277,15 @@ module.exports = {
         }
 
         /**
+         * Determines if a given expression node is an IIFE
+         * @param {ASTNode} node The node to check
+         * @returns {boolean} `true` if the given node is an IIFE
+         */
+        function isIIFE(node) {
+            return node.type === "CallExpression" && node.callee.type === "FunctionExpression";
+        }
+
+        /**
          * Report the node
          * @param {ASTNode} node node to evaluate
          * @returns {void}
@@ -286,8 +295,14 @@ module.exports = {
             const leftParenToken = sourceCode.getTokenBefore(node);
             const rightParenToken = sourceCode.getTokenAfter(node);
 
-            if (tokensToIgnore.has(sourceCode.getFirstToken(node)) && !isParenthesisedTwice(node)) {
-                return;
+            if (!isParenthesisedTwice(node)) {
+                if (tokensToIgnore.has(sourceCode.getFirstToken(node))) {
+                    return;
+                }
+
+                if (isIIFE(node) && !isParenthesised(node.callee)) {
+                    return;
+                }
             }
 
             context.report({
@@ -328,15 +343,12 @@ module.exports = {
          * @private
          */
         function checkCallNew(node) {
-            if (hasExcessParens(node.callee) && precedence(node.callee) >= precedence(node) && !(
-                node.type === "CallExpression" &&
-                (node.callee.type === "FunctionExpression" ||
-                  node.callee.type === "NewExpression" && !isNewExpressionWithParens(node.callee)) &&
+            if (hasExcessParens(node.callee) && precedence(node.callee) >= precedence(node)) {
+                const hasNewParensException = node.callee.type === "NewExpression" && !isNewExpressionWithParens(node.callee);
 
-                // One set of parentheses are allowed for a function expression
-                !hasDoubleExcessParens(node.callee)
-            )) {
-                report(node.callee);
+                if (hasDoubleExcessParens(node.callee) || !isIIFE(node) && !hasNewParensException) {
+                    report(node.callee);
+                }
             }
             if (node.arguments.length === 1) {
                 if (hasDoubleExcessParens(node.arguments[0]) && precedence(node.arguments[0]) >= PRECEDENCE_OF_ASSIGNMENT_EXPR) {

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -175,6 +175,7 @@ ruleTester.run("no-extra-parens", rule, {
         "var o = { foo: (function() { return bar(); })() };",
         "o.foo = (function(){ return bar(); })();",
         "(function(){ return bar(); })(), (function(){ return bar(); })()",
+        "function foo() { return (function(){}()); }",
 
         // parens are required around yield
         "var foo = (function*() { if ((yield foo()) + 1) { return; } }())",


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (https://github.com/eslint/eslint/issues/9140)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates `no-extra-parens` to handle IIFEs more consistently by doing an IIFE check as part of the `report` call, rather than overloading the precedence calculation with special logic for IIFEs.

The bug occurred because the rule was assuming that the precedence calculation would always return -1 for an IIFE, preventing it from ever being reported (since any surrounding parens would always be considered necessary). However, the `ReturnStatement` listener doesn't check the precedence of its argument (since it correctly assumes that `return` statements have the lowest precedence), so it incorrectly caused the IIFE to be reported.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
