### PR TITLE
Chore: remove Linter#reset (refs #9161)

### DIFF
--- a/docs/developer-guide/nodejs-api.md
+++ b/docs/developer-guide/nodejs-api.md
@@ -60,16 +60,16 @@ var linter = new Linter();
 
 ### Linter#verify
 
-The most important method on `Linter` is `verify()`, which initiates linting of the given text. This method accepts four arguments:
+The most important method on `Linter` is `verify()`, which initiates linting of the given text. This method accepts three arguments:
 
 * `code` - the source code to lint (a string or instance of `SourceCode`).
 * `config` - a configuration object that has been processed and normalized by CLIEngine using eslintrc files and/or other configuration arguments.
     * **Note**: If you want to lint text and have your configuration be read and processed, use CLIEngine's [`executeOnFiles`](#executeonfiles) or [`executeOnText`](#executeontext) instead.
-* `optionsOrFilename` - (optional) Additional options for this run or a string representing the filename to associate with the code being linted.
+* `options` - (optional) Additional options for this run.
     * `filename` - (optional) the filename to associate with the source code.
-    * `saveState` - (optional) see below. This will override any value passed as the fourth argument if an options object is used here instead of the filename.
     * `allowInlineConfig` - (optional) set to `false` to disable inline comments from changing eslint rules.
-* `saveState` - (optional) set to true to maintain the internal state of `linter` after linting (mostly used for testing purposes)
+
+If the third argument is a string, it is interpreted as the `filename`.
 
 You can call `verify()` like this:
 

--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -142,10 +142,6 @@ function calculateStatsPerRun(results) {
  * @private
  */
 function processText(text, configHelper, filename, fix, allowInlineConfig, linter) {
-
-    // clear all existing settings for a new file
-    linter.reset();
-
     let filePath,
         messages,
         fileExtension,

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -710,14 +710,6 @@ module.exports = class Linter {
     }
 
     /**
-     * Resets the internal state of the object.
-     * @returns {void}
-     */
-    reset() {
-        this.sourceCode = null;
-    }
-
-    /**
      * Configuration object for the `verify` API. A JS representation of the eslintrc files.
      * @typedef {Object} ESLintConfig
      * @property {Object} rules The rule configuration to verify against.
@@ -735,13 +727,11 @@ module.exports = class Linter {
      * @param {(string|Object)} [filenameOrOptions] The optional filename of the file being checked.
      *      If this is not set, the filename will default to '<input>' in the rule context. If
      *      an object, then it has "filename", "saveState", and "allowInlineConfig" properties.
-     * @param {boolean} [saveState] Indicates if the state from the last run should be saved.
-     *      Mostly useful for testing purposes.
      * @param {boolean} [filenameOrOptions.allowInlineConfig] Allow/disallow inline comments' ability to change config once it is set. Defaults to true if not supplied.
      *      Useful if you want to validate JS without comments overriding rules.
      * @returns {Object[]} The results as an array of messages or null if no messages.
      */
-    verify(textOrSourceCode, config, filenameOrOptions, saveState) {
+    verify(textOrSourceCode, config, filenameOrOptions) {
         let text,
             parserServices,
             allowInlineConfig,
@@ -751,16 +741,11 @@ module.exports = class Linter {
         if (typeof filenameOrOptions === "object") {
             providedFilename = filenameOrOptions.filename;
             allowInlineConfig = filenameOrOptions.allowInlineConfig;
-            saveState = filenameOrOptions.saveState;
         } else {
             providedFilename = filenameOrOptions;
         }
 
         const filename = typeof providedFilename === "string" ? providedFilename : "<input>";
-
-        if (!saveState) {
-            this.reset();
-        }
 
         if (typeof textOrSourceCode === "string") {
             this.sourceCode = null;

--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -332,8 +332,6 @@ class RuleTester {
              * The goal is to check whether or not AST was modified when
              * running the rule under test.
              */
-            linter.reset();
-
             linter.defineRule("rule-tester/validate-ast", () => ({
                 Program(node) {
                     beforeAST = cloneDeeplyExcludesParent(node);

--- a/tests/lib/ast-utils.js
+++ b/tests/lib/ast-utils.js
@@ -56,8 +56,6 @@ describe("ast-utils", () => {
                 `Expected ${func.toString()} to be called at least once but it was not called`
             );
         });
-
-        linter.reset();
     });
 
     describe("isTokenOnSameLine", () => {

--- a/tests/lib/code-path-analysis/code-path-analyzer.js
+++ b/tests/lib/code-path-analysis/code-path-analyzer.js
@@ -54,11 +54,6 @@ function getExpectedDotArrows(source) {
 //------------------------------------------------------------------------------
 
 describe("CodePathAnalyzer", () => {
-
-    afterEach(() => {
-        linter.reset();
-    });
-
     EventGeneratorTester.testEventGeneratorInterface(
         new CodePathAnalyzer(new NodeEventGenerator(new EventEmitter()))
     );

--- a/tests/lib/code-path-analysis/code-path.js
+++ b/tests/lib/code-path-analysis/code-path.js
@@ -26,7 +26,6 @@ const linter = new Linter();
 function parseCodePaths(code) {
     const retv = [];
 
-    linter.reset();
     linter.defineRule("test", () => ({
         onCodePathStart(codePath) {
             retv.push(codePath);

--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -171,7 +171,6 @@ describe("Linter", () => {
         const code = TEST_CODE;
 
         it("should retrieve SourceCode object after reset", () => {
-            linter.reset();
             linter.verify(code, {}, filename, true);
 
             const sourceCode = linter.getSourceCode();
@@ -182,7 +181,6 @@ describe("Linter", () => {
         });
 
         it("should retrieve SourceCode object without reset", () => {
-            linter.reset();
             linter.verify(code, {}, filename);
 
             const sourceCode = linter.getSourceCode();
@@ -860,7 +858,6 @@ describe("Linter", () => {
         const code = "test-rule";
 
         it("should pass settings to all rules", () => {
-            linter.reset();
             linter.defineRule(code, context => ({
                 Literal(node) {
                     context.report(node, context.settings.info);
@@ -878,7 +875,6 @@ describe("Linter", () => {
         });
 
         it("should not have any settings if they were not passed in", () => {
-            linter.reset();
             linter.defineRule(code, context => ({
                 Literal(node) {
                     if (Object.getOwnPropertyNames(context.settings).length !== 0) {
@@ -908,7 +904,6 @@ describe("Linter", () => {
                 }
             };
 
-            linter.reset();
             linter.defineRule("test-rule", sandbox.mock().withArgs(
                 sinon.match({ parserOptions })
             ).returns({}));
@@ -922,7 +917,6 @@ describe("Linter", () => {
 
             const parserOptions = {};
 
-            linter.reset();
             linter.defineRule("test-rule", sandbox.mock().withArgs(
                 sinon.match({ parserOptions })
             ).returns({}));
@@ -942,7 +936,6 @@ describe("Linter", () => {
 
                 const alternateParser = "esprima-fb";
 
-                linter.reset();
                 linter.defineRule("test-rule", sandbox.mock().withArgs(
                     sinon.match({ parserPath: alternateParser })
                 ).returns({}));
@@ -955,9 +948,6 @@ describe("Linter", () => {
             it("should use parseForESLint() in custom parser when custom parser is specified", () => {
 
                 const alternateParser = path.resolve(__dirname, "../fixtures/parsers/enhanced-parser.js");
-
-                linter.reset();
-
                 const config = { rules: {}, parser: alternateParser };
                 const messages = linter.verify("0", config, filename);
 
@@ -968,7 +958,6 @@ describe("Linter", () => {
 
                 const alternateParser = path.resolve(__dirname, "../fixtures/parsers/enhanced-parser.js");
 
-                linter.reset();
                 linter.defineRule("test-service-rule", context => ({
                     Literal(node) {
                         context.report({
@@ -1007,7 +996,6 @@ describe("Linter", () => {
                 config = { rules: {} };
 
             config.rules[rule] = 1;
-            linter.reset();
 
             const messages = linter.verify(code, config, filename, true);
 
@@ -1020,7 +1008,6 @@ describe("Linter", () => {
                 config = { rules: {} };
 
             config.rules[rule] = "warn";
-            linter.reset();
 
             const messages = linter.verify(code, config, filename, true);
 
@@ -1034,7 +1021,6 @@ describe("Linter", () => {
                 config = { rules: {} };
 
             config.rules[rule] = [1];
-            linter.reset();
 
             const messages = linter.verify(code, config, filename, true);
 
@@ -1047,7 +1033,6 @@ describe("Linter", () => {
                 config = { rules: {} };
 
             config.rules[rule] = ["warn"];
-            linter.reset();
 
             const messages = linter.verify(code, config, filename, true);
 
@@ -1061,7 +1046,6 @@ describe("Linter", () => {
                 config = { rules: {} };
 
             config.rules[rule] = "1";
-            linter.reset();
 
             const messages = linter.verify(code, config, filename, true);
 
@@ -1070,8 +1054,6 @@ describe("Linter", () => {
 
         it("should process empty config", () => {
             const config = {};
-
-            linter.reset();
             const messages = linter.verify(code, config, filename, true);
 
             assert.equal(messages.length, 0);
@@ -1415,7 +1397,6 @@ describe("Linter", () => {
         const code = "new-rule";
 
         it("can add a rule dynamically", () => {
-            linter.reset();
             linter.defineRule(code, context => ({
                 Literal(node) {
                     context.report(node, "message");
@@ -1438,7 +1419,6 @@ describe("Linter", () => {
         const code = ["new-rule-0", "new-rule-1"];
 
         it("can add multiple rules dynamically", () => {
-            linter.reset();
             const config = { rules: {} };
             const newRules = {};
 
@@ -1470,7 +1450,6 @@ describe("Linter", () => {
         const code = "filename-rule";
 
         it("has access to the filename", () => {
-            linter.reset();
             linter.defineRule(code, context => ({
                 Literal(node) {
                     context.report(node, context.getFilename());
@@ -1487,7 +1466,6 @@ describe("Linter", () => {
         });
 
         it("defaults filename to '<input>'", () => {
-            linter.reset();
             linter.defineRule(code, context => ({
                 Literal(node) {
                     context.report(node, context.getFilename());
@@ -1522,8 +1500,6 @@ describe("Linter", () => {
             const config = { rules: { strict: 2 } };
             const codeA = "/*eslint strict: 0*/ function bar() { return 2; }";
             const codeB = "function foo() { return 1; }";
-
-            linter.reset();
             let messages = linter.verify(codeA, config, filename, false);
 
             assert.equal(messages.length, 0);
@@ -1536,8 +1512,6 @@ describe("Linter", () => {
             const config = { rules: { quotes: [2, "double"] } };
             const codeA = "/*eslint quotes: 0*/ function bar() { return '2'; }";
             const codeB = "function foo() { return '1'; }";
-
-            linter.reset();
             let messages = linter.verify(codeA, config, filename, false);
 
             assert.equal(messages.length, 0);
@@ -1550,8 +1524,6 @@ describe("Linter", () => {
             const config = { rules: { quotes: [2, "double"] } };
             const codeA = "/*eslint quotes: [0, \"single\"]*/ function bar() { return '2'; }";
             const codeB = "function foo() { return '1'; }";
-
-            linter.reset();
             let messages = linter.verify(codeA, config, filename, false);
 
             assert.equal(messages.length, 0);
@@ -1564,8 +1536,6 @@ describe("Linter", () => {
             const config = { rules: { "no-unused-vars": [2, { vars: "all" }] } };
             const codeA = "/*eslint no-unused-vars: [0, {\"vars\": \"local\"}]*/ var a = 44;";
             const codeB = "var b = 55;";
-
-            linter.reset();
             let messages = linter.verify(codeA, config, filename, false);
 
             assert.equal(messages.length, 0);
@@ -1691,8 +1661,6 @@ describe("Linter", () => {
             const config = { rules: { "test-plugin/test-rule": 2 } };
             const codeA = "/*eslint test-plugin/test-rule: 0*/ var a = \"trigger violation\";";
             const codeB = "var a = \"trigger violation\";";
-
-            linter.reset();
             let messages = linter.verify(codeA, config, filename, false);
 
             assert.equal(messages.length, 0);
@@ -2904,16 +2872,6 @@ describe("Linter", () => {
                 linter.defineRule("checker", filenameChecker);
                 linter.verify("foo;", { rules: { checker: "error" } });
                 assert(filenameChecker.calledOnce);
-            });
-        });
-
-        describe("saveState", () => {
-            it("should save the state when saveState is passed as an option", () => {
-
-                const spy = sinon.spy(linter, "reset");
-
-                linter.verify("foo;", {}, { saveState: true });
-                assert.equal(spy.callCount, 0);
             });
         });
 

--- a/tests/lib/util/source-code.js
+++ b/tests/lib/util/source-code.js
@@ -216,10 +216,6 @@ describe("SourceCode", () => {
 
         const sandbox = sinon.sandbox.create();
 
-        beforeEach(() => {
-            linter.reset();
-        });
-
         afterEach(() => {
             sandbox.verifyAndRestore();
         });
@@ -905,7 +901,6 @@ describe("SourceCode", () => {
 
 
         beforeEach(() => {
-            linter.reset();
             unusedAssertionFuncs = new Set();
         });
 

--- a/tests/tools/eslint-fuzzer.js
+++ b/tests/tools/eslint-fuzzer.js
@@ -38,7 +38,6 @@ describe("eslint-fuzzer", function() {
     });
 
     after(() => {
-        linter.reset();
         configRule.createCoreRuleConfigs.restore();
     });
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates `Linter` to remove the undocumented `reset` method.

It also removes the fourth argument from `Linter#verify`, because that argument now has no effect at all. (It was previously used to control what happened to the internal state of the `Linter` instance, but now the `Linter` instance has no internal state except for the `sourceCode` property, which was always reset regardless). In fact, the fourth argument has never had any effect for users that only used documented APIs. Integrations that use the fourth argument will continue to work the same way that they did before (the fourth argument will just be ignored now).

~~This builds on top of https://github.com/eslint/eslint/pull/9267. The first commit is from that PR. For this PR, only look at the [second commit](https://github.com/eslint/eslint/pull/9268/commits/b4ed508a6fcc8a9c9891f628d613cf4de0a6bd29) for now (I'll rebase after https://github.com/eslint/eslint/pull/9267 is merged).~~

Refs: #9161

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
