### PR TITLE
Chore: avoid using private Linter APIs in SourceCode tests (refs #9161)

### DIFF
--- a/tests/lib/util/source-code.js
+++ b/tests/lib/util/source-code.js
@@ -213,8 +213,7 @@ describe("SourceCode", () => {
 
     describe("getJSDocComment()", () => {
 
-        const sandbox = sinon.sandbox.create(),
-            filename = "foo.js";
+        const sandbox = sinon.sandbox.create();
 
         beforeEach(() => {
             linter.reset();
@@ -246,8 +245,8 @@ describe("SourceCode", () => {
 
             const spy = sandbox.spy(assertJSDoc);
 
-            linter.on("FunctionExpression", spy);
-            linter.verify(code, { rules: {} }, filename, true);
+            linter.defineRule("checker", () => ({ FunctionExpression: spy }));
+            linter.verify(code, { rules: { checker: "error" } });
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
 
         });
@@ -274,8 +273,8 @@ describe("SourceCode", () => {
 
             const spy = sandbox.spy(assertJSDoc);
 
-            linter.on("FunctionExpression", spy);
-            linter.verify(code, { rules: {} }, filename, true);
+            linter.defineRule("checker", () => ({ FunctionExpression: spy }));
+            linter.verify(code, { rules: { checker: "error" } });
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
 
         });
@@ -304,8 +303,8 @@ describe("SourceCode", () => {
 
             const spy = sandbox.spy(assertJSDoc);
 
-            linter.on("FunctionExpression", spy);
-            linter.verify(code, { rules: {} }, filename, true);
+            linter.defineRule("checker", () => ({ FunctionExpression: spy }));
+            linter.verify(code, { rules: { checker: "error" } });
             assert.isTrue(spy.calledTwice, "Event handler should be called twice.");
 
         });
@@ -336,8 +335,8 @@ describe("SourceCode", () => {
 
             const spy = sandbox.spy(assertJSDoc);
 
-            linter.on("FunctionExpression", spy);
-            linter.verify(code, { rules: {} }, filename, true);
+            linter.defineRule("checker", () => ({ FunctionExpression: spy }));
+            linter.verify(code, { rules: { checker: "error" } });
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
         });
 
@@ -364,8 +363,8 @@ describe("SourceCode", () => {
 
             const spy = sandbox.spy(assertJSDoc);
 
-            linter.on("FunctionDeclaration", spy);
-            linter.verify(code, { rules: {} }, filename, true);
+            linter.defineRule("checker", () => ({ FunctionDeclaration: spy }));
+            linter.verify(code, { rules: { checker: "error" } });
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
 
         });
@@ -393,8 +392,8 @@ describe("SourceCode", () => {
 
             const spy = sandbox.spy(assertJSDoc);
 
-            linter.on("FunctionDeclaration", spy);
-            linter.verify(code, { parserOptions: { sourceType: "module" }, rules: {} }, filename, true);
+            linter.defineRule("checker", () => ({ FunctionDeclaration: spy }));
+            linter.verify(code, { rules: { checker: "error" }, parserOptions: { sourceType: "module" } });
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
 
         });
@@ -424,8 +423,8 @@ describe("SourceCode", () => {
 
             const spy = sandbox.spy(assertJSDoc);
 
-            linter.on("FunctionDeclaration", spy);
-            linter.verify(code, { rules: {} }, filename, true);
+            linter.defineRule("checker", () => ({ FunctionDeclaration: spy }));
+            linter.verify(code, { rules: { checker: "error" } });
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
 
         });
@@ -455,8 +454,8 @@ describe("SourceCode", () => {
 
             const spy = sandbox.spy(assertJSDoc);
 
-            linter.on("FunctionDeclaration", spy);
-            linter.verify(code, { rules: {} }, filename, true);
+            linter.defineRule("checker", () => ({ FunctionDeclaration: spy }));
+            linter.verify(code, { rules: { checker: "error" } });
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
 
         });
@@ -485,8 +484,8 @@ describe("SourceCode", () => {
 
             const spy = sandbox.spy(assertJSDoc);
 
-            linter.on("FunctionDeclaration", spy);
-            linter.verify(code, { rules: {} }, filename, true);
+            linter.defineRule("checker", () => ({ FunctionDeclaration: spy }));
+            linter.verify(code, { rules: { checker: "error" } });
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
 
         });
@@ -517,8 +516,8 @@ describe("SourceCode", () => {
 
             const spy = sandbox.spy(assertJSDoc);
 
-            linter.on("FunctionDeclaration", spy);
-            linter.verify(code, { rules: {} }, filename, true);
+            linter.defineRule("checker", () => ({ FunctionDeclaration: spy }));
+            linter.verify(code, { rules: { checker: "error" } });
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
         });
 
@@ -548,8 +547,8 @@ describe("SourceCode", () => {
 
             const spy = sandbox.spy(assertJSDoc);
 
-            linter.on("FunctionExpression", spy);
-            linter.verify(code, { rules: {} }, filename, true);
+            linter.defineRule("checker", () => ({ FunctionExpression: spy }));
+            linter.verify(code, { rules: { checker: "error" } });
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
         });
 
@@ -579,8 +578,8 @@ describe("SourceCode", () => {
 
             const spy = sandbox.spy(assertJSDoc);
 
-            linter.on("ArrowFunctionExpression", spy);
-            linter.verify(code, { parserOptions: { ecmaVersion: 6 }, rules: {} }, filename, true);
+            linter.defineRule("checker", () => ({ ArrowFunctionExpression: spy }));
+            linter.verify(code, { rules: { checker: "error" }, parserOptions: { ecmaVersion: 6 } });
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
         });
 
@@ -608,8 +607,8 @@ describe("SourceCode", () => {
 
             const spy = sandbox.spy(assertJSDoc);
 
-            linter.on("FunctionExpression", spy);
-            linter.verify(code, { rules: {} }, filename, true);
+            linter.defineRule("checker", () => ({ FunctionExpression: spy }));
+            linter.verify(code, { rules: { checker: "error" } });
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
         });
 
@@ -641,8 +640,8 @@ describe("SourceCode", () => {
 
             const spy = sandbox.spy(assertJSDoc);
 
-            linter.on("FunctionExpression", spy);
-            linter.verify(code, { rules: {} }, filename, true);
+            linter.defineRule("checker", () => ({ FunctionExpression: spy }));
+            linter.verify(code, { rules: { checker: "error" } });
             assert.isTrue(spy.calledTwice, "Event handler should be called.");
         });
 
@@ -673,8 +672,8 @@ describe("SourceCode", () => {
 
             const spy = sandbox.spy(assertJSDoc);
 
-            linter.on("FunctionExpression", spy);
-            linter.verify(code, { rules: {} }, filename, true);
+            linter.defineRule("checker", () => ({ FunctionExpression: spy }));
+            linter.verify(code, { rules: { checker: "error" } });
             assert.isTrue(spy.calledTwice, "Event handler should be called.");
         });
 
@@ -703,8 +702,8 @@ describe("SourceCode", () => {
 
             const spy = sandbox.spy(assertJSDoc);
 
-            linter.on("FunctionExpression", spy);
-            linter.verify(code, { rules: {} }, filename, true);
+            linter.defineRule("checker", () => ({ FunctionExpression: spy }));
+            linter.verify(code, { rules: { checker: "error" } });
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
         });
 
@@ -741,8 +740,8 @@ describe("SourceCode", () => {
 
             const spy = sandbox.spy(assertJSDoc);
 
-            linter.on("FunctionExpression", spy);
-            linter.verify(code, { rules: {} }, filename, true);
+            linter.defineRule("checker", () => ({ FunctionExpression: spy }));
+            linter.verify(code, { rules: { checker: "error" } });
             assert.isTrue(spy.calledTwice, "Event handler should be called.");
         });
 
@@ -770,8 +769,8 @@ describe("SourceCode", () => {
 
             const spy = sandbox.spy(assertJSDoc);
 
-            linter.on("ClassExpression", spy);
-            linter.verify(code, { rules: {}, parserOptions: { ecmaVersion: 6 } }, filename, true);
+            linter.defineRule("checker", () => ({ ClassExpression: spy }));
+            linter.verify(code, { rules: { checker: "error" }, parserOptions: { ecmaVersion: 6 } });
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
         });
 
@@ -799,8 +798,8 @@ describe("SourceCode", () => {
 
             const spy = sandbox.spy(assertJSDoc);
 
-            linter.on("ClassDeclaration", spy);
-            linter.verify(code, { rules: {}, parserOptions: { ecmaVersion: 6 } }, filename, true);
+            linter.defineRule("checker", () => ({ ClassDeclaration: spy }));
+            linter.verify(code, { rules: { checker: "error" }, parserOptions: { ecmaVersion: 6 } });
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
         });
 
@@ -828,8 +827,8 @@ describe("SourceCode", () => {
 
             const spy = sandbox.spy(assertJSDoc);
 
-            linter.on("FunctionExpression", spy);
-            linter.verify(code, { rules: {}, parserOptions: { ecmaVersion: 6 } }, filename, true);
+            linter.defineRule("checker", () => ({ FunctionExpression: spy }));
+            linter.verify(code, { rules: { checker: "error" }, parserOptions: { ecmaVersion: 6 } });
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
         });
 
@@ -861,8 +860,8 @@ describe("SourceCode", () => {
 
             const spy = sandbox.spy(assertJSDoc);
 
-            linter.on("FunctionExpression", spy);
-            linter.verify(code, { rules: {}, parserOptions: { ecmaVersion: 6 } }, filename, true);
+            linter.defineRule("checker", () => ({ FunctionExpression: spy }));
+            linter.verify(code, { rules: { checker: "error" }, parserOptions: { ecmaVersion: 6 } });
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
         });
 
@@ -892,15 +891,22 @@ describe("SourceCode", () => {
 
             const spy = sandbox.spy(assertJSDoc);
 
-            linter.on("FunctionDeclaration", spy);
-            linter.verify(code, { rules: {}, parserOptions: { ecmaVersion: 6 } }, filename, true);
+            linter.defineRule("checker", () => ({ FunctionDeclaration: spy }));
+            linter.verify(code, { rules: { checker: "error" }, parserOptions: { ecmaVersion: 6 } });
             assert.isTrue(spy.calledOnce, "Event handler should be called.");
         });
 
     });
 
     describe("getComments()", () => {
-        const config = { rules: {} };
+        const config = { rules: { checker: "error" }, parserOptions: { sourceType: "module" } };
+        let unusedAssertionFuncs;
+
+
+        beforeEach(() => {
+            linter.reset();
+            unusedAssertionFuncs = new Set();
+        });
 
         /**
          * Check comment count
@@ -910,17 +916,30 @@ describe("SourceCode", () => {
          * @private
          */
         function assertCommentCount(leading, trailing) {
-            return function(node) {
+
+            /**
+             * Asserts the comment count for a node
+             * @param {ASTNode} node the node being traversed
+             * @returns {void}
+             */
+            function assertionFunc(node) {
+                unusedAssertionFuncs.delete(assertionFunc);
                 const sourceCode = linter.getSourceCode();
                 const comments = sourceCode.getComments(node);
 
                 assert.equal(comments.leading.length, leading);
                 assert.equal(comments.trailing.length, trailing);
-            };
+            }
+            unusedAssertionFuncs.add(assertionFunc);
+            return assertionFunc;
         }
 
-        beforeEach(() => {
-            linter.reset();
+        afterEach(() => {
+            assert.strictEqual(
+                unusedAssertionFuncs.size,
+                0,
+                "An assertion function was created with assertCommentCount, but the function was not called."
+            );
         });
 
         it("should return comments around nodes", () => {
@@ -930,13 +949,15 @@ describe("SourceCode", () => {
                 "/* Trailing comment for VariableDeclaration */"
             ].join("\n");
 
-            linter.on("Program", assertCommentCount(0, 0));
-            linter.on("VariableDeclaration", assertCommentCount(1, 1));
-            linter.on("VariableDeclarator", assertCommentCount(0, 0));
-            linter.on("Identifier", assertCommentCount(0, 0));
-            linter.on("Literal", assertCommentCount(0, 0));
+            linter.defineRule("checker", () => ({
+                Program: assertCommentCount(0, 0),
+                VariableDeclaration: assertCommentCount(1, 1),
+                VariableDeclarator: assertCommentCount(0, 0),
+                Identifier: assertCommentCount(0, 0),
+                Literal: assertCommentCount(0, 0)
+            }));
 
-            linter.verify(code, config, "", true);
+            assert.isEmpty(linter.verify(code, config));
         });
 
         it("should return trailing comments inside a block", () => {
@@ -947,13 +968,15 @@ describe("SourceCode", () => {
                 "}"
             ].join("\n");
 
-            linter.on("Program", assertCommentCount(0, 0));
-            linter.on("BlockStatement", assertCommentCount(0, 0));
-            linter.on("ExpressionStatement", assertCommentCount(0, 1));
-            linter.on("CallExpression", assertCommentCount(0, 0));
-            linter.on("Identifier", assertCommentCount(0, 0));
+            linter.defineRule("checker", () => ({
+                Program: assertCommentCount(0, 0),
+                BlockStatement: assertCommentCount(0, 0),
+                ExpressionStatement: assertCommentCount(0, 1),
+                CallExpression: assertCommentCount(0, 0),
+                Identifier: assertCommentCount(0, 0)
+            }));
 
-            linter.verify(code, config, "", true);
+            assert.isEmpty(linter.verify(code, config));
         });
 
         it("should return comments within a conditional", () => {
@@ -962,12 +985,14 @@ describe("SourceCode", () => {
                 "if (/* Leading comment for Identifier */ a) {}"
             ].join("\n");
 
-            linter.on("Program", assertCommentCount(0, 0));
-            linter.on("IfStatement", assertCommentCount(1, 0));
-            linter.on("Identifier", assertCommentCount(1, 0));
-            linter.on("BlockStatement", assertCommentCount(0, 0));
+            linter.defineRule("checker", () => ({
+                Program: assertCommentCount(0, 0),
+                IfStatement: assertCommentCount(1, 0),
+                Identifier: assertCommentCount(1, 0),
+                BlockStatement: assertCommentCount(0, 0)
+            }));
 
-            linter.verify(code, config, "", true);
+            assert.isEmpty(linter.verify(code, config));
         });
 
         it("should not return comments within a previous node", () => {
@@ -980,15 +1005,17 @@ describe("SourceCode", () => {
                 "}"
             ].join("\n");
 
-            linter.on("Program", assertCommentCount(0, 0));
-            linter.on("Identifier", assertCommentCount(0, 0));
-            linter.on("BlockStatement", assertCommentCount(0, 0));
-            linter.on("VariableDeclaration", assertCommentCount(0, 0));
-            linter.on("VariableDeclarator", assertCommentCount(0, 0));
-            linter.on("ObjectExpression", assertCommentCount(0, 1));
-            linter.on("ReturnStatement", assertCommentCount(0, 0));
+            linter.defineRule("checker", () => ({
+                Program: assertCommentCount(0, 0),
+                Identifier: assertCommentCount(0, 0),
+                BlockStatement: assertCommentCount(0, 0),
+                VariableDeclaration: assertCommentCount(0, 0),
+                VariableDeclarator: assertCommentCount(0, 0),
+                ObjectExpression: assertCommentCount(0, 1),
+                ReturnStatement: assertCommentCount(0, 0)
+            }));
 
-            linter.verify(code, config, "", true);
+            assert.isEmpty(linter.verify(code, config));
         });
 
         it("should return comments only for children of parent node", () => {
@@ -1000,15 +1027,17 @@ describe("SourceCode", () => {
                 "var baz;"
             ].join("\n");
 
-            linter.on("Program", assertCommentCount(0, 0));
-            linter.on("VariableDeclaration", assertCommentCount(0, 0));
-            linter.on("VariableDeclerator", assertCommentCount(0, 0));
-            linter.on("Identifier", assertCommentCount(0, 0));
-            linter.on("ObjectExpression", assertCommentCount(0, 0));
-            linter.on("Property", assertCommentCount(0, 1));
-            linter.on("Literal", assertCommentCount(0, 0));
+            linter.defineRule("checker", () => ({
+                Program: assertCommentCount(0, 0),
+                VariableDeclaration: assertCommentCount(0, 0),
+                VariableDeclarator: assertCommentCount(0, 0),
+                Identifier: assertCommentCount(0, 0),
+                ObjectExpression: assertCommentCount(0, 0),
+                Property: assertCommentCount(0, 1),
+                Literal: assertCommentCount(0, 0)
+            }));
 
-            linter.verify(code, config, "", true);
+            assert.isEmpty(linter.verify(code, config));
         });
 
         it("should return comments for an export default anonymous class", () => {
@@ -1025,16 +1054,18 @@ describe("SourceCode", () => {
                 "}"
             ].join("\n");
 
-            linter.on("Program", assertCommentCount(0, 0));
-            linter.on("ExportDefaultDeclaration", assertCommentCount(1, 0));
-            linter.on("ClassDeclaration", assertCommentCount(0, 0));
-            linter.on("ClassBody", assertCommentCount(0, 0));
-            linter.on("MethodDefinition", assertCommentCount(1, 0));
-            linter.on("Identifier", assertCommentCount(0, 0));
-            linter.on("FunctionExpression", assertCommentCount(0, 0));
-            linter.on("BlockStatement", assertCommentCount(0, 0));
+            linter.defineRule("checker", () => ({
+                Program: assertCommentCount(0, 0),
+                ExportDefaultDeclaration: assertCommentCount(1, 0),
+                ClassDeclaration: assertCommentCount(0, 0),
+                ClassBody: assertCommentCount(0, 0),
+                MethodDefinition: assertCommentCount(1, 0),
+                Identifier: assertCommentCount(0, 0),
+                FunctionExpression: assertCommentCount(0, 0),
+                BlockStatement: assertCommentCount(0, 0)
+            }));
 
-            linter.verify(code, config, "", true);
+            assert.isEmpty(linter.verify(code, config));
         });
 
         it("should return leading comments", () => {
@@ -1046,19 +1077,21 @@ describe("SourceCode", () => {
             ].join("\n");
             let varDeclCount = 0;
 
-            linter.on("Program", assertCommentCount(0, 0));
-            linter.on("VariableDeclaration", node => {
-                if (varDeclCount === 0) {
-                    assertCommentCount(1, 1)(node);
-                } else {
-                    assertCommentCount(1, 0)(node);
-                }
-                varDeclCount++;
-            });
-            linter.on("VariableDeclarator", assertCommentCount(0, 0));
-            linter.on("Identifier", assertCommentCount(0, 0));
+            linter.defineRule("checker", () => ({
+                Program: assertCommentCount(0, 0),
+                VariableDeclaration(node) {
+                    if (varDeclCount === 0) {
+                        assertCommentCount(1, 1)(node);
+                    } else {
+                        assertCommentCount(1, 0)(node);
+                    }
+                    varDeclCount++;
+                },
+                VariableDeclarator: assertCommentCount(0, 0),
+                Identifier: assertCommentCount(0, 0)
+            }));
 
-            linter.verify(code, config, "", true);
+            assert.isEmpty(linter.verify(code, config));
         });
 
         it("should return shebang comments", () => {
@@ -1070,26 +1103,28 @@ describe("SourceCode", () => {
             ].join("\n");
             let varDeclCount = 0;
 
-            linter.on("Program", assertCommentCount(0, 0));
-            linter.on("VariableDeclaration", node => {
-                if (varDeclCount === 0) {
-                    assertCommentCount(1, 1)(node);
-                } else {
-                    assertCommentCount(1, 0)(node);
-                }
-                varDeclCount++;
-            });
-            linter.on("VariableDeclarator", assertCommentCount(0, 0));
-            linter.on("Identifier", assertCommentCount(0, 0));
+            linter.defineRule("checker", () => ({
+                Program: assertCommentCount(0, 0),
+                VariableDeclaration(node) {
+                    if (varDeclCount === 0) {
+                        assertCommentCount(1, 1)(node);
+                    } else {
+                        assertCommentCount(1, 0)(node);
+                    }
+                    varDeclCount++;
+                },
+                Identifier: assertCommentCount(0, 0)
+            }));
 
-            linter.verify(code, config, "", true);
+            assert.isEmpty(linter.verify(code, config));
         });
 
         it("should include shebang comment when program only contains shebang", () => {
             const code = "#!/usr/bin/env node";
 
-            linter.on("Program", assertCommentCount(1, 0));
-            linter.verify(code, config, "", true);
+            linter.defineRule("checker", () => ({ Program: assertCommentCount(1, 0) }));
+
+            assert.isEmpty(linter.verify(code, config));
         });
 
         it("should return mixture of line and block comments", () => {
@@ -1099,13 +1134,15 @@ describe("SourceCode", () => {
                 "// Trailing comment for VariableDeclaration"
             ].join("\n");
 
-            linter.on("Program", assertCommentCount(0, 0));
-            linter.on("VariableDeclaration", assertCommentCount(1, 1));
-            linter.on("VariableDeclarator", assertCommentCount(0, 0));
-            linter.on("Identifier", assertCommentCount(0, 1));
-            linter.on("Literal", assertCommentCount(0, 0));
+            linter.defineRule("checker", () => ({
+                Program: assertCommentCount(0, 0),
+                VariableDeclaration: assertCommentCount(1, 1),
+                VariableDeclarator: assertCommentCount(0, 0),
+                Identifier: assertCommentCount(0, 1),
+                Literal: assertCommentCount(0, 0)
+            }));
 
-            linter.verify(code, config, "", true);
+            assert.isEmpty(linter.verify(code, config));
         });
 
         it("should return comments surrounding a call expression", () => {
@@ -1117,14 +1154,16 @@ describe("SourceCode", () => {
                 "}"
             ].join("\n");
 
-            linter.on("Program", assertCommentCount(0, 0));
-            linter.on("FunctionDeclaration", assertCommentCount(0, 0));
-            linter.on("Identifier", assertCommentCount(0, 0));
-            linter.on("BlockStatement", assertCommentCount(0, 0));
-            linter.on("ExpressionStatement", assertCommentCount(1, 1));
-            linter.on("CallExpression", assertCommentCount(0, 0));
+            linter.defineRule("checker", () => ({
+                Program: assertCommentCount(0, 0),
+                FunctionDeclaration: assertCommentCount(0, 0),
+                Identifier: assertCommentCount(0, 0),
+                BlockStatement: assertCommentCount(0, 0),
+                ExpressionStatement: assertCommentCount(1, 1),
+                CallExpression: assertCommentCount(0, 0)
+            }));
 
-            linter.verify(code, config, "", true);
+            assert.isEmpty(linter.verify(code, config));
         });
 
         it("should return comments surrounding a debugger statement", () => {
@@ -1136,13 +1175,15 @@ describe("SourceCode", () => {
                 "}"
             ].join("\n");
 
-            linter.on("Program", assertCommentCount(0, 0));
-            linter.on("FunctionDeclaration", assertCommentCount(0, 0));
-            linter.on("Identifier", assertCommentCount(0, 0));
-            linter.on("BlockStatement", assertCommentCount(0, 0));
-            linter.on("DebuggerStatement", assertCommentCount(1, 1));
+            linter.defineRule("checker", () => ({
+                Program: assertCommentCount(0, 0),
+                FunctionDeclaration: assertCommentCount(0, 0),
+                Identifier: assertCommentCount(0, 0),
+                BlockStatement: assertCommentCount(0, 0),
+                DebuggerStatement: assertCommentCount(1, 1)
+            }));
 
-            linter.verify(code, config, "", true);
+            assert.isEmpty(linter.verify(code, config));
         });
 
         it("should return comments surrounding a return statement", () => {
@@ -1154,13 +1195,15 @@ describe("SourceCode", () => {
                 "}"
             ].join("\n");
 
-            linter.on("Program", assertCommentCount(0, 0));
-            linter.on("FunctionDeclaration", assertCommentCount(0, 0));
-            linter.on("Identifier", assertCommentCount(0, 0));
-            linter.on("BlockStatement", assertCommentCount(0, 0));
-            linter.on("ReturnStatement", assertCommentCount(1, 1));
+            linter.defineRule("checker", () => ({
+                Program: assertCommentCount(0, 0),
+                FunctionDeclaration: assertCommentCount(0, 0),
+                Identifier: assertCommentCount(0, 0),
+                BlockStatement: assertCommentCount(0, 0),
+                ReturnStatement: assertCommentCount(1, 1)
+            }));
 
-            linter.verify(code, config, "", true);
+            assert.isEmpty(linter.verify(code, config));
         });
 
         it("should return comments surrounding a throw statement", () => {
@@ -1172,13 +1215,15 @@ describe("SourceCode", () => {
                 "}"
             ].join("\n");
 
-            linter.on("Program", assertCommentCount(0, 0));
-            linter.on("FunctionDeclaration", assertCommentCount(0, 0));
-            linter.on("Identifier", assertCommentCount(0, 0));
-            linter.on("BlockStatement", assertCommentCount(0, 0));
-            linter.on("ThrowStatement", assertCommentCount(1, 1));
+            linter.defineRule("checker", () => ({
+                Program: assertCommentCount(0, 0),
+                FunctionDeclaration: assertCommentCount(0, 0),
+                Identifier: assertCommentCount(0, 0),
+                BlockStatement: assertCommentCount(0, 0),
+                ThrowStatement: assertCommentCount(1, 1)
+            }));
 
-            linter.verify(code, config, "", true);
+            assert.isEmpty(linter.verify(code, config));
         });
 
         it("should return comments surrounding a while loop", () => {
@@ -1191,16 +1236,18 @@ describe("SourceCode", () => {
                 "}"
             ].join("\n");
 
-            linter.on("Program", assertCommentCount(0, 0));
-            linter.on("FunctionDeclaration", assertCommentCount(0, 0));
-            linter.on("Identifier", assertCommentCount(0, 0));
-            linter.on("BlockStatement", assertCommentCount(0, 0));
-            linter.on("WhileStatement", assertCommentCount(1, 1));
-            linter.on("Literal", assertCommentCount(0, 0));
-            linter.on("VariableDeclaration", assertCommentCount(1, 0));
-            linter.on("VariableDeclarator", assertCommentCount(0, 0));
+            linter.defineRule("checker", () => ({
+                Program: assertCommentCount(0, 0),
+                FunctionDeclaration: assertCommentCount(0, 0),
+                Identifier: assertCommentCount(0, 0),
+                BlockStatement: assertCommentCount(0, 0),
+                WhileStatement: assertCommentCount(1, 1),
+                Literal: assertCommentCount(0, 0),
+                VariableDeclaration: assertCommentCount(1, 0),
+                VariableDeclarator: assertCommentCount(0, 0)
+            }));
 
-            linter.verify(code, config, "", true);
+            assert.isEmpty(linter.verify(code, config));
         });
 
         it("should return switch case fallthrough comments in functions", () => {
@@ -1217,24 +1264,26 @@ describe("SourceCode", () => {
             ].join("\n");
             let switchCaseCount = 0;
 
-            linter.on("Program", assertCommentCount(0, 0));
-            linter.on("FunctionDeclaration", assertCommentCount(0, 0));
-            linter.on("Identifier", assertCommentCount(0, 0));
-            linter.on("BlockStatement", assertCommentCount(0, 0));
-            linter.on("SwitchStatement", assertCommentCount(0, 0));
-            linter.on("SwitchCase", node => {
-                if (switchCaseCount === 0) {
-                    assertCommentCount(1, 1)(node);
-                } else {
-                    assertCommentCount(1, 0)(node);
-                }
-                switchCaseCount++;
-            });
-            linter.on("Literal", assertCommentCount(0, 0));
-            linter.on("ExpressionStatement", assertCommentCount(0, 0));
-            linter.on("CallExpression", assertCommentCount(0, 0));
+            linter.defineRule("checker", () => ({
+                Program: assertCommentCount(0, 0),
+                FunctionDeclaration: assertCommentCount(0, 0),
+                Identifier: assertCommentCount(0, 0),
+                BlockStatement: assertCommentCount(0, 0),
+                SwitchStatement: assertCommentCount(0, 0),
+                SwitchCase: node => {
+                    if (switchCaseCount === 0) {
+                        assertCommentCount(1, 1)(node);
+                    } else {
+                        assertCommentCount(1, 0)(node);
+                    }
+                    switchCaseCount++;
+                },
+                Literal: assertCommentCount(0, 0),
+                ExpressionStatement: assertCommentCount(0, 0),
+                CallExpression: assertCommentCount(0, 0)
+            }));
 
-            linter.verify(code, config, "", true);
+            assert.isEmpty(linter.verify(code, config));
         });
 
         it("should return switch case fallthrough comments", () => {
@@ -1249,21 +1298,23 @@ describe("SourceCode", () => {
             ].join("\n");
             let switchCaseCount = 0;
 
-            linter.on("Program", assertCommentCount(0, 0));
-            linter.on("SwitchStatement", assertCommentCount(0, 0));
-            linter.on("SwitchCase", node => {
-                if (switchCaseCount === 0) {
-                    assertCommentCount(1, 1)(node);
-                } else {
-                    assertCommentCount(1, 0)(node);
-                }
-                switchCaseCount++;
-            });
-            linter.on("Literal", assertCommentCount(0, 0));
-            linter.on("ExpressionStatement", assertCommentCount(0, 0));
-            linter.on("CallExpression", assertCommentCount(0, 0));
+            linter.defineRule("checker", () => ({
+                Program: assertCommentCount(0, 0),
+                SwitchStatement: assertCommentCount(0, 0),
+                SwitchCase: node => {
+                    if (switchCaseCount === 0) {
+                        assertCommentCount(1, 1)(node);
+                    } else {
+                        assertCommentCount(1, 0)(node);
+                    }
+                    switchCaseCount++;
+                },
+                Literal: assertCommentCount(0, 0),
+                ExpressionStatement: assertCommentCount(0, 0),
+                CallExpression: assertCommentCount(0, 0)
+            }));
 
-            linter.verify(code, config, "", true);
+            assert.isEmpty(linter.verify(code, config));
         });
 
         it("should return switch case no-default comments in functions", () => {
@@ -1280,23 +1331,25 @@ describe("SourceCode", () => {
             ].join("\n");
             let breakStatementCount = 0;
 
-            linter.on("Program", assertCommentCount(0, 0));
-            linter.on("FunctionDeclaration", assertCommentCount(0, 0));
-            linter.on("Identifier", assertCommentCount(0, 0));
-            linter.on("BlockStatement", assertCommentCount(0, 0));
-            linter.on("SwitchStatement", assertCommentCount(0, 0));
-            linter.on("SwitchCase", node => {
-                if (breakStatementCount === 0) {
-                    assertCommentCount(0, 0)(node);
-                } else {
-                    assertCommentCount(0, 1)(node);
-                }
-                breakStatementCount++;
-            });
-            linter.on("BreakStatement", assertCommentCount(0, 0));
-            linter.on("Literal", assertCommentCount(0, 0));
+            linter.defineRule("checker", () => ({
+                Program: assertCommentCount(0, 0),
+                FunctionDeclaration: assertCommentCount(0, 0),
+                Identifier: assertCommentCount(0, 0),
+                BlockStatement: assertCommentCount(0, 0),
+                SwitchStatement: assertCommentCount(0, 0),
+                SwitchCase: node => {
+                    if (breakStatementCount === 0) {
+                        assertCommentCount(0, 0)(node);
+                    } else {
+                        assertCommentCount(0, 1)(node);
+                    }
+                    breakStatementCount++;
+                },
+                BreakStatement: assertCommentCount(0, 0),
+                Literal: assertCommentCount(0, 0)
+            }));
 
-            linter.verify(code, config, "", true);
+            assert.isEmpty(linter.verify(code, config));
         });
 
         it("should return switch case no-default comments", () => {
@@ -1308,14 +1361,16 @@ describe("SourceCode", () => {
                 "}"
             ].join("\n");
 
-            linter.on("Program", assertCommentCount(0, 0));
-            linter.on("SwitchStatement", assertCommentCount(0, 0));
-            linter.on("Identifier", assertCommentCount(0, 0));
-            linter.on("SwitchCase", assertCommentCount(0, 1));
-            linter.on("BreakStatement", assertCommentCount(0, 0));
-            linter.on("Literal", assertCommentCount(0, 0));
+            linter.defineRule("checker", () => ({
+                Program: assertCommentCount(0, 0),
+                SwitchStatement: assertCommentCount(0, 0),
+                Identifier: assertCommentCount(0, 0),
+                SwitchCase: assertCommentCount(0, 1),
+                BreakStatement: assertCommentCount(0, 0),
+                Literal: assertCommentCount(0, 0)
+            }));
 
-            linter.verify(code, config, "", true);
+            assert.isEmpty(linter.verify(code, config));
         });
 
         it("should return switch case no-default comments in nested functions", () => {
@@ -1332,22 +1387,24 @@ describe("SourceCode", () => {
                 "};"
             ].join("\n");
 
-            linter.on("Program", assertCommentCount(0, 0));
-            linter.on("ExpressionStatement", assertCommentCount(0, 0));
-            linter.on("AssignmentExpression", assertCommentCount(0, 0));
-            linter.on("MemberExpression", assertCommentCount(0, 0));
-            linter.on("Identifier", assertCommentCount(0, 0));
-            linter.on("FunctionExpression", assertCommentCount(0, 0));
-            linter.on("BlockStatement", assertCommentCount(0, 0));
-            linter.on("FunctionDeclaration", assertCommentCount(0, 0));
-            linter.on("SwitchStatement", assertCommentCount(0, 0));
-            linter.on("SwitchCase", assertCommentCount(0, 1));
-            linter.on("ReturnStatement", assertCommentCount(0, 0));
-            linter.on("CallExpression", assertCommentCount(0, 0));
-            linter.on("BinaryExpression", assertCommentCount(0, 0));
-            linter.on("Literal", assertCommentCount(0, 0));
+            linter.defineRule("checker", () => ({
+                Program: assertCommentCount(0, 0),
+                ExpressionStatement: assertCommentCount(0, 0),
+                AssignmentExpression: assertCommentCount(0, 0),
+                MemberExpression: assertCommentCount(0, 0),
+                Identifier: assertCommentCount(0, 0),
+                FunctionExpression: assertCommentCount(0, 0),
+                BlockStatement: assertCommentCount(0, 0),
+                FunctionDeclaration: assertCommentCount(0, 0),
+                SwitchStatement: assertCommentCount(0, 0),
+                SwitchCase: assertCommentCount(0, 1),
+                ReturnStatement: assertCommentCount(0, 0),
+                CallExpression: assertCommentCount(0, 0),
+                BinaryExpression: assertCommentCount(0, 0),
+                Literal: assertCommentCount(0, 0)
+            }));
 
-            linter.verify(code, config, "", true);
+            assert.isEmpty(linter.verify(code, config));
         });
 
         it("should return leading comments if the code only contains comments", () => {
@@ -1356,9 +1413,9 @@ describe("SourceCode", () => {
                 "/*another comment*/"
             ].join("\n");
 
-            linter.on("Program", assertCommentCount(2, 0));
+            linter.defineRule("checker", () => ({ Program: assertCommentCount(2, 0) }));
 
-            linter.verify(code, config, "", true);
+            assert.isEmpty(linter.verify(code, config));
         });
 
         it("should return trailing comments if a block statement only contains comments", () => {
@@ -1369,10 +1426,12 @@ describe("SourceCode", () => {
                 "}"
             ].join("\n");
 
-            linter.on("Program", assertCommentCount(0, 0));
-            linter.on("BlockStatement", assertCommentCount(0, 2));
+            linter.defineRule("checker", () => ({
+                Program: assertCommentCount(0, 0),
+                BlockStatement: assertCommentCount(0, 2)
+            }));
 
-            linter.verify(code, config, "", true);
+            assert.isEmpty(linter.verify(code, config));
         });
 
         it("should return trailing comments if a class body only contains comments", () => {
@@ -1383,11 +1442,13 @@ describe("SourceCode", () => {
                 "}"
             ].join("\n");
 
-            linter.on("Program", assertCommentCount(0, 0));
-            linter.on("ClassDeclaration", assertCommentCount(0, 0));
-            linter.on("ClassBody", assertCommentCount(0, 2));
+            linter.defineRule("checker", () => ({
+                Program: assertCommentCount(0, 0),
+                ClassDeclaration: assertCommentCount(0, 0),
+                ClassBody: assertCommentCount(0, 2)
+            }));
 
-            linter.verify(code, config, "", true);
+            assert.isEmpty(linter.verify(code, config));
         });
 
         it("should return trailing comments if an object only contains comments", () => {
@@ -1398,11 +1459,13 @@ describe("SourceCode", () => {
                 "})"
             ].join("\n");
 
-            linter.on("Program", assertCommentCount(0, 0));
-            linter.on("ExpressionStatement", assertCommentCount(0, 0));
-            linter.on("ObjectExpression", assertCommentCount(0, 2));
+            linter.defineRule("checker", () => ({
+                Program: assertCommentCount(0, 0),
+                ExpressionStatement: assertCommentCount(0, 0),
+                ObjectExpression: assertCommentCount(0, 2)
+            }));
 
-            linter.verify(code, config, "", true);
+            assert.isEmpty(linter.verify(code, config));
         });
 
         it("should return trailing comments if an array only contains comments", () => {
@@ -1413,11 +1476,13 @@ describe("SourceCode", () => {
                 "]"
             ].join("\n");
 
-            linter.on("Program", assertCommentCount(0, 0));
-            linter.on("ExpressionStatement", assertCommentCount(0, 0));
-            linter.on("ArrayExpression", assertCommentCount(0, 2));
+            linter.defineRule("checker", () => ({
+                Program: assertCommentCount(0, 0),
+                ExpressionStatement: assertCommentCount(0, 0),
+                ArrayExpression: assertCommentCount(0, 2)
+            }));
 
-            linter.verify(code, config, "", true);
+            assert.isEmpty(linter.verify(code, config));
         });
 
         it("should return trailing comments if a switch statement only contains comments", () => {
@@ -1428,11 +1493,13 @@ describe("SourceCode", () => {
                 "}"
             ].join("\n");
 
-            linter.on("Program", assertCommentCount(0, 0));
-            linter.on("SwitchStatement", assertCommentCount(0, 2));
-            linter.on("Identifier", assertCommentCount(0, 0));
+            linter.defineRule("checker", () => ({
+                Program: assertCommentCount(0, 0),
+                SwitchStatement: assertCommentCount(0, 2),
+                Identifier: assertCommentCount(0, 0)
+            }));
 
-            linter.verify(code, config, "", true);
+            assert.isEmpty(linter.verify(code, config));
         });
 
         it("should return comments for multiple declarations with a single variable", () => {
@@ -1445,21 +1512,23 @@ describe("SourceCode", () => {
             ].join("\n");
             let varDeclCount = 0;
 
-            linter.on("Program", assertCommentCount(0, 0));
-            linter.on("VariableDeclaration", assertCommentCount(1, 2));
-            linter.on("VariableDeclarator", node => {
-                if (varDeclCount === 0) {
-                    assertCommentCount(0, 0)(node);
-                } else if (varDeclCount === 1) {
-                    assertCommentCount(1, 0)(node);
-                } else {
-                    assertCommentCount(1, 0)(node);
-                }
-                varDeclCount++;
-            });
-            linter.on("Identifier", assertCommentCount(0, 0));
+            linter.defineRule("checker", () => ({
+                Program: assertCommentCount(0, 0),
+                VariableDeclaration: assertCommentCount(1, 2),
+                VariableDeclarator: node => {
+                    if (varDeclCount === 0) {
+                        assertCommentCount(0, 0)(node);
+                    } else if (varDeclCount === 1) {
+                        assertCommentCount(1, 0)(node);
+                    } else {
+                        assertCommentCount(1, 0)(node);
+                    }
+                    varDeclCount++;
+                },
+                Identifier: assertCommentCount(0, 0)
+            }));
 
-            linter.verify(code, config, "", true);
+            assert.isEmpty(linter.verify(code, config));
         });
 
         it("should return comments when comments exist between var keyword and VariableDeclarator", () => {
@@ -1469,52 +1538,60 @@ describe("SourceCode", () => {
                 "    a;"
             ].join("\n");
 
-            linter.on("Program", assertCommentCount(0, 0));
-            linter.on("VariableDeclaration", assertCommentCount(0, 0));
-            linter.on("VariableDeclarator", assertCommentCount(2, 0));
-            linter.on("Identifier", assertCommentCount(0, 0));
+            linter.defineRule("checker", () => ({
+                Program: assertCommentCount(0, 0),
+                VariableDeclaration: assertCommentCount(0, 0),
+                VariableDeclarator: assertCommentCount(2, 0),
+                Identifier: assertCommentCount(0, 0)
+            }));
 
-            linter.verify(code, config, "", true);
+            assert.isEmpty(linter.verify(code, config));
         });
 
         it("should return attached comments between tokens to the correct nodes for empty function declarations", () => {
             const code = "/* 1 */ function /* 2 */ foo(/* 3 */) /* 4 */ { /* 5 */ } /* 6 */";
 
-            linter.on("Program", assertCommentCount(0, 0));
-            linter.on("FunctionDeclaration", assertCommentCount(1, 1));
-            linter.on("Identifier", assertCommentCount(1, 0));
-            linter.on("BlockStatement", assertCommentCount(1, 1));
+            linter.defineRule("checker", () => ({
+                Program: assertCommentCount(0, 0),
+                FunctionDeclaration: assertCommentCount(1, 1),
+                Identifier: assertCommentCount(1, 0),
+                BlockStatement: assertCommentCount(1, 1)
+            }));
 
-            linter.verify(code, config, "", true);
+            assert.isEmpty(linter.verify(code, config));
         });
 
         it("should return attached comments between tokens to the correct nodes for empty class declarations", () => {
             const code = "/* 1 */ class /* 2 */ Foo /* 3 */ extends /* 4 */ Bar /* 5 */ { /* 6 */ } /* 7 */";
             let idCount = 0;
 
-            linter.on("Program", assertCommentCount(0, 0));
-            linter.on("ClassDeclaration", assertCommentCount(1, 1));
-            linter.on("Identifier", node => {
-                if (idCount === 0) {
-                    assertCommentCount(1, 1)(node);
-                } else {
-                    assertCommentCount(1, 1)(node);
-                }
-                idCount++;
-            });
-            linter.on("ClassBody", assertCommentCount(1, 1));
+            linter.defineRule("checker", () => ({
+                Program: assertCommentCount(0, 0),
+                ClassDeclaration: assertCommentCount(1, 1),
+                Identifier: node => {
+                    if (idCount === 0) {
+                        assertCommentCount(1, 1)(node);
+                    } else {
+                        assertCommentCount(1, 1)(node);
+                    }
+                    idCount++;
+                },
+                ClassBody: assertCommentCount(1, 1)
+            }));
 
-            linter.verify(code, config, "", true);
+            assert.isEmpty(linter.verify(code, config));
         });
 
         it("should return attached comments between tokens to the correct nodes for empty switch statements", () => {
             const code = "/* 1 */ switch /* 2 */ (/* 3 */ foo /* 4 */) /* 5 */ { /* 6 */ } /* 7 */";
 
-            linter.on("Program", assertCommentCount(0, 0));
-            linter.on("SwitchStatement", assertCommentCount(1, 6));
-            linter.on("Identifier", assertCommentCount(1, 1));
+            linter.defineRule("checker", () => ({
+                Program: assertCommentCount(0, 0),
+                SwitchStatement: assertCommentCount(1, 6),
+                Identifier: assertCommentCount(1, 1)
+            }));
 
-            linter.verify(code, config, "", true);
+            assert.isEmpty(linter.verify(code, config));
         });
     });
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates the tests for `SourceCode` to use the public `Linter#defineRule` API rather than the private `Linter#on` API.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
