### PR TITLE
Chore: avoid using globals in CLIEngine tests

### DIFF
--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -19,11 +19,7 @@ const assert = require("chai").assert,
     os = require("os"),
     hash = require("../../lib/util/hash");
 
-require("shelljs/global");
-
 const proxyquire = require("proxyquire").noCallThru().noPreserveCache();
-
-/* global mkdir, rm, cp */
 
 //------------------------------------------------------------------------------
 // Tests
@@ -87,8 +83,8 @@ describe("CLIEngine", () => {
     // copy into clean area so as not to get "infected" by this project's .eslintrc files
     before(() => {
         fixtureDir = path.join(os.tmpdir(), "/eslint/fixtures");
-        mkdir("-p", fixtureDir);
-        cp("-r", "./tests/fixtures/.", fixtureDir);
+        shell.mkdir("-p", fixtureDir);
+        shell.cp("-r", "./tests/fixtures/.", fixtureDir);
         fixtureDir = fs.realpathSync(fixtureDir);
     });
 
@@ -97,7 +93,7 @@ describe("CLIEngine", () => {
     });
 
     after(() => {
-        rm("-r", fixtureDir);
+        shell.rm("-r", fixtureDir);
     });
 
     describe("new CLIEngine(options)", () => {


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates the `CLIEngine` tests to avoid using globals and patching `String.prototype`, since this leaks into other tests and isn't really necessary.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular