### PR TITLE
New: Add allowImplicit option to array-callback-return (fixes #8539)

### DIFF
--- a/docs/rules/array-callback-return.md
+++ b/docs/rules/array-callback-return.md
@@ -76,7 +76,7 @@ var bar = foo.map(node => node.getAttribute("id"));
 
 This rule has an object option:
 
-* `"allowImplicit": false` (default) disallows implicitly returning undefined with a return; statement.
+* `"allowImplicit": false` (default) disallows implicitly returning `undefined` with a `return` statement.
 
 Examples of **correct** code for the `{ "allowImplicit": true }` option:
 

--- a/docs/rules/array-callback-return.md
+++ b/docs/rules/array-callback-return.md
@@ -76,7 +76,7 @@ var bar = foo.map(node => node.getAttribute("id"));
 
 This rule has an object option:
 
-* `"allowImplicit": false` (default) disallows implicitly returning `undefined` with a `return` statement.
+* `"allowImplicit": false` (default) When set to true, allows implicitly returning `undefined` with a `return` statement containing no expression.
 
 Examples of **correct** code for the `{ "allowImplicit": true }` option:
 

--- a/docs/rules/array-callback-return.md
+++ b/docs/rules/array-callback-return.md
@@ -72,6 +72,21 @@ var foo = Array.from(nodes, function(node) {
 var bar = foo.map(node => node.getAttribute("id"));
 ```
 
+## Options
+
+This rule has an object option:
+
+* `"allowImplicit": false` (default) disallows implicitly returning undefined with a return; statement.
+
+Examples of **correct** code for the `{ "allowImplicit": true }` option:
+
+```js
+/*eslint array-callback-return: ["error", { allowImplicit: true }]*/
+var undefAllTheThings = myArray.map(function(item) {
+    return;
+});
+```
+
 ## Known Limitations
 
 This rule checks callback functions of methods with the given names, *even if* the object which has the method is *not* an array.

--- a/lib/rules/array-callback-return.js
+++ b/lib/rules/array-callback-return.js
@@ -141,10 +141,23 @@ module.exports = {
             recommended: false
         },
 
-        schema: []
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    allowImplicit: {
+                        type: "boolean"
+                    }
+                },
+                additionalProperties: false
+            }
+        ]
     },
 
     create(context) {
+
+        const options = context.options[0] || { allowImplicit: false };
+
         let funcInfo = {
             upper: null,
             codePath: null,
@@ -208,7 +221,8 @@ module.exports = {
                 if (funcInfo.shouldCheck) {
                     funcInfo.hasReturn = true;
 
-                    if (!node.argument) {
+                    // if allowImplicit: false, should also check node.argument
+                    if (!options.allowImplicit && !node.argument) {
                         context.report({
                             node,
                             message: "{{name}} expected a return value.",

--- a/tests/lib/rules/array-callback-return.js
+++ b/tests/lib/rules/array-callback-return.js
@@ -22,6 +22,8 @@ ruleTester.run("array-callback-return", rule, {
         // options: { allowImplicit: false }
         "Array.from(x, function() { return true; })",
         "Int32Array.from(x, function() { return true; })",
+        { code: "Array.from(x, function() { return true; })", options: [{ allowImplicit: false }] },
+        { code: "Int32Array.from(x, function() { return true; })", options: [{ allowImplicit: false }] },
 
         // options: { allowImplicit: true }
         { code: "Array.from(x, function() { return; })", allowImplicitOptions },

--- a/tests/lib/rules/array-callback-return.js
+++ b/tests/lib/rules/array-callback-return.js
@@ -69,7 +69,7 @@ ruleTester.run("array-callback-return", rule, {
 
         // options: { allowImplicit: true }
         { code: "foo.every(() => { return; })", options: allowImplicitOptions, parserOptions: { ecmaVersion: 6 } },
-        { code: "foo.every(function() { if (a) return; else return; })", options: allowImplicitOptions },
+        { code: "foo.every(function() { if (a) return; else return a; })", options: allowImplicitOptions },
         { code: "foo.every(function() { switch (a) { case 0: bar(); default: return; } })", options: allowImplicitOptions },
         { code: "foo.every(function() { try { bar(); return; } catch (err) { return; } })", options: allowImplicitOptions },
         { code: "foo.every(function() { try { bar(); } finally { return; } })", options: allowImplicitOptions },

--- a/tests/lib/rules/array-callback-return.js
+++ b/tests/lib/rules/array-callback-return.js
@@ -14,7 +14,7 @@ const rule = require("../../../lib/rules/array-callback-return"),
 
 const ruleTester = new RuleTester();
 
-const options = [{ allowImplicit: true }];
+const allowImplicitOptions = [{ allowImplicit: true }];
 
 ruleTester.run("array-callback-return", rule, {
     valid: [
@@ -24,8 +24,8 @@ ruleTester.run("array-callback-return", rule, {
         "Int32Array.from(x, function() { return true; })",
 
         // options: { allowImplicit: true }
-        { code: "Array.from(x, function() { return; })", options },
-        { code: "Int32Array.from(x, function() { return; })", options },
+        { code: "Array.from(x, function() { return; })", allowImplicitOptions },
+        { code: "Int32Array.from(x, function() { return; })", allowImplicitOptions },
 
         "Arrow.from(x, function() {})",
 
@@ -41,15 +41,15 @@ ruleTester.run("array-callback-return", rule, {
         "foo.sort(function() { return 0; })",
 
         // options: { allowImplicit: true }
-        { code: "foo.every(function() { return; })", options },
-        { code: "foo.filter(function() { return; })", options },
-        { code: "foo.find(function() { return; })", options },
-        { code: "foo.findIndex(function() { return; })", options },
-        { code: "foo.map(function() { return; })", options },
-        { code: "foo.reduce(function() { return; })", options },
-        { code: "foo.reduceRight(function() { return; })", options },
-        { code: "foo.some(function() { return; })", options },
-        { code: "foo.sort(function() { return; })", options },
+        { code: "foo.every(function() { return; })", allowImplicitOptions },
+        { code: "foo.filter(function() { return; })", allowImplicitOptions },
+        { code: "foo.find(function() { return; })", allowImplicitOptions },
+        { code: "foo.findIndex(function() { return; })", allowImplicitOptions },
+        { code: "foo.map(function() { return; })", allowImplicitOptions },
+        { code: "foo.reduce(function() { return; })", allowImplicitOptions },
+        { code: "foo.reduceRight(function() { return; })", allowImplicitOptions },
+        { code: "foo.some(function() { return; })", allowImplicitOptions },
+        { code: "foo.sort(function() { return; })", allowImplicitOptions },
 
         "foo.abc(function() {})",
         "every(function() {})",
@@ -66,11 +66,11 @@ ruleTester.run("array-callback-return", rule, {
         "foo.every(function() { try { bar(); } finally { return true; } })",
 
         // options: { allowImplicit: true }
-        { code: "foo.every(() => { return; })", options, parserOptions: { ecmaVersion: 6 } },
-        { code: "foo.every(function() { if (a) return; else return; })", options },
-        { code: "foo.every(function() { switch (a) { case 0: bar(); default: return; } })", options },
-        { code: "foo.every(function() { try { bar(); return; } catch (err) { return; } })", options },
-        { code: "foo.every(function() { try { bar(); } finally { return; } })", options },
+        { code: "foo.every(() => { return; })", allowImplicitOptions, parserOptions: { ecmaVersion: 6 } },
+        { code: "foo.every(function() { if (a) return; else return; })", allowImplicitOptions },
+        { code: "foo.every(function() { switch (a) { case 0: bar(); default: return; } })", allowImplicitOptions },
+        { code: "foo.every(function() { try { bar(); return; } catch (err) { return; } })", allowImplicitOptions },
+        { code: "foo.every(function() { try { bar(); } finally { return; } })", allowImplicitOptions },
 
         "foo.every(function(){}())",
         "foo.every(function(){ return function() { return true; }; }())",

--- a/tests/lib/rules/array-callback-return.js
+++ b/tests/lib/rules/array-callback-return.js
@@ -26,8 +26,8 @@ ruleTester.run("array-callback-return", rule, {
         { code: "Int32Array.from(x, function() { return true; })", options: [{ allowImplicit: false }] },
 
         // options: { allowImplicit: true }
-        { code: "Array.from(x, function() { return; })", allowImplicitOptions },
-        { code: "Int32Array.from(x, function() { return; })", allowImplicitOptions },
+        { code: "Array.from(x, function() { return; })", options: allowImplicitOptions },
+        { code: "Int32Array.from(x, function() { return; })", options: allowImplicitOptions },
 
         "Arrow.from(x, function() {})",
 
@@ -43,15 +43,15 @@ ruleTester.run("array-callback-return", rule, {
         "foo.sort(function() { return 0; })",
 
         // options: { allowImplicit: true }
-        { code: "foo.every(function() { return; })", allowImplicitOptions },
-        { code: "foo.filter(function() { return; })", allowImplicitOptions },
-        { code: "foo.find(function() { return; })", allowImplicitOptions },
-        { code: "foo.findIndex(function() { return; })", allowImplicitOptions },
-        { code: "foo.map(function() { return; })", allowImplicitOptions },
-        { code: "foo.reduce(function() { return; })", allowImplicitOptions },
-        { code: "foo.reduceRight(function() { return; })", allowImplicitOptions },
-        { code: "foo.some(function() { return; })", allowImplicitOptions },
-        { code: "foo.sort(function() { return; })", allowImplicitOptions },
+        { code: "foo.every(function() { return; })", options: allowImplicitOptions },
+        { code: "foo.filter(function() { return; })", options: allowImplicitOptions },
+        { code: "foo.find(function() { return; })", options: allowImplicitOptions },
+        { code: "foo.findIndex(function() { return; })", options: allowImplicitOptions },
+        { code: "foo.map(function() { return; })", options: allowImplicitOptions },
+        { code: "foo.reduce(function() { return; })", options: allowImplicitOptions },
+        { code: "foo.reduceRight(function() { return; })", options: allowImplicitOptions },
+        { code: "foo.some(function() { return; })", options: allowImplicitOptions },
+        { code: "foo.sort(function() { return; })", options: allowImplicitOptions },
 
         "foo.abc(function() {})",
         "every(function() {})",
@@ -68,11 +68,11 @@ ruleTester.run("array-callback-return", rule, {
         "foo.every(function() { try { bar(); } finally { return true; } })",
 
         // options: { allowImplicit: true }
-        { code: "foo.every(() => { return; })", parserOptions: { ecmaVersion: 6 }, allowImplicitOptions },
-        { code: "foo.every(function() { if (a) return; else return; })", allowImplicitOptions },
-        { code: "foo.every(function() { switch (a) { case 0: bar(); default: return; } })", allowImplicitOptions },
-        { code: "foo.every(function() { try { bar(); return; } catch (err) { return; } })", allowImplicitOptions },
-        { code: "foo.every(function() { try { bar(); } finally { return; } })", allowImplicitOptions },
+        { code: "foo.every(() => { return; })", options: allowImplicitOptions, parserOptions: { ecmaVersion: 6 } },
+        { code: "foo.every(function() { if (a) return; else return; })", options: allowImplicitOptions },
+        { code: "foo.every(function() { switch (a) { case 0: bar(); default: return; } })", options: allowImplicitOptions },
+        { code: "foo.every(function() { try { bar(); return; } catch (err) { return; } })", options: allowImplicitOptions },
+        { code: "foo.every(function() { try { bar(); } finally { return; } })", options: allowImplicitOptions },
 
         "foo.every(function(){}())",
         "foo.every(function(){ return function() { return true; }; }())",

--- a/tests/lib/rules/array-callback-return.js
+++ b/tests/lib/rules/array-callback-return.js
@@ -126,6 +126,8 @@ ruleTester.run("array-callback-return", rule, {
         { code: "foo.every(a ? function() {} : function() {})", errors: ["Expected to return a value in function.", "Expected to return a value in function."] },
         { code: "foo.every(a ? function foo() {} : function bar() {})", errors: ["Expected to return a value in function 'foo'.", "Expected to return a value in function 'bar'."] },
         { code: "foo.every(function(){ return function() {}; }())", errors: [{ message: "Expected to return a value in function.", column: 30 }] },
-        { code: "foo.every(function(){ return function foo() {}; }())", errors: [{ message: "Expected to return a value in function 'foo'.", column: 39 }] }
+        { code: "foo.every(function(){ return function foo() {}; }())", errors: [{ message: "Expected to return a value in function 'foo'.", column: 39 }] },
+        { code: "foo.every(() => {})", options: [{ allowImplicit: false }], parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected to return a value in arrow function." }] },
+        { code: "foo.every(() => {})", options: [{ allowImplicit: true }], parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected to return a value in arrow function." }] }
     ]
 });

--- a/tests/lib/rules/array-callback-return.js
+++ b/tests/lib/rules/array-callback-return.js
@@ -68,7 +68,7 @@ ruleTester.run("array-callback-return", rule, {
         "foo.every(function() { try { bar(); } finally { return true; } })",
 
         // options: { allowImplicit: true }
-        { code: "foo.every(() => { return; })", allowImplicitOptions, parserOptions: { ecmaVersion: 6 } },
+        { code: "foo.every(() => { return; })", parserOptions: { ecmaVersion: 6 }, allowImplicitOptions },
         { code: "foo.every(function() { if (a) return; else return; })", allowImplicitOptions },
         { code: "foo.every(function() { switch (a) { case 0: bar(); default: return; } })", allowImplicitOptions },
         { code: "foo.every(function() { try { bar(); return; } catch (err) { return; } })", allowImplicitOptions },

--- a/tests/lib/rules/array-callback-return.js
+++ b/tests/lib/rules/array-callback-return.js
@@ -14,11 +14,22 @@ const rule = require("../../../lib/rules/array-callback-return"),
 
 const ruleTester = new RuleTester();
 
+const options = [{ allowImplicit: true }];
+
 ruleTester.run("array-callback-return", rule, {
     valid: [
+
+        // options: { allowImplicit: false }
         "Array.from(x, function() { return true; })",
         "Int32Array.from(x, function() { return true; })",
+
+        // options: { allowImplicit: true }
+        { code: "Array.from(x, function() { return; })", options },
+        { code: "Int32Array.from(x, function() { return; })", options },
+
         "Arrow.from(x, function() {})",
+
+        // options: { allowImplicit: false }
         "foo.every(function() { return true; })",
         "foo.filter(function() { return true; })",
         "foo.find(function() { return true; })",
@@ -28,17 +39,39 @@ ruleTester.run("array-callback-return", rule, {
         "foo.reduceRight(function() { return true; })",
         "foo.some(function() { return true; })",
         "foo.sort(function() { return 0; })",
+
+        // options: { allowImplicit: true }
+        { code: "foo.every(function() { return; })", options },
+        { code: "foo.filter(function() { return; })", options },
+        { code: "foo.find(function() { return; })", options },
+        { code: "foo.findIndex(function() { return; })", options },
+        { code: "foo.map(function() { return; })", options },
+        { code: "foo.reduce(function() { return; })", options },
+        { code: "foo.reduceRight(function() { return; })", options },
+        { code: "foo.some(function() { return; })", options },
+        { code: "foo.sort(function() { return; })", options },
+
         "foo.abc(function() {})",
         "every(function() {})",
         "foo[every](function() {})",
         "var every = function() {}",
         { code: "foo[`${every}`](function() {})", parserOptions: { ecmaVersion: 6 } },
         { code: "foo.every(() => true)", parserOptions: { ecmaVersion: 6 } },
+
+        // options: { allowImplicit: false }
         { code: "foo.every(() => { return true; })", parserOptions: { ecmaVersion: 6 } },
         "foo.every(function() { if (a) return true; else return false; })",
         "foo.every(function() { switch (a) { case 0: bar(); default: return true; } })",
         "foo.every(function() { try { bar(); return true; } catch (err) { return false; } })",
         "foo.every(function() { try { bar(); } finally { return true; } })",
+
+        // options: { allowImplicit: true }
+        { code: "foo.every(() => { return; })", options, parserOptions: { ecmaVersion: 6 } },
+        { code: "foo.every(function() { if (a) return; else return; })", options },
+        { code: "foo.every(function() { switch (a) { case 0: bar(); default: return; } })", options },
+        { code: "foo.every(function() { try { bar(); return; } catch (err) { return; } })", options },
+        { code: "foo.every(function() { try { bar(); } finally { return; } })", options },
+
         "foo.every(function(){}())",
         "foo.every(function(){ return function() { return true; }; }())",
         "foo.every(function(){ return function() { return; }; })",


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
Implements: #8539 

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Added an `allowImplicit` option to `array-callback-return` that is consistent with the [`allowImplicit` option in `getter-return`](https://eslint.org/docs/rules/getter-return#options).

**Is there anything you'd like reviewers to focus on?**

Please double-check this implementation is consistent with [`getter-return`'s `allowImplicit`](https://eslint.org/docs/rules/getter-return#options).