### PR TITLE
Fix: Formatters keep trailing '.' if preceded by a space (fixes #9154)

### DIFF
--- a/lib/formatters/codeframe.js
+++ b/lib/formatters/codeframe.js
@@ -47,7 +47,7 @@ function formatFilePath(filePath, line, column) {
  */
 function formatMessage(message, parentResult) {
     const type = (message.fatal || message.severity === 2) ? chalk.red("error") : chalk.yellow("warning");
-    const msg = `${chalk.bold(message.message.replace(/\.$/, ""))}`;
+    const msg = message.message.search(/ \.$/) >= 0 ? `${chalk.bold(message.message)}` : `${chalk.bold(message.message.replace(/\.$/, ""))}`;
     const ruleId = message.fatal ? "" : chalk.dim(`(${message.ruleId})`);
     const filePath = formatFilePath(parentResult.filePath, message.line, message.column);
     const sourceCode = parentResult.output ? parentResult.output : parentResult.source;

--- a/lib/formatters/codeframe.js
+++ b/lib/formatters/codeframe.js
@@ -47,7 +47,7 @@ function formatFilePath(filePath, line, column) {
  */
 function formatMessage(message, parentResult) {
     const type = (message.fatal || message.severity === 2) ? chalk.red("error") : chalk.yellow("warning");
-    const msg = message.message.search(/ \.$/) >= 0 ? `${chalk.bold(message.message)}` : `${chalk.bold(message.message.replace(/\.$/, ""))}`;
+    const msg = `${chalk.bold(message.message.replace(/([^ ])\.$/, "$1"))}`;
     const ruleId = message.fatal ? "" : chalk.dim(`(${message.ruleId})`);
     const filePath = formatFilePath(parentResult.filePath, message.line, message.column);
     const sourceCode = parentResult.output ? parentResult.output : parentResult.source;

--- a/lib/formatters/stylish.js
+++ b/lib/formatters/stylish.js
@@ -65,7 +65,7 @@ module.exports = function(results) {
                     message.line || 0,
                     message.column || 0,
                     messageType,
-                    message.message.replace(/\.$/, ""),
+                    message.message.search(/ \.$/) >= 0 ? message.message : message.message.replace(/\.$/, ""),
                     chalk.dim(message.ruleId || "")
                 ];
             }),

--- a/lib/formatters/stylish.js
+++ b/lib/formatters/stylish.js
@@ -65,7 +65,7 @@ module.exports = function(results) {
                     message.line || 0,
                     message.column || 0,
                     messageType,
-                    message.message.search(/ \.$/) >= 0 ? message.message : message.message.replace(/\.$/, ""),
+                    message.message.replace(/([^ ])\.$/, "$1"),
                     chalk.dim(message.ruleId || "")
                 ];
             }),

--- a/tests/lib/formatters/codeframe.js
+++ b/tests/lib/formatters/codeframe.js
@@ -170,6 +170,26 @@ describe("formatter:codeframe", () => {
         });
     });
 
+    describe("when passed a message that ends with ' .'", () => {
+        const code = [{
+            filePath: "foo.js",
+            messages: [{
+                ruleId: "foo",
+                message: "Unexpected .",
+                severity: 2,
+                source: "foo"
+            }],
+            errorCount: 1,
+            warningCount: 0
+        }];
+
+        it("should return a string in the correct format (retaining the ' .')", () => {
+            const result = formatter(code);
+
+            assert.equal(stripAnsi(result), "error: Unexpected . (foo) at foo.js\n\n\n1 error found.");
+        });
+    });
+
     describe("when passed multiple messages", () => {
         const code = [{
             filePath: "foo.js",

--- a/tests/lib/formatters/stylish.js
+++ b/tests/lib/formatters/stylish.js
@@ -152,6 +152,31 @@ describe("formatter:stylish", () => {
         });
     });
 
+    describe("when passed a message that ends with ' .'", () => {
+        const code = [{
+            filePath: "foo.js",
+            errorCount: 0,
+            warningCount: 1,
+            fixableErrorCount: 0,
+            fixableWarningCount: 0,
+            messages: [{
+                message: "Unexpected .",
+                severity: 1,
+                line: 5,
+                column: 10,
+                ruleId: "foo"
+            }]
+        }];
+
+        it("should return a string in the correct format (retaining the ' .')", () => {
+            const result = formatter(code);
+
+            assert.equal(result, "\nfoo.js\n  5:10  warning  Unexpected .  foo\n\n\u2716 1 problem (0 errors, 1 warning)\n");
+            assert.equal(chalkStub.yellow.bold.callCount, 1);
+            assert.equal(chalkStub.red.bold.callCount, 0);
+        });
+    });
+
     describe("when passed a fatal error message", () => {
         const code = [{
             filePath: "foo.js",


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    https://github.com/eslint/eslint/issues/9154
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
For codeframe.js and stylish.js, I checked if the reported messages end with a " ." - if they do, the " ." is kept in the output. For "."s that aren't preceded by a space, the "." is removed in the output (how all "."s were handled by codeframe.js and stylish.js originally). I also added tests for the new behaviour.

**Is there anything you'd like reviewers to focus on?**
N/A

