### PR TITLE
Fix: Correct a typo in generator-star-spacing documentation

### DIFF
--- a/docs/rules/generator-star-spacing.md
+++ b/docs/rules/generator-star-spacing.md
@@ -93,7 +93,7 @@ An example of a configuration with overrides:
 ```
 
 In the example configuration above, the top level "before" and "after" options define the default behavior of
-the rule, while the "anonymous", "method", and "static" options override the default behavior.
+the rule, while the "anonymous" and "method" options override the default behavior.
 Overrides can be either an object with "before" and "after", or a shorthand string as above.
 
 ## Examples


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
I fixed a typo in the docs which refers to a setting that was removed from the PR during review.

**Is there anything you'd like reviewers to focus on?**
This should get in pretty soon, otherwise it could cause some confusion.

