### PR TITLE
Build: avoid process leak when generating website

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -3,7 +3,7 @@
  * @author nzakas
  */
 
-/* global cat, cd, cp, echo, exec, exit, find, ls, mkdir, pwd, rm, target, test*/
+/* global target */
 /* eslint no-use-before-define: "off", no-console: "off" */
 "use strict";
 
@@ -24,9 +24,23 @@ const lodash = require("lodash"),
     os = require("os"),
     path = require("path"),
     semver = require("semver"),
+    shell = require("shelljs"),
     ejs = require("ejs"),
     loadPerf = require("load-perf"),
     yaml = require("js-yaml");
+
+const cat = shell.cat;
+const cd = shell.cd;
+const cp = shell.cp;
+const echo = shell.echo;
+const exec = shell.exec;
+const exit = shell.exit;
+const find = shell.find;
+const ls = shell.ls;
+const mkdir = shell.mkdir;
+const pwd = shell.pwd;
+const rm = shell.rm;
+const test = shell.test;
 
 //------------------------------------------------------------------------------
 // Settings
@@ -146,7 +160,7 @@ function generateRulesIndex(basedir) {
  * @returns {string} The result of the executed command.
  */
 function execSilent(cmd) {
-    return exec(cmd, { silent: true }).output;
+    return exec(cmd, { silent: true }).stdout;
 }
 
 /**
@@ -329,7 +343,7 @@ function getFirstCommitOfFile(filePath) {
  * @param {string} filePath The file path to check.
  * @returns {string} The tag name.
  */
-function getTagOfFirstOccurrence(filePath) {
+function getFirstVersionOfFile(filePath) {
     const firstCommit = getFirstCommitOfFile(filePath);
     let tags = execSilent(`git tag --contains ${firstCommit}`);
 
@@ -341,15 +355,6 @@ function getTagOfFirstOccurrence(filePath) {
         }
         return list;
     }, []).sort(semver.compare)[0];
-}
-
-/**
- * Gets the version number where a given file was introduced first.
- * @param {string} filePath The file path to check.
- * @returns {string} The version number.
- */
-function getFirstVersionOfFile(filePath) {
-    return getTagOfFirstOccurrence(filePath);
 }
 
 /**


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix

**Tell us about your environment**

* **ESLint Version:** master
* **Node Version:** 8.4.0
* **npm Version:** 5.3.0

**What parser (default, Babel-ESLint, etc.) are you using?**

N/A

**Please show your full configuration:**

N/A

**What did you do? Please include the actual source code causing the issue.**

I cloned the ESLint repo and ran

```bash
$ node Makefile.js gensite
```

**What did you expect to happen?**

I expected the website to generate in a reasonable amount of time, and I expected the build script to not spawn hundreds of concurrent processes.

**What actually happened? Please include the actual, raw output from ESLint.**

The build script froze after generating about 300/350 docs files. Running `ps` in a separate terminal tab indicated that hundreds of processes had been created.

**What changes did you make? (Give an overview)**

This updates `Makefile.js` to use the `shelljs` functions as variables, rather than relying on `shelljs` to set its own globals.

We rely on [shelljs-nodecli](https://github.com/nzakas/shelljs-nodecli), which has a dependency on `shelljs@~0.2`. `shelljs-nodecli` is also overwriting all the `shelljs` globals (see https://github.com/nzakas/shelljs-nodecli/pull/5), so the `exec` global available from `Makefile.js` is actually the `exec` function from `shelljs@0.2.6`, even though we have `shelljs@0.7.8` as a direct dependency. The `exec` function from `shelljs@0.2.6` appears have an issue where it doesn't shut down the processes it creates, which causes the `gensite` script to freeze as it exceeds the process limit.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
