### PR TITLE
Proposal: `context.version`

### DIFF
--- a/docs/developer-guide/working-with-rules.md
+++ b/docs/developer-guide/working-with-rules.md
@@ -110,6 +110,7 @@ The `context` object contains additional functionality that is helpful for rules
 * `settings` - the [shared settings](/docs/user-guide/configuring#adding-shared-settings) from configuration.
 * `parserPath` - the name of the `parser` from configuration.
 * `parserServices` - an object containing parser-provided services for rules. The default parser does not provide any services. However, if a rule is intended to be used with a custom parser, it could use `parserServices` to access anything provided by that parser. (For example, a TypeScript parser could provide the ability to get the computed type of a given node.)
+* `version` - the ESLint version as a string (e.g. `"4.7.0"`).
 
 Additionally, the `context` object has the following methods:
 

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -708,7 +708,7 @@ const BASE_TRAVERSAL_CONTEXT = Object.freeze(
                     return sourceCode[DEPRECATED_SOURCECODE_PASSTHROUGHS[methodName]].apply(sourceCode, arguments);
                 }
             }),
-        {}
+        { version: pkg.version }
     )
 );
 

--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -3190,6 +3190,17 @@ describe("Linter", () => {
             linter.verify("x", { rules: { "foo-bar-baz": "error" } });
             assert(spy.calledOnce);
         });
+
+        it("should pass 'version' to rule contexts with the ESLint version", () => {
+            const spy = sandbox.spy(context => {
+                assert(/^\d+\.\d+\.\d+(?:-.+)?$/.test(context.version));
+                return {};
+            });
+
+            linter.defineRule("verify-version", spy);
+            linter.verify("x", { rules: { "verify-version": "error" } });
+            assert(spy.calledOnce);
+        });
     });
 
     describe("Variables and references", () => {


### PR DESCRIPTION
## What is the purpose of this pull request? (put an "X" next to item)

[X] Add something to the core

I request to add `version` to the rule context.

```js
exports.create = (context) => {
    console.log(context.version) // → 4.7.0
    return {}
}
```

The `context.version` is useful in many cases. Below cases are examples, though this is too late. 

### Check the behavior of directive comments

Since `4.7.0`, `eslint-enable`'s behavior was changed a bit (https://github.com/eslint/eslint/pull/9216#discussion_r136707906).
[eslint-plugin-eslint-comments](https://github.com/mysticatea/eslint-plugin-eslint-comments) plugin want to follow the change. It wants to detect the actual behavior on the ESLint which is running, but cannot know without the `context.version`.

### Check the behavior of auto-fixing.

Since `4.1.0`, `fix` functions which are passed to `context.report` can return an iterable object (includes an array) (#8101).
I want to use it and to avoid critical error on `<4.1.0`, but rules cannot know whether the `fix` functions can return an iterable object or not without the `context.version`.

### Check the behavior of the location of problems.

Since `3.1.0`, `loc` properties which are passed to `context.report` can be `{start: object, end: object}` to express the range of the problem (#6640).
I had wanted to use it and to avoid critical error on `<3.1.0`, but rules could not know whether the `context.report` accepts the range or not without `context.version`.

## What changes did you make? (Give an overview)

This PR adds the `version` property into rule contexts.

## Is there anything you'd like reviewers to focus on?

Direction.
