### PR TITLE
Fix: off-by-one error in eslint-disable comment checking

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -404,7 +404,7 @@ function modifyConfigsFromComments(filename, ast, config, linterContext) {
  * Check if message of rule with ruleId should be ignored in location
  * @param  {Object[]} reportingConfig  Collection of ignore records
  * @param  {string} ruleId   Id of rule
- * @param  {Object} location Location of message
+ * @param  {Object} location 1-indexed location of message
  * @returns {boolean}          True if message should be ignored, false otherwise
  */
 function isDisabledByReportingConfig(reportingConfig, ruleId, location) {
@@ -414,8 +414,8 @@ function isDisabledByReportingConfig(reportingConfig, ruleId, location) {
         const ignore = reportingConfig[i];
 
         if ((!ignore.rule || ignore.rule === ruleId) &&
-            (location.line > ignore.start.line || (location.line === ignore.start.line && location.column >= ignore.start.column)) &&
-            (!ignore.end || (location.line < ignore.end.line || (location.line === ignore.end.line && location.column <= ignore.end.column)))) {
+            (location.line > ignore.start.line || (location.line === ignore.start.line && location.column > ignore.start.column)) &&
+            (!ignore.end || (location.line < ignore.end.line || (location.line === ignore.end.line && location.column - 1 <= ignore.end.column)))) {
             return true;
         }
     }

--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -1548,6 +1548,33 @@ describe("Linter", () => {
             assert.equal(messages.length, 0);
         });
 
+        it("should report a violation when the report is right before the comment", () => {
+            const code = " /* eslint-disable */ ";
+
+            linter.defineRule("checker", context => ({
+                Program() {
+                    context.report({ loc: { line: 1, column: 0 }, message: "foo" });
+                }
+            }));
+            const problems = linter.verify(code, { rules: { checker: "error" } });
+
+            assert.strictEqual(problems.length, 1);
+            assert.strictEqual(problems[0].message, "foo");
+        });
+
+        it("should not report a violation when the report is right at the start of the comment", () => {
+            const code = " /* eslint-disable */ ";
+
+            linter.defineRule("checker", context => ({
+                Program() {
+                    context.report({ loc: { line: 1, column: 1 }, message: "foo" });
+                }
+            }));
+            const problems = linter.verify(code, { rules: { checker: "error" } });
+
+            assert.strictEqual(problems.length, 0);
+        });
+
         it("rules should not change initial config", () => {
             const config = { rules: { "test-plugin/test-rule": 2 } };
             const codeA = "/*eslint test-plugin/test-rule: 0*/ var a = \"trigger violation\";";


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->
**Tell us about your environment**

* **ESLint Version:** master
* **Node Version:** 8.4.0
* **npm Version:** 5.3.0

**What parser (default, Babel-ESLint, etc.) are you using?**

N/A

**Please show your full configuration:**

N/A

**What did you do? Please include the actual source code causing the issue.**

```js
const eslint = require("eslint");
const linter = new eslint.Linter();

linter.defineRule("checker", context => ({
    Program() {
        context.report({ loc: { line: 1, column: 0 }, message: "foo" });
    }
}));

linter.verify(" /* eslint-disable */", { rules: { checker: "error" } });
```

**What did you expect to happen?**

I expected an error to be reported, because the report location is before the start of the `eslint-disable` comment.

**What actually happened? Please include the actual, raw output from ESLint.**

No error was reported. An empty array was returned.

**What changes did you make? (Give an overview)**

This updates `isDisabledByReportingConfig` in `Linter` to fix an off-by-one error introduced in https://github.com/eslint/eslint/commit/d672aef42b2950c710d598cb970d630f49b2be4b. `isDisabledByReportingConfig` is now accepting locations with 1-based columns rather than 0-based columns, so it needs to offset them appropriately when comparing them against comments with 0-based columns.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
