### PR TITLE
Fix: Add meta element with charset attribute.

### DIFF
--- a/lib/formatters/html-template-page.html
+++ b/lib/formatters/html-template-page.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
+<html>
     <head>
+        <meta charset="UTF-8">
         <title>ESLint Report</title>
         <style>
             body {


### PR DESCRIPTION
Open html output file used Firefox and output the following error message in console.
'The character encoding of the HTML document was not declared. The document will render with garbled text in some browser configurations if the document contains characters from outside the US-ASCII range. The character encoding of the page must be declared in the document or in the transfer protocol.'
So add meta element with charset(UTF-8) attribute.

<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment**

* **ESLint Version:** 4.7.2
* **Node Version:** 6.10.2
* **npm Version:** 5.4.1

**What parser (default, Babel-ESLint, etc.) are you using?**
default

**Please show your full configuration:**
```js
module.exports = {
    "env": {
        "browser": true
    },
    "extends": "eslint:recommended",
    "rules": {
        "indent": [
            "error",
            4
        ],
        "linebreak-style": [
            "error",
            "unix"
        ],
        "quotes": [
            "error",
            "single"
        ],
        "semi": [
            "error",
            "always"
        ]
    }
};
```

**What did you do? Please include the actual source code causing the issue.**
eslint --format html --output-file lint.html yourfile.js

**What did you expect to happen?**
output no error message in console.

**What actually happened? Please include the actual, raw output from ESLint.**
output the following error message in console.
```
The character encoding of the HTML document was not declared. The document will render with garbled text in some browser configurations if the document contains characters from outside the US-ASCII range. The character encoding of the page must be declared in the document or in the transfer protocol.
```
lint.html

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
add meta element with charset(UTF-8) attribute.

**Is there anything you'd like reviewers to focus on?**
An html element's start tag can be omitted.
Should be omitted it ?