### PR TITLE
Fix: recognise multiline comments as multiline arrays (fixes #9211)

### DIFF
--- a/lib/rules/array-bracket-newline.js
+++ b/lib/rules/array-bracket-newline.js
@@ -194,6 +194,12 @@ module.exports = {
                     options.multiline &&
                     elements.length > 0 &&
                     firstIncComment.loc.start.line !== lastIncComment.loc.end.line
+                ) ||
+                (
+                    elements.length === 0 &&
+                    firstIncComment.type === "Block" &&
+                    firstIncComment.loc.start.line !== lastIncComment.loc.end.line &&
+                    firstIncComment === lastIncComment
                 )
             );
 

--- a/tests/lib/rules/array-bracket-newline.js
+++ b/tests/lib/rules/array-bracket-newline.js
@@ -40,6 +40,8 @@ ruleTester.run("array-bracket-newline", rule, {
         "var foo = [\n1, 2\n// any comment\n];",
         "var foo = [\n1,\n2\n];",
         "var foo = [\nfunction foo() {\nreturn dosomething();\n}\n];",
+        "var foo = [/* \nany comment\n */];",
+        "var foo = [/* single line multiline comment for no real reason */];",
 
         // "always"
         { code: "var foo = [\n];", options: ["always"] },
@@ -72,6 +74,7 @@ ruleTester.run("array-bracket-newline", rule, {
         { code: "var foo = [\n1, 2\n// any comment\n];", options: [{ multiline: true }] },
         { code: "var foo = [\n1,\n2\n];", options: [{ multiline: true }] },
         { code: "var foo = [\nfunction foo() {\nreturn dosomething();\n}\n];", options: [{ multiline: true }] },
+        { code: "var foo = [/* \nany comment\n */];", options: [{ multiline: true }] },
 
         // { multiline: false }
         { code: "var foo = [];", options: [{ multiline: false }] },


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->
Fixes #9211

**What is the purpose of this pull request? (put an "X" next to item)**
[X] Bug fix

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Added another case for requiring line breaks. This is when an array contains only a comment and spans multiple lines. Before it failed on this as it did not recognise the new lines as it was empty according to the check.


**Is there anything you'd like reviewers to focus on?**

No
