### PR TITLE
Chore: refactor config hash caching in CLIEngine

### DIFF
--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -372,6 +372,8 @@ function getCacheFile(cacheFile, cwd) {
     return resolvedCacheFile;
 }
 
+const configHashCache = new WeakMap();
+
 //------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
@@ -496,7 +498,6 @@ class CLIEngine {
         const options = this.options,
             fileCache = this._fileCache,
             configHelper = this.config;
-        let prevConfig; // the previous configuration used
         const cacheFile = getCacheFile(this.options.cacheLocation || this.options.cacheFile, this.options.cwd);
 
         if (!options.cache && fs.existsSync(cacheFile)) {
@@ -511,25 +512,11 @@ class CLIEngine {
         function hashOfConfigFor(filename) {
             const config = configHelper.getConfig(filename);
 
-            if (!prevConfig) {
-                prevConfig = {};
+            if (!configHashCache.has(config)) {
+                configHashCache.set(config, hash(`${pkg.version}_${stringify(config)}`));
             }
 
-            // reuse the previously hashed config if the config hasn't changed
-            if (prevConfig.config !== config) {
-
-                /*
-                 * config changed so we need to calculate the hash of the config
-                 * and the hash of the plugins being used
-                 */
-                prevConfig.config = config;
-
-                const eslintVersion = pkg.version;
-
-                prevConfig.hash = hash(`${eslintVersion}_${stringify(config)}`);
-            }
-
-            return prevConfig.hash;
+            return configHashCache.get(config);
         }
 
         const startTime = Date.now();


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Previously, CLIEngine would store the last config object when executing on multiple files, as a performance optimization to avoid rehashing configs if the same config was used for multiple files.

This can be better implemented by using a WeakMap to map config objects to hash results.

**Is there anything you'd like reviewers to focus on?**

No