### PR TITLE
Fix: avoid adding globals when an env is used with `false` (fixes #9202)

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -178,7 +178,7 @@ function addDeclaredGlobals(program, globalScope, config, envContext) {
 
     Object.assign(declaredGlobals, builtin);
 
-    Object.keys(config.env).forEach(name => {
+    Object.keys(config.env).filter(name => config.env[name]).forEach(name => {
         const env = envContext.get(name),
             environmentGlobals = env && env.globals;
 

--- a/tests/lib/rules/no-catch-shadow.js
+++ b/tests/lib/rules/no-catch-shadow.js
@@ -36,6 +36,10 @@ ruleTester.run("no-catch-shadow", rule, {
                 "module.exports = broken;"
             ].join("\n"),
             parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "try {} catch (error) {}",
+            env: { shelljs: false }
         }
     ],
     invalid: [

--- a/tests/lib/rules/no-redeclare.js
+++ b/tests/lib/rules/no-redeclare.js
@@ -35,7 +35,12 @@ ruleTester.run("no-redeclare", rule, {
         { code: "var top = 0;", env: { browser: true } },
         { code: "var top = 0;", options: [{ builtinGlobals: true }] },
         { code: "var top = 0;", options: [{ builtinGlobals: true }], parserOptions: { ecmaFeatures: { globalReturn: true } }, env: { browser: true } },
-        { code: "var top = 0;", options: [{ builtinGlobals: true }], parserOptions: { sourceType: "module" }, env: { browser: true } }
+        { code: "var top = 0;", options: [{ builtinGlobals: true }], parserOptions: { sourceType: "module" }, env: { browser: true } },
+        {
+            code: "var self = 1",
+            options: [{ builtinGlobals: true }],
+            env: { browser: false }
+        }
     ],
     invalid: [
         { code: "var a = 3; var a = 10;", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' is already defined.", type: "Identifier" }] },


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (https://github.com/eslint/eslint/issues/9202)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This fixes a regression introduced in f005e2467edda78a6654c4717aa23e99b3289131 (merged as part of 60c51486849c3765ac21fb63e615db2c56b614fd) where globals would get added to environments when the env was set to `false` in a config file. (The globals would not get added if the env was omitted).

I had originally assumed this was a dead code path because it wasn't covered in any tests (and I had thought environments with `env: false` where stripped out of the config beforehand). However, it turns out that we just didn't have tests for this case.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular