### PR TITLE
Chore: avoid storing list of problems on Linter instance (refs #9161)

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -761,7 +761,6 @@ const BASE_TRAVERSAL_CONTEXT = Object.freeze(
 class Linter {
 
     constructor() {
-        this.messages = [];
         this.currentConfig = null;
         this.scopeManager = null;
         this.currentFilename = null;
@@ -779,7 +778,6 @@ class Linter {
      * @returns {void}
      */
     reset() {
-        this.messages = [];
         this.currentConfig = null;
         this.scopeManager = null;
         this.traverser = null;
@@ -878,12 +876,14 @@ class Linter {
             this.sourceCode = new SourceCode(text, parseResult.ast);
         }
 
+        const problems = [];
+
         // parse global comments and modify config
         if (allowInlineConfig !== false) {
             const modifyConfigResult = modifyConfigsFromComments(this.currentFilename, this.sourceCode.ast, config, this);
 
             config = modifyConfigResult.config;
-            modifyConfigResult.problems.forEach(problem => this.messages.push(problem));
+            modifyConfigResult.problems.forEach(problem => problems.push(problem));
         }
 
         // ensure that severities are normalized in the config
@@ -955,9 +955,7 @@ class Linter {
                                 if (problem.fix && ruleCreator.meta && !ruleCreator.meta.fixable) {
                                     throw new Error("Fixable rules should export a `meta.fixable` property.");
                                 }
-                                if (!isDisabledByReportingConfig(this.reportingConfig, ruleId, problem)) {
-                                    this.messages.push(problem);
-                                }
+                                problems.push(problem);
 
                                 /*
                                  * This is used to avoid breaking rules that used monkeypatch Linter, and relied on
@@ -1039,18 +1037,9 @@ class Linter {
             }
         });
 
-        // sort by line and column
-        this.messages.sort((a, b) => {
-            const lineDiff = a.line - b.line;
-
-            if (lineDiff === 0) {
-                return a.column - b.column;
-            }
-            return lineDiff;
-
-        });
-
-        return this.messages;
+        return problems
+            .filter(problem => !isDisabledByReportingConfig(this.reportingConfig, problem.ruleId, problem))
+            .sort((problemA, problemB) => problemA.line - problemB.line || problemA.column - problemB.column);
     }
 
     /**


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates `Linter#verify` to create a new array of problems rather than storing problems in `this.messages`. As a result, the private `messages` property can be removed.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
