### PR TITLE
Update: object-curly-spacing spaceInEmptyObject option (fixes #7927)

### DIFF
--- a/docs/rules/object-curly-spacing.md
+++ b/docs/rules/object-curly-spacing.md
@@ -37,6 +37,8 @@ Object option:
 * `"arraysInObjects": false` disallows spacing inside of braces of objects beginning and/or ending with an array element (applies when the first option is set to `always`)
 * `"objectsInObjects": true` requires spacing inside of braces of objects beginning and/or ending with an object element (applies when the first option is set to `never`)
 * `"objectsInObjects": false` disallows spacing inside of braces of objects beginning and/or ending with an object element (applies when the first option is set to `always`)
+* `"spaceInEmptyObject": "always"`: requires a space inside an empty object literal (`{ }` is valid, `{}` is invalid)
+* `"spaceInEmptyObject": "never"`: disallows a space inside an empty object literal (`{}` is valid, `{ }` is invalid)
 
 ### never
 
@@ -143,6 +145,64 @@ Examples of additional **correct** code for this rule with the `"always", { "obj
 /*eslint object-curly-spacing: ["error", "always", { "objectsInObjects": false }]*/
 
 var obj = { "foo": { "baz": 1, "bar": 2 }};
+```
+
+#### spaceInEmptyObject
+
+Examples of **incorrect** code for this rule with the `{ "spaceInEmptyObject": "always" }` options:
+
+```js
+/*eslint object-curly-spacing: ["error", "never", { "spaceInEmptyObject": "always" }]*/
+
+var obj = {};
+```
+
+```js
+/*eslint object-curly-spacing: ["error", "always", { "spaceInEmptyObject": "always" }]*/
+
+var obj = {};
+```
+
+Examples of **incorrect** code for this rule with the `{ "spaceInEmptyObject": "never" }` options:
+
+```js
+/*eslint object-curly-spacing: ["error", "never", { "spaceInEmptyObject": "never" }]*/
+
+var obj = { };
+```
+
+```js
+/*eslint object-curly-spacing: ["error", "always", { "spaceInEmptyObject": "never" }]*/
+
+var obj = { };
+```
+
+Examples of **correct** code for this rule with the `{ "spaceInEmptyObject": "always" }` options:
+
+```js
+/*eslint object-curly-spacing: ["error", "never", { "spaceInEmptyObject": "always" }]*/
+
+var obj = { };
+```
+
+```js
+/*eslint object-curly-spacing: ["error", "always", { "spaceInEmptyObject": "always" }]*/
+
+var obj = { };
+```
+
+Examples of **correct** code for this rule with the `{ "spaceInEmptyObject": "never" }` options:
+
+```js
+/*eslint object-curly-spacing: ["error", "never", { "spaceInEmptyObject": "never" }]*/
+
+var obj = {};
+```
+
+```js
+/*eslint object-curly-spacing: ["error", "always", { "spaceInEmptyObject": "never" }]*/
+
+var obj = {};
 ```
 
 ## When Not To Use It

--- a/lib/rules/object-curly-spacing.js
+++ b/lib/rules/object-curly-spacing.js
@@ -32,6 +32,9 @@ module.exports = {
                     },
                     objectsInObjects: {
                         type: "boolean"
+                    },
+                    spaceInEmptyObject: {
+                        enum: ["always", "never"]
                     }
                 },
                 additionalProperties: false
