### PR TITLE
Chore: avoid using internal Linter APIs in RuleTester (refs #9161)

### DIFF
--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -159,7 +159,8 @@ class RuleTester {
 
             // we have to clone because merge uses the first argument for recipient
             lodash.cloneDeep(defaultConfig),
-            testerConfig
+            testerConfig,
+            { rules: { "rule-tester/validate-ast": "error" } }
         );
 
         /**
@@ -333,13 +334,14 @@ class RuleTester {
              */
             linter.reset();
 
-            linter.on("Program", node => {
-                beforeAST = cloneDeeplyExcludesParent(node);
-            });
-
-            linter.on("Program:exit", node => {
-                afterAST = node;
-            });
+            linter.defineRule("rule-tester/validate-ast", () => ({
+                Program(node) {
+                    beforeAST = cloneDeeplyExcludesParent(node);
+                },
+                "Program:exit"(node) {
+                    afterAST = node;
+                }
+            }));
 
             // Freezes rule-context properties.
             const originalGet = linter.rules.get;


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates `RuleTester` to use the public `Linter#defineRule` API rather than the private `Linter#on` API.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular