### PR TITLE
New: add consistent option to array-bracket-newline rule (fixes #9136)

### DIFF
--- a/docs/rules/array-bracket-newline.md
+++ b/docs/rules/array-bracket-newline.md
@@ -242,7 +242,7 @@ let d = [
 1, 2];
 let e = [1,
 2];
-let [f 
+let [f
 ] = [1];
 let [,
 g] = [1];
@@ -261,7 +261,7 @@ Examples of **correct** code for this rule with the `{ "consistent": true }` opt
 /*eslint-env es6*/
 let a = [1];
 let b = [1, 2];
-let c = [ 
+let c = [
     1,
     2,
 ];

--- a/docs/rules/array-bracket-newline.md
+++ b/docs/rules/array-bracket-newline.md
@@ -229,8 +229,51 @@ var e = [
 Examples of **incorrect** code for this rule with the `{ "consistent": true }` option:
 
 ```js
+/*eslint array-bracket-newline: ["error", { "consistent": true }]*/
+/*eslint-env es6*/
+
+let a = [1,
+];
+let b = [,
+1];
+let c = [1, 2
+];
+let d = [
+1, 2];
+let e = [1,
+2];
+let [f 
+] = [1];
+let [,
+g] = [1];
+let [h, i
+] = [1, 2];
+let [
+j, k] = [1, 2];
+let [l,
+m] = [1, 2];
+```
+
+Examples of **correct** code for this rule with the `{ "consistent": true }` option:
+
+```js
+/*eslint array-bracket-newline: ["error", { "consistent": true }]*/
+/*eslint-env es6*/
+let a = [1];
+let b = [1, 2];
+let c = [ 
+    1,
+    2,
+];
+let [d] = [1];
+let [e, f] = [1, 2];
+let [
+    a,
+    b,
+] = [1, 2];
 
 ```
+
 
 
 ## When Not To Use It

--- a/docs/rules/array-bracket-newline.md
+++ b/docs/rules/array-bracket-newline.md
@@ -17,6 +17,7 @@ Or an object option (Requires line breaks if any of properties is satisfied. Oth
 
 * `"multiline": true` (default) requires line breaks if there are line breaks inside elements or between elements. If this is false, this condition is disabled.
 * `"minItems": null` (default) requires line breaks if the number of elements is at least the given integer. If this is 0, this condition will act the same as the option `"always"`. If this is `null` (the default), this condition is disabled.
+* `"consistent": true` requires that either both square brackets, or neither, directly enclose newlines.
 
 ### always
 
@@ -221,6 +222,14 @@ var e = [
         dosomething();
     }
 ];
+```
+
+### consistent
+
+Examples of **incorrect** code for this rule with the `{ "consistent": true }` option:
+
+```js
+
 ```
 
 

--- a/lib/rules/array-bracket-newline.js
+++ b/lib/rules/array-bracket-newline.js
@@ -34,6 +34,9 @@ module.exports = {
                             minItems: {
                                 type: ["integer", "null"],
                                 minimum: 0
+                            },
+                            consistent: {
+                                type: "boolean"
                             }
                         },
                         additionalProperties: false
@@ -60,6 +63,7 @@ module.exports = {
         function normalizeOptionValue(option) {
             let multiline = false;
             let minItems = 0;
+            let consistent = false;
 
             if (option) {
                 if (option === "always" || option.minItems === 0) {
@@ -69,13 +73,14 @@ module.exports = {
                 } else {
                     multiline = Boolean(option.multiline);
                     minItems = option.minItems || Number.POSITIVE_INFINITY;
+                    consistent = Boolean(option.consistent);
                 }
             } else {
                 multiline = true;
                 minItems = Number.POSITIVE_INFINITY;
             }
 
-            return { multiline, minItems };
+            return { multiline, minItems, consistent };
         }
 
         /**
@@ -214,10 +219,20 @@ module.exports = {
                     reportRequiredEndingLinebreak(node, closeBracket);
                 }
             } else {
-                if (!astUtils.isTokenOnSameLine(openBracket, first)) {
+                const consistent = options.consistent;
+                const hasLineBreakBetweenOpenBracketAndfirst = !astUtils.isTokenOnSameLine(openBracket, first);
+                const hasLineBreakBetweenCloseBracketAndLast = !astUtils.isTokenOnSameLine(last, closeBracket);
+
+                if (
+                    (!consistent && !astUtils.isTokenOnSameLine(openBracket, first)) ||
+                    (consistent && hasLineBreakBetweenOpenBracketAndfirst && !hasLineBreakBetweenCloseBracketAndLast)
+                ) {
                     reportNoBeginningLinebreak(node, openBracket);
                 }
-                if (!astUtils.isTokenOnSameLine(last, closeBracket)) {
+                if (
+                    (!consistent && !astUtils.isTokenOnSameLine(last, closeBracket)) ||
+                    (consistent && !hasLineBreakBetweenOpenBracketAndfirst && hasLineBreakBetweenCloseBracketAndLast)
+                ) {
                     reportNoEndingLinebreak(node, closeBracket);
                 }
             }

--- a/tests/lib/rules/array-bracket-newline.js
+++ b/tests/lib/rules/array-bracket-newline.js
@@ -308,7 +308,7 @@ ruleTester.run("array-bracket-newline", rule, {
             ].join("\n"),
             options: [{ multiline: true, consistent: true, minItems: 2 }],
             parserOptions: { ecmaVersion: 6 }
-        },
+        }
     ],
 
     invalid: [
@@ -766,7 +766,7 @@ ruleTester.run("array-bracket-newline", rule, {
             errors: [
                 { line: 2, column: 1, message: ERR_NO_BREAK_BEFORE }
             ]
-        },        
+        }, 
         {
             code: [
                 "var b = [",
@@ -777,7 +777,7 @@ ruleTester.run("array-bracket-newline", rule, {
             ].join("\n"),
             options: [{ multiline: true, consistent: true }],
             errors: [
-                { line: 1, column: 9, message:ERR_NO_BREAK_AFTER }
+                { line: 1, column: 9, message: ERR_NO_BREAK_AFTER }
             ]
         },
         {

--- a/tests/lib/rules/array-bracket-newline.js
+++ b/tests/lib/rules/array-bracket-newline.js
@@ -766,7 +766,7 @@ ruleTester.run("array-bracket-newline", rule, {
             errors: [
                 { line: 2, column: 1, message: ERR_NO_BREAK_BEFORE }
             ]
-        }, 
+        },
         {
             code: [
                 "var b = [",

--- a/tests/lib/rules/array-bracket-newline.js
+++ b/tests/lib/rules/array-bracket-newline.js
@@ -152,8 +152,163 @@ ruleTester.run("array-bracket-newline", rule, {
         { code: "var [ // any comment\na, b\n] = foo;", options: [{ multiline: true }], parserOptions: { ecmaVersion: 6 } },
         { code: "var [\n// any comment\na, b\n] = foo;", options: [{ multiline: true }], parserOptions: { ecmaVersion: 6 } },
         { code: "var [\na, b\n// any comment\n] = foo;", options: [{ multiline: true }], parserOptions: { ecmaVersion: 6 } },
-        { code: "var [\na,\nb\n] = foo;", options: [{ multiline: true }], parserOptions: { ecmaVersion: 6 } }
+        { code: "var [\na,\nb\n] = foo;", options: [{ multiline: true }], parserOptions: { ecmaVersion: 6 } },
 
+        // { consistent: true }
+        {
+            code: [
+                "var b = [",
+                "    1",
+                "];"
+            ].join("\n"),
+            options: [{ multiline: true, consistent: true }]
+        },
+        {
+            code: [
+                "var c = [1, 2];"
+            ].join("\n"),
+            options: [{ multiline: true, consistent: true }]
+        },
+        {
+            code: [
+                "var c = [",
+                "    1,",
+                "    2",
+                "];"
+            ].join("\n"),
+
+            options: [{ multiline: true, consistent: true }]
+        },
+        {
+            code: [
+                "var e = [function() { dosomething();}];"
+            ].join("\n"),
+            options: [{ multiline: true, consistent: true }]
+        },
+        {
+            code: [
+                "var e = [",
+                "    function() { dosomething();}",
+                "];"
+            ].join("\n"),
+            options: [{ multiline: true, consistent: true }]
+        },
+        {
+            code: [
+                "let [] = [1];"
+            ].join("\n"),
+            options: [{ multiline: true, consistent: true }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: [
+                "let [a] = [1];"
+            ].join("\n"),
+            options: [{ multiline: true, consistent: true }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: [
+                "let [",
+                "] = [1];"
+            ].join("\n"),
+            options: [{ multiline: true, consistent: true }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: [
+                "let [",
+                "    a",
+                "] = [1];"
+            ].join("\n"),
+            options: [{ multiline: true, consistent: true }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: [
+                "let [a, b] = [1, 2];"
+            ].join("\n"),
+            options: [{ multiline: true, consistent: true }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: [
+                "let [",
+                "    a, b",
+                "] = [1, 2];"
+            ].join("\n"),
+            options: [{ multiline: true, consistent: true }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: [
+                "let [k = function() {dosomething();}] = arr;"
+            ].join("\n"),
+            options: [{ multiline: true, consistent: true }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: [
+                "let [",
+                "    k = function() {",
+                "        dosomething();",
+                "    }",
+                "] = arr;"
+            ].join("\n"),
+            options: [{ multiline: true, consistent: true }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: [
+                "var c = [1,",
+                "2];"
+            ].join("\n"),
+            options: [{ multiline: false, consistent: true }]
+        },
+        {
+            code: [
+                "let [a,",
+                "b] = [1, 2];"
+            ].join("\n"),
+            options: [{ multiline: false, consistent: true }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+
+        // "consistent" and "minItems"
+        {
+            code: [
+                "var c = [ 1 ];"
+            ].join("\n"),
+            options: [{ multiline: true, consistent: true, minItems: 2 }]
+        },
+        {
+            code: [
+                "var c = [",
+                "1",
+                "];"
+            ].join("\n"),
+            options: [{ multiline: true, consistent: true, minItems: 2 }]
+        },
+        {
+            code: [
+                "let [a] = [",
+                "1",
+                "];"
+            ].join("\n"),
+            options: [{ multiline: true, consistent: true, minItems: 2 }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: [
+                "let [",
+                "a",
+                "] = [",
+                "1",
+                "];"
+            ].join("\n"),
+            options: [{ multiline: true, consistent: true, minItems: 2 }],
+            parserOptions: { ecmaVersion: 6 }
+        },
     ],
 
     invalid: [
@@ -595,6 +750,289 @@ ruleTester.run("array-bracket-newline", rule, {
                     line: 3,
                     column: 2
                 }
+            ]
+        },
+
+        // { consistent: true }
+        {
+            code: [
+                "var b = [1",
+                "];"
+            ].join("\n"),
+            output: [
+                "var b = [1];"
+            ].join("\n"),
+            options: [{ multiline: true, consistent: true }],
+            errors: [
+                { line: 2, column: 1, message: ERR_NO_BREAK_BEFORE }
+            ]
+        },        
+        {
+            code: [
+                "var b = [",
+                "1];"
+            ].join("\n"),
+            output: [
+                "var b = [1];"
+            ].join("\n"),
+            options: [{ multiline: true, consistent: true }],
+            errors: [
+                { line: 1, column: 9, message:ERR_NO_BREAK_AFTER }
+            ]
+        },
+        {
+            code: [
+                "var c = [1, 2",
+                "];"
+            ].join("\n"),
+            output: [
+                "var c = [1, 2];"
+            ].join("\n"),
+            options: [{ multiline: true, consistent: true }],
+            errors: [
+                { line: 2, column: 1, message: ERR_NO_BREAK_BEFORE }
+            ]
+        },
+        {
+            code: [
+                "var c = [",
+                "1, 2];"
+            ].join("\n"),
+            output: [
+                "var c = [1, 2];"
+            ].join("\n"),
+            options: [{ multiline: true, consistent: true }],
+            errors: [
+                { line: 1, column: 9, message: ERR_NO_BREAK_AFTER }
+            ]
+        },
+        {
+            code: [
+                "var c = [1,",
+                "2];"
+            ].join("\n"),
+            output: [
+                "var c = [",
+                "1,",
+                "2",
+                "];"
+            ].join("\n"),
+            options: [{ multiline: true, consistent: true }],
+            errors: [
+                { line: 1, column: 9, message: ERR_BREAK_AFTER },
+                { line: 2, column: 2, message: ERR_BREAK_BEFORE }
+            ]
+        },
+        {
+            code: [
+                "var e = [function() {",
+                "dosomething();",
+                "}];"
+            ].join("\n"),
+            output: [
+                "var e = [",
+                "function() {",
+                "dosomething();",
+                "}",
+                "];"
+            ].join("\n"),
+            options: [{ multiline: true, consistent: true }],
+            errors: [
+                { line: 1, column: 9, message: ERR_BREAK_AFTER },
+                { line: 3, column: 2, message: ERR_BREAK_BEFORE }
+            ]
+        },
+        {
+            code: [
+                "let [a",
+                "] = [1]"
+            ].join("\n"),
+            output: [
+                "let [a] = [1]"
+            ].join("\n"),
+            options: [{ multiline: true, consistent: true }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                { line: 2, column: 1, message: ERR_NO_BREAK_BEFORE }
+            ]
+        },
+        {
+            code: [
+                "let [",
+                "a] = [1]"
+            ].join("\n"),
+            output: [
+                "let [a] = [1]"
+            ].join("\n"),
+            options: [{ multiline: true, consistent: true }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                { line: 1, column: 5, message: ERR_NO_BREAK_AFTER }
+            ]
+        },
+        {
+            code: [
+                "let [a, b",
+                "] = [1, 2]"
+            ].join("\n"),
+            output: [
+                "let [a, b] = [1, 2]"
+            ].join("\n"),
+            options: [{ multiline: true, consistent: true }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                { line: 2, column: 1, message: ERR_NO_BREAK_BEFORE }
+            ]
+        },
+        {
+            code: [
+                "let [",
+                "a, b] = [1, 2]"
+            ].join("\n"),
+            output: [
+                "let [a, b] = [1, 2]"
+            ].join("\n"),
+            options: [{ multiline: true, consistent: true }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                { line: 1, column: 5, message: ERR_NO_BREAK_AFTER }
+            ]
+        },
+        {
+            code: [
+                "let [a,",
+                "b] = [1, 2]"
+            ].join("\n"),
+            output: [
+                "let [",
+                "a,",
+                "b",
+                "] = [1, 2]"
+            ].join("\n"),
+            options: [{ multiline: true, consistent: true }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                { line: 1, column: 5, message: ERR_BREAK_AFTER },
+                { line: 2, column: 2, message: ERR_BREAK_BEFORE }
+            ]
+        },
+        {
+            code: [
+                "let [e = function() {",
+                "dosomething();",
+                "}] = a;"
+            ].join("\n"),
+            output: [
+                "let [",
+                "e = function() {",
+                "dosomething();",
+                "}",
+                "] = a;"
+            ].join("\n"),
+            options: [{ multiline: true, consistent: true }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                { line: 1, column: 5, message: ERR_BREAK_AFTER },
+                { line: 3, column: 2, message: ERR_BREAK_BEFORE }
+            ]
+        },
+        {
+            code: [
+                "var c = [",
+                "1,",
+                "2];"
+            ].join("\n"),
+            output: [
+                "var c = [1,",
+                "2];"
+            ].join("\n"),
+            options: [{ multiline: false, consistent: true }],
+            errors: [
+                { line: 1, column: 9, message: ERR_NO_BREAK_AFTER }
+            ]
+        },
+        {
+            code: [
+                "var c = [1,",
+                "2",
+                "];"
+            ].join("\n"),
+            output: [
+                "var c = [1,",
+                "2];"
+            ].join("\n"),
+            options: [{ multiline: false, consistent: true }],
+            errors: [
+                { line: 3, column: 1, message: ERR_NO_BREAK_BEFORE }
+            ]
+        },
+        {
+            code: [
+                "let [",
+                "a,",
+                "b] = [1, 2];"
+            ].join("\n"),
+            output: [
+                "let [a,",
+                "b] = [1, 2];"
+            ].join("\n"),
+            options: [{ multiline: false, consistent: true }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                { line: 1, column: 5, message: ERR_NO_BREAK_AFTER }
+            ]
+        },
+        {
+            code: [
+                "let [a,",
+                "b",
+                "] = [1, 2];"
+            ].join("\n"),
+            output: [
+                "let [a,",
+                "b] = [1, 2];"
+            ].join("\n"),
+            options: [{ multiline: false, consistent: true }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                { line: 3, column: 1, message: ERR_NO_BREAK_BEFORE }
+            ]
+        },
+
+        // "consistent" and "minItems"
+        {
+            code: [
+                "var c = [1, 2];"
+            ].join("\n"),
+            output: [
+                "var c = [",
+                "1, 2",
+                "];"
+            ].join("\n"),
+            options: [{ multiline: true, consistent: true, minItems: 2 }],
+            errors: [
+                { line: 1, column: 9, message: ERR_BREAK_AFTER },
+                { line: 1, column: 14, message: ERR_BREAK_BEFORE }
+            ]
+        },
+        {
+            code: [
+                "let [a, b] = [",
+                "1, 2",
+                "];"
+            ].join("\n"),
+            output: [
+                "let [",
+                "a, b",
+                "] = [",
+                "1, 2",
+                "];"
+            ].join("\n"),
+            options: [{ multiline: true, consistent: true, minItems: 2 }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                { line: 1, column: 5, message: ERR_BREAK_AFTER },
+                { line: 1, column: 10, message: ERR_BREAK_BEFORE }
             ]
         },
 

--- a/tests/lib/rules/array-bracket-newline.js
+++ b/tests/lib/rules/array-bracket-newline.js
@@ -845,10 +845,10 @@ ruleTester.run("array-bracket-newline", rule, {
         {
             code: [
                 "let [a",
-                "] = [1]"
+                "] = [1];"
             ].join("\n"),
             output: [
-                "let [a] = [1]"
+                "let [a] = [1];"
             ].join("\n"),
             options: [{ multiline: true, consistent: true }],
             parserOptions: { ecmaVersion: 6 },
@@ -859,10 +859,10 @@ ruleTester.run("array-bracket-newline", rule, {
         {
             code: [
                 "let [",
-                "a] = [1]"
+                "a] = [1];"
             ].join("\n"),
             output: [
-                "let [a] = [1]"
+                "let [a] = [1];"
             ].join("\n"),
             options: [{ multiline: true, consistent: true }],
             parserOptions: { ecmaVersion: 6 },
@@ -873,10 +873,10 @@ ruleTester.run("array-bracket-newline", rule, {
         {
             code: [
                 "let [a, b",
-                "] = [1, 2]"
+                "] = [1, 2];"
             ].join("\n"),
             output: [
-                "let [a, b] = [1, 2]"
+                "let [a, b] = [1, 2];"
             ].join("\n"),
             options: [{ multiline: true, consistent: true }],
             parserOptions: { ecmaVersion: 6 },
@@ -887,10 +887,10 @@ ruleTester.run("array-bracket-newline", rule, {
         {
             code: [
                 "let [",
-                "a, b] = [1, 2]"
+                "a, b] = [1, 2];"
             ].join("\n"),
             output: [
-                "let [a, b] = [1, 2]"
+                "let [a, b] = [1, 2];"
             ].join("\n"),
             options: [{ multiline: true, consistent: true }],
             parserOptions: { ecmaVersion: 6 },
@@ -901,13 +901,13 @@ ruleTester.run("array-bracket-newline", rule, {
         {
             code: [
                 "let [a,",
-                "b] = [1, 2]"
+                "b] = [1, 2];"
             ].join("\n"),
             output: [
                 "let [",
                 "a,",
                 "b",
-                "] = [1, 2]"
+                "] = [1, 2];"
             ].join("\n"),
             options: [{ multiline: true, consistent: true }],
             parserOptions: { ecmaVersion: 6 },


### PR DESCRIPTION

most tests are based on https://eslint.org/docs/rules/object-curly-newline
their implementation and tests are very similar.


[X] Changes an existing rule ([template]


What rule do you want to change?**
array-bracket-newline rule

**Does this change cause the rule to produce more or fewer warnings?**
More warnings depending on how you configure the options

**How will the change be implemented? (New option, new default behavior, etc.)?**
New option
