### PR TITLE
Docs: show console call with no-restricted-syntax (fixes #7806)

### DIFF
--- a/docs/rules/no-console.md
+++ b/docs/rules/no-console.md
@@ -49,6 +49,45 @@ console.error("Log an error level message.");
 
 If you're using Node.js, however, `console` is used to output information to the user and so is not strictly used for debugging purposes. If you are developing for Node.js then you most likely do not want this rule enabled.
 
+Another case where you might not use this rule is if you want to enforce console calls and not console overwrites. For example:
+
+```js
+console.error = function (message) {
+  throw new Error(message);
+};
+``` 
+
+With the `no-console` rule, this will receive a warning/error. For the above example, you can disable the rule:
+
+```js
+// eslint-disable-next-line no-console
+console.error = function (message) {
+  throw new Error(message);
+};
+
+// or
+
+console.error = function (message) {  // eslint-disable-line no-console
+  throw new Error(message);
+};
+```
+
+However, you might not want to manually add `eslint-disable-next-line` or `eslint-disable-line`. You can achieve the effect of only receiving errors for console calls with the `no-restricted-syntax` rule:
+
+```json
+{
+    "rules": {
+        "no-restricted-syntax": [
+            "error",
+            {
+                "selector": "CallExpression[callee.object.name='console'][callee.property.name=/^(log|warn|error|info|trace)$/]",
+                "message": "Unexpected property on console object was called"
+            }
+        ]
+    }
+}
+```
+
 ## Related Rules
 
 * [no-alert](no-alert.md)

--- a/docs/rules/no-console.md
+++ b/docs/rules/no-console.md
@@ -55,7 +55,7 @@ Another case where you might not use this rule is if you want to enforce console
 console.error = function (message) {
   throw new Error(message);
 };
-``` 
+```
 
 With the `no-console` rule, this will receive a warning/error. For the above example, you can disable the rule:
 

--- a/docs/rules/no-console.md
+++ b/docs/rules/no-console.md
@@ -52,12 +52,13 @@ If you're using Node.js, however, `console` is used to output information to the
 Another case where you might not use this rule is if you want to enforce console calls and not console overwrites. For example:
 
 ```js
+/*eslint no-console: ["error", { allow: ["warn"] }] */
 console.error = function (message) {
   throw new Error(message);
 };
 ```
 
-With the `no-console` rule, this will receive a warning/error. For the above example, you can disable the rule:
+With the `no-console` rule in the above example, ESLint will report an error. For the above example, you can disable the rule:
 
 ```js
 // eslint-disable-next-line no-console


### PR DESCRIPTION

[X] Documentation update

**What changes did you make? (Give an overview)**
Add documentation on how to show warnings/error for console calls and not method overwrites with the use of no-restricted-syntax

**Is there anything you'd like reviewers to focus on?**
That I got all the details from the opened issue

