### PR TITLE
Fix: dot notation rule failing to catch string template (fixes #9350)

### DIFF
--- a/lib/rules/dot-notation.js
+++ b/lib/rules/dot-notation.js
@@ -54,46 +54,67 @@ module.exports = {
             allowPattern = new RegExp(options.allowPattern);
         }
 
+        /**
+        * Check if the property is valid dot notation
+        * @param {ASTNode} node The dot notation node
+        * @param {string} value Value which is to be checked
+        * @returns {void}
+        */
+        function checkComputedProperty(node, value) {
+            if (
+                validIdentifier.test(value) &&
+                (allowKeywords || keywords.indexOf(String(value)) === -1) &&
+                !(allowPattern && allowPattern.test(value))
+            ) {
+                const formattedValue = node.property.type === "Literal" ? JSON.stringify(value) : `\`${value}\``;
+
+                context.report({
+                    node: node.property,
+                    message: "[{{propertyValue}}] is better written in dot notation.",
+                    data: {
+                        propertyValue: formattedValue
+                    },
+                    fix(fixer) {
+                        const leftBracket = sourceCode.getTokenAfter(node.object, astUtils.isOpeningBracketToken);
+                        const rightBracket = sourceCode.getLastToken(node);
+
+                        if (sourceCode.getFirstTokenBetween(leftBracket, rightBracket, { includeComments: true, filter: astUtils.isCommentToken })) {
+
+                            // Don't perform any fixes if there are comments inside the brackets.
+                            return null;
+                        }
+
+                        const tokenAfterProperty = sourceCode.getTokenAfter(rightBracket);
+                        const needsSpaceAfterProperty = tokenAfterProperty &&
+                            rightBracket.range[1] === tokenAfterProperty.range[0] &&
+                            !astUtils.canTokensBeAdjacent(String(value), tokenAfterProperty);
+
+                        const textBeforeDot = astUtils.isDecimalInteger(node.object) ? " " : "";
+                        const textAfterProperty = needsSpaceAfterProperty ? " " : "";
+
+                        return fixer.replaceTextRange(
+                            [leftBracket.range[0], rightBracket.range[1]],
+                            `${textBeforeDot}.${value}${textAfterProperty}`
+                        );
+                    }
+                });
+            }
+        }
+
         return {
             MemberExpression(node) {
                 if (
                     node.computed &&
-                    node.property.type === "Literal" &&
-                    validIdentifier.test(node.property.value) &&
-                    (allowKeywords || keywords.indexOf(String(node.property.value)) === -1)
+                    node.property.type === "Literal"
                 ) {
-                    if (!(allowPattern && allowPattern.test(node.property.value))) {
-                        context.report({
-                            node: node.property,
-                            message: "[{{propertyValue}}] is better written in dot notation.",
-                            data: {
-                                propertyValue: JSON.stringify(node.property.value)
-                            },
-                            fix(fixer) {
-                                const leftBracket = sourceCode.getTokenAfter(node.object, astUtils.isOpeningBracketToken);
-                                const rightBracket = sourceCode.getLastToken(node);
-
-                                if (sourceCode.getFirstTokenBetween(leftBracket, rightBracket, { includeComments: true, filter: astUtils.isCommentToken })) {
-
-                                    // Don't perform any fixes if there are comments inside the brackets.
-                                    return null;
-                                }
-
-                                const tokenAfterProperty = sourceCode.getTokenAfter(rightBracket);
-                                const needsSpaceAfterProperty = tokenAfterProperty &&
-                                    rightBracket.range[1] === tokenAfterProperty.range[0] &&
-                                    !astUtils.canTokensBeAdjacent(String(node.property.value), tokenAfterProperty);
-
-                                const textBeforeDot = astUtils.isDecimalInteger(node.object) ? " " : "";
-                                const textAfterProperty = needsSpaceAfterProperty ? " " : "";
-
-                                return fixer.replaceTextRange(
-                                    [leftBracket.range[0], rightBracket.range[1]],
-                                    `${textBeforeDot}.${node.property.value}${textAfterProperty}`
-                                );
-                            }
-                        });
-                    }
+                    checkComputedProperty(node, node.property.value);
+                }
+                if (
+                    node.computed &&
+                    node.property.type === "TemplateLiteral" &&
+                    node.property.expressions.length === 0
+                ) {
+                    checkComputedProperty(node, node.property.quasis[0].value.cooked);
                 }
                 if (
                     !allowKeywords &&

--- a/tests/lib/rules/dot-notation.js
+++ b/tests/lib/rules/dot-notation.js
@@ -40,6 +40,9 @@ ruleTester.run("dot-notation", rule, {
         { code: "a.null;", options: [{ allowKeywords: true }] },
         { code: "a['snake_case'];", options: [{ allowPattern: "^[a-z]+(_[a-z]+)+$" }] },
         { code: "a['lots_of_snake_case'];", options: [{ allowPattern: "^[a-z]+(_[a-z]+)+$" }] },
+        { code: "a[`time${range}`];", parserOptions: { ecmaVersion: 6 } },
+        { code: "a[`while`];", options: [{ allowKeywords: false }], parserOptions: { ecmaVersion: 6 } },
+        { code: "a[`time range`];", parserOptions: { ecmaVersion: 6 } },
         "a.true;",
         "a.null;",
         "a[undefined];",
@@ -57,6 +60,12 @@ ruleTester.run("dot-notation", rule, {
             code: "a['true'];",
             output: "a.true;",
             errors: [{ message: "[\"true\"] is better written in dot notation." }]
+        },
+        {
+            code: "a[`time`];",
+            output: "a.time;",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "[`time`] is better written in dot notation." }]
         },
         {
             code: "a[null];",


### PR DESCRIPTION
Fixes #9350

<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

I added a check for `TemplateLiteral` and if it is the case then it checks the quasi associated as long as no expression is found, as if it has an expression is not a valid dot notation.

As the fix would be reused in my chance I pulled that into a function.

Added a few test cases.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
