### PR TITLE
Chore: avoid applying eslint-env comments twice

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -290,7 +290,7 @@ function createDisableDirectives(type, loc, value) {
  */
 function modifyConfigsFromComments(filename, ast, config, linterContext) {
 
-    let commentConfig = {
+    const commentConfig = {
         exported: {},
         astGlobals: {},
         rules: {},
@@ -317,10 +317,6 @@ function modifyConfigsFromComments(filename, ast, config, linterContext) {
                     case "globals":
                     case "global":
                         Object.assign(commentConfig.astGlobals, parseBooleanConfig(value, comment));
-                        break;
-
-                    case "eslint-env":
-                        Object.assign(commentConfig.env, parseListConfig(value));
                         break;
 
                     case "eslint-disable":
@@ -360,14 +356,6 @@ function modifyConfigsFromComments(filename, ast, config, linterContext) {
         }
     });
 
-    // apply environment configs
-    Object.keys(commentConfig.env).forEach(name => {
-        const env = linterContext.environments.get(name);
-
-        if (env) {
-            commentConfig = ConfigOps.merge(commentConfig, env);
-        }
-    });
     Object.assign(commentConfig.rules, commentRules);
 
     return {


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

`/* eslint-env */` comments are processed differently from other directive comments in that they're actually [matched by a regex](https://github.com/eslint/eslint/blob/4ae7ad3325abe962f4f56cd7b547476b313d6024/lib/linter.js#L461-L478) and applied before parsing occurs. This was done as a fix for https://github.com/eslint/eslint/issues/2134 in order to allow `/* eslint-env */` comments to change the parser options. (A side-effect is that some envs are incorrectly added when `/* eslint-env */` appears in a string rather than a comment, like [this](https://github.com/eslint/eslint/blob/4ae7ad3325abe962f4f56cd7b547476b313d6024/tests/lib/linter.js#L1146), but that's a separate concern.)

Since `envs` are applied before parsing, it's not necessary to also apply them after parsing as part of the normal comment processing step. This commit removes the double-processing.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
