### PR TITLE
Chore: remove internal Linter#getDeclaredVariables method (refs #9161)

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -823,7 +823,7 @@ module.exports = class Linter {
                 Object.create(BASE_TRAVERSAL_CONTEXT),
                 {
                     getAncestors: () => this.traverser.parents(),
-                    getDeclaredVariables: this.getDeclaredVariables.bind(this),
+                    getDeclaredVariables: node => this.scopeManager && this.scopeManager.getDeclaredVariables(node) || [],
                     getFilename: () => filename,
                     getScope: () => getScope(this.scopeManager, this.traverser.current(), this.currentConfig.parserOptions.ecmaVersion),
                     getSourceCode: () => sourceCode,
@@ -1038,29 +1038,6 @@ module.exports = class Linter {
      */
     getRules() {
         return this.rules.getAllLoadedRules();
-    }
-
-    /**
-     * Gets variables that are declared by a specified node.
-     *
-     * The variables are its `defs[].node` or `defs[].parent` is same as the specified node.
-     * Specifically, below:
-     *
-     * - `VariableDeclaration` - variables of its all declarators.
-     * - `VariableDeclarator` - variables.
-     * - `FunctionDeclaration`/`FunctionExpression` - its function name and parameters.
-     * - `ArrowFunctionExpression` - its parameters.
-     * - `ClassDeclaration`/`ClassExpression` - its class name.
-     * - `CatchClause` - variables of its exception.
-     * - `ImportDeclaration` - variables of  its all specifiers.
-     * - `ImportSpecifier`/`ImportDefaultSpecifier`/`ImportNamespaceSpecifier` - a variable.
-     * - others - always an empty array.
-     *
-     * @param {ASTNode} node A node to get.
-     * @returns {eslint-scope.Variable[]} Variables that are declared by the node.
-     */
-    getDeclaredVariables(node) {
-        return (this.scopeManager && this.scopeManager.getDeclaredVariables(node)) || [];
     }
 
     /**

--- a/tests/lib/ast-utils.js
+++ b/tests/lib/ast-utils.js
@@ -117,9 +117,9 @@ describe("ast-utils", () => {
 
         // catch
         it("should return true if reference is assigned for catch", () => {
-            linter.defineRule("checker", mustCall(() => ({
+            linter.defineRule("checker", mustCall(context => ({
                 CatchClause: mustCall(node => {
-                    const variables = linter.getDeclaredVariables(node);
+                    const variables = context.getDeclaredVariables(node);
 
                     assert.lengthOf(astUtils.getModifyingReferences(variables[0].references), 1);
                 })
@@ -130,9 +130,9 @@ describe("ast-utils", () => {
 
         // const
         it("should return true if reference is assigned for const", () => {
-            linter.defineRule("checker", mustCall(() => ({
+            linter.defineRule("checker", mustCall(context => ({
                 VariableDeclaration: mustCall(node => {
-                    const variables = linter.getDeclaredVariables(node);
+                    const variables = context.getDeclaredVariables(node);
 
                     assert.lengthOf(astUtils.getModifyingReferences(variables[0].references), 1);
                 })
@@ -142,9 +142,9 @@ describe("ast-utils", () => {
         });
 
         it("should return false if reference is not assigned for const", () => {
-            linter.defineRule("checker", mustCall(() => ({
+            linter.defineRule("checker", mustCall(context => ({
                 VariableDeclaration: mustCall(node => {
-                    const variables = linter.getDeclaredVariables(node);
+                    const variables = context.getDeclaredVariables(node);
 
                     assert.lengthOf(astUtils.getModifyingReferences(variables[0].references), 0);
                 })
@@ -155,9 +155,9 @@ describe("ast-utils", () => {
 
         // class
         it("should return true if reference is assigned for class", () => {
-            linter.defineRule("checker", mustCall(() => ({
+            linter.defineRule("checker", mustCall(context => ({
                 ClassDeclaration: mustCall(node => {
-                    const variables = linter.getDeclaredVariables(node);
+                    const variables = context.getDeclaredVariables(node);
 
                     assert.lengthOf(astUtils.getModifyingReferences(variables[0].references), 1);
                     assert.lengthOf(astUtils.getModifyingReferences(variables[1].references), 0);
@@ -168,9 +168,9 @@ describe("ast-utils", () => {
         });
 
         it("should return false if reference is not assigned for class", () => {
-            linter.defineRule("checker", mustCall(() => ({
+            linter.defineRule("checker", mustCall(context => ({
                 ClassDeclaration: mustCall(node => {
-                    const variables = linter.getDeclaredVariables(node);
+                    const variables = context.getDeclaredVariables(node);
 
                     assert.lengthOf(astUtils.getModifyingReferences(variables[0].references), 0);
                 })

--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -3334,19 +3334,10 @@ describe("Linter", () => {
         });
     });
 
-    describe("getDeclaredVariables(node)", () => {
+    describe("context.getDeclaredVariables(node)", () => {
 
         /**
-         * Assert `eslint.getDeclaredVariables(node)` is empty.
-         * @param {ASTNode} node - A node to check.
-         * @returns {void}
-         */
-        function checkEmpty(node) {
-            assert.equal(0, linter.getDeclaredVariables(node).length);
-        }
-
-        /**
-         * Assert `eslint.getDeclaredVariables(node)` is valid.
+         * Assert `context.getDeclaredVariables(node)` is valid.
          * @param {string} code - A code to check.
          * @param {string} type - A type string of ASTNode. This method checks variables on the node of the type.
          * @param {Array<Array<string>>} expectedNamesList - An array of expected variable names. The expected variable names is an array of string.
@@ -3355,6 +3346,15 @@ describe("Linter", () => {
         function verify(code, type, expectedNamesList) {
             linter.defineRules({
                 test(context) {
+
+                    /**
+                     * Assert `context.getDeclaredVariables(node)` is empty.
+                     * @param {ASTNode} node - A node to check.
+                     * @returns {void}
+                     */
+                    function checkEmpty(node) {
+                        assert.equal(0, context.getDeclaredVariables(node).length);
+                    }
                     const rule = {
                         Program: checkEmpty,
                         EmptyStatement: checkEmpty,


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates `Linter` to remove the `Linter#getDeclaredVariables` method. The `context.getDeclaredVariables` method is still available to rules -- this just removes the version of the method on `Linter`.

**Is there anything you'd like reviewers to focus on?**

No