### PR TITLE
Chore: remove internal Linter#getAncestors helper (refs #9161)

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -900,7 +900,7 @@ class Linter {
             Object.assign(
                 Object.create(BASE_TRAVERSAL_CONTEXT),
                 {
-                    getAncestors: this.getAncestors.bind(this),
+                    getAncestors: () => this.traverser.parents(),
                     getDeclaredVariables: this.getDeclaredVariables.bind(this),
                     getFilename: this.getFilename.bind(this),
                     getScope: this.getScope.bind(this),
@@ -1048,14 +1048,6 @@ class Linter {
      */
     getSourceCode() {
         return this.sourceCode;
-    }
-
-    /**
-     * Gets nodes that are ancestors of current node.
-     * @returns {ASTNode[]} Array of objects representing ancestors.
-     */
-    getAncestors() {
-        return this.traverser.parents();
     }
 
     /**

--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -302,36 +302,43 @@ describe("Linter", () => {
 
     });
 
-    describe("when calling getAncestors", () => {
+    describe("when calling context.getAncestors", () => {
         const code = TEST_CODE;
 
         it("should retrieve all ancestors when used", () => {
 
             const config = { rules: { checker: "error" } };
-            const spy = sandbox.spy(() => {
-                const ancestors = linter.getAncestors();
+            let spy;
 
-                assert.equal(ancestors.length, 3);
+            linter.defineRule("checker", context => {
+                spy = sandbox.spy(() => {
+                    const ancestors = context.getAncestors();
+
+                    assert.equal(ancestors.length, 3);
+                });
+                return { BinaryExpression: spy };
             });
 
-            linter.defineRule("checker", () => ({ BinaryExpression: spy }));
-
             linter.verify(code, config, filename, true);
-            assert(spy.calledOnce);
+            assert(spy && spy.calledOnce);
         });
 
         it("should retrieve empty ancestors for root node", () => {
             const config = { rules: { checker: "error" } };
-            const spy = sandbox.spy(() => {
-                const ancestors = linter.getAncestors();
+            let spy;
 
-                assert.equal(ancestors.length, 0);
+            linter.defineRule("checker", context => {
+                spy = sandbox.spy(() => {
+                    const ancestors = context.getAncestors();
+
+                    assert.equal(ancestors.length, 0);
+                });
+
+                return { Program: spy };
             });
 
-            linter.defineRule("checker", () => ({ Program: spy }));
-
             linter.verify(code, config);
-            assert(spy.calledOnce);
+            assert(spy && spy.calledOnce);
         });
     });
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates `Linter` to remove the internal `getAncestors` method. (The documented `context.getAncestors` method in rules is still available.)

**Is there anything you'd like reviewers to focus on?**

Nothing in particular