### PR TITLE
Fix: parsing YAML .eslintrc with JS-like comments

### DIFF
--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -133,7 +133,18 @@ function loadLegacyConfigFile(filePath) {
     const yaml = require("js-yaml");
 
     try {
-        return yaml.safeLoad(stripComments(readFile(filePath))) || /* istanbul ignore next */ {};
+        const fileContents = readFile(filePath);
+
+        // it's not always safe to strip JS-like comments from a YAML file
+        // try parsing file as-is, strip and retry if necessary
+        try {
+            return yaml.safeLoad(fileContents) || /* istanbul ignore next */ {};
+        } catch (ignored) {
+
+            // fall-through to ignore parsing error, strip, and retry
+        }
+
+        return yaml.safeLoad(stripComments(fileContents)) || /* istanbul ignore next */ {};
     } catch (e) {
         debug(`Error reading YAML file: ${filePath}`);
         e.message = `Cannot read config file: ${filePath}\nError: ${e.message}`;

--- a/tests/fixtures/configurations/yaml-js-comments/.eslintrc
+++ b/tests/fixtures/configurations/yaml-js-comments/.eslintrc
@@ -1,0 +1,4 @@
+rules:
+  max-len: [2, 80, 2, {
+    ignorePattern: '^\s*//'
+  }]

--- a/tests/lib/config.js
+++ b/tests/lib/config.js
@@ -378,6 +378,17 @@ describe("Config", () => {
             assert.equal(noUndef, 2);
         });
 
+        // YAML files can have JS comments in strings.  Need to be careful
+        // about this when file could be JSON-with-comments or YAML.
+        it("should not mangle a YAML config file with JS-style comments", () => {
+            const configPath = path.resolve(__dirname, "..", "fixtures", "configurations", "yaml-js-comments", ".eslintrc"),
+                configHelper = new Config({ configFile: configPath }, linter),
+                maxLen = configHelper.specificConfig.rules["max-len"],
+                ignorePattern = maxLen[3].ignorePattern;
+
+            assert.equal(ignorePattern, "^\\s*//");
+        });
+
         it("should contain the correct value for parser when a custom parser is specified", () => {
             const configPath = path.resolve(__dirname, "../fixtures/configurations/parser/.eslintrc.json"),
                 configHelper = new Config({ cwd: process.cwd() }, linter),


### PR DESCRIPTION
A YAML .eslintrc file can contain single-quoted strings with JavaScript comment markers.  Naive comment removal will incorrectly remove such strings and possibly prevent YAML parsing of the file.  For example, the following will fail to parse due to `//'` being removed:

```yaml
rules:
  max-len: [2, 80, 2, {
    ignorePattern: '^\s*//'
  }]
```

Avoid this by trying to parse the file as YAML without comment removal, then retrying with comment removal as a fallback.

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**Tell us about your environment**

* **ESLint Version:** master (v4.6.1-4-g55c786cc)
* **Node Version:** v8.2.1
* **npm Version:** 4.1.1

**What parser (default, Babel-ESLint, etc.) are you using?** default

**Please show your full configuration:**

```yaml
rules:
  max-len: [2, 80, 2, {
    ignorePattern: '^\s*//'
  }]
```

**What did you do? Please include the actual source code causing the issue.**

Run `eslint --print-config foo.js`

**What did you expect to happen?**

It would print the configuration.

**What actually happened? Please include the actual, raw output from ESLint.**

	Cannot read config file: /path/to/project/.eslintrc
	Error: unexpected end of the stream within a single quoted scalar at line 5, column 1:
	    
	    ^
	YAMLException: Cannot read config file: /path/to/project/.eslintrc
	Error: unexpected end of the stream within a single quoted scalar at line 5, column 1:
	    
	    ^
	    at generateError (/path/to/project/node_modules/js-yaml/lib/js-yaml/loader.js:165:10)
	    at throwError (/path/to/project/node_modules/js-yaml/lib/js-yaml/loader.js:171:9)
	    at readSingleQuotedScalar (/path/to/project/node_modules/js-yaml/lib/js-yaml/loader.js:559:3)
	    at composeNode (/path/to/project/node_modules/js-yaml/lib/js-yaml/loader.js:1337:13)
	    at readFlowCollection (/path/to/project/node_modules/js-yaml/lib/js-yaml/loader.js:719:7)
	    at composeNode (/path/to/project/node_modules/js-yaml/lib/js-yaml/loader.js:1333:11)
	    at readFlowCollection (/path/to/project/node_modules/js-yaml/lib/js-yaml/loader.js:708:5)
	    at composeNode (/path/to/project/node_modules/js-yaml/lib/js-yaml/loader.js:1333:11)
	    at readBlockMapping (/path/to/project/node_modules/js-yaml/lib/js-yaml/loader.js:1062:11)
	    at composeNode (/path/to/project/node_modules/js-yaml/lib/js-yaml/loader.js:1332:12)

**What changes did you make? (Give an overview)**

Changed `configFile.loadLegacyConfigFile` to attempt YAML parsing without comment stripping then retry with comment stripping on failure.

**Is there anything you'd like reviewers to focus on?**

This implementation choice has performance implications.  It may be possible to either detect JSON before parsing or try `stripComments`+`JSON.parse` with `yaml.safeLoad` as fallback for increased performance at the increased risk of incompatibilities.  I'd appreciate your thoughts on the preferred implementation.