### PR TITLE
Fix: Handle error when running init without npm

### DIFF
--- a/lib/config/config-initializer.js
+++ b/lib/config/config-initializer.js
@@ -65,6 +65,7 @@ function writeFile(config, format) {
  * @param {string} moduleName The module name to get.
  * @returns {Object} The peer dependencies of the given module.
  * This object is the object of `peerDependencies` field of `package.json`.
+ * Returns null if npm was not found.
  */
 function getPeerDependencies(moduleName) {
     let result = getPeerDependencies.cache.get(moduleName);
@@ -356,7 +357,8 @@ function hasESLintVersionConflict(answers) {
     // Get the required range of ESLint version.
     const configName = getStyleGuideName(answers);
     const moduleName = `eslint-config-${configName}@latest`;
-    const requiredESLintVersionRange = getPeerDependencies(moduleName).eslint;
+    const peerDependencies = getPeerDependencies(moduleName) || {};
+    const requiredESLintVersionRange = peerDependencies.eslint;
 
     if (!requiredESLintVersionRange) {
         return false;

--- a/lib/util/npm-util.js
+++ b/lib/util/npm-util.js
@@ -53,22 +53,39 @@ function installSyncSaveDev(packages) {
     if (!Array.isArray(packages)) {
         packages = [packages];
     }
-    spawn.sync("npm", ["i", "--save-dev"].concat(packages), { stdio: "inherit" });
+    const npmProcess = spawn.sync("npm", ["i", "--save-dev"].concat(packages),
+        { stdio: "inherit" });
+    const error = npmProcess.error;
+
+    if (error && error.code === "ENOENT") {
+        const pluralS = packages.length > 1 ? "s" : "";
+
+        log.error(`Could not execute npm. Please install the following package${pluralS} with your package manager of choice: ${packages.join(", ")}`);
+    }
 }
 
 /**
  * Fetch `peerDependencies` of the given package by `npm show` command.
  * @param {string} packageName The package name to fetch peerDependencies.
- * @returns {Object} Gotten peerDependencies.
+ * @returns {Object} Gotten peerDependencies. Returns null if npm was not found.
  */
 function fetchPeerDependencies(packageName) {
-    const fetchedText = spawn.sync(
+    const npmProcess = spawn.sync(
         "npm",
         ["show", "--json", packageName, "peerDependencies"],
         { encoding: "utf8" }
-    ).stdout.trim();
+    );
+
+    const error = npmProcess.error;
+
+    if (error && error.code === "ENOENT") {
+        return null;
+    }
+    const fetchedText = npmProcess.stdout.trim();
 
     return JSON.parse(fetchedText || "{}");
+
+
 }
 
 /**


### PR DESCRIPTION
Fix init command crashing on machines that don't have npm installed #9102 .

### Before:

![screenshot from 2017-08-27 22-57-08](https://user-images.githubusercontent.com/5729175/29759855-d4a7801e-8b84-11e7-9159-e1a0c4af9c8f.png)

### After:

![screenshot from 2017-08-27 23-59-58](https://user-images.githubusercontent.com/5729175/29759863-e2beaf74-8b84-11e7-93dc-67ebbc80af3f.png)



<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ X ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Modify `fetchPeerDependencies()` function in npm-util to retun null if the npm process exited with an `ENOENT` error.
Modify `installSyncSaveDev()` function in npm-util to log an error message  if the npm process exited with an `ENOENT` error.
Write new tests for `fetchPeerDependencies()` and `installSyncSaveDev()` to cover these scenarios.
Modify the sync stub in other `installSyncSaveDev()` tests to return an object more similar to the child_process object specified in the node.js docs, to avoid undefined field errors.

**Is there anything you'd like reviewers to focus on?**

I'm not sure if returning `null` in `fetchPeerDependencies()` might be the best way of error handling. A consequence of this is that `getPeerDependencies()` also has to return null in this scenario. Let me know if you think there are better alternatives.
With this change, `hasESLintVersionConflict()` could potentially throw an error when trying to access the `eslint` field of a null object. I decided check for null and use an empty object instead, which results in the function returning false in this scenario. I'm not sure what consequences might this change have, and I couldn't figure  out a way to test it since it is a private method.
