### PR TITLE
Chore: remove unused eslint-disable comment

### DIFF
--- a/lib/code-path-analysis/code-path.js
+++ b/lib/code-path-analysis/code-path.js
@@ -206,7 +206,7 @@ class CodePath {
 
                 // Call the callback when the first time.
                 if (!skippedSegment) {
-                    callback.call(this, segment, controller); // eslint-disable-line callback-return
+                    callback.call(this, segment, controller);
                     if (segment === lastSegment) {
                         controller.skip();
                     }


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This removes an unused `eslint-disable` comment (found by the implementation in https://github.com/eslint/eslint/issues/9250).

**Is there anything you'd like reviewers to focus on?**

No
