### PR TITLE
Build: re-run browserify when generating site

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -792,6 +792,7 @@ target.gensite = function(prereleaseVersion) {
     // 13. Update demos, but only for non-prereleases
     if (!prereleaseVersion) {
         echo("> Updating the demos (Step 13)");
+        target.browserify();
         cp("-f", "build/eslint.js", `${SITE_DIR}js/app/eslint.js`);
     } else {
         echo("> Skipped updating the demos (Step 13)");


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (fixes https://github.com/eslint/eslint.github.io/issues/407)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates the `npm run gensite` script to run browserify as part of the site generation, rather than using whatever it finds in `build/eslint.js`. This has a few advantages:

* The built file will always be up-to-date (previously, it would reflect the state of the repository whenever `npm test` was last run).
* The gensite script won't fail if it's run on its own and there isn't a `build/` directory.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
