### PR TITLE
Docs: remove line about removing rules from semver policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,6 @@ ESLint follows [semantic versioning](http://semver.org). However, due to the nat
 * Major release (likely to break your lint build)
     * `eslint:recommended` is updated.
     * A new option to an existing rule that results in ESLint reporting more errors by default.
-    * An existing rule is removed.
     * An existing formatter is removed.
     * Part of the public API is removed or changed in an incompatible way.
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

With the new [rule deprecation policy](https://eslint.org/docs/user-guide/rule-deprecation), we don't remove rules even in major releases.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular