### PR TITLE
Update: run rules after `node.parent` is already set (fixes #9122)

### DIFF
--- a/docs/developer-guide/working-with-plugins.md
+++ b/docs/developer-guide/working-with-plugins.md
@@ -174,7 +174,7 @@ All nodes must have `range` property.
 * `range` (`number[]`) is an array of two numbers. Both numbers are a 0-based index which is the position in the array of source code characters. The first is the start position of the node, the second is the end position of the node. `code.slice(node.range[0], node.range[1])` must be the text of the node. This range does not include spaces/parentheses which are around the node.
 * `loc` (`SourceLocation`) must not be `null`. [The `loc` property is defined as nullable by ESTree](https://github.com/estree/estree/blob/25834f7247d44d3156030f8e8a2d07644d771fdb/es5.md#node-objects), but ESLint requires this property. On the other hand, `SourceLocation#source` property can be `undefined`. ESLint does not use the `SourceLocation#source` property.
 
-The `parent` property of all nodes must be rewriteable. ESLint sets each node's parent properties to its parent node while traversing.
+The `parent` property of all nodes must be rewriteable. ESLint sets each node's `parent` property to its parent node while traversing, before any rules have access to the AST.
 
 #### The `Program` node:
 

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -653,6 +653,22 @@ function markVariableAsUsed(scopeManager, currentNode, parserOptions, name) {
     return false;
 }
 
+/**
+ * Gets all the ancestors of a given node
+ * @param {ASTNode} node The node
+ * @returns {ASTNode[]} All the ancestor nodes in the AST, not including the provided node, starting
+ * from the root node and going inwards to the parent node.
+ */
+function getAncestors(node) {
+    if (node.parent) {
+        const parentAncestors = getAncestors(node.parent);
+
+        parentAncestors.push(node.parent);
+        return parentAncestors;
+    }
+    return [];
+}
+
 // methods that exist on SourceCode object
 const DEPRECATED_SOURCECODE_PASSTHROUGHS = {
     getSource: "getText",
@@ -812,7 +828,6 @@ module.exports = class Linter {
         }
 
         const emitter = new EventEmitter().setMaxListeners(Infinity);
-        const traverser = new Traverser();
         const ecmaFeatures = config.parserOptions.ecmaFeatures || {};
         const ecmaVersion = config.parserOptions.ecmaVersion || 5;
         const scopeManager = eslintScope.analyze(sourceCode.ast, {
@@ -824,6 +839,19 @@ module.exports = class Linter {
             fallback: Traverser.getKeys
         });
 
+        let currentNode = sourceCode.ast;
+        const nodeQueue = [];
+
+        new Traverser().traverse(sourceCode.ast, {
+            enter(node, parent) {
+                node.parent = parent;
+                nodeQueue.push({ isEntering: true, node });
+            },
+            leave(node) {
+                nodeQueue.push({ isEntering: false, node });
+            }
+        });
+
         /*
          * Create a frozen object with the ruleContext properties and methods that are shared by all rules.
          * All rule contexts will inherit from this object. This avoids the performance penalty of copying all the
@@ -833,12 +861,12 @@ module.exports = class Linter {
             Object.assign(
                 Object.create(BASE_TRAVERSAL_CONTEXT),
                 {
-                    getAncestors: () => traverser.parents(),
+                    getAncestors: () => getAncestors(currentNode),
                     getDeclaredVariables: scopeManager.getDeclaredVariables.bind(scopeManager),
                     getFilename: () => filename,
-                    getScope: () => getScope(scopeManager, traverser.current(), config.parserOptions.ecmaVersion),
+                    getScope: () => getScope(scopeManager, currentNode, config.parserOptions.ecmaVersion),
                     getSourceCode: () => sourceCode,
-                    markVariableAsUsed: name => markVariableAsUsed(scopeManager, traverser.current(), config.parserOptions, name),
+                    markVariableAsUsed: name => markVariableAsUsed(scopeManager, currentNode, config.parserOptions, name),
                     parserOptions: config.parserOptions,
                     parserPath: config.parser,
                     parserServices,
@@ -943,19 +971,13 @@ module.exports = class Linter {
 
         const eventGenerator = new CodePathAnalyzer(new NodeEventGenerator(emitter));
 
-        /*
-         * Each node has a type property. Whenever a particular type of
-         * node is found, an event is fired. This allows any listeners to
-         * automatically be informed that this type of node has been found
-         * and react accordingly.
-         */
-        traverser.traverse(sourceCode.ast, {
-            enter(node, parent) {
-                node.parent = parent;
-                eventGenerator.enterNode(node);
-            },
-            leave(node) {
-                eventGenerator.leaveNode(node);
+        nodeQueue.forEach(traversalInfo => {
+            currentNode = traversalInfo.node;
+
+            if (traversalInfo.isEntering) {
+                eventGenerator.enterNode(currentNode);
+            } else {
+                eventGenerator.leaveNode(currentNode);
             }
         });
 

--- a/lib/util/source-code.js
+++ b/lib/util/source-code.js
@@ -349,15 +349,13 @@ class SourceCode extends TokenStore {
      * @returns {ASTNode} The node if found or null if not found.
      */
     getNodeByRangeIndex(index) {
-        let result = null,
-            resultParent = null;
+        let result = null;
         const traverser = new Traverser();
 
         traverser.traverse(this.ast, {
-            enter(node, parent) {
+            enter(node) {
                 if (node.range[0] <= index && index < node.range[1]) {
                     result = node;
-                    resultParent = parent;
                 } else {
                     this.skip();
                 }
@@ -369,7 +367,7 @@ class SourceCode extends TokenStore {
             }
         });
 
-        return result ? Object.assign({ parent: resultParent }, result) : null;
+        return result;
     }
 
     /**

--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -100,6 +100,21 @@ describe("Linter", () => {
                 linter.verify(code, config, filename, true);
             }, "Intentional error.");
         });
+
+        it("has all the `parent` properties on nodes when the rule listeners are created", () => {
+            linter.defineRule("checker", context => {
+                const ast = context.getSourceCode().ast;
+
+                assert.strictEqual(ast.body[0].parent, ast);
+                assert.strictEqual(ast.body[0].expression.parent, ast.body[0]);
+                assert.strictEqual(ast.body[0].expression.left.parent, ast.body[0].expression);
+                assert.strictEqual(ast.body[0].expression.right.parent, ast.body[0].expression);
+
+                return {};
+            });
+
+            linter.verify("foo + bar", { rules: { checker: "error" } });
+        });
     });
 
     describe("context.getSourceLines()", () => {
@@ -432,43 +447,6 @@ describe("Linter", () => {
             linter.verify(code, config);
             assert(spy.calledOnce);
         });
-
-        it("should attach the node's parent", () => {
-            const config = { rules: { checker: "error" } };
-            const spy = sandbox.spy(context => {
-                const node = context.getNodeByRangeIndex(14);
-
-                assert.property(node, "parent");
-                assert.equal(node.parent.type, "VariableDeclarator");
-                return {};
-            });
-
-            linter.defineRule("checker", spy);
-            linter.verify(code, config);
-            assert(spy.calledOnce);
-        });
-
-        it("should not modify the node when attaching the parent", () => {
-            const config = { rules: { checker: "error" } };
-            const spy = sandbox.spy(context => {
-                const node1 = context.getNodeByRangeIndex(10);
-
-                assert.equal(node1.type, "VariableDeclarator");
-
-                const node2 = context.getNodeByRangeIndex(4);
-
-                assert.equal(node2.type, "Identifier");
-                assert.property(node2, "parent");
-                assert.equal(node2.parent.type, "VariableDeclarator");
-                assert.notProperty(node2.parent, "parent");
-                return {};
-            });
-
-            linter.defineRule("checker", spy);
-            linter.verify(code, config);
-            assert(spy.calledOnce);
-        });
-
     });
 
 

--- a/tests/lib/util/source-code.js
+++ b/tests/lib/util/source-code.js
@@ -1775,25 +1775,6 @@ describe("SourceCode", () => {
             node = sourceCode.getNodeByRangeIndex(-99);
             assert.isNull(node);
         });
-
-        it("should attach the node's parent", () => {
-            const node = sourceCode.getNodeByRangeIndex(14);
-
-            assert.property(node, "parent");
-            assert.equal(node.parent.type, "VariableDeclarator");
-        });
-
-        it("should not modify the node when attaching the parent", () => {
-            let node = sourceCode.getNodeByRangeIndex(10);
-
-            assert.equal(node.type, "VariableDeclarator");
-            node = sourceCode.getNodeByRangeIndex(4);
-            assert.equal(node.type, "Identifier");
-            assert.property(node, "parent");
-            assert.equal(node.parent.type, "VariableDeclarator");
-            assert.notProperty(node.parent, "parent");
-        });
-
     });
 
     describe("isSpaceBetweenTokens()", () => {


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Add something to the core

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This is a reference implementation of #9122. With this change, rules don't have to worry about whether `node.parent` has been set at any given point, because all of the `node.parent` properties will be assigned by the time the rule gets run.

~~This builds on https://github.com/eslint/eslint/pull/9268, and should not be merged until https://github.com/eslint/eslint/pull/9268 is merged. For now, only look at the [second commit](https://github.com/eslint/eslint/pull/9283/commits/f65fdac1b0f8962cd44a899a4c6cf1a10e852fbf).~~

Since this stores nodes in a queue rather than doing another traversal, this has very little performance impact:

<details>
<summary>Performance metrics</summary>

On 9ecd264 (without this change applied):

```
((HEAD detached at 7685fed3))$ npm run perf

> eslint@4.6.1 perf /path/to/eslint
> node Makefile.js perf


Loading:
  Load performance Run #1:  120.599158ms
  Load performance Run #2:  114.98305ms
  Load performance Run #3:  114.749014ms
  Load performance Run #4:  119.581881ms
  Load performance Run #5:  120.72974ms

  Load Performance median:  119.581881ms


Single File:
  CPU Speed is 3100 with multiplier 13000000
  Performance Run #1:  5545.881914ms
  Performance Run #2:  5494.320288ms
  Performance Run #3:  5507.513848ms
  Performance Run #4:  5535.386212ms
  Performance Run #5:  5487.6923289999995ms

  Performance budget exceeded: 5507.513848ms (limit: 4193.548387096775ms)


Multi Files (0 files):
  CPU Speed is 3100 with multiplier 39000000
  Performance Run #1:  13472.871353ms
  Performance Run #2:  13794.571958ms
  Performance Run #3:  13790.013038000001ms
  Performance Run #4:  13667.251705ms
  Performance Run #5:  13450.531616ms

  Performance budget exceeded: 13667.251705ms (limit: 12580.645161290322ms)
```

On `deferred-listener-calls` (with this change applied):

```
(deferred-listener-calls)$ npm run perf

> eslint@4.6.1 perf /Users/tkatz/code/eslint
> node Makefile.js perf


Loading:
  Load performance Run #1:  116.02172ms
  Load performance Run #2:  122.795839ms
  Load performance Run #3:  120.586319ms
  Load performance Run #4:  117.875192ms
  Load performance Run #5:  117.937884ms

  Load Performance median:  117.937884ms


Single File:
  CPU Speed is 3100 with multiplier 13000000
  Performance Run #1:  5591.12559ms
  Performance Run #2:  5558.3983530000005ms
  Performance Run #3:  5500.023409ms
  Performance Run #4:  5587.691358ms
  Performance Run #5:  5585.687514ms

  Performance budget exceeded: 5585.687514ms (limit: 4193.548387096775ms)


Multi Files (0 files):
  CPU Speed is 3100 with multiplier 39000000
  Performance Run #1:  13529.686102ms
  Performance Run #2:  13508.945281ms
  Performance Run #3:  13482.570723ms
  Performance Run #4:  13340.607641ms
  Performance Run #5:  13524.828015ms

  Performance budget exceeded: 13508.945281ms (limit: 12580.645161290322ms)
```

These numbers indicate a 1% performance decrease on the single-file benchmark, and a 1% improvement on the multi-file benchmark. I suspect at least some of this is noise, but if there is a performance impact it seems quite small.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular