### PR TITLE
Fix: special EventEmitter keys leak information about other rules

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -19,6 +19,7 @@ const eslintScope = require("eslint-scope"),
     validator = require("./config/config-validator"),
     Environments = require("./config/environments"),
     applyDisableDirectives = require("./util/apply-disable-directives"),
+    createEmitter = require("./util/safe-emitter"),
     NodeEventGenerator = require("./util/node-event-generator"),
     SourceCode = require("./util/source-code"),
     Traverser = require("./util/traverser"),
@@ -47,40 +48,6 @@ const MAX_AUTOFIX_PASSES = 10;
 //------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
-
-/**
- * Creates an object which can listen for and emit events.
- * This is similar to the EventEmitter API in Node's standard library, but it has a few differences.
- * The goal is to allow multiple modules to attach arbitrary listeners to the same emitter, without
- * letting the modules know about each other at all.
- * 1. It has no special keys like `error` and `newListener`, which would allow modules to detect when
- * another module throws an error or registers a listener.
- * 2. It calls listener functions without any `this` value. (`EventEmitter` calls listeners with a
- * `this` value of the emitter instance, which would give listeners access to other listeners.)
- * 3. Events can be emitted with at most 3 arguments.
- * @returns {{on: Function, emit: Function, eventNames: Function}} An emitter
- */
-function createEmitter() {
-    const listeners = Object.create(null);
-
-    return Object.freeze({
-        on(eventName, listener) {
-            if (eventName in listeners) {
-                listeners[eventName].push(listener);
-            } else {
-                listeners[eventName] = [listener];
-            }
-        },
-        emit(eventName, a, b, c) {
-            if (eventName in listeners) {
-                listeners[eventName].forEach(listener => listener(a, b, c));
-            }
-        },
-        eventNames() {
-            return Object.keys(listeners);
-        }
-    });
-}
 
 /**
  * Parses a list of "name:boolean_value" or/and "name" options divided by comma or

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -9,8 +9,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const EventEmitter = require("events").EventEmitter,
-    eslintScope = require("eslint-scope"),
+const eslintScope = require("eslint-scope"),
     levn = require("levn"),
     lodash = require("lodash"),
     blankScriptAST = require("../conf/blank-script.json"),
@@ -48,6 +47,40 @@ const MAX_AUTOFIX_PASSES = 10;
 //------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
+
+/**
+ * Creates an object which can listen for and emit events.
+ * This is similar to the EventEmitter API in Node's standard library, but it has a few differences.
+ * The goal is to allow multiple modules to attach arbitrary listeners to the same emitter, without
+ * letting the modules know about each other at all.
+ * 1. It has no special keys like `error` and `newListener`, which would allow modules to detect when
+ * another module throws an error or registers a listener.
+ * 2. It calls listener functions without any `this` value. (`EventEmitter` calls listeners with a
+ * `this` value of the emitter instance, which would give listeners access to other listeners.)
+ * 3. Events can be emitted with at most 3 arguments.
+ * @returns {{on: Function, emit: Function, eventNames: Function}} An emitter
+ */
+function createEmitter() {
+    const listeners = Object.create(null);
+
+    return Object.freeze({
+        on(eventName, listener) {
+            if (eventName in listeners) {
+                listeners[eventName].push(listener);
+            } else {
+                listeners[eventName] = [listener];
+            }
+        },
+        emit(eventName, a, b, c) {
+            if (eventName in listeners) {
+                listeners[eventName].forEach(listener => listener(a, b, c));
+            }
+        },
+        eventNames() {
+            return Object.keys(listeners);
+        }
+    });
+}
 
 /**
  * Parses a list of "name:boolean_value" or/and "name" options divided by comma or
@@ -817,7 +850,7 @@ module.exports = class Linter {
             disableDirectives = [];
         }
 
-        const emitter = new EventEmitter().setMaxListeners(Infinity);
+        const emitter = createEmitter();
         const traverser = new Traverser();
         const ecmaFeatures = config.parserOptions.ecmaFeatures || {};
         const ecmaVersion = config.parserOptions.ecmaVersion || 5;
@@ -860,7 +893,7 @@ module.exports = class Linter {
                      */
                     _linter: {
                         report() {},
-                        on: emitter.on.bind(emitter)
+                        on: emitter.on
                     }
                 }
             )

