### PR TITLE
Fix: remove dupe error message in bin/eslint (fixes #8964)

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -49,7 +49,6 @@ process.once("uncaughtException", err => {
         console.error(`\nESLint: ${pkg.version}.\n${template(err.messageData || {})}`);
     } else {
 
-        console.error(err.message);
         console.error(err.stack);
     }
 

--- a/tests/bin/eslint.js
+++ b/tests/bin/eslint.js
@@ -263,7 +263,7 @@ describe("bin/eslint.js", () => {
     });
 
     describe("handling crashes", () => {
-        it("prints the error message to stderr in the event of a crash", () => {
+        it("prints the error message exactly once to stderr in the event of a crash", () => {
             const child = runESLint(["--rule=no-restricted-syntax:[error, 'Invalid Selector [[[']", "Makefile.js"]);
             const exitCodeAssertion = assertExitCode(child, 1);
             const outputAssertion = getOutput(child).then(output => {
@@ -271,6 +271,9 @@ describe("bin/eslint.js", () => {
 
                 assert.strictEqual(output.stdout, "");
                 assert.include(output.stderr, expectedSubstring);
+
+                // The message should appear exactly once in stderr
+                assert.strictEqual(output.stderr.indexOf(expectedSubstring), output.stderr.lastIndexOf(expectedSubstring));
             });
 
             return Promise.all([exitCodeAssertion, outputAssertion]);

--- a/tests/bin/eslint.js
+++ b/tests/bin/eslint.js
@@ -284,7 +284,7 @@ describe("bin/eslint.js", () => {
             const child = runESLint(["--no-ignore", invalidConfig]);
             const exitCodeAssertion = assertExitCode(child, 1);
             const outputAssertion = getOutput(child).then(output => {
-                const expectedSubstring = "Error: bad indentation of a mapping entry at line";
+                const expectedSubstring = "bad indentation of a mapping entry at line";
 
                 assert.strictEqual(output.stdout, "");
                 assert.include(output.stderr, expectedSubstring);


### PR DESCRIPTION

[X ] Other, please explain: remove the dupe error message which re-adds what was previously fixed in [here](https://github.com/eslint/eslint/commit/fc2abb0933e4f34bfaa2d591f5a882e4f1ccf481)



