### PR TITLE
Chore: Make SourceCodeFixer accept text instead of a SourceCode instance

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -1217,7 +1217,7 @@ class Linter extends EventEmitter {
             messages = this.verify(text, config, options);
 
             debug(`Generating fixed text for ${debugTextDescription} (pass ${passNumber})`);
-            fixedResult = SourceCodeFixer.applyFixes(this.getSourceCode(), messages, shouldFix);
+            fixedResult = SourceCodeFixer.applyFixes(text, messages, shouldFix);
 
             // stop if there are any syntax errors.
             // 'fixedResult.output' is a empty string.

--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -521,7 +521,7 @@ class RuleTester {
                         "Expected no autofixes to be suggested"
                     );
                 } else {
-                    const fixResult = SourceCodeFixer.applyFixes(linter.getSourceCode(), messages);
+                    const fixResult = SourceCodeFixer.applyFixes(item.code, messages);
 
                     assert.equal(fixResult.output, item.output, "Output is incorrect.");
                 }

--- a/lib/util/source-code-fixer.js
+++ b/lib/util/source-code-fixer.js
@@ -53,37 +53,28 @@ function SourceCodeFixer() {
 /**
  * Applies the fixes specified by the messages to the given text. Tries to be
  * smart about the fixes and won't apply fixes over the same area in the text.
- * @param {SourceCode} sourceCode The source code to apply the changes to.
+ * @param {string} sourceText The text to apply the changes to.
  * @param {Message[]} messages The array of messages reported by ESLint.
  * @param {boolean|Function} [shouldFix=true] Determines whether each message should be fixed
  * @returns {Object} An object containing the fixed text and any unfixed messages.
  */
-SourceCodeFixer.applyFixes = function(sourceCode, messages, shouldFix) {
+SourceCodeFixer.applyFixes = function(sourceText, messages, shouldFix) {
     debug("Applying fixes");
-
-    if (!sourceCode) {
-        debug("No source code to fix");
-        return {
-            fixed: false,
-            messages,
-            output: ""
-        };
-    }
 
     if (shouldFix === false) {
         debug("shouldFix parameter was false, not attempting fixes");
         return {
             fixed: false,
             messages,
-            output: sourceCode.text
+            output: sourceText
         };
     }
 
     // clone the array
     const remainingMessages = [],
         fixes = [],
-        bom = (sourceCode.hasBOM ? BOM : ""),
-        text = sourceCode.text;
+        bom = sourceText.startsWith(BOM) ? BOM : "",
+        text = bom ? sourceText.slice(1) : sourceText;
     let lastPos = Number.NEGATIVE_INFINITY,
         output = bom;
 

--- a/tools/eslint-fuzzer.js
+++ b/tools/eslint-fuzzer.js
@@ -97,7 +97,7 @@ function fuzz(options) {
             }
 
             lastGoodText = currentText;
-            currentText = SourceCodeFixer.applyFixes(linter.getSourceCode(), messages).output;
+            currentText = SourceCodeFixer.applyFixes(currentText, messages).output;
         } while (lastGoodText !== currentText);
 
         return lastGoodText;


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates `SourceCodeFixer` to operate on a string containing the source text, rather than a `SourceCode` instance. This removes the need for `Linter` to retain a reference to a given `SourceCode` instance after calling `verify`. (This change was also included as part of https://github.com/eslint/eslint/pull/9090, but it's probably better to separate it.)

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
