### PR TITLE
Chore: remove undocumented defaults() method (refs #9161)

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -1096,14 +1096,6 @@ class Linter {
     }
 
     /**
-     * Gets the default eslint configuration.
-     * @returns {Object} Object mapping rule IDs to their default configurations
-     */
-    defaults() { // eslint-disable-line class-methods-use-this
-        return defaultConfig;
-    }
-
-    /**
      * Gets an object with all loaded rules.
      * @returns {Map} All loaded rules
      */

--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -908,14 +908,13 @@ describe("Linter", () => {
         }
 
         it("should pass parser as parserPath to all rules when default parser is used", () => {
-            const spy = sandbox.spy(context => {
-                assert.strictEqual(context.parserPath, "espree");
-                return {};
-            });
+            linter.defineRule("test-rule", sandbox.mock().withArgs(
+                sinon.match({ parserPath: "espree" })
+            ).returns({}));
 
-            linter.defineRule("test-rule", spy);
-            linter.verify("0", { rules: { "test-rule": 2 } });
-            assert(spy.calledOnce);
+            const config = { rules: { "test-rule": 2 } };
+
+            linter.verify("0", config, filename);
         });
 
     });

--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -908,17 +908,14 @@ describe("Linter", () => {
         }
 
         it("should pass parser as parserPath to all rules when default parser is used", () => {
+            const spy = sandbox.spy(context => {
+                assert.strictEqual(context.parserPath, "espree");
+                return {};
+            });
 
-            const DEFAULT_PARSER = linter.defaults().parser;
-
-            linter.reset();
-            linter.defineRule("test-rule", sandbox.mock().withArgs(
-                sinon.match({ parserPath: DEFAULT_PARSER })
-            ).returns({}));
-
-            const config = { rules: { "test-rule": 2 } };
-
-            linter.verify("0", config, filename);
+            linter.defineRule("test-rule", spy);
+            linter.verify("0", { rules: { "test-rule": 2 } });
+            assert(spy.calledOnce);
         });
 
     });
@@ -2386,14 +2383,6 @@ describe("Linter", () => {
             assert.throws(() => {
                 linter.verify(code, { rules: { foobar: null } });
             }, /Invalid config for rule 'foobar'\./);
-        });
-    });
-
-    describe("when calling defaults", () => {
-        it("should return back config object", () => {
-            const config = linter.defaults();
-
-            assert.isNotNull(config.rules);
         });
     });
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This removes the undocumented `defaults()` method from `Linter.prototype`. (Also see: #9161)

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
