### PR TITLE
Fix handling of no-extra-parens on some MemberExpression cases

### DIFF
--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -350,7 +350,7 @@ module.exports = {
                 currentNodeType = currentNode.type;
             }
 
-            return currentNodeType === 'CallExpression';
+            return currentNodeType === "CallExpression";
         }
 
         /**
@@ -369,10 +369,10 @@ module.exports = {
                     hasDoubleExcessParens(callee) ||
                     !isIIFE(node) && !hasNewParensException && !(
 
-                      // Allow extra parens around a new expression if there are
-                      // intervening parentheses.
-                      callee.type === "MemberExpression" &&
-                      doesMemberExpressionContainCallExpression(callee)
+                        // Allow extra parens around a new expression if
+                        // there are intervening parentheses.
+                        callee.type === "MemberExpression" &&
+                        doesMemberExpressionContainCallExpression(callee)
                     )
                 ) {
                     report(node.callee);
@@ -604,7 +604,7 @@ module.exports = {
             MemberExpression(node) {
                 if (
                     hasExcessParens(node.object) && (
-                    (node.object.type === "CallExpression" &&
+                        (node.object.type === "CallExpression" &&
                      node.parent.type !== "NewExpression") ||
                     precedence(node.object) >= precedence(node) &&
                     (
@@ -616,7 +616,7 @@ module.exports = {
                             (node.object.type === "Literal" && node.object.regex)
                         )
                     )
-                )) {
+                    )) {
                     report(node.object);
                 }
                 if (node.computed && hasExcessParens(node.property)) {

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -361,15 +361,17 @@ module.exports = {
          */
         function checkCallNew(node) {
             const callee = node.callee;
+
             if (hasExcessParens(callee) && precedence(callee) >= precedence(node)) {
                 const hasNewParensException = callee.type === "NewExpression" && !isNewExpressionWithParens(callee);
 
                 if (
-                  hasDoubleExcessParens(callee) ||
+                    hasDoubleExcessParens(callee) ||
                   !isIIFE(node) && !hasNewParensException && !(
-                    // Allow extra parens around a new expression if there are
-                    // intervening parentheses.
-                    callee.type === "MemberExpression" &&
+
+                      // Allow extra parens around a new expression if there are
+                      // intervening parentheses.
+                      callee.type === "MemberExpression" &&
                       doesMemberExpressionContainCallExpression(callee)
                   )
                 ) {

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -337,16 +337,42 @@ module.exports = {
         }
 
         /**
+         * Check if a member expression contains a call expression
+         * @param {ASTNode} node MemberExpression node to evaluate
+         * @returns {boolean} true if found, false if not
+         */
+        function doesMemberExpressionContainCallExpression(node) {
+            let currentNode = node.object;
+            let currentNodeType = node.object.type;
+
+            while (currentNodeType !== "Identifier" && currentNodeType !== "CallExpression") {
+                currentNode = currentNode.object;
+                currentNodeType = currentNode.type;
+            }
+
+            return currentNodeType === "CallExpression";
+        }
+
+        /**
          * Evaluate a new call
          * @param {ASTNode} node node to evaluate
          * @returns {void}
          * @private
          */
         function checkCallNew(node) {
-            if (hasExcessParens(node.callee) && precedence(node.callee) >= precedence(node)) {
-                const hasNewParensException = node.callee.type === "NewExpression" && !isNewExpressionWithParens(node.callee);
+            const callee = node.callee;
+            if (hasExcessParens(callee) && precedence(callee) >= precedence(node)) {
+                const hasNewParensException = callee.type === "NewExpression" && !isNewExpressionWithParens(callee);
 
-                if (hasDoubleExcessParens(node.callee) || !isIIFE(node) && !hasNewParensException) {
+                if (
+                  hasDoubleExcessParens(callee) ||
+                  !isIIFE(node) && !hasNewParensException && !(
+                    // Allow extra parens around a new expression if there are
+                    // intervening parentheses.
+                    callee.type === "MemberExpression" &&
+                      doesMemberExpressionContainCallExpression(callee)
+                  )
+                ) {
                     report(node.callee);
                 }
             }
@@ -493,7 +519,14 @@ module.exports = {
             },
 
             BinaryExpression: checkBinaryLogical,
-            CallExpression: checkCallNew,
+
+            CallExpression(node) {
+                if (hasExcessParens(node) && node.parent.type === "MemberExpression") {
+                    report(node);
+                }
+
+                checkCallNew(node);
+            },
 
             ConditionalExpression(node) {
                 if (isReturnAssignException(node)) {

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -602,10 +602,10 @@ module.exports = {
             LogicalExpression: checkBinaryLogical,
 
             MemberExpression(node) {
+                const nodeObjHasExcessParens = hasExcessParens(node.object);
+
                 if (
-                    hasExcessParens(node.object) && (
-                        (node.object.type === "CallExpression" &&
-                     node.parent.type !== "NewExpression") ||
+                    nodeObjHasExcessParens &&
                     precedence(node.object) >= precedence(node) &&
                     (
                         node.computed ||
@@ -616,9 +616,16 @@ module.exports = {
                             (node.object.type === "Literal" && node.object.regex)
                         )
                     )
-                    )) {
+                ) {
                     report(node.object);
                 }
+
+                if (nodeObjHasExcessParens &&
+                  node.object.type === "CallExpression" &&
+                  node.parent.type !== "NewExpression") {
+                    report(node.object);
+                }
+
                 if (node.computed && hasExcessParens(node.property)) {
                     report(node.property);
                 }

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -337,11 +337,11 @@ module.exports = {
         }
 
         /**
-         * Find the nearest child call expression in a member expression
+         * Check if a member expression contains a call expression
          * @param {ASTNode} node MemberExpression node to evaluate
-         * @returns {(ASTNode|null)} node CallExpression if found, null if not
+         * @returns {boolean} true if found, false if not
          */
-        function findNearestCallExpressionInMemberExpression(node) {
+        function doesMemberExpressionContainCallExpression(node) {
             let currentNode = node.object;
             let currentNodeType = node.object.type;
 
@@ -350,11 +350,7 @@ module.exports = {
                 currentNodeType = currentNode.type;
             }
 
-            if (currentNodeType !== 'CallExpression') {
-              return null
-            }
-
-            return currentNode;
+            return currentNodeType === 'CallExpression';
         }
 
         /**
@@ -376,7 +372,7 @@ module.exports = {
                       // Allow extra parens around a new expression if there are
                       // intervening parentheses.
                       callee.type === "MemberExpression" &&
-                      findNearestCallExpressionInMemberExpression(callee)
+                      doesMemberExpressionContainCallExpression(callee)
                     )
                 ) {
                     report(node.callee);
@@ -525,7 +521,6 @@ module.exports = {
             },
 
             BinaryExpression: checkBinaryLogical,
-
             CallExpression: checkCallNew,
 
             ConditionalExpression(node) {
@@ -624,7 +619,6 @@ module.exports = {
                 )) {
                     report(node.object);
                 }
-
                 if (node.computed && hasExcessParens(node.property)) {
                     report(node.property);
                 }

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -337,20 +337,24 @@ module.exports = {
         }
 
         /**
-         * Check if a member expression contains a call expression
+         * Find the nearest child call expression in a member expression
          * @param {ASTNode} node MemberExpression node to evaluate
-         * @returns {boolean} true if found, false if not
+         * @returns {(ASTNode|null)} node CallExpression if found, null if not
          */
-        function doesMemberExpressionContainCallExpression(node) {
+        function findNearestCallExpressionInMemberExpression(node) {
             let currentNode = node.object;
             let currentNodeType = node.object.type;
 
-            while (currentNodeType !== "Identifier" && currentNodeType !== "CallExpression") {
+            while (currentNodeType === "MemberExpression") {
                 currentNode = currentNode.object;
                 currentNodeType = currentNode.type;
             }
 
-            return currentNodeType === "CallExpression";
+            if (currentNodeType !== 'CallExpression') {
+              return null
+            }
+
+            return currentNode;
         }
 
         /**
@@ -367,13 +371,13 @@ module.exports = {
 
                 if (
                     hasDoubleExcessParens(callee) ||
-                  !isIIFE(node) && !hasNewParensException && !(
+                    !isIIFE(node) && !hasNewParensException && !(
 
                       // Allow extra parens around a new expression if there are
                       // intervening parentheses.
                       callee.type === "MemberExpression" &&
-                      doesMemberExpressionContainCallExpression(callee)
-                  )
+                      findNearestCallExpressionInMemberExpression(callee)
+                    )
                 ) {
                     report(node.callee);
                 }
@@ -522,13 +526,7 @@ module.exports = {
 
             BinaryExpression: checkBinaryLogical,
 
-            CallExpression(node) {
-                if (hasExcessParens(node) && node.parent.type === "MemberExpression") {
-                    report(node);
-                }
-
-                checkCallNew(node);
-            },
+            CallExpression: checkCallNew,
 
             ConditionalExpression(node) {
                 if (isReturnAssignException(node)) {
@@ -610,7 +608,9 @@ module.exports = {
 
             MemberExpression(node) {
                 if (
-                    hasExcessParens(node.object) &&
+                    hasExcessParens(node.object) && (
+                    (node.object.type === "CallExpression" &&
+                     node.parent.type !== "NewExpression") ||
                     precedence(node.object) >= precedence(node) &&
                     (
                         node.computed ||
@@ -621,9 +621,10 @@ module.exports = {
                             (node.object.type === "Literal" && node.object.regex)
                         )
                     )
-                ) {
+                )) {
                     report(node.object);
                 }
+
                 if (node.computed && hasExcessParens(node.property)) {
                     report(node.property);
                 }

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -91,6 +91,9 @@ ruleTester.run("no-extra-parens", rule, {
         "new (A())",
         "new (foo.Baz().foo)",
         "new (foo.baz.bar().foo.baz)",
+        "new ({}.baz.bar.foo().baz)",
+        "new (doSomething().baz.bar().foo)",
+        "new ([][0].baz.foo().bar.foo)",
         "new (foo\n.baz\n.bar()\n.foo.baz)",
         "new A()()",
         "(new A)()",
@@ -444,9 +447,6 @@ ruleTester.run("no-extra-parens", rule, {
     ],
 
     invalid: [
-        invalid("(foo()).bar", "foo().bar", "CallExpression"),
-        invalid("(foo.bar()).baz", "foo.bar().baz", "CallExpression"),
-        invalid("(foo\n.bar())\n.baz", "foo\n.bar()\n.baz", "CallExpression"),
         invalid("(0)", "0", "Literal"),
         invalid("(  0  )", "  0  ", "Literal"),
         invalid("if((0));", "if(0);", "Literal"),
@@ -522,6 +522,9 @@ ruleTester.run("no-extra-parens", rule, {
         invalid("new (\nfunction(){}\n)", "new \nfunction(){}\n", "FunctionExpression", 1),
         invalid("((function foo() {return 1;}))()", "(function foo() {return 1;})()", "FunctionExpression"),
         invalid("((function(){ return bar(); })())", "(function(){ return bar(); })()", "CallExpression"),
+        invalid("(foo()).bar", "foo().bar", "CallExpression"),
+        invalid("(foo.bar()).baz", "foo.bar().baz", "CallExpression"),
+        invalid("(foo\n.bar())\n.baz", "foo\n.bar()\n.baz", "CallExpression"),
 
         invalid("new (A)", "new A", "Identifier"),
         invalid("(new A())()", "new A()()", "NewExpression"),

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -89,6 +89,9 @@ ruleTester.run("no-extra-parens", rule, {
         "a(b = c, (d, e))",
         "(++a)(b); (c++)(d);",
         "new (A())",
+        "new (foo.Baz().foo)",
+        "new (foo.baz.bar().foo.baz)",
+        "new (foo\n.baz\n.bar()\n.foo.baz)",
         "new A()()",
         "(new A)()",
         "(new (Foo || Bar))()",
@@ -441,6 +444,9 @@ ruleTester.run("no-extra-parens", rule, {
     ],
 
     invalid: [
+        invalid("(foo()).bar", "foo().bar", "CallExpression"),
+        invalid("(foo.bar()).baz", "foo.bar().baz", "CallExpression"),
+        invalid("(foo\n.bar())\n.baz", "foo\n.bar()\n.baz", "CallExpression"),
         invalid("(0)", "0", "Literal"),
         invalid("(  0  )", "  0  ", "Literal"),
         invalid("if((0));", "if(0);", "Literal"),
@@ -521,6 +527,8 @@ ruleTester.run("no-extra-parens", rule, {
         invalid("(new A())()", "new A()()", "NewExpression"),
         invalid("(new A(1))()", "new A(1)()", "NewExpression"),
         invalid("((new A))()", "(new A)()", "NewExpression"),
+        invalid("new (foo\n.baz\n.bar\n.foo.baz)", "new foo\n.baz\n.bar\n.foo.baz", "MemberExpression"),
+        invalid("new (foo.baz.bar.baz)", "new foo.baz.bar.baz", "MemberExpression"),
 
         invalid("0, (_ => 0)", "0, _ => 0", "ArrowFunctionExpression", 1),
         invalid("(_ => 0), 0", "_ => 0, 0", "ArrowFunctionExpression", 1),


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix 

For https://github.com/eslint/eslint/issues/9156.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

- Report any call expression wrapped in parentheses in a member expression
- Do not report any member expression wrapped in parentheses in a new expression if the member expression contains any call expression

**Is there anything you'd like reviewers to focus on?**

- Let me know if this is the correct behavior.
- Let me know if there is a simpler implementation you have in mind.


