### PR TITLE
Chore: Simply line-comment handling in fix for #9318

### DIFF
--- a/lib/util/apply-disable-directives.js
+++ b/lib/util/apply-disable-directives.js
@@ -7,8 +7,6 @@
 
 const lodash = require("lodash");
 
-const ALL_RULE_IDENTIFIER = Symbol("all");
-
 /**
  * Compares the locations of two objects in a source file
  * @param {{line: number, column: number}} itemA The first object
@@ -70,38 +68,25 @@ module.exports = options => {
 
     // enabledRules is only used when there is an active global /* eslint-disable */ comment.
     const enabledRules = new Set();
-    const lineDisabledRules = new Map();
+
+    const lineDisabledRules = new Set();
+    let globalLineDisableActive = false;
 
     for (const problem of options.problems) {
-        let tempDisabledByLine = new Set();
-        let directive = {};
-        const lineDisabledRule = lineDisabledRules.get(problem.line);
-
-        if (lineDisabledRule && problem.column - lineDisabledRule.column >= 0) {
-            tempDisabledByLine = lineDisabledRule.disabledRules;
-        }
-
         while (
             nextDirectiveIndex < processedDirectives.length &&
             compareLocations(processedDirectives[nextDirectiveIndex], problem) <= 0
         ) {
-            directive = processedDirectives[nextDirectiveIndex++];
+            const directive = processedDirectives[nextDirectiveIndex++];
 
             switch (directive.type) {
-                case "disable-line":
-                    tempDisabledByLine.add(directive.ruleId === null ? ALL_RULE_IDENTIFIER : directive.ruleId);
-                    break;
-
-                case "enable-line":
-                    tempDisabledByLine.delete(directive.ruleId === null ? ALL_RULE_IDENTIFIER : directive.ruleId);
-                    break;
-
                 case "disable":
                     if (directive.ruleId === null) {
                         globalDisableActive = true;
                         enabledRules.clear();
-                    } else {
+                    } else if (globalDisableActive) {
                         enabledRules.delete(directive.ruleId);
+                    } else {
                         disabledRules.add(directive.ruleId);
                     }
                     break;
@@ -109,13 +94,29 @@ module.exports = options => {
                 case "enable":
                     if (directive.ruleId === null) {
                         globalDisableActive = false;
+                        globalLineDisableActive = false;
                         disabledRules.clear();
-                        tempDisabledByLine.clear();
+                        lineDisabledRules.clear();
                     } else if (globalDisableActive) {
                         enabledRules.add(directive.ruleId);
                     } else {
                         disabledRules.delete(directive.ruleId);
+                        lineDisabledRules.delete(directive.ruleId);
                     }
+                    break;
+
+                case "disable-line":
+                    if (directive.ruleId === null) {
+                        globalLineDisableActive = true;
+                        lineDisabledRules.clear();
+                    } else {
+                        lineDisabledRules.add(directive.ruleId);
+                    }
+                    break;
+
+                case "enable-line":
+                    lineDisabledRules.clear();
+                    globalLineDisableActive = false;
                     break;
 
                 // no default
@@ -123,17 +124,13 @@ module.exports = options => {
         }
 
         if (
-            enabledRules.has(problem.ruleId) ||
-            (!tempDisabledByLine.has(ALL_RULE_IDENTIFIER) && !tempDisabledByLine.has(problem.ruleId) &&
-            !globalDisableActive && !disabledRules.has(problem.ruleId))
+            !globalLineDisableActive && !lineDisabledRules.has(problem.ruleId) && (
+                globalDisableActive && enabledRules.has(problem.ruleId) ||
+                !globalDisableActive && !disabledRules.has(problem.ruleId)
+            )
         ) {
             problems.push(problem);
         }
-
-        lineDisabledRules.set(problem.line, {
-            column: directive.column || 0,
-            disabledRules: tempDisabledByLine
-        });
     }
 
     return problems;


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This is a PR onto https://github.com/eslint/eslint/pull/9322 to simplify `eslint-disable-line` handling.

With this implementation, it's not necessary to keep track of the location of `disable-line` comments after processing them -- the comments can be processed in order like before. This also gets rid of the special "all" value in favor of a separate boolean.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
