### PR TITLE
Chore: enable eslint-plugin/no-deprecated-context-methods

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -9,7 +9,7 @@ extends:
     - "plugin:eslint-plugin/recommended"
 rules:
     eslint-plugin/consistent-output: "error"
-    eslint-plugin/no-identical-tests: "error"
+    eslint-plugin/no-deprecated-context-methods: "error"
     eslint-plugin/prefer-output-null: "error"
     eslint-plugin/prefer-placeholders: "error"
     eslint-plugin/report-message-format: ["error", '[^a-z].*\.$']

--- a/lib/rules/indent-legacy.js
+++ b/lib/rules/indent-legacy.js
@@ -1040,7 +1040,7 @@ module.exports = {
 
                 const checkNodes = [node.property];
 
-                const dot = context.getTokenBefore(node.property);
+                const dot = sourceCode.getTokenBefore(node.property);
 
                 if (dot.type === "Punctuator" && dot.value === ".") {
                     checkNodes.push(dot);

--- a/lib/rules/no-tabs.js
+++ b/lib/rules/no-tabs.js
@@ -27,7 +27,7 @@ module.exports = {
     create(context) {
         return {
             Program(node) {
-                context.getSourceLines().forEach((line, index) => {
+                context.getSourceCode().getLines().forEach((line, index) => {
                     const match = regex.exec(line);
 
                     if (match) {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "coveralls": "^2.13.1",
     "dateformat": "^2.0.0",
     "ejs": "^2.5.6",
-    "eslint-plugin-eslint-plugin": "^1.0.0",
+    "eslint-plugin-eslint-plugin": "^1.2.0",
     "eslint-plugin-node": "^5.1.0",
     "eslint-release": "^0.10.1",
     "eslump": "1.6.0",


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This upgrades [`eslint-plugin-eslint-plugin`](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin) to v1.2.0, and enables the new [`no-deprecated-context-methods`](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/master/docs/rules/no-deprecated-context-methods.md) rule, which disallows calls to deprecated methods like `context.getFirstToken`.

[Full changelog](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/efae7daaeecc96545aac3714c043e4b564aa0edd/CHANGELOG.md)

**Is there anything you'd like reviewers to focus on?**

Nothing in particular