### PR TITLE
Fix: allow "@" in  comment configs.

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -146,7 +146,7 @@ function parseJsonConfig(string, location) {
  */
 function parseListConfig(string) {
     const items = {};
-    const reg = /[\w\-/]+/g;
+    const reg = /[@\w\-/]+/g;
     const elementMatches = string.match(reg);
 
     if (elementMatches) {


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:
https://github.com/eslint/eslint/commit/12388d449f8d86358c22a2e39c9fe98bd3715823
I'm a little worried that the config might be something like `@not-an-aardvark/eslint-plugin/some-rule`. will it?(if yes, I'd love to have some tests for it)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**


**Is there anything you'd like reviewers to focus on?**