--- a/lib/util/node-event-generator.js
+++ b/lib/util/node-event-generator.js
@@ -194,7 +194,7 @@ const parseSelector = lodash.memoize(rawSelector => {
  *
  * ```ts
  * interface EventGenerator {
- *     emitter: EventEmitter;
+ *     emitter: {{on: Function, emit: Function, eventNames: Function}};
  *     enterNode(node: ASTNode): void;
  *     leaveNode(node: ASTNode): void;
  * }
@@ -203,7 +203,8 @@ const parseSelector = lodash.memoize(rawSelector => {
 class NodeEventGenerator {
 
     /**
-    * @param {EventEmitter} emitter - An event emitter which is the destination of events. This emitter must already
+    * @param {{on: Function, emit: Function, eventNames: Function}} emitter
+    * An event emitter which is the destination of events. This emitter must already
     * have registered listeners for all of the events that it needs to listen for.
     * @returns {NodeEventGenerator} new instance
     */
@@ -215,23 +216,7 @@ class NodeEventGenerator {
         this.anyTypeEnterSelectors = [];
         this.anyTypeExitSelectors = [];
 
-        const eventNames = typeof emitter.eventNames === "function"
-
-            // Use the built-in eventNames() function if available (Node 6+)
-            ? emitter.eventNames()
-
-            /*
-             * Otherwise, use the private _events property.
-             * Using a private property isn't ideal here, but this seems to
-             * be the best way to get a list of event names without overriding
-             * addEventListener, which would hurt performance. This property
-             * is widely used and unlikely to be removed in a future version
-             * (see https://github.com/nodejs/node/issues/1817). Also, future
-             * node versions will have eventNames() anyway.
-             */
-            : Object.keys(emitter._events); // eslint-disable-line no-underscore-dangle
-
-        eventNames.forEach(rawSelector => {
+        emitter.eventNames().forEach(rawSelector => {
             const selector = parseSelector(rawSelector);
 
             if (selector.listenerTypes) {

--- a/lib/util/node-event-generator.js
+++ b/lib/util/node-event-generator.js
@@ -194,7 +194,7 @@ const parseSelector = lodash.memoize(rawSelector => {
  *
  * ```ts
  * interface EventGenerator {
- *     emitter: {{on: Function, emit: Function, eventNames: Function}};
+ *     emitter: SafeEmitter;
  *     enterNode(node: ASTNode): void;
  *     leaveNode(node: ASTNode): void;
  * }
@@ -203,9 +203,10 @@ const parseSelector = lodash.memoize(rawSelector => {
 class NodeEventGenerator {
 
     /**
-    * @param {{on: Function, emit: Function, eventNames: Function}} emitter
-    * An event emitter which is the destination of events. This emitter must already
+    * @param {SafeEmitter} emitter
+    * An SafeEmitter which is the destination of events. This emitter must already
     * have registered listeners for all of the events that it needs to listen for.
+    * (See lib/util/safe-emitter.js for more details on `SafeEmitter`.)
     * @returns {NodeEventGenerator} new instance
     */
     constructor(emitter) {

--- a/lib/util/safe-emitter.js
+++ b/lib/util/safe-emitter.js
@@ -1,0 +1,54 @@
+/**
+ * @fileoverview A variant of EventEmitter which does not give listeners information about each other
+ * @author Teddy Katz
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Typedefs
+//------------------------------------------------------------------------------
+
+/**
+ * An object describing an AST selector
+ * @typedef {Object} SafeEmitter
+ * @property {function(eventName: string, listenerFunc: Function): void} on Adds a listener for a given event name
+ * @property {function(eventName: string, arg1?: any, arg2?: any, arg3?: any)} emit Emits an event with a given name.
+ * This calls all the listeners that were listening for that name, with `arg1`, `arg2`, and `arg3` as arguments.
+ * @property {function(): string[]} eventNames Gets the list of event names that have registered listeners.
+ */
+
+/**
+ * Creates an object which can listen for and emit events.
+ * This is similar to the EventEmitter API in Node's standard library, but it has a few differences.
+ * The goal is to allow multiple modules to attach arbitrary listeners to the same emitter, without
+ * letting the modules know about each other at all.
+ * 1. It has no special keys like `error` and `newListener`, which would allow modules to detect when
+ * another module throws an error or registers a listener.
+ * 2. It calls listener functions without any `this` value. (`EventEmitter` calls listeners with a
+ * `this` value of the emitter instance, which would give listeners access to other listeners.)
+ * 3. Events can be emitted with at most 3 arguments. (For example: when using `emitter.emit('foo', a, b, c)`,
+ * the arguments `a`, `b`, and `c` will be passed to the listener functions.)
+ * @returns {SafeEmitter} An emitter
+ */
+module.exports = () => {
+    const listeners = Object.create(null);
+
+    return Object.freeze({
+        on(eventName, listener) {
+            if (eventName in listeners) {
+                listeners[eventName].push(listener);
+            } else {
+                listeners[eventName] = [listener];
+            }
+        },
+        emit(eventName, a, b, c) {
+            if (eventName in listeners) {
+                listeners[eventName].forEach(listener => listener(a, b, c));
+            }
+        },
+        eventNames() {
+            return Object.keys(listeners);
+        }
+    });
+};

--- a/tests/lib/code-path-analysis/code-path-analyzer.js
+++ b/tests/lib/code-path-analysis/code-path-analyzer.js
@@ -10,7 +10,6 @@
 //------------------------------------------------------------------------------
 
 const assert = require("assert"),
-    EventEmitter = require("events").EventEmitter,
     fs = require("fs"),
     path = require("path"),
     Linter = require("../../../lib/linter"),
@@ -55,7 +54,7 @@ function getExpectedDotArrows(source) {
 
 describe("CodePathAnalyzer", () => {
     EventGeneratorTester.testEventGeneratorInterface(
-        new CodePathAnalyzer(new NodeEventGenerator(new EventEmitter()))
+        new CodePathAnalyzer(new NodeEventGenerator({ emit() {}, on() {}, eventNames: () => [] }))
     );
 
     describe("interface of code paths", () => {

--- a/tests/lib/code-path-analysis/code-path-analyzer.js
+++ b/tests/lib/code-path-analysis/code-path-analyzer.js
@@ -14,6 +14,7 @@ const assert = require("assert"),
     path = require("path"),
     Linter = require("../../../lib/linter"),
     EventGeneratorTester = require("../../../tools/internal-testers/event-generator-tester"),
+    createEmitter = require("../../../lib/util/safe-emitter"),
     debug = require("../../../lib/code-path-analysis/debug-helpers"),
     CodePath = require("../../../lib/code-path-analysis/code-path"),
     CodePathAnalyzer = require("../../../lib/code-path-analysis/code-path-analyzer"),
@@ -54,7 +55,7 @@ function getExpectedDotArrows(source) {
 
 describe("CodePathAnalyzer", () => {
     EventGeneratorTester.testEventGeneratorInterface(
-        new CodePathAnalyzer(new NodeEventGenerator({ emit() {}, on() {}, eventNames: () => [] }))
+        new CodePathAnalyzer(new NodeEventGenerator(createEmitter()))
     );
 
     describe("interface of code paths", () => {

--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -100,6 +100,24 @@ describe("Linter", () => {
                 linter.verify(code, config, filename, true);
             }, "Intentional error.");
         });
+
+        it("does not call rule listeners with a `this` value", () => {
+            const spy = sandbox.spy(function() {
+                assert.strictEqual(this, void 0); // eslint-disable-line no-invalid-this
+            });
+
+            linter.defineRule("checker", () => ({ Program: spy }));
+            linter.verify("foo", { rules: { checker: "error" } });
+            assert(spy.calledOnce);
+        });
+
+        it("does not allow listeners to use special EventEmitter values", () => {
+            const spy = sandbox.spy();
+
+            linter.defineRule("checker", () => ({ newListener: spy }));
+            linter.verify("foo", { rules: { checker: "error", "no-undef": "error" } });
+            assert(!spy.calledOnce);
+        });
     });
 
     describe("context.getSourceLines()", () => {

--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -102,13 +102,12 @@ describe("Linter", () => {
         });
 
         it("does not call rule listeners with a `this` value", () => {
-            const spy = sandbox.spy(function() {
-                assert.strictEqual(this, void 0); // eslint-disable-line no-invalid-this
-            });
+            const spy = sandbox.spy();
 
             linter.defineRule("checker", () => ({ Program: spy }));
             linter.verify("foo", { rules: { checker: "error" } });
             assert(spy.calledOnce);
+            assert.strictEqual(spy.firstCall.thisValue, void 0);
         });
 
         it("does not allow listeners to use special EventEmitter values", () => {
@@ -116,7 +115,7 @@ describe("Linter", () => {
 
             linter.defineRule("checker", () => ({ newListener: spy }));
             linter.verify("foo", { rules: { checker: "error", "no-undef": "error" } });
-            assert(!spy.calledOnce);
+            assert(spy.notCalled);
         });
     });
 

--- a/tests/lib/util/safe-emitter.js
+++ b/tests/lib/util/safe-emitter.js
@@ -1,0 +1,43 @@
+/**
+ * @fileoverview Tests for safe-emitter
+ * @author Teddy Katz
+ */
+
+"use strict";
+
+const createEmitter = require("../../../lib/util/safe-emitter");
+const assert = require("chai").assert;
+
+describe("safe-emitter", () => {
+    describe("emit() and on()", () => {
+        it("allows listeners to be registered calls them when emitted", () => {
+            const emitter = createEmitter();
+            const colors = [];
+
+            emitter.on("foo", () => colors.push("red"));
+            emitter.on("foo", () => colors.push("blue"));
+            emitter.on("bar", () => colors.push("green"));
+
+            emitter.emit("foo");
+            assert.deepEqual(colors, ["red", "blue"]);
+
+            emitter.on("bar", color => colors.push(color));
+            emitter.emit("bar", "yellow");
+
+            assert.deepEqual(colors, ["red", "blue", "green", "yellow"]);
+        });
+
+        it("calls listeners with no `this` value", () => {
+            const emitter = createEmitter();
+            let called = false;
+
+            emitter.on("foo", function() {
+                assert.strictEqual(this, void 0); // eslint-disable-line no-invalid-this
+                called = true;
+            });
+
+            emitter.emit("foo");
+            assert(called);
+        });
+    });
+});


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment**

* **ESLint Version:** master
* **Node Version:** 8.5.0
* **npm Version:** 5.3.0

**What parser (default, Babel-ESLint, etc.) are you using?**

N/A

**Please show your full configuration:**

N/A

**What did you do? Please include the actual source code causing the issue.**

```js
"use strict";

const eslint = require("eslint");
const linter = new eslint.Linter();

linter.defineRule("foo-rule", context => {
    return {
        newListener() {
            assert(false);
        }
    }
});

linter.verify("foo", { rules: { "foo-rule": "error", "no-undef": "error" } });
```

**What did you expect to happen?**

I expected the `newListener` method to never get called, because there are no nodes with type `newListener`.

**What actually happened? Please include the actual, raw output from ESLint.**

The `newListener` method got called because a listener was added from `no-undef`, and the string `"newListener"` has [special behavior](https://nodejs.org/api/events.html#events_event_newlistener) when added to an event emitter.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

`Linter` uses Node's `EventEmitter` API to register listeners for rules. However, the `EventEmitter` API has a few problems for this use case:

* `EventEmitter` has three "special" events (`newListener`, `removeListener`, and `error`) which are called when something happens with another listener. This is undesirable because `Linter` allows rules to register listeners for arbitrary string events, and we don't want rule listeners to be able to detect each other.
* `EventEmitter` calls listeners with a `this` value of the event emitter itself. This is undesirable because this would allow rules to modify or tamper with listeners registered by other rules.

This commit fixes the problem by updating `Linter` to use a custom event-emitting object with a similar API, rather than `EventEmitter` itself.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular