### PR TITLE
Chore: remove currentFilename prop from Linter instances (refs #9161)

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -763,7 +763,6 @@ class Linter {
     constructor() {
         this.currentConfig = null;
         this.scopeManager = null;
-        this.currentFilename = null;
         this.traverser = null;
         this.reportingConfig = [];
         this.sourceCode = null;
@@ -822,14 +821,18 @@ class Linter {
             text = this.sourceCode.text;
         }
 
+        let providedFilename;
+
         // evaluate arguments
         if (typeof filenameOrOptions === "object") {
-            this.currentFilename = filenameOrOptions.filename;
+            providedFilename = filenameOrOptions.filename;
             allowInlineConfig = filenameOrOptions.allowInlineConfig;
             saveState = filenameOrOptions.saveState;
         } else {
-            this.currentFilename = filenameOrOptions;
+            providedFilename = filenameOrOptions;
         }
+
+        const filename = typeof providedFilename === "string" ? providedFilename : "<input>";
 
         if (!saveState) {
             this.reset();
@@ -865,7 +868,7 @@ class Linter {
                 stripUnicodeBOM(text).replace(astUtils.SHEBANG_MATCHER, (match, captured) => `//${captured}`),
                 config.parserOptions,
                 config.parser,
-                this.currentFilename
+                filename
             );
 
             if (!parseResult.success) {
@@ -880,7 +883,7 @@ class Linter {
 
         // parse global comments and modify config
         if (allowInlineConfig !== false) {
-            const modifyConfigResult = modifyConfigsFromComments(this.currentFilename, this.sourceCode.ast, config, this);
+            const modifyConfigResult = modifyConfigsFromComments(filename, this.sourceCode.ast, config, this);
 
             config = modifyConfigResult.config;
             modifyConfigResult.problems.forEach(problem => problems.push(problem));
@@ -902,7 +905,7 @@ class Linter {
                 {
                     getAncestors: this.getAncestors.bind(this),
                     getDeclaredVariables: this.getDeclaredVariables.bind(this),
-                    getFilename: this.getFilename.bind(this),
+                    getFilename: () => filename,
                     getScope: this.getScope.bind(this),
                     getSourceCode: () => this.sourceCode,
                     markVariableAsUsed: this.markVariableAsUsed.bind(this),
@@ -1132,19 +1135,6 @@ class Linter {
         } while ((scope = scope.upper));
 
         return false;
-    }
-
-    /**
-     * Gets the filename for the currently parsed source.
-     * @returns {string} The filename associated with the source being parsed.
-     *     Defaults to "<input>" if no filename info is present.
-     */
-    getFilename() {
-        if (typeof this.currentFilename === "string") {
-            return this.currentFilename;
-        }
-        return "<input>";
-
     }
 
     /**


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This removes the undocumented `currentFilename` property from `Linter` instances.

This relies on https://github.com/eslint/eslint/pull/9218. The tests will pass after https://github.com/eslint/eslint/pull/9218 is merged.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
