### PR TITLE
Docs: fix wrong config in max-len example.

### DIFF
--- a/docs/rules/max-len.md
+++ b/docs/rules/max-len.md
@@ -147,7 +147,7 @@ var longRegExpLiteral = /this is a really really really really really long regul
 Examples of **correct** code for this rule with the `{ "ignorePattern": true }` option:
 
 ```js
-/*eslint max-len: ["error", { "ignorePattern": "^\\s*var\\s.+=\\s*require\\s*\\(/" }]*/
+/*eslint max-len: ["error", { "ignorePattern": "^\\s*var\\s.+=\\s*require\\s*\(" }]*/
 
 var dep = require('really/really/really/really/really/really/really/really/long/module');
 ```

--- a/docs/rules/max-len.md
+++ b/docs/rules/max-len.md
@@ -144,7 +144,7 @@ var longRegExpLiteral = /this is a really really really really really long regul
 
 ### ignorePattern
 
-Examples of **correct** code for this rule with the `{ "ignorePattern": true }` option:
+Examples of **correct** code for this rule with the `ignorePattern` option:
 
 ```js
 /*eslint max-len: ["error", { "ignorePattern": "^\\s*var\\s.+=\\s*require\\s*\(" }]*/


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
this regex will cause an error:
![image](https://user-images.githubusercontent.com/13050025/30484160-1e0989ce-9a5c-11e7-8476-89b532ba6604.png)


**Is there anything you'd like reviewers to focus on?**

```js
new RegExp("^\\s*var\\s.+=\\s*require\\s*\\(/");
```

it didn't cause an error, but when apply the config, it didn't work. is this expected?

