### PR TITLE
Chore: prefer smaller scope for variables in codebase

### DIFF
--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -668,7 +668,6 @@ class CLIEngine {
      */
     getFormatter(format) {
 
-        let formatterPath;
 
         // default is stylish
         format = format || "stylish";
@@ -678,6 +677,8 @@ class CLIEngine {
 
             // replace \ with / for Windows compatibility
             format = format.replace(/\\/g, "/");
+
+            let formatterPath;
 
             // if there's a slash, then it's a file
             if (format.indexOf("/") > -1) {

--- a/lib/code-path-analysis/code-path-state.js
+++ b/lib/code-path-analysis/code-path-state.js
@@ -843,15 +843,14 @@ class CodePathState {
          * This segment will leave at the end of this finally block.
          */
         const segments = forkContext.makeNext(-1, -1);
-        let j;
 
         for (let i = 0; i < forkContext.count; ++i) {
             const prevSegsOfLeavingSegment = [headOfLeavingSegments[i]];
 
-            for (j = 0; j < returned.segmentsList.length; ++j) {
+            for (let j = 0; j < returned.segmentsList.length; ++j) {
                 prevSegsOfLeavingSegment.push(returned.segmentsList[j][i]);
             }
-            for (j = 0; j < thrown.segmentsList.length; ++j) {
+            for (let j = 0; j < thrown.segmentsList.length; ++j) {
                 prevSegsOfLeavingSegment.push(thrown.segmentsList[j][i]);
             }
 
@@ -985,7 +984,6 @@ class CodePathState {
 
         const forkContext = this.forkContext;
         const brokenForkContext = this.popBreakContext().brokenForkContext;
-        let choiceContext;
 
         // Creates a looped path.
         switch (context.type) {
@@ -1000,7 +998,7 @@ class CodePathState {
                 break;
 
             case "DoWhileStatement": {
-                choiceContext = this.popChoiceContext();
+                const choiceContext = this.popChoiceContext();
 
                 if (!choiceContext.processed) {
                     choiceContext.trueForkContext.add(forkContext.head);

--- a/lib/config/autoconfig.js
+++ b/lib/config/autoconfig.js
@@ -269,10 +269,8 @@ class Registry {
      * @returns {Registry}              New registry with errorCount populated
      */
     lintSourceCode(sourceCodes, config, cb) {
-        let ruleSetIdx,
-            lintedRegistry;
+        let lintedRegistry = new Registry();
 
-        lintedRegistry = new Registry();
         lintedRegistry.rules = Object.assign({}, this.rules);
 
         const ruleSets = lintedRegistry.buildRuleSets();
@@ -287,7 +285,7 @@ class Registry {
         filenames.forEach(filename => {
             debug(`Linting file: ${filename}`);
 
-            ruleSetIdx = 0;
+            let ruleSetIdx = 0;
 
             ruleSets.forEach(ruleSet => {
                 const lintConfig = Object.assign({}, config, { rules: ruleSet });

--- a/lib/config/config-initializer.js
+++ b/lib/config/config-initializer.js
@@ -382,7 +382,6 @@ function hasESLintVersionConflict(answers) {
  * @returns {Promise} The promise with the result of the prompt
  */
 function promptUser() {
-    let config;
 
     return inquirer.prompt([
         {
@@ -469,7 +468,8 @@ function promptUser() {
                 earlyAnswers.styleguide = "airbnb-base";
             }
 
-            config = getConfigForStyleGuide(earlyAnswers.styleguide, earlyAnswers.installESLint);
+            const config = getConfigForStyleGuide(earlyAnswers.styleguide, earlyAnswers.installESLint);
+
             writeFile(config, earlyAnswers.format);
 
             return void 0;
@@ -529,7 +529,8 @@ function promptUser() {
             if (earlyAnswers.source === "auto") {
                 const combinedAnswers = Object.assign({}, earlyAnswers, secondAnswers);
 
-                config = processAnswers(combinedAnswers);
+                const config = processAnswers(combinedAnswers);
+
                 installModules(config);
                 writeFile(config, earlyAnswers.format);
 
@@ -575,7 +576,8 @@ function promptUser() {
             ]).then(answers => {
                 const totalAnswers = Object.assign({}, earlyAnswers, secondAnswers, answers);
 
-                config = processAnswers(totalAnswers);
+                const config = processAnswers(totalAnswers);
+
                 installModules(config);
                 writeFile(config, answers.format);
             });

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -988,9 +988,7 @@ module.exports = class Linter {
     markVariableAsUsed(name) {
         const hasGlobalReturn = this.currentConfig.parserOptions.ecmaFeatures && this.currentConfig.parserOptions.ecmaFeatures.globalReturn,
             specialScope = hasGlobalReturn || this.currentConfig.parserOptions.sourceType === "module";
-        let scope = getScope(this.scopeManager, this.traverser.current(), this.currentConfig.parserOptions.ecmaVersion),
-            i,
-            len;
+        let scope = getScope(this.scopeManager, this.traverser.current(), this.currentConfig.parserOptions.ecmaVersion);
 
         // Special Node.js scope means we need to start one level deeper
         if (scope.type === "global" && specialScope) {
@@ -1000,7 +998,7 @@ module.exports = class Linter {
         do {
             const variables = scope.variables;
 
-            for (i = 0, len = variables.length; i < len; i++) {
+            for (let i = 0; i < variables.length; i++) {
                 if (variables[i].name === name) {
                     variables[i].eslintUsed = true;
                     return true;

--- a/lib/rules/key-spacing.js
+++ b/lib/rules/key-spacing.js
@@ -420,7 +420,6 @@ module.exports = {
                 isExtra = diff > 0,
                 diffAbs = Math.abs(diff),
                 spaces = Array(diffAbs + 1).join(" ");
-            let fix;
 
             if ((
                 diff && mode === "strict" ||
@@ -428,6 +427,8 @@ module.exports = {
                 diff > 0 && !expected && mode === "minimum") &&
                 !(expected && containsLineTerminator(whitespace))
             ) {
+                let fix;
+
                 if (isExtra) {
                     let range;
 

--- a/lib/rules/no-unmodified-loop-condition.js
+++ b/lib/rules/no-unmodified-loop-condition.js
@@ -213,13 +213,13 @@ function getEncloseFunctionDeclaration(reference) {
  * @returns {void}
  */
 function updateModifiedFlag(conditions, modifiers) {
-    let funcNode, funcVar;
 
     for (let i = 0; i < conditions.length; ++i) {
         const condition = conditions[i];
 
         for (let j = 0; !condition.modified && j < modifiers.length; ++j) {
             const modifier = modifiers[j];
+            let funcNode, funcVar;
 
             /*
              * Besides checking for the condition being in the loop, we want to

--- a/lib/rules/quote-props.js
+++ b/lib/rules/quote-props.js
@@ -135,13 +135,14 @@ module.exports = {
          */
         function checkUnnecessaryQuotes(node) {
             const key = node.key;
-            let tokens;
 
             if (node.method || node.computed || node.shorthand) {
                 return;
             }
 
             if (key.type === "Literal" && typeof key.value === "string") {
+                let tokens;
+
                 try {
                     tokens = espree.tokenize(key.value);
                 } catch (e) {
@@ -215,7 +216,6 @@ module.exports = {
 
             node.properties.forEach(property => {
                 const key = property.key;
-                let tokens;
 
                 if (!key || property.method || property.computed || property.shorthand) {
                     return;
@@ -226,6 +226,8 @@ module.exports = {
                     quotedProps.push(property);
 
                     if (checkQuotesRedundancy) {
+                        let tokens;
+
                         try {
                             tokens = espree.tokenize(key.value);
                         } catch (e) {

--- a/lib/rules/quotes.js
+++ b/lib/rules/quotes.js
@@ -229,10 +229,9 @@ module.exports = {
             Literal(node) {
                 const val = node.value,
                     rawVal = node.raw;
-                let isValid;
 
                 if (settings && typeof val === "string") {
-                    isValid = (quoteOption === "backtick" && isAllowedAsNonBacktick(node)) ||
+                    let isValid = (quoteOption === "backtick" && isAllowedAsNonBacktick(node)) ||
                         isJSXLiteral(node) ||
                         astUtils.isSurroundedBy(rawVal, settings.quote);
 

--- a/lib/rules/space-before-blocks.js
+++ b/lib/rules/space-before-blocks.js
@@ -82,11 +82,11 @@ module.exports = {
          */
         function checkPrecedingSpace(node) {
             const precedingToken = sourceCode.getTokenBefore(node);
-            let requireSpace;
 
             if (precedingToken && !isConflicted(precedingToken) && astUtils.isTokenOnSameLine(precedingToken, node)) {
                 const hasSpace = sourceCode.isSpaceBetweenTokens(precedingToken, node);
                 const parent = context.getAncestors().pop();
+                let requireSpace;
 
                 if (parent.type === "FunctionExpression" || parent.type === "FunctionDeclaration") {
                     requireSpace = checkFunctions;

--- a/lib/rules/valid-jsdoc.js
+++ b/lib/rules/valid-jsdoc.js
@@ -231,11 +231,11 @@ module.exports = {
                 hasConstructor = false,
                 isInterface = false,
                 isOverride = false,
-                isAbstract = false,
-                jsdoc;
+                isAbstract = false;
 
             // make sure only to validate JSDoc comments
             if (jsdocNode) {
+                let jsdoc;
 
                 try {
                     jsdoc = doctrine.parse(jsdocNode.value, {


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

I made an attempt at implementing the `prefer-smaller-scope` rule proposal, which was originally proposed in https://github.com/eslint/eslint/issues/5284. That attempt can be found [here](https://gist.github.com/not-an-aardvark/e7cc13acbb593f402035b587aab226ec).

Unfortunately, I found that the rule would incorrectly report some places where declaring a variable in an outer scope is necessary if an inner scope is executed multiple times. I don't know of a good way to avoid those false positives while still keeping the rule useful.

```js
let flag; // `flag` is only ever used in the function, but still needs to be declared outside it.

function doSomethingAfterFirstCall() {
    if (flag) foo();
    flag = flag || true;
}
```

However, by implementing the rule I found a number of cases where we can reduce the scope of the variables.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
