### PR TITLE
Chore: make executeOnFile a pure function in CLIEngine

### DIFF
--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -493,8 +493,7 @@ class CLIEngine {
      * @returns {Object} The results for all files that were linted.
      */
     executeOnFiles(patterns) {
-        const results = [],
-            options = this.options,
+        const options = this.options,
             fileCache = this._fileCache,
             configHelper = this.config;
         let prevConfig; // the previous configuration used
@@ -533,21 +532,11 @@ class CLIEngine {
             return prevConfig.hash;
         }
 
-        /**
-         * Executes the linter on a file defined by the `filename`. Skips
-         * unsupported file extensions and any files that are already linted.
-         * @param {string} filename The resolved filename of the file to be linted
-         * @param {boolean} warnIgnored always warn when a file is ignored
-         * @param {Linter} linter Linter context
-         * @returns {void}
-         */
-        function executeOnFile(filename, warnIgnored, linter) {
-            let hashOfConfig,
-                descriptor;
-
-            if (warnIgnored) {
-                results.push(createIgnoreResult(filename, options.cwd));
-                return;
+        const startTime = Date.now();
+        const fileList = globUtil.listFilesToProcess(this.resolveFileGlobPatterns(patterns), options);
+        const results = fileList.map(fileInfo => {
+            if (fileInfo.ignored) {
+                return createIgnoreResult(fileInfo.filename, options.cwd);
             }
 
             if (options.cache) {
@@ -557,15 +546,12 @@ class CLIEngine {
                  * with the metadata and the flag that determines if
                  * the file has changed
                  */
-                descriptor = fileCache.getFileDescriptor(filename);
-                const meta = descriptor.meta || {};
-
-                hashOfConfig = hashOfConfigFor(filename);
-
-                const changed = descriptor.changed || meta.hashOfConfig !== hashOfConfig;
+                const descriptor = fileCache.getFileDescriptor(fileInfo.filename);
+                const hashOfConfig = hashOfConfigFor(fileInfo.filename);
+                const changed = descriptor.changed || descriptor.meta.hashOfConfig !== hashOfConfig;
 
                 if (!changed) {
-                    debug(`Skipping file since hasn't changed: ${filename}`);
+                    debug(`Skipping file since hasn't changed: ${fileInfo.filename}`);
 
                     /*
                      * Add the the cached results (always will be 0 error and
@@ -573,62 +559,44 @@ class CLIEngine {
                      * failed, in order to guarantee that next execution will
                      * process those files as well.
                      */
-                    results.push(descriptor.meta.results);
-
-                    // move to the next file
-                    return;
+                    return descriptor.meta.results;
                 }
             }
 
-            debug(`Processing ${filename}`);
+            debug(`Processing ${fileInfo.filename}`);
 
-            const res = processFile(filename, configHelper, options, linter);
+            return processFile(fileInfo.filename, configHelper, options, this.linter);
+        });
 
-            if (options.cache) {
+        if (options.cache) {
+            results.forEach(result => {
+                if (result.messages.length) {
 
-                /*
-                 * if a file contains errors or warnings we don't want to
-                 * store the file in the cache so we can guarantee that
-                 * next execution will also operate on this file
-                 */
-                if (res.errorCount > 0 || res.warningCount > 0) {
-                    debug(`File has problems, skipping it: ${filename}`);
-
-                    // remove the entry from the cache
-                    fileCache.removeEntry(filename);
+                    /*
+                    * if a file contains errors or warnings we don't want to
+                    * store the file in the cache so we can guarantee that
+                    * next execution will also operate on this file
+                    */
+                    fileCache.removeEntry(result.filePath);
                 } else {
 
                     /*
                      * since the file passed we store the result here
-                     * TODO: check this as we might not need to store the
-                     * successful runs as it will always should be 0 errors and
-                     * 0 warnings.
+                     * TODO: it might not be necessary to store the results list in the cache,
+                     * since it should always be 0 errors/warnings
                      */
-                    descriptor.meta.hashOfConfig = hashOfConfig;
-                    descriptor.meta.results = res;
+                    const descriptor = fileCache.getFileDescriptor(result.filePath);
+
+                    descriptor.meta.hashOfConfig = hashOfConfigFor(result.filePath);
+                    descriptor.meta.results = result;
                 }
-            }
-
-            results.push(res);
-        }
-
-        const startTime = Date.now();
-
-
-        patterns = this.resolveFileGlobPatterns(patterns);
-        const fileList = globUtil.listFilesToProcess(patterns, options);
-
-        fileList.forEach(fileInfo => {
-            executeOnFile(fileInfo.filename, fileInfo.ignored, this.linter);
-        });
-
-        const stats = calculateStatsPerRun(results);
-
-        if (options.cache) {
+            });
 
             // persist the cache to disk
             fileCache.reconcile();
         }
+
+        const stats = calculateStatsPerRun(results);
 
         debug(`Linting complete in: ${Date.now() - startTime}ms`);
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates `executeOnFile` in `CLIEngine` to avoid modifying the cache for each file, and instead modify the cache for all the results at the end. 

This will make it easier to accumulate results from multiple workers, which needs to happen for https://github.com/eslint/eslint/issues/3565.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
