### PR TITLE
Chore: avoid relying on undocumented Linter#getFilename API in tests

### DIFF
--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -2711,35 +2711,48 @@ describe("Linter", () => {
     describe("verify()", () => {
         describe("filenames", () => {
             it("should allow filename to be passed on options object", () => {
+                const filenameChecker = sandbox.spy(context => {
+                    assert.strictEqual(context.getFilename(), "foo.js");
+                    return {};
+                });
 
-                linter.verify("foo;", {}, { filename: "foo.js" });
-                const result = linter.getFilename();
-
-                assert.equal(result, "foo.js");
+                linter.defineRule("checker", filenameChecker);
+                linter.defineRule("checker", filenameChecker);
+                linter.verify("foo;", { rules: { checker: "error" } }, { filename: "foo.js" });
+                assert(filenameChecker.calledOnce);
             });
 
             it("should allow filename to be passed as third argument", () => {
+                const filenameChecker = sandbox.spy(context => {
+                    assert.strictEqual(context.getFilename(), "bar.js");
+                    return {};
+                });
 
-                linter.verify("foo;", {}, "foo.js");
-                const result = linter.getFilename();
-
-                assert.equal(result, "foo.js");
+                linter.defineRule("checker", filenameChecker);
+                linter.verify("foo;", { rules: { checker: "error" } }, "bar.js");
+                assert(filenameChecker.calledOnce);
             });
 
             it("should default filename to <input> when options object doesn't have filename", () => {
+                const filenameChecker = sandbox.spy(context => {
+                    assert.strictEqual(context.getFilename(), "<input>");
+                    return {};
+                });
 
-                linter.verify("foo;", {}, {});
-                const result = linter.getFilename();
-
-                assert.equal(result, "<input>");
+                linter.defineRule("checker", filenameChecker);
+                linter.verify("foo;", { rules: { checker: "error" } }, {});
+                assert(filenameChecker.calledOnce);
             });
 
             it("should default filename to <input> when only two arguments are passed", () => {
+                const filenameChecker = sandbox.spy(context => {
+                    assert.strictEqual(context.getFilename(), "<input>");
+                    return {};
+                });
 
-                linter.verify("foo;", {});
-                const result = linter.getFilename();
-
-                assert.equal(result, "<input>");
+                linter.defineRule("checker", filenameChecker);
+                linter.verify("foo;", { rules: { checker: "error" } });
+                assert(filenameChecker.calledOnce);
             });
         });
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates the tests for `Linter` to avoid relying on the undocumented `getFilename` method.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular