### PR TITLE
Chore: remove currentScopes property from Linter instances (refs #9161)

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -747,7 +747,6 @@ class Linter {
     constructor() {
         this.messages = [];
         this.currentConfig = null;
-        this.currentScopes = null;
         this.scopeManager = null;
         this.currentFilename = null;
         this.traverser = null;
@@ -766,7 +765,6 @@ class Linter {
     reset() {
         this.messages = [];
         this.currentConfig = null;
-        this.currentScopes = null;
         this.scopeManager = null;
         this.traverser = null;
         this.reportingConfig = [];
@@ -969,10 +967,8 @@ class Linter {
             fallback: Traverser.getKeys
         });
 
-        this.currentScopes = this.scopeManager.scopes;
-
         // augment global scope with declared global variables
-        addDeclaredGlobals(this.sourceCode.ast, this.currentScopes[0], this.currentConfig, this.environments);
+        addDeclaredGlobals(this.sourceCode.ast, this.scopeManager.scopes[0], this.currentConfig, this.environments);
 
         const eventGenerator = new CodePathAnalyzer(new NodeEventGenerator(emitter));
 
@@ -1063,7 +1059,7 @@ class Linter {
 
         }
 
-        return this.currentScopes[0];
+        return this.scopeManager.scopes[0];
     }
 
     /**


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

The `currentScopes` property is undocumented, and is redundant with the `scopeManager` property. This commit removes it.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
