### PR TITLE
Chore: remove SourceCode passthroughs from Linter.prototype (refs #9161)

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -640,7 +640,7 @@ const BASE_TRAVERSAL_CONTEXT = Object.freeze(
  * Object that is responsible for verifying JavaScript text
  * @name eslint
  */
-class Linter {
+module.exports = class Linter {
 
     constructor() {
         this.currentConfig = null;
@@ -1140,23 +1140,4 @@ class Linter {
 
         return fixedResult;
     }
-}
-
-Object.keys(DEPRECATED_SOURCECODE_PASSTHROUGHS).forEach(methodName => {
-    const exMethodName = DEPRECATED_SOURCECODE_PASSTHROUGHS[methodName];
-
-    // Applies the SourceCode methods to the Linter prototype
-    Object.defineProperty(Linter.prototype, methodName, {
-        value() {
-            if (this.sourceCode) {
-                return this.sourceCode[exMethodName].apply(this.sourceCode, arguments);
-            }
-            return null;
-        },
-        configurable: true,
-        writable: true,
-        enumerable: false
-    });
-});
-
-module.exports = Linter;
+};

--- a/tests/lib/ast-utils.js
+++ b/tests/lib/ast-utils.js
@@ -62,9 +62,9 @@ describe("ast-utils", () => {
 
     describe("isTokenOnSameLine", () => {
         it("should return false if the tokens are not on the same line", () => {
-            linter.defineRule("checker", mustCall(() => ({
+            linter.defineRule("checker", mustCall(context => ({
                 BlockStatement: mustCall(node => {
-                    assert.isFalse(astUtils.isTokenOnSameLine(linter.getTokenBefore(node), node));
+                    assert.isFalse(astUtils.isTokenOnSameLine(context.getTokenBefore(node), node));
                 })
             })));
 
@@ -73,9 +73,9 @@ describe("ast-utils", () => {
 
         it("should return true if the tokens are on the same line", () => {
 
-            linter.defineRule("checker", mustCall(() => ({
+            linter.defineRule("checker", mustCall(context => ({
                 BlockStatement: mustCall(node => {
-                    assert.isTrue(astUtils.isTokenOnSameLine(linter.getTokenBefore(node), node));
+                    assert.isTrue(astUtils.isTokenOnSameLine(context.getTokenBefore(node), node));
                 })
             })));
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates `Linter` to remove undocumented methods like `Linter#getSource` and `Linter#getSourceLines`.

Note that the deprecated `context.getSource` and `context.getSourceLines` methods are still available to rules. This just removes the duplicate methods from `Linter`.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
