### PR TITLE
Chore: use consistent names for apply-disable-directives in tests

### DIFF
--- a/tests/lib/util/apply-disable-directives.js
+++ b/tests/lib/util/apply-disable-directives.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Tests for filter-by-disable-comments
+ * @fileoverview Tests for apply-disable-directives
  * @author Teddy Katz
  */
 
@@ -8,7 +8,7 @@
 const assert = require("chai").assert;
 const applyDisableDirectives = require("../../../lib/util/apply-disable-directives");
 
-describe("comment-reporting-config", () => {
+describe("apply-disable-directives", () => {
     describe("/* eslint-disable */ comments without rules", () => {
         it("keeps problems before the comment on the same line", () => {
             assert.deepEqual(


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates the test file for `apply-disable-directives` to always use the correct name.

When working on this locally, I went through a few different names for the module before settling on `apply-disable-directives`. However, there were a few places I forgot to update with the latest name.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular