### PR TITLE
New: add option to report unused eslint-disable directives (fixes #9249)

### DIFF
--- a/conf/default-cli-options.js
+++ b/conf/default-cli-options.js
@@ -23,5 +23,6 @@ module.exports = {
     cacheLocation: "",
     cacheFile: ".eslintcache",
     fix: false,
-    allowInlineConfig: true
+    allowInlineConfig: true,
+    reportUnusedDisableDirectives: false
 };

--- a/docs/developer-guide/nodejs-api.md
+++ b/docs/developer-guide/nodejs-api.md
@@ -70,6 +70,7 @@ The most important method on `Linter` is `verify()`, which initiates linting of 
     * `preprocess` - (optional) A function that accepts a string containing source text, and returns an array of strings containing blocks of code to lint. Also see: [Processors in Plugins](/docs/developer-guide/working-with-plugins#processors-in-plugins)
     * `postprocess` - (optional) A function that accepts an array of problem lists (one list of problems for each block of code from `preprocess`), and returns a one-dimensional array of problems containing problems for the original, unprocessed text. Also see: [Processors in Plugins](/docs/developer-guide/working-with-plugins#processors-in-plugins)
     * `allowInlineConfig` - (optional) set to `false` to disable inline comments from changing eslint rules.
+    * `reportUnusedDisableDirectives` - (optional) when set to `true`, adds reported errors for unused `eslint-disable` directives when no problems would be reported in the disabled area anyway.
 
 If the third argument is a string, it is interpreted as the `filename`.
 
@@ -297,6 +298,7 @@ The `CLIEngine` is a constructor, and you can create a new instance by passing i
 * `parser` - Specify the parser to be used (default: `espree`). Corresponds to `--parser`.
 * `parserOptions` - An object containing parser options (default: empty object). Corresponds to `--parser-options`.
 * `plugins` - An array of plugins to load (default: empty array). Corresponds to `--plugin`.
+* `reportUnusedDisableDirectives` - When set to `true`, adds reported errors for unused `eslint-disable` directives when no problems would be reported in the disabled area anyway (default: false). Corresponds to `--report-unused-disable-directives`.
 * `rulePaths` - An array of directories to load custom rules from (default: empty array). Corresponds to `--rulesdir`.
 * `rules` - An object of rules to use (default: null). Corresponds to `--rule`.
 * `useEslintrc` - Set to false to disable use of `.eslintrc` files (default: true). Corresponds to `--no-eslintrc`.

--- a/docs/user-guide/command-line-interface.md
+++ b/docs/user-guide/command-line-interface.md
@@ -30,50 +30,51 @@ The command line utility has several options. You can view the options by runnin
 eslint [options] file.js [file.js] [dir]
 
 Basic configuration:
-  -c, --config path::String    Use configuration from this file or shareable config
-  --no-eslintrc                Disable use of configuration from .eslintrc
-  --env [String]               Specify environments
-  --ext [String]               Specify JavaScript file extensions - default: .js
-  --global [String]            Define global variables
-  --parser String              Specify the parser to be used
-  --parser-options Object      Specify parser options
+  -c, --config path::String      Use configuration from this file or shareable config
+  --no-eslintrc                  Disable use of configuration from .eslintrc
+  --env [String]                 Specify environments
+  --ext [String]                 Specify JavaScript file extensions - default: .js
+  --global [String]              Define global variables
+  --parser String                Specify the parser to be used
+  --parser-options Object        Specify parser options
 
 Caching:
-  --cache                      Only check changed files - default: false
-  --cache-file path::String    Path to the cache file. Deprecated: use --cache-location - default: .eslintcache
+  --cache                        Only check changed files - default: false
+  --cache-file path::String      Path to the cache file. Deprecated: use --cache-location - default: .eslintcache
   --cache-location path::String  Path to the cache file or directory
 
 Specifying rules and plugins:
-  --rulesdir [path::String]    Use additional rules from this directory
-  --plugin [String]            Specify plugins
-  --rule Object                Specify rules
+  --rulesdir [path::String]      Use additional rules from this directory
+  --plugin [String]              Specify plugins
+  --rule Object                  Specify rules
 
 Ignoring files:
-  --ignore-path path::String   Specify path of ignore file
-  --no-ignore                  Disable use of ignore files and patterns
-  --ignore-pattern [String]    Pattern of files to ignore (in addition to those in .eslintignore)
+  --ignore-path path::String     Specify path of ignore file
+  --no-ignore                    Disable use of ignore files and patterns
+  --ignore-pattern [String]      Pattern of files to ignore (in addition to those in .eslintignore)
 
 Using stdin:
-  --stdin                      Lint code provided on <STDIN> - default: false
-  --stdin-filename String      Specify filename to process STDIN as
+  --stdin                        Lint code provided on <STDIN> - default: false
+  --stdin-filename String        Specify filename to process STDIN as
 
 Handling warnings:
-  --quiet                      Report errors only - default: false
-  --max-warnings Int           Number of warnings to trigger nonzero exit code - default: -1
+  --quiet                        Report errors only - default: false
+  --max-warnings Int             Number of warnings to trigger nonzero exit code - default: -1
 
 Output:
   -o, --output-file path::String  Specify file to write report to
-  -f, --format String          Use a specific output format - default: stylish
-  --color, --no-color          Force enabling/disabling of color
+  -f, --format String            Use a specific output format - default: stylish
+  --color, --no-color            Force enabling/disabling of color
 
 Miscellaneous:
-  --init                       Run config initialization wizard - default: false
-  --fix                        Automatically fix problems
-  --debug                      Output debugging information
-  -h, --help                   Show help
-  -v, --version                Output the version number
-  --no-inline-config           Prevent comments from changing config or rules
-  --print-config path::String  Print the configuration for the given file
+  --init                         Run config initialization wizard - default: false
+  --fix                          Automatically fix problems
+  --debug                        Output debugging information
+  -h, --help                     Show help
+  -v, --version                  Output the version number
+  --no-inline-config             Prevent comments from changing config or rules
+  --report-unused-disable-directives  Adds reported errors for unused eslint-disable directives
+  --print-config path::String    Print the configuration for the given file
 ```
 
 Options that accept array values can be specified by repeating the option or with a comma-delimited list (other than `--ignore-pattern` which does not allow the second style).
@@ -390,6 +391,16 @@ config without files modifying it. All inline config comments are ignored, e.g.:
 Example:
 
     eslint --no-inline-config file.js
+
+#### `--report-unused-disable-directives`
+
+This option causes ESLint to report directive comments like `// eslint-disable-line` when no errors would have been reported on that line anyway. This can be useful to prevent future errors from unexpectedly being suppressed, by cleaning up old `eslint-disable` comments which are no longer applicable.
+
+**Warning**: When using this option, it is possible that new errors will start being reported whenever ESLint or custom rules are upgraded. For example, suppose a rule has a bug that causes it to report a false positive, and an `eslint-disable` comment is added to suppress the incorrect report. If the bug is then fixed in a patch release of ESLint, the `eslint-disable` comment will become unused since ESLint is no longer generating an incorrect report. This will result in a new reported error for the unused directive if the `report-unused-disable-directives` option is used.
+
+Example:
+
+    eslint --report-unused-disable-directives file.js
 
 #### `--print-config`
 

--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -56,6 +56,7 @@ const debug = require("debug")("eslint:cli-engine");
  * @property {string[]} plugins An array of plugins to load.
  * @property {Object<string,*>} rules An object of rules to use.
  * @property {string[]} rulePaths An array of directories to load custom rules from.
+ * @property {boolean} reportUnusedDisableDirectives `true` adds reports for unused eslint-disable directives
  */
 
 /**
@@ -137,11 +138,12 @@ function calculateStatsPerRun(results) {
  * @param {string} filename An optional string representing the texts filename.
  * @param {boolean|Function} fix Indicates if fixes should be processed.
  * @param {boolean} allowInlineConfig Allow/ignore comments that change config.
+ * @param {boolean} reportUnusedDisableDirectives Allow/ignore comments that change config.
  * @param {Linter} linter Linter context
  * @returns {LintResult} The results for linting on this text.
  * @private
  */
-function processText(text, configHelper, filename, fix, allowInlineConfig, linter) {
+function processText(text, configHelper, filename, fix, allowInlineConfig, reportUnusedDisableDirectives, linter) {
     let filePath,
         fileExtension,
         processor;
@@ -173,6 +175,7 @@ function processText(text, configHelper, filename, fix, allowInlineConfig, linte
     const fixedResult = linter.verifyAndFix(text, config, {
         filename,
         allowInlineConfig,
+        reportUnusedDisableDirectives,
         fix: !!autofixingEnabled && fix,
         preprocess: processor && (rawText => processor.preprocess(rawText, filename)),
         postprocess: processor && (problemLists => processor.postprocess(problemLists, filename))
@@ -213,7 +216,15 @@ function processText(text, configHelper, filename, fix, allowInlineConfig, linte
 function processFile(filename, configHelper, options, linter) {
 
     const text = fs.readFileSync(path.resolve(filename), "utf8"),
-        result = processText(text, configHelper, filename, options.fix, options.allowInlineConfig, linter);
+        result = processText(
+            text,
+            configHelper,
+            filename,
+            options.fix,
+            options.allowInlineConfig,
+            options.reportUnusedDisableDirectives,
+            linter
+        );
 
     return result;
 
@@ -591,7 +602,17 @@ class CLIEngine {
                 results.push(createIgnoreResult(filename, options.cwd));
             }
         } else {
-            results.push(processText(text, configHelper, filename, options.fix, options.allowInlineConfig, this.linter));
+            results.push(
+                processText(
+                    text,
+                    configHelper,
+                    filename,
+                    options.fix,
+                    options.allowInlineConfig,
+                    options.reportUnusedDisableDirectives,
+                    this.linter
+                )
+            );
         }
 
         const stats = calculateStatsPerRun(results);

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -64,7 +64,8 @@ function translateOptions(cliOptions) {
         cacheFile: cliOptions.cacheFile,
         cacheLocation: cliOptions.cacheLocation,
         fix: cliOptions.fix && (cliOptions.quiet ? quietFixPredicate : true),
-        allowInlineConfig: cliOptions.inlineConfig
+        allowInlineConfig: cliOptions.inlineConfig,
+        reportUnusedDisableDirectives: cliOptions.reportUnusedDisableDirectives
     };
 }
 

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -734,20 +734,24 @@ module.exports = class Linter {
      * @param {(string|Object)} [filenameOrOptions] The optional filename of the file being checked.
      *      If this is not set, the filename will default to '<input>' in the rule context. If
      *      an object, then it has "filename", "saveState", and "allowInlineConfig" properties.
-     * @param {boolean} [filenameOrOptions.allowInlineConfig] Allow/disallow inline comments' ability to change config once it is set. Defaults to true if not supplied.
+     * @param {boolean} [filenameOrOptions.allowInlineConfig=true] Allow/disallow inline comments' ability to change config once it is set. Defaults to true if not supplied.
      *      Useful if you want to validate JS without comments overriding rules.
+     * @param {boolean} [filenameOrOptions.reportUnusedDisableDirectives=false] Adds reported errors for unused
+     *      eslint-disable directives
      * @returns {Object[]} The results as an array of messages or null if no messages.
      */
     _verifyWithoutProcessors(textOrSourceCode, config, filenameOrOptions) {
         let text,
             parserServices,
             allowInlineConfig,
-            providedFilename;
+            providedFilename,
+            reportUnusedDisableDirectives;
 
         // evaluate arguments
         if (typeof filenameOrOptions === "object") {
             providedFilename = filenameOrOptions.filename;
             allowInlineConfig = filenameOrOptions.allowInlineConfig;
+            reportUnusedDisableDirectives = filenameOrOptions.reportUnusedDisableDirectives;
         } else {
             providedFilename = filenameOrOptions;
         }
@@ -968,7 +972,8 @@ module.exports = class Linter {
 
         return applyDisableDirectives({
             directives: disableDirectives,
-            problems: problems.sort((problemA, problemB) => problemA.line - problemB.line || problemA.column - problemB.column)
+            problems: problems.sort((problemA, problemB) => problemA.line - problemB.line || problemA.column - problemB.column),
+            reportUnusedDisableDirectives
         });
     }
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -215,6 +215,12 @@ module.exports = optionator({
             description: "Prevent comments from changing config or rules"
         },
         {
+            option: "report-unused-disable-directives",
+            type: "Boolean",
+            default: false,
+            description: "Adds reported errors for unused eslint-disable directives"
+        },
+        {
             option: "print-config",
             type: "path::String",
             description: "Print the configuration for the given file"

--- a/lib/util/apply-disable-directives.js
+++ b/lib/util/apply-disable-directives.js
@@ -19,20 +19,24 @@ function compareLocations(itemA, itemB) {
 }
 
 /**
- * This is the same as the exported function, except that it doesn't handle disable-line and disable-next-line directives.
- * @param {Object} options options (see the exported function)
- * @returns {Problem[]} Filtered problems (see the exported function)
+ * This is the same as the exported function, except that it
+ * doesn't handle disable-line and disable-next-line directives, and it always reports unused
+ * disable directives.
+ * @param {Object} options options for applying directives. This is the same as the options
+ * for the exported function, except that `reportUnusedDisableDirectives` is not supported
+ * (this function always reports unused disable directives).
+ * @returns {{problems: Problem[], unusedDisableDirectives: Problem[]}} An object with a list
+ * of filtered problems and unused eslint-disable directives
  */
 function applyDirectives(options) {
     const problems = [];
     let nextDirectiveIndex = 0;
-    let globalDisableActive = false;
+    let currentGlobalDisableDirective = null;
+    const disabledRuleMap = new Map();
 
-    // disabledRules is only used when there is no active global /* eslint-disable */ comment.
-    const disabledRules = new Set();
-
-    // enabledRules is only used when there is an active global /* eslint-disable */ comment.
+    // enabledRules is only used when there is a current global disable directive.
     const enabledRules = new Set();
+    const usedDisableDirectives = new Set();
 
     for (const problem of options.problems) {
         while (
@@ -44,23 +48,26 @@ function applyDirectives(options) {
             switch (directive.type) {
                 case "disable":
                     if (directive.ruleId === null) {
-                        globalDisableActive = true;
+                        currentGlobalDisableDirective = directive;
+                        disabledRuleMap.clear();
                         enabledRules.clear();
-                    } else if (globalDisableActive) {
+                    } else if (currentGlobalDisableDirective) {
                         enabledRules.delete(directive.ruleId);
+                        disabledRuleMap.set(directive.ruleId, directive);
                     } else {
-                        disabledRules.add(directive.ruleId);
+                        disabledRuleMap.set(directive.ruleId, directive);
                     }
                     break;
 
                 case "enable":
                     if (directive.ruleId === null) {
-                        globalDisableActive = false;
-                        disabledRules.clear();
-                    } else if (globalDisableActive) {
+                        currentGlobalDisableDirective = null;
+                        disabledRuleMap.clear();
+                    } else if (currentGlobalDisableDirective) {
                         enabledRules.add(directive.ruleId);
+                        disabledRuleMap.delete(directive.ruleId);
                     } else {
-                        disabledRules.delete(directive.ruleId);
+                        disabledRuleMap.delete(directive.ruleId);
                     }
                     break;
 
@@ -68,15 +75,30 @@ function applyDirectives(options) {
             }
         }
 
-        if (
-            globalDisableActive && enabledRules.has(problem.ruleId) ||
-            !globalDisableActive && !disabledRules.has(problem.ruleId)
-        ) {
+        if (disabledRuleMap.has(problem.ruleId)) {
+            usedDisableDirectives.add(disabledRuleMap.get(problem.ruleId));
+        } else if (currentGlobalDisableDirective && !enabledRules.has(problem.ruleId)) {
+            usedDisableDirectives.add(currentGlobalDisableDirective);
+        } else {
             problems.push(problem);
         }
     }
 
-    return problems;
+    const unusedDisableDirectives = options.directives
+        .filter(directive => directive.type === "disable" && !usedDisableDirectives.has(directive))
+        .map(directive => ({
+            ruleId: null,
+            message: directive.ruleId
+                ? `Unused eslint-disable directive (no problems were reported from '${directive.ruleId}').`
+                : "Unused eslint-disable directive (no problems were reported).",
+            line: directive.unprocessedDirective.line,
+            column: directive.unprocessedDirective.column,
+            severity: 2,
+            source: null,
+            nodeType: null
+        }));
+
+    return { problems, unusedDisableDirectives };
 }
 
 /**
@@ -93,12 +115,14 @@ function applyDirectives(options) {
  * comment for two different rules is represented as two directives).
  * @param {{ruleId: (string|null), line: number, column: number}[]} options.problems
  * A list of problems reported by rules, sorted by increasing location in the file, with one-based columns.
+ * @param {boolean} options.reportUnusedDisableDirectives If `true`, adds additional problems for unused directives
  * @returns {{ruleId: (string|null), line: number, column: number}[]}
  * A list of reported problems that were not disabled by the directive comments.
  */
 module.exports = options => {
     const blockDirectives = options.directives
         .filter(directive => directive.type === "disable" || directive.type === "enable")
+        .map(directive => Object.assign({}, directive, { unprocessedDirective: directive }))
         .sort(compareLocations);
 
     const lineDirectives = lodash.flatMap(options.directives, directive => {
@@ -109,14 +133,14 @@ module.exports = options => {
 
             case "disable-line":
                 return [
-                    { type: "disable", line: directive.line, column: 1, ruleId: directive.ruleId },
-                    { type: "enable", line: directive.line + 1, column: 0, ruleId: directive.ruleId }
+                    { type: "disable", line: directive.line, column: 1, ruleId: directive.ruleId, unprocessedDirective: directive },
+                    { type: "enable", line: directive.line + 1, column: 0, ruleId: directive.ruleId, unprocessedDirective: directive }
                 ];
 
             case "disable-next-line":
                 return [
-                    { type: "disable", line: directive.line + 1, column: 1, ruleId: directive.ruleId },
-                    { type: "enable", line: directive.line + 2, column: 0, ruleId: directive.ruleId }
+                    { type: "disable", line: directive.line + 1, column: 1, ruleId: directive.ruleId, unprocessedDirective: directive },
+                    { type: "enable", line: directive.line + 2, column: 0, ruleId: directive.ruleId, unprocessedDirective: directive }
                 ];
 
             default:
@@ -124,8 +148,13 @@ module.exports = options => {
         }
     }).sort(compareLocations);
 
-    const problemsAfterBlockDirectives = applyDirectives({ problems: options.problems, directives: blockDirectives });
-    const problemsAfterLineDirectives = applyDirectives({ problems: problemsAfterBlockDirectives, directives: lineDirectives });
+    const blockDirectivesResult = applyDirectives({ problems: options.problems, directives: blockDirectives });
+    const lineDirectivesResult = applyDirectives({ problems: blockDirectivesResult.problems, directives: lineDirectives });
 
-    return problemsAfterLineDirectives.sort(compareLocations);
+    return options.reportUnusedDisableDirectives
+        ? lineDirectivesResult.problems
+            .concat(blockDirectivesResult.unusedDisableDirectives)
+            .concat(lineDirectivesResult.unusedDisableDirectives)
+            .sort(compareLocations)
+        : lineDirectivesResult.problems;
 };

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -2971,6 +2971,43 @@ describe("CLIEngine", () => {
 
     });
 
+    describe("when evaluating code when reportUnusedDisableDirectives is enabled", () => {
+        it("should report problems for unused eslint-disable directives", () => {
+            const cliEngine = new CLIEngine({ useEslintrc: false, reportUnusedDisableDirectives: true });
+
+            assert.deepEqual(
+                cliEngine.executeOnText("/* eslint-disable */"),
+                {
+                    results: [
+                        {
+                            filePath: "<text>",
+                            messages: [
+                                {
+                                    ruleId: null,
+                                    message: "Unused eslint-disable directive (no problems were reported).",
+                                    line: 1,
+                                    column: 1,
+                                    severity: 2,
+                                    source: null,
+                                    nodeType: null
+                                }
+                            ],
+                            errorCount: 1,
+                            warningCount: 0,
+                            fixableErrorCount: 0,
+                            fixableWarningCount: 0,
+                            source: "/* eslint-disable */"
+                        }
+                    ],
+                    errorCount: 1,
+                    warningCount: 0,
+                    fixableErrorCount: 0,
+                    fixableWarningCount: 0
+                }
+            );
+        });
+    });
+
     describe("when retreiving version number", () => {
         it("should return current version number", () => {
             const eslintCLI = require("../../lib/cli-engine");

--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -2831,6 +2831,25 @@ describe("Linter", () => {
         });
     });
 
+    describe("reportUnusedDisable option", () => {
+        it("reports problems for unused eslint-disable comments", () => {
+            assert.deepEqual(
+                linter.verify("/* eslint-disable */", {}, { reportUnusedDisableDirectives: true }),
+                [
+                    {
+                        ruleId: null,
+                        message: "Unused eslint-disable directive (no problems were reported).",
+                        line: 1,
+                        column: 1,
+                        severity: 2,
+                        source: null,
+                        nodeType: null
+                    }
+                ]
+            );
+        });
+    });
+
     describe("when evaluating code with comments to change config when allowInlineConfig is disabled", () => {
         it("should not report a violation", () => {
             const code = [

--- a/tests/lib/util/apply-disable-directives.js
+++ b/tests/lib/util/apply-disable-directives.js
@@ -424,4 +424,484 @@ describe("apply-disable-directives", () => {
             );
         });
     });
+
+    describe("unused directives", () => {
+        it("Adds a problem for /* eslint-disable */", () => {
+            assert.deepEqual(
+                applyDisableDirectives({
+                    directives: [{ type: "disable", line: 1, column: 5 }],
+                    problems: [],
+                    reportUnusedDisableDirectives: true
+                }),
+                [
+                    {
+                        ruleId: null,
+                        message: "Unused eslint-disable directive (no problems were reported).",
+                        line: 1,
+                        column: 5,
+                        severity: 2,
+                        source: null,
+                        nodeType: null
+                    }
+                ]
+            );
+        });
+
+        it("Does not add a problem for /* eslint-disable */ /* (problem) */", () => {
+            assert.deepEqual(
+                applyDisableDirectives({
+                    directives: [{ type: "disable", line: 1, column: 5, ruleId: null }],
+                    problems: [{ line: 2, column: 1, ruleId: "foo" }],
+                    reportUnusedDisableDirectives: true
+                }),
+                []
+            );
+        });
+
+        it("Adds a problem for /* eslint-disable foo */", () => {
+            assert.deepEqual(
+                applyDisableDirectives({
+                    directives: [{ type: "disable", line: 1, column: 5, ruleId: "foo" }],
+                    problems: [],
+                    reportUnusedDisableDirectives: true
+                }),
+                [
+                    {
+                        ruleId: null,
+                        message: "Unused eslint-disable directive (no problems were reported from 'foo').",
+                        line: 1,
+                        column: 5,
+                        severity: 2,
+                        source: null,
+                        nodeType: null
+                    }
+                ]
+            );
+        });
+
+        it("Adds a problem for /* eslint-disable foo */ /* (problem from another rule) */", () => {
+            assert.deepEqual(
+                applyDisableDirectives({
+                    directives: [{ type: "disable", line: 1, column: 5, ruleId: "foo" }],
+                    problems: [{ line: 1, column: 20, ruleId: "not-foo" }],
+                    reportUnusedDisableDirectives: true
+                }),
+                [
+                    {
+                        ruleId: null,
+                        message: "Unused eslint-disable directive (no problems were reported from 'foo').",
+                        line: 1,
+                        column: 5,
+                        severity: 2,
+                        source: null,
+                        nodeType: null
+                    },
+                    {
+                        ruleId: "not-foo",
+                        line: 1,
+                        column: 20
+                    }
+                ]
+            );
+        });
+
+        it("Adds a problem for /* (problem from foo) */ /* eslint-disable */ /* eslint-enable foo */", () => {
+            assert.deepEqual(
+                applyDisableDirectives({
+                    directives: [
+                        { type: "disable", line: 1, column: 5, ruleId: null },
+                        { type: "enable", line: 1, column: 6, ruleId: "foo" }
+                    ],
+                    problems: [{ line: 1, column: 2, ruleId: "foo" }],
+                    reportUnusedDisableDirectives: true
+                }),
+                [
+                    {
+                        ruleId: "foo",
+                        line: 1,
+                        column: 2
+                    },
+                    {
+                        ruleId: null,
+                        message: "Unused eslint-disable directive (no problems were reported).",
+                        line: 1,
+                        column: 5,
+                        severity: 2,
+                        source: null,
+                        nodeType: null
+                    }
+                ]
+            );
+        });
+
+        it("Adds a problem for /* eslint-disable */ /* eslint-enable */", () => {
+            assert.deepEqual(
+                applyDisableDirectives({
+                    directives: [
+                        { type: "disable", line: 1, column: 5, ruleId: null },
+                        { type: "enable", line: 1, column: 6, ruleId: null }
+                    ],
+                    problems: [],
+                    reportUnusedDisableDirectives: true
+                }),
+                [
+                    {
+                        ruleId: null,
+                        message: "Unused eslint-disable directive (no problems were reported).",
+                        line: 1,
+                        column: 5,
+                        severity: 2,
+                        source: null,
+                        nodeType: null
+                    }
+                ]
+            );
+        });
+
+        it("Adds two problems for /* eslint-disable */ /* eslint-disable */", () => {
+            assert.deepEqual(
+                applyDisableDirectives({
+                    directives: [
+                        { type: "disable", line: 1, column: 1, ruleId: null },
+                        { type: "disable", line: 2, column: 1, ruleId: null }
+                    ],
+                    problems: [],
+                    reportUnusedDisableDirectives: true
+                }),
+                [
+                    {
+                        ruleId: null,
+                        message: "Unused eslint-disable directive (no problems were reported).",
+                        line: 1,
+                        column: 1,
+                        severity: 2,
+                        source: null,
+                        nodeType: null
+                    },
+                    {
+                        ruleId: null,
+                        message: "Unused eslint-disable directive (no problems were reported).",
+                        line: 2,
+                        column: 1,
+                        severity: 2,
+                        source: null,
+                        nodeType: null
+                    }
+                ]
+            );
+        });
+
+        it("Adds a problem for /* eslint-disable */ /* eslint-disable */ /* (problem) */", () => {
+            assert.deepEqual(
+                applyDisableDirectives({
+                    directives: [
+                        { type: "disable", line: 1, column: 1, ruleId: null },
+                        { type: "disable", line: 2, column: 1, ruleId: null }
+                    ],
+                    problems: [{ line: 3, column: 1, ruleId: "foo" }],
+                    reportUnusedDisableDirectives: true
+                }),
+                [
+                    {
+                        ruleId: null,
+                        message: "Unused eslint-disable directive (no problems were reported).",
+                        line: 1,
+                        column: 1,
+                        severity: 2,
+                        source: null,
+                        nodeType: null
+                    }
+                ]
+            );
+        });
+
+        it("Adds a problem for /* eslint-disable foo */ /* eslint-disable */ /* (problem from foo) */", () => {
+            assert.deepEqual(
+                applyDisableDirectives({
+                    directives: [
+                        { type: "disable", line: 1, column: 1, ruleId: "foo" },
+                        { type: "disable", line: 2, column: 1, ruleId: null }
+                    ],
+                    problems: [{ line: 3, column: 1, ruleId: "foo" }],
+                    reportUnusedDisableDirectives: true
+                }),
+                [
+                    {
+                        ruleId: null,
+                        message: "Unused eslint-disable directive (no problems were reported from 'foo').",
+                        line: 1,
+                        column: 1,
+                        severity: 2,
+                        source: null,
+                        nodeType: null
+                    }
+                ]
+            );
+        });
+
+        it("Does not add a problem for /* eslint-disable foo */ /* (problem from foo) */", () => {
+            assert.deepEqual(
+                applyDisableDirectives({
+                    directives: [{ type: "disable", line: 1, column: 5, ruleId: "foo" }],
+                    problems: [{ line: 1, column: 6, ruleId: "foo" }],
+                    reportUnusedDisableDirectives: true
+                }),
+                []
+            );
+        });
+
+        it("Adds a problem for /* eslint-disable */ /* eslint-disable foo */ /* (problem from foo) */", () => {
+            assert.deepEqual(
+                applyDisableDirectives({
+                    directives: [
+                        { type: "disable", line: 1, column: 1, ruleId: null },
+                        { type: "disable", line: 2, column: 1, ruleId: "foo" }
+                    ],
+                    problems: [{ line: 3, column: 1, ruleId: "foo" }],
+                    reportUnusedDisableDirectives: true
+                }),
+                [
+                    {
+                        ruleId: null,
+                        message: "Unused eslint-disable directive (no problems were reported).",
+                        line: 1,
+                        column: 1,
+                        severity: 2,
+                        source: null,
+                        nodeType: null
+                    }
+                ]
+            );
+        });
+
+        it("Adds a problem for /* eslint-disable */ /* eslint-disable foo */ /* (problem from another rule) */", () => {
+            assert.deepEqual(
+                applyDisableDirectives({
+                    directives: [
+                        { type: "disable", line: 1, column: 1, ruleId: null },
+                        { type: "disable", line: 2, column: 1, ruleId: "foo" }
+                    ],
+                    problems: [{ line: 3, column: 1, ruleId: "bar" }],
+                    reportUnusedDisableDirectives: true
+                }),
+                [
+                    {
+                        ruleId: null,
+                        message: "Unused eslint-disable directive (no problems were reported from 'foo').",
+                        line: 2,
+                        column: 1,
+                        severity: 2,
+                        source: null,
+                        nodeType: null
+                    }
+                ]
+            );
+        });
+
+        it("Adds a problem for /* eslint-disable foo */ /* eslint-enable foo */ /* (problem from foo) */", () => {
+            assert.deepEqual(
+                applyDisableDirectives({
+                    directives: [
+                        { type: "disable", line: 1, column: 5, ruleId: "foo" },
+                        { type: "enable", line: 1, column: 8, ruleId: "foo" }
+                    ],
+                    problems: [{ line: 1, column: 10, ruleId: "foo" }],
+                    reportUnusedDisableDirectives: true
+                }),
+                [
+                    {
+                        ruleId: null,
+                        message: "Unused eslint-disable directive (no problems were reported from 'foo').",
+                        line: 1,
+                        column: 5,
+                        severity: 2,
+                        source: null,
+                        nodeType: null
+                    },
+                    {
+                        ruleId: "foo",
+                        line: 1,
+                        column: 10
+                    }
+                ]
+            );
+        });
+
+        it("Adds a problem for /* eslint-disable foo */ /* eslint-enable */ /* (problem from foo) */", () => {
+            assert.deepEqual(
+                applyDisableDirectives({
+                    directives: [
+                        { type: "disable", line: 1, column: 5, ruleId: "foo" },
+                        { type: "enable", line: 1, column: 8, ruleId: null }
+                    ],
+                    problems: [{ line: 1, column: 10, ruleId: "foo" }],
+                    reportUnusedDisableDirectives: true
+                }),
+                [
+                    {
+                        ruleId: null,
+                        message: "Unused eslint-disable directive (no problems were reported from 'foo').",
+                        line: 1,
+                        column: 5,
+                        severity: 2,
+                        source: null,
+                        nodeType: null
+                    },
+                    {
+                        ruleId: "foo",
+                        line: 1,
+                        column: 10
+                    }
+                ]
+            );
+        });
+
+        it("Adds two problems for /* eslint-disable */ /* eslint-disable foo */ /* eslint-enable foo */ /* (problem from foo) */", () => {
+            assert.deepEqual(
+                applyDisableDirectives({
+                    directives: [
+                        { type: "disable", line: 1, column: 1, ruleId: null },
+                        { type: "disable", line: 2, column: 1, ruleId: "foo" },
+                        { type: "enable", line: 3, column: 1, ruleId: "foo" }
+                    ],
+                    problems: [{ line: 4, column: 1, ruleId: "foo" }],
+                    reportUnusedDisableDirectives: true
+                }),
+                [
+                    {
+                        ruleId: null,
+                        message: "Unused eslint-disable directive (no problems were reported).",
+                        line: 1,
+                        column: 1,
+                        severity: 2,
+                        source: null,
+                        nodeType: null
+                    },
+                    {
+                        ruleId: null,
+                        message: "Unused eslint-disable directive (no problems were reported from 'foo').",
+                        line: 2,
+                        column: 1,
+                        severity: 2,
+                        source: null,
+                        nodeType: null
+                    },
+                    {
+                        ruleId: "foo",
+                        line: 4,
+                        column: 1
+                    }
+                ]
+            );
+        });
+
+        it("Adds a problem for // eslint-disable-line", () => {
+            assert.deepEqual(
+                applyDisableDirectives({
+                    directives: [{ type: "disable-line", line: 1, column: 5, ruleId: null }],
+                    problems: [],
+                    reportUnusedDisableDirectives: true
+                }),
+                [
+                    {
+                        ruleId: null,
+                        message: "Unused eslint-disable directive (no problems were reported).",
+                        line: 1,
+                        column: 5,
+                        severity: 2,
+                        source: null,
+                        nodeType: null
+                    }
+                ]
+            );
+        });
+
+
+        it("Does not add a problem for // eslint-disable-line (problem)", () => {
+            assert.deepEqual(
+                applyDisableDirectives({
+                    directives: [{ type: "disable-line", line: 1, column: 5, ruleId: null }],
+                    problems: [{ line: 1, column: 10, ruleId: "foo" }],
+                    reportUnusedDisableDirectives: true
+                }),
+                []
+            );
+        });
+
+        it("Adds a problem for // eslint-disable-next-line", () => {
+            assert.deepEqual(
+                applyDisableDirectives({
+                    directives: [{ type: "disable-next-line", line: 1, column: 5, ruleId: null }],
+                    problems: [],
+                    reportUnusedDisableDirectives: true
+                }),
+                [
+                    {
+                        ruleId: null,
+                        message: "Unused eslint-disable directive (no problems were reported).",
+                        line: 1,
+                        column: 5,
+                        severity: 2,
+                        source: null,
+                        nodeType: null
+                    }
+                ]
+            );
+        });
+
+        it("Does not add a problem for // eslint-disable-next-line \\n (problem)", () => {
+            assert.deepEqual(
+                applyDisableDirectives({
+                    directives: [{ type: "disable-next-line", line: 1, column: 5, ruleId: null }],
+                    problems: [{ line: 2, column: 10, ruleId: "foo" }],
+                    reportUnusedDisableDirectives: true
+                }),
+                []
+            );
+        });
+
+        it("adds two problems for /* eslint-disable */ // eslint-disable-line", () => {
+            assert.deepEqual(
+                applyDisableDirectives({
+                    directives: [
+                        { type: "disable", line: 1, column: 1, ruleId: null },
+                        { type: "disable-line", line: 1, column: 5, ruleId: null }
+                    ],
+                    problems: [],
+                    reportUnusedDisableDirectives: true
+                }),
+                [
+                    {
+                        ruleId: null,
+                        message: "Unused eslint-disable directive (no problems were reported).",
+                        line: 1,
+                        column: 1,
+                        severity: 2,
+                        source: null,
+                        nodeType: null
+                    },
+                    {
+                        ruleId: null,
+                        message: "Unused eslint-disable directive (no problems were reported).",
+                        line: 1,
+                        column: 5,
+                        severity: 2,
+                        source: null,
+                        nodeType: null
+                    }
+                ]
+            );
+        });
+
+        it("Does not add problems when reportUnusedDisableDirectives: false is used", () => {
+            assert.deepEqual(
+                applyDisableDirectives({
+                    directives: [{ type: "disable-next-line", line: 1, column: 5, ruleId: null }],
+                    problems: [],
+                    reportUnusedDisableDirectives: false
+                }),
+                []
+            );
+        });
+    });
 });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Add something to the core (see https://github.com/eslint/eslint/issues/9249)

**What changes did you make? (Give an overview)**

This adds the `--report-unused-disable-directives` CLI flag, and the `reportUnusedDisableDirectives` option to `CLIEngine` and `Linter`, as described in https://github.com/eslint/eslint/issues/9249.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
