### PR TITLE
Chore: don't make Linter a subclass of EventEmitter (refs #9161)

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -731,10 +731,9 @@ const BASE_TRAVERSAL_CONTEXT = Object.freeze(
  * Object that is responsible for verifying JavaScript text
  * @name eslint
  */
-class Linter extends EventEmitter {
+class Linter {
 
     constructor() {
-        super();
         this.messages = [];
         this.currentConfig = null;
         this.currentScopes = null;
@@ -747,9 +746,6 @@ class Linter extends EventEmitter {
 
         this.rules = new Rules();
         this.environments = new Environments();
-
-        // set unlimited listeners (see https://github.com/eslint/eslint/issues/524)
-        this.setMaxListeners(0);
     }
 
     /**
@@ -757,7 +753,6 @@ class Linter extends EventEmitter {
      * @returns {void}
      */
     reset() {
-        this.removeAllListeners();
         this.messages = [];
         this.currentConfig = null;
         this.currentScopes = null;
@@ -859,6 +854,10 @@ class Linter extends EventEmitter {
             ast = this.sourceCode.ast;
         }
 
+        const emitter = new EventEmitter();
+
+        emitter.setMaxListeners(Infinity);
+
         // if espree failed to parse the file, there's no sense in setting up rules
         if (ast) {
 
@@ -939,7 +938,7 @@ class Linter extends EventEmitter {
 
                     // add all the selectors from the rule as listeners
                     Object.keys(rule).forEach(selector => {
-                        this.on(selector, timing.enabled
+                        emitter.on(selector, timing.enabled
                             ? timing.time(ruleId, rule[selector])
                             : rule[selector]
                         );
@@ -972,9 +971,7 @@ class Linter extends EventEmitter {
             // augment global scope with declared global variables
             addDeclaredGlobals(ast, this.currentScopes[0], this.currentConfig, this.environments);
 
-            let eventGenerator = new NodeEventGenerator(this);
-
-            eventGenerator = new CodePathAnalyzer(eventGenerator);
+            const eventGenerator = new CodePathAnalyzer(new NodeEventGenerator(emitter));
 
             /*
              * Each node has a type property. Whenever a particular type of


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates `Linter` to not be a subclass of `EventEmitter`. The reasoning for this is described in https://github.com/eslint/eslint/issues/9161.

None of the inherited `EventEmitter` methods are considered part of the public API, but a lot of tests were using them. As a result, this PR is blocked on ~~#9172~~, ~~#9173~~, ~~#9174~~, and ~~#9175~~, which fix the tests to only use the public API. After those are merged, the tests in this PR will pass.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular