### PR TITLE
Chore: Make parseJsonConfig() a pure function in Linter

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -87,10 +87,9 @@ function parseBooleanConfig(string, comment) {
  * Parses a JSON-like config.
  * @param {string} string The string to parse.
  * @param {Object} location Start line and column of comments for potential error message.
- * @param {Object[]} messages The messages queue for potential error message.
- * @returns {Object} Result map object
+ * @returns {({success: true, config: Object}|{success: false, error: Problem})} Result map object
  */
-function parseJsonConfig(string, location, messages) {
+function parseJsonConfig(string, location) {
     let items = {};
 
     // Parses a JSON-like comment by the same way as parsing CLI option.
@@ -102,7 +101,10 @@ function parseJsonConfig(string, location, messages) {
         //     "no-alert: 2 no-console: 2" --> {"no-alert": "2 no-console: 2"}
         // Should ignore that case as well.
         if (ConfigOps.isEverySeverityValid(items)) {
-            return items;
+            return {
+                success: true,
+                config: items
+            };
         }
     } catch (ex) {
 
@@ -116,20 +118,25 @@ function parseJsonConfig(string, location, messages) {
     try {
         items = JSON.parse(`{${string}}`);
     } catch (ex) {
-
-        messages.push({
-            ruleId: null,
-            fatal: true,
-            severity: 2,
-            source: null,
-            message: `Failed to parse JSON from '${string}': ${ex.message}`,
-            line: location.start.line,
-            column: location.start.column + 1
-        });
+        return {
+            success: false,
+            error: {
+                ruleId: null,
+                fatal: true,
+                severity: 2,
+                source: null,
+                message: `Failed to parse JSON from '${string}': ${ex.message}`,
+                line: location.start.line,
+                column: location.start.column + 1
+            }
+        };
 
     }
 
-    return items;
+    return {
+        success: true,
+        config: items
+    };
 }
 
 /**
@@ -316,7 +323,8 @@ function enableReporting(reportingConfig, start, rulesToEnable) {
  * @param {ASTNode} ast The top node of the AST.
  * @param {Object} config The existing configuration data.
  * @param {Linter} linterContext Linter context object
- * @returns {Object} Modified config object
+ * @returns {{config: Object, problems: Problem[]}} Modified config object, along with any problems encountered
+ * while parsing config comments
  */
 function modifyConfigsFromComments(filename, ast, config, linterContext) {
 
@@ -327,7 +335,7 @@ function modifyConfigsFromComments(filename, ast, config, linterContext) {
         env: {}
     };
     const commentRules = {};
-    const messages = linterContext.messages;
+    const problems = [];
     const reportingConfig = linterContext.reportingConfig;
 
     ast.comments.forEach(comment => {
@@ -362,14 +370,19 @@ function modifyConfigsFromComments(filename, ast, config, linterContext) {
                         break;
 
                     case "eslint": {
-                        const items = parseJsonConfig(value, comment.loc, messages);
+                        const parseResult = parseJsonConfig(value, comment.loc);
 
-                        Object.keys(items).forEach(name => {
-                            const ruleValue = items[name];
+                        if (parseResult.success) {
+                            Object.keys(parseResult.config).forEach(name => {
+                                const ruleValue = parseResult.config[name];
 
-                            validator.validateRuleOptions(name, ruleValue, `${filename} line ${comment.loc.start.line}`, linterContext.rules);
-                            commentRules[name] = ruleValue;
-                        });
+                                validator.validateRuleOptions(name, ruleValue, `${filename} line ${comment.loc.start.line}`, linterContext.rules);
+                                commentRules[name] = ruleValue;
+                            });
+                        } else {
+                            problems.push(parseResult.error);
+                        }
+
                         break;
                     }
 
@@ -397,7 +410,10 @@ function modifyConfigsFromComments(filename, ast, config, linterContext) {
     });
     Object.assign(commentConfig.rules, commentRules);
 
-    return ConfigOps.merge(config, commentConfig);
+    return {
+        config: ConfigOps.merge(config, commentConfig),
+        problems
+    };
 }
 
 /**
@@ -866,7 +882,10 @@ class Linter {
 
         // parse global comments and modify config
         if (allowInlineConfig !== false) {
-            config = modifyConfigsFromComments(this.currentFilename, this.sourceCode.ast, config, this);
+            const modifyConfigResult = modifyConfigsFromComments(this.currentFilename, this.sourceCode.ast, config, this);
+
+            config = modifyConfigResult.config;
+            modifyConfigResult.problems.forEach(problem => this.messages.push(problem));
         }
 
         // ensure that severities are normalized in the config


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates the `parseJsonConfig` function in `Linter` to return a result object rather than pushing problems to a provided list of messages. The goal of this change is to give the `verify` method sole control of the `messages` array. This will make the code easier to follow (since the array won't be mutated from a distance), and it will also allow the array to be replaced with a local variable rather than an instance property.

(refs #9161)

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
