### PR TITLE
Chore: avoid internal SourceCode methods in Linter tests (refs #9161)

### DIFF
--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -102,61 +102,66 @@ describe("Linter", () => {
         });
     });
 
-    describe("getSourceLines()", () => {
+    describe("context.getSourceLines()", () => {
 
         it("should get proper lines when using \\n as a line break", () => {
             const code = "a;\nb;";
+            const spy = sandbox.spy(context => {
+                assert.deepEqual(context.getSourceLines(), ["a;", "b;"]);
+                return {};
+            });
 
-            linter.verify(code, {}, filename, true);
-
-            const lines = linter.getSourceLines();
-
-            assert.equal(lines[0], "a;");
-            assert.equal(lines[1], "b;");
+            linter.defineRule("checker", spy);
+            linter.verify(code, { rules: { checker: "error" } });
+            assert(spy.calledOnce);
         });
 
         it("should get proper lines when using \\r\\n as a line break", () => {
             const code = "a;\r\nb;";
+            const spy = sandbox.spy(context => {
+                assert.deepEqual(context.getSourceLines(), ["a;", "b;"]);
+                return {};
+            });
 
-            linter.verify(code, {}, filename, true);
-
-            const lines = linter.getSourceLines();
-
-            assert.equal(lines[0], "a;");
-            assert.equal(lines[1], "b;");
+            linter.defineRule("checker", spy);
+            linter.verify(code, { rules: { checker: "error" } });
+            assert(spy.calledOnce);
         });
 
         it("should get proper lines when using \\r as a line break", () => {
             const code = "a;\rb;";
+            const spy = sandbox.spy(context => {
+                assert.deepEqual(context.getSourceLines(), ["a;", "b;"]);
+                return {};
+            });
 
-            linter.verify(code, {}, filename, true);
-
-            const lines = linter.getSourceLines();
-
-            assert.equal(lines[0], "a;");
-            assert.equal(lines[1], "b;");
+            linter.defineRule("checker", spy);
+            linter.verify(code, { rules: { checker: "error" } });
+            assert(spy.calledOnce);
         });
 
         it("should get proper lines when using \\u2028 as a line break", () => {
             const code = "a;\u2028b;";
+            const spy = sandbox.spy(context => {
+                assert.deepEqual(context.getSourceLines(), ["a;", "b;"]);
+                return {};
+            });
 
-            linter.verify(code, {}, filename, true);
-
-            const lines = linter.getSourceLines();
-
-            assert.equal(lines[0], "a;");
-            assert.equal(lines[1], "b;");
+            linter.defineRule("checker", spy);
+            linter.verify(code, { rules: { checker: "error" } });
+            assert(spy.calledOnce);
         });
 
         it("should get proper lines when using \\u2029 as a line break", () => {
             const code = "a;\u2029b;";
+            const spy = sandbox.spy(context => {
+                assert.deepEqual(context.getSourceLines(), ["a;", "b;"]);
+                return {};
+            });
 
-            linter.verify(code, {}, filename, true);
-
-            const lines = linter.getSourceLines();
-
-            assert.equal(lines[0], "a;");
-            assert.equal(lines[1], "b;");
+            linter.defineRule("checker", spy);
+            linter.verify(code, { rules: { checker: "error" } });
+            assert(spy.calledOnce);
         });
 
 
@@ -189,115 +194,113 @@ describe("Linter", () => {
 
     });
 
-    describe("getSource()", () => {
+    describe("context.getSource()", () => {
         const code = TEST_CODE;
 
         it("should retrieve all text when used without parameters", () => {
 
-            const config = { rules: { checker: "error" } },
+            const config = { rules: { checker: "error" } };
+            let spy;
+
+            linter.defineRule("checker", context => {
                 spy = sandbox.spy(() => {
-                    const source = linter.getSource();
-
-                    assert.equal(source, TEST_CODE);
+                    assert.equal(context.getSource(), TEST_CODE);
                 });
+                return { Program: spy };
+            });
 
-            linter.defineRule("checker", () => ({ Program: spy }));
-
-            linter.verify(code, config, filename, true);
-            assert(spy.calledOnce);
+            linter.verify(code, config);
+            assert(spy && spy.calledOnce);
         });
 
         it("should retrieve all text for root node", () => {
             const config = { rules: { checker: "error" } };
-            const spy = sandbox.spy(node => {
-                const source = linter.getSource(node);
+            let spy;
 
-                assert.equal(source, TEST_CODE);
+            linter.defineRule("checker", context => {
+                spy = sandbox.spy(node => {
+                    assert.equal(context.getSource(node), TEST_CODE);
+                });
+                return { Program: spy };
             });
 
-            linter.defineRule("checker", () => ({ Program: spy }));
-
-            linter.verify(code, config, filename, true);
-            assert(spy.calledOnce);
+            linter.verify(code, config);
+            assert(spy && spy.calledOnce);
         });
 
         it("should clamp to valid range when retrieving characters before start of source", () => {
+            const config = { rules: { checker: "error" } };
+            let spy;
 
-            /**
-             * Callback handler
-             * @param {ASTNode} node node to examine
-             * @returns {void}
-             */
-            function handler(node) {
-                const source = linter.getSource(node, 2, 0);
+            linter.defineRule("checker", context => {
+                spy = sandbox.spy(node => {
+                    assert.equal(context.getSource(node, 2, 0), TEST_CODE);
+                });
+                return { Program: spy };
+            });
 
-                assert.equal(source, TEST_CODE);
-            }
-
-            const config = { rules: { checker: "error" } },
-                spy = sandbox.spy(handler);
-
-            linter.defineRule("checker", () => ({ Program: spy }));
-
-            linter.verify(code, config, filename, true);
-            assert(spy.calledOnce);
+            linter.verify(code, config);
+            assert(spy && spy.calledOnce);
         });
 
         it("should retrieve all text for binary expression", () => {
-            const spy = sandbox.spy(node => {
-                const source = linter.getSource(node);
+            const config = { rules: { checker: "error" } };
+            let spy;
 
-                assert.equal(source, "6 * 7");
+            linter.defineRule("checker", context => {
+                spy = sandbox.spy(node => {
+                    assert.equal(context.getSource(node), "6 * 7");
+                });
+                return { BinaryExpression: spy };
             });
 
-            const config = { rules: { checker: "error" } };
-
-            linter.defineRule("checker", () => ({ BinaryExpression: spy }));
-            linter.verify(code, config, filename, true);
-            assert(spy.calledOnce);
+            linter.verify(code, config);
+            assert(spy && spy.calledOnce);
         });
 
         it("should retrieve all text plus two characters before for binary expression", () => {
             const config = { rules: { checker: "error" } };
+            let spy;
 
-            const spy = sandbox.spy(node => {
-                const source = linter.getSource(node, 2);
-
-                assert.equal(source, "= 6 * 7");
+            linter.defineRule("checker", context => {
+                spy = sandbox.spy(node => {
+                    assert.equal(context.getSource(node, 2), "= 6 * 7");
+                });
+                return { BinaryExpression: spy };
             });
 
-            linter.defineRule("checker", () => ({ BinaryExpression: spy }));
-
-            linter.verify(code, config, filename, true);
-            assert(spy.calledOnce);
+            linter.verify(code, config);
+            assert(spy && spy.calledOnce);
         });
 
         it("should retrieve all text plus one character after for binary expression", () => {
             const config = { rules: { checker: "error" } };
-            const spy = sandbox.spy(node => {
-                const source = linter.getSource(node, 0, 1);
+            let spy;
 
-                assert.strictEqual(source, "6 * 7;");
+            linter.defineRule("checker", context => {
+                spy = sandbox.spy(node => {
+                    assert.strictEqual(context.getSource(node, 0, 1), "6 * 7;");
+                });
+                return { BinaryExpression: spy };
             });
 
-            linter.defineRule("checker", () => ({ BinaryExpression: spy }));
-
-            linter.verify(code, config, filename, true);
-            assert(spy.calledOnce);
+            linter.verify(code, config);
+            assert(spy && spy.calledOnce);
         });
 
         it("should retrieve all text plus two characters before and one character after for binary expression", () => {
             const config = { rules: { checker: "error" } };
-            const spy = sandbox.spy(node => {
-                const source = linter.getSource(node, 2, 1);
+            let spy;
 
-                assert.equal(source, "= 6 * 7;");
+            linter.defineRule("checker", context => {
+                spy = sandbox.spy(node => {
+                    assert.equal(context.getSource(node, 2, 1), "= 6 * 7;");
+                });
+                return { BinaryExpression: spy };
             });
 
-            linter.defineRule("checker", () => ({ BinaryExpression: spy }));
-
-            linter.verify(code, config, filename, true);
-            assert(spy.calledOnce);
+            linter.verify(code, config);
+            assert(spy && spy.calledOnce);
         });
 
     });
@@ -342,126 +345,128 @@ describe("Linter", () => {
         });
     });
 
-    describe("when calling getNodeByRangeIndex", () => {
+    describe("when calling context.getNodeByRangeIndex", () => {
         const code = TEST_CODE;
 
         it("should retrieve a node starting at the given index", () => {
             const config = { rules: { checker: "error" } };
-            const spy = sandbox.spy(() => {
-                const node = linter.getNodeByRangeIndex(4);
-
-                assert.equal(node.type, "Identifier");
+            const spy = sandbox.spy(context => {
+                assert.equal(context.getNodeByRangeIndex(4).type, "Identifier");
+                return {};
             });
 
-            linter.defineRule("checker", () => ({ Program: spy }));
-
+            linter.defineRule("checker", spy);
             linter.verify(code, config);
             assert(spy.calledOnce);
         });
 
         it("should retrieve a node containing the given index", () => {
             const config = { rules: { checker: "error" } };
-            const spy = sandbox.spy(() => {
-                const node = linter.getNodeByRangeIndex(6);
-
-                assert.equal(node.type, "Identifier");
+            const spy = sandbox.spy(context => {
+                assert.equal(context.getNodeByRangeIndex(6).type, "Identifier");
+                return {};
             });
 
-            linter.defineRule("checker", () => ({ Program: spy }));
-
+            linter.defineRule("checker", spy);
             linter.verify(code, config);
             assert(spy.calledOnce);
         });
 
         it("should retrieve a node that is exactly the given index", () => {
             const config = { rules: { checker: "error" } };
-            const spy = sandbox.spy(() => {
-                const node = linter.getNodeByRangeIndex(13);
+            const spy = sandbox.spy(context => {
+                const node = context.getNodeByRangeIndex(13);
 
                 assert.equal(node.type, "Literal");
                 assert.equal(node.value, 6);
+                return {};
             });
 
-            linter.defineRule("checker", () => ({ Program: spy }));
-
+            linter.defineRule("checker", spy);
             linter.verify(code, config);
             assert(spy.calledOnce);
         });
 
         it("should retrieve a node ending with the given index", () => {
             const config = { rules: { checker: "error" } };
-            const spy = sandbox.spy(() => {
-                const node = linter.getNodeByRangeIndex(9);
-
-                assert.equal(node.type, "Identifier");
+            const spy = sandbox.spy(context => {
+                assert.equal(context.getNodeByRangeIndex(9).type, "Identifier");
+                return {};
             });
 
-            linter.defineRule("checker", () => ({ Program: spy }));
-
+            linter.defineRule("checker", spy);
             linter.verify(code, config);
             assert(spy.calledOnce);
         });
 
         it("should retrieve the deepest node containing the given index", () => {
             const config = { rules: { checker: "error" } };
-            const spy = sandbox.spy(() => {
-                let node = linter.getNodeByRangeIndex(14);
+            const spy = sandbox.spy(context => {
+                const node1 = context.getNodeByRangeIndex(14);
 
-                assert.equal(node.type, "BinaryExpression");
-                node = linter.getNodeByRangeIndex(3);
-                assert.equal(node.type, "VariableDeclaration");
+                assert.equal(node1.type, "BinaryExpression");
+
+                const node2 = context.getNodeByRangeIndex(3);
+
+                assert.equal(node2.type, "VariableDeclaration");
+                return {};
             });
 
-            linter.defineRule("checker", () => ({ Program: spy }));
+            linter.defineRule("checker", spy);
             linter.verify(code, config);
             assert(spy.calledOnce);
         });
 
         it("should return null if the index is outside the range of any node", () => {
             const config = { rules: { checker: "error" } };
-            const spy = sandbox.spy(() => {
-                let node = linter.getNodeByRangeIndex(-1);
+            const spy = sandbox.spy(context => {
+                const node1 = context.getNodeByRangeIndex(-1);
 
-                assert.isNull(node);
-                node = linter.getNodeByRangeIndex(-99);
-                assert.isNull(node);
+                assert.isNull(node1);
+
+                const node2 = context.getNodeByRangeIndex(-99);
+
+                assert.isNull(node2);
+                return {};
             });
 
-            linter.defineRule("checker", () => ({ Program: spy }));
+            linter.defineRule("checker", spy);
             linter.verify(code, config);
             assert(spy.calledOnce);
         });
 
         it("should attach the node's parent", () => {
             const config = { rules: { checker: "error" } };
-            const spy = sandbox.spy(() => {
-                const node = linter.getNodeByRangeIndex(14);
+            const spy = sandbox.spy(context => {
+                const node = context.getNodeByRangeIndex(14);
 
                 assert.property(node, "parent");
                 assert.equal(node.parent.type, "VariableDeclarator");
+                return {};
             });
 
-            linter.defineRule("checker", () => ({ Program: spy }));
-
+            linter.defineRule("checker", spy);
             linter.verify(code, config);
             assert(spy.calledOnce);
         });
 
         it("should not modify the node when attaching the parent", () => {
             const config = { rules: { checker: "error" } };
-            const spy = sandbox.spy(() => {
-                let node = linter.getNodeByRangeIndex(10);
+            const spy = sandbox.spy(context => {
+                const node1 = context.getNodeByRangeIndex(10);
 
-                assert.equal(node.type, "VariableDeclarator");
-                node = linter.getNodeByRangeIndex(4);
-                assert.equal(node.type, "Identifier");
-                assert.property(node, "parent");
-                assert.equal(node.parent.type, "VariableDeclarator");
-                assert.notProperty(node.parent, "parent");
+                assert.equal(node1.type, "VariableDeclarator");
+
+                const node2 = context.getNodeByRangeIndex(4);
+
+                assert.equal(node2.type, "Identifier");
+                assert.property(node2, "parent");
+                assert.equal(node2.parent.type, "VariableDeclarator");
+                assert.notProperty(node2.parent, "parent");
+                return {};
             });
 
-            linter.defineRule("checker", () => ({ Program: spy }));
-
+            linter.defineRule("checker", spy);
             linter.verify(code, config);
             assert(spy.calledOnce);
         });
@@ -999,34 +1004,6 @@ describe("Linter", () => {
         });
     });
 
-    describe("after calling reset()", () => {
-        const code = TEST_CODE;
-
-        it("text should not be available", () => {
-            const config = { rules: {} };
-
-            linter.reset();
-            const messages = linter.verify(code, config, filename, true);
-
-            linter.reset();
-
-            assert.equal(messages.length, 0);
-            assert.isNull(linter.getSource());
-        });
-
-        it("source for nodes should not be available", () => {
-            const config = { rules: {} };
-
-            linter.reset();
-            const messages = linter.verify(code, config, filename, true);
-
-            linter.reset();
-
-            assert.equal(messages.length, 0);
-            assert.isNull(linter.getSource({}));
-        });
-    });
-
     describe("when evaluating code containing /*global */ and /*globals */ blocks", () => {
         const code = "/*global a b:true c:false*/ function foo() {} /*globals d:true*/";
 
@@ -1288,17 +1265,6 @@ describe("Linter", () => {
             linter.defineRule("checker", () => ({ Program: spy }));
             linter.verify(code, config);
             assert(spy.calledOnce);
-        });
-    });
-
-    describe("when evaluating empty code", () => {
-        const code = "",
-            config = { rules: {} };
-
-        it("getSource() should return an empty string", () => {
-            linter.reset();
-            linter.verify(code, config, filename, true);
-            assert.equal(linter.getSource(), "");
         });
     });
 
@@ -2308,14 +2274,15 @@ describe("Linter", () => {
 
         it("should have a comment with the shebang in it", () => {
             const config = { rules: { checker: "error" } };
-            const spy = sandbox.spy(() => {
-                const comments = linter.getAllComments();
+            const spy = sandbox.spy(context => {
+                const comments = context.getAllComments();
 
                 assert.equal(comments.length, 1);
                 assert.equal(comments[0].type, "Shebang");
+                return {};
             });
 
-            linter.defineRule("checker", () => ({ Program: spy }));
+            linter.defineRule("checker", spy);
             linter.verify(code, config);
             assert(spy.calledOnce);
         });
@@ -2735,13 +2702,17 @@ describe("Linter", () => {
         it("should comment hashbang without breaking offset", () => {
             const code = "#!/usr/bin/env node\n'123';";
             const config = { rules: { checker: "error" } };
-            const spy = sandbox.spy(node => {
-                assert.equal(linter.getSource(node), "'123';");
+            let spy;
+
+            linter.defineRule("checker", context => {
+                spy = sandbox.spy(node => {
+                    assert.equal(context.getSource(node), "'123';");
+                });
+                return { ExpressionStatement: spy };
             });
 
-            linter.defineRule("checker", () => ({ ExpressionStatement: spy }));
             linter.verify(code, config);
-            assert(spy.calledOnce);
+            assert(spy && spy.calledOnce);
         });
     });
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates the tests for `Linter` to avoid using undocumented methods as passthroughs to `SourceCode`.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
