### PR TITLE
Fix code snippet to refer to the correct option

### DIFF
--- a/docs/rules/prefer-arrow-callback.md
+++ b/docs/rules/prefer-arrow-callback.md
@@ -76,7 +76,7 @@ By default `{ "allowUnboundThis": true }`, this `boolean` option allows function
 
 When set to `false` this option prohibits the use of function expressions as callbacks or function arguments entirely, without exception.
 
-`{ "allowNamedFunctions": false }` **will** flag the following examples:
+`{ "allowUnboundThis": false }` **will** flag the following examples:
 
 ```js
 /* eslint prefer-arrow-callback: [ "error", { "allowUnboundThis": false } ] */


### PR DESCRIPTION
Fixes a small copy-paste mistake.

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

The documentation is talking about the `allowUnboundThis` option here, but this code snippet refers to the `allowNamedFunctions` option instead. A small copy-paste mistake.
