### PR TITLE
Chore: avoid monkeypatching Linter instances in RuleTester

### DIFF
--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -307,7 +307,17 @@ class RuleTester {
                 config.rules[ruleName] = 1;
             }
 
-            linter.defineRule(ruleName, rule);
+            linter.defineRule(ruleName, Object.assign({}, rule, {
+
+                // Create a wrapper rule that freezes the `context` properties.
+                create(context) {
+                    freezeDeeply(context.options);
+                    freezeDeeply(context.settings);
+                    freezeDeeply(context.parserOptions);
+
+                    return (typeof rule === "function" ? rule : rule.create)(context);
+                }
+            }));
 
             const schema = validator.getRuleOptionsSchema(ruleName, linter.rules);
 
@@ -343,35 +353,11 @@ class RuleTester {
                 }
             }));
 
-            // Freezes rule-context properties.
-            const originalGet = linter.rules.get;
-
-            try {
-                linter.rules.get = function(ruleId) {
-                    const originalRule = originalGet.call(linter.rules, ruleId);
-
-                    return {
-                        meta: originalRule.meta,
-                        create(context) {
-                            Object.freeze(context);
-                            freezeDeeply(context.options);
-                            freezeDeeply(context.settings);
-                            freezeDeeply(context.parserOptions);
-
-                            return originalRule.create(context);
-                        }
-                    };
-
-                };
-
-                return {
-                    messages: linter.verify(code, config, filename, true),
-                    beforeAST,
-                    afterAST: cloneDeeplyExcludesParent(afterAST)
-                };
-            } finally {
-                linter.rules.get = originalGet;
-            }
+            return {
+                messages: linter.verify(code, config, filename, true),
+                beforeAST,
+                afterAST: cloneDeeplyExcludesParent(afterAST)
+            };
         }
 
         /**


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates `RuleTester` to avoid monkeypatching its `Linter` instance, and use rule composition instead in order to freeze the context properties.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
