### PR TITLE
Chore: remove undocumented Linter#markVariableAsUsed method (refs #9161)

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -631,6 +631,34 @@ function getScope(scopeManager, currentNode, ecmaVersion) {
     return scopeManager.scopes[0];
 }
 
+/**
+ * Marks a variable as used in the current scope
+ * @param {ScopeManager} scopeManager The scope manager for this AST. The scope may be mutated by this function.
+ * @param {ASTNode} currentNode The node currently being traversed
+ * @param {Object} parserOptions The options used to parse this text
+ * @param {string} name The name of the variable that should be marked as used.
+ * @returns {boolean} True if the variable was found and marked as used, false if not.
+ */
+function markVariableAsUsed(scopeManager, currentNode, parserOptions, name) {
+    const hasGlobalReturn = parserOptions.ecmaFeatures && parserOptions.ecmaFeatures.globalReturn;
+    const specialScope = hasGlobalReturn || parserOptions.sourceType === "module";
+    const currentScope = getScope(scopeManager, currentNode, parserOptions.ecmaVersion);
+
+    // Special Node.js scope means we need to start one level deeper
+    const initialScope = currentScope.type === "global" && specialScope ? currentScope.childScopes[0] : currentScope;
+
+    for (let scope = initialScope; scope; scope = scope.upper) {
+        const variable = scope.variables.find(scopeVar => scopeVar.name === name);
+
+        if (variable) {
+            variable.eslintUsed = true;
+            return true;
+        }
+    }
+
+    return false;
+}
+
 // methods that exist on SourceCode object
 const DEPRECATED_SOURCECODE_PASSTHROUGHS = {
     getSource: "getText",
@@ -827,7 +855,7 @@ module.exports = class Linter {
                     getFilename: () => filename,
                     getScope: () => getScope(this.scopeManager, this.traverser.current(), this.currentConfig.parserOptions.ecmaVersion),
                     getSourceCode: () => sourceCode,
-                    markVariableAsUsed: this.markVariableAsUsed.bind(this),
+                    markVariableAsUsed: name => markVariableAsUsed(this.scopeManager, this.traverser.current(), this.currentConfig.parserOptions, name),
                     parserOptions: config.parserOptions,
                     parserPath: config.parser,
                     parserServices,
@@ -977,36 +1005,6 @@ module.exports = class Linter {
      */
     getSourceCode() {
         return this.sourceCode;
-    }
-
-    /**
-     * Record that a particular variable has been used in code
-     * @param {string} name The name of the variable to mark as used
-     * @returns {boolean} True if the variable was found and marked as used,
-     *      false if not.
-     */
-    markVariableAsUsed(name) {
-        const hasGlobalReturn = this.currentConfig.parserOptions.ecmaFeatures && this.currentConfig.parserOptions.ecmaFeatures.globalReturn,
-            specialScope = hasGlobalReturn || this.currentConfig.parserOptions.sourceType === "module";
-        let scope = getScope(this.scopeManager, this.traverser.current(), this.currentConfig.parserOptions.ecmaVersion);
-
-        // Special Node.js scope means we need to start one level deeper
-        if (scope.type === "global" && specialScope) {
-            scope = scope.childScopes[0];
-        }
-
-        do {
-            const variables = scope.variables;
-
-            for (let i = 0; i < variables.length; i++) {
-                if (variables[i].name === name) {
-                    variables[i].eslintUsed = true;
-                    return true;
-                }
-            }
-        } while ((scope = scope.upper));
-
-        return false;
     }
 
     /**


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates `Linter` to remove the `markVariableAsUsed` method. (The `context.markVariableAsUsed` function is still available to rules -- this just removes the version on `Linter`.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular