### PR TITLE
Docs: Replace misleading CLA links (#9133)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Before filing an issue, please be sure to read the guidelines for what you're re
 
 ## Contributing Code
 
-Please sign our [Contributor License Agreement](https://js.foundation/CLA) and read over the [Pull Request Guidelines](http://eslint.org/docs/developer-guide/contributing/pull-requests).
+Please sign our [Contributor License Agreement](https://cla.js.foundation/eslint/eslint) and read over the [Pull Request Guidelines](http://eslint.org/docs/developer-guide/contributing/pull-requests).
 
 ## Full Documentation
 

--- a/docs/developer-guide/contributing/README.md
+++ b/docs/developer-guide/contributing/README.md
@@ -10,7 +10,7 @@ ESLint welcomes contributions from everyone and adheres to the [JS Foundation Co
 
 ## [Signing the CLA](https://contribute.jquery.org/cla)
 
-In order to submit code or documentation to an ESLint project, please electronically sign the [Contributor License Agreement](https://contribute.jquery.org/cla). The CLA is you giving us permission to use your contribution.
+In order to submit code or documentation to an ESLint project, you will need to electronically sign our [Contributor License Agreement](https://cla.js.foundation/eslint/eslint). The CLA is you giving us permission to use your contribution.
 
 ## [Bug Reporting](reporting-bugs)
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    https://github.com/eslint/eslint/issues/9133
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
I changed the CLA link from https://contribute.jquery.org/cla to https://cla.js.foundation/eslint/eslint in the following pages:

- https://github.com/eslint/eslint/blob/master/CONTRIBUTING.md
- https://github.com/eslint/eslint/blob/master/docs/developer-guide/contributing/README.md

The reason for this change is twofold:

1. To avoid confusion - https://cla.js.foundation/eslint/eslint is the actual page where ESLint contributors can sign the CLA, not https://contribute.jquery.org/cla
2. To keep them consistent with the [Pull Request Guidelines](http://eslint.org/docs/developer-guide/contributing/pull-requests) page which links to https://cla.js.foundation/eslint/eslint

**Is there anything you'd like reviewers to focus on?**
N/A

