### PR TITLE
Chore: remove undocumented Linter#getScope method

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -594,6 +594,43 @@ function parse(text, providedParserOptions, parserName, filePath) {
     }
 }
 
+/**
+ * Gets the scope for the current node
+ * @param {ScopeManager} scopeManager The scope manager for this AST
+ * @param {ASTNode} currentNode The node to get the scope of
+ * @param {number} ecmaVersion The `ecmaVersion` setting that this code was parsed with
+ * @returns {eslint-scope.Scope} The scope information for this node
+ */
+function getScope(scopeManager, currentNode, ecmaVersion) {
+    let initialNode;
+
+    // if current node introduces a scope, add it to the list
+    if (
+        ["FunctionDeclaration", "FunctionExpression", "ArrowFunctionExpression"].indexOf(currentNode.type) >= 0 ||
+        ecmaVersion >= 6 && ["BlockStatement", "SwitchStatement", "CatchClause"].indexOf(currentNode.type) >= 0
+    ) {
+        initialNode = currentNode;
+    } else {
+        initialNode = currentNode.parent;
+    }
+
+    // Ascend the current node's parents
+    for (let node = initialNode; node; node = node.parent) {
+
+        // Get the innermost scope
+        const scope = scopeManager.acquire(node, true);
+
+        if (scope) {
+            if (scope.type === "function-expression-name") {
+                return scope.childScopes[0];
+            }
+            return scope;
+        }
+    }
+
+    return scopeManager.scopes[0];
+}
+
 // methods that exist on SourceCode object
 const DEPRECATED_SOURCECODE_PASSTHROUGHS = {
     getSource: "getText",
@@ -788,7 +825,7 @@ class Linter {
                     getAncestors: () => this.traverser.parents(),
                     getDeclaredVariables: this.getDeclaredVariables.bind(this),
                     getFilename: () => filename,
-                    getScope: this.getScope.bind(this),
+                    getScope: () => getScope(this.scopeManager, this.traverser.current(), this.currentConfig.parserOptions.ecmaVersion),
                     getSourceCode: () => sourceCode,
                     markVariableAsUsed: this.markVariableAsUsed.bind(this),
                     parserOptions: config.parserOptions,
@@ -943,50 +980,6 @@ class Linter {
     }
 
     /**
-     * Gets the scope for the current node.
-     * @returns {Object} An object representing the current node's scope.
-     */
-    getScope() {
-        const parents = this.traverser.parents();
-
-        // Don't do this for Program nodes - they have no parents
-        if (parents.length) {
-
-            // if current node introduces a scope, add it to the list
-            const current = this.traverser.current();
-
-            if (this.currentConfig.parserOptions.ecmaVersion >= 6) {
-                if (["BlockStatement", "SwitchStatement", "CatchClause", "FunctionDeclaration", "FunctionExpression", "ArrowFunctionExpression"].indexOf(current.type) >= 0) {
-                    parents.push(current);
-                }
-            } else {
-                if (["FunctionDeclaration", "FunctionExpression", "ArrowFunctionExpression"].indexOf(current.type) >= 0) {
-                    parents.push(current);
-                }
-            }
-
-            // Ascend the current node's parents
-            for (let i = parents.length - 1; i >= 0; --i) {
-
-                // Get the innermost scope
-                const scope = this.scopeManager.acquire(parents[i], true);
-
-                if (scope) {
-                    if (scope.type === "function-expression-name") {
-                        return scope.childScopes[0];
-                    }
-                    return scope;
-
-                }
-
-            }
-
-        }
-
-        return this.scopeManager.scopes[0];
-    }
-
-    /**
      * Record that a particular variable has been used in code
      * @param {string} name The name of the variable to mark as used
      * @returns {boolean} True if the variable was found and marked as used,
@@ -995,7 +988,7 @@ class Linter {
     markVariableAsUsed(name) {
         const hasGlobalReturn = this.currentConfig.parserOptions.ecmaFeatures && this.currentConfig.parserOptions.ecmaFeatures.globalReturn,
             specialScope = hasGlobalReturn || this.currentConfig.parserOptions.sourceType === "module";
-        let scope = this.getScope(),
+        let scope = getScope(this.scopeManager, this.traverser.current(), this.currentConfig.parserOptions.ecmaVersion),
             i,
             len;
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates `Linter` to remove the undocumented `getScope` method. It doesn't make sense to call `getScope` from a `Linter` instance, since API users can't access the `Linter` instance while the AST is being traversed.

Note that the documented `context.getScope` method still exists, and is still available to rules. This just removes the `getScope` method on `Linter`.

(refs #9161)

~~This is blocked by https://github.com/eslint/eslint/pull/9252. The tests will fail until https://github.com/eslint/eslint/pull/9252 is merged.~~

**Is there anything you'd like reviewers to focus on?**

Nothing in particular