### PR TITLE
Chore: remove sourceCode property from Linter (refs #9161)

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -697,6 +697,8 @@ const BASE_TRAVERSAL_CONTEXT = Object.freeze(
     )
 );
 
+const lastSourceCodes = new WeakMap();
+
 //------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
@@ -708,7 +710,7 @@ const BASE_TRAVERSAL_CONTEXT = Object.freeze(
 module.exports = class Linter {
 
     constructor() {
-        this.sourceCode = null;
+        lastSourceCodes.set(this, null);
         this.version = pkg.version;
 
         this.rules = new Rules();
@@ -754,11 +756,11 @@ module.exports = class Linter {
         const filename = typeof providedFilename === "string" ? providedFilename : "<input>";
 
         if (typeof textOrSourceCode === "string") {
-            this.sourceCode = null;
+            lastSourceCodes.set(this, null);
             text = textOrSourceCode;
         } else {
-            this.sourceCode = textOrSourceCode;
-            text = this.sourceCode.text;
+            lastSourceCodes.set(this, textOrSourceCode);
+            text = textOrSourceCode.text;
         }
 
         // search and apply "eslint-env *".
@@ -777,13 +779,13 @@ module.exports = class Linter {
         // process initial config to make it safe to extend
         config = prepareConfig(config, this.environments);
 
-        if (this.sourceCode) {
+        if (lastSourceCodes.get(this)) {
             parserServices = {};
         } else {
 
             // there's no input, just exit here
             if (text.trim().length === 0) {
-                this.sourceCode = new SourceCode(text, blankScriptAST);
+                lastSourceCodes.set(this, new SourceCode(text, blankScriptAST));
                 return [];
             }
 
@@ -799,11 +801,11 @@ module.exports = class Linter {
             }
 
             parserServices = parseResult.services;
-            this.sourceCode = new SourceCode(text, parseResult.ast);
+            lastSourceCodes.set(this, new SourceCode(text, parseResult.ast));
         }
 
         const problems = [];
-        const sourceCode = this.sourceCode;
+        const sourceCode = lastSourceCodes.get(this);
         let disableDirectives;
 
         // parse global comments and modify config
@@ -1005,7 +1007,7 @@ module.exports = class Linter {
      * @returns {SourceCode} The SourceCode object.
      */
     getSourceCode() {
-        return this.sourceCode;
+        return lastSourceCodes.get(this);
     }
 
     /**


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This removes the `sourceCode` property from `Linter` instances, as part of the ongoing effort in #9161 to reduce undocumented API surface area.

The `sourceCode` property was used because `Linter` has a `getSourceCode` method which points to the `SourceCode` instance from the last `verify` call. This is unfortunate, because it prevents `Linter#verify` from being side-effect-free as described in #9161. However, we can't remove it right now, because it's documented [here](https://eslint.org/docs/developer-guide/nodejs-api#linterverify). Eventually I think we should deprecate and remove that, but that is a separate issue.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
