### PR TITLE
Chore: handle disable-line comments in a separate pass

### DIFF
--- a/lib/util/apply-disable-directives.js
+++ b/lib/util/apply-disable-directives.js
@@ -19,6 +19,67 @@ function compareLocations(itemA, itemB) {
 }
 
 /**
+ * This is the same as the exported function, except that it doesn't handle disable-line and disable-next-line directives.
+ * @param {Object} options options (see the exported function)
+ * @returns {Problem[]} Filtered problems (see the exported function)
+ */
+function applyDirectives(options) {
+    const problems = [];
+    let nextDirectiveIndex = 0;
+    let globalDisableActive = false;
+
+    // disabledRules is only used when there is no active global /* eslint-disable */ comment.
+    const disabledRules = new Set();
+
+    // enabledRules is only used when there is an active global /* eslint-disable */ comment.
+    const enabledRules = new Set();
+
+    for (const problem of options.problems) {
+        while (
+            nextDirectiveIndex < options.directives.length &&
+            compareLocations(options.directives[nextDirectiveIndex], problem) <= 0
+        ) {
+            const directive = options.directives[nextDirectiveIndex++];
+
+            switch (directive.type) {
+                case "disable":
+                    if (directive.ruleId === null) {
+                        globalDisableActive = true;
+                        enabledRules.clear();
+                    } else if (globalDisableActive) {
+                        enabledRules.delete(directive.ruleId);
+                    } else {
+                        disabledRules.add(directive.ruleId);
+                    }
+                    break;
+
+                case "enable":
+                    if (directive.ruleId === null) {
+                        globalDisableActive = false;
+                        disabledRules.clear();
+                    } else if (globalDisableActive) {
+                        enabledRules.add(directive.ruleId);
+                    } else {
+                        disabledRules.delete(directive.ruleId);
+                    }
+                    break;
+
+                // no default
+            }
+        }
+
+        if (
+            globalDisableActive && enabledRules.has(problem.ruleId) ||
+            !globalDisableActive && !disabledRules.has(problem.ruleId)
+        ) {
+            problems.push(problem);
+        }
+    }
+
+    return problems;
+}
+
+/**
  * Given a list of directive comments (i.e. metadata about eslint-disable and eslint-enable comments) and a list
  * of reported problems, determines which problems should be reported.
  * @param {Object} options Information about directives and problems
@@ -36,22 +97,26 @@ function compareLocations(itemA, itemB) {
  * A list of reported problems that were not disabled by the directive comments.
  */
 module.exports = options => {
-    const processedDirectives = lodash.flatMap(options.directives, directive => {
+    const blockDirectives = options.directives
+        .filter(directive => directive.type === "disable" || directive.type === "enable")
+        .sort(compareLocations);
+
+    const lineDirectives = lodash.flatMap(options.directives, directive => {
         switch (directive.type) {
             case "disable":
             case "enable":
-                return [directive];
+                return [];
 
             case "disable-line":
                 return [
-                    { type: "disable-line", line: directive.line, column: 1, ruleId: directive.ruleId },
-                    { type: "enable-line", line: directive.line + 1, column: 1, ruleId: directive.ruleId }
+                    { type: "disable", line: directive.line, column: 1, ruleId: directive.ruleId },
+                    { type: "enable", line: directive.line + 1, column: 0, ruleId: directive.ruleId }
                 ];
 
             case "disable-next-line":
                 return [
-                    { type: "disable-line", line: directive.line + 1, column: 1, ruleId: directive.ruleId },
-                    { type: "enable-line", line: directive.line + 2, column: 1, ruleId: directive.ruleId }
+                    { type: "disable", line: directive.line + 1, column: 1, ruleId: directive.ruleId },
+                    { type: "enable", line: directive.line + 2, column: 0, ruleId: directive.ruleId }
                 ];
 
             default:
@@ -59,79 +124,8 @@ module.exports = options => {
         }
     }).sort(compareLocations);
 
-    const problems = [];
-    let nextDirectiveIndex = 0;
-    let globalDisableActive = false;
+    const problemsAfterBlockDirectives = applyDirectives({ problems: options.problems, directives: blockDirectives });
+    const problemsAfterLineDirectives = applyDirectives({ problems: problemsAfterBlockDirectives, directives: lineDirectives });
 
-    // disabledRules is only used when there is no active global /* eslint-disable */ comment.
-    const disabledRules = new Set();
-
-    // enabledRules is only used when there is an active global /* eslint-disable */ comment.
-    const enabledRules = new Set();
-
-    const lineDisabledRules = new Set();
-    let globalLineDisableActive = false;
-
-    for (const problem of options.problems) {
-        while (
-            nextDirectiveIndex < processedDirectives.length &&
-            compareLocations(processedDirectives[nextDirectiveIndex], problem) <= 0
-        ) {
-            const directive = processedDirectives[nextDirectiveIndex++];
-
-            switch (directive.type) {
-                case "disable":
-                    if (directive.ruleId === null) {
-                        globalDisableActive = true;
-                        enabledRules.clear();
-                    } else if (globalDisableActive) {
-                        enabledRules.delete(directive.ruleId);
-                    } else {
-                        disabledRules.add(directive.ruleId);
-                    }
-                    break;
-
-                case "enable":
-                    if (directive.ruleId === null) {
-                        globalDisableActive = false;
-                        globalLineDisableActive = false;
-                        disabledRules.clear();
-                        lineDisabledRules.clear();
-                    } else if (globalDisableActive) {
-                        enabledRules.add(directive.ruleId);
-                    } else {
-                        disabledRules.delete(directive.ruleId);
-                        lineDisabledRules.delete(directive.ruleId);
-                    }
-                    break;
-
-                case "disable-line":
-                    if (directive.ruleId === null) {
-                        globalLineDisableActive = true;
-                        lineDisabledRules.clear();
-                    } else {
-                        lineDisabledRules.add(directive.ruleId);
-                    }
-                    break;
-
-                case "enable-line":
-                    lineDisabledRules.clear();
-                    globalLineDisableActive = false;
-                    break;
-
-                // no default
-            }
-        }
-
-        if (
-            !globalLineDisableActive && !lineDisabledRules.has(problem.ruleId) && (
-                globalDisableActive && enabledRules.has(problem.ruleId) ||
-                !globalDisableActive && !disabledRules.has(problem.ruleId)
-            )
-        ) {
-            problems.push(problem);
-        }
-    }
-
-    return problems;
+    return problemsAfterLineDirectives.sort(compareLocations);
 };

--- a/tests/lib/util/apply-disable-directives.js
+++ b/tests/lib/util/apply-disable-directives.js
@@ -326,6 +326,23 @@ describe("apply-disable-directives", () => {
                 []
             );
         });
+
+        it("handles consecutive comments appropriately", () => {
+            assert.deepEqual(
+                applyDisableDirectives({
+                    directives: [
+                        { type: "disable-line", line: 1, column: 5, ruleId: "foo" },
+                        { type: "disable-line", line: 2, column: 5, ruleId: "foo" },
+                        { type: "disable-line", line: 3, column: 5, ruleId: "foo" },
+                        { type: "disable-line", line: 4, column: 5, ruleId: "foo" },
+                        { type: "disable-line", line: 5, column: 5, ruleId: "foo" },
+                        { type: "disable-line", line: 6, column: 5, ruleId: "foo" }
+                    ],
+                    problems: [{ line: 2, column: 1, ruleId: "foo" }]
+                }),
+                []
+            );
+        });
     });
 
     describe("eslint-disable-next-line comments without rules", () => {
@@ -369,19 +386,6 @@ describe("apply-disable-directives", () => {
                     problems: [{ line: 2, column: 2, ruleId: "foo" }]
                 }),
                 []
-            );
-        });
-
-        it("keeps problems on the next line if there is an eslint-enable comment before the problem on the next line", () => {
-            assert.deepEqual(
-                applyDisableDirectives({
-                    directives: [
-                        { type: "disable-next-line", line: 1, column: 1, ruleId: null },
-                        { type: "enable", line: 2, column: 1, ruleId: null }
-                    ],
-                    problems: [{ line: 2, column: 2, ruleId: "foo" }]
-                }),
-                [{ line: 2, column: 2, ruleId: "foo" }]
             );
         });
     });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This is another patch on https://github.com/eslint/eslint/pull/9322.

It makes the fix simpler again by just treating `line` and `block` directive comments separately, to avoid needing to keeping track of extra state.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular