### PR TITLE
Fix: indent crash on sparse arrays with "off" option (fixes #9157)

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -802,10 +802,19 @@ module.exports = {
                 return;
             }
             elements.forEach((element, index) => {
+                if (!element) {
+
+                    // Skip holes in arrays
+                    return;
+                }
                 if (offset === "off") {
+
+                    // Ignore the first token of every element if the "off" option is used
                     offsets.ignoreToken(getFirstToken(element));
                 }
-                if (index === 0 || !element) {
+
+                // Offset the following elements correctly relative to the first element
+                if (index === 0) {
                     return;
                 }
                 if (offset === "first" && tokenInfo.isFirstTokenOfLine(getFirstToken(element))) {

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -3223,6 +3223,10 @@ ruleTester.run("indent", rule, {
             options: [2, { ArrayExpression: "first" }]
         },
         {
+            code: "[,]",
+            options: [2, { ArrayExpression: "off" }]
+        },
+        {
             code: unIndent`
                 [
                     ,


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (https://github.com/eslint/eslint/issues/9157)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates `indent` to add a missing null check for sparse arrays when using the `ArrayExpression: "off"` option.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
