### PR TITLE
Fix: Check that node.body is defined

### DIFF
--- a/lib/rules/array-callback-return.js
+++ b/lib/rules/array-callback-return.js
@@ -190,6 +190,7 @@ module.exports = {
                     hasReturn: false,
                     shouldCheck:
                         TARGET_NODE_TYPE.test(node.type) &&
+                        node.body &&
                         node.body.type === "BlockStatement" &&
                         isCallbackOfArrayMethod(node) &&
                         !node.async &&

--- a/lib/rules/getter-return.js
+++ b/lib/rules/getter-return.js
@@ -109,7 +109,7 @@ module.exports = {
         function isGetter(node) {
             const parent = node.parent;
 
-            if (TARGET_NODE_TYPE.test(node.type) && node.body.type === "BlockStatement") {
+            if (TARGET_NODE_TYPE.test(node.type) && node.body && node.body.type === "BlockStatement") {
                 if (parent.kind === "get") {
                     return true;
                 }

--- a/lib/rules/strict.js
+++ b/lib/rules/strict.js
@@ -217,7 +217,7 @@ module.exports = {
          * @returns {void}
          */
         function enterFunction(node) {
-            const isBlock = node.body.type === "BlockStatement",
+            const isBlock = node.body && node.body.type === "BlockStatement",
                 useStrictDirectives = isBlock
                     ? getUseStrictDirectives(node.body.body) : [];
 

--- a/tests/fixtures/parsers/typescript-parsers/array-callback-return.js
+++ b/tests/fixtures/parsers/typescript-parsers/array-callback-return.js
@@ -1,0 +1,320 @@
+"use strict";
+
+/**
+ * Parser: typescript-eslint-parser-3.0.0
+ * Source code:
+ * [0,1,2].map((num: number) => {
+    console.log(num);
+  });
+ */
+
+exports.parse = () => ({
+  type: "Program",
+  range: [0, 54],
+  loc: {
+    start: {
+      line: 1,
+      column: 0
+    },
+    end: {
+      line: 3,
+      column: 3
+    }
+  },
+  body: [
+    {
+      type: "ExpressionStatement",
+      range: [0, 54],
+      loc: {
+        start: {
+          line: 1,
+          column: 0
+        },
+        end: {
+          line: 3,
+          column: 3
+        }
+      },
+      expression: {
+        type: "CallExpression",
+        range: [0, 53],
+        loc: {
+          start: {
+            line: 1,
+            column: 0
+          },
+          end: {
+            line: 3,
+            column: 2
+          }
+        },
+        callee: {
+          type: "MemberExpression",
+          range: [0, 11],
+          loc: {
+            start: {
+              line: 1,
+              column: 0
+            },
+            end: {
+              line: 1,
+              column: 11
+            }
+          },
+          object: {
+            type: "ArrayExpression",
+            range: [0, 7],
+            loc: {
+              start: {
+                line: 1,
+                column: 0
+              },
+              end: {
+                line: 1,
+                column: 7
+              }
+            },
+            elements: [
+              {
+                type: "Literal",
+                range: [1, 2],
+                loc: {
+                  start: {
+                    line: 1,
+                    column: 1
+                  },
+                  end: {
+                    line: 1,
+                    column: 2
+                  }
+                },
+                value: 0,
+                raw: "0"
+              },
+              {
+                type: "Literal",
+                range: [3, 4],
+                loc: {
+                  start: {
+                    line: 1,
+                    column: 3
+                  },
+                  end: {
+                    line: 1,
+                    column: 4
+                  }
+                },
+                value: 1,
+                raw: "1"
+              },
+              {
+                type: "Literal",
+                range: [5, 6],
+                loc: {
+                  start: {
+                    line: 1,
+                    column: 5
+                  },
+                  end: {
+                    line: 1,
+                    column: 6
+                  }
+                },
+                value: 2,
+                raw: "2"
+              }
+            ]
+          },
+          property: {
+            type: "Identifier",
+            range: [8, 11],
+            loc: {
+              start: {
+                line: 1,
+                column: 8
+              },
+              end: {
+                line: 1,
+                column: 11
+              }
+            },
+            name: "map"
+          },
+          computed: false
+        },
+        arguments: [
+          {
+            type: "ArrowFunctionExpression",
+            range: [12, 52],
+            loc: {
+              start: {
+                line: 1,
+                column: 12
+              },
+              end: {
+                line: 3,
+                column: 1
+              }
+            },
+            generator: false,
+            id: null,
+            params: [
+              {
+                type: "Identifier",
+                range: [13, 16],
+                loc: {
+                  start: {
+                    line: 1,
+                    column: 13
+                  },
+                  end: {
+                    line: 1,
+                    column: 16
+                  }
+                },
+                name: "num",
+                typeAnnotation: {
+                  type: "TypeAnnotation",
+                  loc: {
+                    start: {
+                      line: 1,
+                      column: 18
+                    },
+                    end: {
+                      line: 1,
+                      column: 24
+                    }
+                  },
+                  range: [18, 24],
+                  typeAnnotation: {
+                    type: "TSNumberKeyword",
+                    range: [18, 24],
+                    loc: {
+                      start: {
+                        line: 1,
+                        column: 18
+                      },
+                      end: {
+                        line: 1,
+                        column: 24
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            body: {
+              type: "BlockStatement",
+              range: [29, 52],
+              loc: {
+                start: {
+                  line: 1,
+                  column: 29
+                },
+                end: {
+                  line: 3,
+                  column: 1
+                }
+              },
+              body: [
+                {
+                  type: "ExpressionStatement",
+                  range: [33, 50],
+                  loc: {
+                    start: {
+                      line: 2,
+                      column: 2
+                    },
+                    end: {
+                      line: 2,
+                      column: 19
+                    }
+                  },
+                  expression: {
+                    type: "CallExpression",
+                    range: [33, 49],
+                    loc: {
+                      start: {
+                        line: 2,
+                        column: 2
+                      },
+                      end: {
+                        line: 2,
+                        column: 18
+                      }
+                    },
+                    callee: {
+                      type: "MemberExpression",
+                      range: [33, 44],
+                      loc: {
+                        start: {
+                          line: 2,
+                          column: 2
+                        },
+                        end: {
+                          line: 2,
+                          column: 13
+                        }
+                      },
+                      object: {
+                        type: "Identifier",
+                        range: [33, 40],
+                        loc: {
+                          start: {
+                            line: 2,
+                            column: 2
+                          },
+                          end: {
+                            line: 2,
+                            column: 9
+                          }
+                        },
+                        name: "console"
+                      },
+                      property: {
+                        type: "Identifier",
+                        range: [41, 44],
+                        loc: {
+                          start: {
+                            line: 2,
+                            column: 10
+                          },
+                          end: {
+                            line: 2,
+                            column: 13
+                          }
+                        },
+                        name: "log"
+                      },
+                      computed: false
+                    },
+                    arguments: [
+                      {
+                        type: "Identifier",
+                        range: [45, 48],
+                        loc: {
+                          start: {
+                            line: 2,
+                            column: 14
+                          },
+                          end: {
+                            line: 2,
+                            column: 17
+                          }
+                        },
+                        name: "num"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            async: false,
+            expression: false
+          }
+        ]
+      }
+    }
+  ],
+  sourceType: "script"
+});

--- a/tests/fixtures/parsers/typescript-parsers/getter-return.js
+++ b/tests/fixtures/parsers/typescript-parsers/getter-return.js
@@ -1,0 +1,158 @@
+"use strict";
+
+/**
+ * Parser: typescript-eslint-parser-3.0.0
+ * Source code:
+ *  const p = {
+      get name() {
+        // no returns
+      }
+    };
+ */
+
+exports.parse = () => ({
+  type: "Program",
+  range: [0, 51],
+  loc: {
+    start: {
+      line: 1,
+      column: 0
+    },
+    end: {
+      line: 5,
+      column: 2
+    }
+  },
+  body: [
+    {
+      type: "VariableDeclaration",
+      range: [0, 51],
+      loc: {
+        start: {
+          line: 1,
+          column: 0
+        },
+        end: {
+          line: 5,
+          column: 2
+        }
+      },
+      declarations: [
+        {
+          type: "VariableDeclarator",
+          range: [6, 50],
+          loc: {
+            start: {
+              line: 1,
+              column: 6
+            },
+            end: {
+              line: 5,
+              column: 1
+            }
+          },
+          id: {
+            type: "Identifier",
+            range: [6, 7],
+            loc: {
+              start: {
+                line: 1,
+                column: 6
+              },
+              end: {
+                line: 1,
+                column: 7
+              }
+            },
+            name: "p"
+          },
+          init: {
+            type: "ObjectExpression",
+            range: [10, 50],
+            loc: {
+              start: {
+                line: 1,
+                column: 10
+              },
+              end: {
+                line: 5,
+                column: 1
+              }
+            },
+            properties: [
+              {
+                type: "Property",
+                range: [14, 48],
+                loc: {
+                  start: {
+                    line: 2,
+                    column: 2
+                  },
+                  end: {
+                    line: 4,
+                    column: 3
+                  }
+                },
+                key: {
+                  type: "Identifier",
+                  range: [18, 22],
+                  loc: {
+                    start: {
+                      line: 2,
+                      column: 6
+                    },
+                    end: {
+                      line: 2,
+                      column: 10
+                    }
+                  },
+                  name: "name"
+                },
+                value: {
+                  type: "FunctionExpression",
+                  id: null,
+                  generator: false,
+                  expression: false,
+                  async: false,
+                  body: {
+                    type: "BlockStatement",
+                    range: [25, 48],
+                    loc: {
+                      start: {
+                        line: 2,
+                        column: 13
+                      },
+                      end: {
+                        line: 4,
+                        column: 3
+                      }
+                    },
+                    body: []
+                  },
+                  range: [22, 48],
+                  loc: {
+                    start: {
+                      line: 2,
+                      column: 10
+                    },
+                    end: {
+                      line: 4,
+                      column: 3
+                    }
+                  },
+                  params: []
+                },
+                computed: false,
+                method: false,
+                shorthand: false,
+                kind: "get"
+              }
+            ]
+          }
+        }
+      ],
+      kind: "const"
+    }
+  ],
+  sourceType: "script"
+});

--- a/tests/fixtures/parsers/typescript-parsers/strict.js
+++ b/tests/fixtures/parsers/typescript-parsers/strict.js
@@ -1,0 +1,199 @@
+"use strict";
+
+/**
+ * Parser: typescript-eslint-parser-3.0.0
+ * Source code:
+ *  function foo() {
+      "use strict";
+
+      console.log('foo');
+    }
+ */
+
+exports.parse = () => ({
+  type: "Program",
+  range: [0, 57],
+  loc: {
+    start: {
+      line: 1,
+      column: 0
+    },
+    end: {
+      line: 5,
+      column: 1
+    }
+  },
+  body: [
+    {
+      type: "FunctionDeclaration",
+      range: [0, 57],
+      loc: {
+        start: {
+          line: 1,
+          column: 0
+        },
+        end: {
+          line: 5,
+          column: 1
+        }
+      },
+      id: {
+        type: "Identifier",
+        range: [9, 12],
+        loc: {
+          start: {
+            line: 1,
+            column: 9
+          },
+          end: {
+            line: 1,
+            column: 12
+          }
+        },
+        name: "foo"
+      },
+      generator: false,
+      expression: false,
+      async: false,
+      params: [],
+      body: {
+        type: "BlockStatement",
+        range: [15, 57],
+        loc: {
+          start: {
+            line: 1,
+            column: 15
+          },
+          end: {
+            line: 5,
+            column: 1
+          }
+        },
+        body: [
+          {
+            type: "ExpressionStatement",
+            range: [19, 32],
+            loc: {
+              start: {
+                line: 2,
+                column: 2
+              },
+              end: {
+                line: 2,
+                column: 15
+              }
+            },
+            expression: {
+              type: "Literal",
+              range: [19, 31],
+              loc: {
+                start: {
+                  line: 2,
+                  column: 2
+                },
+                end: {
+                  line: 2,
+                  column: 14
+                }
+              },
+              value: "use strict",
+              raw: '"use strict"'
+            }
+          },
+          {
+            type: "ExpressionStatement",
+            range: [36, 55],
+            loc: {
+              start: {
+                line: 4,
+                column: 2
+              },
+              end: {
+                line: 4,
+                column: 21
+              }
+            },
+            expression: {
+              type: "CallExpression",
+              range: [36, 54],
+              loc: {
+                start: {
+                  line: 4,
+                  column: 2
+                },
+                end: {
+                  line: 4,
+                  column: 20
+                }
+              },
+              callee: {
+                type: "MemberExpression",
+                range: [36, 47],
+                loc: {
+                  start: {
+                    line: 4,
+                    column: 2
+                  },
+                  end: {
+                    line: 4,
+                    column: 13
+                  }
+                },
+                object: {
+                  type: "Identifier",
+                  range: [36, 43],
+                  loc: {
+                    start: {
+                      line: 4,
+                      column: 2
+                    },
+                    end: {
+                      line: 4,
+                      column: 9
+                    }
+                  },
+                  name: "console"
+                },
+                property: {
+                  type: "Identifier",
+                  range: [44, 47],
+                  loc: {
+                    start: {
+                      line: 4,
+                      column: 10
+                    },
+                    end: {
+                      line: 4,
+                      column: 13
+                    }
+                  },
+                  name: "log"
+                },
+                computed: false
+              },
+              arguments: [
+                {
+                  type: "Literal",
+                  range: [48, 53],
+                  loc: {
+                    start: {
+                      line: 4,
+                      column: 14
+                    },
+                    end: {
+                      line: 4,
+                      column: 19
+                    }
+                  },
+                  value: "foo",
+                  raw: "'foo'"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ],
+  sourceType: "script"
+});


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix: https://github.com/eslint/typescript-eslint-parser/issues/389

**What changes did you make? (Give an overview)**
A few eslint rules access properties in `node.body` when `node.body` may be undefined. These typically discovered when using the `typescript-eslint-parser`, since Typescript code may have empty body functions. 


**Is there anything you'd like reviewers to focus on?**
No. 


