### PR TITLE
Fix: reuse the AST of source code object in verify

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -691,17 +691,8 @@ class Linter {
     verify(textOrSourceCode, config, filenameOrOptions, saveState) {
         let text,
             parserServices,
-            allowInlineConfig;
-
-        if (typeof textOrSourceCode === "string") {
-            this.sourceCode = null;
-            text = textOrSourceCode;
-        } else {
-            this.sourceCode = textOrSourceCode;
-            text = this.sourceCode.text;
-        }
-
-        let providedFilename;
+            allowInlineConfig,
+            providedFilename;
 
         // evaluate arguments
         if (typeof filenameOrOptions === "object") {
@@ -716,6 +707,14 @@ class Linter {
 
         if (!saveState) {
             this.reset();
+        }
+
+        if (typeof textOrSourceCode === "string") {
+            this.sourceCode = null;
+            text = textOrSourceCode;
+        } else {
+            this.sourceCode = textOrSourceCode;
+            text = this.sourceCode.text;
         }
 
         // search and apply "eslint-env *".

--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -3049,6 +3049,29 @@ describe("Linter", () => {
             linter.verify(linter.getSourceCode(), { parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } });
         });
 
+        it("should reuse the SourceCode object", () => {
+            let ast1 = null,
+                ast2 = null;
+
+            linter.defineRule("save-ast1", () => ({
+                Program(node) {
+                    ast1 = node;
+                }
+            }));
+            linter.defineRule("save-ast2", () => ({
+                Program(node) {
+                    ast2 = node;
+                }
+            }));
+
+            linter.verify("function render() { return <div className='test'>{hello}</div> }", { parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } }, rules: { "save-ast1": 2 } });
+            linter.verify(linter.getSourceCode(), { parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } }, rules: { "save-ast2": 2 } });
+
+            assert(ast1 !== null);
+            assert(ast2 !== null);
+            assert(ast1 === ast2);
+        });
+
         it("should allow 'await' as a property name in modules", () => {
             const result = linter.verify(
                 "obj.await",


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

**Tell us about your environment**

* **ESLint Version:** `master`
* **Node Version:** 8.4.0
* **npm Version:** 5.4.1

**What parser (default, Babel-ESLint, etc.) are you using?**

- default

**Please show your full configuration:**

- nothing

**What did you do? Please include the actual source code causing the issue.**

Gave a `SourceCode` object to `linter.verify()`.

In more accurate, I resolved conflictions between #8755 and `master`, then [this test](https://github.com/eslint/eslint/pull/8755/files#diff-c6fc98e70cf39f54c23015c3db45f14aR3794) got broken.

**What did you expect to happen?**

It reuses the AST of the `SourceCode` object.

**What actually happened? Please include the actual, raw output from ESLint.**

It re-parsed the source code text.

**What changes did you make? (Give an overview)**

This PR moved the statement `this.sourceCode = textOrSourceCode;` to the next of `this.reset()` because `this.reset()` set `null` to `this.sourceCode`.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.
