### PR TITLE
Fix: avoid breaking eslint-plugin-eslint-comments (fixes #9193)

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -890,7 +890,20 @@ class Linter {
                     parserOptions: config.parserOptions,
                     parserPath: config.parser,
                     parserServices,
-                    settings: config.settings
+                    settings: config.settings,
+
+                    /**
+                     * This is used to avoid breaking rules that used to monkeypatch the `Linter#report` method
+                     * by using the `_linter` property on rule contexts.
+                     *
+                     * This should be removed in a major release after we create a better way to
+                     * lint for unused disable comments.
+                     * https://github.com/eslint/eslint/issues/9193
+                     */
+                    _linter: {
+                        report() {},
+                        on: emitter.on.bind(emitter)
+                    }
                 }
             )
         );
@@ -926,6 +939,24 @@ class Linter {
                                 if (!isDisabledByReportingConfig(this.reportingConfig, ruleId, problem)) {
                                     this.messages.push(problem);
                                 }
+
+                                /*
+                                 * This is used to avoid breaking rules that used monkeypatch Linter, and relied on
+                                 * `linter.report` getting called with report info every time a rule reports a problem.
+                                 * To continue to support this, make sure that `context._linter.report` is called every
+                                 * time a problem is reported by a rule, even though `context._linter` is no longer a
+                                 * `Linter` instance.
+                                 *
+                                 * This should be removed in a major release after we create a better way to
+                                 * lint for unused disable comments.
+                                 * https://github.com/eslint/eslint/issues/9193
+                                 */
+                                sharedTraversalContext._linter.report( // eslint-disable-line no-underscore-dangle
+                                    ruleId,
+                                    severity,
+                                    { loc: { start: { line: problem.line, column: problem.column - 1 } } },
+                                    problem.message
+                                );
                             }
                         ])
                     }

--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -1563,6 +1563,31 @@ describe("Linter", () => {
         });
     });
 
+    describe("when evaluating rules that monkeypatch Linter", () => {
+        it("should call `context._linter.report` appropriately", () => {
+            linter.defineRule("foo", context => ({
+                Program() {
+                    context.report({ loc: { line: 5, column: 4 }, message: "foo" });
+                }
+            }));
+
+            const spy = sandbox.spy((ruleId, severity, node, message) => {
+                assert.strictEqual(ruleId, "foo");
+                assert.strictEqual(severity, 2);
+                assert.deepEqual(node.loc, { start: { line: 5, column: 4 } });
+                assert.strictEqual(message, "foo");
+            });
+
+            linter.defineRule("bar", context => {
+                context._linter.report = spy; // eslint-disable-line no-underscore-dangle
+                return {};
+            });
+
+            linter.verify("foo", { rules: { foo: "error", bar: "error" } });
+            assert(spy.calledOnce);
+        });
+    });
+
     describe("when evaluating code with comments to enable and disable all reporting", () => {
         it("should report a violation", () => {
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (https://github.com/eslint/eslint/issues/9193)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This provides a fix for https://github.com/eslint/eslint/issues/9193 so that libraries like `eslint-plugin-eslint-comments` will still work.

Rather than reverting https://github.com/eslint/eslint/commit/d672aef42b2950c710d598cb970d630f49b2be4b and https://github.com/eslint/eslint/commit/1be5634efe6bedb6f5d9dab5b431fc8eed2f62be, this tries to provide the minimum possible legacy behavior to make `eslint-plugin-eslint-comments` and `eslint-plugin-github` work, without giving rules full access to the `linter` instance again.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular