### PR TITLE
Fix: id-match mysteriously fails when defined in a comment. (fixes #9…

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -94,6 +94,10 @@ function parseJsonConfig(string, location) {
 
     // Parses a JSON-like comment by the same way as parsing CLI option.
     try {
+
+        // https://github.com/eslint/eslint/issues/9366
+        string = string.replace(/\\\\/g, "\\");
+
         items = levn.parse("Object", string) || {};
 
         // Some tests say that it should ignore invalid comments such as `/*eslint no-alert:abc*/`.

--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -1513,6 +1513,15 @@ describe("Linter", () => {
             assert.include(messages[0].nodeType, "CallExpression");
         });
 
+        // https://github.com/eslint/eslint/issues/9366
+        it("rules should parse regex option correctly", () => {
+            const config = {};
+            const code = String.raw`/* eslint id-match: [2, "^(([^$\\W]|\\$[a-f\\d]{2})+|[$_]\\w*|[^\\W\\d]\\w*|[A-Z]([A-Z_]*[A-Z])?)$", {properties: true}] */ var is$2dvoid = 0;`;
+            const messages = linter.verify(code, config, filename, false);
+
+            assert.equal(messages.length, 0);
+        });
+
         it("rules should not change initial config", () => {
             const config = { rules: { strict: 2 } };
             const codeA = "/*eslint strict: 0*/ function bar() { return 2; }";


### PR DESCRIPTION
…366)

<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
fixes #9366 

When the option value is a regex, we use `levn.parse()` and `new Regex()` to get it. It should be unescaped twice if working correctly: 
```js
levn.parse('\\\\n');   => '\\n'
new Regex('\\n');      => /\n/
```

But since `levn` don't support escape `\`, the parsed result would be `'\\\\n'` -- this is not right. this PR simply replace `'\\\\'` to `'\\'`, so the result can be right.


**Is there anything you'd like reviewers to focus on?**