@@ -57,7 +60,8 @@ module.exports = {
         const options = {
             spaced,
             arraysInObjectsException: isOptionSet("arraysInObjects"),
-            objectsInObjectsException: isOptionSet("objectsInObjects")
+            objectsInObjectsException: isOptionSet("objectsInObjects"),
+            spaceInEmptyObject: context.options[1] && context.options[1].spaceInEmptyObject
         };
 
         //--------------------------------------------------------------------------
@@ -159,6 +163,7 @@ module.exports = {
          */
         function validateBraceSpacing(node, first, second, penultimate, last) {
             if (astUtils.isTokenOnSameLine(first, second)) {
+
                 const firstSpaced = sourceCode.isSpaceBetweenTokens(first, second);
 
                 if (options.spaced && !firstSpaced) {
@@ -205,9 +210,11 @@ module.exports = {
          * @returns {Token} '}' token.
          */
         function getClosingBraceOfObject(node) {
-            const lastProperty = node.properties[node.properties.length - 1];
+            const lastNodeWithinObject = (node.properties.length === 0)
+                ? sourceCode.getFirstToken(node)
+                : node.properties[node.properties.length - 1];
 
-            return sourceCode.getTokenAfter(lastProperty, astUtils.isClosingBraceToken);
+            return sourceCode.getTokenAfter(lastNodeWithinObject, astUtils.isClosingBraceToken);
         }
 
         /**
@@ -216,14 +223,24 @@ module.exports = {
          * @returns {void}
          */
         function checkForObject(node) {
-            if (node.properties.length === 0) {
-                return;
-            }
-
             const first = sourceCode.getFirstToken(node),
                 last = getClosingBraceOfObject(node),
                 second = sourceCode.getTokenAfter(first),
                 penultimate = sourceCode.getTokenBefore(last);
+
+
+            if (node.properties.length === 0) {
+                const hasSpace = sourceCode.isSpaceBetweenTokens(first, last);
+                const hasComment = context.getSourceCode().getCommentsInside(node).length > 0;
+
+                if (options.spaceInEmptyObject === "never" && hasSpace && !hasComment) {
+                    reportNoBeginningSpace(node, first);
+                }
+                if (options.spaceInEmptyObject === "always" && !hasSpace && !hasComment) {
+                    reportRequiredBeginningSpace(node, first);
+                }
+                return;
+            }
 
             validateBraceSpacing(node, first, second, penultimate, last);
         }

--- a/tests/lib/rules/object-curly-spacing.js
+++ b/tests/lib/rules/object-curly-spacing.js
@@ -58,6 +58,13 @@ ruleTester.run("object-curly-spacing", rule, {
 
         // always - empty object
         { code: "var foo = {};", options: ["always"] },
+        { code: "var foo = { };", options: ["always"] },
+        { code: "var foo = {};", options: ["always", { spaceInEmptyObject: "never" }] },
+        { code: "var foo = { };", options: ["always", { spaceInEmptyObject: "always" }] },
+        { code: "var foo = {/* there is no space but there is a comment */};", options: ["always", { spaceInEmptyObject: "always" }] },
+        { code: "var foo = { /* comments surrounded by spaces */ };", options: ["always", { spaceInEmptyObject: "always" }] },
+        { code: "var foo = {\n};", options: ["always", { spaceInEmptyObject: "always" }] },
+        { code: "var foo = {  \r\n \t };", options: ["always", { spaceInEmptyObject: "always" }] },
 
         // always - objectsInObjects
         { code: "var obj = { 'foo': { 'bar': 1, 'baz': 2 }};", options: ["always", { objectsInObjects: false }] },
@@ -120,6 +127,13 @@ ruleTester.run("object-curly-spacing", rule, {
 
         // never - empty object
         { code: "var foo = {};", options: ["never"] },
+        { code: "var foo = { };", options: ["never"] },
+        { code: "var foo = {};", options: ["never", { spaceInEmptyObject: "never" }] },
+        { code: "var foo = { };", options: ["never", { spaceInEmptyObject: "always" }] },
+        { code: "var foo = {/* there is no space but there is a comment */};", options: ["never", { spaceInEmptyObject: "never" }] },
+        { code: "var foo = { /* comment surrounded by spaces */ };", options: ["never", { spaceInEmptyObject: "never" }] },
+        { code: "var foo = {\n};", options: ["never", { spaceInEmptyObject: "always" }] },
+        { code: "var foo = { \r\n \t };", options: ["never", { spaceInEmptyObject: "always" }] },
 
         // never - objectsInObjects
         { code: "var obj = {'foo': {'bar': 1, 'baz': 2} };", options: ["never", { objectsInObjects: true }] },
@@ -775,6 +789,43 @@ ruleTester.run("object-curly-spacing", rule, {
                 }
             ],
             parser: resolvePath(__dirname, "../../fixtures/parsers/object-curly-spacing/flow-stub-parser-never-invalid")
+        },
+
+        // spaceInEmptyObject: "never"
+        {
+            code: "var foo = { };",
+            output: "var foo = {};",
+            options: ["never", { spaceInEmptyObject: "never" }],
+            errors: [
+                {
+                    message: "There should be no space after '{'.",
+                    type: "ObjectExpression"
+                }
+            ]
+        },
+        {
+            code: "var foo = {\n};",
+            output: "var foo = {};",
+            options: ["always", { spaceInEmptyObject: "never" }],
+            errors: [
+                {
+                    message: "There should be no space after '{'.",
+                    type: "ObjectExpression"
+                }
+            ]
+        },
+
+        // spaceInEmptyObject: "always"
+        {
+            code: "var foo = {};",
+            output: "var foo = { };",
+            options: ["never", { spaceInEmptyObject: "always" }],
+            errors: [
+                {
+                    message: "A space is required after '{'.",
+                    type: "ObjectExpression"
+                }
+            ]
         }
     ]
 });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

https://github.com/eslint/eslint/issues/7927

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Added a new option, "spaceInEmptyObject". It can be "never" or "always". The default is to ignore empty objects, as the rule does now. 


**Is there anything you'd like reviewers to focus on?**

No. 
