### PR TITLE
Fix: remove autofix for var undef inits (fixes #9231)

### DIFF
--- a/lib/rules/no-undef-init.js
+++ b/lib/rules/no-undef-init.js
@@ -43,6 +43,10 @@ module.exports = {
                         message: "It's not necessary to initialize '{{name}}' to undefined.",
                         data: { name },
                         fix(fixer) {
+                            if (node.parent.kind === "var") {
+                                return null;
+                            }
+
                             if (node.id.type === "ArrayPattern" || node.id.type === "ObjectPattern") {
 
                                 // Don't fix destructuring assignment to `undefined`.

--- a/tests/lib/rules/no-undef-init.js
+++ b/tests/lib/rules/no-undef-init.js
@@ -92,6 +92,6 @@ ruleTester.run("no-undef-init", rule, {
             output: "for(var i in [1,2,3]){let a; for(var j in [1,2,3]){}}",
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "It's not necessary to initialize 'a' to undefined.", type: "VariableDeclarator" }]
-        },
+        }
     ]
 });

--- a/tests/lib/rules/no-undef-init.js
+++ b/tests/lib/rules/no-undef-init.js
@@ -27,17 +27,17 @@ ruleTester.run("no-undef-init", rule, {
     invalid: [
         {
             code: "var a = undefined;",
-            output: "var a;",
+            output: null,
             errors: [{ message: "It's not necessary to initialize 'a' to undefined.", type: "VariableDeclarator" }]
         },
         {
             code: "var a = undefined, b = 1;",
-            output: "var a, b = 1;",
+            output: null,
             errors: [{ message: "It's not necessary to initialize 'a' to undefined.", type: "VariableDeclarator" }]
         },
         {
             code: "var a = 1, b = undefined, c = 5;",
-            output: "var a = 1, b, c = 5;",
+            output: null,
             errors: [{ message: "It's not necessary to initialize 'b' to undefined.", type: "VariableDeclarator" }]
         },
         {
@@ -51,6 +51,18 @@ ruleTester.run("no-undef-init", rule, {
             output: null,
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "It's not necessary to initialize '{a}' to undefined.", type: "VariableDeclarator" }]
+        },
+        {
+            code: "let a = undefined;",
+            output: "let a;",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "It's not necessary to initialize 'a' to undefined.", type: "VariableDeclarator" }]
+        },
+        {
+            code: "for(var i in [1,2,3]){var a = undefined; for(var j in [1,2,3]){}}",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "It's not necessary to initialize 'a' to undefined.", type: "VariableDeclarator" }]
         }
     ]
 });

--- a/tests/lib/rules/no-undef-init.js
+++ b/tests/lib/rules/no-undef-init.js
@@ -53,16 +53,45 @@ ruleTester.run("no-undef-init", rule, {
             errors: [{ message: "It's not necessary to initialize '{a}' to undefined.", type: "VariableDeclarator" }]
         },
         {
+            code: "for(var i in [1,2,3]){var a = undefined; for(var j in [1,2,3]){}}",
+            output: null,
+            errors: [{ message: "It's not necessary to initialize 'a' to undefined.", type: "VariableDeclarator" }]
+        },
+        {
             code: "let a = undefined;",
             output: "let a;",
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "It's not necessary to initialize 'a' to undefined.", type: "VariableDeclarator" }]
         },
         {
-            code: "for(var i in [1,2,3]){var a = undefined; for(var j in [1,2,3]){}}",
-            output: null,
+            code: "let a = undefined, b = 1;",
+            output: "let a, b = 1;",
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "It's not necessary to initialize 'a' to undefined.", type: "VariableDeclarator" }]
-        }
+        },
+        {
+            code: "let a = 1, b = undefined, c = 5;",
+            output: "let a = 1, b, c = 5;",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "It's not necessary to initialize 'b' to undefined.", type: "VariableDeclarator" }]
+        },
+        {
+            code: "let [a] = undefined;",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "It's not necessary to initialize '[a]' to undefined.", type: "VariableDeclarator" }]
+        },
+        {
+            code: "let {a} = undefined;",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "It's not necessary to initialize '{a}' to undefined.", type: "VariableDeclarator" }]
+        },
+        {
+            code: "for(var i in [1,2,3]){let a = undefined; for(var j in [1,2,3]){}}",
+            output: "for(var i in [1,2,3]){let a; for(var j in [1,2,3]){}}",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "It's not necessary to initialize 'a' to undefined.", type: "VariableDeclarator" }]
+        },
     ]
 });


### PR DESCRIPTION

**What is the purpose of this pull request? (put an "X" next to item)**

[X ] Other, please explain: Remove autofixing to no-undef-init rule, particularly for var declarations


**What changes did you make? (Give an overview)**


**Is there anything you'd like reviewers to focus on?**
1. To the point in #9231 about not using let: Using let looks like it still works, so I want to make sure I understand.
```
function fun() {
  for (var p in [0, 1, 2]) {
    let selected = undefined;// auto fix will remove `= undefined`

    for (var i in [0, 1, 2]) {
      if (!selected) {
        console.log('selected');
      }
      selected = i;
    }
  }
}

fun();
```
2. Is it okay to keep as separate if? I didn't include in the same if as line 50 since the inner comment wouldn't make sense.
3. I am checking node.parent.kind because it looks to distinguish between var and let