### PR TITLE
Chore: avoid loose equality assertions

### DIFF
--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -384,7 +384,7 @@ class RuleTester {
             const result = runRuleForItem(item);
             const messages = result.messages;
 
-            assert.equal(messages.length, 0, util.format("Should have no errors but had %d: %s",
+            assert.strictEqual(messages.length, 0, util.format("Should have no errors but had %d: %s",
                 messages.length, util.inspect(messages)));
 
             assertASTDidntChange(result.beforeAST, result.afterAST);
@@ -408,7 +408,7 @@ class RuleTester {
                     `Expected '${actual}' to match ${expected}`
                 );
             } else {
-                assert.equal(actual, expected);
+                assert.strictEqual(actual, expected);
             }
         }
 
@@ -428,10 +428,10 @@ class RuleTester {
 
 
             if (typeof item.errors === "number") {
-                assert.equal(messages.length, item.errors, util.format("Should have %d error%s but had %d: %s",
+                assert.strictEqual(messages.length, item.errors, util.format("Should have %d error%s but had %d: %s",
                     item.errors, item.errors === 1 ? "" : "s", messages.length, util.inspect(messages)));
             } else {
-                assert.equal(
+                assert.strictEqual(
                     messages.length, item.errors.length,
                     util.format(
                         "Should have %d error%s but had %d: %s",
@@ -460,23 +460,35 @@ class RuleTester {
                             assertMessageMatches(messages[i].message, item.errors[i].message);
                         }
 
+                        // The following checks use loose equality assertions for backwards compatibility.
+
                         if (item.errors[i].type) {
+
+                            // eslint-disable-next-line no-restricted-properties
                             assert.equal(messages[i].nodeType, item.errors[i].type, `Error type should be ${item.errors[i].type}, found ${messages[i].nodeType}`);
                         }
 
                         if (item.errors[i].hasOwnProperty("line")) {
+
+                            // eslint-disable-next-line no-restricted-properties
                             assert.equal(messages[i].line, item.errors[i].line, `Error line should be ${item.errors[i].line}`);
                         }
 
                         if (item.errors[i].hasOwnProperty("column")) {
+
+                            // eslint-disable-next-line no-restricted-properties
                             assert.equal(messages[i].column, item.errors[i].column, `Error column should be ${item.errors[i].column}`);
                         }
 
                         if (item.errors[i].hasOwnProperty("endLine")) {
+
+                            // eslint-disable-next-line no-restricted-properties
                             assert.equal(messages[i].endLine, item.errors[i].endLine, `Error endLine should be ${item.errors[i].endLine}`);
                         }
 
                         if (item.errors[i].hasOwnProperty("endColumn")) {
+
+                            // eslint-disable-next-line no-restricted-properties
                             assert.equal(messages[i].endColumn, item.errors[i].endColumn, `Error endColumn should be ${item.errors[i].endColumn}`);
                         }
                     } else {
@@ -497,6 +509,7 @@ class RuleTester {
                 } else {
                     const fixResult = SourceCodeFixer.applyFixes(item.code, messages);
 
+                    // eslint-disable-next-line no-restricted-properties
                     assert.equal(fixResult.output, item.output, "Output is incorrect.");
                 }
             }

--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -369,6 +369,7 @@ class RuleTester {
             if (!lodash.isEqual(beforeAST, afterAST)) {
 
                 // Not using directly to avoid performance problem in node 6.1.0. See #6111
+                // eslint-disable-next-line no-restricted-properties
                 assert.deepEqual(beforeAST, afterAST, "Rule should not modify AST.");
             }
         }

--- a/packages/eslint-config-eslint/default.yml
+++ b/packages/eslint-config-eslint/default.yml
@@ -85,7 +85,9 @@ rules:
     no-restricted-properties: [
         "error",
         { property: "substring", message: "Use .slice instead of .substring." },
-        { property: "substr", message: "Use .slice instead of .substr." }
+        { property: "substr", message: "Use .slice instead of .substr." },
+        { object: "assert", property: "equal", message: "Use assert.strictEqual instead of assert.equal." },
+        { object: "assert", property: "notEqual", message: "Use assert.notStrictEqual instead of assert.notEqual." }
     ]
     no-return-assign: "error"
     no-script-url: "error"

--- a/packages/eslint-config-eslint/default.yml
+++ b/packages/eslint-config-eslint/default.yml
@@ -87,7 +87,9 @@ rules:
         { property: "substring", message: "Use .slice instead of .substring." },
         { property: "substr", message: "Use .slice instead of .substr." },
         { object: "assert", property: "equal", message: "Use assert.strictEqual instead of assert.equal." },
-        { object: "assert", property: "notEqual", message: "Use assert.notStrictEqual instead of assert.notEqual." }
+        { object: "assert", property: "notEqual", message: "Use assert.notStrictEqual instead of assert.notEqual." },
+        { object: "assert", property: "deepEqual", message: "Use assert.deepStrictEqual instead of assert.deepStrictEqual." },
+        { object: "assert", property: "notDeepEqual", message: "Use assert.notDeepStrictEqual instead of assert.notDeepEqual." }
     ]
     no-return-assign: "error"
     no-script-url: "error"

--- a/tests/conf/eslint-all.js
+++ b/tests/conf/eslint-all.js
@@ -34,6 +34,6 @@ describe("eslint-all", () => {
         const ruleNames = Object.keys(rules);
         const nonErrorRules = ruleNames.filter(ruleName => rules[ruleName] !== "error");
 
-        assert.equal(nonErrorRules.length, 0);
+        assert.strictEqual(nonErrorRules.length, 0);
     });
 });

--- a/tests/lib/ast-utils.js
+++ b/tests/lib/ast-utils.js
@@ -552,42 +552,42 @@ describe("ast-utils", () => {
             const ast = espree.parse("if (a) { b(); }");
             const node = ast.body[0];
 
-            assert.deepEqual(astUtils.getDirectivePrologue(node), []);
+            assert.deepStrictEqual(astUtils.getDirectivePrologue(node), []);
         });
 
         it("should return empty array if node is a braceless ArrowFunctionExpression node", () => {
             const ast = espree.parse("var foo = () => 'use strict';", { ecmaVersion: 6 });
             const node = ast.body[0].declarations[0].init;
 
-            assert.deepEqual(astUtils.getDirectivePrologue(node), []);
+            assert.deepStrictEqual(astUtils.getDirectivePrologue(node), []);
         });
 
         it("should return empty array if there are no directives in Program body", () => {
             const ast = espree.parse("var foo;");
             const node = ast;
 
-            assert.deepEqual(astUtils.getDirectivePrologue(node), []);
+            assert.deepStrictEqual(astUtils.getDirectivePrologue(node), []);
         });
 
         it("should return empty array if there are no directives in FunctionDeclaration body", () => {
             const ast = espree.parse("function foo() { return bar; }");
             const node = ast.body[0];
 
-            assert.deepEqual(astUtils.getDirectivePrologue(node), []);
+            assert.deepStrictEqual(astUtils.getDirectivePrologue(node), []);
         });
 
         it("should return empty array if there are no directives in FunctionExpression body", () => {
             const ast = espree.parse("var foo = function() { return bar; }");
             const node = ast.body[0].declarations[0].init;
 
-            assert.deepEqual(astUtils.getDirectivePrologue(node), []);
+            assert.deepStrictEqual(astUtils.getDirectivePrologue(node), []);
         });
 
         it("should return empty array if there are no directives in ArrowFunctionExpression body", () => {
             const ast = espree.parse("var foo = () => { return bar; };", { ecmaVersion: 6 });
             const node = ast.body[0].declarations[0].init;
 
-            assert.deepEqual(astUtils.getDirectivePrologue(node), []);
+            assert.deepStrictEqual(astUtils.getDirectivePrologue(node), []);
         });
 
         it("should return directives in Program body", () => {
@@ -770,7 +770,7 @@ describe("ast-utils", () => {
             it(`should return "${JSON.stringify(expectedLoc)}" for "${key}".`, () => {
                 linter.defineRule("checker", mustCall(() => ({
                     ":function": mustCall(node => {
-                        assert.deepEqual(
+                        assert.deepStrictEqual(
                             astUtils.getFunctionHeadLoc(node, linter.getSourceCode()),
                             expectedLoc
                         );

--- a/tests/lib/ast-utils.js
+++ b/tests/lib/ast-utils.js
@@ -374,7 +374,7 @@ describe("ast-utils", () => {
             linter.verify(code, { rules: { checker: "error" }, parserOptions: { ecmaVersion: 6 } });
 
             assert.lengthOf(results, 1);
-            assert.equal(results[0], expectedInLoop);
+            assert.strictEqual(results[0], expectedInLoop);
         }
 
         it("should return true for a loop itself", () => {
@@ -594,36 +594,36 @@ describe("ast-utils", () => {
             const ast = espree.parse("'use strict'; 'use asm'; var foo;");
             const result = astUtils.getDirectivePrologue(ast);
 
-            assert.equal(result.length, 2);
-            assert.equal(result[0].expression.value, "use strict");
-            assert.equal(result[1].expression.value, "use asm");
+            assert.strictEqual(result.length, 2);
+            assert.strictEqual(result[0].expression.value, "use strict");
+            assert.strictEqual(result[1].expression.value, "use asm");
         });
 
         it("should return directives in FunctionDeclaration body", () => {
             const ast = espree.parse("function foo() { 'use strict'; 'use asm'; return bar; }");
             const result = astUtils.getDirectivePrologue(ast.body[0]);
 
-            assert.equal(result.length, 2);
-            assert.equal(result[0].expression.value, "use strict");
-            assert.equal(result[1].expression.value, "use asm");
+            assert.strictEqual(result.length, 2);
+            assert.strictEqual(result[0].expression.value, "use strict");
+            assert.strictEqual(result[1].expression.value, "use asm");
         });
 
         it("should return directives in FunctionExpression body", () => {
             const ast = espree.parse("var foo = function() { 'use strict'; 'use asm'; return bar; }");
             const result = astUtils.getDirectivePrologue(ast.body[0].declarations[0].init);
 
-            assert.equal(result.length, 2);
-            assert.equal(result[0].expression.value, "use strict");
-            assert.equal(result[1].expression.value, "use asm");
+            assert.strictEqual(result.length, 2);
+            assert.strictEqual(result[0].expression.value, "use strict");
+            assert.strictEqual(result[1].expression.value, "use asm");
         });
 
         it("should return directives in ArrowFunctionExpression body", () => {
             const ast = espree.parse("var foo = () => { 'use strict'; 'use asm'; return bar; };", { ecmaVersion: 6 });
             const result = astUtils.getDirectivePrologue(ast.body[0].declarations[0].init);
 
-            assert.equal(result.length, 2);
-            assert.equal(result[0].expression.value, "use strict");
-            assert.equal(result[1].expression.value, "use asm");
+            assert.strictEqual(result.length, 2);
+            assert.strictEqual(result[0].expression.value, "use strict");
+            assert.strictEqual(result[1].expression.value, "use asm");
         });
     });
 
@@ -876,7 +876,7 @@ describe("ast-utils", () => {
 
         tokens.forEach((token, index) => {
             it(`should return ${expected[index]} for '${token.value}'.`, () => {
-                assert.equal(astUtils.isArrowToken(token), expected[index]);
+                assert.strictEqual(astUtils.isArrowToken(token), expected[index]);
             });
         });
     });
@@ -889,7 +889,7 @@ describe("ast-utils", () => {
         describe("isClosingBraceToken", () => {
             tokens.forEach((token, index) => {
                 it(`should return ${expected[index]} for '${token.value}'.`, () => {
-                    assert.equal(astUtils.isClosingBraceToken(token), expected[index]);
+                    assert.strictEqual(astUtils.isClosingBraceToken(token), expected[index]);
                 });
             });
         });
@@ -897,7 +897,7 @@ describe("ast-utils", () => {
         describe("isNotClosingBraceToken", () => {
             tokens.forEach((token, index) => {
                 it(`should return ${expected[index]} for '${token.value}'.`, () => {
-                    assert.equal(astUtils.isNotClosingBraceToken(token), !expected[index]);
+                    assert.strictEqual(astUtils.isNotClosingBraceToken(token), !expected[index]);
                 });
             });
         });
@@ -911,7 +911,7 @@ describe("ast-utils", () => {
         describe("isClosingBracketToken", () => {
             tokens.forEach((token, index) => {
                 it(`should return ${expected[index]} for '${token.value}'.`, () => {
-                    assert.equal(astUtils.isClosingBracketToken(token), expected[index]);
+                    assert.strictEqual(astUtils.isClosingBracketToken(token), expected[index]);
                 });
             });
         });
@@ -919,7 +919,7 @@ describe("ast-utils", () => {
         describe("isNotClosingBracketToken", () => {
             tokens.forEach((token, index) => {
                 it(`should return ${expected[index]} for '${token.value}'.`, () => {
-                    assert.equal(astUtils.isNotClosingBracketToken(token), !expected[index]);
+                    assert.strictEqual(astUtils.isNotClosingBracketToken(token), !expected[index]);
                 });
             });
         });
@@ -933,7 +933,7 @@ describe("ast-utils", () => {
         describe("isClosingParenToken", () => {
             tokens.forEach((token, index) => {
                 it(`should return ${expected[index]} for '${token.value}'.`, () => {
-                    assert.equal(astUtils.isClosingParenToken(token), expected[index]);
+                    assert.strictEqual(astUtils.isClosingParenToken(token), expected[index]);
                 });
             });
         });
@@ -941,7 +941,7 @@ describe("ast-utils", () => {
         describe("isNotClosingParenToken", () => {
             tokens.forEach((token, index) => {
                 it(`should return ${expected[index]} for '${token.value}'.`, () => {
-                    assert.equal(astUtils.isNotClosingParenToken(token), !expected[index]);
+                    assert.strictEqual(astUtils.isNotClosingParenToken(token), !expected[index]);
                 });
             });
         });
@@ -955,7 +955,7 @@ describe("ast-utils", () => {
         describe("isColonToken", () => {
             tokens.forEach((token, index) => {
                 it(`should return ${expected[index]} for '${token.value}'.`, () => {
-                    assert.equal(astUtils.isColonToken(token), expected[index]);
+                    assert.strictEqual(astUtils.isColonToken(token), expected[index]);
                 });
             });
         });
@@ -963,7 +963,7 @@ describe("ast-utils", () => {
         describe("isNotColonToken", () => {
             tokens.forEach((token, index) => {
                 it(`should return ${expected[index]} for '${token.value}'.`, () => {
-                    assert.equal(astUtils.isNotColonToken(token), !expected[index]);
+                    assert.strictEqual(astUtils.isNotColonToken(token), !expected[index]);
                 });
             });
         });
@@ -977,7 +977,7 @@ describe("ast-utils", () => {
         describe("isCommaToken", () => {
             tokens.forEach((token, index) => {
                 it(`should return ${expected[index]} for '${token.value}'.`, () => {
-                    assert.equal(astUtils.isCommaToken(token), expected[index]);
+                    assert.strictEqual(astUtils.isCommaToken(token), expected[index]);
                 });
             });
         });
@@ -985,7 +985,7 @@ describe("ast-utils", () => {
         describe("isNotCommaToken", () => {
             tokens.forEach((token, index) => {
                 it(`should return ${expected[index]} for '${token.value}'.`, () => {
-                    assert.equal(astUtils.isNotCommaToken(token), !expected[index]);
+                    assert.strictEqual(astUtils.isNotCommaToken(token), !expected[index]);
                 });
             });
         });
@@ -997,12 +997,12 @@ describe("ast-utils", () => {
 
         ast.tokens.forEach(token => {
             it(`should return false for '${token.value}'.`, () => {
-                assert.equal(astUtils.isCommentToken(token), false);
+                assert.strictEqual(astUtils.isCommentToken(token), false);
             });
         });
         ast.comments.forEach(comment => {
             it(`should return true for '${comment.value}'.`, () => {
-                assert.equal(astUtils.isCommentToken(comment), true);
+                assert.strictEqual(astUtils.isCommentToken(comment), true);
             });
         });
     });
@@ -1014,7 +1014,7 @@ describe("ast-utils", () => {
 
         tokens.forEach((token, index) => {
             it(`should return ${expected[index]} for '${token.value}'.`, () => {
-                assert.equal(astUtils.isKeywordToken(token), expected[index]);
+                assert.strictEqual(astUtils.isKeywordToken(token), expected[index]);
             });
         });
     });
@@ -1027,7 +1027,7 @@ describe("ast-utils", () => {
         describe("isOpeningBraceToken", () => {
             tokens.forEach((token, index) => {
                 it(`should return ${expected[index]} for '${token.value}'.`, () => {
-                    assert.equal(astUtils.isOpeningBraceToken(token), expected[index]);
+                    assert.strictEqual(astUtils.isOpeningBraceToken(token), expected[index]);
                 });
             });
         });
@@ -1035,7 +1035,7 @@ describe("ast-utils", () => {
         describe("isNotOpeningBraceToken", () => {
             tokens.forEach((token, index) => {
                 it(`should return ${expected[index]} for '${token.value}'.`, () => {
-                    assert.equal(astUtils.isNotOpeningBraceToken(token), !expected[index]);
+                    assert.strictEqual(astUtils.isNotOpeningBraceToken(token), !expected[index]);
                 });
             });
         });
@@ -1049,7 +1049,7 @@ describe("ast-utils", () => {
         describe("isOpeningBracketToken", () => {
             tokens.forEach((token, index) => {
                 it(`should return ${expected[index]} for '${token.value}'.`, () => {
-                    assert.equal(astUtils.isOpeningBracketToken(token), expected[index]);
+                    assert.strictEqual(astUtils.isOpeningBracketToken(token), expected[index]);
                 });
             });
         });
@@ -1057,7 +1057,7 @@ describe("ast-utils", () => {
         describe("isNotOpeningBracketToken", () => {
             tokens.forEach((token, index) => {
                 it(`should return ${expected[index]} for '${token.value}'.`, () => {
-                    assert.equal(astUtils.isNotOpeningBracketToken(token), !expected[index]);
+                    assert.strictEqual(astUtils.isNotOpeningBracketToken(token), !expected[index]);
                 });
             });
         });
@@ -1071,7 +1071,7 @@ describe("ast-utils", () => {
         describe("isOpeningParenToken", () => {
             tokens.forEach((token, index) => {
                 it(`should return ${expected[index]} for '${token.value}'.`, () => {
-                    assert.equal(astUtils.isOpeningParenToken(token), expected[index]);
+                    assert.strictEqual(astUtils.isOpeningParenToken(token), expected[index]);
                 });
             });
         });
@@ -1079,7 +1079,7 @@ describe("ast-utils", () => {
         describe("isNotOpeningParenToken", () => {
             tokens.forEach((token, index) => {
                 it(`should return ${expected[index]} for '${token.value}'.`, () => {
-                    assert.equal(astUtils.isNotOpeningParenToken(token), !expected[index]);
+                    assert.strictEqual(astUtils.isNotOpeningParenToken(token), !expected[index]);
                 });
             });
         });
@@ -1093,7 +1093,7 @@ describe("ast-utils", () => {
         describe("isSemicolonToken", () => {
             tokens.forEach((token, index) => {
                 it(`should return ${expected[index]} for '${token.value}'.`, () => {
-                    assert.equal(astUtils.isSemicolonToken(token), expected[index]);
+                    assert.strictEqual(astUtils.isSemicolonToken(token), expected[index]);
                 });
             });
         });
@@ -1101,7 +1101,7 @@ describe("ast-utils", () => {
         describe("isNotSemicolonToken", () => {
             tokens.forEach((token, index) => {
                 it(`should return ${expected[index]} for '${token.value}'.`, () => {
-                    assert.equal(astUtils.isNotSemicolonToken(token), !expected[index]);
+                    assert.strictEqual(astUtils.isNotSemicolonToken(token), !expected[index]);
                 });
             });
         });

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -102,7 +102,7 @@ describe("CLIEngine", () => {
             try {
                 const engine = new CLIEngine();
 
-                assert.equal(engine.options.cwd, __dirname);
+                assert.strictEqual(engine.options.cwd, __dirname);
             } finally {
                 process.chdir(originalDir);
             }
@@ -119,19 +119,19 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnText("var foo = 'bar';");
 
-            assert.equal(report.results.length, 1);
-            assert.equal(report.errorCount, 5);
-            assert.equal(report.warningCount, 0);
-            assert.equal(report.fixableErrorCount, 3);
-            assert.equal(report.fixableWarningCount, 0);
-            assert.equal(report.results[0].messages.length, 5);
-            assert.equal(report.results[0].messages[0].ruleId, "strict");
-            assert.equal(report.results[0].messages[1].ruleId, "no-var");
-            assert.equal(report.results[0].messages[2].ruleId, "no-unused-vars");
-            assert.equal(report.results[0].messages[3].ruleId, "quotes");
-            assert.equal(report.results[0].messages[4].ruleId, "eol-last");
-            assert.equal(report.results[0].fixableErrorCount, 3);
-            assert.equal(report.results[0].fixableWarningCount, 0);
+            assert.strictEqual(report.results.length, 1);
+            assert.strictEqual(report.errorCount, 5);
+            assert.strictEqual(report.warningCount, 0);
+            assert.strictEqual(report.fixableErrorCount, 3);
+            assert.strictEqual(report.fixableWarningCount, 0);
+            assert.strictEqual(report.results[0].messages.length, 5);
+            assert.strictEqual(report.results[0].messages[0].ruleId, "strict");
+            assert.strictEqual(report.results[0].messages[1].ruleId, "no-var");
+            assert.strictEqual(report.results[0].messages[2].ruleId, "no-unused-vars");
+            assert.strictEqual(report.results[0].messages[3].ruleId, "quotes");
+            assert.strictEqual(report.results[0].messages[4].ruleId, "eol-last");
+            assert.strictEqual(report.results[0].fixableErrorCount, 3);
+            assert.strictEqual(report.results[0].fixableWarningCount, 0);
         });
 
         it("should report the toatl and per file warnings when using local cwd .eslintrc", () => {
@@ -148,19 +148,19 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnText("var foo = 'bar';");
 
-            assert.equal(report.results.length, 1);
-            assert.equal(report.errorCount, 0);
-            assert.equal(report.warningCount, 5);
-            assert.equal(report.fixableErrorCount, 0);
-            assert.equal(report.fixableWarningCount, 3);
-            assert.equal(report.results[0].messages.length, 5);
-            assert.equal(report.results[0].messages[0].ruleId, "strict");
-            assert.equal(report.results[0].messages[1].ruleId, "no-var");
-            assert.equal(report.results[0].messages[2].ruleId, "no-unused-vars");
-            assert.equal(report.results[0].messages[3].ruleId, "quotes");
-            assert.equal(report.results[0].messages[4].ruleId, "eol-last");
-            assert.equal(report.results[0].fixableErrorCount, 0);
-            assert.equal(report.results[0].fixableWarningCount, 3);
+            assert.strictEqual(report.results.length, 1);
+            assert.strictEqual(report.errorCount, 0);
+            assert.strictEqual(report.warningCount, 5);
+            assert.strictEqual(report.fixableErrorCount, 0);
+            assert.strictEqual(report.fixableWarningCount, 3);
+            assert.strictEqual(report.results[0].messages.length, 5);
+            assert.strictEqual(report.results[0].messages[0].ruleId, "strict");
+            assert.strictEqual(report.results[0].messages[1].ruleId, "no-var");
+            assert.strictEqual(report.results[0].messages[2].ruleId, "no-unused-vars");
+            assert.strictEqual(report.results[0].messages[3].ruleId, "quotes");
+            assert.strictEqual(report.results[0].messages[4].ruleId, "eol-last");
+            assert.strictEqual(report.results[0].fixableErrorCount, 0);
+            assert.strictEqual(report.results[0].fixableWarningCount, 3);
         });
 
         it("should report one message when using specific config file", () => {
@@ -173,17 +173,17 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnText("var foo = 'bar';");
 
-            assert.equal(report.results.length, 1);
-            assert.equal(report.errorCount, 1);
-            assert.equal(report.warningCount, 0);
-            assert.equal(report.fixableErrorCount, 1);
-            assert.equal(report.fixableWarningCount, 0);
-            assert.equal(report.results[0].messages.length, 1);
-            assert.equal(report.results[0].messages[0].ruleId, "quotes");
+            assert.strictEqual(report.results.length, 1);
+            assert.strictEqual(report.errorCount, 1);
+            assert.strictEqual(report.warningCount, 0);
+            assert.strictEqual(report.fixableErrorCount, 1);
+            assert.strictEqual(report.fixableWarningCount, 0);
+            assert.strictEqual(report.results[0].messages.length, 1);
+            assert.strictEqual(report.results[0].messages[0].ruleId, "quotes");
             assert.isUndefined(report.results[0].messages[0].output);
-            assert.equal(report.results[0].errorCount, 1);
-            assert.equal(report.results[0].fixableErrorCount, 1);
-            assert.equal(report.results[0].warningCount, 0);
+            assert.strictEqual(report.results[0].errorCount, 1);
+            assert.strictEqual(report.results[0].fixableErrorCount, 1);
+            assert.strictEqual(report.results[0].warningCount, 0);
         });
 
         it("should report the filename when passed in", () => {
@@ -195,7 +195,7 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnText("var foo = 'bar';", "test.js");
 
-            assert.equal(report.results[0].filePath, getFixturePath("test.js"));
+            assert.strictEqual(report.results[0].filePath, getFixturePath("test.js"));
         });
 
         it("should return a warning when given a filename by --stdin-filename in excluded files list if warnIgnored is true", () => {
@@ -206,19 +206,19 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnText("var bar = foo;", "fixtures/passing.js", true);
 
-            assert.equal(report.results.length, 1);
-            assert.equal(report.errorCount, 0);
-            assert.equal(report.warningCount, 1);
-            assert.equal(report.fixableErrorCount, 0);
-            assert.equal(report.fixableWarningCount, 0);
-            assert.equal(report.results[0].filePath, getFixturePath("passing.js"));
-            assert.equal(report.results[0].messages[0].severity, 1);
-            assert.equal(report.results[0].messages[0].message, "File ignored because of a matching ignore pattern. Use \"--no-ignore\" to override.");
+            assert.strictEqual(report.results.length, 1);
+            assert.strictEqual(report.errorCount, 0);
+            assert.strictEqual(report.warningCount, 1);
+            assert.strictEqual(report.fixableErrorCount, 0);
+            assert.strictEqual(report.fixableWarningCount, 0);
+            assert.strictEqual(report.results[0].filePath, getFixturePath("passing.js"));
+            assert.strictEqual(report.results[0].messages[0].severity, 1);
+            assert.strictEqual(report.results[0].messages[0].message, "File ignored because of a matching ignore pattern. Use \"--no-ignore\" to override.");
             assert.isUndefined(report.results[0].messages[0].output);
-            assert.equal(report.results[0].errorCount, 0);
-            assert.equal(report.results[0].warningCount, 1);
-            assert.equal(report.results[0].fixableErrorCount, 0);
-            assert.equal(report.results[0].fixableWarningCount, 0);
+            assert.strictEqual(report.results[0].errorCount, 0);
+            assert.strictEqual(report.results[0].warningCount, 1);
+            assert.strictEqual(report.results[0].fixableErrorCount, 0);
+            assert.strictEqual(report.results[0].fixableWarningCount, 0);
         });
 
         it("should not return a warning when given a filename by --stdin-filename in excluded files list if warnIgnored is false", () => {
@@ -231,7 +231,7 @@ describe("CLIEngine", () => {
             const report = engine.executeOnText("va r bar = foo;", "fixtures/passing.js", false);
 
             // should not report anything because the file is ignored
-            assert.equal(report.results.length, 0);
+            assert.strictEqual(report.results.length, 0);
         });
 
         it("should suppress excluded file warnings by default", () => {
@@ -243,7 +243,7 @@ describe("CLIEngine", () => {
             const report = engine.executeOnText("var bar = foo;", "fixtures/passing.js");
 
             // should not report anything because there are no errors
-            assert.equal(report.results.length, 0);
+            assert.strictEqual(report.results.length, 0);
         });
 
         it("should return a message when given a filename by --stdin-filename in excluded files list and ignore is off", () => {
@@ -260,10 +260,10 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnText("var bar = foo;", "fixtures/passing.js");
 
-            assert.equal(report.results.length, 1);
-            assert.equal(report.results[0].filePath, getFixturePath("passing.js"));
-            assert.equal(report.results[0].messages[0].ruleId, "no-undef");
-            assert.equal(report.results[0].messages[0].severity, 2);
+            assert.strictEqual(report.results.length, 1);
+            assert.strictEqual(report.results[0].filePath, getFixturePath("passing.js"));
+            assert.strictEqual(report.results[0].messages[0].ruleId, "no-undef");
+            assert.strictEqual(report.results[0].messages[0].severity, 2);
             assert.isUndefined(report.results[0].messages[0].output);
         });
 
@@ -465,7 +465,7 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnText("var foo = 'bar'");
 
-            assert.equal(report.results[0].source, "var foo = 'bar'");
+            assert.strictEqual(report.results[0].source, "var foo = 'bar'");
         });
 
         it("should return source code of file in `source` property when warnings are present", () => {
@@ -476,7 +476,7 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnText("var foo = 'bar'");
 
-            assert.equal(report.results[0].source, "var foo = 'bar'");
+            assert.strictEqual(report.results[0].source, "var foo = 'bar'");
         });
 
 
@@ -505,7 +505,7 @@ describe("CLIEngine", () => {
             const report = engine.executeOnText("var msg = 'hi' + foo\n");
 
             assert.isUndefined(report.results[0].source);
-            assert.equal(report.results[0].output, "var msg = 'hi' + foo;\n");
+            assert.strictEqual(report.results[0].output, "var msg = 'hi' + foo;\n");
         });
 
         it("should return a `source` property when a parsing error has occurred", () => {
@@ -556,9 +556,9 @@ describe("CLIEngine", () => {
             const report = engine.executeOnText("var bar = foo;", "node_modules/passing.js", true);
             const expectedMsg = "File ignored by default. Use \"--ignore-pattern '!node_modules/*'\" to override.";
 
-            assert.equal(report.results.length, 1);
-            assert.equal(report.results[0].filePath, getFixturePath("node_modules/passing.js"));
-            assert.equal(report.results[0].messages[0].message, expectedMsg);
+            assert.strictEqual(report.results.length, 1);
+            assert.strictEqual(report.results[0].filePath, getFixturePath("node_modules/passing.js"));
+            assert.strictEqual(report.results[0].messages[0].message, expectedMsg);
         });
 
     });
@@ -577,9 +577,9 @@ describe("CLIEngine", () => {
             const filePath = path.resolve(__dirname, "../fixtures/configurations/parser/custom.js");
             const report = engine.executeOnFiles([filePath]);
 
-            assert.equal(report.results.length, 1);
-            assert.equal(report.results[0].messages.length, 1);
-            assert.equal(report.results[0].messages[0].message, "Parsing error: Boom!");
+            assert.strictEqual(report.results.length, 1);
+            assert.strictEqual(report.results[0].messages.length, 1);
+            assert.strictEqual(report.results[0].messages[0].message, "Parsing error: Boom!");
 
         });
 
@@ -593,9 +593,9 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnFiles(["lib/cli*.js"]);
 
-            assert.equal(report.results.length, 2);
-            assert.equal(report.results[0].messages.length, 0);
-            assert.equal(report.results[1].messages.length, 0);
+            assert.strictEqual(report.results.length, 2);
+            assert.strictEqual(report.results[0].messages.length, 0);
+            assert.strictEqual(report.results[1].messages.length, 0);
         });
 
         it("should handle multiple patterns with overlapping files", () => {
@@ -607,9 +607,9 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnFiles(["lib/cli*.js", "lib/cli.?s", "lib/{cli,cli-engine}.js"]);
 
-            assert.equal(report.results.length, 2);
-            assert.equal(report.results[0].messages.length, 0);
-            assert.equal(report.results[1].messages.length, 0);
+            assert.strictEqual(report.results.length, 2);
+            assert.strictEqual(report.results[0].messages.length, 0);
+            assert.strictEqual(report.results[1].messages.length, 0);
         });
 
         it("should report zero messages when given a config file and a valid file and espree as parser", () => {
@@ -622,8 +622,8 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnFiles(["lib/cli.js"]);
 
-            assert.equal(report.results.length, 1);
-            assert.equal(report.results[0].messages.length, 0);
+            assert.strictEqual(report.results.length, 1);
+            assert.strictEqual(report.results[0].messages.length, 0);
         });
 
         it("should report zero messages when given a config file and a valid file and esprima as parser", () => {
@@ -635,8 +635,8 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnFiles(["lib/cli.js"]);
 
-            assert.equal(report.results.length, 1);
-            assert.equal(report.results[0].messages.length, 0);
+            assert.strictEqual(report.results.length, 1);
+            assert.strictEqual(report.results[0].messages.length, 0);
         });
 
         it("should report one fatal message when given a config file and a valid file and invalid parser", () => {
@@ -662,8 +662,8 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnFiles([getFixturePath("files/foo.js2")]);
 
-            assert.equal(report.results.length, 1);
-            assert.equal(report.results[0].messages.length, 0);
+            assert.strictEqual(report.results.length, 1);
+            assert.strictEqual(report.results[0].messages.length, 0);
         });
 
         it("should report zero messages when given a directory with a .js and a .js2 file", () => {
@@ -676,9 +676,9 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnFiles(["fixtures/files/"]);
 
-            assert.equal(report.results.length, 2);
-            assert.equal(report.results[0].messages.length, 0);
-            assert.equal(report.results[1].messages.length, 0);
+            assert.strictEqual(report.results.length, 2);
+            assert.strictEqual(report.results[0].messages.length, 0);
+            assert.strictEqual(report.results[1].messages.length, 0);
         });
 
         it("should report zero messages when given a '**' pattern with a .js and a .js2 file", () => {
@@ -691,9 +691,9 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnFiles(["fixtures/files/*"]);
 
-            assert.equal(report.results.length, 2);
-            assert.equal(report.results[0].messages.length, 0);
-            assert.equal(report.results[1].messages.length, 0);
+            assert.strictEqual(report.results.length, 2);
+            assert.strictEqual(report.results[0].messages.length, 0);
+            assert.strictEqual(report.results[1].messages.length, 0);
         });
 
         it("should report on all files passed explicitly, even if ignored by default", () => {
@@ -705,12 +705,12 @@ describe("CLIEngine", () => {
             const report = engine.executeOnFiles(["node_modules/foo.js"]);
             const expectedMsg = "File ignored by default. Use \"--ignore-pattern '!node_modules/*'\" to override.";
 
-            assert.equal(report.results.length, 1);
-            assert.equal(report.results[0].errorCount, 0);
-            assert.equal(report.results[0].warningCount, 1);
-            assert.equal(report.results[0].fixableErrorCount, 0);
-            assert.equal(report.results[0].fixableWarningCount, 0);
-            assert.equal(report.results[0].messages[0].message, expectedMsg);
+            assert.strictEqual(report.results.length, 1);
+            assert.strictEqual(report.results[0].errorCount, 0);
+            assert.strictEqual(report.results[0].warningCount, 1);
+            assert.strictEqual(report.results[0].fixableErrorCount, 0);
+            assert.strictEqual(report.results[0].fixableWarningCount, 0);
+            assert.strictEqual(report.results[0].messages[0].message, expectedMsg);
         });
 
         it("should report on globs with explicit inclusion of dotfiles, even though ignored by default", () => {
@@ -724,11 +724,11 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnFiles(["hidden/.hiddenfolder/*.js"]);
 
-            assert.equal(report.results.length, 1);
-            assert.equal(report.results[0].errorCount, 1);
-            assert.equal(report.results[0].warningCount, 0);
-            assert.equal(report.results[0].fixableErrorCount, 1);
-            assert.equal(report.results[0].fixableWarningCount, 0);
+            assert.strictEqual(report.results.length, 1);
+            assert.strictEqual(report.results[0].errorCount, 1);
+            assert.strictEqual(report.results[0].warningCount, 0);
+            assert.strictEqual(report.results[0].fixableErrorCount, 1);
+            assert.strictEqual(report.results[0].fixableWarningCount, 0);
         });
 
         it("should not check default ignored files without --no-ignore flag", () => {
@@ -739,7 +739,7 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnFiles(["node_modules"]);
 
-            assert.equal(report.results.length, 0);
+            assert.strictEqual(report.results.length, 0);
         });
 
         // https://github.com/eslint/eslint/issues/5547
@@ -752,7 +752,7 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnFiles(["node_modules"]);
 
-            assert.equal(report.results.length, 0);
+            assert.strictEqual(report.results.length, 0);
         });
 
         it("should not check .hidden files if they are passed explicitly without --no-ignore flag", () => {
@@ -768,12 +768,12 @@ describe("CLIEngine", () => {
             const report = engine.executeOnFiles(["fixtures/files/.bar.js"]);
             const expectedMsg = "File ignored by default.  Use a negated ignore pattern (like \"--ignore-pattern '!<relative/path/to/filename>'\") to override.";
 
-            assert.equal(report.results.length, 1);
-            assert.equal(report.results[0].errorCount, 0);
-            assert.equal(report.results[0].warningCount, 1);
-            assert.equal(report.results[0].fixableErrorCount, 0);
-            assert.equal(report.results[0].fixableWarningCount, 0);
-            assert.equal(report.results[0].messages[0].message, expectedMsg);
+            assert.strictEqual(report.results.length, 1);
+            assert.strictEqual(report.results[0].errorCount, 0);
+            assert.strictEqual(report.results[0].warningCount, 1);
+            assert.strictEqual(report.results[0].fixableErrorCount, 0);
+            assert.strictEqual(report.results[0].fixableWarningCount, 0);
+            assert.strictEqual(report.results[0].messages[0].message, expectedMsg);
         });
 
         it("should check .hidden files if they are passed explicitly with --no-ignore flag", () => {
@@ -789,12 +789,12 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnFiles(["fixtures/files/.bar.js"]);
 
-            assert.equal(report.results.length, 1);
-            assert.equal(report.results[0].warningCount, 0);
-            assert.equal(report.results[0].errorCount, 1);
-            assert.equal(report.results[0].fixableErrorCount, 1);
-            assert.equal(report.results[0].fixableWarningCount, 0);
-            assert.equal(report.results[0].messages[0].ruleId, "quotes");
+            assert.strictEqual(report.results.length, 1);
+            assert.strictEqual(report.results[0].warningCount, 0);
+            assert.strictEqual(report.results[0].errorCount, 1);
+            assert.strictEqual(report.results[0].fixableErrorCount, 1);
+            assert.strictEqual(report.results[0].fixableWarningCount, 0);
+            assert.strictEqual(report.results[0].messages[0].ruleId, "quotes");
         });
 
         it("should check .hidden files if they are unignored with an --ignore-pattern", () => {
@@ -811,12 +811,12 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnFiles(["hidden/"]);
 
-            assert.equal(report.results.length, 1);
-            assert.equal(report.results[0].warningCount, 0);
-            assert.equal(report.results[0].errorCount, 1);
-            assert.equal(report.results[0].fixableErrorCount, 1);
-            assert.equal(report.results[0].fixableWarningCount, 0);
-            assert.equal(report.results[0].messages[0].ruleId, "quotes");
+            assert.strictEqual(report.results.length, 1);
+            assert.strictEqual(report.results[0].warningCount, 0);
+            assert.strictEqual(report.results[0].errorCount, 1);
+            assert.strictEqual(report.results[0].fixableErrorCount, 1);
+            assert.strictEqual(report.results[0].fixableWarningCount, 0);
+            assert.strictEqual(report.results[0].messages[0].ruleId, "quotes");
         });
 
         it("should report zero messages when given a pattern with a .js and a .js2 file", () => {
@@ -829,9 +829,9 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnFiles(["fixtures/files/*.?s*"]);
 
-            assert.equal(report.results.length, 2);
-            assert.equal(report.results[0].messages.length, 0);
-            assert.equal(report.results[1].messages.length, 0);
+            assert.strictEqual(report.results.length, 2);
+            assert.strictEqual(report.results[0].messages.length, 0);
+            assert.strictEqual(report.results[1].messages.length, 0);
         });
 
         it("should return one error message when given a config with rules with options and severity level set to error", () => {
@@ -842,18 +842,18 @@ describe("CLIEngine", () => {
             });
             const report = engine.executeOnFiles([getFixturePath("single-quoted.js")]);
 
-            assert.equal(report.results.length, 1);
-            assert.equal(report.results[0].messages.length, 1);
-            assert.equal(report.errorCount, 1);
-            assert.equal(report.warningCount, 0);
-            assert.equal(report.fixableErrorCount, 1);
-            assert.equal(report.fixableWarningCount, 0);
-            assert.equal(report.results[0].messages[0].ruleId, "quotes");
-            assert.equal(report.results[0].messages[0].severity, 2);
-            assert.equal(report.results[0].errorCount, 1);
-            assert.equal(report.results[0].warningCount, 0);
-            assert.equal(report.results[0].fixableErrorCount, 1);
-            assert.equal(report.results[0].fixableWarningCount, 0);
+            assert.strictEqual(report.results.length, 1);
+            assert.strictEqual(report.results[0].messages.length, 1);
+            assert.strictEqual(report.errorCount, 1);
+            assert.strictEqual(report.warningCount, 0);
+            assert.strictEqual(report.fixableErrorCount, 1);
+            assert.strictEqual(report.fixableWarningCount, 0);
+            assert.strictEqual(report.results[0].messages[0].ruleId, "quotes");
+            assert.strictEqual(report.results[0].messages[0].severity, 2);
+            assert.strictEqual(report.results[0].errorCount, 1);
+            assert.strictEqual(report.results[0].warningCount, 0);
+            assert.strictEqual(report.results[0].fixableErrorCount, 1);
+            assert.strictEqual(report.results[0].fixableWarningCount, 0);
         });
 
         it("should return 3 messages when given a config file and a directory of 3 valid files", () => {
@@ -865,26 +865,26 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnFiles([getFixturePath("formatters")]);
 
-            assert.equal(report.results.length, 3);
-            assert.equal(report.errorCount, 0);
-            assert.equal(report.warningCount, 0);
-            assert.equal(report.fixableErrorCount, 0);
-            assert.equal(report.fixableWarningCount, 0);
-            assert.equal(report.results[0].messages.length, 0);
-            assert.equal(report.results[1].messages.length, 0);
-            assert.equal(report.results[2].messages.length, 0);
-            assert.equal(report.results[0].errorCount, 0);
-            assert.equal(report.results[0].warningCount, 0);
-            assert.equal(report.results[0].fixableErrorCount, 0);
-            assert.equal(report.results[0].fixableWarningCount, 0);
-            assert.equal(report.results[1].errorCount, 0);
-            assert.equal(report.results[1].warningCount, 0);
-            assert.equal(report.results[1].fixableErrorCount, 0);
-            assert.equal(report.results[1].fixableWarningCount, 0);
-            assert.equal(report.results[2].errorCount, 0);
-            assert.equal(report.results[2].warningCount, 0);
-            assert.equal(report.results[2].fixableErrorCount, 0);
-            assert.equal(report.results[2].fixableWarningCount, 0);
+            assert.strictEqual(report.results.length, 3);
+            assert.strictEqual(report.errorCount, 0);
+            assert.strictEqual(report.warningCount, 0);
+            assert.strictEqual(report.fixableErrorCount, 0);
+            assert.strictEqual(report.fixableWarningCount, 0);
+            assert.strictEqual(report.results[0].messages.length, 0);
+            assert.strictEqual(report.results[1].messages.length, 0);
+            assert.strictEqual(report.results[2].messages.length, 0);
+            assert.strictEqual(report.results[0].errorCount, 0);
+            assert.strictEqual(report.results[0].warningCount, 0);
+            assert.strictEqual(report.results[0].fixableErrorCount, 0);
+            assert.strictEqual(report.results[0].fixableWarningCount, 0);
+            assert.strictEqual(report.results[1].errorCount, 0);
+            assert.strictEqual(report.results[1].warningCount, 0);
+            assert.strictEqual(report.results[1].fixableErrorCount, 0);
+            assert.strictEqual(report.results[1].fixableWarningCount, 0);
+            assert.strictEqual(report.results[2].errorCount, 0);
+            assert.strictEqual(report.results[2].warningCount, 0);
+            assert.strictEqual(report.results[2].fixableErrorCount, 0);
+            assert.strictEqual(report.results[2].fixableWarningCount, 0);
         });
 
 
@@ -897,22 +897,22 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnFiles([getFixturePath("formatters")]);
 
-            assert.equal(report.errorCount, 6);
-            assert.equal(report.warningCount, 0);
-            assert.equal(report.fixableErrorCount, 6);
-            assert.equal(report.fixableWarningCount, 0);
-            assert.equal(report.results[0].errorCount, 0);
-            assert.equal(report.results[0].warningCount, 0);
-            assert.equal(report.results[0].fixableErrorCount, 0);
-            assert.equal(report.results[0].fixableWarningCount, 0);
-            assert.equal(report.results[1].errorCount, 3);
-            assert.equal(report.results[1].warningCount, 0);
-            assert.equal(report.results[1].fixableErrorCount, 3);
-            assert.equal(report.results[1].fixableWarningCount, 0);
-            assert.equal(report.results[2].errorCount, 3);
-            assert.equal(report.results[2].warningCount, 0);
-            assert.equal(report.results[2].fixableErrorCount, 3);
-            assert.equal(report.results[2].fixableWarningCount, 0);
+            assert.strictEqual(report.errorCount, 6);
+            assert.strictEqual(report.warningCount, 0);
+            assert.strictEqual(report.fixableErrorCount, 6);
+            assert.strictEqual(report.fixableWarningCount, 0);
+            assert.strictEqual(report.results[0].errorCount, 0);
+            assert.strictEqual(report.results[0].warningCount, 0);
+            assert.strictEqual(report.results[0].fixableErrorCount, 0);
+            assert.strictEqual(report.results[0].fixableWarningCount, 0);
+            assert.strictEqual(report.results[1].errorCount, 3);
+            assert.strictEqual(report.results[1].warningCount, 0);
+            assert.strictEqual(report.results[1].fixableErrorCount, 3);
+            assert.strictEqual(report.results[1].fixableWarningCount, 0);
+            assert.strictEqual(report.results[2].errorCount, 3);
+            assert.strictEqual(report.results[2].warningCount, 0);
+            assert.strictEqual(report.results[2].fixableErrorCount, 3);
+            assert.strictEqual(report.results[2].fixableWarningCount, 0);
         });
 
         it("should process when file is given by not specifying extensions", () => {
@@ -924,8 +924,8 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnFiles(["fixtures/files/foo.js2"]);
 
-            assert.equal(report.results.length, 1);
-            assert.equal(report.results[0].messages.length, 0);
+            assert.strictEqual(report.results.length, 1);
+            assert.strictEqual(report.results[0].messages.length, 0);
         });
 
         it("should return zero messages when given a config with environment set to browser", () => {
@@ -937,8 +937,8 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnFiles([fs.realpathSync(getFixturePath("globals-browser.js"))]);
 
-            assert.equal(report.results.length, 1);
-            assert.equal(report.results[0].messages.length, 0);
+            assert.strictEqual(report.results.length, 1);
+            assert.strictEqual(report.results[0].messages.length, 0);
         });
 
         it("should return zero messages when given an option to set environment to browser", () => {
@@ -954,8 +954,8 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnFiles([fs.realpathSync(getFixturePath("globals-browser.js"))]);
 
-            assert.equal(report.results.length, 1);
-            assert.equal(report.results[0].messages.length, 0);
+            assert.strictEqual(report.results.length, 1);
+            assert.strictEqual(report.results[0].messages.length, 0);
         });
 
         it("should return zero messages when given a config with environment set to Node.js", () => {
@@ -967,8 +967,8 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnFiles([fs.realpathSync(getFixturePath("globals-node.js"))]);
 
-            assert.equal(report.results.length, 1);
-            assert.equal(report.results[0].messages.length, 0);
+            assert.strictEqual(report.results.length, 1);
+            assert.strictEqual(report.results[0].messages.length, 0);
         });
 
         it("should not return results from previous call when calling more than once", () => {
@@ -986,16 +986,16 @@ describe("CLIEngine", () => {
 
             let report = engine.executeOnFiles([failFilePath]);
 
-            assert.equal(report.results.length, 1);
-            assert.equal(report.results[0].filePath, failFilePath);
-            assert.equal(report.results[0].messages.length, 1);
-            assert.equal(report.results[0].messages[0].ruleId, "semi");
-            assert.equal(report.results[0].messages[0].severity, 2);
+            assert.strictEqual(report.results.length, 1);
+            assert.strictEqual(report.results[0].filePath, failFilePath);
+            assert.strictEqual(report.results[0].messages.length, 1);
+            assert.strictEqual(report.results[0].messages[0].ruleId, "semi");
+            assert.strictEqual(report.results[0].messages[0].severity, 2);
 
             report = engine.executeOnFiles([passFilePath]);
-            assert.equal(report.results.length, 1);
-            assert.equal(report.results[0].filePath, passFilePath);
-            assert.equal(report.results[0].messages.length, 0);
+            assert.strictEqual(report.results.length, 1);
+            assert.strictEqual(report.results[0].filePath, passFilePath);
+            assert.strictEqual(report.results[0].messages.length, 0);
 
         });
 
@@ -1007,7 +1007,7 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnFiles([getFixturePath("./")]);
 
-            assert.equal(report.results.length, 0);
+            assert.strictEqual(report.results.length, 0);
         });
 
         it("should return zero messages when all given files are ignored", () => {
@@ -1017,7 +1017,7 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnFiles(["tests/fixtures/"]);
 
-            assert.equal(report.results.length, 0);
+            assert.strictEqual(report.results.length, 0);
         });
 
         it("should return zero messages when all given files are ignored event with a `./` prefix", () => {
@@ -1027,7 +1027,7 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnFiles(["./tests/fixtures/"]);
 
-            assert.equal(report.results.length, 0);
+            assert.strictEqual(report.results.length, 0);
         });
 
         // https://github.com/eslint/eslint/issues/3788
@@ -1043,11 +1043,11 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnFiles(["."]);
 
-            assert.equal(report.results.length, 1);
-            assert.equal(report.results[0].errorCount, 0);
-            assert.equal(report.results[0].warningCount, 0);
-            assert.equal(report.results[0].fixableErrorCount, 0);
-            assert.equal(report.results[0].fixableWarningCount, 0);
+            assert.strictEqual(report.results.length, 1);
+            assert.strictEqual(report.results[0].errorCount, 0);
+            assert.strictEqual(report.results[0].warningCount, 0);
+            assert.strictEqual(report.results[0].fixableErrorCount, 0);
+            assert.strictEqual(report.results[0].fixableWarningCount, 0);
         });
 
         // https://github.com/eslint/eslint/issues/3812
@@ -1062,7 +1062,7 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnFiles(["./tests/fixtures/cli-engine/"]);
 
-            assert.equal(report.results.length, 0);
+            assert.strictEqual(report.results.length, 0);
         });
 
         it("should return zero messages when all given files are ignored via ignore-pattern", () => {
@@ -1072,7 +1072,7 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnFiles(["tests/fixtures/*-quoted.js"]);
 
-            assert.equal(report.results.length, 0);
+            assert.strictEqual(report.results.length, 0);
         });
 
         it("should return a warning when an explicitly given file is ignored", () => {
@@ -1085,18 +1085,18 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnFiles([filePath]);
 
-            assert.equal(report.results.length, 1);
-            assert.equal(report.errorCount, 0);
-            assert.equal(report.warningCount, 1);
-            assert.equal(report.fixableErrorCount, 0);
-            assert.equal(report.fixableWarningCount, 0);
-            assert.equal(report.results[0].filePath, filePath);
-            assert.equal(report.results[0].messages[0].severity, 1);
-            assert.equal(report.results[0].messages[0].message, "File ignored because of a matching ignore pattern. Use \"--no-ignore\" to override.");
-            assert.equal(report.results[0].errorCount, 0);
-            assert.equal(report.results[0].warningCount, 1);
-            assert.equal(report.results[0].fixableErrorCount, 0);
-            assert.equal(report.results[0].fixableWarningCount, 0);
+            assert.strictEqual(report.results.length, 1);
+            assert.strictEqual(report.errorCount, 0);
+            assert.strictEqual(report.warningCount, 1);
+            assert.strictEqual(report.fixableErrorCount, 0);
+            assert.strictEqual(report.fixableWarningCount, 0);
+            assert.strictEqual(report.results[0].filePath, filePath);
+            assert.strictEqual(report.results[0].messages[0].severity, 1);
+            assert.strictEqual(report.results[0].messages[0].message, "File ignored because of a matching ignore pattern. Use \"--no-ignore\" to override.");
+            assert.strictEqual(report.results[0].errorCount, 0);
+            assert.strictEqual(report.results[0].warningCount, 1);
+            assert.strictEqual(report.results[0].fixableErrorCount, 0);
+            assert.strictEqual(report.results[0].fixableWarningCount, 0);
         });
 
         it("should return two messages when given a file in excluded files list while ignore is off", () => {
@@ -1113,12 +1113,12 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnFiles([filePath]);
 
-            assert.equal(report.results.length, 1);
-            assert.equal(report.results[0].filePath, filePath);
-            assert.equal(report.results[0].messages[0].ruleId, "no-undef");
-            assert.equal(report.results[0].messages[0].severity, 2);
-            assert.equal(report.results[0].messages[1].ruleId, "no-undef");
-            assert.equal(report.results[0].messages[1].severity, 2);
+            assert.strictEqual(report.results.length, 1);
+            assert.strictEqual(report.results[0].filePath, filePath);
+            assert.strictEqual(report.results[0].messages[0].ruleId, "no-undef");
+            assert.strictEqual(report.results[0].messages[0].severity, 2);
+            assert.strictEqual(report.results[0].messages[1].ruleId, "no-undef");
+            assert.strictEqual(report.results[0].messages[1].severity, 2);
         });
 
         it("should return zero messages when executing a file with a shebang", () => {
@@ -1129,8 +1129,8 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnFiles([getFixturePath("shebang.js")]);
 
-            assert.equal(report.results.length, 1);
-            assert.equal(report.results[0].messages.length, 0);
+            assert.strictEqual(report.results.length, 1);
+            assert.strictEqual(report.results[0].messages.length, 0);
         });
 
         it("should give a warning when loading a custom rule that doesn't exist", () => {
@@ -1142,11 +1142,11 @@ describe("CLIEngine", () => {
             });
             const report = engine.executeOnFiles([getFixturePath("rules", "test", "test-custom-rule.js")]);
 
-            assert.equal(report.results.length, 1);
-            assert.equal(report.results[0].messages.length, 1);
-            assert.equal(report.results[0].messages[0].ruleId, "missing-rule");
-            assert.equal(report.results[0].messages[0].severity, 1);
-            assert.equal(report.results[0].messages[0].message, "Definition for rule 'missing-rule' was not found");
+            assert.strictEqual(report.results.length, 1);
+            assert.strictEqual(report.results[0].messages.length, 1);
+            assert.strictEqual(report.results[0].messages[0].ruleId, "missing-rule");
+            assert.strictEqual(report.results[0].messages[0].severity, 1);
+            assert.strictEqual(report.results[0].messages[0].message, "Definition for rule 'missing-rule' was not found");
 
 
         });
@@ -1178,11 +1178,11 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnFiles([filePath]);
 
-            assert.equal(report.results.length, 1);
-            assert.equal(report.results[0].filePath, filePath);
-            assert.equal(report.results[0].messages.length, 2);
-            assert.equal(report.results[0].messages[0].ruleId, "custom-rule");
-            assert.equal(report.results[0].messages[0].severity, 1);
+            assert.strictEqual(report.results.length, 1);
+            assert.strictEqual(report.results[0].filePath, filePath);
+            assert.strictEqual(report.results[0].messages.length, 2);
+            assert.strictEqual(report.results[0].messages[0].ruleId, "custom-rule");
+            assert.strictEqual(report.results[0].messages[0].severity, 1);
         });
 
         it("should load custom rule from the provided cwd", () => {
@@ -1199,11 +1199,11 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnFiles([filePath]);
 
-            assert.equal(report.results.length, 1);
-            assert.equal(report.results[0].filePath, filePath);
-            assert.equal(report.results[0].messages.length, 2);
-            assert.equal(report.results[0].messages[0].ruleId, "custom-rule");
-            assert.equal(report.results[0].messages[0].severity, 1);
+            assert.strictEqual(report.results.length, 1);
+            assert.strictEqual(report.results[0].filePath, filePath);
+            assert.strictEqual(report.results[0].messages.length, 2);
+            assert.strictEqual(report.results[0].messages[0].ruleId, "custom-rule");
+            assert.strictEqual(report.results[0].messages[0].severity, 1);
         });
 
         it("should return messages when multiple custom rules match a file", () => {
@@ -1221,13 +1221,13 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnFiles([filePath]);
 
-            assert.equal(report.results.length, 1);
-            assert.equal(report.results[0].filePath, filePath);
-            assert.equal(report.results[0].messages.length, 2);
-            assert.equal(report.results[0].messages[0].ruleId, "no-literals");
-            assert.equal(report.results[0].messages[0].severity, 2);
-            assert.equal(report.results[0].messages[1].ruleId, "no-strings");
-            assert.equal(report.results[0].messages[1].severity, 2);
+            assert.strictEqual(report.results.length, 1);
+            assert.strictEqual(report.results[0].filePath, filePath);
+            assert.strictEqual(report.results[0].messages.length, 2);
+            assert.strictEqual(report.results[0].messages[0].ruleId, "no-literals");
+            assert.strictEqual(report.results[0].messages[0].severity, 2);
+            assert.strictEqual(report.results[0].messages[1].ruleId, "no-strings");
+            assert.strictEqual(report.results[0].messages[1].severity, 2);
         });
 
         it("should return zero messages when executing without useEslintrc flag", () => {
@@ -1241,9 +1241,9 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnFiles([filePath]);
 
-            assert.equal(report.results.length, 1);
-            assert.equal(report.results[0].filePath, filePath);
-            assert.equal(report.results[0].messages.length, 0);
+            assert.strictEqual(report.results.length, 1);
+            assert.strictEqual(report.results[0].filePath, filePath);
+            assert.strictEqual(report.results[0].messages.length, 0);
         });
 
         it("should return zero messages when executing without useEslintrc flag in Node.js environment", () => {
@@ -1258,9 +1258,9 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnFiles([filePath]);
 
-            assert.equal(report.results.length, 1);
-            assert.equal(report.results[0].filePath, filePath);
-            assert.equal(report.results[0].messages.length, 0);
+            assert.strictEqual(report.results.length, 1);
+            assert.strictEqual(report.results[0].filePath, filePath);
+            assert.strictEqual(report.results[0].messages.length, 0);
         });
 
         it("should return zero messages when executing with base-config flag set to false", () => {
@@ -1275,9 +1275,9 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnFiles([filePath]);
 
-            assert.equal(report.results.length, 1);
-            assert.equal(report.results[0].filePath, filePath);
-            assert.equal(report.results[0].messages.length, 0);
+            assert.strictEqual(report.results.length, 1);
+            assert.strictEqual(report.results[0].filePath, filePath);
+            assert.strictEqual(report.results[0].messages.length, 0);
         });
 
         it("should return zero messages and ignore .eslintrc files when executing with no-eslintrc flag", () => {
@@ -1292,9 +1292,9 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnFiles([filePath]);
 
-            assert.equal(report.results.length, 1);
-            assert.equal(report.results[0].filePath, filePath);
-            assert.equal(report.results[0].messages.length, 0);
+            assert.strictEqual(report.results.length, 1);
+            assert.strictEqual(report.results[0].filePath, filePath);
+            assert.strictEqual(report.results[0].messages.length, 0);
         });
 
         it("should return zero messages and ignore package.json files when executing with no-eslintrc flag", () => {
@@ -1309,9 +1309,9 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnFiles([filePath]);
 
-            assert.equal(report.results.length, 1);
-            assert.equal(report.results[0].filePath, filePath);
-            assert.equal(report.results[0].messages.length, 0);
+            assert.strictEqual(report.results.length, 1);
+            assert.strictEqual(report.results[0].filePath, filePath);
+            assert.strictEqual(report.results[0].messages.length, 0);
         });
 
         it("should not fail if an ignored file cannot be resolved", () => {
@@ -1452,8 +1452,8 @@ describe("CLIEngine", () => {
 
                 const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/console-wrong-quotes.js`)]);
 
-                assert.equal(report.results.length, 1);
-                assert.equal(report.results[0].messages.length, 0);
+                assert.strictEqual(report.results.length, 1);
+                assert.strictEqual(report.results[0].messages.length, 0);
             });
 
             // No default configuration rules - conf/environments.js (/*eslint-env node*/)
@@ -1467,8 +1467,8 @@ describe("CLIEngine", () => {
 
                 const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/console-wrong-quotes-node.js`)]);
 
-                assert.equal(report.results.length, 1);
-                assert.equal(report.results[0].messages.length, 0);
+                assert.strictEqual(report.results.length, 1);
+                assert.strictEqual(report.results[0].messages.length, 0);
             });
 
             // Project configuration - first level .eslintrc
@@ -1480,8 +1480,8 @@ describe("CLIEngine", () => {
 
                 const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/process-exit.js`)]);
 
-                assert.equal(report.results.length, 1);
-                assert.equal(report.results[0].messages.length, 0);
+                assert.strictEqual(report.results.length, 1);
+                assert.strictEqual(report.results[0].messages.length, 0);
             });
 
             // Project configuration - first level .eslintrc
@@ -1493,8 +1493,8 @@ describe("CLIEngine", () => {
 
                 const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/process-exit.js`)]);
 
-                assert.equal(report.results.length, 1);
-                assert.equal(report.results[0].messages.length, 0);
+                assert.strictEqual(report.results.length, 1);
+                assert.strictEqual(report.results[0].messages.length, 0);
             });
 
             // Project configuration - first level .eslintrc
@@ -1506,10 +1506,10 @@ describe("CLIEngine", () => {
 
                 const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/console-wrong-quotes.js`)]);
 
-                assert.equal(report.results.length, 1);
-                assert.equal(report.results[0].messages.length, 1);
-                assert.equal(report.results[0].messages[0].ruleId, "quotes");
-                assert.equal(report.results[0].messages[0].severity, 2);
+                assert.strictEqual(report.results.length, 1);
+                assert.strictEqual(report.results[0].messages.length, 1);
+                assert.strictEqual(report.results[0].messages[0].ruleId, "quotes");
+                assert.strictEqual(report.results[0].messages[0].severity, 2);
             });
 
             // Project configuration - second level .eslintrc
@@ -1521,10 +1521,10 @@ describe("CLIEngine", () => {
 
                 const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/subbroken/console-wrong-quotes.js`)]);
 
-                assert.equal(report.results.length, 1);
-                assert.equal(report.results[0].messages.length, 1);
-                assert.equal(report.results[0].messages[0].ruleId, "no-console");
-                assert.equal(report.results[0].messages[0].severity, 1);
+                assert.strictEqual(report.results.length, 1);
+                assert.strictEqual(report.results[0].messages.length, 1);
+                assert.strictEqual(report.results[0].messages[0].ruleId, "no-console");
+                assert.strictEqual(report.results[0].messages[0].severity, 1);
             });
 
             // Project configuration - third level .eslintrc
@@ -1536,10 +1536,10 @@ describe("CLIEngine", () => {
 
                 const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/subbroken/subsubbroken/console-wrong-quotes.js`)]);
 
-                assert.equal(report.results.length, 1);
-                assert.equal(report.results[0].messages.length, 1);
-                assert.equal(report.results[0].messages[0].ruleId, "quotes");
-                assert.equal(report.results[0].messages[0].severity, 1);
+                assert.strictEqual(report.results.length, 1);
+                assert.strictEqual(report.results[0].messages.length, 1);
+                assert.strictEqual(report.results[0].messages[0].ruleId, "quotes");
+                assert.strictEqual(report.results[0].messages[0].severity, 1);
             });
 
             // Project configuration - first level package.json
@@ -1551,10 +1551,10 @@ describe("CLIEngine", () => {
 
                 const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/packagejson/subdir/wrong-quotes.js`)]);
 
-                assert.equal(report.results.length, 1);
-                assert.equal(report.results[0].messages.length, 1);
-                assert.equal(report.results[0].messages[0].ruleId, "quotes");
-                assert.equal(report.results[0].messages[0].severity, 1);
+                assert.strictEqual(report.results.length, 1);
+                assert.strictEqual(report.results[0].messages.length, 1);
+                assert.strictEqual(report.results[0].messages[0].ruleId, "quotes");
+                assert.strictEqual(report.results[0].messages[0].severity, 1);
             });
 
             // Project configuration - second level package.json
@@ -1566,8 +1566,8 @@ describe("CLIEngine", () => {
 
                 const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/packagejson/subdir/subsubdir/wrong-quotes.js`)]);
 
-                assert.equal(report.results.length, 1);
-                assert.equal(report.results[0].messages.length, 0);
+                assert.strictEqual(report.results.length, 1);
+                assert.strictEqual(report.results[0].messages.length, 0);
             });
 
             // Project configuration - third level package.json
@@ -1579,10 +1579,10 @@ describe("CLIEngine", () => {
 
                 const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/packagejson/subdir/subsubdir/subsubsubdir/wrong-quotes.js`)]);
 
-                assert.equal(report.results.length, 1);
-                assert.equal(report.results[0].messages.length, 1);
-                assert.equal(report.results[0].messages[0].ruleId, "quotes");
-                assert.equal(report.results[0].messages[0].severity, 2);
+                assert.strictEqual(report.results.length, 1);
+                assert.strictEqual(report.results[0].messages.length, 1);
+                assert.strictEqual(report.results[0].messages[0].ruleId, "quotes");
+                assert.strictEqual(report.results[0].messages[0].severity, 2);
             });
 
             // Project configuration - .eslintrc overrides package.json in same directory
@@ -1594,10 +1594,10 @@ describe("CLIEngine", () => {
 
                 const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/packagejson/wrong-quotes.js`)]);
 
-                assert.equal(report.results.length, 1);
-                assert.equal(report.results[0].messages.length, 1);
-                assert.equal(report.results[0].messages[0].ruleId, "quotes");
-                assert.equal(report.results[0].messages[0].severity, 2);
+                assert.strictEqual(report.results.length, 1);
+                assert.strictEqual(report.results[0].messages.length, 1);
+                assert.strictEqual(report.results[0].messages[0].ruleId, "quotes");
+                assert.strictEqual(report.results[0].messages[0].severity, 2);
             });
 
             // Command line configuration - --config with first level .eslintrc
@@ -1610,12 +1610,12 @@ describe("CLIEngine", () => {
 
                 const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/console-wrong-quotes.js`)]);
 
-                assert.equal(report.results.length, 1);
-                assert.equal(report.results[0].messages.length, 2);
-                assert.equal(report.results[0].messages[0].ruleId, "quotes");
-                assert.equal(report.results[0].messages[0].severity, 2);
-                assert.equal(report.results[0].messages[1].ruleId, "semi");
-                assert.equal(report.results[0].messages[1].severity, 1);
+                assert.strictEqual(report.results.length, 1);
+                assert.strictEqual(report.results[0].messages.length, 2);
+                assert.strictEqual(report.results[0].messages[0].ruleId, "quotes");
+                assert.strictEqual(report.results[0].messages[0].severity, 2);
+                assert.strictEqual(report.results[0].messages[1].ruleId, "semi");
+                assert.strictEqual(report.results[0].messages[1].severity, 1);
             });
 
             // Command line configuration - --config with first level .eslintrc
@@ -1628,8 +1628,8 @@ describe("CLIEngine", () => {
 
                 const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/console-wrong-quotes.js`)]);
 
-                assert.equal(report.results.length, 1);
-                assert.equal(report.results[0].messages.length, 0);
+                assert.strictEqual(report.results.length, 1);
+                assert.strictEqual(report.results[0].messages.length, 0);
             });
 
             // Command line configuration - --config with second level .eslintrc
@@ -1642,12 +1642,12 @@ describe("CLIEngine", () => {
 
                 const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/subbroken/console-wrong-quotes.js`)]);
 
-                assert.equal(report.results.length, 1);
-                assert.equal(report.results[0].messages.length, 2);
-                assert.equal(report.results[0].messages[0].ruleId, "no-console");
-                assert.equal(report.results[0].messages[0].severity, 1);
-                assert.equal(report.results[0].messages[1].ruleId, "semi");
-                assert.equal(report.results[0].messages[1].severity, 1);
+                assert.strictEqual(report.results.length, 1);
+                assert.strictEqual(report.results[0].messages.length, 2);
+                assert.strictEqual(report.results[0].messages[0].ruleId, "no-console");
+                assert.strictEqual(report.results[0].messages[0].severity, 1);
+                assert.strictEqual(report.results[0].messages[1].ruleId, "semi");
+                assert.strictEqual(report.results[0].messages[1].severity, 1);
             });
 
             // Command line configuration - --config with second level .eslintrc
@@ -1660,10 +1660,10 @@ describe("CLIEngine", () => {
 
                 const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/subbroken/console-wrong-quotes.js`)]);
 
-                assert.equal(report.results.length, 1);
-                assert.equal(report.results[0].messages.length, 1);
-                assert.equal(report.results[0].messages[0].ruleId, "no-console");
-                assert.equal(report.results[0].messages[0].severity, 1);
+                assert.strictEqual(report.results.length, 1);
+                assert.strictEqual(report.results[0].messages.length, 1);
+                assert.strictEqual(report.results[0].messages[0].ruleId, "no-console");
+                assert.strictEqual(report.results[0].messages[0].severity, 1);
             });
 
             // Command line configuration - --config with first level .eslintrc
@@ -1676,8 +1676,8 @@ describe("CLIEngine", () => {
 
                 const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/console-wrong-quotes.js`)]);
 
-                assert.equal(report.results.length, 1);
-                assert.equal(report.results[0].messages.length, 0);
+                assert.strictEqual(report.results.length, 1);
+                assert.strictEqual(report.results[0].messages.length, 0);
             });
 
             // Command line configuration - --rule with --config and first level .eslintrc
@@ -1693,10 +1693,10 @@ describe("CLIEngine", () => {
 
                 const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/console-wrong-quotes.js`)]);
 
-                assert.equal(report.results.length, 1);
-                assert.equal(report.results[0].messages.length, 1);
-                assert.equal(report.results[0].messages[0].ruleId, "quotes");
-                assert.equal(report.results[0].messages[0].severity, 1);
+                assert.strictEqual(report.results.length, 1);
+                assert.strictEqual(report.results[0].messages.length, 1);
+                assert.strictEqual(report.results[0].messages[0].ruleId, "quotes");
+                assert.strictEqual(report.results[0].messages[0].severity, 1);
             });
 
             // Command line configuration - --rule with --config and first level .eslintrc
@@ -1712,10 +1712,10 @@ describe("CLIEngine", () => {
 
                 const report = engine.executeOnFiles([getFixturePath("config-hierarchy/broken/console-wrong-quotes.js")]);
 
-                assert.equal(report.results.length, 1);
-                assert.equal(report.results[0].messages.length, 1);
-                assert.equal(report.results[0].messages[0].ruleId, "quotes");
-                assert.equal(report.results[0].messages[0].severity, 1);
+                assert.strictEqual(report.results.length, 1);
+                assert.strictEqual(report.results[0].messages.length, 1);
+                assert.strictEqual(report.results[0].messages[0].ruleId, "quotes");
+                assert.strictEqual(report.results[0].messages[0].severity, 1);
             });
 
         });
@@ -1730,9 +1730,9 @@ describe("CLIEngine", () => {
 
                 const report = engine.executeOnFiles([fs.realpathSync(getFixturePath("rules", "test/test-custom-rule.js"))]);
 
-                assert.equal(report.results.length, 1);
-                assert.equal(report.results[0].messages.length, 2);
-                assert.equal(report.results[0].messages[0].ruleId, "example/example-rule");
+                assert.strictEqual(report.results.length, 1);
+                assert.strictEqual(report.results[0].messages.length, 2);
+                assert.strictEqual(report.results[0].messages[0].ruleId, "example/example-rule");
             });
 
             it("should return two messages when executing with config file that specifies a plugin with namespace", () => {
@@ -1744,9 +1744,9 @@ describe("CLIEngine", () => {
 
                 const report = engine.executeOnFiles([fs.realpathSync(getFixturePath("rules", "test", "test-custom-rule.js"))]);
 
-                assert.equal(report.results.length, 1);
-                assert.equal(report.results[0].messages.length, 2);
-                assert.equal(report.results[0].messages[0].ruleId, "example/example-rule");
+                assert.strictEqual(report.results.length, 1);
+                assert.strictEqual(report.results[0].messages.length, 2);
+                assert.strictEqual(report.results[0].messages[0].ruleId, "example/example-rule");
             });
 
             it("should return two messages when executing with config file that specifies a plugin without prefix", () => {
@@ -1758,9 +1758,9 @@ describe("CLIEngine", () => {
 
                 const report = engine.executeOnFiles([fs.realpathSync(getFixturePath("rules", "test", "test-custom-rule.js"))]);
 
-                assert.equal(report.results.length, 1);
-                assert.equal(report.results[0].messages.length, 2);
-                assert.equal(report.results[0].messages[0].ruleId, "example/example-rule");
+                assert.strictEqual(report.results.length, 1);
+                assert.strictEqual(report.results[0].messages.length, 2);
+                assert.strictEqual(report.results[0].messages[0].ruleId, "example/example-rule");
             });
 
             it("should return two messages when executing with config file that specifies a plugin without prefix and with namespace", () => {
@@ -1772,9 +1772,9 @@ describe("CLIEngine", () => {
 
                 const report = engine.executeOnFiles([fs.realpathSync(getFixturePath("rules", "test", "test-custom-rule.js"))]);
 
-                assert.equal(report.results.length, 1);
-                assert.equal(report.results[0].messages.length, 2);
-                assert.equal(report.results[0].messages[0].ruleId, "example/example-rule");
+                assert.strictEqual(report.results.length, 1);
+                assert.strictEqual(report.results[0].messages.length, 2);
+                assert.strictEqual(report.results[0].messages[0].ruleId, "example/example-rule");
             });
 
             it("should return two messages when executing with cli option that specifies a plugin", () => {
@@ -1787,9 +1787,9 @@ describe("CLIEngine", () => {
 
                 const report = engine.executeOnFiles([fs.realpathSync(getFixturePath("rules", "test", "test-custom-rule.js"))]);
 
-                assert.equal(report.results.length, 1);
-                assert.equal(report.results[0].messages.length, 2);
-                assert.equal(report.results[0].messages[0].ruleId, "example/example-rule");
+                assert.strictEqual(report.results.length, 1);
+                assert.strictEqual(report.results[0].messages.length, 2);
+                assert.strictEqual(report.results[0].messages[0].ruleId, "example/example-rule");
             });
 
             it("should return two messages when executing with cli option that specifies preloaded plugin", () => {
@@ -1804,9 +1804,9 @@ describe("CLIEngine", () => {
 
                 const report = engine.executeOnFiles([fs.realpathSync(getFixturePath("rules", "test", "test-custom-rule.js"))]);
 
-                assert.equal(report.results.length, 1);
-                assert.equal(report.results[0].messages.length, 2);
-                assert.equal(report.results[0].messages[0].ruleId, "test/example-rule");
+                assert.strictEqual(report.results.length, 1);
+                assert.strictEqual(report.results[0].messages.length, 2);
+                assert.strictEqual(report.results[0].messages[0].ruleId, "test/example-rule");
             });
         });
 
@@ -1973,8 +1973,8 @@ describe("CLIEngine", () => {
 
                 const result = engine.executeOnFiles([file]);
 
-                assert.equal(result.errorCount + result.warningCount, 0, "the file passed without errors or warnings");
-                assert.equal(spy.getCall(0).args[0], file, "the module read the file because is considered changed");
+                assert.strictEqual(result.errorCount + result.warningCount, 0, "the file passed without errors or warnings");
+                assert.strictEqual(spy.getCall(0).args[0], file, "the module read the file because is considered changed");
                 assert.isTrue(shell.test("-f", path.resolve(".eslintcache")), "the cache for eslint was created");
 
                 // destroy the spy
@@ -1998,8 +1998,8 @@ describe("CLIEngine", () => {
 
                 const cachedResult = engine.executeOnFiles([file]);
 
-                assert.equal(spy.getCall(0).args[0], file, "the module read the file because is considered changed because the config changed");
-                assert.equal(cachedResult.errorCount, 1, "since configuration changed the cache was not used an one error was reported");
+                assert.strictEqual(spy.getCall(0).args[0], file, "the module read the file because is considered changed because the config changed");
+                assert.strictEqual(cachedResult.errorCount, 1, "since configuration changed the cache was not used an one error was reported");
                 assert.isTrue(shell.test("-f", path.resolve(".eslintcache")), "the cache for eslint was created");
             });
 
@@ -2028,7 +2028,7 @@ describe("CLIEngine", () => {
 
                 const result = engine.executeOnFiles([file]);
 
-                assert.equal(spy.getCall(0).args[0], file, "the module read the file because is considered changed");
+                assert.strictEqual(spy.getCall(0).args[0], file, "the module read the file because is considered changed");
                 assert.isTrue(shell.test("-f", path.resolve(".eslintcache")), "the cache for eslint was created");
 
                 // destroy the spy
@@ -2357,8 +2357,8 @@ describe("CLIEngine", () => {
 
                 const report = engine.executeOnFiles([fs.realpathSync(getFixturePath("processors", "test", "test-processor.txt"))]);
 
-                assert.equal(report.results.length, 1);
-                assert.equal(report.results[0].messages.length, 2);
+                assert.strictEqual(report.results.length, 1);
+                assert.strictEqual(report.results[0].messages.length, 2);
             });
             it("should return two messages when executing with config file that specifies preloaded processor", () => {
                 engine = new CLIEngine({
@@ -2387,8 +2387,8 @@ describe("CLIEngine", () => {
 
                 const report = engine.executeOnFiles([fs.realpathSync(getFixturePath("processors", "test", "test-processor.txt"))]);
 
-                assert.equal(report.results.length, 1);
-                assert.equal(report.results[0].messages.length, 2);
+                assert.strictEqual(report.results.length, 1);
+                assert.strictEqual(report.results[0].messages.length, 2);
             });
             it("should run processors when calling executeOnFiles with config file that specifies a processor", () => {
                 engine = cliEngineWithPlugins({
@@ -2400,8 +2400,8 @@ describe("CLIEngine", () => {
 
                 const report = engine.executeOnFiles([getFixturePath("processors", "test", "test-processor.txt")]);
 
-                assert.equal(report.results[0].messages[0].message, "'b' is defined but never used.");
-                assert.equal(report.results[0].messages[0].ruleId, "post-processed");
+                assert.strictEqual(report.results[0].messages[0].message, "'b' is defined but never used.");
+                assert.strictEqual(report.results[0].messages[0].ruleId, "post-processed");
             });
             it("should run processors when calling executeOnFiles with config file that specifies preloaded processor", () => {
                 engine = new CLIEngine({
@@ -2431,8 +2431,8 @@ describe("CLIEngine", () => {
 
                 const report = engine.executeOnFiles([getFixturePath("processors", "test", "test-processor.txt")]);
 
-                assert.equal(report.results[0].messages[0].message, "'b' is defined but never used.");
-                assert.equal(report.results[0].messages[0].ruleId, "post-processed");
+                assert.strictEqual(report.results[0].messages[0].message, "'b' is defined but never used.");
+                assert.strictEqual(report.results[0].messages[0].ruleId, "post-processed");
             });
             it("should run processors when calling executeOnText with config file that specifies a processor", () => {
                 engine = cliEngineWithPlugins({
@@ -2444,8 +2444,8 @@ describe("CLIEngine", () => {
 
                 const report = engine.executeOnText("function a() {console.log(\"Test\");}", "tests/fixtures/processors/test/test-processor.txt");
 
-                assert.equal(report.results[0].messages[0].message, "'b' is defined but never used.");
-                assert.equal(report.results[0].messages[0].ruleId, "post-processed");
+                assert.strictEqual(report.results[0].messages[0].message, "'b' is defined but never used.");
+                assert.strictEqual(report.results[0].messages[0].ruleId, "post-processed");
             });
             it("should run processors when calling executeOnText with config file that specifies preloaded processor", () => {
                 engine = new CLIEngine({
@@ -2475,8 +2475,8 @@ describe("CLIEngine", () => {
 
                 const report = engine.executeOnText("function a() {console.log(\"Test\");}", "tests/fixtures/processors/test/test-processor.txt");
 
-                assert.equal(report.results[0].messages[0].message, "'b' is defined but never used.");
-                assert.equal(report.results[0].messages[0].ruleId, "post-processed");
+                assert.strictEqual(report.results[0].messages[0].message, "'b' is defined but never used.");
+                assert.strictEqual(report.results[0].messages[0].ruleId, "post-processed");
             });
 
             describe("autofixing with processors", () => {
@@ -2742,19 +2742,19 @@ describe("CLIEngine", () => {
             const errorResults = CLIEngine.getErrorResults(report.results);
 
             assert.lengthOf(errorResults[0].messages, 5);
-            assert.equal(errorResults[0].errorCount, 5);
-            assert.equal(errorResults[0].fixableErrorCount, 3);
-            assert.equal(errorResults[0].fixableWarningCount, 0);
-            assert.equal(errorResults[0].messages[0].ruleId, "strict");
-            assert.equal(errorResults[0].messages[0].severity, 2);
-            assert.equal(errorResults[0].messages[1].ruleId, "no-var");
-            assert.equal(errorResults[0].messages[1].severity, 2);
-            assert.equal(errorResults[0].messages[2].ruleId, "no-unused-vars");
-            assert.equal(errorResults[0].messages[2].severity, 2);
-            assert.equal(errorResults[0].messages[3].ruleId, "quotes");
-            assert.equal(errorResults[0].messages[3].severity, 2);
-            assert.equal(errorResults[0].messages[4].ruleId, "eol-last");
-            assert.equal(errorResults[0].messages[4].severity, 2);
+            assert.strictEqual(errorResults[0].errorCount, 5);
+            assert.strictEqual(errorResults[0].fixableErrorCount, 3);
+            assert.strictEqual(errorResults[0].fixableWarningCount, 0);
+            assert.strictEqual(errorResults[0].messages[0].ruleId, "strict");
+            assert.strictEqual(errorResults[0].messages[0].severity, 2);
+            assert.strictEqual(errorResults[0].messages[1].ruleId, "no-var");
+            assert.strictEqual(errorResults[0].messages[1].severity, 2);
+            assert.strictEqual(errorResults[0].messages[2].ruleId, "no-unused-vars");
+            assert.strictEqual(errorResults[0].messages[2].severity, 2);
+            assert.strictEqual(errorResults[0].messages[3].ruleId, "quotes");
+            assert.strictEqual(errorResults[0].messages[3].severity, 2);
+            assert.strictEqual(errorResults[0].messages[4].ruleId, "eol-last");
+            assert.strictEqual(errorResults[0].messages[4].severity, 2);
         });
 
         it("should report a warningCount of 0 when looking for errors only", () => {
@@ -2765,8 +2765,8 @@ describe("CLIEngine", () => {
             const report = engine.executeOnText("var foo = 'bar';");
             const errorResults = CLIEngine.getErrorResults(report.results);
 
-            assert.equal(errorResults[0].warningCount, 0);
-            assert.equal(errorResults[0].fixableWarningCount, 0);
+            assert.strictEqual(errorResults[0].warningCount, 0);
+            assert.strictEqual(errorResults[0].fixableWarningCount, 0);
         });
 
         it("should return 0 error or warning messages even when the file has warnings", () => {
@@ -2780,14 +2780,14 @@ describe("CLIEngine", () => {
 
             assert.lengthOf(errorReport, 0);
             assert.lengthOf(report.results, 1);
-            assert.equal(report.errorCount, 0);
-            assert.equal(report.warningCount, 1);
-            assert.equal(report.fixableErrorCount, 0);
-            assert.equal(report.fixableWarningCount, 0);
-            assert.equal(report.results[0].errorCount, 0);
-            assert.equal(report.results[0].warningCount, 1);
-            assert.equal(report.fixableErrorCount, 0);
-            assert.equal(report.fixableWarningCount, 0);
+            assert.strictEqual(report.errorCount, 0);
+            assert.strictEqual(report.warningCount, 1);
+            assert.strictEqual(report.fixableErrorCount, 0);
+            assert.strictEqual(report.fixableWarningCount, 0);
+            assert.strictEqual(report.results[0].errorCount, 0);
+            assert.strictEqual(report.results[0].warningCount, 1);
+            assert.strictEqual(report.fixableErrorCount, 0);
+            assert.strictEqual(report.fixableWarningCount, 0);
         });
 
         it("should return source code of file in the `source` property", () => {
@@ -2802,7 +2802,7 @@ describe("CLIEngine", () => {
             const errorResults = CLIEngine.getErrorResults(report.results);
 
             assert.lengthOf(errorResults[0].messages, 1);
-            assert.equal(errorResults[0].source, "var foo = 'bar';");
+            assert.strictEqual(errorResults[0].source, "var foo = 'bar';");
         });
 
         it("should contain `output` property after fixes", () => {
@@ -2820,7 +2820,7 @@ describe("CLIEngine", () => {
             const errorResults = CLIEngine.getErrorResults(report.results);
 
             assert.lengthOf(errorResults[0].messages, 1);
-            assert.equal(errorResults[0].output, "console.log('foo');");
+            assert.strictEqual(errorResults[0].output, "console.log('foo');");
         });
     });
 
@@ -2855,7 +2855,7 @@ describe("CLIEngine", () => {
 
             localCLIEngine.outputFixes(report);
 
-            assert.equal(spy.callCount, 2);
+            assert.strictEqual(spy.callCount, 2);
             assert.isTrue(spy.firstCall.calledWithExactly("foo.js", "bar"), "First call was incorrect.");
             assert.isTrue(spy.secondCall.calledWithExactly("bar.js", "baz"), "Second call was incorrect.");
 
@@ -2887,7 +2887,7 @@ describe("CLIEngine", () => {
 
             localCLIEngine.outputFixes(report);
 
-            assert.equal(spy.callCount, 2);
+            assert.strictEqual(spy.callCount, 2);
             assert.isTrue(spy.firstCall.calledWithExactly("foo.js", "bar"), "First call was incorrect.");
             assert.isTrue(spy.secondCall.calledWithExactly("bar.js", "baz"), "Second call was incorrect.");
 
@@ -2908,7 +2908,7 @@ describe("CLIEngine", () => {
 
                 const result = engine.resolveFileGlobPatterns([input]);
 
-                assert.equal(result[0], expected);
+                assert.strictEqual(result[0], expected);
 
             });
         });
@@ -2939,8 +2939,8 @@ describe("CLIEngine", () => {
             const report = eslintCLI.executeOnText(code);
             const messages = report.results[0].messages;
 
-            assert.equal(messages.length, 1);
-            assert.equal(messages[0].ruleId, "no-alert");
+            assert.strictEqual(messages.length, 1);
+            assert.strictEqual(messages[0].ruleId, "no-alert");
         });
 
         it("should not report a violation by default", () => {
@@ -2966,7 +2966,7 @@ describe("CLIEngine", () => {
             const report = eslintCLI.executeOnText(code);
             const messages = report.results[0].messages;
 
-            assert.equal(messages.length, 0);
+            assert.strictEqual(messages.length, 0);
         });
 
     });

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -281,7 +281,7 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnText("var bar = foo", "passing.js");
 
-            assert.deepEqual(report, {
+            assert.deepStrictEqual(report, {
                 results: [
                     {
                         filePath: getFixturePath("passing.js"),
@@ -342,7 +342,7 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnText("var bar = foo", "passing.js");
 
-            assert.deepEqual(report, {
+            assert.deepStrictEqual(report, {
                 results: [
                     {
                         filePath: getFixturePath("passing.js"),
@@ -386,7 +386,7 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnText("var bar = foo", "test.js");
 
-            assert.deepEqual(report, {
+            assert.deepStrictEqual(report, {
                 results: [
                     {
                         filePath: getFixturePath("test.js"),
@@ -428,7 +428,7 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnText("var bar =", "test.js");
 
-            assert.deepEqual(report, {
+            assert.deepStrictEqual(report, {
                 results: [
                     {
                         filePath: getFixturePath("test.js"),
@@ -516,7 +516,7 @@ describe("CLIEngine", () => {
 
             const report = engine.executeOnText("var bar = foothis is a syntax error.\n return bar;");
 
-            assert.deepEqual(report, {
+            assert.deepStrictEqual(report, {
                 results: [
                     {
                         filePath: "<text>",
@@ -1369,7 +1369,7 @@ describe("CLIEngine", () => {
                 const report = engine.executeOnFiles([path.resolve(fixtureDir, `${fixtureDir}/fixmode`)]);
 
                 report.results.forEach(convertCRLF);
-                assert.deepEqual(report, {
+                assert.deepStrictEqual(report, {
                     results: [
                         {
                             filePath: fs.realpathSync(path.resolve(fixtureDir, "fixmode/multipass.js")),
@@ -2052,7 +2052,7 @@ describe("CLIEngine", () => {
 
                 const cachedResult = engine.executeOnFiles([file]);
 
-                assert.deepEqual(result, cachedResult, "the result is the same regardless of using cache or not");
+                assert.deepStrictEqual(result, cachedResult, "the result is the same regardless of using cache or not");
 
                 // assert the file was not processed because the cache was used
                 assert.isFalse(spy.called, "the file was not loaded because it used the cache");
@@ -2130,7 +2130,7 @@ describe("CLIEngine", () => {
 
                 const cachedResult = engine.executeOnFiles([badFile, goodFile]);
 
-                assert.deepEqual(result, cachedResult, "result is the same with or without cache");
+                assert.deepStrictEqual(result, cachedResult, "result is the same with or without cache");
             });
 
             it("should not contain in the cache a file that was deleted", () => {
@@ -2341,7 +2341,7 @@ describe("CLIEngine", () => {
 
                     const cachedResult = engine.executeOnFiles([badFile, goodFile]);
 
-                    assert.deepEqual(result, cachedResult, "result is the same with or without cache");
+                    assert.deepStrictEqual(result, cachedResult, "result is the same with or without cache");
                 });
             });
         });
@@ -2581,7 +2581,7 @@ describe("CLIEngine", () => {
 
             const filePath = getFixturePath("single-quoted.js");
 
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 engine.getConfigForFile(filePath),
                 configHelper.getConfig(filePath)
             );
@@ -2600,7 +2600,7 @@ describe("CLIEngine", () => {
             const filePath = getFixturePath("config-hierarchy", "root-true", "parent", "root", ".eslintrc");
             const config = engine.getConfigForFile("./.eslintrc");
 
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 config,
                 configHelper.getConfig(filePath)
             );
@@ -2975,7 +2975,7 @@ describe("CLIEngine", () => {
         it("should report problems for unused eslint-disable directives", () => {
             const cliEngine = new CLIEngine({ useEslintrc: false, reportUnusedDisableDirectives: true });
 
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 cliEngine.executeOnText("/* eslint-disable */"),
                 {
                     results: [

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -98,21 +98,21 @@ describe("cli", () => {
             const configFile = getFixturePath("configurations", "quotes-error.json");
             const result = cli.execute(`-c ${configFile}`, "var foo = 'bar';");
 
-            assert.equal(result, 1);
+            assert.strictEqual(result, 1);
         });
 
         it("should return no error when --ext .js2 is specified", () => {
             const filePath = getFixturePath("files");
             const result = cli.execute(`--ext .js2 ${filePath}`);
 
-            assert.equal(result, 0);
+            assert.strictEqual(result, 0);
         });
 
         it("should exit with console error when passed unsupported arguments", () => {
             const filePath = getFixturePath("files");
             const result = cli.execute(`--blah --another ${filePath}`);
 
-            assert.equal(result, 1);
+            assert.strictEqual(result, 1);
         });
 
     });
@@ -154,7 +154,7 @@ describe("cli", () => {
 
             const exitStatus = cli.execute(code);
 
-            assert.equal(exitStatus, 1);
+            assert.strictEqual(exitStatus, 1);
         });
     });
 
@@ -170,7 +170,7 @@ describe("cli", () => {
                 exitStatus = cli.execute(code);
             });
 
-            assert.equal(exitStatus, 0);
+            assert.strictEqual(exitStatus, 0);
         });
     });
 
@@ -182,7 +182,7 @@ describe("cli", () => {
 
             const exit = cli.execute(code);
 
-            assert.equal(exit, 0);
+            assert.strictEqual(exit, 0);
         });
     });
 
@@ -194,7 +194,7 @@ describe("cli", () => {
 
             const exit = cli.execute(code);
 
-            assert.equal(exit, 0);
+            assert.strictEqual(exit, 0);
         });
     });
 
@@ -206,7 +206,7 @@ describe("cli", () => {
 
             const exit = cli.execute(code);
 
-            assert.equal(exit, 0);
+            assert.strictEqual(exit, 0);
         });
     });
 
@@ -218,7 +218,7 @@ describe("cli", () => {
 
             const exit = cli.execute(code);
 
-            assert.equal(exit, 0);
+            assert.strictEqual(exit, 0);
         });
     });
 
@@ -227,7 +227,7 @@ describe("cli", () => {
             const filePath = getFixturePath("passing.js");
             const exit = cli.execute(`-f checkstyle ${filePath}`);
 
-            assert.equal(exit, 0);
+            assert.strictEqual(exit, 0);
         });
     });
 
@@ -236,7 +236,7 @@ describe("cli", () => {
             const filePath = getFixturePath("passing.js");
             const exit = cli.execute(`-f fakeformatter ${filePath}`);
 
-            assert.equal(exit, 1);
+            assert.strictEqual(exit, 1);
         });
     });
 
@@ -246,7 +246,7 @@ describe("cli", () => {
             const filePath = getFixturePath("passing.js");
             const exit = cli.execute(`-f ${formatterPath} ${filePath}`);
 
-            assert.equal(exit, 0);
+            assert.strictEqual(exit, 0);
         });
     });
 
@@ -256,7 +256,7 @@ describe("cli", () => {
             const filePath = getFixturePath("passing.js");
             const exit = cli.execute(`-f ${formatterPath} ${filePath}`);
 
-            assert.equal(exit, 1);
+            assert.strictEqual(exit, 1);
         });
     });
 
@@ -267,7 +267,7 @@ describe("cli", () => {
 
             const exit = cli.execute(code);
 
-            assert.equal(exit, 1);
+            assert.strictEqual(exit, 1);
         });
     });
 
@@ -276,7 +276,7 @@ describe("cli", () => {
             const filePath = getFixturePath("syntax-error.js");
             const exit = cli.execute(`--no-ignore ${filePath}`);
 
-            assert.equal(exit, 1);
+            assert.strictEqual(exit, 1);
         });
     });
 
@@ -301,7 +301,7 @@ describe("cli", () => {
         it("should print out current version", () => {
             cli.execute("-v");
 
-            assert.equal(log.info.callCount, 1);
+            assert.strictEqual(log.info.callCount, 1);
         });
     });
 
@@ -309,7 +309,7 @@ describe("cli", () => {
         it("should print out help", () => {
             cli.execute("-h");
 
-            assert.equal(log.info.callCount, 1);
+            assert.strictEqual(log.info.callCount, 1);
         });
     });
 
@@ -320,7 +320,7 @@ describe("cli", () => {
             const exit = cli.execute(`--ignore-path ${ignorePath} ${filePath}`);
 
             assert.isTrue(log.info.notCalled);
-            assert.equal(exit, 0);
+            assert.strictEqual(exit, 0);
         });
     });
 
@@ -333,7 +333,7 @@ describe("cli", () => {
 
             // a warning about the ignored file
             assert.isTrue(log.info.called);
-            assert.equal(exit, 0);
+            assert.strictEqual(exit, 0);
         });
 
         it("should process the file when forced", () => {
@@ -343,7 +343,7 @@ describe("cli", () => {
 
             // no warnings
             assert.isFalse(log.info.called);
-            assert.equal(exit, 0);
+            assert.strictEqual(exit, 0);
         });
     });
 
@@ -355,7 +355,7 @@ describe("cli", () => {
 
             // warnings about the ignored files
             assert.isTrue(log.info.called);
-            assert.equal(exit, 0);
+            assert.strictEqual(exit, 0);
         });
     });
 
@@ -379,7 +379,7 @@ describe("cli", () => {
             const filePath = getFixturePath("shebang.js");
             const exit = cli.execute(`--no-ignore ${filePath}`);
 
-            assert.equal(exit, 0);
+            assert.strictEqual(exit, 0);
         });
     });
 
@@ -394,7 +394,7 @@ describe("cli", () => {
             assert.throws(() => {
                 const exit = cli.execute(code);
 
-                assert.equal(exit, 1);
+                assert.strictEqual(exit, 1);
             }, /Error while loading rule 'custom-rule': Cannot read property/);
         });
 
@@ -425,7 +425,7 @@ describe("cli", () => {
             assert.isTrue(call.args[0].indexOf("Literal!") > -1);
             assert.isTrue(call.args[0].indexOf("2 problems") > -1);
             assert.isTrue(log.info.neverCalledWith(""));
-            assert.equal(exit, 1);
+            assert.strictEqual(exit, 1);
         });
 
 
@@ -437,7 +437,7 @@ describe("cli", () => {
             const exit = cli.execute(`--no-eslintrc --no-ignore ${filePath}`);
 
             assert.isTrue(log.info.notCalled);
-            assert.equal(exit, 0);
+            assert.strictEqual(exit, 0);
         });
     });
 
@@ -447,7 +447,7 @@ describe("cli", () => {
             const exit = cli.execute(`--no-ignore ${filePath}`);
 
             assert.isTrue(log.info.calledOnce);
-            assert.equal(exit, 1);
+            assert.strictEqual(exit, 1);
         });
     });
 
@@ -460,7 +460,7 @@ describe("cli", () => {
 
             cli.execute(`--no-eslintrc --config ./conf/eslint-recommended.js --no-ignore ${files.join(" ")}`);
 
-            assert.equal(log.info.args[0][0].split("\n").length, 11);
+            assert.strictEqual(log.info.args[0][0].split("\n").length, 11);
         });
     });
 
@@ -470,7 +470,7 @@ describe("cli", () => {
             const exit = cli.execute(`--global baz,bat --no-ignore --rule no-global-assign:2 ${filePath}`);
 
             assert.isTrue(log.info.calledOnce);
-            assert.equal(exit, 1);
+            assert.strictEqual(exit, 1);
         });
 
         it("should allow defining writable global variables", () => {
@@ -478,7 +478,7 @@ describe("cli", () => {
             const exit = cli.execute(`--global baz:false,bat:true --no-ignore ${filePath}`);
 
             assert.isTrue(log.info.notCalled);
-            assert.equal(exit, 0);
+            assert.strictEqual(exit, 0);
         });
 
         it("should allow defining variables with multiple flags", () => {
@@ -486,7 +486,7 @@ describe("cli", () => {
             const exit = cli.execute(`--global baz --global bat:true --no-ignore ${filePath}`);
 
             assert.isTrue(log.info.notCalled);
-            assert.equal(exit, 0);
+            assert.strictEqual(exit, 0);
         });
     });
 
@@ -496,7 +496,7 @@ describe("cli", () => {
             const code = `--no-ignore --rule 'quotes: [2, double]' ${filePath}`;
             const exitStatus = cli.execute(code);
 
-            assert.equal(exitStatus, 1);
+            assert.strictEqual(exitStatus, 1);
         });
     });
 
@@ -550,7 +550,7 @@ describe("cli", () => {
 
             const exit = cli.execute(code);
 
-            assert.equal(exit, 1);
+            assert.strictEqual(exit, 1);
             assert.isTrue(log.info.notCalled);
             assert.isTrue(log.error.calledOnce);
         });
@@ -563,7 +563,7 @@ describe("cli", () => {
 
             const exit = cli.execute(code);
 
-            assert.equal(exit, 1);
+            assert.strictEqual(exit, 1);
             assert.isTrue(log.info.notCalled);
             assert.isTrue(log.error.calledOnce);
         });
@@ -586,14 +586,14 @@ describe("cli", () => {
             const filePath = getFixturePath("passing.js");
             const exit = cli.execute(`--no-ignore --parser test111 ${filePath}`);
 
-            assert.equal(exit, 1);
+            assert.strictEqual(exit, 1);
         });
 
         it("should exit with no error if parser is valid", () => {
             const filePath = getFixturePath("passing.js");
             const exit = cli.execute(`--no-ignore --parser espree ${filePath}`);
 
-            assert.equal(exit, 0);
+            assert.strictEqual(exit, 0);
         });
     });
 
@@ -602,28 +602,28 @@ describe("cli", () => {
             const filePath = getFixturePath("passing.js");
             const exit = cli.execute(`--no-ignore --parser-options test111 ${filePath}`);
 
-            assert.equal(exit, 1);
+            assert.strictEqual(exit, 1);
         });
 
         it("should exit with no error if parser is valid", () => {
             const filePath = getFixturePath("passing.js");
             const exit = cli.execute(`--no-ignore --parser-options=ecmaVersion:6 ${filePath}`);
 
-            assert.equal(exit, 0);
+            assert.strictEqual(exit, 0);
         });
 
         it("should exit with an error on ecmaVersion 7 feature in ecmaVersion 6", () => {
             const filePath = getFixturePath("passing-es7.js");
             const exit = cli.execute(`--no-ignore --parser-options=ecmaVersion:6 ${filePath}`);
 
-            assert.equal(exit, 1);
+            assert.strictEqual(exit, 1);
         });
 
         it("should exit with no error on ecmaVersion 7 feature in ecmaVersion 7", () => {
             const filePath = getFixturePath("passing-es7.js");
             const exit = cli.execute(`--no-ignore --parser-options=ecmaVersion:7 ${filePath}`);
 
-            assert.equal(exit, 0);
+            assert.strictEqual(exit, 0);
         });
 
         it("should exit with no error on ecmaVersion 7 feature with config ecmaVersion 6 and command line ecmaVersion 7", () => {
@@ -631,7 +631,7 @@ describe("cli", () => {
             const filePath = getFixturePath("passing-es7.js");
             const exit = cli.execute(`--no-ignore --config ${configPath} --parser-options=ecmaVersion:7 ${filePath}`);
 
-            assert.equal(exit, 0);
+            assert.strictEqual(exit, 0);
         });
     });
 
@@ -640,14 +640,14 @@ describe("cli", () => {
             const filePath = getFixturePath("max-warnings");
             const exitCode = cli.execute(`--no-ignore --max-warnings 10 ${filePath}`);
 
-            assert.equal(exitCode, 0);
+            assert.strictEqual(exitCode, 0);
         });
 
         it("should exit with exit code 1 if warning count exceeds threshold", () => {
             const filePath = getFixturePath("max-warnings");
             const exitCode = cli.execute(`--no-ignore --max-warnings 5 ${filePath}`);
 
-            assert.equal(exitCode, 1);
+            assert.strictEqual(exitCode, 1);
             assert.ok(log.error.calledOnce);
             assert.include(log.error.getCall(0).args[0], "ESLint found too many warnings");
         });
@@ -656,14 +656,14 @@ describe("cli", () => {
             const filePath = getFixturePath("max-warnings");
             const exitCode = cli.execute(`--no-ignore --max-warnings 6 ${filePath}`);
 
-            assert.equal(exitCode, 0);
+            assert.strictEqual(exitCode, 0);
         });
 
         it("should not change exit code if flag is not specified and there are warnings", () => {
             const filePath = getFixturePath("max-warnings");
             const exitCode = cli.execute(filePath);
 
-            assert.equal(exitCode, 0);
+            assert.strictEqual(exitCode, 0);
         });
     });
 
@@ -728,7 +728,7 @@ describe("cli", () => {
 
             const exitCode = localCLI.execute(".");
 
-            assert.equal(exitCode, 0);
+            assert.strictEqual(exitCode, 0);
 
         });
 
@@ -764,7 +764,7 @@ describe("cli", () => {
 
             const exitCode = localCLI.execute("--fix .");
 
-            assert.equal(exitCode, 0);
+            assert.strictEqual(exitCode, 0);
 
         });
 
@@ -800,7 +800,7 @@ describe("cli", () => {
 
             const exitCode = localCLI.execute("--fix .");
 
-            assert.equal(exitCode, 1);
+            assert.strictEqual(exitCode, 1);
 
         });
 
@@ -837,7 +837,7 @@ describe("cli", () => {
 
             const exitCode = localCLI.execute("--fix --quiet .");
 
-            assert.equal(exitCode, 0);
+            assert.strictEqual(exitCode, 0);
 
         });
 
@@ -853,7 +853,7 @@ describe("cli", () => {
 
             const exitCode = localCLI.execute("--fix .", "foo = bar;");
 
-            assert.equal(exitCode, 1);
+            assert.strictEqual(exitCode, 1);
         });
 
     });
@@ -887,7 +887,7 @@ describe("cli", () => {
 
             const exitCode = localCLI.execute("--fix-dry-run .");
 
-            assert.equal(exitCode, 0);
+            assert.strictEqual(exitCode, 0);
 
         });
 
@@ -923,7 +923,7 @@ describe("cli", () => {
 
             const exitCode = localCLI.execute("--fix-dry-run .");
 
-            assert.equal(exitCode, 1);
+            assert.strictEqual(exitCode, 1);
 
         });
 
@@ -960,7 +960,7 @@ describe("cli", () => {
 
             const exitCode = localCLI.execute("--fix-dry-run --quiet .");
 
-            assert.equal(exitCode, 0);
+            assert.strictEqual(exitCode, 0);
 
         });
 
@@ -996,7 +996,7 @@ describe("cli", () => {
 
             const exitCode = localCLI.execute("--fix-dry-run .", "foo = bar;");
 
-            assert.equal(exitCode, 1);
+            assert.strictEqual(exitCode, 1);
         });
 
         it("should not call CLIEngine and return 1 when used with --fix", () => {
@@ -1011,7 +1011,7 @@ describe("cli", () => {
 
             const exitCode = localCLI.execute("--fix --fix-dry-run .", "foo = bar;");
 
-            assert.equal(exitCode, 1);
+            assert.strictEqual(exitCode, 1);
         });
     });
 
@@ -1022,7 +1022,7 @@ describe("cli", () => {
             const exitCode = cli.execute(`--print-config ${filePath}`);
 
             assert.isTrue(log.info.calledOnce);
-            assert.equal(exitCode, 0);
+            assert.strictEqual(exitCode, 0);
         });
 
         it("should error if any positional file arguments are passed", () => {
@@ -1033,7 +1033,7 @@ describe("cli", () => {
 
             assert.isTrue(log.info.notCalled);
             assert.isTrue(log.error.calledOnce);
-            assert.equal(exitCode, 1);
+            assert.strictEqual(exitCode, 1);
         });
 
         it("should error out when executing on text", () => {
@@ -1041,7 +1041,7 @@ describe("cli", () => {
 
             assert.isTrue(log.info.notCalled);
             assert.isTrue(log.error.calledOnce);
-            assert.equal(exitCode, 1);
+            assert.strictEqual(exitCode, 1);
         });
     });
 

--- a/tests/lib/code-path-analysis/code-path-analyzer.js
+++ b/tests/lib/code-path-analysis/code-path-analyzer.js
@@ -559,11 +559,11 @@ describe("CodePathAnalyzer", () => {
                 }));
                 const messages = linter.verify(source, { rules: { test: 2 }, env: { es6: true } });
 
-                assert.equal(messages.length, 0);
-                assert.equal(actual.length, expected.length, "a count of code paths is wrong.");
+                assert.strictEqual(messages.length, 0);
+                assert.strictEqual(actual.length, expected.length, "a count of code paths is wrong.");
 
                 for (let i = 0; i < actual.length; ++i) {
-                    assert.equal(actual[i], expected[i]);
+                    assert.strictEqual(actual[i], expected[i]);
                 }
             });
         });

--- a/tests/lib/code-path-analysis/code-path.js
+++ b/tests/lib/code-path-analysis/code-path.js
@@ -70,7 +70,7 @@ describe("CodePathAnalyzer", () => {
                 const codePath = parseCodePaths("foo(); bar(); baz();")[0];
                 const order = getOrderOfTraversing(codePath);
 
-                assert.deepEqual(order, ["s1_1"]);
+                assert.deepStrictEqual(order, ["s1_1"]);
 
                 /*
                 digraph {
@@ -87,7 +87,7 @@ describe("CodePathAnalyzer", () => {
                 const codePath = parseCodePaths("if (a) foo(); else bar(); baz();")[0];
                 const order = getOrderOfTraversing(codePath);
 
-                assert.deepEqual(order, ["s1_1", "s1_2", "s1_3", "s1_4"]);
+                assert.deepStrictEqual(order, ["s1_1", "s1_2", "s1_3", "s1_4"]);
 
                 /*
                 digraph {
@@ -108,7 +108,7 @@ describe("CodePathAnalyzer", () => {
                 const codePath = parseCodePaths("switch (a) { case 0: foo(); break; case 1: bar(); } baz();")[0];
                 const order = getOrderOfTraversing(codePath);
 
-                assert.deepEqual(order, ["s1_1", "s1_2", "s1_4", "s1_5", "s1_6"]);
+                assert.deepStrictEqual(order, ["s1_1", "s1_2", "s1_4", "s1_5", "s1_6"]);
 
                 /*
                 digraph {
@@ -133,7 +133,7 @@ describe("CodePathAnalyzer", () => {
                 const codePath = parseCodePaths("while (a) foo(); bar();")[0];
                 const order = getOrderOfTraversing(codePath);
 
-                assert.deepEqual(order, ["s1_1", "s1_2", "s1_3", "s1_4"]);
+                assert.deepStrictEqual(order, ["s1_1", "s1_2", "s1_3", "s1_4"]);
 
                 /*
                 digraph {
@@ -153,7 +153,7 @@ describe("CodePathAnalyzer", () => {
                 const codePath = parseCodePaths("for (var i = 0; i < 10; ++i) foo(i); bar();")[0];
                 const order = getOrderOfTraversing(codePath);
 
-                assert.deepEqual(order, ["s1_1", "s1_2", "s1_3", "s1_4", "s1_5"]);
+                assert.deepStrictEqual(order, ["s1_1", "s1_2", "s1_3", "s1_4", "s1_5"]);
 
                 /*
                 digraph {
@@ -174,7 +174,7 @@ describe("CodePathAnalyzer", () => {
                 const codePath = parseCodePaths("for (var key in obj) foo(key); bar();")[0];
                 const order = getOrderOfTraversing(codePath);
 
-                assert.deepEqual(order, ["s1_1", "s1_3", "s1_2", "s1_4", "s1_5"]);
+                assert.deepStrictEqual(order, ["s1_1", "s1_3", "s1_2", "s1_4", "s1_5"]);
 
                 /*
                 digraph {
@@ -197,7 +197,7 @@ describe("CodePathAnalyzer", () => {
                 const codePath = parseCodePaths("try { foo(); } catch (e) { bar(); } baz();")[0];
                 const order = getOrderOfTraversing(codePath);
 
-                assert.deepEqual(order, ["s1_1", "s1_2", "s1_3", "s1_4"]);
+                assert.deepStrictEqual(order, ["s1_1", "s1_2", "s1_3", "s1_4"]);
 
                 /*
                 digraph {
@@ -223,7 +223,7 @@ describe("CodePathAnalyzer", () => {
                 last: codePath.initialSegment.nextSegments[0].nextSegments[1]
             });
 
-            assert.deepEqual(order, ["s1_2", "s1_3", "s1_4"]);
+            assert.deepStrictEqual(order, ["s1_2", "s1_3", "s1_4"]);
 
             /*
             digraph {
@@ -252,7 +252,7 @@ describe("CodePathAnalyzer", () => {
                 }
             });
 
-            assert.deepEqual(order, ["s1_1", "s1_2"]);
+            assert.deepStrictEqual(order, ["s1_1", "s1_2"]);
 
             /*
             digraph {
@@ -281,7 +281,7 @@ describe("CodePathAnalyzer", () => {
                 }
             });
 
-            assert.deepEqual(order, ["s1_1", "s1_2", "s1_5", "s1_6"]);
+            assert.deepStrictEqual(order, ["s1_1", "s1_2", "s1_5", "s1_6"]);
 
             /*
             digraph {

--- a/tests/lib/config.js
+++ b/tests/lib/config.js
@@ -155,7 +155,7 @@ describe("Config", () => {
 
             // at one point, customBaseConfig.format would end up equal to "foo"...that's bad
             assert.deepEqual(customBaseConfig, { foo: "bar" });
-            assert.equal(configHelper.options.format, "foo");
+            assert.strictEqual(configHelper.options.format, "foo");
         });
 
         it("should create config object when using baseConfig with extends", () => {
@@ -215,7 +215,7 @@ describe("Config", () => {
                     configHelper.findLocalConfigFiles(getFakeFixturePath("broken"))
                 );
 
-            assert.equal(actual[0], expected);
+            assert.strictEqual(actual[0], expected);
         });
 
         it("should return an empty array when an .eslintrc file is not found", () => {
@@ -236,8 +236,8 @@ describe("Config", () => {
                     configHelper.findLocalConfigFiles(getFakeFixturePath("packagejson", "subdir"))
                 );
 
-            assert.equal(actual[0], expected0);
-            assert.equal(actual[1], expected1);
+            assert.strictEqual(actual[0], expected0);
+            assert.strictEqual(actual[1], expected1);
         });
 
         it("should return the only one config file even if there are multiple found", () => {
@@ -249,8 +249,8 @@ describe("Config", () => {
                     configHelper.findLocalConfigFiles(getFakeFixturePath("broken"))
                 );
 
-            assert.equal(actual.length, 1);
-            assert.equal(actual, expected);
+            assert.strictEqual(actual.length, 1);
+            assert.deepEqual(actual, [expected]);
         });
 
         it("should return all possible files when multiple are found", () => {
@@ -284,7 +284,7 @@ describe("Config", () => {
             const configHelper = new Config({ cwd: process.cwd() }, linter),
                 actual = configHelper.getConfig();
 
-            assert.equal(actual.rules.strict[1], "global");
+            assert.strictEqual(actual.rules.strict[1], "global");
         });
 
         it("should not retain configs from previous directories when called multiple times", () => {
@@ -296,9 +296,9 @@ describe("Config", () => {
             let config;
 
             config = configHelper.getConfig(firstpath);
-            assert.equal(config.rules["no-new"], 0);
+            assert.strictEqual(config.rules["no-new"], 0);
             config = configHelper.getConfig(secondpath);
-            assert.equal(config.rules["no-new"], 1);
+            assert.strictEqual(config.rules["no-new"], 1);
         });
 
         it("should throw an error when an invalid path is given", () => {
@@ -353,7 +353,7 @@ describe("Config", () => {
 
             configHelper.getConfig(configPath);
 
-            assert.equal(configHelper.findLocalConfigFiles.callcount, callcount);
+            assert.strictEqual(configHelper.findLocalConfigFiles.callcount, callcount);
         });
 
         // make sure JS-style comments don't throw an error
@@ -363,8 +363,8 @@ describe("Config", () => {
                 semi = configHelper.specificConfig.rules.semi,
                 strict = configHelper.specificConfig.rules.strict;
 
-            assert.equal(semi, 1);
-            assert.equal(strict, 0);
+            assert.strictEqual(semi, 1);
+            assert.strictEqual(strict, 0);
         });
 
         // make sure YAML files work correctly
@@ -374,8 +374,8 @@ describe("Config", () => {
                 noAlert = configHelper.specificConfig.rules["no-alert"],
                 noUndef = configHelper.specificConfig.rules["no-undef"];
 
-            assert.equal(noAlert, 0);
-            assert.equal(noUndef, 2);
+            assert.strictEqual(noAlert, 0);
+            assert.strictEqual(noUndef, 2);
         });
 
         it("should contain the correct value for parser when a custom parser is specified", () => {
@@ -383,7 +383,7 @@ describe("Config", () => {
                 configHelper = new Config({ cwd: process.cwd() }, linter),
                 config = configHelper.getConfig(configPath);
 
-            assert.equal(config.parser, path.resolve(path.dirname(configPath), "./custom.js"));
+            assert.strictEqual(config.parser, path.resolve(path.dirname(configPath), "./custom.js"));
         });
 
         // Configuration hierarchy ---------------------------------------------

--- a/tests/lib/config.js
+++ b/tests/lib/config.js
@@ -54,7 +54,7 @@ function createStubbedConfigWithPlugins(plugins) {
 }
 
 /**
- * Asserts that two configs are equal. This is necessary because assert.deepEqual()
+ * Asserts that two configs are equal. This is necessary because assert.deepStrictEqual()
  * gets confused when properties are in different orders.
  * @param {Object} actual The config object to check.
  * @param {Object} expected What the config object should look like.
@@ -63,23 +63,23 @@ function createStubbedConfigWithPlugins(plugins) {
  */
 function assertConfigsEqual(actual, expected) {
     if (actual.env && expected.env) {
-        assert.deepEqual(actual.env, expected.env);
+        assert.deepStrictEqual(actual.env, expected.env);
     }
 
     if (actual.parserOptions && expected.parserOptions) {
-        assert.deepEqual(actual.parserOptions, expected.parserOptions);
+        assert.deepStrictEqual(actual.parserOptions, expected.parserOptions);
     }
 
     if (actual.globals && expected.globals) {
-        assert.deepEqual(actual.globals, expected.globals);
+        assert.deepStrictEqual(actual.globals, expected.globals);
     }
 
     if (actual.rules && expected.rules) {
-        assert.deepEqual(actual.rules, expected.rules);
+        assert.deepStrictEqual(actual.rules, expected.rules);
     }
 
     if (actual.plugins && expected.plugins) {
-        assert.deepEqual(actual.plugins, expected.plugins);
+        assert.deepStrictEqual(actual.plugins, expected.plugins);
     }
 }
 
@@ -154,7 +154,7 @@ describe("Config", () => {
                 configHelper = new Config({ baseConfig: customBaseConfig, format: "foo" }, linter);
 
             // at one point, customBaseConfig.format would end up equal to "foo"...that's bad
-            assert.deepEqual(customBaseConfig, { foo: "bar" });
+            assert.deepStrictEqual(customBaseConfig, { foo: "bar" });
             assert.strictEqual(configHelper.options.format, "foo");
         });
 
@@ -164,12 +164,12 @@ describe("Config", () => {
             };
             const configHelper = new Config({ baseConfig: customBaseConfig }, linter);
 
-            assert.deepEqual(configHelper.baseConfig.env, {
+            assert.deepStrictEqual(configHelper.baseConfig.env, {
                 browser: false,
                 es6: true,
                 node: true
             });
-            assert.deepEqual(configHelper.baseConfig.rules, {
+            assert.deepStrictEqual(configHelper.baseConfig.rules, {
                 "no-empty": 1,
                 "comma-dangle": 2,
                 "no-console": 2
@@ -250,7 +250,7 @@ describe("Config", () => {
                 );
 
             assert.strictEqual(actual.length, 1);
-            assert.deepEqual(actual, [expected]);
+            assert.deepStrictEqual(actual, [expected]);
         });
 
         it("should return all possible files when multiple are found", () => {
@@ -266,7 +266,7 @@ describe("Config", () => {
                 );
 
 
-            assert.deepEqual(actual.length, expected.length);
+            assert.deepStrictEqual(actual.length, expected.length);
         });
 
         it("should return an empty array when a package.json file is not found", () => {
@@ -885,7 +885,7 @@ describe("Config", () => {
                         }
                     };
 
-                assert.deepEqual(actual, expected);
+                assert.deepStrictEqual(actual, expected);
 
                 // Ensure that the personal config is cached and isn't reloaded on every call
                 assert.strictEqual(config.getPersonalConfig(), config.getPersonalConfig());
@@ -914,7 +914,7 @@ describe("Config", () => {
                         }
                     };
 
-                assert.deepEqual(actual, expected);
+                assert.deepStrictEqual(actual, expected);
             });
 
             it("should ignore the personal config if config is passed through cli", () => {
@@ -941,7 +941,7 @@ describe("Config", () => {
                         }
                     };
 
-                assert.deepEqual(actual, expected);
+                assert.deepStrictEqual(actual, expected);
             });
 
             it("should still load the project config if the current working directory is the same as the home folder", () => {
@@ -967,7 +967,7 @@ describe("Config", () => {
                         }
                     };
 
-                assert.deepEqual(actual, expected);
+                assert.deepStrictEqual(actual, expected);
             });
         });
 

--- a/tests/lib/config/autoconfig.js
+++ b/tests/lib/config/autoconfig.js
@@ -63,7 +63,7 @@ describe("autoconfig", () => {
             const expectedRules = Object.keys(rulesConfig);
             const registry = new autoconfig.Registry(rulesConfig);
 
-            assert.equal(Object.keys(registry.rules).length, 3);
+            assert.strictEqual(Object.keys(registry.rules).length, 3);
             assert.sameMembers(Object.keys(registry.rules), expectedRules);
             assert.isArray(registry.rules.semi);
             assert.isArray(registry.rules["semi-spacing"]);
@@ -94,7 +94,7 @@ describe("autoconfig", () => {
         it("should populate the config property correctly", () => {
             const registry = new autoconfig.Registry(rulesConfig);
 
-            assert.equal(registry.rules.quotes[0].config, SEVERITY);
+            assert.strictEqual(registry.rules.quotes[0].config, SEVERITY);
             assert.deepEqual(registry.rules.quotes[1].config, [SEVERITY, "single"]);
             assert.deepEqual(registry.rules.quotes[2].config, [SEVERITY, "double"]);
             assert.deepEqual(registry.rules.quotes[3].config, [SEVERITY, "backtick"]);
@@ -106,9 +106,9 @@ describe("autoconfig", () => {
         it("should assign the correct specificity", () => {
             const registry = new autoconfig.Registry(rulesConfig);
 
-            assert.equal(registry.rules.quotes[0].specificity, 1);
-            assert.equal(registry.rules.quotes[1].specificity, 2);
-            assert.equal(registry.rules.quotes[6].specificity, 3);
+            assert.strictEqual(registry.rules.quotes[0].specificity, 1);
+            assert.strictEqual(registry.rules.quotes[1].specificity, 2);
+            assert.strictEqual(registry.rules.quotes[6].specificity, 3);
         });
 
         it("should initially leave the errorCount as undefined", () => {
@@ -137,7 +137,7 @@ describe("autoconfig", () => {
                 registry.populateFromCoreRules();
                 const semiCount = Object.keys(registry.rules).filter(ruleId => ruleId === "semi").length;
 
-                assert.equal(semiCount, 1);
+                assert.strictEqual(semiCount, 1);
             });
         });
 
@@ -193,10 +193,10 @@ describe("autoconfig", () => {
             });
 
             it("should correctly set the error count of configurations", () => {
-                assert.equal(registry.rules.semi[0].config, SEVERITY);
-                assert.equal(registry.rules.semi[0].errorCount, 0);
+                assert.strictEqual(registry.rules.semi[0].config, SEVERITY);
+                assert.strictEqual(registry.rules.semi[0].errorCount, 0);
                 assert.deepEqual(registry.rules.semi[2].config, [SEVERITY, "never"]);
-                assert.equal(registry.rules.semi[2].errorCount, 3);
+                assert.strictEqual(registry.rules.semi[2].errorCount, 3);
             });
 
             it("should respect inline eslint config comments (and not crash when they make linting errors)", () => {
@@ -232,13 +232,13 @@ describe("autoconfig", () => {
                 assert.lengthOf(registry.rules["semi-spacing"], 3);
                 assert.lengthOf(registry.rules.quotes, 1);
                 registry.rules.semi.forEach(registryItem => {
-                    assert.equal(registryItem.errorCount, 0);
+                    assert.strictEqual(registryItem.errorCount, 0);
                 });
                 registry.rules["semi-spacing"].forEach(registryItem => {
-                    assert.equal(registryItem.errorCount, 0);
+                    assert.strictEqual(registryItem.errorCount, 0);
                 });
                 registry.rules.quotes.forEach(registryItem => {
-                    assert.equal(registryItem.errorCount, 0);
+                    assert.strictEqual(registryItem.errorCount, 0);
                 });
             });
         });

--- a/tests/lib/config/autoconfig.js
+++ b/tests/lib/config/autoconfig.js
@@ -95,12 +95,12 @@ describe("autoconfig", () => {
             const registry = new autoconfig.Registry(rulesConfig);
 
             assert.strictEqual(registry.rules.quotes[0].config, SEVERITY);
-            assert.deepEqual(registry.rules.quotes[1].config, [SEVERITY, "single"]);
-            assert.deepEqual(registry.rules.quotes[2].config, [SEVERITY, "double"]);
-            assert.deepEqual(registry.rules.quotes[3].config, [SEVERITY, "backtick"]);
-            assert.deepEqual(registry.rules.quotes[4].config, [SEVERITY, "single", "avoid-escape"]);
-            assert.deepEqual(registry.rules.quotes[5].config, [SEVERITY, "double", "avoid-escape"]);
-            assert.deepEqual(registry.rules.quotes[6].config, [SEVERITY, "backtick", "avoid-escape"]);
+            assert.deepStrictEqual(registry.rules.quotes[1].config, [SEVERITY, "single"]);
+            assert.deepStrictEqual(registry.rules.quotes[2].config, [SEVERITY, "double"]);
+            assert.deepStrictEqual(registry.rules.quotes[3].config, [SEVERITY, "backtick"]);
+            assert.deepStrictEqual(registry.rules.quotes[4].config, [SEVERITY, "single", "avoid-escape"]);
+            assert.deepStrictEqual(registry.rules.quotes[5].config, [SEVERITY, "double", "avoid-escape"]);
+            assert.deepStrictEqual(registry.rules.quotes[6].config, [SEVERITY, "backtick", "avoid-escape"]);
         });
 
         it("should assign the correct specificity", () => {
@@ -159,7 +159,7 @@ describe("autoconfig", () => {
             });
 
             it("should create the first set from default rule configs (severity only)", () => {
-                assert.deepEqual(ruleSets[0], { semi: SEVERITY, "semi-spacing": SEVERITY, quotes: SEVERITY });
+                assert.deepStrictEqual(ruleSets[0], { semi: SEVERITY, "semi-spacing": SEVERITY, quotes: SEVERITY });
             });
 
             it("should create as many ruleSets as the highest number of configs in a rule", () => {
@@ -195,7 +195,7 @@ describe("autoconfig", () => {
             it("should correctly set the error count of configurations", () => {
                 assert.strictEqual(registry.rules.semi[0].config, SEVERITY);
                 assert.strictEqual(registry.rules.semi[0].errorCount, 0);
-                assert.deepEqual(registry.rules.semi[2].config, [SEVERITY, "never"]);
+                assert.deepStrictEqual(registry.rules.semi[2].config, [SEVERITY, "never"]);
                 assert.strictEqual(registry.rules.semi[2].errorCount, 3);
             });
 
@@ -211,7 +211,7 @@ describe("autoconfig", () => {
                 registry = new autoconfig.Registry(rulesConfig);
                 registry = registry.lintSourceCode(sourceCode, defaultOptions);
 
-                assert.deepEqual(registry.rules.semi, expectedRegistry);
+                assert.deepStrictEqual(registry.rules.semi, expectedRegistry);
             });
         });
 
@@ -258,7 +258,7 @@ describe("autoconfig", () => {
             it("should return a registry with no registryItems with an errorCount of zero", () => {
                 const failingRules = Object.keys(failingRegistry.rules);
 
-                assert.deepEqual(failingRules, ["no-unused-vars"]);
+                assert.deepStrictEqual(failingRules, ["no-unused-vars"]);
                 assert.lengthOf(failingRegistry.rules["no-unused-vars"], 1);
                 assert(failingRegistry.rules["no-unused-vars"][0].errorCount > 0);
             });
@@ -284,11 +284,11 @@ describe("autoconfig", () => {
             it("should add rules which have only one registryItem to the config", () => {
                 const configuredRules = Object.keys(createdConfig.rules);
 
-                assert.deepEqual(configuredRules, ["quotes"]);
+                assert.deepStrictEqual(configuredRules, ["quotes"]);
             });
 
             it("should set the configuration of the rule to the registryItem's `config` value", () => {
-                assert.deepEqual(createdConfig.rules.quotes, [2, "double", "avoid-escape"]);
+                assert.deepStrictEqual(createdConfig.rules.quotes, [2, "double", "avoid-escape"]);
             });
 
             it("should not care how many errors the config has", () => {
@@ -302,7 +302,7 @@ describe("autoconfig", () => {
                 createdConfig = failingRegistry.createConfig();
                 const configuredRules = Object.keys(createdConfig.rules);
 
-                assert.deepEqual(configuredRules, ["no-unused-vars"]);
+                assert.deepStrictEqual(configuredRules, ["no-unused-vars"]);
             });
         });
 

--- a/tests/lib/config/config-file.js
+++ b/tests/lib/config/config-file.js
@@ -191,8 +191,8 @@ describe("ConfigFile", () => {
                 extends: "eslint:all"
             }, configContext, "/whatever");
 
-            assert.equal(config.rules.eqeqeq, "error");
-            assert.equal(config.rules.curly, "error");
+            assert.strictEqual(config.rules.eqeqeq, "error");
+            assert.strictEqual(config.rules.curly, "error");
 
         });
 
@@ -1026,7 +1026,7 @@ describe("ConfigFile", () => {
 
                     const result = StubbedConfigFile.resolve(input);
 
-                    assert.equal(result.filePath, expected);
+                    assert.strictEqual(result.filePath, expected);
                 });
             });
         });
@@ -1061,7 +1061,7 @@ describe("ConfigFile", () => {
 
                     const result = StubbedConfigFile.resolve(input, relativeTo);
 
-                    assert.equal(result.filePath, expected);
+                    assert.strictEqual(result.filePath, expected);
                 });
             });
 
@@ -1083,7 +1083,7 @@ describe("ConfigFile", () => {
 
                     const result = StubbedConfigFile.resolve(input, relativeTo);
 
-                    assert.equal(result.filePath, expected);
+                    assert.strictEqual(result.filePath, expected);
                 });
             });
 
@@ -1099,27 +1099,27 @@ describe("ConfigFile", () => {
             it("should return project path when config file is in home directory", () => {
                 const result = ConfigFile.getBaseDir(userHome);
 
-                assert.equal(result, PROJECT_PATH);
+                assert.strictEqual(result, PROJECT_PATH);
             });
         }
 
         it("should return project path when config file is in an ancestor directory of the project path", () => {
             const result = ConfigFile.getBaseDir(path.resolve(PROJECT_PATH, "../../"));
 
-            assert.equal(result, PROJECT_PATH);
+            assert.strictEqual(result, PROJECT_PATH);
         });
 
         it("should return config file path when config file is in a descendant directory of the project path", () => {
             const configFilePath = path.resolve(PROJECT_PATH, "./foo/bar/"),
                 result = ConfigFile.getBaseDir(path.resolve(PROJECT_PATH, "./foo/bar/"));
 
-            assert.equal(result, configFilePath);
+            assert.strictEqual(result, configFilePath);
         });
 
         it("should return project path when config file is not an ancestor or descendant of the project path", () => {
             const result = ConfigFile.getBaseDir(path.resolve("/tmp/foo"));
 
-            assert.equal(result, PROJECT_PATH);
+            assert.strictEqual(result, PROJECT_PATH);
         });
 
     });
@@ -1132,27 +1132,27 @@ describe("ConfigFile", () => {
             it("should return project path when config file is in home directory", () => {
                 const result = ConfigFile.getLookupPath(userHome);
 
-                assert.equal(result, PROJECT_DEPS_PATH);
+                assert.strictEqual(result, PROJECT_DEPS_PATH);
             });
         }
 
         it("should return project path when config file is in an ancestor directory of the project path", () => {
             const result = ConfigFile.getLookupPath(path.resolve(PROJECT_DEPS_PATH, "../../"));
 
-            assert.equal(result, PROJECT_DEPS_PATH);
+            assert.strictEqual(result, PROJECT_DEPS_PATH);
         });
 
         it("should return config file path when config file is in a descendant directory of the project path", () => {
             const configFilePath = path.resolve(PROJECT_DEPS_PATH, "./foo/bar/node_modules"),
                 result = ConfigFile.getLookupPath(path.resolve(PROJECT_DEPS_PATH, "./foo/bar/"));
 
-            assert.equal(result, configFilePath);
+            assert.strictEqual(result, configFilePath);
         });
 
         it("should return project path when config file is not an ancestor or descendant of the project path", () => {
             const result = ConfigFile.getLookupPath(path.resolve("/tmp/foo"));
 
-            assert.equal(result, PROJECT_DEPS_PATH);
+            assert.strictEqual(result, PROJECT_DEPS_PATH);
         });
 
     });
@@ -1169,7 +1169,7 @@ describe("ConfigFile", () => {
             it(`should return ${expected} when passed ${input}`, () => {
                 const result = ConfigFile.getFilenameForDirectory(input);
 
-                assert.equal(result, path.resolve(input, expected));
+                assert.strictEqual(result, path.resolve(input, expected));
             });
         });
 
@@ -1189,7 +1189,7 @@ describe("ConfigFile", () => {
             it(`should return ${expected} when passed ${input}`, () => {
                 const result = ConfigFile.normalizePackageName(input, "eslint-config");
 
-                assert.equal(result, expected);
+                assert.strictEqual(result, expected);
             });
         });
 

--- a/tests/lib/config/config-file.js
+++ b/tests/lib/config/config-file.js
@@ -169,7 +169,7 @@ describe("ConfigFile", () => {
                 rules: { eqeqeq: 2 }
             }, configContext, "/whatever");
 
-            assert.deepEqual(config, {
+            assert.deepStrictEqual(config, {
                 baseDirectory: path.dirname(resolvedPath),
                 filePath: resolvedPath,
                 extends: "foo",
@@ -326,7 +326,7 @@ describe("ConfigFile", () => {
                 rules: { eqeqeq: 2 }
             }, configContext, "/whatever");
 
-            assert.deepEqual(config, {
+            assert.deepStrictEqual(config, {
                 baseDirectory: path.dirname(resolvedPaths[0]),
                 filePath: resolvedPaths[0],
                 extends: "foo",
@@ -351,7 +351,7 @@ describe("ConfigFile", () => {
                 rules: { eqeqeq: 2 }
             }, configContext, filePath);
 
-            assert.deepEqual(config, {
+            assert.deepStrictEqual(config, {
                 baseDirectory: path.dirname(filePath),
                 filePath: path.join(path.dirname(filePath), extendsFile),
                 extends: extendsFile,
@@ -376,7 +376,7 @@ describe("ConfigFile", () => {
                 rules: { eqeqeq: 2 }
             }, configContext, filePath);
 
-            assert.deepEqual(config, {
+            assert.deepStrictEqual(config, {
                 baseDirectory: path.dirname(filePath),
                 filePath: path.join(path.dirname(filePath), extendsFile),
                 extends: extendsFile,
@@ -400,7 +400,7 @@ describe("ConfigFile", () => {
                 rules: { eqeqeq: 2 }
             }, configContext, filePath);
 
-            assert.deepEqual(config, {
+            assert.deepStrictEqual(config, {
                 baseDirectory: path.dirname(filePath),
                 filePath: path.join(path.dirname(filePath), extendsFile),
                 extends: extendsFile,
@@ -425,7 +425,7 @@ describe("ConfigFile", () => {
                 rules: { eqeqeq: 2 }
             }, configContext, filePath);
 
-            assert.deepEqual(config, {
+            assert.deepStrictEqual(config, {
                 baseDirectory: path.dirname(path.resolve(path.dirname(filePath), extendsFile)),
                 filePath: path.resolve(path.dirname(filePath), extendsFile),
                 extends: extendsFile,
@@ -457,7 +457,7 @@ describe("ConfigFile", () => {
             const configFilePath = getFixturePath("legacy/.eslintrc");
             const config = ConfigFile.load(configFilePath, configContext);
 
-            assert.deepEqual(config, {
+            assert.deepStrictEqual(config, {
                 baseDirectory: path.dirname(configFilePath),
                 filePath: configFilePath,
                 parserOptions: {},
@@ -473,7 +473,7 @@ describe("ConfigFile", () => {
             const configFilePath = getFixturePath("js/.eslintrc.js");
             const config = ConfigFile.load(configFilePath, configContext);
 
-            assert.deepEqual(config, {
+            assert.deepStrictEqual(config, {
                 baseDirectory: path.dirname(configFilePath),
                 filePath: configFilePath,
                 parserOptions: {},
@@ -495,7 +495,7 @@ describe("ConfigFile", () => {
             const configFilePath = getFixturePath("js/.eslintrc.parser.js");
             const config = ConfigFile.load(configFilePath, configContext);
 
-            assert.deepEqual(config, {
+            assert.deepStrictEqual(config, {
                 baseDirectory: path.dirname(configFilePath),
                 filePath: configFilePath,
                 parser: path.resolve(getFixturePath("js/node_modules/foo/index.js")),
@@ -512,7 +512,7 @@ describe("ConfigFile", () => {
             const configFilePath = getFixturePath("js/.eslintrc.parser2.js");
             const config = ConfigFile.load(configFilePath, configContext);
 
-            assert.deepEqual(config, {
+            assert.deepStrictEqual(config, {
                 baseDirectory: path.dirname(configFilePath),
                 filePath: configFilePath,
                 parser: path.resolve(getFixturePath("js/not-a-config.js")),
@@ -529,7 +529,7 @@ describe("ConfigFile", () => {
             const configFilePath = getFixturePath("js/.eslintrc.parser3.js");
             const config = ConfigFile.load(configFilePath, configContext);
 
-            assert.deepEqual(config, {
+            assert.deepStrictEqual(config, {
                 baseDirectory: path.dirname(configFilePath),
                 filePath: configFilePath,
                 parser: require.resolve("espree"),
@@ -546,7 +546,7 @@ describe("ConfigFile", () => {
             const configFilePath = getFixturePath("json/.eslintrc.json");
             const config = ConfigFile.load(configFilePath, configContext);
 
-            assert.deepEqual(config, {
+            assert.deepStrictEqual(config, {
                 baseDirectory: path.dirname(configFilePath),
                 filePath: configFilePath,
                 parserOptions: {},
@@ -579,14 +579,14 @@ describe("ConfigFile", () => {
                 tmpFilePath = writeTempConfigFile(initialConfig, tmpFilename);
             let config = ConfigFile.load(tmpFilePath, configContext);
 
-            assert.deepEqual(config, Object.assign({}, initialConfig, {
+            assert.deepStrictEqual(config, Object.assign({}, initialConfig, {
                 baseDirectory: path.dirname(tmpFilePath),
                 filePath: tmpFilePath
             }));
             writeTempConfigFile(updatedConfig, tmpFilename, path.dirname(tmpFilePath));
             configContext = new Config({}, new Linter());
             config = ConfigFile.load(tmpFilePath, configContext);
-            assert.deepEqual(config, Object.assign({}, updatedConfig, {
+            assert.deepStrictEqual(config, Object.assign({}, updatedConfig, {
                 baseDirectory: path.dirname(tmpFilePath),
                 filePath: tmpFilePath
             }));
@@ -596,7 +596,7 @@ describe("ConfigFile", () => {
             const configFilePath = getFixturePath("package-json/package.json");
             const config = ConfigFile.load(configFilePath, configContext);
 
-            assert.deepEqual(config, {
+            assert.deepStrictEqual(config, {
                 baseDirectory: path.dirname(configFilePath),
                 filePath: configFilePath,
                 parserOptions: {},
@@ -637,14 +637,14 @@ describe("ConfigFile", () => {
                 tmpFilePath = writeTempConfigFile(initialConfig, tmpFilename);
             let config = ConfigFile.load(tmpFilePath, configContext);
 
-            assert.deepEqual(config, Object.assign({}, initialConfig.eslintConfig, {
+            assert.deepStrictEqual(config, Object.assign({}, initialConfig.eslintConfig, {
                 baseDirectory: path.dirname(tmpFilePath),
                 filePath: tmpFilePath
             }));
             writeTempConfigFile(updatedConfig, tmpFilename, path.dirname(tmpFilePath));
             configContext = new Config({}, new Linter());
             config = ConfigFile.load(tmpFilePath, configContext);
-            assert.deepEqual(config, Object.assign({}, updatedConfig.eslintConfig, {
+            assert.deepStrictEqual(config, Object.assign({}, updatedConfig.eslintConfig, {
                 baseDirectory: path.dirname(tmpFilePath),
                 filePath: tmpFilePath
             }));
@@ -671,14 +671,14 @@ describe("ConfigFile", () => {
                 tmpFilePath = writeTempJsConfigFile(initialConfig, tmpFilename);
             let config = ConfigFile.load(tmpFilePath, configContext);
 
-            assert.deepEqual(config, Object.assign({}, initialConfig, {
+            assert.deepStrictEqual(config, Object.assign({}, initialConfig, {
                 baseDirectory: path.dirname(tmpFilePath),
                 filePath: tmpFilePath
             }));
             writeTempJsConfigFile(updatedConfig, tmpFilename, path.dirname(tmpFilePath));
             configContext = new Config({}, new Linter());
             config = ConfigFile.load(tmpFilePath, configContext);
-            assert.deepEqual(config, Object.assign({}, updatedConfig, {
+            assert.deepStrictEqual(config, Object.assign({}, updatedConfig, {
                 baseDirectory: path.dirname(tmpFilePath),
                 filePath: tmpFilePath
             }));
@@ -688,7 +688,7 @@ describe("ConfigFile", () => {
             const configFilePath = getFixturePath("yaml/.eslintrc.yaml");
             const config = ConfigFile.load(configFilePath, configContext);
 
-            assert.deepEqual(config, {
+            assert.deepStrictEqual(config, {
                 baseDirectory: path.dirname(configFilePath),
                 filePath: configFilePath,
                 parserOptions: {},
@@ -702,7 +702,7 @@ describe("ConfigFile", () => {
             const configFilePath = getFixturePath("yaml/.eslintrc.empty.yaml");
             const config = ConfigFile.load(configFilePath, configContext);
 
-            assert.deepEqual(config, {
+            assert.deepStrictEqual(config, {
                 baseDirectory: path.dirname(configFilePath),
                 filePath: configFilePath,
                 parserOptions: {},
@@ -716,7 +716,7 @@ describe("ConfigFile", () => {
             const configFilePath = getFixturePath("yml/.eslintrc.yml");
             const config = ConfigFile.load(configFilePath, configContext);
 
-            assert.deepEqual(config, {
+            assert.deepStrictEqual(config, {
                 baseDirectory: path.dirname(configFilePath),
                 filePath: configFilePath,
                 parserOptions: {},
@@ -730,7 +730,7 @@ describe("ConfigFile", () => {
             const configFilePath = getFixturePath("extends/.eslintrc.yml");
             const config = ConfigFile.load(configFilePath, configContext);
 
-            assert.deepEqual(config, {
+            assert.deepStrictEqual(config, {
                 baseDirectory: path.dirname(configFilePath),
                 filePath: configFilePath,
                 env: { es6: true },
@@ -745,7 +745,7 @@ describe("ConfigFile", () => {
             const configFilePath = getFixturePath("extends-chain/.eslintrc.json");
             const config = ConfigFile.load(configFilePath, configContext);
 
-            assert.deepEqual(config, {
+            assert.deepStrictEqual(config, {
                 baseDirectory: path.dirname(configFilePath),
                 filePath: configFilePath,
                 env: {},
@@ -764,7 +764,7 @@ describe("ConfigFile", () => {
             const configFilePath = getFixturePath("extends-chain-2/.eslintrc.json");
             const config = ConfigFile.load(configFilePath, configContext);
 
-            assert.deepEqual(config, {
+            assert.deepStrictEqual(config, {
                 baseDirectory: path.dirname(configFilePath),
                 filePath: configFilePath,
                 env: {},
@@ -782,7 +782,7 @@ describe("ConfigFile", () => {
             const configFilePath = getFixturePath("extends-chain-2/relative.eslintrc.json");
             const config = ConfigFile.load(configFilePath, configContext);
 
-            assert.deepEqual(config, {
+            assert.deepStrictEqual(config, {
                 baseDirectory: path.dirname(configFilePath),
                 filePath: configFilePath,
                 env: {},
@@ -801,7 +801,7 @@ describe("ConfigFile", () => {
             const config = ConfigFile.load(configFilePath, configContext);
             const parserPath = getFixturePath("extends-chain-2/parser.js");
 
-            assert.deepEqual(config, {
+            assert.deepStrictEqual(config, {
                 baseDirectory: path.dirname(configFilePath),
                 filePath: configFilePath,
                 env: {},
@@ -831,7 +831,7 @@ describe("ConfigFile", () => {
                 const configFilePath = path.join(fixturePath, "relative.eslintrc.json");
                 const config = ConfigFile.load(configFilePath, configContext);
 
-                assert.deepEqual(config, {
+                assert.deepStrictEqual(config, {
                     baseDirectory: path.dirname(configFilePath),
                     filePath: configFilePath,
                     env: {},
@@ -850,7 +850,7 @@ describe("ConfigFile", () => {
                 const config = ConfigFile.load(configFilePath, configContext);
                 const parserPath = path.join(fixturePath, "parser.js");
 
-                assert.deepEqual(config, {
+                assert.deepStrictEqual(config, {
                     baseDirectory: path.dirname(configFilePath),
                     filePath: configFilePath,
                     env: {},
@@ -877,7 +877,7 @@ describe("ConfigFile", () => {
                 const configFilePath = getFixturePath("plugins/.eslintrc.yml");
                 const config = ConfigFile.load(configFilePath, stubConfig);
 
-                assert.deepEqual(config, {
+                assert.deepStrictEqual(config, {
                     baseDirectory: path.dirname(configFilePath),
                     filePath: configFilePath,
                     parserOptions: {},
@@ -915,7 +915,7 @@ describe("ConfigFile", () => {
                 const configFilePath = getFixturePath("plugins/.eslintrc2.yml");
                 const config = StubbedConfigFile.load(configFilePath, stubConfig);
 
-                assert.deepEqual(config, {
+                assert.deepStrictEqual(config, {
                     baseDirectory: path.dirname(configFilePath),
                     filePath: configFilePath,
                     parserOptions: {},
@@ -939,7 +939,7 @@ describe("ConfigFile", () => {
                 const configFilePath = getFixturePath("bom/.eslintrc.json");
                 const config = ConfigFile.load(configFilePath, configContext);
 
-                assert.deepEqual(config, {
+                assert.deepStrictEqual(config, {
                     baseDirectory: path.dirname(configFilePath),
                     filePath: configFilePath,
                     env: {},
@@ -955,7 +955,7 @@ describe("ConfigFile", () => {
                 const configFilePath = getFixturePath("bom/.eslintrc.yaml");
                 const config = ConfigFile.load(configFilePath, configContext);
 
-                assert.deepEqual(config, {
+                assert.deepStrictEqual(config, {
                     baseDirectory: path.dirname(configFilePath),
                     filePath: configFilePath,
                     env: {},
@@ -971,7 +971,7 @@ describe("ConfigFile", () => {
                 const configFilePath = getFixturePath("bom/package.json");
                 const config = ConfigFile.load(configFilePath, configContext);
 
-                assert.deepEqual(config, {
+                assert.deepStrictEqual(config, {
                     baseDirectory: path.dirname(configFilePath),
                     filePath: configFilePath,
                     env: {},

--- a/tests/lib/config/config-initializer.js
+++ b/tests/lib/config/config-initializer.js
@@ -144,10 +144,10 @@ describe("configInitializer", () => {
                 assert.deepEqual(config.rules.quotes, ["error", "single"]);
                 assert.deepEqual(config.rules["linebreak-style"], ["error", "unix"]);
                 assert.deepEqual(config.rules.semi, ["error", "always"]);
-                assert.equal(config.env.es6, true);
-                assert.equal(config.parserOptions.sourceType, "module");
-                assert.equal(config.env.browser, true);
-                assert.equal(config.extends, "eslint:recommended");
+                assert.strictEqual(config.env.es6, true);
+                assert.strictEqual(config.parserOptions.sourceType, "module");
+                assert.strictEqual(config.env.browser, true);
+                assert.strictEqual(config.extends, "eslint:recommended");
             });
 
             it("should disable semi", () => {
@@ -161,7 +161,7 @@ describe("configInitializer", () => {
                 answers.jsx = true;
                 const config = init.processAnswers(answers);
 
-                assert.equal(config.parserOptions.ecmaFeatures.jsx, true);
+                assert.strictEqual(config.parserOptions.ecmaFeatures.jsx, true);
             });
 
             it("should enable react plugin", () => {
@@ -169,8 +169,8 @@ describe("configInitializer", () => {
                 answers.react = true;
                 const config = init.processAnswers(answers);
 
-                assert.equal(config.parserOptions.ecmaFeatures.jsx, true);
-                assert.equal(config.parserOptions.ecmaFeatures.experimentalObjectRestSpread, true);
+                assert.strictEqual(config.parserOptions.ecmaFeatures.jsx, true);
+                assert.strictEqual(config.parserOptions.ecmaFeatures.experimentalObjectRestSpread, true);
                 assert.deepEqual(config.plugins, ["react"]);
             });
 
@@ -184,7 +184,7 @@ describe("configInitializer", () => {
             it("should extend eslint:recommended", () => {
                 const config = init.processAnswers(answers);
 
-                assert.equal(config.extends, "eslint:recommended");
+                assert.strictEqual(config.extends, "eslint:recommended");
             });
 
             it("should not use commonjs by default", () => {
@@ -271,7 +271,7 @@ describe("configInitializer", () => {
                     it("should return false.", () => {
                         const result = init.hasESLintVersionConflict({ styleguide: "airbnb" });
 
-                        assert.equal(result, false);
+                        assert.strictEqual(result, false);
                     });
                 });
 
@@ -283,7 +283,7 @@ describe("configInitializer", () => {
                     it("should return false.", () => {
                         const result = init.hasESLintVersionConflict({ styleguide: "airbnb" });
 
-                        assert.equal(result, false);
+                        assert.strictEqual(result, false);
                     });
                 });
 
@@ -295,7 +295,7 @@ describe("configInitializer", () => {
                     it("should return true.", () => {
                         const result = init.hasESLintVersionConflict({ styleguide: "airbnb" });
 
-                        assert.equal(result, true);
+                        assert.strictEqual(result, true);
                     });
                 });
 
@@ -307,7 +307,7 @@ describe("configInitializer", () => {
                     it("should return true.", () => {
                         const result = init.hasESLintVersionConflict({ styleguide: "airbnb" });
 
-                        assert.equal(result, true);
+                        assert.strictEqual(result, true);
                     });
                 });
             });
@@ -360,11 +360,11 @@ describe("configInitializer", () => {
 
             it("should create the config based on examined files", () => {
                 assert.deepEqual(config.rules.quotes, ["error", "double"]);
-                assert.equal(config.rules.semi, "off");
+                assert.strictEqual(config.rules.semi, "off");
             });
 
             it("should extend and not disable recommended rules", () => {
-                assert.equal(config.extends, "eslint:recommended");
+                assert.strictEqual(config.extends, "eslint:recommended");
                 assert.notProperty(config.rules, "no-console");
             });
 

--- a/tests/lib/config/config-initializer.js
+++ b/tests/lib/config/config-initializer.js
@@ -140,10 +140,10 @@ describe("configInitializer", () => {
             it("should create default config", () => {
                 const config = init.processAnswers(answers);
 
-                assert.deepEqual(config.rules.indent, ["error", 2]);
-                assert.deepEqual(config.rules.quotes, ["error", "single"]);
-                assert.deepEqual(config.rules["linebreak-style"], ["error", "unix"]);
-                assert.deepEqual(config.rules.semi, ["error", "always"]);
+                assert.deepStrictEqual(config.rules.indent, ["error", 2]);
+                assert.deepStrictEqual(config.rules.quotes, ["error", "single"]);
+                assert.deepStrictEqual(config.rules["linebreak-style"], ["error", "unix"]);
+                assert.deepStrictEqual(config.rules.semi, ["error", "always"]);
                 assert.strictEqual(config.env.es6, true);
                 assert.strictEqual(config.parserOptions.sourceType, "module");
                 assert.strictEqual(config.env.browser, true);
@@ -154,7 +154,7 @@ describe("configInitializer", () => {
                 answers.semi = false;
                 const config = init.processAnswers(answers);
 
-                assert.deepEqual(config.rules.semi, ["error", "never"]);
+                assert.deepStrictEqual(config.rules.semi, ["error", "never"]);
             });
 
             it("should enable jsx flag", () => {
@@ -171,7 +171,7 @@ describe("configInitializer", () => {
 
                 assert.strictEqual(config.parserOptions.ecmaFeatures.jsx, true);
                 assert.strictEqual(config.parserOptions.ecmaFeatures.experimentalObjectRestSpread, true);
-                assert.deepEqual(config.plugins, ["react"]);
+                assert.deepStrictEqual(config.plugins, ["react"]);
             });
 
             it("should not enable es6", () => {
@@ -205,25 +205,25 @@ describe("configInitializer", () => {
             it("should support the google style guide", () => {
                 const config = init.getConfigForStyleGuide("google");
 
-                assert.deepEqual(config, { extends: "google", installedESLint: true });
+                assert.deepStrictEqual(config, { extends: "google", installedESLint: true });
             });
 
             it("should support the airbnb style guide", () => {
                 const config = init.getConfigForStyleGuide("airbnb");
 
-                assert.deepEqual(config, { extends: "airbnb", installedESLint: true });
+                assert.deepStrictEqual(config, { extends: "airbnb", installedESLint: true });
             });
 
             it("should support the airbnb base style guide", () => {
                 const config = init.getConfigForStyleGuide("airbnb-base");
 
-                assert.deepEqual(config, { extends: "airbnb-base", installedESLint: true });
+                assert.deepStrictEqual(config, { extends: "airbnb-base", installedESLint: true });
             });
 
             it("should support the standard style guide", () => {
                 const config = init.getConfigForStyleGuide("standard");
 
-                assert.deepEqual(config, { extends: "standard", installedESLint: true });
+                assert.deepStrictEqual(config, { extends: "standard", installedESLint: true });
             });
 
             it("should throw when encountering an unsupported style guide", () => {
@@ -250,7 +250,7 @@ describe("configInitializer", () => {
                 assert(npmFetchPeerDependenciesStub.calledOnce);
                 assert(npmFetchPeerDependenciesStub.firstCall.args[0] === "eslint-config-airbnb@latest");
                 assert(npmInstallStub.calledOnce);
-                assert.deepEqual(
+                assert.deepStrictEqual(
                     npmInstallStub.firstCall.args[0],
                     [
                         "eslint-config-airbnb@latest",
@@ -359,7 +359,7 @@ describe("configInitializer", () => {
             });
 
             it("should create the config based on examined files", () => {
-                assert.deepEqual(config.rules.quotes, ["error", "double"]);
+                assert.deepStrictEqual(config.rules.quotes, ["error", "double"]);
                 assert.strictEqual(config.rules.semi, "off");
             });
 

--- a/tests/lib/config/config-ops.js
+++ b/tests/lib/config/config-ops.js
@@ -37,7 +37,7 @@ describe("ConfigOps", () => {
 
             const result = ConfigOps.applyEnvironments(config, envContext);
 
-            assert.deepEqual(result, {
+            assert.deepStrictEqual(result, {
                 env: config.env,
                 rules: config.rules,
                 parserOptions: {
@@ -72,7 +72,7 @@ describe("ConfigOps", () => {
 
             const result = ConfigOps.applyEnvironments(config, envContext);
 
-            assert.deepEqual(result, {
+            assert.deepStrictEqual(result, {
                 env: config.env,
                 rules: config.rules,
                 parserOptions: {
@@ -89,7 +89,7 @@ describe("ConfigOps", () => {
         it("should return empty config if called without any config", () => {
             const config = ConfigOps.createEnvironmentConfig(null, envContext);
 
-            assert.deepEqual(config, {
+            assert.deepStrictEqual(config, {
                 globals: {},
                 env: {},
                 rules: {},
@@ -100,7 +100,7 @@ describe("ConfigOps", () => {
         it("should return correct config for env with no globals", () => {
             const config = ConfigOps.createEnvironmentConfig({ test: true }, new Environments());
 
-            assert.deepEqual(config, {
+            assert.deepStrictEqual(config, {
                 globals: {},
                 env: {
                     test: true
@@ -113,7 +113,7 @@ describe("ConfigOps", () => {
         it("should create the correct config for Node.js environment", () => {
             const config = ConfigOps.createEnvironmentConfig({ node: true }, envContext);
 
-            assert.deepEqual(config, {
+            assert.deepStrictEqual(config, {
                 env: {
                     node: true
                 },
@@ -128,7 +128,7 @@ describe("ConfigOps", () => {
         it("should create the correct config for ES6 environment", () => {
             const config = ConfigOps.createEnvironmentConfig({ es6: true }, envContext);
 
-            assert.deepEqual(config, {
+            assert.deepStrictEqual(config, {
                 env: {
                     es6: true
                 },
@@ -143,7 +143,7 @@ describe("ConfigOps", () => {
         it("should create empty config when no environments are specified", () => {
             const config = ConfigOps.createEnvironmentConfig({}, envContext);
 
-            assert.deepEqual(config, {
+            assert.deepStrictEqual(config, {
                 env: {},
                 parserOptions: {},
                 globals: {},
@@ -154,7 +154,7 @@ describe("ConfigOps", () => {
         it("should create empty config when an unknown environment is specified", () => {
             const config = ConfigOps.createEnvironmentConfig({ foo: true }, envContext);
 
-            assert.deepEqual(config, {
+            assert.deepStrictEqual(config, {
                 env: {
                     foo: true
                 },
@@ -224,7 +224,7 @@ describe("ConfigOps", () => {
 
             const result = ConfigOps.merge(config[0], config[1]);
 
-            assert.deepEqual(result, {
+            assert.deepStrictEqual(result, {
                 parserOptions: {
                     ecmaFeatures: {
                         blockBindings: true,
@@ -234,8 +234,8 @@ describe("ConfigOps", () => {
             });
 
             // double-check that originals were not changed
-            assert.deepEqual(config[0], { parserOptions: { ecmaFeatures: { blockBindings: true } } });
-            assert.deepEqual(config[1], { parserOptions: { ecmaFeatures: { forOf: true } } });
+            assert.deepStrictEqual(config[0], { parserOptions: { ecmaFeatures: { blockBindings: true } } });
+            assert.deepStrictEqual(config[1], { parserOptions: { ecmaFeatures: { forOf: true } } });
         });
 
         it("should override configs when passed configs with the same ecmaFeatures", () => {
@@ -246,7 +246,7 @@ describe("ConfigOps", () => {
 
             const result = ConfigOps.merge(config[0], config[1]);
 
-            assert.deepEqual(result, {
+            assert.deepStrictEqual(result, {
                 parserOptions: {
                     ecmaFeatures: {
                         forOf: true
@@ -267,8 +267,8 @@ describe("ConfigOps", () => {
             assert.isArray(result.rules["no-mixed-requires"]);
             assert.strictEqual(result.rules["no-mixed-requires"][0], 1);
             assert.strictEqual(result.rules["no-mixed-requires"][1], false);
-            assert.deepEqual(config[0], { rules: { "no-mixed-requires": [0, false] } });
-            assert.deepEqual(config[1], { rules: { "no-mixed-requires": 1 } });
+            assert.deepStrictEqual(config[0], { rules: { "no-mixed-requires": [0, false] } });
+            assert.deepStrictEqual(config[1], { rules: { "no-mixed-requires": 1 } });
         });
 
         it("should combine configs and override rules options completely", () => {
@@ -281,9 +281,9 @@ describe("ConfigOps", () => {
             const result = ConfigOps.merge(config[0], config[1]);
 
             assert.isArray(result.rules["no-mixed-requires"]);
-            assert.deepEqual(result.rules["no-mixed-requires"][1], { err: ["error", "e"] });
-            assert.deepEqual(config[0], { rules: { "no-mixed-requires": [1, { event: ["evt", "e"] }] } });
-            assert.deepEqual(config[1], { rules: { "no-mixed-requires": [1, { err: ["error", "e"] }] } });
+            assert.deepStrictEqual(result.rules["no-mixed-requires"][1], { err: ["error", "e"] });
+            assert.deepStrictEqual(config[0], { rules: { "no-mixed-requires": [1, { event: ["evt", "e"] }] } });
+            assert.deepStrictEqual(config[1], { rules: { "no-mixed-requires": [1, { err: ["error", "e"] }] } });
         });
 
         it("should combine configs and override rules options without array or object", () => {
@@ -298,8 +298,8 @@ describe("ConfigOps", () => {
             assert.strictEqual(result.rules["no-mixed-requires"][0], 2);
             assert.strictEqual(result.rules["no-mixed-requires"][1], "requirejs");
             assert.isUndefined(result.rules["no-mixed-requires"][2]);
-            assert.deepEqual(config[0], { rules: { "no-mixed-requires": ["warn", "nconf", "underscore"] } });
-            assert.deepEqual(config[1], { rules: { "no-mixed-requires": [2, "requirejs"] } });
+            assert.deepStrictEqual(config[0], { rules: { "no-mixed-requires": ["warn", "nconf", "underscore"] } });
+            assert.deepStrictEqual(config[1], { rules: { "no-mixed-requires": [2, "requirejs"] } });
         });
 
         it("should combine configs and override rules options without array or object but special case", () => {
@@ -314,8 +314,8 @@ describe("ConfigOps", () => {
             assert.strictEqual(result.rules["no-mixed-requires"][0], "error");
             assert.strictEqual(result.rules["no-mixed-requires"][1], "nconf");
             assert.strictEqual(result.rules["no-mixed-requires"][2], "underscore");
-            assert.deepEqual(config[0], { rules: { "no-mixed-requires": [1, "nconf", "underscore"] } });
-            assert.deepEqual(config[1], { rules: { "no-mixed-requires": "error" } });
+            assert.deepStrictEqual(config[0], { rules: { "no-mixed-requires": [1, "nconf", "underscore"] } });
+            assert.deepStrictEqual(config[1], { rules: { "no-mixed-requires": "error" } });
         });
 
         it("should combine extends correctly", () => {
@@ -364,7 +364,7 @@ describe("ConfigOps", () => {
 
             const result = ConfigOps.merge(config[0], config[1]);
 
-            assert.deepEqual(result, {
+            assert.deepStrictEqual(result, {
                 parserOptions: {
                     ecmaFeatures: {
                         blockBindings: true,
@@ -399,7 +399,7 @@ describe("ConfigOps", () => {
                     "valid-jsdoc": 2
                 }
             });
-            assert.deepEqual(config[0], {
+            assert.deepStrictEqual(config[0], {
                 rules: {
                     "no-mixed-requires": [1, { event: ["evt", "e"] }],
                     "valid-jsdoc": 1,
@@ -413,7 +413,7 @@ describe("ConfigOps", () => {
                 env: { browser: true },
                 globals: { foo: false }
             });
-            assert.deepEqual(config[1], {
+            assert.deepStrictEqual(config[1], {
                 rules: {
                     "no-mixed-requires": [1, { err: ["error", "e"] }],
                     "valid-jsdoc": 2,
@@ -455,9 +455,9 @@ describe("ConfigOps", () => {
                     expectedResult = { plugins: ["foo", "bar", "baz"] },
                     result = ConfigOps.merge(baseConfig, customConfig);
 
-                assert.deepEqual(result, expectedResult);
-                assert.deepEqual(baseConfig, { plugins: ["foo", "bar"] });
-                assert.deepEqual(customConfig, { plugins: ["baz"] });
+                assert.deepStrictEqual(result, expectedResult);
+                assert.deepStrictEqual(baseConfig, { plugins: ["foo", "bar"] });
+                assert.deepStrictEqual(customConfig, { plugins: ["baz"] });
             });
 
             it("should avoid duplicate plugin entries when each config has the same plugin", () => {
@@ -465,14 +465,14 @@ describe("ConfigOps", () => {
                     expectedResult = { plugins: ["foo", "bar"] },
                     result = ConfigOps.merge(baseConfig, customConfig);
 
-                assert.deepEqual(result, expectedResult);
+                assert.deepStrictEqual(result, expectedResult);
             });
 
             it("should create a valid config when one argument is an empty object", () => {
                 const customConfig = { plugins: ["foo"] },
                     result = ConfigOps.merge({}, customConfig);
 
-                assert.deepEqual(result, customConfig);
+                assert.deepStrictEqual(result, customConfig);
                 assert.notStrictEqual(result, customConfig);
             });
         });
@@ -490,7 +490,7 @@ describe("ConfigOps", () => {
 
                 const result = ConfigOps.merge(baseConfig, customConfig);
 
-                assert.deepEqual(result, expectedResult);
+                assert.deepStrictEqual(result, expectedResult);
             });
 
             it("should work if the base config doesn’t have an overrides property", () => {
@@ -504,7 +504,7 @@ describe("ConfigOps", () => {
 
                 const result = ConfigOps.merge(baseConfig, customConfig);
 
-                assert.deepEqual(result, expectedResult);
+                assert.deepStrictEqual(result, expectedResult);
             });
 
             it("should work if the custom config doesn’t have an overrides property", () => {
@@ -518,7 +518,7 @@ describe("ConfigOps", () => {
 
                 const result = ConfigOps.merge(baseConfig, customConfig);
 
-                assert.deepEqual(result, expectedResult);
+                assert.deepStrictEqual(result, expectedResult);
             });
 
             it("should work if overrides are null in the base config", () => {
@@ -532,7 +532,7 @@ describe("ConfigOps", () => {
 
                 const result = ConfigOps.merge(baseConfig, customConfig);
 
-                assert.deepEqual(result, expectedResult);
+                assert.deepStrictEqual(result, expectedResult);
             });
 
             it("should work if overrides are null in the custom config", () => {
@@ -546,7 +546,7 @@ describe("ConfigOps", () => {
 
                 const result = ConfigOps.merge(baseConfig, customConfig);
 
-                assert.deepEqual(result, expectedResult);
+                assert.deepStrictEqual(result, expectedResult);
             });
         });
     });
@@ -594,7 +594,7 @@ describe("ConfigOps", () => {
 
             ConfigOps.normalizeToStrings(config);
 
-            assert.deepEqual(config, {
+            assert.deepStrictEqual(config, {
                 rules: {
                     foo: "error",
                     bar: "error"
@@ -612,7 +612,7 @@ describe("ConfigOps", () => {
 
             ConfigOps.normalizeToStrings(config);
 
-            assert.deepEqual(config, {
+            assert.deepStrictEqual(config, {
                 rules: {
                     foo: ["error", "something"],
                     bar: "error"
@@ -630,7 +630,7 @@ describe("ConfigOps", () => {
 
             ConfigOps.normalizeToStrings(config);
 
-            assert.deepEqual(config, {
+            assert.deepStrictEqual(config, {
                 rules: {
                     foo: "warn",
                     bar: "warn"
@@ -648,7 +648,7 @@ describe("ConfigOps", () => {
 
             ConfigOps.normalizeToStrings(config);
 
-            assert.deepEqual(config, {
+            assert.deepStrictEqual(config, {
                 rules: {
                     foo: ["warn", "something"],
                     bar: "warn"
@@ -666,7 +666,7 @@ describe("ConfigOps", () => {
 
             ConfigOps.normalizeToStrings(config);
 
-            assert.deepEqual(config, {
+            assert.deepStrictEqual(config, {
                 rules: {
                     foo: "off",
                     bar: "off"
@@ -684,7 +684,7 @@ describe("ConfigOps", () => {
 
             ConfigOps.normalizeToStrings(config);
 
-            assert.deepEqual(config, {
+            assert.deepStrictEqual(config, {
                 rules: {
                     foo: ["off", "something"],
                     bar: "off"
@@ -702,7 +702,7 @@ describe("ConfigOps", () => {
 
             ConfigOps.normalizeToStrings(config);
 
-            assert.deepEqual(config, {
+            assert.deepStrictEqual(config, {
                 rules: {
                     foo: "off",
                     bar: "off"
@@ -720,7 +720,7 @@ describe("ConfigOps", () => {
 
             ConfigOps.normalizeToStrings(config);
 
-            assert.deepEqual(config, {
+            assert.deepStrictEqual(config, {
                 rules: {
                     foo: ["off", "something"],
                     bar: "off"
@@ -771,7 +771,7 @@ describe("ConfigOps", () => {
 
             const result = ConfigOps.getConfigFromVector(vector, configCache);
 
-            assert.deepEqual(result, merged);
+            assert.deepStrictEqual(result, merged);
         });
 
         it("should get from raw cached configs when no merged vectors are cached", () => {

--- a/tests/lib/config/config-ops.js
+++ b/tests/lib/config/config-ops.js
@@ -56,7 +56,7 @@ describe("ConfigOps", () => {
 
             const result = ConfigOps.applyEnvironments(config, envContext);
 
-            assert.equal(result, config);
+            assert.strictEqual(result, config);
         });
 
         it("should apply multiple environment settings to config without destroying original settings", () => {
@@ -176,7 +176,7 @@ describe("ConfigOps", () => {
 
             const result = ConfigOps.merge(config[0], config[1]);
 
-            assert.equal(result.globals.foo, "bar");
+            assert.strictEqual(result.globals.foo, "bar");
             assert.isTrue(result.env.browser);
         });
 
@@ -188,7 +188,7 @@ describe("ConfigOps", () => {
 
             const result = ConfigOps.merge(config[0], config[1]);
 
-            assert.equal(result.env.node, null);
+            assert.strictEqual(result.env.node, null);
             assert.isTrue(result.env.browser);
         });
 
@@ -200,7 +200,7 @@ describe("ConfigOps", () => {
 
             const result = ConfigOps.merge(config[0], config[1]);
 
-            assert.equal(result.parser, "espree");
+            assert.strictEqual(result.parser, "espree");
         });
 
         it("should combine configs and override rules when passed configs with the same rules", () => {
@@ -212,8 +212,8 @@ describe("ConfigOps", () => {
             const result = ConfigOps.merge(config[0], config[1]);
 
             assert.isArray(result.rules["no-mixed-requires"]);
-            assert.equal(result.rules["no-mixed-requires"][0], 1);
-            assert.equal(result.rules["no-mixed-requires"][1], true);
+            assert.strictEqual(result.rules["no-mixed-requires"][0], 1);
+            assert.strictEqual(result.rules["no-mixed-requires"][1], true);
         });
 
         it("should combine configs when passed configs with parserOptions", () => {
@@ -265,8 +265,8 @@ describe("ConfigOps", () => {
             const result = ConfigOps.merge(config[0], config[1]);
 
             assert.isArray(result.rules["no-mixed-requires"]);
-            assert.equal(result.rules["no-mixed-requires"][0], 1);
-            assert.equal(result.rules["no-mixed-requires"][1], false);
+            assert.strictEqual(result.rules["no-mixed-requires"][0], 1);
+            assert.strictEqual(result.rules["no-mixed-requires"][1], false);
             assert.deepEqual(config[0], { rules: { "no-mixed-requires": [0, false] } });
             assert.deepEqual(config[1], { rules: { "no-mixed-requires": 1 } });
         });
@@ -473,7 +473,7 @@ describe("ConfigOps", () => {
                     result = ConfigOps.merge({}, customConfig);
 
                 assert.deepEqual(result, customConfig);
-                assert.notEqual(result, customConfig);
+                assert.notStrictEqual(result, customConfig);
             });
         });
 
@@ -746,7 +746,7 @@ describe("ConfigOps", () => {
             it(`should return ${expected}when passed ${input}`, () => {
                 const result = ConfigOps.isErrorSeverity(input);
 
-                assert.equal(result, expected);
+                assert.strictEqual(result, expected);
             });
 
         });
@@ -802,8 +802,8 @@ describe("ConfigOps", () => {
 
             const result = ConfigOps.getConfigFromVector(vector, configCache);
 
-            assert.equal(result.rules.foo1, "error");
-            assert.equal(result.rules.foo2, "off");
+            assert.strictEqual(result.rules.foo1, "error");
+            assert.strictEqual(result.rules.foo2, "off");
         });
     });
 });

--- a/tests/lib/config/config-rule.js
+++ b/tests/lib/config/config-rule.js
@@ -43,17 +43,17 @@ describe("ConfigRule", () => {
 
             it("should create an array of configs", () => {
                 assert.isArray(actualConfigs);
-                assert.equal(actualConfigs.length, 3);
+                assert.strictEqual(actualConfigs.length, 3);
             });
 
             it("should include the error severity (2) without options as the first config", () => {
-                assert.equal(actualConfigs[0], SEVERITY);
+                assert.strictEqual(actualConfigs[0], SEVERITY);
             });
 
             it("should set all configs to error severity (2)", () => {
                 actualConfigs.forEach(actualConfig => {
                     if (Array.isArray(actualConfig)) {
-                        assert.equal(actualConfig[0], SEVERITY);
+                        assert.strictEqual(actualConfig[0], SEVERITY);
                     }
                 });
             });
@@ -82,7 +82,7 @@ describe("ConfigRule", () => {
             it("should use the object property name from the schema", () => {
                 const propName = "enumProperty";
 
-                assert.equal(actualConfigs.length, 3);
+                assert.strictEqual(actualConfigs.length, 3);
                 actualConfigs.slice(1).forEach(actualConfig => {
                     const actualConfigOption = actualConfig[1];
 
@@ -112,7 +112,7 @@ describe("ConfigRule", () => {
             it("should create configs for all properties in each config", () => {
                 const expectedProperties = ["firstEnum", "anotherEnum"];
 
-                assert.equal(actualConfigs.length, 7);
+                assert.strictEqual(actualConfigs.length, 7);
                 actualConfigs.slice(1).forEach(actualConfig => {
                     const configOption = actualConfig[1];
                     const actualProperties = Object.keys(configOption);
@@ -144,7 +144,7 @@ describe("ConfigRule", () => {
             });
 
             it("should return configs with option objects", () => {
-                assert.equal(actualConfigs.length, 3);
+                assert.strictEqual(actualConfigs.length, 3);
                 actualConfigs.slice(1).forEach(actualConfig => {
                     const actualConfigOption = actualConfig[1];
 
@@ -155,7 +155,7 @@ describe("ConfigRule", () => {
             it("should use the object property name from the schema", () => {
                 const propName = "boolProperty";
 
-                assert.equal(actualConfigs.length, 3);
+                assert.strictEqual(actualConfigs.length, 3);
                 actualConfigs.slice(1).forEach(actualConfig => {
                     const actualConfigOption = actualConfig[1];
 
@@ -185,7 +185,7 @@ describe("ConfigRule", () => {
             it("should create configs for all properties in each config", () => {
                 const expectedProperties = ["firstBool", "anotherBool"];
 
-                assert.equal(actualConfigs.length, 5);
+                assert.strictEqual(actualConfigs.length, 5);
                 actualConfigs.slice(1).forEach(config => {
                     const configOption = config[1];
                     const actualProperties = Object.keys(configOption);
@@ -214,15 +214,15 @@ describe("ConfigRule", () => {
             });
 
             it("should create configs with only the enum values", () => {
-                assert.equal(actualConfigs[1].length, 2);
-                assert.equal(actualConfigs[2].length, 2);
+                assert.strictEqual(actualConfigs[1].length, 2);
+                assert.strictEqual(actualConfigs[2].length, 2);
                 const actualOptions = [actualConfigs[1][1], actualConfigs[2][1]];
 
                 assert.sameMembers(actualOptions, ["always", "never"]);
             });
 
             it("should create configs with a string and an object", () => {
-                assert.equal(actualConfigs.length, 7);
+                assert.strictEqual(actualConfigs.length, 7);
                 actualConfigs.slice(3).forEach(config => {
                     assert.isString(config[1]);
                     assert.isObject(config[2]);

--- a/tests/lib/config/config-rule.js
+++ b/tests/lib/config/config-rule.js
@@ -27,12 +27,12 @@ describe("ConfigRule", () => {
 
         it("should create a config with only severity for an empty schema", () => {
             actualConfigs = ConfigRule.generateConfigsFromSchema([]);
-            assert.deepEqual(actualConfigs, [SEVERITY]);
+            assert.deepStrictEqual(actualConfigs, [SEVERITY]);
         });
 
         it("should create a config with only severity with no arguments", () => {
             actualConfigs = ConfigRule.generateConfigsFromSchema();
-            assert.deepEqual(actualConfigs, [SEVERITY]);
+            assert.deepStrictEqual(actualConfigs, [SEVERITY]);
         });
 
         describe("for a single enum schema", () => {

--- a/tests/lib/config/config-validator.js
+++ b/tests/lib/config/config-validator.js
@@ -405,7 +405,7 @@ describe("Validator", () => {
     describe("getRuleOptionsSchema", () => {
 
         it("should return null for a missing rule", () => {
-            assert.equal(validator.getRuleOptionsSchema("non-existent-rule", linter.rules), null);
+            assert.strictEqual(validator.getRuleOptionsSchema("non-existent-rule", linter.rules), null);
         });
 
         it("should not modify object schema", () => {

--- a/tests/lib/config/config-validator.js
+++ b/tests/lib/config/config-validator.js
@@ -410,7 +410,7 @@ describe("Validator", () => {
 
         it("should not modify object schema", () => {
             linter.defineRule("mock-object-rule", mockObjectRule);
-            assert.deepEqual(validator.getRuleOptionsSchema("mock-object-rule", linter.rules), {
+            assert.deepStrictEqual(validator.getRuleOptionsSchema("mock-object-rule", linter.rules), {
                 enum: ["first", "second"]
             });
         });

--- a/tests/lib/config/environments.js
+++ b/tests/lib/config/environments.js
@@ -27,7 +27,7 @@ describe("Environments", () => {
 
         it("should have all default environments loaded", () => {
             Object.keys(envs).forEach(envName => {
-                assert.deepEqual(environments.get(envName), envs[envName]);
+                assert.deepStrictEqual(environments.get(envName), envs[envName]);
             });
         });
     });
@@ -40,7 +40,7 @@ describe("Environments", () => {
 
             const result = environments.get("foo");
 
-            assert.deepEqual(result, env);
+            assert.deepStrictEqual(result, env);
         });
     });
 
@@ -62,8 +62,8 @@ describe("Environments", () => {
             const fooEnv = environments.get("plugin/foo"),
                 barEnv = environments.get("plugin/bar");
 
-            assert.deepEqual(fooEnv, plugin.environments.foo);
-            assert.deepEqual(barEnv, plugin.environments.bar);
+            assert.deepStrictEqual(fooEnv, plugin.environments.foo);
+            assert.deepStrictEqual(barEnv, plugin.environments.bar);
         });
     });
 });

--- a/tests/lib/config/plugins.js
+++ b/tests/lib/config/plugins.js
@@ -74,8 +74,8 @@ describe("Plugins", () => {
 
             StubbedPlugins.load("eslint-plugin-example");
 
-            assert.deepEqual(environments.get("example/foo"), plugin.environments.foo);
-            assert.deepEqual(environments.get("example/bar"), plugin.environments.bar);
+            assert.deepStrictEqual(environments.get("example/foo"), plugin.environments.foo);
+            assert.deepStrictEqual(environments.get("example/bar"), plugin.environments.bar);
         });
 
         it("should register rules when plugin has rules", () => {
@@ -86,8 +86,8 @@ describe("Plugins", () => {
 
             StubbedPlugins.load("eslint-plugin-example");
 
-            assert.deepEqual(rules.get("example/baz"), plugin.rules.baz);
-            assert.deepEqual(rules.get("example/qux"), plugin.rules.qux);
+            assert.deepStrictEqual(rules.get("example/baz"), plugin.rules.baz);
+            assert.deepStrictEqual(rules.get("example/qux"), plugin.rules.qux);
         });
 
         it("should throw an error when a plugin has whitespace", () => {

--- a/tests/lib/config/plugins.js
+++ b/tests/lib/config/plugins.js
@@ -54,12 +54,12 @@ describe("Plugins", () => {
 
         it("should load a plugin when referenced by short name", () => {
             StubbedPlugins.load("example");
-            assert.equal(StubbedPlugins.get("example"), plugin);
+            assert.strictEqual(StubbedPlugins.get("example"), plugin);
         });
 
         it("should load a plugin when referenced by long name", () => {
             StubbedPlugins.load("eslint-plugin-example");
-            assert.equal(StubbedPlugins.get("example"), plugin);
+            assert.strictEqual(StubbedPlugins.get("example"), plugin);
         });
 
         it("should register environments when plugin has environments", () => {
@@ -128,12 +128,12 @@ describe("Plugins", () => {
 
         it("should load a scoped plugin when referenced by short name", () => {
             StubbedPlugins.load("@scope/example");
-            assert.equal(StubbedPlugins.get("@scope/example"), scopedPlugin);
+            assert.strictEqual(StubbedPlugins.get("@scope/example"), scopedPlugin);
         });
 
         it("should load a scoped plugin when referenced by long name", () => {
             StubbedPlugins.load("@scope/eslint-plugin-example");
-            assert.equal(StubbedPlugins.get("@scope/example"), scopedPlugin);
+            assert.strictEqual(StubbedPlugins.get("@scope/example"), scopedPlugin);
         });
 
         it("should register environments when scoped plugin has environments", () => {
@@ -142,7 +142,7 @@ describe("Plugins", () => {
             };
             StubbedPlugins.load("@scope/eslint-plugin-example");
 
-            assert.equal(environments.get("@scope/example/foo"), scopedPlugin.environments.foo);
+            assert.strictEqual(environments.get("@scope/example/foo"), scopedPlugin.environments.foo);
         });
 
         it("should register rules when scoped plugin has rules", () => {
@@ -151,18 +151,18 @@ describe("Plugins", () => {
             };
             StubbedPlugins.load("@scope/eslint-plugin-example");
 
-            assert.equal(rules.get("@scope/example/foo"), scopedPlugin.rules.foo);
+            assert.strictEqual(rules.get("@scope/example/foo"), scopedPlugin.rules.foo);
         });
 
         describe("when referencing a scope plugin and omitting @scope/", () => {
             it("should load a scoped plugin when referenced by short name, but should not get the plugin if '@scope/' is omitted", () => {
                 StubbedPlugins.load("@scope/example");
-                assert.equal(StubbedPlugins.get("example"), null);
+                assert.strictEqual(StubbedPlugins.get("example"), null);
             });
 
             it("should load a scoped plugin when referenced by long name, but should not get the plugin if '@scope/' is omitted", () => {
                 StubbedPlugins.load("@scope/eslint-plugin-example");
-                assert.equal(StubbedPlugins.get("example"), null);
+                assert.strictEqual(StubbedPlugins.get("example"), null);
             });
 
             it("should register environments when scoped plugin has environments, but should not get the environment if '@scope/' is omitted", () => {
@@ -171,7 +171,7 @@ describe("Plugins", () => {
                 };
                 StubbedPlugins.load("@scope/eslint-plugin-example");
 
-                assert.equal(environments.get("example/foo"), null);
+                assert.strictEqual(environments.get("example/foo"), null);
             });
 
             it("should register rules when scoped plugin has rules, but should not get the rule if '@scope/' is omitted", () => {
@@ -204,8 +204,8 @@ describe("Plugins", () => {
 
         it("should load plugins when passed multiple plugins", () => {
             StubbedPlugins.loadAll(["example1", "example2"]);
-            assert.equal(StubbedPlugins.get("example1"), plugin1);
-            assert.equal(StubbedPlugins.get("example2"), plugin2);
+            assert.strictEqual(StubbedPlugins.get("example1"), plugin1);
+            assert.strictEqual(StubbedPlugins.get("example2"), plugin2);
         });
 
         it("should load environments from plugins when passed multiple plugins", () => {
@@ -218,8 +218,8 @@ describe("Plugins", () => {
             };
 
             StubbedPlugins.loadAll(["example1", "example2"]);
-            assert.equal(environments.get("example1/foo"), plugin1.environments.foo);
-            assert.equal(environments.get("example2/bar"), plugin2.environments.bar);
+            assert.strictEqual(environments.get("example1/foo"), plugin1.environments.foo);
+            assert.strictEqual(environments.get("example2/bar"), plugin2.environments.bar);
         });
 
         it("should load rules from plugins when passed multiple plugins", () => {
@@ -232,8 +232,8 @@ describe("Plugins", () => {
             };
 
             StubbedPlugins.loadAll(["example1", "example2"]);
-            assert.equal(rules.get("example1/foo"), plugin1.rules.foo);
-            assert.equal(rules.get("example2/bar"), plugin2.rules.bar);
+            assert.strictEqual(rules.get("example1/foo"), plugin1.rules.foo);
+            assert.strictEqual(rules.get("example2/bar"), plugin2.rules.bar);
         });
 
         it("should throw an error if plugins is not an array", () => {
@@ -246,13 +246,13 @@ describe("Plugins", () => {
         it("should remove common prefix when passed a plugin name  with a prefix", () => {
             const pluginName = Plugins.removePrefix("eslint-plugin-test");
 
-            assert.equal(pluginName, "test");
+            assert.strictEqual(pluginName, "test");
         });
 
         it("should not modify plugin name when passed a plugin name without a prefix", () => {
             const pluginName = Plugins.removePrefix("test");
 
-            assert.equal(pluginName, "test");
+            assert.strictEqual(pluginName, "test");
         });
     });
 
@@ -260,7 +260,7 @@ describe("Plugins", () => {
         it("should remove namepace when passed with namepace", () => {
             const namespace = Plugins.getNamespace("@namepace/eslint-plugin-test");
 
-            assert.equal(namespace, "@namepace/");
+            assert.strictEqual(namespace, "@namepace/");
         });
     });
 
@@ -268,7 +268,7 @@ describe("Plugins", () => {
         it("should remove namepace when passed with namepace", () => {
             const namespace = Plugins.removeNamespace("@namepace/eslint-plugin-test");
 
-            assert.equal(namespace, "eslint-plugin-test");
+            assert.strictEqual(namespace, "eslint-plugin-test");
         });
     });
 

--- a/tests/lib/file-finder.js
+++ b/tests/lib/file-finder.js
@@ -39,7 +39,7 @@ describe("FileFinder", () => {
                 expected = path.join(fileFinderDir, uniqueFileName);
 
                 assert.isArray(actual);
-                assert.equal(actual[0], expected);
+                assert.strictEqual(actual[0], expected);
             });
         });
 
@@ -51,7 +51,7 @@ describe("FileFinder", () => {
                 expected = path.join(fileFinderDir, "subdir", uniqueFileName);
 
                 assert.isArray(actual);
-                assert.equal(actual[0], expected);
+                assert.strictEqual(actual[0], expected);
             });
         });
 
@@ -63,7 +63,7 @@ describe("FileFinder", () => {
                 expected = path.join(fileFinderDir, "subdir", uniqueFileName);
 
                 assert.isArray(actual);
-                assert.equal(actual[0], expected);
+                assert.strictEqual(actual[0], expected);
             });
         });
 
@@ -76,9 +76,9 @@ describe("FileFinder", () => {
                 finder = new FileFinder(["empty", uniqueFileName], process.cwd());
                 actual = Array.from(finder.findAllInDirectoryAndParents(subdir));
 
-                assert.equal(actual.length, 2);
-                assert.equal(actual[0], firstExpected);
-                assert.equal(actual[1], secondExpected);
+                assert.strictEqual(actual.length, 2);
+                assert.strictEqual(actual[0], firstExpected);
+                assert.strictEqual(actual[1], secondExpected);
             });
 
             it("should return the second file when the first is missing", () => {
@@ -88,9 +88,9 @@ describe("FileFinder", () => {
                 finder = new FileFinder(["notreal", uniqueFileName], process.cwd());
                 actual = Array.from(finder.findAllInDirectoryAndParents(subdir));
 
-                assert.equal(actual.length, 2);
-                assert.equal(actual[0], firstExpected);
-                assert.equal(actual[1], secondExpected);
+                assert.strictEqual(actual.length, 2);
+                assert.strictEqual(actual[0], firstExpected);
+                assert.strictEqual(actual[1], secondExpected);
             });
 
             it("should return multiple files when the first is missing and more than one filename is requested", () => {
@@ -100,9 +100,9 @@ describe("FileFinder", () => {
                 finder = new FileFinder(["notreal", uniqueFileName, "empty2"], process.cwd());
                 actual = Array.from(finder.findAllInDirectoryAndParents(subdir));
 
-                assert.equal(actual.length, 2);
-                assert.equal(actual[0], firstExpected);
-                assert.equal(actual[1], secondExpected);
+                assert.strictEqual(actual.length, 2);
+                assert.strictEqual(actual[0], firstExpected);
+                assert.strictEqual(actual[1], secondExpected);
             });
 
         });
@@ -119,20 +119,20 @@ describe("FileFinder", () => {
                 actual = Array.from(finder.findAllInDirectoryAndParents(subsubsubdir));
 
                 assert.isArray(actual);
-                assert.equal(actual[0], firstExpected);
-                assert.equal(actual[1], secondExpected);
+                assert.strictEqual(actual[0], firstExpected);
+                assert.strictEqual(actual[1], secondExpected);
             });
 
             it("should be in the cache after they have been found", () => {
 
-                assert.equal(finder.cache[subsubsubdir][0], firstExpected);
-                assert.equal(finder.cache[subsubsubdir][1], secondExpected);
-                assert.equal(finder.cache[subsubdir][0], firstExpected);
-                assert.equal(finder.cache[subsubdir][1], secondExpected);
-                assert.equal(finder.cache[subdir][0], firstExpected);
-                assert.equal(finder.cache[subdir][1], secondExpected);
-                assert.equal(finder.cache[fileFinderDir][0], secondExpected);
-                assert.equal(finder.cache[fileFinderDir][1], void 0);
+                assert.strictEqual(finder.cache[subsubsubdir][0], firstExpected);
+                assert.strictEqual(finder.cache[subsubsubdir][1], secondExpected);
+                assert.strictEqual(finder.cache[subsubdir][0], firstExpected);
+                assert.strictEqual(finder.cache[subsubdir][1], secondExpected);
+                assert.strictEqual(finder.cache[subdir][0], firstExpected);
+                assert.strictEqual(finder.cache[subdir][1], secondExpected);
+                assert.strictEqual(finder.cache[fileFinderDir][0], secondExpected);
+                assert.strictEqual(finder.cache[fileFinderDir][1], void 0);
             });
         });
 
@@ -170,7 +170,7 @@ describe("FileFinder", () => {
                  */
                 actual = actual.filter(file => (file || "").indexOf(process.cwd()) === 0);
 
-                assert.equal(actual, expected);
+                assert.deepEqual(actual, [expected]);
             });
         });
     });

--- a/tests/lib/file-finder.js
+++ b/tests/lib/file-finder.js
@@ -170,7 +170,7 @@ describe("FileFinder", () => {
                  */
                 actual = actual.filter(file => (file || "").indexOf(process.cwd()) === 0);
 
-                assert.deepEqual(actual, [expected]);
+                assert.deepStrictEqual(actual, [expected]);
             });
         });
     });

--- a/tests/lib/formatters/checkstyle.js
+++ b/tests/lib/formatters/checkstyle.js
@@ -32,14 +32,14 @@ describe("formatter:checkstyle", () => {
         it("should return a string in the format filename: line x, col y, Error - z for errors", () => {
             const result = formatter(code);
 
-            assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"foo.js\"><error line=\"5\" column=\"10\" severity=\"error\" message=\"Unexpected foo. (foo)\" source=\"eslint.rules.foo\" /></file></checkstyle>");
+            assert.strictEqual(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"foo.js\"><error line=\"5\" column=\"10\" severity=\"error\" message=\"Unexpected foo. (foo)\" source=\"eslint.rules.foo\" /></file></checkstyle>");
         });
 
         it("should return a string in the format filename: line x, col y, Warning - z for warnings", () => {
             code[0].messages[0].severity = 1;
             const result = formatter(code);
 
-            assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"foo.js\"><error line=\"5\" column=\"10\" severity=\"warning\" message=\"Unexpected foo. (foo)\" source=\"eslint.rules.foo\" /></file></checkstyle>");
+            assert.strictEqual(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"foo.js\"><error line=\"5\" column=\"10\" severity=\"warning\" message=\"Unexpected foo. (foo)\" source=\"eslint.rules.foo\" /></file></checkstyle>");
         });
     });
 
@@ -58,7 +58,7 @@ describe("formatter:checkstyle", () => {
         it("should return a string in the format filename: line x, col y, Error - z", () => {
             const result = formatter(code);
 
-            assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"&lt;&gt;&amp;&quot;&apos;.js\"><error line=\"&lt;\" column=\"&gt;\" severity=\"error\" message=\"Unexpected &lt;&gt;&amp;&quot;&apos;&#8;&#9;&#10;&#12;&#13;&#29275;&#36924;. (foo)\" source=\"eslint.rules.foo\" /></file></checkstyle>");
+            assert.strictEqual(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"&lt;&gt;&amp;&quot;&apos;.js\"><error line=\"&lt;\" column=\"&gt;\" severity=\"error\" message=\"Unexpected &lt;&gt;&amp;&quot;&apos;&#8;&#9;&#10;&#12;&#13;&#29275;&#36924;. (foo)\" source=\"eslint.rules.foo\" /></file></checkstyle>");
         });
     });
 
@@ -77,7 +77,7 @@ describe("formatter:checkstyle", () => {
         it("should return a string in the format filename: line x, col y, Error - z", () => {
             const result = formatter(code);
 
-            assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"foo.js\"><error line=\"5\" column=\"10\" severity=\"error\" message=\"Unexpected foo. (foo)\" source=\"eslint.rules.foo\" /></file></checkstyle>");
+            assert.strictEqual(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"foo.js\"><error line=\"5\" column=\"10\" severity=\"error\" message=\"Unexpected foo. (foo)\" source=\"eslint.rules.foo\" /></file></checkstyle>");
         });
     });
 
@@ -102,7 +102,7 @@ describe("formatter:checkstyle", () => {
         it("should return a string with multiple entries", () => {
             const result = formatter(code);
 
-            assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"foo.js\"><error line=\"5\" column=\"10\" severity=\"error\" message=\"Unexpected foo. (foo)\" source=\"eslint.rules.foo\" /><error line=\"6\" column=\"11\" severity=\"warning\" message=\"Unexpected bar. (bar)\" source=\"eslint.rules.bar\" /></file></checkstyle>");
+            assert.strictEqual(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"foo.js\"><error line=\"5\" column=\"10\" severity=\"error\" message=\"Unexpected foo. (foo)\" source=\"eslint.rules.foo\" /><error line=\"6\" column=\"11\" severity=\"warning\" message=\"Unexpected bar. (bar)\" source=\"eslint.rules.bar\" /></file></checkstyle>");
         });
     });
 
@@ -130,7 +130,7 @@ describe("formatter:checkstyle", () => {
         it("should return a string with multiple entries", () => {
             const result = formatter(code);
 
-            assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"foo.js\"><error line=\"5\" column=\"10\" severity=\"error\" message=\"Unexpected foo. (foo)\" source=\"eslint.rules.foo\" /></file><file name=\"bar.js\"><error line=\"6\" column=\"11\" severity=\"warning\" message=\"Unexpected bar. (bar)\" source=\"eslint.rules.bar\" /></file></checkstyle>");
+            assert.strictEqual(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"foo.js\"><error line=\"5\" column=\"10\" severity=\"error\" message=\"Unexpected foo. (foo)\" source=\"eslint.rules.foo\" /></file><file name=\"bar.js\"><error line=\"6\" column=\"11\" severity=\"warning\" message=\"Unexpected bar. (bar)\" source=\"eslint.rules.bar\" /></file></checkstyle>");
         });
     });
 
@@ -148,7 +148,7 @@ describe("formatter:checkstyle", () => {
         it("should return a string in the format filename: line x, col y, Error - z for errors", () => {
             const result = formatter(code);
 
-            assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"foo.js\"><error line=\"5\" column=\"10\" severity=\"error\" message=\"Unexpected foo.\" source=\"\" /></file></checkstyle>");
+            assert.strictEqual(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"foo.js\"><error line=\"5\" column=\"10\" severity=\"error\" message=\"Unexpected foo.\" source=\"\" /></file></checkstyle>");
         });
     });
 });

--- a/tests/lib/formatters/codeframe.js
+++ b/tests/lib/formatters/codeframe.js
@@ -63,7 +63,7 @@ describe("formatter:codeframe", () => {
         it("should return nothing", () => {
             const result = formatter(code);
 
-            assert.equal(result, "");
+            assert.strictEqual(result, "");
         });
     });
 
@@ -87,7 +87,7 @@ describe("formatter:codeframe", () => {
         it("should return a string in the correct format for warnings", () => {
             const result = formatter(code);
 
-            assert.equal(stripAnsi(result), [
+            assert.strictEqual(stripAnsi(result), [
                 `warning: Unexpected foo (foo) at ${path.join("lib", "foo.js")}:1:5:`,
                 "> 1 | var foo = 1;",
                 "    |     ^",
@@ -104,8 +104,8 @@ describe("formatter:codeframe", () => {
 
             formatter(code);
 
-            assert.equal(chalkStub.yellow.bold.callCount, 1);
-            assert.equal(chalkStub.red.bold.callCount, 0);
+            assert.strictEqual(chalkStub.yellow.bold.callCount, 1);
+            assert.strictEqual(chalkStub.red.bold.callCount, 0);
         });
 
         describe("when the warning is fixable", () => {
@@ -116,7 +116,7 @@ describe("formatter:codeframe", () => {
             it("should return a string in the correct format", () => {
                 const result = formatter(code);
 
-                assert.equal(stripAnsi(result), [
+                assert.strictEqual(stripAnsi(result), [
                     `warning: Unexpected foo (foo) at ${path.join("lib", "foo.js")}:1:5:`,
                     "> 1 | var foo = 1;",
                     "    |     ^",
@@ -148,7 +148,7 @@ describe("formatter:codeframe", () => {
         it("should return a string in the correct format for errors", () => {
             const result = formatter(code);
 
-            assert.equal(stripAnsi(result), [
+            assert.strictEqual(stripAnsi(result), [
                 `error: Unexpected foo (foo) at ${path.join("lib", "foo.js")}:1:5:`,
                 "> 1 | var foo = 1;",
                 "    |     ^",
@@ -165,8 +165,8 @@ describe("formatter:codeframe", () => {
 
             formatter(code);
 
-            assert.equal(chalkStub.yellow.bold.callCount, 0);
-            assert.equal(chalkStub.red.bold.callCount, 1);
+            assert.strictEqual(chalkStub.yellow.bold.callCount, 0);
+            assert.strictEqual(chalkStub.red.bold.callCount, 1);
         });
     });
 
@@ -186,7 +186,7 @@ describe("formatter:codeframe", () => {
         it("should return a string in the correct format (retaining the ' .')", () => {
             const result = formatter(code);
 
-            assert.equal(stripAnsi(result), "error: Unexpected . (foo) at foo.js\n\n\n1 error found.");
+            assert.strictEqual(stripAnsi(result), "error: Unexpected . (foo) at foo.js\n\n\n1 error found.");
         });
     });
 
@@ -214,7 +214,7 @@ describe("formatter:codeframe", () => {
         it("should return a string with multiple entries", () => {
             const result = formatter(code);
 
-            assert.equal(stripAnsi(result), [
+            assert.strictEqual(stripAnsi(result), [
                 "error: Missing semicolon (semi) at foo.js:1:14:",
                 "> 1 | const foo = 1",
                 "    |              ^",
@@ -238,8 +238,8 @@ describe("formatter:codeframe", () => {
 
             formatter(code);
 
-            assert.equal(chalkStub.yellow.bold.callCount, 0);
-            assert.equal(chalkStub.red.bold.callCount, 1);
+            assert.strictEqual(chalkStub.yellow.bold.callCount, 0);
+            assert.strictEqual(chalkStub.red.bold.callCount, 1);
         });
     });
 
@@ -262,7 +262,7 @@ describe("formatter:codeframe", () => {
         it("should return a string with code preview pointing to the correct location after fixes", () => {
             const result = formatter(code);
 
-            assert.equal(stripAnsi(result), [
+            assert.strictEqual(stripAnsi(result), [
                 "error: 'foo' is assigned a value but never used (no-unused-vars) at foo.js:4:11:",
                 "  2 | ",
                 "  3 |     // a comment",
@@ -307,7 +307,7 @@ describe("formatter:codeframe", () => {
         it("should return a string with multiple entries", () => {
             const result = formatter(code);
 
-            assert.equal(stripAnsi(result), [
+            assert.strictEqual(stripAnsi(result), [
                 "error: Missing semicolon (semi) at foo.js:1:14:",
                 "> 1 | const foo = 1",
                 "    |              ^",
@@ -343,7 +343,7 @@ describe("formatter:codeframe", () => {
         it("should return a string in the correct format", () => {
             const result = formatter(code);
 
-            assert.equal(stripAnsi(result), [
+            assert.strictEqual(stripAnsi(result), [
                 "error: Parsing error: Unexpected token { at foo.js:1:2:",
                 "> 1 | e{}",
                 "    |  ^",
@@ -368,7 +368,7 @@ describe("formatter:codeframe", () => {
         it("should return a string without code preview (codeframe)", () => {
             const result = formatter(code);
 
-            assert.equal(stripAnsi(result), "error: Couldn't find foo.js at foo.js\n\n\n1 error found.");
+            assert.strictEqual(stripAnsi(result), "error: Couldn't find foo.js at foo.js\n\n\n1 error found.");
         });
     });
 
@@ -388,13 +388,13 @@ describe("formatter:codeframe", () => {
         it("should return a string without code preview (codeframe)", () => {
             const result = formatter(code);
 
-            assert.equal(stripAnsi(result), "error: Unexpected foo (foo) at foo.js\n\n\n1 error found.");
+            assert.strictEqual(stripAnsi(result), "error: Unexpected foo (foo) at foo.js\n\n\n1 error found.");
         });
 
         it("should output filepath but without 'line:column' appended", () => {
             const result = formatter(code);
 
-            assert.equal(stripAnsi(result), "error: Unexpected foo (foo) at foo.js\n\n\n1 error found.");
+            assert.strictEqual(stripAnsi(result), "error: Unexpected foo (foo) at foo.js\n\n\n1 error found.");
         });
     });
 

--- a/tests/lib/formatters/compact.js
+++ b/tests/lib/formatters/compact.js
@@ -26,7 +26,7 @@ describe("formatter:compact", () => {
         it("should return nothing", () => {
             const result = formatter(code);
 
-            assert.equal(result, "");
+            assert.strictEqual(result, "");
         });
     });
 
@@ -45,14 +45,14 @@ describe("formatter:compact", () => {
         it("should return a string in the format filename: line x, col y, Error - z for errors", () => {
             const result = formatter(code);
 
-            assert.equal(result, "foo.js: line 5, col 10, Error - Unexpected foo. (foo)\n\n1 problem");
+            assert.strictEqual(result, "foo.js: line 5, col 10, Error - Unexpected foo. (foo)\n\n1 problem");
         });
 
         it("should return a string in the format filename: line x, col y, Warning - z for warnings", () => {
             code[0].messages[0].severity = 1;
             const result = formatter(code);
 
-            assert.equal(result, "foo.js: line 5, col 10, Warning - Unexpected foo. (foo)\n\n1 problem");
+            assert.strictEqual(result, "foo.js: line 5, col 10, Warning - Unexpected foo. (foo)\n\n1 problem");
         });
     });
 
@@ -71,7 +71,7 @@ describe("formatter:compact", () => {
         it("should return a string in the format filename: line x, col y, Error - z", () => {
             const result = formatter(code);
 
-            assert.equal(result, "foo.js: line 5, col 10, Error - Unexpected foo. (foo)\n\n1 problem");
+            assert.strictEqual(result, "foo.js: line 5, col 10, Error - Unexpected foo. (foo)\n\n1 problem");
         });
     });
 
@@ -96,7 +96,7 @@ describe("formatter:compact", () => {
         it("should return a string with multiple entries", () => {
             const result = formatter(code);
 
-            assert.equal(result, "foo.js: line 5, col 10, Error - Unexpected foo. (foo)\nfoo.js: line 6, col 11, Warning - Unexpected bar. (bar)\n\n2 problems");
+            assert.strictEqual(result, "foo.js: line 5, col 10, Error - Unexpected foo. (foo)\nfoo.js: line 6, col 11, Warning - Unexpected bar. (bar)\n\n2 problems");
         });
     });
 
@@ -124,7 +124,7 @@ describe("formatter:compact", () => {
         it("should return a string with multiple entries", () => {
             const result = formatter(code);
 
-            assert.equal(result, "foo.js: line 5, col 10, Error - Unexpected foo. (foo)\nbar.js: line 6, col 11, Warning - Unexpected bar. (bar)\n\n2 problems");
+            assert.strictEqual(result, "foo.js: line 5, col 10, Error - Unexpected foo. (foo)\nbar.js: line 6, col 11, Warning - Unexpected bar. (bar)\n\n2 problems");
         });
     });
 
@@ -140,7 +140,7 @@ describe("formatter:compact", () => {
         it("should return a string without line and column", () => {
             const result = formatter(code);
 
-            assert.equal(result, "foo.js: line 0, col 0, Error - Couldn't find foo.js.\n\n1 problem");
+            assert.strictEqual(result, "foo.js: line 0, col 0, Error - Couldn't find foo.js.\n\n1 problem");
         });
     });
 });

--- a/tests/lib/formatters/html.js
+++ b/tests/lib/formatters/html.js
@@ -25,7 +25,7 @@ const cheerio = require("cheerio");
  */
 function checkOverview($, args) {
     assert($("#overview").hasClass(args.bgColor), "Check if color is correct");
-    assert.equal($("#overview span").text(), args.problems, "Check if correct problem totals");
+    assert.strictEqual($("#overview span").text(), args.problems, "Check if correct problem totals");
 }
 
 /**
@@ -38,9 +38,9 @@ function checkOverview($, args) {
 function checkHeaderRow($, row, args) {
     row = $(row);
     assert(row.hasClass(args.bgColor), "Check that background color is correct");
-    assert.equal(row.attr("data-group"), args.group, "Check that header group is correct");
-    assert.equal(row.find("th span").text(), args.problems, "Check if correct totals");
-    assert.equal(row.find("th").html().trim().match(/ [^<]*/)[0].trim(), args.file, "Check if correctly displays filePath");
+    assert.strictEqual(row.attr("data-group"), args.group, "Check that header group is correct");
+    assert.strictEqual(row.find("th span").text(), args.problems, "Check if correct totals");
+    assert.strictEqual(row.find("th").html().trim().match(/ [^<]*/)[0].trim(), args.file, "Check if correctly displays filePath");
 }
 
 /**
@@ -53,10 +53,10 @@ function checkHeaderRow($, row, args) {
 function checkContentRow($, row, args) {
     row = $(row);
     assert(row.hasClass(args.group), "Check that linked to correct header");
-    assert.equal($(row.find("td")[0]).text(), args.lineCol, "Check that line:column is correct");
+    assert.strictEqual($(row.find("td")[0]).text(), args.lineCol, "Check that line:column is correct");
     assert($(row.find("td")[1]).hasClass(args.color), "Check that severity color is correct");
-    assert.equal($(row.find("td")[2]).html(), args.message, "Check that message is correct");
-    assert.equal($(row.find("td")[3]).find("a").text(), args.ruleId, "Check that ruleId is correct");
+    assert.strictEqual($(row.find("td")[2]).html(), args.message, "Check that message is correct");
+    assert.strictEqual($(row.find("td")[3]).find("a").text(), args.ruleId, "Check that ruleId is correct");
 }
 
 //------------------------------------------------------------------------------
@@ -88,8 +88,8 @@ describe("formatter:html", () => {
             checkOverview($, { bgColor: "bg-2", problems: "1 problem (1 error, 0 warnings)" });
 
             // Check rows
-            assert.equal($("tr").length, 2, "Check that there are two (1 header, 1 content)");
-            assert.equal($("tr[data-group|=\"f\"]").length, 1, "Check that is 1 header row (implying 1 content row)");
+            assert.strictEqual($("tr").length, 2, "Check that there are two (1 header, 1 content)");
+            assert.strictEqual($("tr[data-group|=\"f\"]").length, 1, "Check that is 1 header row (implying 1 content row)");
             checkHeaderRow($, $("tr")[0], { bgColor: "bg-2", group: "f-0", file: "foo.js", problems: "1 problem (1 error, 0 warnings)" });
             checkContentRow($, $("tr")[1], { group: "f-0", lineCol: "5:10", color: "clr-2", message: "Unexpected foo.", ruleId: "foo" });
         });
@@ -119,8 +119,8 @@ describe("formatter:html", () => {
             checkOverview($, { bgColor: "bg-1", problems: "1 problem (0 errors, 1 warning)" });
 
             // Check rows
-            assert.equal($("tr").length, 2, "Check that there are two (1 header, 1 content)");
-            assert.equal($("tr[data-group|=\"f\"]").length, 1, "Check that is 1 header row (implying 1 content row)");
+            assert.strictEqual($("tr").length, 2, "Check that there are two (1 header, 1 content)");
+            assert.strictEqual($("tr[data-group|=\"f\"]").length, 1, "Check that is 1 header row (implying 1 content row)");
             checkHeaderRow($, $("tr")[0], { bgColor: "bg-1", group: "f-0", file: "foo.js", problems: "1 problem (0 errors, 1 warning)" });
             checkContentRow($, $("tr")[1], { group: "f-0", lineCol: "5:10", color: "clr-1", message: "Unexpected foo.", ruleId: "foo" });
         });
@@ -150,8 +150,8 @@ describe("formatter:html", () => {
             checkOverview($, { bgColor: "bg-2", problems: "1 problem (1 error, 0 warnings)" });
 
             // Check rows
-            assert.equal($("tr").length, 2, "Check that there are two (1 header, 1 content)");
-            assert.equal($("tr[data-group|=\"f\"]").length, 1, "Check that is 1 header row (implying 1 content row)");
+            assert.strictEqual($("tr").length, 2, "Check that there are two (1 header, 1 content)");
+            assert.strictEqual($("tr[data-group|=\"f\"]").length, 1, "Check that is 1 header row (implying 1 content row)");
             checkHeaderRow($, $("tr")[0], { bgColor: "bg-2", group: "f-0", file: "foo.js", problems: "1 problem (1 error, 0 warnings)" });
             checkContentRow($, $("tr")[1], { group: "f-0", lineCol: "5:10", color: "clr-2", message: "Unexpected foo.", ruleId: "foo" });
         });
@@ -174,7 +174,7 @@ describe("formatter:html", () => {
             checkOverview($, { bgColor: "bg-0", problems: "0 problems" });
 
             // Check rows
-            assert.equal($("tr").length, 1, "Check that there is 1 row (header)");
+            assert.strictEqual($("tr").length, 1, "Check that there is 1 row (header)");
             checkHeaderRow($, $("tr")[0], { bgColor: "bg-0", group: "f-0", file: "foo.js", problems: "0 problems" });
         });
     });
@@ -209,8 +209,8 @@ describe("formatter:html", () => {
             checkOverview($, { bgColor: "bg-2", problems: "2 problems (1 error, 1 warning)" });
 
             // Check rows
-            assert.equal($("tr").length, 3, "Check that there are two (1 header, 2 content)");
-            assert.equal($("tr[data-group|=\"f\"]").length, 1, "Check that is 1 header row (implying 2 content row)");
+            assert.strictEqual($("tr").length, 3, "Check that there are two (1 header, 2 content)");
+            assert.strictEqual($("tr[data-group|=\"f\"]").length, 1, "Check that is 1 header row (implying 2 content row)");
             checkHeaderRow($, $("tr")[0], { bgColor: "bg-2", group: "f-0", file: "foo.js", problems: "2 problems (1 error, 1 warning)" });
             checkContentRow($, $("tr")[1], { group: "f-0", lineCol: "5:10", color: "clr-2", message: "Unexpected foo.", ruleId: "foo" });
             checkContentRow($, $("tr")[2], { group: "f-0", lineCol: "6:11", color: "clr-1", message: "Unexpected bar.", ruleId: "bar" });
@@ -252,8 +252,8 @@ describe("formatter:html", () => {
             checkOverview($, { bgColor: "bg-2", problems: "2 problems (1 error, 1 warning)" });
 
             // Check rows
-            assert.equal($("tr").length, 4, "Check that there are two (2 header, 2 content)");
-            assert.equal($("tr[data-group|=\"f\"]").length, 2, "Check that is 2 header row (implying 2 content row)");
+            assert.strictEqual($("tr").length, 4, "Check that there are two (2 header, 2 content)");
+            assert.strictEqual($("tr[data-group|=\"f\"]").length, 2, "Check that is 2 header row (implying 2 content row)");
             checkHeaderRow($, $("tr")[0], { bgColor: "bg-2", group: "f-0", file: "foo.js", problems: "1 problem (1 error, 0 warnings)" });
             checkContentRow($, $("tr")[1], { group: "f-0", lineCol: "5:10", color: "clr-2", message: "Unexpected foo.", ruleId: "foo" });
             checkHeaderRow($, $("tr")[2], { bgColor: "bg-1", group: "f-1", file: "bar.js", problems: "1 problem (0 errors, 1 warning)" });
@@ -296,8 +296,8 @@ describe("formatter:html", () => {
             checkOverview($, { bgColor: "bg-1", problems: "2 problems (0 errors, 2 warnings)" });
 
             // Check rows
-            assert.equal($("tr").length, 4, "Check that there are two (2 header, 2 content)");
-            assert.equal($("tr[data-group|=\"f\"]").length, 2, "Check that is 2 header row (implying 2 content row)");
+            assert.strictEqual($("tr").length, 4, "Check that there are two (2 header, 2 content)");
+            assert.strictEqual($("tr[data-group|=\"f\"]").length, 2, "Check that is 2 header row (implying 2 content row)");
             checkHeaderRow($, $("tr")[0], { bgColor: "bg-1", group: "f-0", file: "foo.js", problems: "1 problem (0 errors, 1 warning)" });
             checkContentRow($, $("tr")[1], { group: "f-0", lineCol: "5:10", color: "clr-1", message: "Unexpected foo.", ruleId: "foo" });
             checkHeaderRow($, $("tr")[2], { bgColor: "bg-1", group: "f-1", file: "bar.js", problems: "1 problem (0 errors, 1 warning)" });
@@ -346,7 +346,7 @@ describe("formatter:html", () => {
 
     //     it("should return a string in HTML format with 1 issue in 1 file", function() {
     //         var result = formatter(code);
-    //         assert.equal(parseHTML(result), "");
+    //         assert.strictEqual(parseHTML(result), "");
     //     });
     // });
     // */

--- a/tests/lib/formatters/jslint-xml.js
+++ b/tests/lib/formatters/jslint-xml.js
@@ -34,7 +34,7 @@ describe("formatter:jslint-xml", () => {
         it("should return a string in JSLint XML format with 1 issue in 1 file", () => {
             const result = formatter(code);
 
-            assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><jslint><file name=\"foo.js\"><issue line=\"5\" char=\"10\" evidence=\"foo\" reason=\"Unexpected foo. (foo)\" /></file></jslint>");
+            assert.strictEqual(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><jslint><file name=\"foo.js\"><issue line=\"5\" char=\"10\" evidence=\"foo\" reason=\"Unexpected foo. (foo)\" /></file></jslint>");
         });
     });
 
@@ -55,7 +55,7 @@ describe("formatter:jslint-xml", () => {
         it("should return a string in JSLint XML format with 1 issue in 1 file", () => {
             const result = formatter(code);
 
-            assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><jslint><file name=\"foo.js\"><issue line=\"5\" char=\"10\" evidence=\"foo\" reason=\"Unexpected foo. (foo)\" /></file></jslint>");
+            assert.strictEqual(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><jslint><file name=\"foo.js\"><issue line=\"5\" char=\"10\" evidence=\"foo\" reason=\"Unexpected foo. (foo)\" /></file></jslint>");
         });
     });
 
@@ -82,7 +82,7 @@ describe("formatter:jslint-xml", () => {
         it("should return a string in JSLint XML format with 2 issues in 1 file", () => {
             const result = formatter(code);
 
-            assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><jslint><file name=\"foo.js\"><issue line=\"5\" char=\"10\" evidence=\"foo\" reason=\"Unexpected foo. (foo)\" /><issue line=\"6\" char=\"11\" evidence=\"bar\" reason=\"Unexpected bar. (bar)\" /></file></jslint>");
+            assert.strictEqual(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><jslint><file name=\"foo.js\"><issue line=\"5\" char=\"10\" evidence=\"foo\" reason=\"Unexpected foo. (foo)\" /><issue line=\"6\" char=\"11\" evidence=\"bar\" reason=\"Unexpected bar. (bar)\" /></file></jslint>");
         });
     });
 
@@ -112,7 +112,7 @@ describe("formatter:jslint-xml", () => {
         it("should return a string in JSLint XML format with 2 issues in 2 files", () => {
             const result = formatter(code);
 
-            assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><jslint><file name=\"foo.js\"><issue line=\"5\" char=\"10\" evidence=\"foo\" reason=\"Unexpected foo. (foo)\" /></file><file name=\"bar.js\"><issue line=\"6\" char=\"11\" evidence=\"bar\" reason=\"Unexpected bar. (bar)\" /></file></jslint>");
+            assert.strictEqual(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><jslint><file name=\"foo.js\"><issue line=\"5\" char=\"10\" evidence=\"foo\" reason=\"Unexpected foo. (foo)\" /></file><file name=\"bar.js\"><issue line=\"6\" char=\"11\" evidence=\"bar\" reason=\"Unexpected bar. (bar)\" /></file></jslint>");
         });
     });
 
@@ -133,7 +133,7 @@ describe("formatter:jslint-xml", () => {
         it("should return a string in JSLint XML format with 1 issue in 1 file", () => {
             const result = formatter(code);
 
-            assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><jslint><file name=\"foo.js\"><issue line=\"5\" char=\"10\" evidence=\"foo\" reason=\"Unexpected &lt;&amp;&quot;&apos;&gt;&#8;&#9;&#10;&#12;&#13;&#29275;&#36924; foo. (foo)\" /></file></jslint>");
+            assert.strictEqual(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><jslint><file name=\"foo.js\"><issue line=\"5\" char=\"10\" evidence=\"foo\" reason=\"Unexpected &lt;&amp;&quot;&apos;&gt;&#8;&#9;&#10;&#12;&#13;&#29275;&#36924; foo. (foo)\" /></file></jslint>");
         });
     });
 
@@ -153,7 +153,7 @@ describe("formatter:jslint-xml", () => {
         it("should return a string in JSLint XML format with 1 issue in 1 file", () => {
             const result = formatter(code);
 
-            assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><jslint><file name=\"foo.js\"><issue line=\"5\" char=\"10\" evidence=\"\" reason=\"Unexpected foo. (foo)\" /></file></jslint>");
+            assert.strictEqual(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><jslint><file name=\"foo.js\"><issue line=\"5\" char=\"10\" evidence=\"\" reason=\"Unexpected foo. (foo)\" /></file></jslint>");
         });
     });
 
@@ -170,7 +170,7 @@ describe("formatter:jslint-xml", () => {
         it("should return a string in JSLint XML format with 1 issue in 1 file", () => {
             const result = formatter(code);
 
-            assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><jslint><file name=\"foo.js\"><issue line=\"5\" char=\"10\" evidence=\"\" reason=\"\" /></file></jslint>");
+            assert.strictEqual(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><jslint><file name=\"foo.js\"><issue line=\"5\" char=\"10\" evidence=\"\" reason=\"\" /></file></jslint>");
         });
     });
 });

--- a/tests/lib/formatters/json.js
+++ b/tests/lib/formatters/json.js
@@ -42,6 +42,6 @@ describe("formatter:json", () => {
     it("should return passed results as a JSON string without any modification", () => {
         const result = JSON.parse(formatter(code));
 
-        assert.deepEqual(result, code);
+        assert.deepStrictEqual(result, code);
     });
 });

--- a/tests/lib/formatters/junit.js
+++ b/tests/lib/formatters/junit.js
@@ -25,7 +25,7 @@ describe("formatter:junit", () => {
         it("should not complain about anything", () => {
             const result = formatter(code);
 
-            assert.equal(result.replace(/\n/g, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites></testsuites>");
+            assert.strictEqual(result.replace(/\n/g, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites></testsuites>");
         });
     });
 
@@ -44,14 +44,14 @@ describe("formatter:junit", () => {
         it("should return a single <testcase> with a message and the line and col number in the body (error)", () => {
             const result = formatter(code);
 
-            assert.equal(result.replace(/\n/g, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><failure message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Error - Unexpected foo. (foo)]]></failure></testcase></testsuite></testsuites>");
+            assert.strictEqual(result.replace(/\n/g, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><failure message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Error - Unexpected foo. (foo)]]></failure></testcase></testsuite></testsuites>");
         });
 
         it("should return a single <testcase> with a message and the line and col number in the body (warning)", () => {
             code[0].messages[0].severity = 1;
             const result = formatter(code);
 
-            assert.equal(result.replace(/\n/g, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><failure message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Warning - Unexpected foo. (foo)]]></failure></testcase></testsuite></testsuites>");
+            assert.strictEqual(result.replace(/\n/g, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><failure message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Warning - Unexpected foo. (foo)]]></failure></testcase></testsuite></testsuites>");
         });
     });
 
@@ -70,7 +70,7 @@ describe("formatter:junit", () => {
         it("should return a single <testcase> and an <error>", () => {
             const result = formatter(code);
 
-            assert.equal(result.replace(/\n/g, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><error message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Error - Unexpected foo. (foo)]]></error></testcase></testsuite></testsuites>");
+            assert.strictEqual(result.replace(/\n/g, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><error message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Error - Unexpected foo. (foo)]]></error></testcase></testsuite></testsuites>");
         });
     });
 
@@ -86,7 +86,7 @@ describe("formatter:junit", () => {
         it("should return a single <testcase> and an <error>", () => {
             const result = formatter(code);
 
-            assert.equal(result.replace(/\n/g, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.unknown\"><error message=\"Unexpected foo.\"><![CDATA[line 0, col 0, Error - Unexpected foo.]]></error></testcase></testsuite></testsuites>");
+            assert.strictEqual(result.replace(/\n/g, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.unknown\"><error message=\"Unexpected foo.\"><![CDATA[line 0, col 0, Error - Unexpected foo.]]></error></testcase></testsuite></testsuites>");
         });
     });
 
@@ -101,7 +101,7 @@ describe("formatter:junit", () => {
         it("should return a single <testcase> and an <error>", () => {
             const result = formatter(code);
 
-            assert.equal(result.replace(/\n/g, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.unknown\"><error message=\"\"><![CDATA[line 0, col 0, Error - ]]></error></testcase></testsuite></testsuites>");
+            assert.strictEqual(result.replace(/\n/g, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.unknown\"><error message=\"\"><![CDATA[line 0, col 0, Error - ]]></error></testcase></testsuite></testsuites>");
         });
     });
 
@@ -126,7 +126,7 @@ describe("formatter:junit", () => {
         it("should return a multiple <testcase>'s", () => {
             const result = formatter(code);
 
-            assert.equal(result.replace(/\n/g, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"2\" errors=\"2\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><failure message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Error - Unexpected foo. (foo)]]></failure></testcase><testcase time=\"0\" name=\"org.eslint.bar\"><failure message=\"Unexpected bar.\"><![CDATA[line 6, col 11, Warning - Unexpected bar. (bar)]]></failure></testcase></testsuite></testsuites>");
+            assert.strictEqual(result.replace(/\n/g, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"2\" errors=\"2\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><failure message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Error - Unexpected foo. (foo)]]></failure></testcase><testcase time=\"0\" name=\"org.eslint.bar\"><failure message=\"Unexpected bar.\"><![CDATA[line 6, col 11, Warning - Unexpected bar. (bar)]]></failure></testcase></testsuite></testsuites>");
         });
     });
 
@@ -145,7 +145,7 @@ describe("formatter:junit", () => {
         it("should make them go away", () => {
             const result = formatter(code);
 
-            assert.equal(result.replace(/\n/g, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><failure message=\"Unexpected &lt;foo&gt;&lt;/foo&gt;&#8;&#9;&#10;&#12;&#13;&#29275;&#36924;.\"><![CDATA[line 5, col 10, Warning - Unexpected &lt;foo&gt;&lt;/foo&gt;&#8;&#9;&#10;&#12;&#13;&#29275;&#36924;. (foo)]]></failure></testcase></testsuite></testsuites>");
+            assert.strictEqual(result.replace(/\n/g, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><failure message=\"Unexpected &lt;foo&gt;&lt;/foo&gt;&#8;&#9;&#10;&#12;&#13;&#29275;&#36924;.\"><![CDATA[line 5, col 10, Warning - Unexpected &lt;foo&gt;&lt;/foo&gt;&#8;&#9;&#10;&#12;&#13;&#29275;&#36924;. (foo)]]></failure></testcase></testsuite></testsuites>");
         });
     });
 
@@ -173,7 +173,7 @@ describe("formatter:junit", () => {
         it("should return 2 <testsuite>'s", () => {
             const result = formatter(code);
 
-            assert.equal(result.replace(/\n/g, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><failure message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Warning - Unexpected foo. (foo)]]></failure></testcase></testsuite><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"bar.js\"><testcase time=\"0\" name=\"org.eslint.bar\"><failure message=\"Unexpected bar.\"><![CDATA[line 6, col 11, Error - Unexpected bar. (bar)]]></failure></testcase></testsuite></testsuites>");
+            assert.strictEqual(result.replace(/\n/g, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><failure message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Warning - Unexpected foo. (foo)]]></failure></testcase></testsuite><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"bar.js\"><testcase time=\"0\" name=\"org.eslint.bar\"><failure message=\"Unexpected bar.\"><![CDATA[line 6, col 11, Error - Unexpected bar. (bar)]]></failure></testcase></testsuite></testsuites>");
         });
     });
 
@@ -195,7 +195,7 @@ describe("formatter:junit", () => {
         it("should return 2 <testsuite>", () => {
             const result = formatter(code);
 
-            assert.equal(result.replace(/\n/g, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><failure message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Warning - Unexpected foo. (foo)]]></failure></testcase></testsuite><testsuite package=\"org.eslint\" time=\"0\" tests=\"0\" errors=\"0\" name=\"bar.js\"></testsuite></testsuites>");
+            assert.strictEqual(result.replace(/\n/g, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><failure message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Warning - Unexpected foo. (foo)]]></failure></testcase></testsuite><testsuite package=\"org.eslint\" time=\"0\" tests=\"0\" errors=\"0\" name=\"bar.js\"></testsuite></testsuites>");
         });
     });
 });

--- a/tests/lib/formatters/stylish.js
+++ b/tests/lib/formatters/stylish.js
@@ -67,9 +67,9 @@ describe("formatter:stylish", () => {
         it("should not return message", () => {
             const result = formatter(code);
 
-            assert.equal(result, "");
-            assert.equal(chalkStub.yellow.bold.callCount, 0);
-            assert.equal(chalkStub.red.bold.callCount, 0);
+            assert.strictEqual(result, "");
+            assert.strictEqual(chalkStub.yellow.bold.callCount, 0);
+            assert.strictEqual(chalkStub.red.bold.callCount, 0);
         });
     });
 
@@ -92,9 +92,9 @@ describe("formatter:stylish", () => {
         it("should return a string in the correct format", () => {
             const result = formatter(code);
 
-            assert.equal(result, "\nfoo.js\n  5:10  error  Unexpected foo  foo\n\n\u2716 1 problem (1 error, 0 warnings)\n");
-            assert.equal(chalkStub.yellow.bold.callCount, 0);
-            assert.equal(chalkStub.red.bold.callCount, 1);
+            assert.strictEqual(result, "\nfoo.js\n  5:10  error  Unexpected foo  foo\n\n\u2716 1 problem (1 error, 0 warnings)\n");
+            assert.strictEqual(chalkStub.yellow.bold.callCount, 0);
+            assert.strictEqual(chalkStub.red.bold.callCount, 1);
         });
 
         describe("when the error is fixable", () => {
@@ -105,9 +105,9 @@ describe("formatter:stylish", () => {
             it("should return a string in the correct format", () => {
                 const result = formatter(code);
 
-                assert.equal(result, "\nfoo.js\n  5:10  error  Unexpected foo  foo\n\n\u2716 1 problem (1 error, 0 warnings)\n  1 error, 0 warnings potentially fixable with the `--fix` option.\n");
-                assert.equal(chalkStub.yellow.bold.callCount, 0);
-                assert.equal(chalkStub.red.bold.callCount, 2);
+                assert.strictEqual(result, "\nfoo.js\n  5:10  error  Unexpected foo  foo\n\n\u2716 1 problem (1 error, 0 warnings)\n  1 error, 0 warnings potentially fixable with the `--fix` option.\n");
+                assert.strictEqual(chalkStub.yellow.bold.callCount, 0);
+                assert.strictEqual(chalkStub.red.bold.callCount, 2);
             });
         });
     });
@@ -131,9 +131,9 @@ describe("formatter:stylish", () => {
         it("should return a string in the correct format", () => {
             const result = formatter(code);
 
-            assert.equal(result, "\nfoo.js\n  5:10  warning  Unexpected foo  foo\n\n\u2716 1 problem (0 errors, 1 warning)\n");
-            assert.equal(chalkStub.yellow.bold.callCount, 1);
-            assert.equal(chalkStub.red.bold.callCount, 0);
+            assert.strictEqual(result, "\nfoo.js\n  5:10  warning  Unexpected foo  foo\n\n\u2716 1 problem (0 errors, 1 warning)\n");
+            assert.strictEqual(chalkStub.yellow.bold.callCount, 1);
+            assert.strictEqual(chalkStub.red.bold.callCount, 0);
         });
 
         describe("when the error is fixable", () => {
@@ -144,9 +144,9 @@ describe("formatter:stylish", () => {
             it("should return a string in the correct format", () => {
                 const result = formatter(code);
 
-                assert.equal(result, "\nfoo.js\n  5:10  warning  Unexpected foo  foo\n\n\u2716 1 problem (0 errors, 1 warning)\n  0 errors, 1 warning potentially fixable with the `--fix` option.\n");
-                assert.equal(chalkStub.yellow.bold.callCount, 2);
-                assert.equal(chalkStub.red.bold.callCount, 0);
+                assert.strictEqual(result, "\nfoo.js\n  5:10  warning  Unexpected foo  foo\n\n\u2716 1 problem (0 errors, 1 warning)\n  0 errors, 1 warning potentially fixable with the `--fix` option.\n");
+                assert.strictEqual(chalkStub.yellow.bold.callCount, 2);
+                assert.strictEqual(chalkStub.red.bold.callCount, 0);
             });
 
         });
@@ -171,9 +171,9 @@ describe("formatter:stylish", () => {
         it("should return a string in the correct format (retaining the ' .')", () => {
             const result = formatter(code);
 
-            assert.equal(result, "\nfoo.js\n  5:10  warning  Unexpected .  foo\n\n\u2716 1 problem (0 errors, 1 warning)\n");
-            assert.equal(chalkStub.yellow.bold.callCount, 1);
-            assert.equal(chalkStub.red.bold.callCount, 0);
+            assert.strictEqual(result, "\nfoo.js\n  5:10  warning  Unexpected .  foo\n\n\u2716 1 problem (0 errors, 1 warning)\n");
+            assert.strictEqual(chalkStub.yellow.bold.callCount, 1);
+            assert.strictEqual(chalkStub.red.bold.callCount, 0);
         });
     });
 
@@ -194,9 +194,9 @@ describe("formatter:stylish", () => {
         it("should return a string in the correct format", () => {
             const result = formatter(code);
 
-            assert.equal(result, "\nfoo.js\n  5:10  error  Unexpected foo  foo\n\n\u2716 1 problem (1 error, 0 warnings)\n");
-            assert.equal(chalkStub.yellow.bold.callCount, 0);
-            assert.equal(chalkStub.red.bold.callCount, 1);
+            assert.strictEqual(result, "\nfoo.js\n  5:10  error  Unexpected foo  foo\n\n\u2716 1 problem (1 error, 0 warnings)\n");
+            assert.strictEqual(chalkStub.yellow.bold.callCount, 0);
+            assert.strictEqual(chalkStub.red.bold.callCount, 1);
         });
     });
 
@@ -223,9 +223,9 @@ describe("formatter:stylish", () => {
         it("should return a string with multiple entries", () => {
             const result = formatter(code);
 
-            assert.equal(result, "\nfoo.js\n  5:10  error    Unexpected foo  foo\n  6:11  warning  Unexpected bar  bar\n\n\u2716 2 problems (1 error, 1 warning)\n");
-            assert.equal(chalkStub.yellow.bold.callCount, 0);
-            assert.equal(chalkStub.red.bold.callCount, 1);
+            assert.strictEqual(result, "\nfoo.js\n  5:10  error    Unexpected foo  foo\n  6:11  warning  Unexpected bar  bar\n\n\u2716 2 problems (1 error, 1 warning)\n");
+            assert.strictEqual(chalkStub.yellow.bold.callCount, 0);
+            assert.strictEqual(chalkStub.red.bold.callCount, 1);
         });
     });
 
@@ -257,9 +257,9 @@ describe("formatter:stylish", () => {
         it("should return a string with multiple entries", () => {
             const result = formatter(code);
 
-            assert.equal(result, "\nfoo.js\n  5:10  error  Unexpected foo  foo\n\nbar.js\n  6:11  warning  Unexpected bar  bar\n\n\u2716 2 problems (1 error, 1 warning)\n");
-            assert.equal(chalkStub.yellow.bold.callCount, 0);
-            assert.equal(chalkStub.red.bold.callCount, 1);
+            assert.strictEqual(result, "\nfoo.js\n  5:10  error  Unexpected foo  foo\n\nbar.js\n  6:11  warning  Unexpected bar  bar\n\n\u2716 2 problems (1 error, 1 warning)\n");
+            assert.strictEqual(chalkStub.yellow.bold.callCount, 0);
+            assert.strictEqual(chalkStub.red.bold.callCount, 1);
         });
 
         it("should add errorCount", () => {
@@ -270,9 +270,9 @@ describe("formatter:stylish", () => {
 
             const result = formatter(code);
 
-            assert.equal(result, "\nfoo.js\n  5:10  error  Unexpected foo  foo\n\nbar.js\n  6:11  warning  Unexpected bar  bar\n\n\u2716 2 problems (2 errors, 0 warnings)\n");
-            assert.equal(chalkStub.yellow.bold.callCount, 0);
-            assert.equal(chalkStub.red.bold.callCount, 1);
+            assert.strictEqual(result, "\nfoo.js\n  5:10  error  Unexpected foo  foo\n\nbar.js\n  6:11  warning  Unexpected bar  bar\n\n\u2716 2 problems (2 errors, 0 warnings)\n");
+            assert.strictEqual(chalkStub.yellow.bold.callCount, 0);
+            assert.strictEqual(chalkStub.red.bold.callCount, 1);
         });
 
         it("should add warningCount", () => {
@@ -283,9 +283,9 @@ describe("formatter:stylish", () => {
 
             const result = formatter(code);
 
-            assert.equal(result, "\nfoo.js\n  5:10  error  Unexpected foo  foo\n\nbar.js\n  6:11  warning  Unexpected bar  bar\n\n\u2716 2 problems (0 errors, 2 warnings)\n");
-            assert.equal(chalkStub.yellow.bold.callCount, 0);
-            assert.equal(chalkStub.red.bold.callCount, 1);
+            assert.strictEqual(result, "\nfoo.js\n  5:10  error  Unexpected foo  foo\n\nbar.js\n  6:11  warning  Unexpected bar  bar\n\n\u2716 2 problems (0 errors, 2 warnings)\n");
+            assert.strictEqual(chalkStub.yellow.bold.callCount, 0);
+            assert.strictEqual(chalkStub.red.bold.callCount, 1);
         });
     });
 
@@ -303,9 +303,9 @@ describe("formatter:stylish", () => {
         it("should return a string without line and column", () => {
             const result = formatter(code);
 
-            assert.equal(result, "\nfoo.js\n  0:0  error  Couldn't find foo.js\n\n\u2716 1 problem (1 error, 0 warnings)\n");
-            assert.equal(chalkStub.yellow.bold.callCount, 0);
-            assert.equal(chalkStub.red.bold.callCount, 1);
+            assert.strictEqual(result, "\nfoo.js\n  0:0  error  Couldn't find foo.js\n\n\u2716 1 problem (1 error, 0 warnings)\n");
+            assert.strictEqual(chalkStub.yellow.bold.callCount, 0);
+            assert.strictEqual(chalkStub.red.bold.callCount, 1);
         });
     });
 

--- a/tests/lib/formatters/table.js
+++ b/tests/lib/formatters/table.js
@@ -39,7 +39,7 @@ describe("formatter:table", () => {
 
             const result = formatter(code);
 
-            assert.equal(result, expectedOutput);
+            assert.strictEqual(result, expectedOutput);
         });
     });
 
@@ -80,7 +80,7 @@ describe("formatter:table", () => {
 
             const result = formatter(code);
 
-            assert.equal(result, expectedOutput);
+            assert.strictEqual(result, expectedOutput);
         });
 
         it("should return a string in the correct format for warnings", () => {
@@ -119,7 +119,7 @@ describe("formatter:table", () => {
 
             const result = formatter(code);
 
-            assert.equal(result, expectedOutput);
+            assert.strictEqual(result, expectedOutput);
         });
     });
 
@@ -160,7 +160,7 @@ describe("formatter:table", () => {
 
             const result = formatter(code);
 
-            assert.equal(result, expectedOutput);
+            assert.strictEqual(result, expectedOutput);
         });
     });
 
@@ -209,7 +209,7 @@ describe("formatter:table", () => {
 
             const result = formatter(code);
 
-            assert.equal(result, expectedOutput);
+            assert.strictEqual(result, expectedOutput);
         });
     });
 
@@ -269,7 +269,7 @@ describe("formatter:table", () => {
 
             const result = formatter(code);
 
-            assert.equal(result, expectedOutput);
+            assert.strictEqual(result, expectedOutput);
         });
     });
 
@@ -307,7 +307,7 @@ describe("formatter:table", () => {
 
             const result = formatter(code);
 
-            assert.equal(result, expectedOutput);
+            assert.strictEqual(result, expectedOutput);
         });
     });
 });

--- a/tests/lib/formatters/tap.js
+++ b/tests/lib/formatters/tap.js
@@ -26,7 +26,7 @@ describe("formatter:tap", () => {
         it("should return nothing", () => {
             const result = formatter(code);
 
-            assert.equal(result, "TAP version 13\n1..1\nok 1 - foo.js\n");
+            assert.strictEqual(result, "TAP version 13\n1..1\nok 1 - foo.js\n");
         });
     });
 
@@ -45,7 +45,7 @@ describe("formatter:tap", () => {
         it("should return a string with YAML severity, line and column", () => {
             const result = formatter(code);
 
-            assert.equal(result, "TAP version 13\n1..1\nnot ok 1 - foo.js\n  ---\n  message: Unexpected foo.\n  severity: error\n  data:\n    line: 5\n    column: 10\n    ruleId: foo\n  ...\n");
+            assert.strictEqual(result, "TAP version 13\n1..1\nnot ok 1 - foo.js\n  ---\n  message: Unexpected foo.\n  severity: error\n  data:\n    line: 5\n    column: 10\n    ruleId: foo\n  ...\n");
         });
 
         it("should return a string with line: x, column: y, severity: warning for warnings", () => {

--- a/tests/lib/formatters/unix.js
+++ b/tests/lib/formatters/unix.js
@@ -26,7 +26,7 @@ describe("formatter:compact", () => {
         it("should return nothing", () => {
             const result = formatter(code);
 
-            assert.equal(result, "");
+            assert.strictEqual(result, "");
         });
     });
 
@@ -45,14 +45,14 @@ describe("formatter:compact", () => {
         it("should return a string in the format filename:line:column: error [Error/rule_id]", () => {
             const result = formatter(code);
 
-            assert.equal(result, "foo.js:5:10: Unexpected foo. [Error/foo]\n\n1 problem");
+            assert.strictEqual(result, "foo.js:5:10: Unexpected foo. [Error/foo]\n\n1 problem");
         });
 
         it("should return a string in the format filename:line:column: warning [Warning/rule_id]", () => {
             code[0].messages[0].severity = 1;
             const result = formatter(code);
 
-            assert.equal(result, "foo.js:5:10: Unexpected foo. [Warning/foo]\n\n1 problem");
+            assert.strictEqual(result, "foo.js:5:10: Unexpected foo. [Warning/foo]\n\n1 problem");
         });
     });
 
@@ -71,7 +71,7 @@ describe("formatter:compact", () => {
         it("should return a string in the format filename:line:column: error [Error/rule_id]", () => {
             const result = formatter(code);
 
-            assert.equal(result, "foo.js:5:10: Unexpected foo. [Error/foo]\n\n1 problem");
+            assert.strictEqual(result, "foo.js:5:10: Unexpected foo. [Error/foo]\n\n1 problem");
         });
     });
 
@@ -96,7 +96,7 @@ describe("formatter:compact", () => {
         it("should return a string with multiple entries", () => {
             const result = formatter(code);
 
-            assert.equal(result, "foo.js:5:10: Unexpected foo. [Error/foo]\nfoo.js:6:11: Unexpected bar. [Warning/bar]\n\n2 problems");
+            assert.strictEqual(result, "foo.js:5:10: Unexpected foo. [Error/foo]\nfoo.js:6:11: Unexpected bar. [Warning/bar]\n\n2 problems");
         });
     });
 
@@ -124,7 +124,7 @@ describe("formatter:compact", () => {
         it("should return a string with multiple entries", () => {
             const result = formatter(code);
 
-            assert.equal(result, "foo.js:5:10: Unexpected foo. [Error/foo]\nbar.js:6:11: Unexpected bar. [Warning/bar]\n\n2 problems");
+            assert.strictEqual(result, "foo.js:5:10: Unexpected foo. [Error/foo]\nbar.js:6:11: Unexpected bar. [Warning/bar]\n\n2 problems");
         });
     });
 
@@ -140,7 +140,7 @@ describe("formatter:compact", () => {
         it("should return a string without line and column", () => {
             const result = formatter(code);
 
-            assert.equal(result, "foo.js:0:0: Couldn't find foo.js. [Error]\n\n1 problem");
+            assert.strictEqual(result, "foo.js:0:0: Couldn't find foo.js. [Error]\n\n1 problem");
         });
     });
 });

--- a/tests/lib/formatters/visualstudio.js
+++ b/tests/lib/formatters/visualstudio.js
@@ -26,7 +26,7 @@ describe("formatter:visualstudio", () => {
         it("should return nothing", () => {
             const result = formatter(code);
 
-            assert.equal(result, "no problems");
+            assert.strictEqual(result, "no problems");
         });
     });
 
@@ -45,14 +45,14 @@ describe("formatter:visualstudio", () => {
         it("should return a string in the format filename(x,y): error z for errors", () => {
             const result = formatter(code);
 
-            assert.equal(result, "foo.js(5,10): error foo : Unexpected foo.\n\n1 problem");
+            assert.strictEqual(result, "foo.js(5,10): error foo : Unexpected foo.\n\n1 problem");
         });
 
         it("should return a string in the format filename(x,y): warning z for warnings", () => {
             code[0].messages[0].severity = 1;
             const result = formatter(code);
 
-            assert.equal(result, "foo.js(5,10): warning foo : Unexpected foo.\n\n1 problem");
+            assert.strictEqual(result, "foo.js(5,10): warning foo : Unexpected foo.\n\n1 problem");
         });
     });
 
@@ -71,7 +71,7 @@ describe("formatter:visualstudio", () => {
         it("should return a string in the format filename(x,y): error  z", () => {
             const result = formatter(code);
 
-            assert.equal(result, "foo.js(5,10): error foo : Unexpected foo.\n\n1 problem");
+            assert.strictEqual(result, "foo.js(5,10): error foo : Unexpected foo.\n\n1 problem");
         });
     });
 
@@ -96,7 +96,7 @@ describe("formatter:visualstudio", () => {
         it("should return a string with multiple entries", () => {
             const result = formatter(code);
 
-            assert.equal(result, "foo.js(5,10): error foo : Unexpected foo.\nfoo.js(6,11): warning bar : Unexpected bar.\n\n2 problems");
+            assert.strictEqual(result, "foo.js(5,10): error foo : Unexpected foo.\nfoo.js(6,11): warning bar : Unexpected bar.\n\n2 problems");
         });
     });
 
@@ -124,7 +124,7 @@ describe("formatter:visualstudio", () => {
         it("should return a string with multiple entries", () => {
             const result = formatter(code);
 
-            assert.equal(result, "foo.js(5,10): error foo : Unexpected foo.\nbar.js(6,11): warning bar : Unexpected bar.\n\n2 problems");
+            assert.strictEqual(result, "foo.js(5,10): error foo : Unexpected foo.\nbar.js(6,11): warning bar : Unexpected bar.\n\n2 problems");
         });
     });
 
@@ -140,7 +140,7 @@ describe("formatter:visualstudio", () => {
         it("should return a string without line and column", () => {
             const result = formatter(code);
 
-            assert.equal(result, "foo.js(0): error : Couldn't find foo.js.\n\n1 problem");
+            assert.strictEqual(result, "foo.js(0): error : Couldn't find foo.js.\n\n1 problem");
         });
     });
 });

--- a/tests/lib/ignored-paths.js
+++ b/tests/lib/ignored-paths.js
@@ -127,7 +127,7 @@ describe("IgnoredPaths", () => {
             const ignorePatterns = getIgnorePatterns(ignoredPaths);
 
             assert.isNotNull(ignoredPaths.baseDir);
-            assert.deepEqual(getIgnoreFiles(ignoredPaths), [expectedIgnoreFile]);
+            assert.deepStrictEqual(getIgnoreFiles(ignoredPaths), [expectedIgnoreFile]);
             assert.include(ignorePatterns, "sampleignorepattern");
         });
 

--- a/tests/lib/ignored-paths.js
+++ b/tests/lib/ignored-paths.js
@@ -127,14 +127,14 @@ describe("IgnoredPaths", () => {
             const ignorePatterns = getIgnorePatterns(ignoredPaths);
 
             assert.isNotNull(ignoredPaths.baseDir);
-            assert.equal(getIgnoreFiles(ignoredPaths), expectedIgnoreFile);
+            assert.deepEqual(getIgnoreFiles(ignoredPaths), [expectedIgnoreFile]);
             assert.include(ignorePatterns, "sampleignorepattern");
         });
 
         it("should set baseDir to cwd when no ignore file was loaded", () => {
             const ignoredPaths = new IgnoredPaths({ cwd: getFixturePath("no-ignore-file") });
 
-            assert.equal(ignoredPaths.baseDir, getFixturePath("no-ignore-file"));
+            assert.strictEqual(ignoredPaths.baseDir, getFixturePath("no-ignore-file"));
         });
 
         it("should not travel to parent directories to find .eslintignore when it's missing and cwd is provided", () => {
@@ -232,7 +232,7 @@ describe("IgnoredPaths", () => {
         it("should set baseDir to directory containing ignorePath if provided", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: true, ignorePath: ignoreFilePath, cwd: getFixturePath() });
 
-            assert.equal(ignoredPaths.baseDir, path.dirname(ignoreFilePath));
+            assert.strictEqual(ignoredPaths.baseDir, path.dirname(ignoreFilePath));
         });
 
     });
@@ -248,19 +248,19 @@ describe("IgnoredPaths", () => {
         it("should work when cwd is a parent directory", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: true, ignorePath: ignoreFilePath, cwd: getFixturePath() });
 
-            assert.notEqual(getIgnoreRules(ignoredPaths).length, countDefaultPatterns(ignoredPaths));
+            assert.notStrictEqual(getIgnoreRules(ignoredPaths).length, countDefaultPatterns(ignoredPaths));
         });
 
         it("should work when the file is in the cwd", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: true, ignorePath: ignoreFilePath, cwd: getFixturePath("custom-name") });
 
-            assert.notEqual(getIgnoreRules(ignoredPaths).length, countDefaultPatterns(ignoredPaths));
+            assert.notStrictEqual(getIgnoreRules(ignoredPaths).length, countDefaultPatterns(ignoredPaths));
         });
 
         it("should work when cwd is a subdirectory", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: true, ignorePath: ignoreFilePath, cwd: getFixturePath("custom-name", "subdirectory") });
 
-            assert.notEqual(getIgnoreRules(ignoredPaths).length, countDefaultPatterns(ignoredPaths));
+            assert.notStrictEqual(getIgnoreRules(ignoredPaths).length, countDefaultPatterns(ignoredPaths));
         });
 
     });
@@ -408,7 +408,7 @@ describe("IgnoredPaths", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: true, ignorePath: ignoreFilePath, cwd: getFixturePath() });
             const ignorePatterns = getIgnorePatterns(ignoredPaths);
 
-            assert.equal(getIgnoreRules(ignoredPaths).length, countDefaultPatterns(ignoredPaths) + 1);
+            assert.strictEqual(getIgnoreRules(ignoredPaths).length, countDefaultPatterns(ignoredPaths) + 1);
             assert.include(ignorePatterns, "this_one_not");
         });
 

--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -194,7 +194,7 @@ describe("Linter", () => {
             const sourceCode = linter.getSourceCode();
 
             assert.isObject(sourceCode);
-            assert.equal(sourceCode.text, code);
+            assert.strictEqual(sourceCode.text, code);
             assert.isObject(sourceCode.ast);
         });
 
@@ -204,7 +204,7 @@ describe("Linter", () => {
             const sourceCode = linter.getSourceCode();
 
             assert.isObject(sourceCode);
-            assert.equal(sourceCode.text, code);
+            assert.strictEqual(sourceCode.text, code);
             assert.isObject(sourceCode.ast);
         });
 
@@ -220,7 +220,7 @@ describe("Linter", () => {
 
             linter.defineRule("checker", context => {
                 spy = sandbox.spy(() => {
-                    assert.equal(context.getSource(), TEST_CODE);
+                    assert.strictEqual(context.getSource(), TEST_CODE);
                 });
                 return { Program: spy };
             });
@@ -235,7 +235,7 @@ describe("Linter", () => {
 
             linter.defineRule("checker", context => {
                 spy = sandbox.spy(node => {
-                    assert.equal(context.getSource(node), TEST_CODE);
+                    assert.strictEqual(context.getSource(node), TEST_CODE);
                 });
                 return { Program: spy };
             });
@@ -250,7 +250,7 @@ describe("Linter", () => {
 
             linter.defineRule("checker", context => {
                 spy = sandbox.spy(node => {
-                    assert.equal(context.getSource(node, 2, 0), TEST_CODE);
+                    assert.strictEqual(context.getSource(node, 2, 0), TEST_CODE);
                 });
                 return { Program: spy };
             });
@@ -265,7 +265,7 @@ describe("Linter", () => {
 
             linter.defineRule("checker", context => {
                 spy = sandbox.spy(node => {
-                    assert.equal(context.getSource(node), "6 * 7");
+                    assert.strictEqual(context.getSource(node), "6 * 7");
                 });
                 return { BinaryExpression: spy };
             });
@@ -280,7 +280,7 @@ describe("Linter", () => {
 
             linter.defineRule("checker", context => {
                 spy = sandbox.spy(node => {
-                    assert.equal(context.getSource(node, 2), "= 6 * 7");
+                    assert.strictEqual(context.getSource(node, 2), "= 6 * 7");
                 });
                 return { BinaryExpression: spy };
             });
@@ -310,7 +310,7 @@ describe("Linter", () => {
 
             linter.defineRule("checker", context => {
                 spy = sandbox.spy(node => {
-                    assert.equal(context.getSource(node, 2, 1), "= 6 * 7;");
+                    assert.strictEqual(context.getSource(node, 2, 1), "= 6 * 7;");
                 });
                 return { BinaryExpression: spy };
             });
@@ -333,7 +333,7 @@ describe("Linter", () => {
                 spy = sandbox.spy(() => {
                     const ancestors = context.getAncestors();
 
-                    assert.equal(ancestors.length, 3);
+                    assert.strictEqual(ancestors.length, 3);
                 });
                 return { BinaryExpression: spy };
             });
@@ -350,7 +350,7 @@ describe("Linter", () => {
                 spy = sandbox.spy(() => {
                     const ancestors = context.getAncestors();
 
-                    assert.equal(ancestors.length, 0);
+                    assert.strictEqual(ancestors.length, 0);
                 });
 
                 return { Program: spy };
@@ -367,7 +367,7 @@ describe("Linter", () => {
         it("should retrieve a node starting at the given index", () => {
             const config = { rules: { checker: "error" } };
             const spy = sandbox.spy(context => {
-                assert.equal(context.getNodeByRangeIndex(4).type, "Identifier");
+                assert.strictEqual(context.getNodeByRangeIndex(4).type, "Identifier");
                 return {};
             });
 
@@ -379,7 +379,7 @@ describe("Linter", () => {
         it("should retrieve a node containing the given index", () => {
             const config = { rules: { checker: "error" } };
             const spy = sandbox.spy(context => {
-                assert.equal(context.getNodeByRangeIndex(6).type, "Identifier");
+                assert.strictEqual(context.getNodeByRangeIndex(6).type, "Identifier");
                 return {};
             });
 
@@ -393,8 +393,8 @@ describe("Linter", () => {
             const spy = sandbox.spy(context => {
                 const node = context.getNodeByRangeIndex(13);
 
-                assert.equal(node.type, "Literal");
-                assert.equal(node.value, 6);
+                assert.strictEqual(node.type, "Literal");
+                assert.strictEqual(node.value, 6);
                 return {};
             });
 
@@ -406,7 +406,7 @@ describe("Linter", () => {
         it("should retrieve a node ending with the given index", () => {
             const config = { rules: { checker: "error" } };
             const spy = sandbox.spy(context => {
-                assert.equal(context.getNodeByRangeIndex(9).type, "Identifier");
+                assert.strictEqual(context.getNodeByRangeIndex(9).type, "Identifier");
                 return {};
             });
 
@@ -420,11 +420,11 @@ describe("Linter", () => {
             const spy = sandbox.spy(context => {
                 const node1 = context.getNodeByRangeIndex(14);
 
-                assert.equal(node1.type, "BinaryExpression");
+                assert.strictEqual(node1.type, "BinaryExpression");
 
                 const node2 = context.getNodeByRangeIndex(3);
 
-                assert.equal(node2.type, "VariableDeclaration");
+                assert.strictEqual(node2.type, "VariableDeclaration");
                 return {};
             });
 
@@ -457,7 +457,7 @@ describe("Linter", () => {
                 const node = context.getNodeByRangeIndex(14);
 
                 assert.property(node, "parent");
-                assert.equal(node.parent.type, "VariableDeclarator");
+                assert.strictEqual(node.parent.type, "VariableDeclarator");
                 return {};
             });
 
@@ -471,13 +471,13 @@ describe("Linter", () => {
             const spy = sandbox.spy(context => {
                 const node1 = context.getNodeByRangeIndex(10);
 
-                assert.equal(node1.type, "VariableDeclarator");
+                assert.strictEqual(node1.type, "VariableDeclarator");
 
                 const node2 = context.getNodeByRangeIndex(4);
 
-                assert.equal(node2.type, "Identifier");
+                assert.strictEqual(node2.type, "Identifier");
                 assert.property(node2, "parent");
-                assert.equal(node2.parent.type, "VariableDeclarator");
+                assert.strictEqual(node2.parent.type, "VariableDeclarator");
                 assert.notProperty(node2.parent, "parent");
                 return {};
             });
@@ -501,7 +501,7 @@ describe("Linter", () => {
                 spy = sandbox.spy(() => {
                     const scope = context.getScope();
 
-                    assert.equal(scope.type, "global");
+                    assert.strictEqual(scope.type, "global");
                 });
                 return { Program: spy };
             });
@@ -518,7 +518,7 @@ describe("Linter", () => {
                 spy = sandbox.spy(() => {
                     const scope = context.getScope();
 
-                    assert.equal(scope.type, "function");
+                    assert.strictEqual(scope.type, "function");
                 });
                 return { FunctionDeclaration: spy };
             });
@@ -535,8 +535,8 @@ describe("Linter", () => {
                 spy = sandbox.spy(() => {
                     const scope = context.getScope();
 
-                    assert.equal(scope.type, "function");
-                    assert.equal(scope.block.id.name, "foo");
+                    assert.strictEqual(scope.type, "function");
+                    assert.strictEqual(scope.block.id.name, "foo");
                 });
                 return { LabeledStatement: spy };
             });
@@ -553,8 +553,8 @@ describe("Linter", () => {
                 spy = sandbox.spy(() => {
                     const scope = context.getScope();
 
-                    assert.equal(scope.type, "function");
-                    assert.equal(scope.block.type, "ArrowFunctionExpression");
+                    assert.strictEqual(scope.type, "function");
+                    assert.strictEqual(scope.block.type, "ArrowFunctionExpression");
                 });
 
                 return { ReturnStatement: spy };
@@ -572,8 +572,8 @@ describe("Linter", () => {
                 spy = sandbox.spy(() => {
                     const scope = context.getScope();
 
-                    assert.equal(scope.type, "switch");
-                    assert.equal(scope.block.type, "SwitchStatement");
+                    assert.strictEqual(scope.type, "switch");
+                    assert.strictEqual(scope.block.type, "SwitchStatement");
                 });
 
                 return { SwitchStatement: spy };
@@ -591,8 +591,8 @@ describe("Linter", () => {
                 spy = sandbox.spy(() => {
                     const scope = context.getScope();
 
-                    assert.equal(scope.type, "block");
-                    assert.equal(scope.block.type, "BlockStatement");
+                    assert.strictEqual(scope.type, "block");
+                    assert.strictEqual(scope.block.type, "BlockStatement");
                 });
 
                 return { BlockStatement: spy };
@@ -610,8 +610,8 @@ describe("Linter", () => {
                 spy = sandbox.spy(() => {
                     const scope = context.getScope();
 
-                    assert.equal(scope.type, "block");
-                    assert.equal(scope.block.type, "BlockStatement");
+                    assert.strictEqual(scope.type, "block");
+                    assert.strictEqual(scope.block.type, "BlockStatement");
                 });
 
                 return { BlockStatement: spy };
@@ -629,8 +629,8 @@ describe("Linter", () => {
                 spy = sandbox.spy(() => {
                     const scope = context.getScope();
 
-                    assert.equal(scope.type, "function");
-                    assert.equal(scope.block.type, "FunctionDeclaration");
+                    assert.strictEqual(scope.type, "function");
+                    assert.strictEqual(scope.block.type, "FunctionDeclaration");
                 });
 
                 return { FunctionDeclaration: spy };
@@ -648,8 +648,8 @@ describe("Linter", () => {
                 spy = sandbox.spy(() => {
                     const scope = context.getScope();
 
-                    assert.equal(scope.type, "function");
-                    assert.equal(scope.block.type, "FunctionExpression");
+                    assert.strictEqual(scope.type, "function");
+                    assert.strictEqual(scope.block.type, "FunctionExpression");
                 });
 
                 return { FunctionExpression: spy };
@@ -667,8 +667,8 @@ describe("Linter", () => {
                 spy = sandbox.spy(() => {
                     const scope = context.getScope();
 
-                    assert.equal(scope.type, "catch");
-                    assert.equal(scope.block.type, "CatchClause");
+                    assert.strictEqual(scope.type, "catch");
+                    assert.strictEqual(scope.block.type, "CatchClause");
                 });
 
                 return { CatchClause: spy };
@@ -686,7 +686,7 @@ describe("Linter", () => {
                 spy = sandbox.spy(() => {
                     const scope = context.getScope();
 
-                    assert.equal(scope.type, "module");
+                    assert.strictEqual(scope.type, "module");
                 });
 
                 return { AssignmentExpression: spy };
@@ -704,7 +704,7 @@ describe("Linter", () => {
                 spy = sandbox.spy(() => {
                     const scope = context.getScope();
 
-                    assert.equal(scope.type, "function");
+                    assert.strictEqual(scope.type, "function");
                 });
 
                 return { AssignmentExpression: spy };
@@ -863,7 +863,7 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, config, filename, true);
 
-            assert.equal(messages.length, 0);
+            assert.strictEqual(messages.length, 0);
             sinon.assert.calledOnce(spyVariableDeclaration);
             sinon.assert.calledOnce(spyVariableDeclarator);
             sinon.assert.calledOnce(spyIdentifier);
@@ -888,8 +888,8 @@ describe("Linter", () => {
 
             const messages = linter.verify("0", config, filename);
 
-            assert.equal(messages.length, 1);
-            assert.equal(messages[0].message, "Hello");
+            assert.strictEqual(messages.length, 1);
+            assert.strictEqual(messages[0].message, "Hello");
         });
 
         it("should not have any settings if they were not passed in", () => {
@@ -907,7 +907,7 @@ describe("Linter", () => {
 
             const messages = linter.verify("0", config, filename);
 
-            assert.equal(messages.length, 0);
+            assert.strictEqual(messages.length, 0);
         });
     });
 
@@ -969,7 +969,7 @@ describe("Linter", () => {
                 const config = { rules: {}, parser: alternateParser };
                 const messages = linter.verify("0", config, filename);
 
-                assert.equal(messages.length, 0);
+                assert.strictEqual(messages.length, 0);
             });
 
             it("should expose parser services when using parseForESLint() and services are specified", () => {
@@ -988,8 +988,8 @@ describe("Linter", () => {
                 const config = { rules: { "test-service-rule": 2 }, parser: alternateParser };
                 const messages = linter.verify("0", config, filename);
 
-                assert.equal(messages.length, 1);
-                assert.equal(messages[0].message, "Hi!");
+                assert.strictEqual(messages.length, 1);
+                assert.strictEqual(messages[0].message, "Hi!");
             });
         }
 
@@ -1017,8 +1017,8 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, config, filename, true);
 
-            assert.equal(messages.length, 1);
-            assert.equal(messages[0].ruleId, rule);
+            assert.strictEqual(messages.length, 1);
+            assert.strictEqual(messages[0].ruleId, rule);
         });
 
         it("should be configurable by only setting the string value", () => {
@@ -1029,9 +1029,9 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, config, filename, true);
 
-            assert.equal(messages.length, 1);
-            assert.equal(messages[0].severity, 1);
-            assert.equal(messages[0].ruleId, rule);
+            assert.strictEqual(messages.length, 1);
+            assert.strictEqual(messages[0].severity, 1);
+            assert.strictEqual(messages[0].ruleId, rule);
         });
 
         it("should be configurable by passing in values as an array", () => {
@@ -1042,8 +1042,8 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, config, filename, true);
 
-            assert.equal(messages.length, 1);
-            assert.equal(messages[0].ruleId, rule);
+            assert.strictEqual(messages.length, 1);
+            assert.strictEqual(messages[0].ruleId, rule);
         });
 
         it("should be configurable by passing in string value as an array", () => {
@@ -1054,9 +1054,9 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, config, filename, true);
 
-            assert.equal(messages.length, 1);
-            assert.equal(messages[0].severity, 1);
-            assert.equal(messages[0].ruleId, rule);
+            assert.strictEqual(messages.length, 1);
+            assert.strictEqual(messages[0].severity, 1);
+            assert.strictEqual(messages[0].ruleId, rule);
         });
 
         it("should not be configurable by setting other value", () => {
@@ -1067,14 +1067,14 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, config, filename, true);
 
-            assert.equal(messages.length, 0);
+            assert.strictEqual(messages.length, 0);
         });
 
         it("should process empty config", () => {
             const config = {};
             const messages = linter.verify(code, config, filename, true);
 
-            assert.equal(messages.length, 0);
+            assert.strictEqual(messages.length, 0);
         });
     });
 
@@ -1093,14 +1093,14 @@ describe("Linter", () => {
                         c = getVariable(scope, "c"),
                         d = getVariable(scope, "d");
 
-                    assert.equal(a.name, "a");
-                    assert.equal(a.writeable, false);
-                    assert.equal(b.name, "b");
-                    assert.equal(b.writeable, true);
-                    assert.equal(c.name, "c");
-                    assert.equal(c.writeable, false);
-                    assert.equal(d.name, "d");
-                    assert.equal(d.writeable, true);
+                    assert.strictEqual(a.name, "a");
+                    assert.strictEqual(a.writeable, false);
+                    assert.strictEqual(b.name, "b");
+                    assert.strictEqual(b.writeable, true);
+                    assert.strictEqual(c.name, "c");
+                    assert.strictEqual(c.writeable, false);
+                    assert.strictEqual(d.name, "d");
+                    assert.strictEqual(d.writeable, true);
                 });
 
                 return { Program: spy };
@@ -1125,12 +1125,12 @@ describe("Linter", () => {
                         b = getVariable(scope, "b"),
                         c = getVariable(scope, "c");
 
-                    assert.equal(a.name, "a");
-                    assert.equal(a.writeable, false);
-                    assert.equal(b.name, "b");
-                    assert.equal(b.writeable, true);
-                    assert.equal(c.name, "c");
-                    assert.equal(c.writeable, false);
+                    assert.strictEqual(a.name, "a");
+                    assert.strictEqual(a.writeable, false);
+                    assert.strictEqual(b.name, "b");
+                    assert.strictEqual(b.writeable, true);
+                    assert.strictEqual(c.name, "c");
+                    assert.strictEqual(c.writeable, false);
                 });
 
                 return { Program: spy };
@@ -1153,8 +1153,8 @@ describe("Linter", () => {
                         exports = getVariable(scope, "exports"),
                         window = getVariable(scope, "window");
 
-                    assert.equal(exports.writeable, true);
-                    assert.equal(window.writeable, false);
+                    assert.strictEqual(exports.writeable, true);
+                    assert.strictEqual(window.writeable, false);
                 });
 
                 return { Program: spy };
@@ -1178,8 +1178,8 @@ describe("Linter", () => {
                         exports = getVariable(scope, "exports"),
                         window = getVariable(scope, "window");
 
-                    assert.equal(exports.writeable, true);
-                    assert.equal(window, null);
+                    assert.strictEqual(exports.writeable, true);
+                    assert.strictEqual(window, null);
                 });
 
                 return { Program: spy };
@@ -1209,7 +1209,7 @@ describe("Linter", () => {
                     const scope = context.getScope(),
                         horse = getVariable(scope, "horse");
 
-                    assert.equal(horse.eslintUsed, true);
+                    assert.strictEqual(horse.eslintUsed, true);
                 });
 
                 return { Program: spy };
@@ -1229,7 +1229,7 @@ describe("Linter", () => {
                     const scope = context.getScope(),
                         horse = getVariable(scope, "horse");
 
-                    assert.equal(horse, null);
+                    assert.strictEqual(horse, null);
                 });
 
                 return { Program: spy };
@@ -1249,7 +1249,7 @@ describe("Linter", () => {
                     const scope = context.getScope(),
                         horse = getVariable(scope, "horse");
 
-                    assert.equal(horse.eslintUsed, true);
+                    assert.strictEqual(horse.eslintUsed, true);
                 });
 
                 return { Program: spy };
@@ -1269,7 +1269,7 @@ describe("Linter", () => {
                     const scope = context.getScope(),
                         horse = getVariable(scope, "horse");
 
-                    assert.equal(horse, null); // there is no global scope at all
+                    assert.strictEqual(horse, null); // there is no global scope at all
                 });
 
                 return { Program: spy };
@@ -1289,7 +1289,7 @@ describe("Linter", () => {
                     const scope = context.getScope(),
                         horse = getVariable(scope, "horse");
 
-                    assert.equal(horse, null); // there is no global scope at all
+                    assert.strictEqual(horse, null); // there is no global scope at all
                 });
 
                 return { Program: spy };
@@ -1311,7 +1311,7 @@ describe("Linter", () => {
                 spy = sandbox.spy(() => {
                     const scope = context.getScope();
 
-                    assert.equal(getVariable(scope, "a"), null);
+                    assert.strictEqual(getVariable(scope, "a"), null);
                 });
 
                 return { Program: spy };
@@ -1333,10 +1333,10 @@ describe("Linter", () => {
                 spy = sandbox.spy(() => {
                     const scope = context.getScope();
 
-                    assert.equal(getVariable(scope, "a"), null);
-                    assert.equal(getVariable(scope, "b"), null);
-                    assert.equal(getVariable(scope, "foo"), null);
-                    assert.equal(getVariable(scope, "c"), null);
+                    assert.strictEqual(getVariable(scope, "a"), null);
+                    assert.strictEqual(getVariable(scope, "b"), null);
+                    assert.strictEqual(getVariable(scope, "foo"), null);
+                    assert.strictEqual(getVariable(scope, "c"), null);
                 });
 
                 return { Program: spy };
@@ -1358,9 +1358,9 @@ describe("Linter", () => {
                 spy = sandbox.spy(() => {
                     const scope = context.getScope();
 
-                    assert.notEqual(getVariable(scope, "Object"), null);
-                    assert.notEqual(getVariable(scope, "Array"), null);
-                    assert.notEqual(getVariable(scope, "undefined"), null);
+                    assert.notStrictEqual(getVariable(scope, "Object"), null);
+                    assert.notStrictEqual(getVariable(scope, "Array"), null);
+                    assert.notStrictEqual(getVariable(scope, "undefined"), null);
                 });
 
                 return { Program: spy };
@@ -1378,9 +1378,9 @@ describe("Linter", () => {
                 spy = sandbox.spy(() => {
                     const scope = context.getScope();
 
-                    assert.equal(getVariable(scope, "Promise"), null);
-                    assert.equal(getVariable(scope, "Symbol"), null);
-                    assert.equal(getVariable(scope, "WeakMap"), null);
+                    assert.strictEqual(getVariable(scope, "Promise"), null);
+                    assert.strictEqual(getVariable(scope, "Symbol"), null);
+                    assert.strictEqual(getVariable(scope, "WeakMap"), null);
                 });
 
                 return { Program: spy };
@@ -1398,9 +1398,9 @@ describe("Linter", () => {
                 spy = sandbox.spy(() => {
                     const scope = context.getScope();
 
-                    assert.notEqual(getVariable(scope, "Promise"), null);
-                    assert.notEqual(getVariable(scope, "Symbol"), null);
-                    assert.notEqual(getVariable(scope, "WeakMap"), null);
+                    assert.notStrictEqual(getVariable(scope, "Promise"), null);
+                    assert.notStrictEqual(getVariable(scope, "Symbol"), null);
+                    assert.notStrictEqual(getVariable(scope, "WeakMap"), null);
                 });
 
                 return { Program: spy };
@@ -1427,9 +1427,9 @@ describe("Linter", () => {
 
             const messages = linter.verify("0", config, filename);
 
-            assert.equal(messages.length, 1);
-            assert.equal(messages[0].ruleId, code);
-            assert.equal(messages[0].nodeType, "Literal");
+            assert.strictEqual(messages.length, 1);
+            assert.strictEqual(messages[0].ruleId, code);
+            assert.strictEqual(messages[0].nodeType, "Literal");
         });
     });
 
@@ -1454,12 +1454,12 @@ describe("Linter", () => {
 
             const messages = linter.verify("0", config, filename);
 
-            assert.equal(messages.length, code.length);
+            assert.strictEqual(messages.length, code.length);
             code.forEach(item => {
                 assert.ok(messages.some(message => message.ruleId === item));
             });
             messages.forEach(message => {
-                assert.equal(message.nodeType, "Literal");
+                assert.strictEqual(message.nodeType, "Literal");
             });
         });
     });
@@ -1480,7 +1480,7 @@ describe("Linter", () => {
 
             const messages = linter.verify("0", config, filename);
 
-            assert.equal(messages[0].message, filename);
+            assert.strictEqual(messages[0].message, filename);
         });
 
         it("defaults filename to '<input>'", () => {
@@ -1496,7 +1496,7 @@ describe("Linter", () => {
 
             const messages = linter.verify("0", config);
 
-            assert.equal(messages[0].message, "<input>");
+            assert.strictEqual(messages[0].message, "<input>");
         });
     });
 
@@ -1508,9 +1508,9 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, config, filename);
 
-            assert.equal(messages.length, 1);
-            assert.equal(messages[0].ruleId, "no-alert");
-            assert.equal(messages[0].message, "Unexpected alert.");
+            assert.strictEqual(messages.length, 1);
+            assert.strictEqual(messages[0].ruleId, "no-alert");
+            assert.strictEqual(messages[0].message, "Unexpected alert.");
             assert.include(messages[0].nodeType, "CallExpression");
         });
 
@@ -1520,10 +1520,10 @@ describe("Linter", () => {
             const codeB = "function foo() { return 1; }";
             let messages = linter.verify(codeA, config, filename, false);
 
-            assert.equal(messages.length, 0);
+            assert.strictEqual(messages.length, 0);
 
             messages = linter.verify(codeB, config, filename, false);
-            assert.equal(messages.length, 1);
+            assert.strictEqual(messages.length, 1);
         });
 
         it("rules should not change initial config", () => {
@@ -1532,10 +1532,10 @@ describe("Linter", () => {
             const codeB = "function foo() { return '1'; }";
             let messages = linter.verify(codeA, config, filename, false);
 
-            assert.equal(messages.length, 0);
+            assert.strictEqual(messages.length, 0);
 
             messages = linter.verify(codeB, config, filename, false);
-            assert.equal(messages.length, 1);
+            assert.strictEqual(messages.length, 1);
         });
 
         it("rules should not change initial config", () => {
@@ -1544,10 +1544,10 @@ describe("Linter", () => {
             const codeB = "function foo() { return '1'; }";
             let messages = linter.verify(codeA, config, filename, false);
 
-            assert.equal(messages.length, 0);
+            assert.strictEqual(messages.length, 0);
 
             messages = linter.verify(codeB, config, filename, false);
-            assert.equal(messages.length, 1);
+            assert.strictEqual(messages.length, 1);
         });
 
         it("rules should not change initial config", () => {
@@ -1556,10 +1556,10 @@ describe("Linter", () => {
             const codeB = "var b = 55;";
             let messages = linter.verify(codeA, config, filename, false);
 
-            assert.equal(messages.length, 0);
+            assert.strictEqual(messages.length, 0);
 
             messages = linter.verify(codeB, config, filename, false);
-            assert.equal(messages.length, 1);
+            assert.strictEqual(messages.length, 1);
         });
     });
 
@@ -1583,7 +1583,7 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, config, filename);
 
-            assert.equal(messages.length, 0);
+            assert.strictEqual(messages.length, 0);
         });
     });
 
@@ -1595,11 +1595,11 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, config, filename);
 
-            assert.equal(messages.length, 2);
-            assert.equal(messages[0].ruleId, "no-alert");
-            assert.equal(messages[0].message, "Unexpected alert.");
+            assert.strictEqual(messages.length, 2);
+            assert.strictEqual(messages[0].ruleId, "no-alert");
+            assert.strictEqual(messages[0].message, "Unexpected alert.");
             assert.include(messages[0].nodeType, "CallExpression");
-            assert.equal(messages[1].ruleId, "no-console");
+            assert.strictEqual(messages[1].ruleId, "no-console");
         });
     });
 
@@ -1611,9 +1611,9 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, config, filename);
 
-            assert.equal(messages.length, 1);
-            assert.equal(messages[0].ruleId, "no-alert");
-            assert.equal(messages[0].message, "Unexpected alert.");
+            assert.strictEqual(messages.length, 1);
+            assert.strictEqual(messages[0].ruleId, "no-alert");
+            assert.strictEqual(messages[0].message, "Unexpected alert.");
             assert.include(messages[0].nodeType, "CallExpression");
         });
     });
@@ -1636,7 +1636,7 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, config, filename);
 
-            assert.equal(messages.length, 0);
+            assert.strictEqual(messages.length, 0);
         });
 
         it("should not report a violation when inline comment disables plugin rule", () => {
@@ -1645,7 +1645,7 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, config, filename);
 
-            assert.equal(messages.length, 0);
+            assert.strictEqual(messages.length, 0);
         });
 
         it("should report a violation when the report is right before the comment", () => {
@@ -1681,10 +1681,10 @@ describe("Linter", () => {
             const codeB = "var a = \"trigger violation\";";
             let messages = linter.verify(codeA, config, filename, false);
 
-            assert.equal(messages.length, 0);
+            assert.strictEqual(messages.length, 0);
 
             messages = linter.verify(codeB, config, filename, false);
-            assert.equal(messages.length, 1);
+            assert.strictEqual(messages.length, 1);
         });
     });
 
@@ -1726,11 +1726,11 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, config, filename);
 
-            assert.equal(messages.length, 1);
-            assert.equal(messages[0].ruleId, "no-alert");
-            assert.equal(messages[0].message, "Unexpected alert.");
+            assert.strictEqual(messages.length, 1);
+            assert.strictEqual(messages[0].ruleId, "no-alert");
+            assert.strictEqual(messages[0].message, "Unexpected alert.");
             assert.include(messages[0].nodeType, "CallExpression");
-            assert.equal(messages[0].line, 4);
+            assert.strictEqual(messages[0].line, 4);
         });
 
         it("should not report a violation", () => {
@@ -1743,7 +1743,7 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, config, filename);
 
-            assert.equal(messages.length, 0);
+            assert.strictEqual(messages.length, 0);
         });
 
         it("should not report a violation", () => {
@@ -1757,9 +1757,9 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, config, filename);
 
-            assert.equal(messages.length, 2);
-            assert.equal(messages[0].column, 21);
-            assert.equal(messages[1].column, 19);
+            assert.strictEqual(messages.length, 2);
+            assert.strictEqual(messages[0].column, 21);
+            assert.strictEqual(messages[1].column, 19);
         });
 
         it("should report a violation", () => {
@@ -1778,7 +1778,7 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, config, filename);
 
-            assert.equal(messages.length, 1);
+            assert.strictEqual(messages.length, 1);
         });
 
 
@@ -1793,7 +1793,7 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, config, filename);
 
-            assert.equal(messages.length, 0);
+            assert.strictEqual(messages.length, 0);
         });
 
         it("should not report a violation", () => {
@@ -1806,7 +1806,7 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, config, filename);
 
-            assert.equal(messages.length, 0);
+            assert.strictEqual(messages.length, 0);
         });
     });
 
@@ -1827,9 +1827,9 @@ describe("Linter", () => {
 
                 const messages = linter.verify(code, config, filename);
 
-                assert.equal(messages.length, 1);
+                assert.strictEqual(messages.length, 1);
 
-                assert.equal(messages[0].ruleId, "no-console");
+                assert.strictEqual(messages[0].ruleId, "no-console");
             });
 
             it("should report a violation", () => {
@@ -1847,9 +1847,9 @@ describe("Linter", () => {
 
                 const messages = linter.verify(code, config, filename);
 
-                assert.equal(messages.length, 1);
+                assert.strictEqual(messages.length, 1);
 
-                assert.equal(messages[0].ruleId, "no-alert");
+                assert.strictEqual(messages[0].ruleId, "no-alert");
             });
 
             it("should report a violation", () => {
@@ -1865,9 +1865,9 @@ describe("Linter", () => {
 
                 const messages = linter.verify(code, config, filename);
 
-                assert.equal(messages.length, 1);
+                assert.strictEqual(messages.length, 1);
 
-                assert.equal(messages[0].ruleId, "no-alert");
+                assert.strictEqual(messages[0].ruleId, "no-alert");
             });
 
             it("should not report a violation", () => {
@@ -1884,7 +1884,7 @@ describe("Linter", () => {
 
                 const messages = linter.verify(code, config, filename);
 
-                assert.equal(messages.length, 0);
+                assert.strictEqual(messages.length, 0);
             });
 
             it("should not report a violation", () => {
@@ -1903,7 +1903,7 @@ describe("Linter", () => {
 
                 const messages = linter.verify(code, config, filename);
 
-                assert.equal(messages.length, 0);
+                assert.strictEqual(messages.length, 0);
             });
         });
 
@@ -1922,8 +1922,8 @@ describe("Linter", () => {
                 };
                 const messages = linter.verify(code, config, filename);
 
-                assert.equal(messages.length, 1);
-                assert.equal(messages[0].ruleId, "no-console");
+                assert.strictEqual(messages.length, 1);
+                assert.strictEqual(messages[0].ruleId, "no-console");
             });
 
             it("should ignore violations only of specified rule", () => {
@@ -1940,9 +1940,9 @@ describe("Linter", () => {
                 };
                 const messages = linter.verify(code, config, filename);
 
-                assert.equal(messages.length, 2);
-                assert.equal(messages[0].ruleId, "no-alert");
-                assert.equal(messages[1].ruleId, "no-console");
+                assert.strictEqual(messages.length, 2);
+                assert.strictEqual(messages[0].ruleId, "no-alert");
+                assert.strictEqual(messages[1].ruleId, "no-console");
             });
 
             it("should ignore violations of multiple rules when specified", () => {
@@ -1960,8 +1960,8 @@ describe("Linter", () => {
                 };
                 const messages = linter.verify(code, config, filename);
 
-                assert.equal(messages.length, 1);
-                assert.equal(messages[0].ruleId, "no-console");
+                assert.strictEqual(messages.length, 1);
+                assert.strictEqual(messages[0].ruleId, "no-console");
             });
 
             it("should ignore violations of only the specified rule on next line", () => {
@@ -1979,9 +1979,9 @@ describe("Linter", () => {
                 };
                 const messages = linter.verify(code, config, filename);
 
-                assert.equal(messages.length, 2);
-                assert.equal(messages[0].ruleId, "no-alert");
-                assert.equal(messages[1].ruleId, "no-console");
+                assert.strictEqual(messages.length, 2);
+                assert.strictEqual(messages[0].ruleId, "no-alert");
+                assert.strictEqual(messages[1].ruleId, "no-console");
             });
 
             it("should ignore violations of specified rule on next line only", () => {
@@ -1999,9 +1999,9 @@ describe("Linter", () => {
                 };
                 const messages = linter.verify(code, config, filename);
 
-                assert.equal(messages.length, 2);
-                assert.equal(messages[0].ruleId, "no-alert");
-                assert.equal(messages[1].ruleId, "no-console");
+                assert.strictEqual(messages.length, 2);
+                assert.strictEqual(messages[0].ruleId, "no-alert");
+                assert.strictEqual(messages[1].ruleId, "no-console");
             });
 
             it("should ignore all rule violations on next line if none specified", () => {
@@ -2020,8 +2020,8 @@ describe("Linter", () => {
                 };
                 const messages = linter.verify(code, config, filename);
 
-                assert.equal(messages.length, 1);
-                assert.equal(messages[0].ruleId, "no-console");
+                assert.strictEqual(messages.length, 1);
+                assert.strictEqual(messages[0].ruleId, "no-console");
             });
 
             it("should not ignore violations if comment is in block quotes", () => {
@@ -2039,10 +2039,10 @@ describe("Linter", () => {
                 };
                 const messages = linter.verify(code, config, filename);
 
-                assert.equal(messages.length, 3);
-                assert.equal(messages[0].ruleId, "no-alert");
-                assert.equal(messages[1].ruleId, "no-alert");
-                assert.equal(messages[2].ruleId, "no-console");
+                assert.strictEqual(messages.length, 3);
+                assert.strictEqual(messages[0].ruleId, "no-alert");
+                assert.strictEqual(messages[1].ruleId, "no-alert");
+                assert.strictEqual(messages[2].ruleId, "no-console");
             });
 
             it("should not ignore violations if comment is of the type Shebang", () => {
@@ -2059,9 +2059,9 @@ describe("Linter", () => {
                 };
                 const messages = linter.verify(code, config, filename);
 
-                assert.equal(messages.length, 2);
-                assert.equal(messages[0].ruleId, "no-alert");
-                assert.equal(messages[1].ruleId, "no-console");
+                assert.strictEqual(messages.length, 2);
+                assert.strictEqual(messages[0].ruleId, "no-alert");
+                assert.strictEqual(messages[1].ruleId, "no-console");
             });
         });
     });
@@ -2078,9 +2078,9 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, config, filename);
 
-            assert.equal(messages.length, 1);
+            assert.strictEqual(messages.length, 1);
 
-            assert.equal(messages[0].ruleId, "no-console");
+            assert.strictEqual(messages[0].ruleId, "no-console");
         });
 
         it("should report no violation", () => {
@@ -2094,7 +2094,7 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, config, filename);
 
-            assert.equal(messages.length, 0);
+            assert.strictEqual(messages.length, 0);
         });
 
         it("should report no violation", () => {
@@ -2109,7 +2109,7 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, config, filename);
 
-            assert.equal(messages.length, 0);
+            assert.strictEqual(messages.length, 0);
         });
 
         it("should report no violation", () => {
@@ -2122,7 +2122,7 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, config, filename);
 
-            assert.equal(messages.length, 0);
+            assert.strictEqual(messages.length, 0);
         });
 
         it("should report a violation", () => {
@@ -2139,12 +2139,12 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, config, filename);
 
-            assert.equal(messages.length, 2);
+            assert.strictEqual(messages.length, 2);
 
-            assert.equal(messages[0].ruleId, "no-alert");
-            assert.equal(messages[0].line, 5);
-            assert.equal(messages[1].ruleId, "no-console");
-            assert.equal(messages[1].line, 6);
+            assert.strictEqual(messages[0].ruleId, "no-alert");
+            assert.strictEqual(messages[0].line, 5);
+            assert.strictEqual(messages[1].ruleId, "no-console");
+            assert.strictEqual(messages[1].line, 6);
         });
 
         it("should report a violation", () => {
@@ -2160,9 +2160,9 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, config, filename);
 
-            assert.equal(messages.length, 1);
+            assert.strictEqual(messages.length, 1);
 
-            assert.equal(messages[0].ruleId, "no-console");
+            assert.strictEqual(messages[0].ruleId, "no-console");
         });
 
 
@@ -2180,10 +2180,10 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, config, filename);
 
-            assert.equal(messages.length, 1);
+            assert.strictEqual(messages.length, 1);
 
-            assert.equal(messages[0].ruleId, "no-alert");
-            assert.equal(messages[0].line, 5);
+            assert.strictEqual(messages[0].ruleId, "no-alert");
+            assert.strictEqual(messages[0].line, 5);
         });
 
 
@@ -2210,19 +2210,19 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, config, filename);
 
-            assert.equal(messages.length, 4);
+            assert.strictEqual(messages.length, 4);
 
-            assert.equal(messages[0].ruleId, "no-alert");
-            assert.equal(messages[0].line, 6);
+            assert.strictEqual(messages[0].ruleId, "no-alert");
+            assert.strictEqual(messages[0].line, 6);
 
-            assert.equal(messages[1].ruleId, "no-console");
-            assert.equal(messages[1].line, 7);
+            assert.strictEqual(messages[1].ruleId, "no-console");
+            assert.strictEqual(messages[1].line, 7);
 
-            assert.equal(messages[2].ruleId, "no-alert");
-            assert.equal(messages[2].line, 9);
+            assert.strictEqual(messages[2].ruleId, "no-alert");
+            assert.strictEqual(messages[2].line, 9);
 
-            assert.equal(messages[3].ruleId, "no-console");
-            assert.equal(messages[3].line, 10);
+            assert.strictEqual(messages[3].ruleId, "no-console");
+            assert.strictEqual(messages[3].line, 10);
 
         });
 
@@ -2247,16 +2247,16 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, config, filename);
 
-            assert.equal(messages.length, 3);
+            assert.strictEqual(messages.length, 3);
 
-            assert.equal(messages[0].ruleId, "no-alert");
-            assert.equal(messages[0].line, 5);
+            assert.strictEqual(messages[0].ruleId, "no-alert");
+            assert.strictEqual(messages[0].line, 5);
 
-            assert.equal(messages[1].ruleId, "no-alert");
-            assert.equal(messages[1].line, 8);
+            assert.strictEqual(messages[1].ruleId, "no-alert");
+            assert.strictEqual(messages[1].line, 8);
 
-            assert.equal(messages[2].ruleId, "no-console");
-            assert.equal(messages[2].line, 9);
+            assert.strictEqual(messages[2].ruleId, "no-console");
+            assert.strictEqual(messages[2].line, 9);
 
         });
 
@@ -2281,16 +2281,16 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, config, filename);
 
-            assert.equal(messages.length, 3);
+            assert.strictEqual(messages.length, 3);
 
-            assert.equal(messages[0].ruleId, "no-alert");
-            assert.equal(messages[0].line, 5);
+            assert.strictEqual(messages[0].ruleId, "no-alert");
+            assert.strictEqual(messages[0].line, 5);
 
-            assert.equal(messages[1].ruleId, "no-alert");
-            assert.equal(messages[1].line, 8);
+            assert.strictEqual(messages[1].ruleId, "no-alert");
+            assert.strictEqual(messages[1].line, 8);
 
-            assert.equal(messages[2].ruleId, "no-console");
-            assert.equal(messages[2].line, 9);
+            assert.strictEqual(messages[2].ruleId, "no-console");
+            assert.strictEqual(messages[2].line, 9);
 
         });
     });
@@ -2303,9 +2303,9 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, config, filename);
 
-            assert.equal(messages.length, 1);
-            assert.equal(messages[0].ruleId, "no-alert");
-            assert.equal(messages[0].message, "Unexpected alert.");
+            assert.strictEqual(messages.length, 1);
+            assert.strictEqual(messages[0].ruleId, "no-alert");
+            assert.strictEqual(messages[0].message, "Unexpected alert.");
             assert.include(messages[0].nodeType, "CallExpression");
         });
     });
@@ -2318,9 +2318,9 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, config, filename);
 
-            assert.equal(messages.length, 1);
-            assert.equal(messages[0].ruleId, "quotes");
-            assert.equal(messages[0].message, "Strings must use doublequote.");
+            assert.strictEqual(messages.length, 1);
+            assert.strictEqual(messages[0].ruleId, "quotes");
+            assert.strictEqual(messages[0].message, "Strings must use doublequote.");
             assert.include(messages[0].nodeType, "Literal");
         });
     });
@@ -2333,9 +2333,9 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, config, filename);
 
-            assert.equal(messages.length, 1);
-            assert.equal(messages[0].ruleId, "quotes");
-            assert.equal(messages[0].message, "Strings must use doublequote.");
+            assert.strictEqual(messages.length, 1);
+            assert.strictEqual(messages[0].ruleId, "quotes");
+            assert.strictEqual(messages[0].message, "Strings must use doublequote.");
             assert.include(messages[0].nodeType, "Literal");
         });
     });
@@ -2348,7 +2348,7 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, config, filename);
 
-            assert.equal(messages.length, 2);
+            assert.strictEqual(messages.length, 2);
 
             /*
              * Incorrectly formatted comment threw error;
@@ -2358,11 +2358,11 @@ describe("Linter", () => {
              * parseJsonConfig function in lib/eslint.js
              */
             assert.match(messages[0].message, /^Failed to parse JSON from ' "no-alert":'1'':/);
-            assert.equal(messages[0].line, 1);
-            assert.equal(messages[0].column, 1);
+            assert.strictEqual(messages[0].line, 1);
+            assert.strictEqual(messages[0].column, 1);
 
-            assert.equal(messages[1].ruleId, "no-alert");
-            assert.equal(messages[1].message, "Unexpected alert.");
+            assert.strictEqual(messages[1].ruleId, "no-alert");
+            assert.strictEqual(messages[1].message, "Unexpected alert.");
             assert.include(messages[1].nodeType, "CallExpression");
         });
 
@@ -2373,7 +2373,7 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, config, filename);
 
-            assert.equal(messages.length, 2);
+            assert.strictEqual(messages.length, 2);
 
             /*
              * Incorrectly formatted comment threw error;
@@ -2383,11 +2383,11 @@ describe("Linter", () => {
              * parseJsonConfig function in lib/eslint.js
              */
             assert.match(messages[0].message, /^Failed to parse JSON from ' "no-alert":abc':/);
-            assert.equal(messages[0].line, 1);
-            assert.equal(messages[0].column, 1);
+            assert.strictEqual(messages[0].line, 1);
+            assert.strictEqual(messages[0].column, 1);
 
-            assert.equal(messages[1].ruleId, "no-alert");
-            assert.equal(messages[1].message, "Unexpected alert.");
+            assert.strictEqual(messages[1].ruleId, "no-alert");
+            assert.strictEqual(messages[1].message, "Unexpected alert.");
             assert.include(messages[1].nodeType, "CallExpression");
         });
 
@@ -2398,7 +2398,7 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, config, filename);
 
-            assert.equal(messages.length, 2);
+            assert.strictEqual(messages.length, 2);
 
             /*
              * Incorrectly formatted comment threw error;
@@ -2408,11 +2408,11 @@ describe("Linter", () => {
              * parseJsonConfig function in lib/eslint.js
              */
             assert.match(messages[0].message, /^Failed to parse JSON from ' "no-alert":0 2':/);
-            assert.equal(messages[0].line, 1);
-            assert.equal(messages[0].column, 1);
+            assert.strictEqual(messages[0].line, 1);
+            assert.strictEqual(messages[0].column, 1);
 
-            assert.equal(messages[1].ruleId, "no-alert");
-            assert.equal(messages[1].message, "Unexpected alert.");
+            assert.strictEqual(messages[1].ruleId, "no-alert");
+            assert.strictEqual(messages[1].message, "Unexpected alert.");
             assert.include(messages[1].nodeType, "CallExpression");
         });
     });
@@ -2423,9 +2423,9 @@ describe("Linter", () => {
         it("should not parse errors, should report a violation", () => {
             const messages = linter.verify(code, {}, filename);
 
-            assert.equal(messages.length, 1);
-            assert.equal(messages[0].ruleId, "max-len");
-            assert.equal(messages[0].message, "Line 1 exceeds the maximum line length of 100.");
+            assert.strictEqual(messages.length, 1);
+            assert.strictEqual(messages[0].ruleId, "max-len");
+            assert.strictEqual(messages[0].message, "Line 1 exceeds the maximum line length of 100.");
             assert.include(messages[0].nodeType, "Program");
         });
     });
@@ -2437,10 +2437,10 @@ describe("Linter", () => {
             const config = { rules: { "no-extra-semi": 1 } };
             const messages = linter.verify(code, config);
 
-            assert.equal(messages.length, 1);
-            assert.equal(messages[0].ruleId, "no-extra-semi");
-            assert.equal(messages[0].nodeType, "EmptyStatement");
-            assert.equal(messages[0].line, 3);
+            assert.strictEqual(messages.length, 1);
+            assert.strictEqual(messages[0].ruleId, "no-extra-semi");
+            assert.strictEqual(messages[0].nodeType, "EmptyStatement");
+            assert.strictEqual(messages[0].line, 3);
         });
 
         it("should have a comment with the shebang in it", () => {
@@ -2448,8 +2448,8 @@ describe("Linter", () => {
             const spy = sandbox.spy(context => {
                 const comments = context.getAllComments();
 
-                assert.equal(comments.length, 1);
-                assert.equal(comments[0].type, "Shebang");
+                assert.strictEqual(comments.length, 1);
+                assert.strictEqual(comments[0].type, "Shebang");
                 return {};
             });
 
@@ -2465,12 +2465,12 @@ describe("Linter", () => {
         it("should report a violation with a useful parse error prefix", () => {
             const messages = linter.verify(code);
 
-            assert.equal(messages.length, 1);
-            assert.equal(messages[0].severity, 2);
+            assert.strictEqual(messages.length, 1);
+            assert.strictEqual(messages[0].severity, 2);
             assert.isNull(messages[0].ruleId);
-            assert.equal(messages[0].source, BROKEN_TEST_CODE);
-            assert.equal(messages[0].line, 1);
-            assert.equal(messages[0].column, 4);
+            assert.strictEqual(messages[0].source, BROKEN_TEST_CODE);
+            assert.strictEqual(messages[0].line, 1);
+            assert.strictEqual(messages[0].column, 4);
             assert.isTrue(messages[0].fatal);
             assert.match(messages[0].message, /^Parsing error:/);
         });
@@ -2484,9 +2484,9 @@ describe("Linter", () => {
             ];
             const messages = linter.verify(inValidCode.join("\n"));
 
-            assert.equal(messages.length, 1);
-            assert.equal(messages[0].severity, 2);
-            assert.equal(messages[0].source, inValidCode[1]);
+            assert.strictEqual(messages.length, 1);
+            assert.strictEqual(messages[0].severity, 2);
+            assert.strictEqual(messages[0].source, inValidCode[1]);
             assert.isTrue(messages[0].fatal);
             assert.match(messages[0].message, /^Parsing error:/);
         });
@@ -2508,18 +2508,18 @@ describe("Linter", () => {
             assert.isArray(results);
             assert.isObject(result);
             assert.property(result, "ruleId");
-            assert.equal(result.ruleId, "foobar");
+            assert.strictEqual(result.ruleId, "foobar");
         });
 
         it("should report that the rule does not exist", () => {
             assert.property(result, "message");
-            assert.equal(result.message, "Definition for rule 'foobar' was not found");
+            assert.strictEqual(result.message, "Definition for rule 'foobar' was not found");
         });
 
         it("should report at the correct severity", () => {
             assert.property(result, "severity");
-            assert.equal(result.severity, 2);
-            assert.equal(warningResult.severity, 1);
+            assert.strictEqual(result.severity, 2);
+            assert.strictEqual(warningResult.severity, 1);
         });
 
         it("should accept any valid rule configuration", () => {
@@ -2550,8 +2550,8 @@ describe("Linter", () => {
         const results = linter.verify(code, { rules: { "no-comma-dangle": 2 } });
 
         it("should report the new rule", () => {
-            assert.equal(results[0].ruleId, "no-comma-dangle");
-            assert.equal(results[0].message, "Rule 'no-comma-dangle' was removed and replaced by: comma-dangle");
+            assert.strictEqual(results[0].ruleId, "no-comma-dangle");
+            assert.strictEqual(results[0].message, "Rule 'no-comma-dangle' was removed and replaced by: comma-dangle");
         });
     });
 
@@ -2591,7 +2591,7 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, config, filename);
 
-            assert.equal(messages.length, 1);
+            assert.strictEqual(messages.length, 1);
         });
 
         it("should report a violation when using Promise", () => {
@@ -2601,7 +2601,7 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, config, filename);
 
-            assert.equal(messages.length, 1);
+            assert.strictEqual(messages.length, 1);
         });
     });
 
@@ -2613,10 +2613,10 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, config, filename);
 
-            assert.equal(messages.length, 1);
-            assert.equal(messages[0].ruleId, "no-undef");
-            assert.equal(messages[0].nodeType, "Identifier");
-            assert.equal(messages[0].line, 1);
+            assert.strictEqual(messages.length, 1);
+            assert.strictEqual(messages[0].ruleId, "no-undef");
+            assert.strictEqual(messages[0].nodeType, "Identifier");
+            assert.strictEqual(messages[0].line, 1);
         });
 
         it("should not report a violation", () => {
@@ -2626,7 +2626,7 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, config, filename);
 
-            assert.equal(messages.length, 0);
+            assert.strictEqual(messages.length, 0);
         });
 
         it("should not report a violation", () => {
@@ -2636,7 +2636,7 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, config, filename);
 
-            assert.equal(messages.length, 0);
+            assert.strictEqual(messages.length, 0);
         });
 
         it("should not report a violation", () => {
@@ -2646,7 +2646,7 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, config, filename);
 
-            assert.equal(messages.length, 0);
+            assert.strictEqual(messages.length, 0);
         });
 
         it("should not report a violation", () => {
@@ -2656,7 +2656,7 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, config, filename);
 
-            assert.equal(messages.length, 0);
+            assert.strictEqual(messages.length, 0);
         });
 
         it("should not report a violation", () => {
@@ -2666,7 +2666,7 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, config, filename);
 
-            assert.equal(messages.length, 0);
+            assert.strictEqual(messages.length, 0);
         });
 
         it("should not report a violation", () => {
@@ -2676,7 +2676,7 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, config, filename);
 
-            assert.equal(messages.length, 0);
+            assert.strictEqual(messages.length, 0);
         });
 
         it("should not report a violation", () => {
@@ -2686,7 +2686,7 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, config, filename);
 
-            assert.equal(messages.length, 0);
+            assert.strictEqual(messages.length, 0);
         });
 
         it("should not report a violation", () => {
@@ -2696,7 +2696,7 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, config, filename);
 
-            assert.equal(messages.length, 0);
+            assert.strictEqual(messages.length, 0);
         });
     });
 
@@ -2716,8 +2716,8 @@ describe("Linter", () => {
                 allowInlineConfig: false
             });
 
-            assert.equal(messages.length, 1);
-            assert.equal(messages[0].ruleId, "no-alert");
+            assert.strictEqual(messages.length, 1);
+            assert.strictEqual(messages[0].ruleId, "no-alert");
         });
 
         it("should report a violation for global variable declarations", () => {
@@ -2739,7 +2739,7 @@ describe("Linter", () => {
                             const sourceCode = context.getSourceCode();
                             const comments = sourceCode.getAllComments();
 
-                            assert.equal(1, comments.length);
+                            assert.strictEqual(1, comments.length);
 
                             const foo = getVariable(scope, "foo");
 
@@ -2771,8 +2771,8 @@ describe("Linter", () => {
                 allowInlineConfig: false
             });
 
-            assert.equal(messages.length, 1);
-            assert.equal(messages[0].ruleId, "no-alert");
+            assert.strictEqual(messages.length, 1);
+            assert.strictEqual(messages[0].ruleId, "no-alert");
         });
 
         it("should not report a violation for rule changes", () => {
@@ -2791,7 +2791,7 @@ describe("Linter", () => {
                 allowInlineConfig: false
             });
 
-            assert.equal(messages.length, 0);
+            assert.strictEqual(messages.length, 0);
         });
 
         it("should report a violation for disable-line", () => {
@@ -2809,8 +2809,8 @@ describe("Linter", () => {
                 allowInlineConfig: false
             });
 
-            assert.equal(messages.length, 1);
-            assert.equal(messages[0].ruleId, "no-alert");
+            assert.strictEqual(messages.length, 1);
+            assert.strictEqual(messages[0].ruleId, "no-alert");
         });
 
         it("should report a violation for env changes", () => {
@@ -2832,7 +2832,7 @@ describe("Linter", () => {
                             const sourceCode = context.getSourceCode();
                             const comments = sourceCode.getAllComments();
 
-                            assert.equal(1, comments.length);
+                            assert.strictEqual(1, comments.length);
 
                             const windowVar = getVariable(scope, "window");
 
@@ -2884,7 +2884,7 @@ describe("Linter", () => {
                 allowInlineConfig: true
             });
 
-            assert.equal(messages.length, 0);
+            assert.strictEqual(messages.length, 0);
         });
     });
 
@@ -2896,7 +2896,7 @@ describe("Linter", () => {
 
             linter.defineRule("checker", context => {
                 spy = sandbox.spy(node => {
-                    assert.equal(context.getSource(node), "'123';");
+                    assert.strictEqual(context.getSource(node), "'123';");
                 });
                 return { ExpressionStatement: spy };
             });
@@ -2961,13 +2961,13 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, config, filename);
 
-            assert.equal(messages.length, 3);
-            assert.equal(messages[0].line, 1);
-            assert.equal(messages[0].column, 6);
-            assert.equal(messages[1].line, 2);
-            assert.equal(messages[1].column, 18);
-            assert.equal(messages[2].line, 2);
-            assert.equal(messages[2].column, 18);
+            assert.strictEqual(messages.length, 3);
+            assert.strictEqual(messages[0].line, 1);
+            assert.strictEqual(messages[0].column, 6);
+            assert.strictEqual(messages[1].line, 2);
+            assert.strictEqual(messages[1].column, 18);
+            assert.strictEqual(messages[2].line, 2);
+            assert.strictEqual(messages[2].column, 18);
         });
 
         describe("ecmaVersion", () => {
@@ -2979,7 +2979,7 @@ describe("Linter", () => {
                         }
                     });
 
-                    assert.equal(messages.length, 0);
+                    assert.strictEqual(messages.length, 0);
                 });
 
                 it("the ECMAScript version number is 2015", () => {
@@ -2989,7 +2989,7 @@ describe("Linter", () => {
                         }
                     });
 
-                    assert.equal(messages.length, 0);
+                    assert.strictEqual(messages.length, 0);
                 });
             });
 
@@ -3000,7 +3000,7 @@ describe("Linter", () => {
                     }
                 });
 
-                assert.equal(messages.length, 1);
+                assert.strictEqual(messages.length, 1);
             });
 
             describe("should properly parse exponentiation operator when", () => {
@@ -3011,7 +3011,7 @@ describe("Linter", () => {
                         }
                     });
 
-                    assert.equal(messages.length, 0);
+                    assert.strictEqual(messages.length, 0);
                 });
 
                 it("the ECMAScript version number is 2016", () => {
@@ -3021,7 +3021,7 @@ describe("Linter", () => {
                         }
                     });
 
-                    assert.equal(messages.length, 0);
+                    assert.strictEqual(messages.length, 0);
                 });
             });
         });
@@ -3037,7 +3037,7 @@ describe("Linter", () => {
                 }
             }, filename);
 
-            assert.equal(messages.length, 0);
+            assert.strictEqual(messages.length, 0);
         });
 
         it("should properly parse global return when passed ecmaFeatures", () => {
@@ -3050,7 +3050,7 @@ describe("Linter", () => {
                 }
             }, filename);
 
-            assert.equal(messages.length, 0);
+            assert.strictEqual(messages.length, 0);
         });
 
         it("should properly parse global return when in Node.js environment", () => {
@@ -3061,7 +3061,7 @@ describe("Linter", () => {
                 }
             }, filename);
 
-            assert.equal(messages.length, 0);
+            assert.strictEqual(messages.length, 0);
         });
 
         it("should not parse global return when in Node.js environment with globalReturn explicitly off", () => {
@@ -3077,23 +3077,23 @@ describe("Linter", () => {
                 }
             }, filename);
 
-            assert.equal(messages.length, 1);
-            assert.equal(messages[0].message, "Parsing error: 'return' outside of function");
+            assert.strictEqual(messages.length, 1);
+            assert.strictEqual(messages[0].message, "Parsing error: 'return' outside of function");
         });
 
         it("should not parse global return when Node.js environment is false", () => {
 
             const messages = linter.verify("return;", {}, filename);
 
-            assert.equal(messages.length, 1);
-            assert.equal(messages[0].message, "Parsing error: 'return' outside of function");
+            assert.strictEqual(messages.length, 1);
+            assert.strictEqual(messages[0].message, "Parsing error: 'return' outside of function");
         });
 
         it("should properly parse sloppy-mode code when impliedStrict is false", () => {
 
             const messages = linter.verify("var private;", {}, filename);
 
-            assert.equal(messages.length, 0);
+            assert.strictEqual(messages.length, 0);
         });
 
         it("should not parse sloppy-mode code when impliedStrict is true", () => {
@@ -3106,8 +3106,8 @@ describe("Linter", () => {
                 }
             }, filename);
 
-            assert.equal(messages.length, 1);
-            assert.equal(messages[0].message, "Parsing error: The keyword 'private' is reserved");
+            assert.strictEqual(messages.length, 1);
+            assert.strictEqual(messages[0].message, "Parsing error: The keyword 'private' is reserved");
         });
 
         it("should properly parse valid code when impliedStrict is true", () => {
@@ -3120,7 +3120,7 @@ describe("Linter", () => {
                 }
             }, filename);
 
-            assert.equal(messages.length, 0);
+            assert.strictEqual(messages.length, 0);
         });
 
         it("should properly parse JSX when passed ecmaFeatures", () => {
@@ -3133,31 +3133,31 @@ describe("Linter", () => {
                 }
             }, filename);
 
-            assert.equal(messages.length, 0);
+            assert.strictEqual(messages.length, 0);
         });
 
         it("should report an error when JSX code is encountered and JSX is not enabled", () => {
             const code = "var myDivElement = <div className=\"foo\" />;";
             const messages = linter.verify(code, {}, "filename");
 
-            assert.equal(messages.length, 1);
-            assert.equal(messages[0].line, 1);
-            assert.equal(messages[0].column, 20);
-            assert.equal(messages[0].message, "Parsing error: Unexpected token <");
+            assert.strictEqual(messages.length, 1);
+            assert.strictEqual(messages[0].line, 1);
+            assert.strictEqual(messages[0].column, 20);
+            assert.strictEqual(messages[0].message, "Parsing error: Unexpected token <");
         });
 
         it("should not report an error when JSX code is encountered and JSX is enabled", () => {
             const code = "var myDivElement = <div className=\"foo\" />;";
             const messages = linter.verify(code, { parserOptions: { ecmaFeatures: { jsx: true } } }, "filename");
 
-            assert.equal(messages.length, 0);
+            assert.strictEqual(messages.length, 0);
         });
 
         it("should not report an error when JSX code contains a spread operator and JSX is enabled", () => {
             const code = "var myDivElement = <div {...this.props} />;";
             const messages = linter.verify(code, { parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } }, "filename");
 
-            assert.equal(messages.length, 0);
+            assert.strictEqual(messages.length, 0);
         });
 
         it("should be able to use es6 features if there is a comment which has \"eslint-env es6\"", () => {
@@ -3186,13 +3186,13 @@ describe("Linter", () => {
 
             const messages = linter.verify(code, null, "eslint-env es6");
 
-            assert.equal(messages.length, 0);
+            assert.strictEqual(messages.length, 0);
         });
 
         it("should be able to return in global if there is a comment which has \"eslint-env node\"", () => {
             const messages = linter.verify("/* eslint-env node */ return;", null, "eslint-env node");
 
-            assert.equal(messages.length, 0);
+            assert.strictEqual(messages.length, 0);
         });
 
         it("should attach a \"/*global\" comment node to declared variables", () => {
@@ -3207,22 +3207,22 @@ describe("Linter", () => {
                             const sourceCode = context.getSourceCode();
                             const comments = sourceCode.getAllComments();
 
-                            assert.equal(2, comments.length);
+                            assert.strictEqual(2, comments.length);
 
                             const foo = getVariable(scope, "foo");
 
-                            assert.equal(true, foo.eslintExplicitGlobal);
-                            assert.equal(comments[0], foo.eslintExplicitGlobalComment);
+                            assert.strictEqual(true, foo.eslintExplicitGlobal);
+                            assert.strictEqual(comments[0], foo.eslintExplicitGlobalComment);
 
                             const bar = getVariable(scope, "bar");
 
-                            assert.equal(true, bar.eslintExplicitGlobal);
-                            assert.equal(comments[1], bar.eslintExplicitGlobalComment);
+                            assert.strictEqual(true, bar.eslintExplicitGlobal);
+                            assert.strictEqual(comments[1], bar.eslintExplicitGlobalComment);
 
                             const baz = getVariable(scope, "baz");
 
-                            assert.equal(true, baz.eslintExplicitGlobal);
-                            assert.equal(comments[1], baz.eslintExplicitGlobalComment);
+                            assert.strictEqual(true, baz.eslintExplicitGlobal);
+                            assert.strictEqual(comments[1], baz.eslintExplicitGlobalComment);
 
                             ok = true;
                         }
@@ -3330,13 +3330,13 @@ describe("Linter", () => {
         });
 
         it("Scope#through should contain references of undefined variables", () => {
-            assert.equal(scope.through.length, 2);
-            assert.equal(scope.through[0].identifier.name, "a");
-            assert.equal(scope.through[0].identifier.loc.start.line, 1);
-            assert.equal(scope.through[0].resolved, null);
-            assert.equal(scope.through[1].identifier.name, "b");
-            assert.equal(scope.through[1].identifier.loc.start.line, 2);
-            assert.equal(scope.through[1].resolved, null);
+            assert.strictEqual(scope.through.length, 2);
+            assert.strictEqual(scope.through[0].identifier.name, "a");
+            assert.strictEqual(scope.through[0].identifier.loc.start.line, 1);
+            assert.strictEqual(scope.through[0].resolved, null);
+            assert.strictEqual(scope.through[1].identifier.name, "b");
+            assert.strictEqual(scope.through[1].identifier.loc.start.line, 2);
+            assert.strictEqual(scope.through[1].resolved, null);
         });
 
         it("Scope#variables should contain global variables", () => {
@@ -3358,39 +3358,39 @@ describe("Linter", () => {
         });
 
         it("Variables#references should contain their references", () => {
-            assert.equal(scope.set.get("Object").references.length, 1);
-            assert.equal(scope.set.get("Object").references[0].identifier.name, "Object");
-            assert.equal(scope.set.get("Object").references[0].identifier.loc.start.line, 3);
-            assert.equal(scope.set.get("Object").references[0].resolved, scope.set.get("Object"));
-            assert.equal(scope.set.get("foo").references.length, 1);
-            assert.equal(scope.set.get("foo").references[0].identifier.name, "foo");
-            assert.equal(scope.set.get("foo").references[0].identifier.loc.start.line, 4);
-            assert.equal(scope.set.get("foo").references[0].resolved, scope.set.get("foo"));
-            assert.equal(scope.set.get("c").references.length, 1);
-            assert.equal(scope.set.get("c").references[0].identifier.name, "c");
-            assert.equal(scope.set.get("c").references[0].identifier.loc.start.line, 6);
-            assert.equal(scope.set.get("c").references[0].resolved, scope.set.get("c"));
-            assert.equal(scope.set.get("d").references.length, 1);
-            assert.equal(scope.set.get("d").references[0].identifier.name, "d");
-            assert.equal(scope.set.get("d").references[0].identifier.loc.start.line, 8);
-            assert.equal(scope.set.get("d").references[0].resolved, scope.set.get("d"));
-            assert.equal(scope.set.get("e").references.length, 1);
-            assert.equal(scope.set.get("e").references[0].identifier.name, "e");
-            assert.equal(scope.set.get("e").references[0].identifier.loc.start.line, 9);
-            assert.equal(scope.set.get("e").references[0].resolved, scope.set.get("e"));
-            assert.equal(scope.set.get("f").references.length, 1);
-            assert.equal(scope.set.get("f").references[0].identifier.name, "f");
-            assert.equal(scope.set.get("f").references[0].identifier.loc.start.line, 10);
-            assert.equal(scope.set.get("f").references[0].resolved, scope.set.get("f"));
+            assert.strictEqual(scope.set.get("Object").references.length, 1);
+            assert.strictEqual(scope.set.get("Object").references[0].identifier.name, "Object");
+            assert.strictEqual(scope.set.get("Object").references[0].identifier.loc.start.line, 3);
+            assert.strictEqual(scope.set.get("Object").references[0].resolved, scope.set.get("Object"));
+            assert.strictEqual(scope.set.get("foo").references.length, 1);
+            assert.strictEqual(scope.set.get("foo").references[0].identifier.name, "foo");
+            assert.strictEqual(scope.set.get("foo").references[0].identifier.loc.start.line, 4);
+            assert.strictEqual(scope.set.get("foo").references[0].resolved, scope.set.get("foo"));
+            assert.strictEqual(scope.set.get("c").references.length, 1);
+            assert.strictEqual(scope.set.get("c").references[0].identifier.name, "c");
+            assert.strictEqual(scope.set.get("c").references[0].identifier.loc.start.line, 6);
+            assert.strictEqual(scope.set.get("c").references[0].resolved, scope.set.get("c"));
+            assert.strictEqual(scope.set.get("d").references.length, 1);
+            assert.strictEqual(scope.set.get("d").references[0].identifier.name, "d");
+            assert.strictEqual(scope.set.get("d").references[0].identifier.loc.start.line, 8);
+            assert.strictEqual(scope.set.get("d").references[0].resolved, scope.set.get("d"));
+            assert.strictEqual(scope.set.get("e").references.length, 1);
+            assert.strictEqual(scope.set.get("e").references[0].identifier.name, "e");
+            assert.strictEqual(scope.set.get("e").references[0].identifier.loc.start.line, 9);
+            assert.strictEqual(scope.set.get("e").references[0].resolved, scope.set.get("e"));
+            assert.strictEqual(scope.set.get("f").references.length, 1);
+            assert.strictEqual(scope.set.get("f").references[0].identifier.name, "f");
+            assert.strictEqual(scope.set.get("f").references[0].identifier.loc.start.line, 10);
+            assert.strictEqual(scope.set.get("f").references[0].resolved, scope.set.get("f"));
         });
 
         it("Reference#resolved should be their variable", () => {
-            assert.equal(scope.set.get("Object").references[0].resolved, scope.set.get("Object"));
-            assert.equal(scope.set.get("foo").references[0].resolved, scope.set.get("foo"));
-            assert.equal(scope.set.get("c").references[0].resolved, scope.set.get("c"));
-            assert.equal(scope.set.get("d").references[0].resolved, scope.set.get("d"));
-            assert.equal(scope.set.get("e").references[0].resolved, scope.set.get("e"));
-            assert.equal(scope.set.get("f").references[0].resolved, scope.set.get("f"));
+            assert.strictEqual(scope.set.get("Object").references[0].resolved, scope.set.get("Object"));
+            assert.strictEqual(scope.set.get("foo").references[0].resolved, scope.set.get("foo"));
+            assert.strictEqual(scope.set.get("c").references[0].resolved, scope.set.get("c"));
+            assert.strictEqual(scope.set.get("d").references[0].resolved, scope.set.get("d"));
+            assert.strictEqual(scope.set.get("e").references[0].resolved, scope.set.get("e"));
+            assert.strictEqual(scope.set.get("f").references[0].resolved, scope.set.get("f"));
         });
     });
 
@@ -3413,7 +3413,7 @@ describe("Linter", () => {
                      * @returns {void}
                      */
                     function checkEmpty(node) {
-                        assert.equal(0, context.getDeclaredVariables(node).length);
+                        assert.strictEqual(0, context.getDeclaredVariables(node).length);
                     }
                     const rule = {
                         Program: checkEmpty,
@@ -3471,9 +3471,9 @@ describe("Linter", () => {
 
                         assert(Array.isArray(expectedNames));
                         assert(Array.isArray(variables));
-                        assert.equal(expectedNames.length, variables.length);
+                        assert.strictEqual(expectedNames.length, variables.length);
                         for (let i = variables.length - 1; i >= 0; i--) {
-                            assert.equal(expectedNames[i], variables[i].name);
+                            assert.strictEqual(expectedNames[i], variables[i].name);
                         }
                     };
                     return rule;
@@ -3488,7 +3488,7 @@ describe("Linter", () => {
             });
 
             // Check all expected names are asserted.
-            assert.equal(0, expectedNamesList.length);
+            assert.strictEqual(0, expectedNamesList.length);
         }
 
         it("VariableDeclaration", () => {
@@ -3807,7 +3807,7 @@ describe("Linter", () => {
                 }
             }, { filename: "test.js" });
 
-            assert.equal(messages.output, "var a;", "Fixes were applied correctly");
+            assert.strictEqual(messages.output, "var a;", "Fixes were applied correctly");
             assert.isTrue(messages.fixed);
         });
 
@@ -3892,21 +3892,21 @@ describe("Linter", () => {
             const code = "import foo from 'foo';";
             const messages = linter.verify(code, { parserOptions: { sourceType: "module" } });
 
-            assert.equal(messages.length, 0);
+            assert.strictEqual(messages.length, 0);
         });
 
         it("should properly parse import all statements when sourceType is module", () => {
             const code = "import * as foo from 'foo';";
             const messages = linter.verify(code, { parserOptions: { sourceType: "module" } });
 
-            assert.equal(messages.length, 0);
+            assert.strictEqual(messages.length, 0);
         });
 
         it("should properly parse default export statements when sourceType is module", () => {
             const code = "export default function initialize() {}";
             const messages = linter.verify(code, { parserOptions: { sourceType: "module" } });
 
-            assert.equal(messages.length, 0);
+            assert.strictEqual(messages.length, 0);
         });
 
         it("should not crash when invalid parentheses syntax is encountered", () => {
@@ -3924,8 +3924,8 @@ describe("Linter", () => {
         it("should report syntax error when a keyword exists in object property shorthand", () => {
             const messages = linter.verify("let a = {this}", { parserOptions: { ecmaVersion: 6 } });
 
-            assert.equal(messages.length, 1);
-            assert.equal(messages[0].fatal, true);
+            assert.strictEqual(messages.length, 1);
+            assert.strictEqual(messages[0].fatal, true);
         });
 
         it("should not rewrite env setting in core (https://github.com/eslint/eslint/issues/4814)", () => {
@@ -3982,35 +3982,35 @@ describe("Linter", () => {
                 const code = "var myDivElement = <div {...this.props} />;";
                 const messages = linter.verify(code, { parser: "esprima-fb" }, "filename");
 
-                assert.equal(messages.length, 0);
+                assert.strictEqual(messages.length, 0);
             });
 
             it("should return an error when the custom parser can't be found", () => {
                 const code = "var myDivElement = <div {...this.props} />;";
                 const messages = linter.verify(code, { parser: "esprima-fbxyz" }, "filename");
 
-                assert.equal(messages.length, 1);
-                assert.equal(messages[0].severity, 2);
-                assert.equal(messages[0].message, "Cannot find module 'esprima-fbxyz'");
+                assert.strictEqual(messages.length, 1);
+                assert.strictEqual(messages[0].severity, 2);
+                assert.strictEqual(messages[0].message, "Cannot find module 'esprima-fbxyz'");
             });
 
             it("should strip leading line: prefix from parser error", () => {
                 const parser = path.join(parserFixtures, "line-error.js");
                 const messages = linter.verify(";", { parser }, "filename");
 
-                assert.equal(messages.length, 1);
-                assert.equal(messages[0].severity, 2);
+                assert.strictEqual(messages.length, 1);
+                assert.strictEqual(messages[0].severity, 2);
                 assert.isNull(messages[0].source);
-                assert.equal(messages[0].message, errorPrefix + require(parser).expectedError);
+                assert.strictEqual(messages[0].message, errorPrefix + require(parser).expectedError);
             });
 
             it("should not modify a parser error message without a leading line: prefix", () => {
                 const parser = path.join(parserFixtures, "no-line-error.js");
                 const messages = linter.verify(";", { parser }, "filename");
 
-                assert.equal(messages.length, 1);
-                assert.equal(messages[0].severity, 2);
-                assert.equal(messages[0].message, errorPrefix + require(parser).expectedError);
+                assert.strictEqual(messages.length, 1);
+                assert.strictEqual(messages[0].severity, 2);
+                assert.strictEqual(messages[0].message, errorPrefix + require(parser).expectedError);
             });
 
             it("should not pass any default parserOptions to the parser", () => {

--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -125,7 +125,7 @@ describe("Linter", () => {
         it("should get proper lines when using \\n as a line break", () => {
             const code = "a;\nb;";
             const spy = sandbox.spy(context => {
-                assert.deepEqual(context.getSourceLines(), ["a;", "b;"]);
+                assert.deepStrictEqual(context.getSourceLines(), ["a;", "b;"]);
                 return {};
             });
 
@@ -137,7 +137,7 @@ describe("Linter", () => {
         it("should get proper lines when using \\r\\n as a line break", () => {
             const code = "a;\r\nb;";
             const spy = sandbox.spy(context => {
-                assert.deepEqual(context.getSourceLines(), ["a;", "b;"]);
+                assert.deepStrictEqual(context.getSourceLines(), ["a;", "b;"]);
                 return {};
             });
 
@@ -149,7 +149,7 @@ describe("Linter", () => {
         it("should get proper lines when using \\r as a line break", () => {
             const code = "a;\rb;";
             const spy = sandbox.spy(context => {
-                assert.deepEqual(context.getSourceLines(), ["a;", "b;"]);
+                assert.deepStrictEqual(context.getSourceLines(), ["a;", "b;"]);
                 return {};
             });
 
@@ -161,7 +161,7 @@ describe("Linter", () => {
         it("should get proper lines when using \\u2028 as a line break", () => {
             const code = "a;\u2028b;";
             const spy = sandbox.spy(context => {
-                assert.deepEqual(context.getSourceLines(), ["a;", "b;"]);
+                assert.deepStrictEqual(context.getSourceLines(), ["a;", "b;"]);
                 return {};
             });
 
@@ -173,7 +173,7 @@ describe("Linter", () => {
         it("should get proper lines when using \\u2029 as a line break", () => {
             const code = "a;\u2029b;";
             const spy = sandbox.spy(context => {
-                assert.deepEqual(context.getSourceLines(), ["a;", "b;"]);
+                assert.deepStrictEqual(context.getSourceLines(), ["a;", "b;"]);
                 return {};
             });
 
@@ -1699,7 +1699,7 @@ describe("Linter", () => {
             const spy = sandbox.spy((ruleId, severity, node, message) => {
                 assert.strictEqual(ruleId, "foo");
                 assert.strictEqual(severity, 2);
-                assert.deepEqual(node.loc, { start: { line: 5, column: 4 } });
+                assert.deepStrictEqual(node.loc, { start: { line: 5, column: 4 } });
                 assert.strictEqual(message, "foo");
             });
 
@@ -2530,7 +2530,7 @@ describe("Linter", () => {
         it("should report multiple missing rules", () => {
             assert.isArray(resultsMultiple);
 
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 resultsMultiple[1],
                 {
                     ruleId: "barfoo",
@@ -2851,7 +2851,7 @@ describe("Linter", () => {
 
     describe("reportUnusedDisable option", () => {
         it("reports problems for unused eslint-disable comments", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 linter.verify("/* eslint-disable */", {}, { reportUnusedDisableDirectives: true }),
                 [
                     {
@@ -3698,7 +3698,7 @@ describe("Linter", () => {
                 );
 
                 assert.strictEqual(problems.length, 3);
-                assert.deepEqual(problems.map(problem => problem.message), ["foo", "bar", "baz"]);
+                assert.deepStrictEqual(problems.map(problem => problem.message), ["foo", "bar", "baz"]);
             });
         });
 
@@ -3743,8 +3743,8 @@ describe("Linter", () => {
                 );
 
                 assert.strictEqual(problems.length, 3);
-                assert.deepEqual(problems.map(problem => problem.message), ["FOO", "BAR", "BAZ"]);
-                assert.deepEqual(problems.map(problem => problem.column), [1, 5, 9]);
+                assert.deepStrictEqual(problems.map(problem => problem.message), ["FOO", "BAR", "BAZ"]);
+                assert.deepStrictEqual(problems.map(problem => problem.column), [1, 5, 9]);
             });
 
             it("should use postprocessed problem ranges when applying autofixes", () => {
@@ -3818,7 +3818,7 @@ describe("Linter", () => {
                 }
             });
 
-            assert.deepEqual(fixResult, {
+            assert.deepStrictEqual(fixResult, {
                 fixed: true,
                 messages: [],
                 output: "var a;"

--- a/tests/lib/options.js
+++ b/tests/lib/options.js
@@ -92,7 +92,7 @@ describe("options", () => {
             const currentOptions = options.parse("--rulesdir /morerules");
 
             assert.isArray(currentOptions.rulesdir);
-            assert.deepEqual(currentOptions.rulesdir, ["/morerules"]);
+            assert.deepStrictEqual(currentOptions.rulesdir, ["/morerules"]);
         });
     });
 

--- a/tests/lib/options.js
+++ b/tests/lib/options.js
@@ -42,7 +42,7 @@ describe("options", () => {
             const currentOptions = options.parse("--config file");
 
             assert.isString(currentOptions.config);
-            assert.equal(currentOptions.config, "file");
+            assert.strictEqual(currentOptions.config, "file");
         });
     });
 
@@ -51,7 +51,7 @@ describe("options", () => {
             const currentOptions = options.parse("-c file");
 
             assert.isString(currentOptions.config);
-            assert.equal(currentOptions.config, "file");
+            assert.strictEqual(currentOptions.config, "file");
         });
     });
 
@@ -60,30 +60,30 @@ describe("options", () => {
             const currentOptions = options.parse("--ext .jsx");
 
             assert.isArray(currentOptions.ext);
-            assert.equal(currentOptions.ext[0], ".jsx");
+            assert.strictEqual(currentOptions.ext[0], ".jsx");
         });
 
         it("should return an array with two items when passed .js and .jsx", () => {
             const currentOptions = options.parse("--ext .jsx --ext .js");
 
             assert.isArray(currentOptions.ext);
-            assert.equal(currentOptions.ext[0], ".jsx");
-            assert.equal(currentOptions.ext[1], ".js");
+            assert.strictEqual(currentOptions.ext[0], ".jsx");
+            assert.strictEqual(currentOptions.ext[1], ".js");
         });
 
         it("should return an array with two items when passed .jsx,.js", () => {
             const currentOptions = options.parse("--ext .jsx,.js");
 
             assert.isArray(currentOptions.ext);
-            assert.equal(currentOptions.ext[0], ".jsx");
-            assert.equal(currentOptions.ext[1], ".js");
+            assert.strictEqual(currentOptions.ext[0], ".jsx");
+            assert.strictEqual(currentOptions.ext[1], ".js");
         });
 
         it("should return an array one item when not passed", () => {
             const currentOptions = options.parse("");
 
             assert.isArray(currentOptions.ext);
-            assert.equal(currentOptions.ext[0], ".js");
+            assert.strictEqual(currentOptions.ext[0], ".js");
         });
     });
 
@@ -92,7 +92,7 @@ describe("options", () => {
             const currentOptions = options.parse("--rulesdir /morerules");
 
             assert.isArray(currentOptions.rulesdir);
-            assert.equal(currentOptions.rulesdir, "/morerules");
+            assert.deepEqual(currentOptions.rulesdir, ["/morerules"]);
         });
     });
 
@@ -101,14 +101,14 @@ describe("options", () => {
             const currentOptions = options.parse("--format compact");
 
             assert.isString(currentOptions.format);
-            assert.equal(currentOptions.format, "compact");
+            assert.strictEqual(currentOptions.format, "compact");
         });
 
         it("should return stylish for .format when not passed", () => {
             const currentOptions = options.parse("");
 
             assert.isString(currentOptions.format);
-            assert.equal(currentOptions.format, "stylish");
+            assert.strictEqual(currentOptions.format, "stylish");
         });
     });
 
@@ -117,7 +117,7 @@ describe("options", () => {
             const currentOptions = options.parse("-f compact");
 
             assert.isString(currentOptions.format);
-            assert.equal(currentOptions.format, "compact");
+            assert.strictEqual(currentOptions.format, "compact");
         });
     });
 
@@ -157,7 +157,7 @@ describe("options", () => {
         it("should return a string for .ignorePath when passed", () => {
             const currentOptions = options.parse("--ignore-path .gitignore");
 
-            assert.equal(currentOptions.ignorePath, ".gitignore");
+            assert.strictEqual(currentOptions.ignorePath, ".gitignore");
         });
     });
 
@@ -166,26 +166,26 @@ describe("options", () => {
             const currentOptions = options.parse("--ignore-pattern *.js");
 
             assert.ok(currentOptions.ignorePattern);
-            assert.equal(currentOptions.ignorePattern.length, 1);
-            assert.equal(currentOptions.ignorePattern[0], "*.js");
+            assert.strictEqual(currentOptions.ignorePattern.length, 1);
+            assert.strictEqual(currentOptions.ignorePattern[0], "*.js");
         });
 
         it("should return a string array for multiple values", () => {
             const currentOptions = options.parse("--ignore-pattern *.js --ignore-pattern *.ts");
 
             assert.ok(currentOptions.ignorePattern);
-            assert.equal(currentOptions.ignorePattern.length, 2);
-            assert.equal(currentOptions.ignorePattern[0], "*.js");
-            assert.equal(currentOptions.ignorePattern[1], "*.ts");
+            assert.strictEqual(currentOptions.ignorePattern.length, 2);
+            assert.strictEqual(currentOptions.ignorePattern[0], "*.js");
+            assert.strictEqual(currentOptions.ignorePattern[1], "*.ts");
         });
 
         it("should return a string array of properly parsed values, when those values include commas", () => {
             const currentOptions = options.parse("--ignore-pattern *.js --ignore-pattern foo-{bar,baz}.js");
 
             assert.ok(currentOptions.ignorePattern);
-            assert.equal(currentOptions.ignorePattern.length, 2);
-            assert.equal(currentOptions.ignorePattern[0], "*.js");
-            assert.equal(currentOptions.ignorePattern[1], "foo-{bar,baz}.js");
+            assert.strictEqual(currentOptions.ignorePattern.length, 2);
+            assert.strictEqual(currentOptions.ignorePattern[0], "*.js");
+            assert.strictEqual(currentOptions.ignorePattern[1], "foo-{bar,baz}.js");
         });
     });
 
@@ -215,7 +215,7 @@ describe("options", () => {
         it("should return a string for .stdinFilename when passed", () => {
             const currentOptions = options.parse("--stdin-filename test.js");
 
-            assert.equal(currentOptions.stdinFilename, "test.js");
+            assert.strictEqual(currentOptions.stdinFilename, "test.js");
         });
     });
 
@@ -224,35 +224,35 @@ describe("options", () => {
             const currentOptions = options.parse("--global foo");
 
             assert.isArray(currentOptions.global);
-            assert.equal(currentOptions.global.length, 1);
-            assert.equal(currentOptions.global[0], "foo");
+            assert.strictEqual(currentOptions.global.length, 1);
+            assert.strictEqual(currentOptions.global[0], "foo");
         });
 
         it("should split variable names using commas", () => {
             const currentOptions = options.parse("--global foo,bar");
 
             assert.isArray(currentOptions.global);
-            assert.equal(currentOptions.global.length, 2);
-            assert.equal(currentOptions.global[0], "foo");
-            assert.equal(currentOptions.global[1], "bar");
+            assert.strictEqual(currentOptions.global.length, 2);
+            assert.strictEqual(currentOptions.global[0], "foo");
+            assert.strictEqual(currentOptions.global[1], "bar");
         });
 
         it("should not split on colons", () => {
             const currentOptions = options.parse("--global foo:false,bar:true");
 
             assert.isArray(currentOptions.global);
-            assert.equal(currentOptions.global.length, 2);
-            assert.equal(currentOptions.global[0], "foo:false");
-            assert.equal(currentOptions.global[1], "bar:true");
+            assert.strictEqual(currentOptions.global.length, 2);
+            assert.strictEqual(currentOptions.global[0], "foo:false");
+            assert.strictEqual(currentOptions.global[1], "bar:true");
         });
 
         it("should concatenate successive occurrences", () => {
             const currentOptions = options.parse("--global foo:true --global bar:false");
 
             assert.isArray(currentOptions.global);
-            assert.equal(currentOptions.global.length, 2);
-            assert.equal(currentOptions.global[0], "foo:true");
-            assert.equal(currentOptions.global[1], "bar:false");
+            assert.strictEqual(currentOptions.global.length, 2);
+            assert.strictEqual(currentOptions.global[0], "foo:true");
+            assert.strictEqual(currentOptions.global[1], "bar:false");
         });
     });
 
@@ -261,26 +261,26 @@ describe("options", () => {
             const currentOptions = options.parse("--plugin single");
 
             assert.isArray(currentOptions.plugin);
-            assert.equal(currentOptions.plugin.length, 1);
-            assert.equal(currentOptions.plugin[0], "single");
+            assert.strictEqual(currentOptions.plugin.length, 1);
+            assert.strictEqual(currentOptions.plugin[0], "single");
         });
 
         it("should return an array when passed a comma-delimiated string", () => {
             const currentOptions = options.parse("--plugin foo,bar");
 
             assert.isArray(currentOptions.plugin);
-            assert.equal(currentOptions.plugin.length, 2);
-            assert.equal(currentOptions.plugin[0], "foo");
-            assert.equal(currentOptions.plugin[1], "bar");
+            assert.strictEqual(currentOptions.plugin.length, 2);
+            assert.strictEqual(currentOptions.plugin[0], "foo");
+            assert.strictEqual(currentOptions.plugin[1], "bar");
         });
 
         it("should return an array when passed multiple times", () => {
             const currentOptions = options.parse("--plugin foo --plugin bar");
 
             assert.isArray(currentOptions.plugin);
-            assert.equal(currentOptions.plugin.length, 2);
-            assert.equal(currentOptions.plugin[0], "foo");
-            assert.equal(currentOptions.plugin[1], "bar");
+            assert.strictEqual(currentOptions.plugin.length, 2);
+            assert.strictEqual(currentOptions.plugin[0], "foo");
+            assert.strictEqual(currentOptions.plugin[1], "bar");
         });
     });
 
@@ -296,13 +296,13 @@ describe("options", () => {
         it("should return correct value for .maxWarnings when passed", () => {
             const currentOptions = options.parse("--max-warnings 10");
 
-            assert.equal(currentOptions.maxWarnings, 10);
+            assert.strictEqual(currentOptions.maxWarnings, 10);
         });
 
         it("should return -1 for .maxWarnings when not passed", () => {
             const currentOptions = options.parse("");
 
-            assert.equal(currentOptions.maxWarnings, -1);
+            assert.strictEqual(currentOptions.maxWarnings, -1);
         });
 
         it("should throw an error when supplied with a non-integer", () => {
@@ -354,7 +354,7 @@ describe("options", () => {
         it("should return a string for --parser when passed", () => {
             const currentOptions = options.parse("--parser test");
 
-            assert.equal(currentOptions.parser, "test");
+            assert.strictEqual(currentOptions.parser, "test");
         });
     });
 

--- a/tests/lib/report-translator.js
+++ b/tests/lib/report-translator.js
@@ -53,7 +53,7 @@ describe("createReportTranslator", () => {
 
     describe("old-style call with location", () => {
         it("should extract the location correctly", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 translateReport(node, location, message, {}),
                 {
                     ruleId: "foo-rule",
@@ -70,7 +70,7 @@ describe("createReportTranslator", () => {
 
     describe("old-style call without location", () => {
         it("should use the start location and end location of the node", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 translateReport(node, message, {}),
                 {
                     ruleId: "foo-rule",
@@ -96,7 +96,7 @@ describe("createReportTranslator", () => {
                 fix: () => ({ range: [1, 2], text: "foo" })
             };
 
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 translateReport(reportDescriptor),
                 {
                     ruleId: "foo-rule",
@@ -123,7 +123,7 @@ describe("createReportTranslator", () => {
                 fix: () => [{ range: [1, 2], text: "foo" }, { range: [4, 5], text: "bar" }]
             };
 
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 translateReport(reportDescriptor),
                 {
                     ruleId: "foo-rule",
@@ -152,7 +152,7 @@ describe("createReportTranslator", () => {
                 }
             };
 
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 translateReport(reportDescriptor),
                 {
                     ruleId: "foo-rule",
@@ -178,7 +178,7 @@ describe("createReportTranslator", () => {
                 fix: () => [{ range: [1, 2], text: "foo" }]
             };
 
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 translateReport(reportDescriptor),
                 {
                     ruleId: "foo-rule",
@@ -204,7 +204,7 @@ describe("createReportTranslator", () => {
                 fix: () => [{ range: [0, 3], text: "\uFEFFfoo" }, { range: [4, 5], text: "x" }]
             };
 
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 translateReport(reportDescriptor),
                 {
                     ruleId: "foo-rule",
@@ -234,7 +234,7 @@ describe("createReportTranslator", () => {
                 fix: () => [{ range: [-1, 3], text: "foo" }, { range: [4, 5], text: "x" }]
             };
 
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 createReportTranslator({ ruleId: "foo-rule", severity: 1, sourceCode })(reportDescriptor),
                 {
                     ruleId: "foo-rule",
@@ -269,7 +269,7 @@ describe("createReportTranslator", () => {
         });
 
         it("should include a fix passed as the last argument when location is passed", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 translateReport(
                     node,
                     { line: 42, column: 23 },
@@ -297,7 +297,7 @@ describe("createReportTranslator", () => {
 
     describe("message interpolation", () => {
         it("should correctly parse a message when being passed all options in an old-style report", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 translateReport(node, node.loc.end, "hello {{dynamic}}", { dynamic: node.type }),
                 {
                     severity: 2,
@@ -312,7 +312,7 @@ describe("createReportTranslator", () => {
         });
 
         it("should correctly parse a message when being passed all options in a new-style report", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 translateReport({ node, loc: node.loc.end, message: "hello {{dynamic}}", data: { dynamic: node.type } }),
                 {
                     severity: 2,
@@ -399,7 +399,7 @@ describe("createReportTranslator", () => {
 
     describe("location inference", () => {
         it("should use the provided location when given in an old-style call", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 translateReport(node, { line: 42, column: 13 }, "hello world"),
                 {
                     severity: 2,
@@ -414,7 +414,7 @@ describe("createReportTranslator", () => {
         });
 
         it("should use the provided location when given in an new-style call", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 translateReport({ node, loc: { line: 42, column: 13 }, message: "hello world" }),
                 {
                     severity: 2,
@@ -429,7 +429,7 @@ describe("createReportTranslator", () => {
         });
 
         it("should extract the start and end locations from a node if no location is provided", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 translateReport(node, "hello world"),
                 {
                     severity: 2,
@@ -446,7 +446,7 @@ describe("createReportTranslator", () => {
         });
 
         it("should have 'endLine' and 'endColumn' when 'loc' property has 'end' property.", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 translateReport({ loc: node.loc, message: "hello world" }),
                 {
                     severity: 2,
@@ -463,7 +463,7 @@ describe("createReportTranslator", () => {
         });
 
         it("should not have 'endLine' and 'endColumn' when 'loc' property does not have 'end' property.", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 translateReport({ loc: node.loc.start, message: "hello world" }),
                 {
                     severity: 2,
@@ -478,7 +478,7 @@ describe("createReportTranslator", () => {
         });
 
         it("should infer an 'endLine' and 'endColumn' property when using the object-based context.report API", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 translateReport({ node, message: "hello world" }),
                 {
                     severity: 2,
@@ -497,7 +497,7 @@ describe("createReportTranslator", () => {
 
     describe("converting old-style calls", () => {
         it("should include a fix passed as the last argument when location is not passed", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 translateReport(node, "my message {{1}}{{0}}", ["!", "testing"], () => ({ range: [1, 1], text: "" })),
                 {
                     severity: 2,
@@ -526,7 +526,7 @@ describe("createReportTranslator", () => {
 
 
         it("should not throw an error if location is provided and node is not in an old-style call", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 translateReport(null, { line: 1, column: 1 }, "hello world"),
                 {
                     severity: 2,
@@ -541,7 +541,7 @@ describe("createReportTranslator", () => {
         });
 
         it("should not throw an error if location is provided and node is not in a new-style call", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 translateReport({ loc: { line: 1, column: 1 }, message: "hello world" }),
                 {
                     severity: 2,

--- a/tests/lib/rules.js
+++ b/tests/lib/rules.js
@@ -39,7 +39,7 @@ describe("rules", () => {
 
         it("should load rules and not throw an error", () => {
             rules.load(code, process.cwd());
-            assert.equal(typeof rules.get("fixture-rule"), "object");
+            assert.strictEqual(typeof rules.get("fixture-rule"), "object");
         });
     });
 
@@ -120,7 +120,7 @@ describe("rules", () => {
             rules.importPlugin(customPlugin, pluginName);
 
             assert.isDefined(rules.get("custom-plugin/custom-rule"));
-            assert.equal(rules.get("custom-plugin/custom-rule").create, customPlugin.rules["custom-rule"]);
+            assert.strictEqual(rules.get("custom-plugin/custom-rule").create, customPlugin.rules["custom-rule"]);
         });
 
         it("should return custom rules as part of getAllLoadedRules", () => {
@@ -128,7 +128,7 @@ describe("rules", () => {
 
             const allRules = rules.getAllLoadedRules();
 
-            assert.equal(allRules.get("custom-plugin/custom-rule").create, customPlugin.rules["custom-rule"]);
+            assert.strictEqual(allRules.get("custom-plugin/custom-rule").create, customPlugin.rules["custom-rule"]);
         });
     });
 

--- a/tests/lib/rules.js
+++ b/tests/lib/rules.js
@@ -60,7 +60,7 @@ describe("rules", () => {
             function rule() {}
             rule.schema = [];
             rules.define("foo", rule);
-            assert.deepEqual(rules.get("foo"), { create: rule, schema: [] });
+            assert.deepStrictEqual(rules.get("foo"), { create: rule, schema: [] });
         });
 
         it("should return the rule as-is if it was defined as an object with a create() method", () => {

--- a/tests/lib/rules/no-implied-eval.js
+++ b/tests/lib/rules/no-implied-eval.js
@@ -92,14 +92,14 @@ ruleTester.run("no-implied-eval", rule, {
                 {
                     message: expectedErrorMessage,
                     type: "CallExpression",
-                    line: "1"
+                    line: 1
                 },
 
                 // no error on line 2
                 {
                     message: expectedErrorMessage,
                     type: "CallExpression",
-                    line: "3"
+                    line: 3
                 }
             ]
         }

--- a/tests/lib/testers/rule-tester.js
+++ b/tests/lib/testers/rule-tester.js
@@ -697,7 +697,7 @@ describe("RuleTester", () => {
 
         RuleTester.setDefaultConfig(config);
         RuleTester.resetDefaultConfig();
-        assert.deepEqual(
+        assert.deepStrictEqual(
             RuleTester.getDefaultConfig(),
             { rules: {} },
             "The default configuration has not reset correctly"

--- a/tests/lib/testers/rule-tester.js
+++ b/tests/lib/testers/rule-tester.js
@@ -606,7 +606,7 @@ describe("RuleTester", () => {
                     }
                 ]
             });
-            assert.equal(spy.args[1][1].parser, "esprima");
+            assert.strictEqual(spy.args[1][1].parser, "esprima");
         });
     });
 

--- a/tests/lib/token-store.js
+++ b/tests/lib/token-store.js
@@ -40,9 +40,9 @@ const SOURCE_CODE = "/*A*/var answer/*B*/=/*C*/a/*D*/* b/*E*///F\n    call();\n/
 function check(tokens, expected) {
     const length = tokens.length;
 
-    assert.equal(length, expected.length);
+    assert.strictEqual(length, expected.length);
     for (let i = 0; i < length; i++) {
-        assert.equal(tokens[i].value, expected[i]);
+        assert.strictEqual(tokens[i].value, expected[i]);
     }
 }
 
@@ -208,64 +208,64 @@ describe("TokenStore", () => {
     describe("when calling getTokenBefore", () => {
 
         it("should retrieve one token before a node", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getTokenBefore(BinaryExpression).value,
                 "="
             );
         });
 
         it("should skip a given number of tokens", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getTokenBefore(BinaryExpression, 1).value,
                 "answer"
             );
-            assert.equal(
+            assert.strictEqual(
                 store.getTokenBefore(BinaryExpression, 2).value,
                 "var"
             );
         });
 
         it("should skip a given number of tokens with skip option", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getTokenBefore(BinaryExpression, { skip: 1 }).value,
                 "answer"
             );
-            assert.equal(
+            assert.strictEqual(
                 store.getTokenBefore(BinaryExpression, { skip: 2 }).value,
                 "var"
             );
         });
 
         it("should retrieve matched token with filter option", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getTokenBefore(BinaryExpression, t => t.value !== "=").value,
                 "answer"
             );
         });
 
         it("should retrieve matched token with skip and filter options", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getTokenBefore(BinaryExpression, { skip: 1, filter: t => t.value !== "=" }).value,
                 "var"
             );
         });
 
         it("should retrieve one token or comment before a node with includeComments option", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getTokenBefore(BinaryExpression, { includeComments: true }).value,
                 "C"
             );
         });
 
         it("should retrieve one token or comment before a node with includeComments and skip options", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getTokenBefore(BinaryExpression, { includeComments: true, skip: 1 }).value,
                 "="
             );
         });
 
         it("should retrieve one token or comment before a node with includeComments and skip and filter options", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getTokenBefore(BinaryExpression, { includeComments: true, skip: 1, filter: t => t.type.startsWith("Block") }).value,
                 "B"
             );
@@ -377,68 +377,68 @@ describe("TokenStore", () => {
     describe("when calling getTokenAfter", () => {
 
         it("should retrieve one token after a node", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getTokenAfter(VariableDeclarator.id).value,
                 "="
             );
         });
 
         it("should skip a given number of tokens", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getTokenAfter(VariableDeclarator.id, 1).value,
                 "a"
             );
-            assert.equal(
+            assert.strictEqual(
                 store.getTokenAfter(VariableDeclarator.id, 2).value,
                 "*"
             );
         });
 
         it("should skip a given number of tokens with skip option", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getTokenAfter(VariableDeclarator.id, { skip: 1 }).value,
                 "a"
             );
-            assert.equal(
+            assert.strictEqual(
                 store.getTokenAfter(VariableDeclarator.id, { skip: 2 }).value,
                 "*"
             );
         });
 
         it("should retrieve matched token with filter option", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getTokenAfter(VariableDeclarator.id, t => t.type === "Identifier").value,
                 "a"
             );
-            assert.equal(
+            assert.strictEqual(
                 store.getTokenAfter(VariableDeclarator.id, { filter: t => t.type === "Identifier" }).value,
                 "a"
             );
         });
 
         it("should retrieve matched token with filter and skip options", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getTokenAfter(VariableDeclarator.id, { skip: 1, filter: t => t.type === "Identifier" }).value,
                 "b"
             );
         });
 
         it("should retrieve one token or comment after a node with includeComments option", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getTokenAfter(VariableDeclarator.id, { includeComments: true }).value,
                 "B"
             );
         });
 
         it("should retrieve one token or comment after a node with includeComments and skip options", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getTokenAfter(VariableDeclarator.id, { includeComments: true, skip: 2 }).value,
                 "C"
             );
         });
 
         it("should retrieve one token or comment after a node with includeComments and skip and filter options", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getTokenAfter(VariableDeclarator.id, { includeComments: true, skip: 2, filter: t => t.type.startsWith("Block") }).value,
                 "D"
             );
@@ -554,68 +554,68 @@ describe("TokenStore", () => {
     describe("when calling getFirstToken", () => {
 
         it("should retrieve the first token of a node's token stream", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getFirstToken(BinaryExpression).value,
                 "a"
             );
         });
 
         it("should skip a given number of tokens", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getFirstToken(BinaryExpression, 1).value,
                 "*"
             );
-            assert.equal(
+            assert.strictEqual(
                 store.getFirstToken(BinaryExpression, 2).value,
                 "b"
             );
         });
 
         it("should skip a given number of tokens with skip option", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getFirstToken(BinaryExpression, { skip: 1 }).value,
                 "*"
             );
-            assert.equal(
+            assert.strictEqual(
                 store.getFirstToken(BinaryExpression, { skip: 2 }).value,
                 "b"
             );
         });
 
         it("should retrieve matched token with filter option", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getFirstToken(BinaryExpression, t => t.type === "Identifier").value,
                 "a"
             );
-            assert.equal(
+            assert.strictEqual(
                 store.getFirstToken(BinaryExpression, { filter: t => t.type === "Identifier" }).value,
                 "a"
             );
         });
 
         it("should retrieve matched token with filter and skip options", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getFirstToken(BinaryExpression, { skip: 1, filter: t => t.type === "Identifier" }).value,
                 "b"
             );
         });
 
         it("should retrieve the first token or comment of a node's token stream with includeComments option", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getFirstToken(BinaryExpression, { includeComments: true }).value,
                 "a"
             );
         });
 
         it("should retrieve the first matched token or comment of a node's token stream with includeComments and skip options", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getFirstToken(BinaryExpression, { includeComments: true, skip: 1 }).value,
                 "D"
             );
         });
 
         it("should retrieve the first matched token or comment of a node's token stream with includeComments and skip and filter options", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getFirstToken(BinaryExpression, { includeComments: true, skip: 1, filter: t => t.value !== "a" }).value,
                 "*"
             );
@@ -733,72 +733,72 @@ describe("TokenStore", () => {
     describe("when calling getLastToken", () => {
 
         it("should retrieve the last token of a node's token stream", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getLastToken(BinaryExpression).value,
                 "b"
             );
-            assert.equal(
+            assert.strictEqual(
                 store.getLastToken(VariableDeclaration).value,
                 "b"
             );
         });
 
         it("should skip a given number of tokens", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getLastToken(BinaryExpression, 1).value,
                 "*"
             );
-            assert.equal(
+            assert.strictEqual(
                 store.getLastToken(BinaryExpression, 2).value,
                 "a"
             );
         });
 
         it("should skip a given number of tokens with skip option", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getLastToken(BinaryExpression, { skip: 1 }).value,
                 "*"
             );
-            assert.equal(
+            assert.strictEqual(
                 store.getLastToken(BinaryExpression, { skip: 2 }).value,
                 "a"
             );
         });
 
         it("should retrieve the last matched token of a node's token stream with filter option", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getLastToken(BinaryExpression, t => t.value !== "b").value,
                 "*"
             );
-            assert.equal(
+            assert.strictEqual(
                 store.getLastToken(BinaryExpression, { filter: t => t.value !== "b" }).value,
                 "*"
             );
         });
 
         it("should retrieve the last matched token of a node's token stream with filter and skip options", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getLastToken(BinaryExpression, { skip: 1, filter: t => t.type === "Identifier" }).value,
                 "a"
             );
         });
 
         it("should retrieve the last token of a node's token stream with includeComments option", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getLastToken(BinaryExpression, { includeComments: true }).value,
                 "b"
             );
         });
 
         it("should retrieve the last token of a node's token stream with includeComments and skip options", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getLastToken(BinaryExpression, { includeComments: true, skip: 2 }).value,
                 "D"
             );
         });
 
         it("should retrieve the last token of a node's token stream with includeComments and skip and filter options", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getLastToken(BinaryExpression, { includeComments: true, skip: 1, filter: t => t.type !== "Identifier" }).value,
                 "D"
             );
@@ -895,64 +895,64 @@ describe("TokenStore", () => {
     describe("when calling getFirstTokenBetween", () => {
 
         it("should return null between adjacent nodes", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getFirstTokenBetween(BinaryExpression, CallExpression),
                 null
             );
         });
 
         it("should retrieve one token between non-adjacent nodes with count option", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getFirstTokenBetween(VariableDeclarator.id, BinaryExpression.right).value,
                 "="
             );
         });
 
         it("should retrieve one token between non-adjacent nodes with skip option", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getFirstTokenBetween(VariableDeclarator.id, BinaryExpression.right, 1).value,
                 "a"
             );
-            assert.equal(
+            assert.strictEqual(
                 store.getFirstTokenBetween(VariableDeclarator.id, BinaryExpression.right, { skip: 2 }).value,
                 "*"
             );
         });
 
         it("should return null if it's skipped beyond the right token", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getFirstTokenBetween(VariableDeclarator.id, BinaryExpression.right, { skip: 3 }),
                 null
             );
-            assert.equal(
+            assert.strictEqual(
                 store.getFirstTokenBetween(VariableDeclarator.id, BinaryExpression.right, { skip: 4 }),
                 null
             );
         });
 
         it("should retrieve the first matched token between non-adjacent nodes with filter option", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getFirstTokenBetween(VariableDeclarator.id, BinaryExpression.right, { filter: t => t.type !== "Identifier" }).value,
                 "="
             );
         });
 
         it("should retrieve first token or comment between non-adjacent nodes with includeComments option", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getFirstTokenBetween(VariableDeclarator.id, BinaryExpression.right, { includeComments: true }).value,
                 "B"
             );
         });
 
         it("should retrieve first token or comment between non-adjacent nodes with includeComments and skip options", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getFirstTokenBetween(VariableDeclarator.id, BinaryExpression.right, { includeComments: true, skip: 1 }).value,
                 "="
             );
         });
 
         it("should retrieve first token or comment between non-adjacent nodes with includeComments and skip and filter options", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getFirstTokenBetween(VariableDeclarator.id, BinaryExpression.right, { includeComments: true, skip: 1, filter: t => t.type !== "Punctuator" }).value,
                 "C"
             );
@@ -1020,64 +1020,64 @@ describe("TokenStore", () => {
     describe("when calling getLastTokenBetween", () => {
 
         it("should return null between adjacent nodes", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getLastTokenBetween(BinaryExpression, CallExpression),
                 null
             );
         });
 
         it("should retrieve one token between non-adjacent nodes with count option", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getLastTokenBetween(VariableDeclarator.id, BinaryExpression.right).value,
                 "*"
             );
         });
 
         it("should retrieve one token between non-adjacent nodes with skip option", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getLastTokenBetween(VariableDeclarator.id, BinaryExpression.right, 1).value,
                 "a"
             );
-            assert.equal(
+            assert.strictEqual(
                 store.getLastTokenBetween(VariableDeclarator.id, BinaryExpression.right, { skip: 2 }).value,
                 "="
             );
         });
 
         it("should return null if it's skipped beyond the right token", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getLastTokenBetween(VariableDeclarator.id, BinaryExpression.right, { skip: 3 }),
                 null
             );
-            assert.equal(
+            assert.strictEqual(
                 store.getLastTokenBetween(VariableDeclarator.id, BinaryExpression.right, { skip: 4 }),
                 null
             );
         });
 
         it("should retrieve the first matched token between non-adjacent nodes with filter option", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getLastTokenBetween(VariableDeclarator.id, BinaryExpression.right, { filter: t => t.type !== "Identifier" }).value,
                 "*"
             );
         });
 
         it("should retrieve first token or comment between non-adjacent nodes with includeComments option", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getLastTokenBetween(VariableDeclarator.id, BinaryExpression.right, { includeComments: true }).value,
                 "*"
             );
         });
 
         it("should retrieve first token or comment between non-adjacent nodes with includeComments and skip options", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getLastTokenBetween(VariableDeclarator.id, BinaryExpression.right, { includeComments: true, skip: 1 }).value,
                 "D"
             );
         });
 
         it("should retrieve first token or comment between non-adjacent nodes with includeComments and skip and filter options", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getLastTokenBetween(VariableDeclarator.id, BinaryExpression.right, { includeComments: true, skip: 1, filter: t => t.type !== "Punctuator" }).value,
                 "a"
             );
@@ -1122,8 +1122,8 @@ describe("TokenStore", () => {
         it("should return identifier token", () => {
             const result = store.getTokenByRangeStart(9);
 
-            assert.equal(result.type, "Identifier");
-            assert.equal(result.value, "answer");
+            assert.strictEqual(result.type, "Identifier");
+            assert.strictEqual(result.value, "answer");
         });
 
         it("should return null when token doesn't exist", () => {
@@ -1135,8 +1135,8 @@ describe("TokenStore", () => {
         it("should return a comment token when includeComments is true", () => {
             const result = store.getTokenByRangeStart(15, { includeComments: true });
 
-            assert.equal(result.type, "Block");
-            assert.equal(result.value, "B");
+            assert.strictEqual(result.type, "Block");
+            assert.strictEqual(result.value, "B");
         });
 
         it("should not return a comment token at the supplied index when includeComments is false", () => {
@@ -1156,18 +1156,18 @@ describe("TokenStore", () => {
     describe("when calling getTokenOrCommentBefore", () => {
 
         it("should retrieve one token or comment before a node", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getTokenOrCommentBefore(BinaryExpression).value,
                 "C"
             );
         });
 
         it("should skip a given number of tokens", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getTokenOrCommentBefore(BinaryExpression, 1).value,
                 "="
             );
-            assert.equal(
+            assert.strictEqual(
                 store.getTokenOrCommentBefore(BinaryExpression, 2).value,
                 "B"
             );
@@ -1178,18 +1178,18 @@ describe("TokenStore", () => {
     describe("when calling getTokenOrCommentAfter", () => {
 
         it("should retrieve one token or comment after a node", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getTokenOrCommentAfter(VariableDeclarator.id).value,
                 "B"
             );
         });
 
         it("should skip a given number of tokens", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getTokenOrCommentAfter(VariableDeclarator.id, 1).value,
                 "="
             );
-            assert.equal(
+            assert.strictEqual(
                 store.getTokenOrCommentAfter(VariableDeclarator.id, 2).value,
                 "C"
             );
@@ -1287,14 +1287,14 @@ describe("TokenStore", () => {
 
     describe("getCommentsBefore", () => {
         it("should retrieve comments before a node", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getCommentsBefore(VariableDeclaration)[0].value,
                 "A"
             );
         });
 
         it("should retrieve comments before a token", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getCommentsBefore(TOKENS[2] /* "=" token */)[0].value,
                 "B"
             );
@@ -1303,13 +1303,13 @@ describe("TokenStore", () => {
         it("should retrieve multiple comments before a node", () => {
             const comments = store.getCommentsBefore(CallExpression);
 
-            assert.equal(comments.length, 2);
-            assert.equal(comments[0].value, "E");
-            assert.equal(comments[1].value, "F");
+            assert.strictEqual(comments.length, 2);
+            assert.strictEqual(comments[0].value, "E");
+            assert.strictEqual(comments[1].value, "F");
         });
 
         it("should retrieve comments before a Program node", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getCommentsBefore(Program)[0].value,
                 "A"
             );
@@ -1329,14 +1329,14 @@ describe("TokenStore", () => {
 
     describe("getCommentsAfter", () => {
         it("should retrieve comments after a node", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getCommentsAfter(VariableDeclarator.id)[0].value,
                 "B"
             );
         });
 
         it("should retrieve comments after a token", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getCommentsAfter(TOKENS[2] /* "=" token */)[0].value,
                 "C"
             );
@@ -1345,13 +1345,13 @@ describe("TokenStore", () => {
         it("should retrieve multiple comments after a node", () => {
             const comments = store.getCommentsAfter(VariableDeclaration);
 
-            assert.equal(comments.length, 2);
-            assert.equal(comments[0].value, "E");
-            assert.equal(comments[1].value, "F");
+            assert.strictEqual(comments.length, 2);
+            assert.strictEqual(comments[0].value, "E");
+            assert.strictEqual(comments[1].value, "F");
         });
 
         it("should retrieve comments after a Program node", () => {
-            assert.equal(
+            assert.strictEqual(
                 store.getCommentsAfter(Program)[0].value,
                 "Z"
             );

--- a/tests/lib/util/apply-disable-directives.js
+++ b/tests/lib/util/apply-disable-directives.js
@@ -11,7 +11,7 @@ const applyDisableDirectives = require("../../../lib/util/apply-disable-directiv
 describe("apply-disable-directives", () => {
     describe("/* eslint-disable */ comments without rules", () => {
         it("keeps problems before the comment on the same line", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{ type: "disable", line: 1, column: 8, ruleId: null }],
                     problems: [{ line: 1, column: 7, ruleId: "foo" }]
@@ -21,7 +21,7 @@ describe("apply-disable-directives", () => {
         });
 
         it("keeps problems on a previous line before the comment", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{ type: "disable", line: 2, column: 8, ruleId: null }],
                     problems: [{ line: 1, column: 10, ruleId: "foo" }]
@@ -31,7 +31,7 @@ describe("apply-disable-directives", () => {
         });
 
         it("filters problems at the same location as the comment", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{ type: "disable", line: 1, column: 8, ruleId: null }],
                     problems: [{ line: 1, column: 8, ruleId: null }]
@@ -41,7 +41,7 @@ describe("apply-disable-directives", () => {
         });
 
         it("filters out problems after the comment on the same line", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{ type: "disable", line: 1, column: 8, ruleId: null }],
                     problems: [{ line: 1, column: 10, ruleId: "foo" }]
@@ -51,7 +51,7 @@ describe("apply-disable-directives", () => {
         });
 
         it("filters out problems on a later line than the comment", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{ type: "disable", line: 1, column: 8, ruleId: null }],
                     problems: [{ line: 2, column: 3, ruleId: "foo" }]
@@ -63,7 +63,7 @@ describe("apply-disable-directives", () => {
 
     describe("/* eslint-disable */ comments with rules", () => {
         it("filters problems after the comment that have the same ruleId", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{ type: "disable", line: 1, column: 8, ruleId: "foo" }],
                     problems: [{ line: 2, column: 3, ruleId: "foo" }]
@@ -73,7 +73,7 @@ describe("apply-disable-directives", () => {
         });
 
         it("filters problems in the same location as the comment that have the same ruleId", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{ type: "disable", line: 1, column: 8, ruleId: "foo" }],
                     problems: [{ line: 1, column: 8, ruleId: "foo" }]
@@ -83,7 +83,7 @@ describe("apply-disable-directives", () => {
         });
 
         it("keeps problems after the comment that have a different ruleId", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{ type: "disable", line: 1, column: 8, ruleId: "foo" }],
                     problems: [{ line: 2, column: 3, ruleId: "not-foo" }]
@@ -93,7 +93,7 @@ describe("apply-disable-directives", () => {
         });
 
         it("keeps problems before the comment that have the same ruleId", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{ type: "disable", line: 1, column: 8, ruleId: "foo" }],
                     problems: [{ line: 1, column: 7, ruleId: "foo" }]
@@ -105,7 +105,7 @@ describe("apply-disable-directives", () => {
 
     describe("eslint-enable comments without rules", () => {
         it("keeps problems after the eslint-enable comment", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [
                         { type: "disable", line: 1, column: 1, ruleId: null },
@@ -118,7 +118,7 @@ describe("apply-disable-directives", () => {
         });
 
         it("keeps problems in the same location as the eslint-enable comment", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [
                         { type: "disable", line: 1, column: 1, ruleId: null },
@@ -131,7 +131,7 @@ describe("apply-disable-directives", () => {
         });
 
         it("filters out problems before the eslint-enable comment", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [
                         { type: "disable", line: 1, column: 1, ruleId: null },
@@ -144,7 +144,7 @@ describe("apply-disable-directives", () => {
         });
 
         it("filter out problems if disable all then enable foo and then disable foo", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [
                         { type: "disable", line: 1, column: 1, ruleId: null },
@@ -158,7 +158,7 @@ describe("apply-disable-directives", () => {
         });
 
         it("filter out problems if disable all then enable foo and then disable all", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [
                         { type: "disable", line: 1, column: 1, ruleId: null },
@@ -172,7 +172,7 @@ describe("apply-disable-directives", () => {
         });
 
         it("keeps problems before the eslint-enable comment if there is no corresponding disable comment", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [
                         { type: "disable", line: 1, column: 1, ruleId: "foo" },
@@ -187,7 +187,7 @@ describe("apply-disable-directives", () => {
 
     describe("eslint-enable comments with rules", () => {
         it("keeps problems after the comment that have the same ruleId as the eslint-enable comment", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [
                         { type: "disable", line: 1, column: 4, ruleId: null },
@@ -200,7 +200,7 @@ describe("apply-disable-directives", () => {
         });
 
         it("keeps problems in the same location as the comment that have the same ruleId as the eslint-enable comment", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [
                         { type: "disable", line: 1, column: 4, ruleId: null },
@@ -213,7 +213,7 @@ describe("apply-disable-directives", () => {
         });
 
         it("filters problems after the comment that have a different ruleId as the eslint-enable comment", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [
                         { type: "disable", line: 1, column: 4, ruleId: null },
@@ -226,7 +226,7 @@ describe("apply-disable-directives", () => {
         });
 
         it("reenables reporting correctly even when followed by another enable comment", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [
                         { type: "disable", line: 1, column: 1, ruleId: null },
@@ -253,7 +253,7 @@ describe("apply-disable-directives", () => {
 
     describe("eslint-disable-line comments without rules", () => {
         it("keeps problems on a previous line", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{ type: "disable-line", line: 2, column: 1, ruleId: null }],
                     problems: [{ line: 1, column: 5, ruleId: "foo" }]
@@ -263,7 +263,7 @@ describe("apply-disable-directives", () => {
         });
 
         it("filters problems before the comment on the same line", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{ type: "disable-line", line: 1, column: 5, ruleId: null }],
                     problems: [{ line: 1, column: 1, ruleId: "foo" }]
@@ -273,7 +273,7 @@ describe("apply-disable-directives", () => {
         });
 
         it("filters problems after the comment on the same line", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{ type: "disable-line", line: 1, column: 5, ruleId: null }],
                     problems: [{ line: 1, column: 10, ruleId: "foo" }]
@@ -283,7 +283,7 @@ describe("apply-disable-directives", () => {
         });
 
         it("keeps problems on a following line", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{ type: "disable-line", line: 1, column: 4 }],
                     problems: [{ line: 2, column: 1, ruleId: "foo" }]
@@ -295,7 +295,7 @@ describe("apply-disable-directives", () => {
 
     describe("eslint-disable-line comments with rules", () => {
         it("filters problems on the current line that match the ruleId", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{ type: "disable-line", line: 1, column: 4, ruleId: "foo" }],
                     problems: [{ line: 1, column: 2, ruleId: "foo" }]
@@ -305,7 +305,7 @@ describe("apply-disable-directives", () => {
         });
 
         it("keeps problems on the current line that do not match the ruleId", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{ type: "disable-line", line: 1, column: 4, ruleId: "foo" }],
                     problems: [{ line: 1, column: 2, ruleId: "not-foo" }]
@@ -315,7 +315,7 @@ describe("apply-disable-directives", () => {
         });
 
         it("filters problems on the current line that do not match the ruleId if preceded by a disable comment", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [
                         { type: "disable", line: 1, column: 1, ruleId: null },
@@ -328,7 +328,7 @@ describe("apply-disable-directives", () => {
         });
 
         it("handles consecutive comments appropriately", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [
                         { type: "disable-line", line: 1, column: 5, ruleId: "foo" },
@@ -347,7 +347,7 @@ describe("apply-disable-directives", () => {
 
     describe("eslint-disable-next-line comments without rules", () => {
         it("filters problems on the next line", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{ type: "disable-next-line", line: 1, column: 1, ruleId: null }],
                     problems: [{ line: 2, column: 3, ruleId: "foo" }]
@@ -357,7 +357,7 @@ describe("apply-disable-directives", () => {
         });
 
         it("keeps problems on the same line", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{ type: "disable-next-line", line: 1, column: 1, ruleId: null }],
                     problems: [{ line: 1, column: 3, ruleId: "foo" }]
@@ -367,7 +367,7 @@ describe("apply-disable-directives", () => {
         });
 
         it("keeps problems after the next line", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{ type: "disable-next-line", line: 1, column: 1, ruleId: null }],
                     problems: [{ line: 3, column: 3, ruleId: "foo" }]
@@ -377,7 +377,7 @@ describe("apply-disable-directives", () => {
         });
 
         it("filters problems on the next line even if there is an eslint-enable comment on the same line", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [
                         { type: "disable-next-line", line: 1, column: 1, ruleId: null },
@@ -392,7 +392,7 @@ describe("apply-disable-directives", () => {
 
     describe("eslint-disable-next-line comments with rules", () => {
         it("filters problems on the next line that match the ruleId", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{ type: "disable-next-line", line: 1, column: 1, ruleId: "foo" }],
                     problems: [{ line: 2, column: 1, ruleId: "foo" }]
@@ -402,7 +402,7 @@ describe("apply-disable-directives", () => {
         });
 
         it("keeps problems on the next line that do not match the ruleId", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{ type: "disable-next-line", line: 1, column: 1, ruleId: "foo" }],
                     problems: [{ line: 2, column: 1, ruleId: "not-foo" }]
@@ -427,7 +427,7 @@ describe("apply-disable-directives", () => {
 
     describe("unused directives", () => {
         it("Adds a problem for /* eslint-disable */", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{ type: "disable", line: 1, column: 5 }],
                     problems: [],
@@ -448,7 +448,7 @@ describe("apply-disable-directives", () => {
         });
 
         it("Does not add a problem for /* eslint-disable */ /* (problem) */", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{ type: "disable", line: 1, column: 5, ruleId: null }],
                     problems: [{ line: 2, column: 1, ruleId: "foo" }],
@@ -459,7 +459,7 @@ describe("apply-disable-directives", () => {
         });
 
         it("Adds a problem for /* eslint-disable foo */", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{ type: "disable", line: 1, column: 5, ruleId: "foo" }],
                     problems: [],
@@ -480,7 +480,7 @@ describe("apply-disable-directives", () => {
         });
 
         it("Adds a problem for /* eslint-disable foo */ /* (problem from another rule) */", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{ type: "disable", line: 1, column: 5, ruleId: "foo" }],
                     problems: [{ line: 1, column: 20, ruleId: "not-foo" }],
@@ -506,7 +506,7 @@ describe("apply-disable-directives", () => {
         });
 
         it("Adds a problem for /* (problem from foo) */ /* eslint-disable */ /* eslint-enable foo */", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [
                         { type: "disable", line: 1, column: 5, ruleId: null },
@@ -535,7 +535,7 @@ describe("apply-disable-directives", () => {
         });
 
         it("Adds a problem for /* eslint-disable */ /* eslint-enable */", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [
                         { type: "disable", line: 1, column: 5, ruleId: null },
@@ -559,7 +559,7 @@ describe("apply-disable-directives", () => {
         });
 
         it("Adds two problems for /* eslint-disable */ /* eslint-disable */", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [
                         { type: "disable", line: 1, column: 1, ruleId: null },
@@ -592,7 +592,7 @@ describe("apply-disable-directives", () => {
         });
 
         it("Adds a problem for /* eslint-disable */ /* eslint-disable */ /* (problem) */", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [
                         { type: "disable", line: 1, column: 1, ruleId: null },
@@ -616,7 +616,7 @@ describe("apply-disable-directives", () => {
         });
 
         it("Adds a problem for /* eslint-disable foo */ /* eslint-disable */ /* (problem from foo) */", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [
                         { type: "disable", line: 1, column: 1, ruleId: "foo" },
@@ -640,7 +640,7 @@ describe("apply-disable-directives", () => {
         });
 
         it("Does not add a problem for /* eslint-disable foo */ /* (problem from foo) */", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{ type: "disable", line: 1, column: 5, ruleId: "foo" }],
                     problems: [{ line: 1, column: 6, ruleId: "foo" }],
@@ -651,7 +651,7 @@ describe("apply-disable-directives", () => {
         });
 
         it("Adds a problem for /* eslint-disable */ /* eslint-disable foo */ /* (problem from foo) */", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [
                         { type: "disable", line: 1, column: 1, ruleId: null },
@@ -675,7 +675,7 @@ describe("apply-disable-directives", () => {
         });
 
         it("Adds a problem for /* eslint-disable */ /* eslint-disable foo */ /* (problem from another rule) */", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [
                         { type: "disable", line: 1, column: 1, ruleId: null },
@@ -699,7 +699,7 @@ describe("apply-disable-directives", () => {
         });
 
         it("Adds a problem for /* eslint-disable foo */ /* eslint-enable foo */ /* (problem from foo) */", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [
                         { type: "disable", line: 1, column: 5, ruleId: "foo" },
@@ -728,7 +728,7 @@ describe("apply-disable-directives", () => {
         });
 
         it("Adds a problem for /* eslint-disable foo */ /* eslint-enable */ /* (problem from foo) */", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [
                         { type: "disable", line: 1, column: 5, ruleId: "foo" },
@@ -757,7 +757,7 @@ describe("apply-disable-directives", () => {
         });
 
         it("Adds two problems for /* eslint-disable */ /* eslint-disable foo */ /* eslint-enable foo */ /* (problem from foo) */", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [
                         { type: "disable", line: 1, column: 1, ruleId: null },
@@ -796,7 +796,7 @@ describe("apply-disable-directives", () => {
         });
 
         it("Adds a problem for // eslint-disable-line", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{ type: "disable-line", line: 1, column: 5, ruleId: null }],
                     problems: [],
@@ -818,7 +818,7 @@ describe("apply-disable-directives", () => {
 
 
         it("Does not add a problem for // eslint-disable-line (problem)", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{ type: "disable-line", line: 1, column: 5, ruleId: null }],
                     problems: [{ line: 1, column: 10, ruleId: "foo" }],
@@ -829,7 +829,7 @@ describe("apply-disable-directives", () => {
         });
 
         it("Adds a problem for // eslint-disable-next-line", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{ type: "disable-next-line", line: 1, column: 5, ruleId: null }],
                     problems: [],
@@ -850,7 +850,7 @@ describe("apply-disable-directives", () => {
         });
 
         it("Does not add a problem for // eslint-disable-next-line \\n (problem)", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{ type: "disable-next-line", line: 1, column: 5, ruleId: null }],
                     problems: [{ line: 2, column: 10, ruleId: "foo" }],
@@ -861,7 +861,7 @@ describe("apply-disable-directives", () => {
         });
 
         it("adds two problems for /* eslint-disable */ // eslint-disable-line", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [
                         { type: "disable", line: 1, column: 1, ruleId: null },
@@ -894,7 +894,7 @@ describe("apply-disable-directives", () => {
         });
 
         it("Does not add problems when reportUnusedDisableDirectives: false is used", () => {
-            assert.deepEqual(
+            assert.deepStrictEqual(
                 applyDisableDirectives({
                     directives: [{ type: "disable-next-line", line: 1, column: 5, ruleId: null }],
                     problems: [],

--- a/tests/lib/util/fix-tracker.js
+++ b/tests/lib/util/fix-tracker.js
@@ -58,7 +58,7 @@ describe("FixTracker", () => {
                 .retainRange([4, 14])
                 .replaceTextRange([10, 11], "-");
 
-            assert.deepEqual(result, {
+            assert.deepStrictEqual(result, {
                 range: [4, 14],
                 text: "foo = -bar"
             });
@@ -70,7 +70,7 @@ describe("FixTracker", () => {
                 .retainRange([5, 7])
                 .replaceTextRange([4, 8], "123");
 
-            assert.deepEqual(result, {
+            assert.deepStrictEqual(result, {
                 range: [4, 8],
                 text: "123"
             });
@@ -81,7 +81,7 @@ describe("FixTracker", () => {
             const result = new FixTracker(ruleFixer, sourceCode)
                 .replaceTextRange([4, 8], "123");
 
-            assert.deepEqual(result, {
+            assert.deepStrictEqual(result, {
                 range: [4, 8],
                 text: "123"
             });
@@ -95,7 +95,7 @@ describe("FixTracker", () => {
                 .retainRange([4, 10])
                 .remove(sourceCode.ast.tokens[4]);
 
-            assert.deepEqual(result, {
+            assert.deepStrictEqual(result, {
                 range: [4, 10],
                 text: "b + c"
             });
@@ -110,7 +110,7 @@ describe("FixTracker", () => {
                 .retainEnclosingFunction(xNode)
                 .replaceTextRange(xNode.range, "y");
 
-            assert.deepEqual(result, {
+            assert.deepStrictEqual(result, {
                 range: [4, 28],
                 text: "function() { return y; }"
             });
@@ -123,7 +123,7 @@ describe("FixTracker", () => {
                 .retainEnclosingFunction(bNode)
                 .replaceTextRange(bNode.range, "c");
 
-            assert.deepEqual(result, {
+            assert.deepStrictEqual(result, {
                 range: [0, 12],
                 text: "const a = c;"
             });
@@ -138,7 +138,7 @@ describe("FixTracker", () => {
                 .retainSurroundingTokens(plusToken)
                 .replaceTextRange(plusToken.range, "*");
 
-            assert.deepEqual(result, {
+            assert.deepStrictEqual(result, {
                 range: [10, 15],
                 text: "j * k"
             });

--- a/tests/lib/util/glob-util.js
+++ b/tests/lib/util/glob-util.js
@@ -58,7 +58,7 @@ describe("globUtil", () => {
             };
             const result = globUtil.resolveFileGlobPatterns(patterns, opts);
 
-            assert.deepEqual(result, ["one-js-file/**/*.js"]);
+            assert.deepStrictEqual(result, ["one-js-file/**/*.js"]);
         });
 
         it("should convert an absolute directory name with no provided extensions into a posix glob pattern", () => {
@@ -69,7 +69,7 @@ describe("globUtil", () => {
             const result = globUtil.resolveFileGlobPatterns(patterns, opts);
             const expected = [`${getFixturePath("glob-util", "one-js-file").replace(/\\/g, "/")}/**/*.js`];
 
-            assert.deepEqual(result, expected);
+            assert.deepStrictEqual(result, expected);
         });
 
         it("should convert a directory name with a single provided extension into a glob pattern", () => {
@@ -80,7 +80,7 @@ describe("globUtil", () => {
             };
             const result = globUtil.resolveFileGlobPatterns(patterns, opts);
 
-            assert.deepEqual(result, ["one-js-file/**/*.jsx"]);
+            assert.deepStrictEqual(result, ["one-js-file/**/*.jsx"]);
         });
 
         it("should convert a directory name with multiple provided extensions into a glob pattern", () => {
@@ -91,7 +91,7 @@ describe("globUtil", () => {
             };
             const result = globUtil.resolveFileGlobPatterns(patterns, opts);
 
-            assert.deepEqual(result, ["one-js-file/**/*.{jsx,js}"]);
+            assert.deepStrictEqual(result, ["one-js-file/**/*.{jsx,js}"]);
         });
 
         it("should convert multiple directory names into glob patterns", () => {
@@ -101,7 +101,7 @@ describe("globUtil", () => {
             };
             const result = globUtil.resolveFileGlobPatterns(patterns, opts);
 
-            assert.deepEqual(result, ["one-js-file/**/*.js", "two-js-files/**/*.js"]);
+            assert.deepStrictEqual(result, ["one-js-file/**/*.js", "two-js-files/**/*.js"]);
         });
 
         it("should remove leading './' from glob patterns", () => {
@@ -111,7 +111,7 @@ describe("globUtil", () => {
             };
             const result = globUtil.resolveFileGlobPatterns(patterns, opts);
 
-            assert.deepEqual(result, ["one-js-file/**/*.js"]);
+            assert.deepStrictEqual(result, ["one-js-file/**/*.js"]);
         });
 
         it("should convert a directory name with a trailing '/' into a glob pattern", () => {
@@ -121,7 +121,7 @@ describe("globUtil", () => {
             };
             const result = globUtil.resolveFileGlobPatterns(patterns, opts);
 
-            assert.deepEqual(result, ["one-js-file/**/*.js"]);
+            assert.deepStrictEqual(result, ["one-js-file/**/*.js"]);
         });
 
         it("should return filenames as they are", () => {
@@ -131,7 +131,7 @@ describe("globUtil", () => {
             };
             const result = globUtil.resolveFileGlobPatterns(patterns, opts);
 
-            assert.deepEqual(result, ["some-file.js"]);
+            assert.deepStrictEqual(result, ["some-file.js"]);
         });
 
         it("should convert backslashes into forward slashes", () => {
@@ -141,7 +141,7 @@ describe("globUtil", () => {
             };
             const result = globUtil.resolveFileGlobPatterns(patterns, opts);
 
-            assert.deepEqual(result, ["one-js-file/example.js"]);
+            assert.deepStrictEqual(result, ["one-js-file/example.js"]);
         });
 
         it("should ignore empty patterns", () => {
@@ -151,7 +151,7 @@ describe("globUtil", () => {
             };
             const result = globUtil.resolveFileGlobPatterns(patterns, opts);
 
-            assert.deepEqual(result, []);
+            assert.deepStrictEqual(result, []);
         });
 
     });
@@ -167,7 +167,7 @@ describe("globUtil", () => {
             const file1 = getFixturePath("glob-util", "one-js-file", "baz.js");
 
             assert.isArray(result);
-            assert.deepEqual(result, [{ filename: file1, ignored: false }]);
+            assert.deepStrictEqual(result, [{ filename: file1, ignored: false }]);
         });
 
         it("should return all files matching a glob pattern", () => {
@@ -180,7 +180,7 @@ describe("globUtil", () => {
             const file2 = getFixturePath("glob-util", "two-js-files", "foo.js");
 
             assert.strictEqual(result.length, 2);
-            assert.deepEqual(result, [
+            assert.deepStrictEqual(result, [
                 { filename: file1, ignored: false },
                 { filename: file2, ignored: false }
             ]);
@@ -200,7 +200,7 @@ describe("globUtil", () => {
             const file3 = getFixturePath("glob-util", "one-js-file", "baz.js");
 
             assert.strictEqual(result.length, 3);
-            assert.deepEqual(result, [
+            assert.deepStrictEqual(result, [
                 { filename: file1, ignored: false },
                 { filename: file2, ignored: false },
                 { filename: file3, ignored: false }
@@ -225,7 +225,7 @@ describe("globUtil", () => {
             const file1 = getFixturePath("glob-util", "hidden", ".foo.js");
 
             assert.strictEqual(result.length, 1);
-            assert.deepEqual(result, [
+            assert.deepStrictEqual(result, [
                 { filename: file1, ignored: false }
             ]);
         });
@@ -248,7 +248,7 @@ describe("globUtil", () => {
             });
 
             assert.strictEqual(result.length, 1);
-            assert.deepEqual(result[0], { filename, ignored: true });
+            assert.deepStrictEqual(result[0], { filename, ignored: true });
         });
 
         it("should silently ignore default ignored files if not passed explicitly even if ignore is false", () => {
@@ -271,7 +271,7 @@ describe("globUtil", () => {
             });
 
             assert.strictEqual(result.length, 1);
-            assert.deepEqual(result[0], { filename, ignored: false });
+            assert.deepStrictEqual(result[0], { filename, ignored: false });
         });
 
         it("should not return a file which does not exist", () => {
@@ -326,7 +326,7 @@ describe("globUtil", () => {
             const file1 = getFixturePath("glob-util", "one-js-file", "baz.js");
 
             assert.isArray(result);
-            assert.deepEqual(result, [
+            assert.deepStrictEqual(result, [
                 { filename: file1, ignored: false }
             ]);
         });
@@ -338,7 +338,7 @@ describe("globUtil", () => {
             const result = globUtil.listFilesToProcess(patterns, options);
 
             assert.strictEqual(result.length, 1);
-            assert.deepEqual(result, [
+            assert.deepStrictEqual(result, [
                 { filename, ignored: true }
             ]);
         });

--- a/tests/lib/util/glob-util.js
+++ b/tests/lib/util/glob-util.js
@@ -179,7 +179,7 @@ describe("globUtil", () => {
             const file1 = getFixturePath("glob-util", "two-js-files", "bar.js");
             const file2 = getFixturePath("glob-util", "two-js-files", "foo.js");
 
-            assert.equal(result.length, 2);
+            assert.strictEqual(result.length, 2);
             assert.deepEqual(result, [
                 { filename: file1, ignored: false },
                 { filename: file2, ignored: false }
@@ -199,7 +199,7 @@ describe("globUtil", () => {
             const file2 = getFixturePath("glob-util", "two-js-files", "foo.js");
             const file3 = getFixturePath("glob-util", "one-js-file", "baz.js");
 
-            assert.equal(result.length, 3);
+            assert.strictEqual(result.length, 3);
             assert.deepEqual(result, [
                 { filename: file1, ignored: false },
                 { filename: file2, ignored: false },
@@ -213,7 +213,7 @@ describe("globUtil", () => {
                 cwd: getFixturePath()
             });
 
-            assert.equal(result.length, 0);
+            assert.strictEqual(result.length, 0);
         });
 
         it("should return hidden files if included in glob pattern", () => {
@@ -224,7 +224,7 @@ describe("globUtil", () => {
 
             const file1 = getFixturePath("glob-util", "hidden", ".foo.js");
 
-            assert.equal(result.length, 1);
+            assert.strictEqual(result.length, 1);
             assert.deepEqual(result, [
                 { filename: file1, ignored: false }
             ]);
@@ -237,7 +237,7 @@ describe("globUtil", () => {
                 cwd: getFixturePath()
             });
 
-            assert.equal(result.length, 0);
+            assert.strictEqual(result.length, 0);
         });
 
         it("should ignore and warn for default ignored files when passed explicitly", () => {
@@ -247,7 +247,7 @@ describe("globUtil", () => {
                 cwd: getFixturePath()
             });
 
-            assert.equal(result.length, 1);
+            assert.strictEqual(result.length, 1);
             assert.deepEqual(result[0], { filename, ignored: true });
         });
 
@@ -259,7 +259,7 @@ describe("globUtil", () => {
                 ignore: false
             });
 
-            assert.equal(result.length, 0);
+            assert.strictEqual(result.length, 0);
         });
 
         it("should not ignore default ignored files when passed explicitly if ignore is false", () => {
@@ -270,7 +270,7 @@ describe("globUtil", () => {
                 ignore: false
             });
 
-            assert.equal(result.length, 1);
+            assert.strictEqual(result.length, 1);
             assert.deepEqual(result[0], { filename, ignored: false });
         });
 
@@ -278,7 +278,7 @@ describe("globUtil", () => {
             const patterns = ["tests/fixtures/glob-util/hidden/bar.js"];
             const result = globUtil.listFilesToProcess(patterns);
 
-            assert.equal(result.length, 0);
+            assert.strictEqual(result.length, 0);
         });
 
         it("should not return an ignored file", () => {
@@ -287,7 +287,7 @@ describe("globUtil", () => {
             const patterns = ["tests/fixtures/glob-util/ignored/**/*.js"];
             const result = globUtil.listFilesToProcess(patterns);
 
-            assert.equal(result.length, 0);
+            assert.strictEqual(result.length, 0);
         });
 
         it("should return an ignored file, if ignore option is turned off", () => {
@@ -295,7 +295,7 @@ describe("globUtil", () => {
             const patterns = [getFixturePath("glob-util", "ignored", "**/*.js")];
             const result = globUtil.listFilesToProcess(patterns, options);
 
-            assert.equal(result.length, 1);
+            assert.strictEqual(result.length, 1);
         });
 
         it("should not return a file from a glob if it matches a pattern in an ignore file", () => {
@@ -303,7 +303,7 @@ describe("globUtil", () => {
             const patterns = [getFixturePath("glob-util", "ignored", "**/*.js")];
             const result = globUtil.listFilesToProcess(patterns, options);
 
-            assert.equal(result.length, 0);
+            assert.strictEqual(result.length, 0);
         });
 
         it("should not return a file from a glob if matching a specified ignore pattern", () => {
@@ -311,7 +311,7 @@ describe("globUtil", () => {
             const patterns = [getFixturePath("glob-util", "ignored", "**/*.js")];
             const result = globUtil.listFilesToProcess(patterns, options);
 
-            assert.equal(result.length, 0);
+            assert.strictEqual(result.length, 0);
         });
 
         it("should return a file only once if listed in more than 1 pattern", () => {
@@ -337,7 +337,7 @@ describe("globUtil", () => {
             const patterns = [filename];
             const result = globUtil.listFilesToProcess(patterns, options);
 
-            assert.equal(result.length, 1);
+            assert.strictEqual(result.length, 1);
             assert.deepEqual(result, [
                 { filename, ignored: true }
             ]);

--- a/tests/lib/util/module-resolver.js
+++ b/tests/lib/util/module-resolver.js
@@ -40,7 +40,7 @@ describe("ModuleResolver", () => {
                 const resolver = new ModuleResolver(),
                     result = resolver.resolve(name, lookupPath);
 
-                assert.equal(result, expected);
+                assert.strictEqual(result, expected);
             });
         });
 

--- a/tests/lib/util/node-event-generator.js
+++ b/tests/lib/util/node-event-generator.js
@@ -120,7 +120,7 @@ describe("NodeEventGenerator", () => {
                 const emissions = getEmissions(ast, possibleQueries)
                     .filter(emission => possibleQueries.indexOf(emission[0]) !== -1);
 
-                assert.deepEqual(emissions, expectedEmissions(ast));
+                assert.deepStrictEqual(emissions, expectedEmissions(ast));
             });
         }
 

--- a/tests/lib/util/npm-util.js
+++ b/tests/lib/util/npm-util.js
@@ -175,7 +175,7 @@ describe("npmUtil", () => {
             npmUtil.installSyncSaveDev("desired-package");
             assert(stub.calledOnce);
             assert.strictEqual(stub.firstCall.args[0], "npm");
-            assert.deepEqual(stub.firstCall.args[1], ["i", "--save-dev", "desired-package"]);
+            assert.deepStrictEqual(stub.firstCall.args[1], ["i", "--save-dev", "desired-package"]);
             stub.restore();
         });
 
@@ -185,7 +185,7 @@ describe("npmUtil", () => {
             npmUtil.installSyncSaveDev(["first-package", "second-package"]);
             assert(stub.calledOnce);
             assert.strictEqual(stub.firstCall.args[0], "npm");
-            assert.deepEqual(stub.firstCall.args[1], ["i", "--save-dev", "first-package", "second-package"]);
+            assert.deepStrictEqual(stub.firstCall.args[1], ["i", "--save-dev", "first-package", "second-package"]);
             stub.restore();
         });
 
@@ -209,7 +209,7 @@ describe("npmUtil", () => {
             npmUtil.fetchPeerDependencies("desired-package");
             assert(stub.calledOnce);
             assert.strictEqual(stub.firstCall.args[0], "npm");
-            assert.deepEqual(stub.firstCall.args[1], ["show", "--json", "desired-package", "peerDependencies"]);
+            assert.deepStrictEqual(stub.firstCall.args[1], ["show", "--json", "desired-package", "peerDependencies"]);
             stub.restore();
         });
 

--- a/tests/lib/util/npm-util.js
+++ b/tests/lib/util/npm-util.js
@@ -81,7 +81,7 @@ describe("npmUtil", () => {
 
             assert.throws(fn, "SyntaxError: Unexpected token v");
             assert(logInfo.calledOnce);
-            assert.equal(logInfo.firstCall.args[0], "Could not read package.json file. Please check that the file contains valid JSON.");
+            assert.strictEqual(logInfo.firstCall.args[0], "Could not read package.json file. Please check that the file contains valid JSON.");
         });
     });
 
@@ -144,7 +144,7 @@ describe("npmUtil", () => {
 
             assert.throws(fn, "SyntaxError: Unexpected token v");
             assert(logInfo.calledOnce);
-            assert.equal(logInfo.firstCall.args[0], "Could not read package.json file. Please check that the file contains valid JSON.");
+            assert.strictEqual(logInfo.firstCall.args[0], "Could not read package.json file. Please check that the file contains valid JSON.");
             logInfo.restore();
         });
     });
@@ -159,12 +159,12 @@ describe("npmUtil", () => {
                 "package.json": "{ \"file\": \"contents\" }"
             });
 
-            assert.equal(npmUtil.checkPackageJson(), true);
+            assert.strictEqual(npmUtil.checkPackageJson(), true);
         });
 
         it("should return false if package.json does not exist", () => {
             mockFs({});
-            assert.equal(npmUtil.checkPackageJson(), false);
+            assert.strictEqual(npmUtil.checkPackageJson(), false);
         });
     });
 
@@ -174,7 +174,7 @@ describe("npmUtil", () => {
 
             npmUtil.installSyncSaveDev("desired-package");
             assert(stub.calledOnce);
-            assert.equal(stub.firstCall.args[0], "npm");
+            assert.strictEqual(stub.firstCall.args[0], "npm");
             assert.deepEqual(stub.firstCall.args[1], ["i", "--save-dev", "desired-package"]);
             stub.restore();
         });
@@ -184,7 +184,7 @@ describe("npmUtil", () => {
 
             npmUtil.installSyncSaveDev(["first-package", "second-package"]);
             assert(stub.calledOnce);
-            assert.equal(stub.firstCall.args[0], "npm");
+            assert.strictEqual(stub.firstCall.args[0], "npm");
             assert.deepEqual(stub.firstCall.args[1], ["i", "--save-dev", "first-package", "second-package"]);
             stub.restore();
         });
@@ -208,7 +208,7 @@ describe("npmUtil", () => {
 
             npmUtil.fetchPeerDependencies("desired-package");
             assert(stub.calledOnce);
-            assert.equal(stub.firstCall.args[0], "npm");
+            assert.strictEqual(stub.firstCall.args[0], "npm");
             assert.deepEqual(stub.firstCall.args[1], ["show", "--json", "desired-package", "peerDependencies"]);
             stub.restore();
         });

--- a/tests/lib/util/path-util.js
+++ b/tests/lib/util/path-util.js
@@ -25,28 +25,28 @@ describe("pathUtil", () => {
             const input = "./relative/file/path.js";
             const result = pathUtil.convertPathToPosix(input);
 
-            assert.equal(result, "relative/file/path.js");
+            assert.strictEqual(result, "relative/file/path.js");
         });
 
         it("should remove interior '../'", () => {
             const input = "./relative/file/../path.js";
             const result = pathUtil.convertPathToPosix(input);
 
-            assert.equal(result, "relative/path.js");
+            assert.strictEqual(result, "relative/path.js");
         });
 
         it("should not remove a leading '../'", () => {
             const input = "../parent/file/path.js";
             const result = pathUtil.convertPathToPosix(input);
 
-            assert.equal(result, "../parent/file/path.js");
+            assert.strictEqual(result, "../parent/file/path.js");
         });
 
         it("should convert windows path seperators into posix style path seperators", () => {
             const input = "windows\\style\\path.js";
             const result = pathUtil.convertPathToPosix(input);
 
-            assert.equal(result, "windows/style/path.js");
+            assert.strictEqual(result, "windows/style/path.js");
         });
 
     });
@@ -58,7 +58,7 @@ describe("pathUtil", () => {
             const basePath = "/absolute/";
             const result = pathUtil.getRelativePath(filePath, basePath);
 
-            assert.equal(result, path.normalize("file/path.js"));
+            assert.strictEqual(result, path.normalize("file/path.js"));
         });
 
         it("should throw if the base path is not absolute", () => {
@@ -77,7 +77,7 @@ describe("pathUtil", () => {
             sinon.stub(process, "cwd").returns("/absolute/");
             const result = pathUtil.getRelativePath(filePath, basePath);
 
-            assert.equal(result, "path.js");
+            assert.strictEqual(result, "path.js");
 
             process.cwd.restore();
         });
@@ -86,7 +86,7 @@ describe("pathUtil", () => {
             const filePath = "/absolute/file/path.js";
             const result = pathUtil.getRelativePath(filePath);
 
-            assert.equal(result, "absolute/file/path.js");
+            assert.strictEqual(result, "absolute/file/path.js");
         });
 
     });

--- a/tests/lib/util/rule-fixer.js
+++ b/tests/lib/util/rule-fixer.js
@@ -23,7 +23,7 @@ describe("RuleFixer", () => {
 
             const result = ruleFixer.insertTextBefore({ range: [0, 1] }, "Hi");
 
-            assert.deepEqual(result, {
+            assert.deepStrictEqual(result, {
                 range: [0, 0],
                 text: "Hi"
             });
@@ -38,7 +38,7 @@ describe("RuleFixer", () => {
 
             const result = ruleFixer.insertTextBeforeRange([0, 1], "Hi");
 
-            assert.deepEqual(result, {
+            assert.deepStrictEqual(result, {
                 range: [0, 0],
                 text: "Hi"
             });
@@ -53,7 +53,7 @@ describe("RuleFixer", () => {
 
             const result = ruleFixer.insertTextAfter({ range: [0, 1] }, "Hi");
 
-            assert.deepEqual(result, {
+            assert.deepStrictEqual(result, {
                 range: [1, 1],
                 text: "Hi"
             });
@@ -68,7 +68,7 @@ describe("RuleFixer", () => {
 
             const result = ruleFixer.insertTextAfterRange([0, 1], "Hi");
 
-            assert.deepEqual(result, {
+            assert.deepStrictEqual(result, {
                 range: [1, 1],
                 text: "Hi"
             });
@@ -83,7 +83,7 @@ describe("RuleFixer", () => {
 
             const result = ruleFixer.remove({ range: [0, 1] });
 
-            assert.deepEqual(result, {
+            assert.deepStrictEqual(result, {
                 range: [0, 1],
                 text: ""
             });
@@ -98,7 +98,7 @@ describe("RuleFixer", () => {
 
             const result = ruleFixer.removeRange([0, 1]);
 
-            assert.deepEqual(result, {
+            assert.deepStrictEqual(result, {
                 range: [0, 1],
                 text: ""
             });
@@ -114,7 +114,7 @@ describe("RuleFixer", () => {
 
             const result = ruleFixer.replaceText({ range: [0, 1] }, "Hi");
 
-            assert.deepEqual(result, {
+            assert.deepStrictEqual(result, {
                 range: [0, 1],
                 text: "Hi"
             });
@@ -129,7 +129,7 @@ describe("RuleFixer", () => {
 
             const result = ruleFixer.replaceTextRange([0, 1], "Hi");
 
-            assert.deepEqual(result, {
+            assert.deepStrictEqual(result, {
                 range: [0, 1],
                 text: "Hi"
             });

--- a/tests/lib/util/safe-emitter.js
+++ b/tests/lib/util/safe-emitter.js
@@ -19,12 +19,12 @@ describe("safe-emitter", () => {
             emitter.on("bar", () => colors.push("green"));
 
             emitter.emit("foo");
-            assert.deepEqual(colors, ["red", "blue"]);
+            assert.deepStrictEqual(colors, ["red", "blue"]);
 
             emitter.on("bar", color => colors.push(color));
             emitter.emit("bar", "yellow");
 
-            assert.deepEqual(colors, ["red", "blue", "green", "yellow"]);
+            assert.deepStrictEqual(colors, ["red", "blue", "green", "yellow"]);
         });
 
         it("calls listeners with no `this` value", () => {

--- a/tests/lib/util/source-code-fixer.js
+++ b/tests/lib/util/source-code-fixer.js
@@ -152,7 +152,7 @@ describe("SourceCodeFixer", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE, [INSERT_AT_END], false);
 
                 assert.isFalse(result.fixed);
-                assert.equal(result.output, TEST_CODE);
+                assert.strictEqual(result.output, TEST_CODE);
             });
 
             it("Should perform fixes if 'shouldFix' is not provided", () => {
@@ -172,7 +172,7 @@ describe("SourceCodeFixer", () => {
                 const shouldFixSpy = sinon.spy();
 
                 SourceCodeFixer.applyFixes(TEST_CODE, [INSERT_AT_START], shouldFixSpy);
-                assert.equal(shouldFixSpy.firstCall.args[0], INSERT_AT_START);
+                assert.strictEqual(shouldFixSpy.firstCall.args[0], INSERT_AT_START);
             });
 
             it("should not perform fixes if 'shouldFix' function returns false", () => {
@@ -186,14 +186,14 @@ describe("SourceCodeFixer", () => {
                 const shouldFixSpy = sinon.spy(() => false);
                 const result = SourceCodeFixer.applyFixes(TEST_CODE, [INSERT_AT_START], shouldFixSpy);
 
-                assert.equal(result.output, TEST_CODE);
+                assert.strictEqual(result.output, TEST_CODE);
             });
 
             it("should only apply fixes for which the 'shouldFix' function returns true", () => {
                 const shouldFixSpy = sinon.spy(problem => problem.message === "foo");
                 const result = SourceCodeFixer.applyFixes(TEST_CODE, [INSERT_AT_START, REPLACE_ID], shouldFixSpy);
 
-                assert.equal(result.output, "var foo = 6 * 7;");
+                assert.strictEqual(result.output, "var foo = 6 * 7;");
             });
 
             it("is called without access to internal eslint state", () => {
@@ -210,36 +210,36 @@ describe("SourceCodeFixer", () => {
             it("should insert text at the end of the code", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE, [INSERT_AT_END]);
 
-                assert.equal(result.output, TEST_CODE + INSERT_AT_END.fix.text);
-                assert.equal(result.messages.length, 0);
+                assert.strictEqual(result.output, TEST_CODE + INSERT_AT_END.fix.text);
+                assert.strictEqual(result.messages.length, 0);
             });
 
             it("should insert text at the beginning of the code", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE, [INSERT_AT_START]);
 
-                assert.equal(result.output, INSERT_AT_START.fix.text + TEST_CODE);
-                assert.equal(result.messages.length, 0);
+                assert.strictEqual(result.output, INSERT_AT_START.fix.text + TEST_CODE);
+                assert.strictEqual(result.messages.length, 0);
             });
 
             it("should insert text in the middle of the code", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE, [INSERT_IN_MIDDLE]);
 
-                assert.equal(result.output, TEST_CODE.replace("6 *", `${INSERT_IN_MIDDLE.fix.text}6 *`));
-                assert.equal(result.messages.length, 0);
+                assert.strictEqual(result.output, TEST_CODE.replace("6 *", `${INSERT_IN_MIDDLE.fix.text}6 *`));
+                assert.strictEqual(result.messages.length, 0);
             });
 
             it("should insert text at the beginning, middle, and end of the code", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE, [INSERT_IN_MIDDLE, INSERT_AT_START, INSERT_AT_END]);
 
-                assert.equal(result.output, INSERT_AT_START.fix.text + TEST_CODE.replace("6 *", `${INSERT_IN_MIDDLE.fix.text}6 *`) + INSERT_AT_END.fix.text);
-                assert.equal(result.messages.length, 0);
+                assert.strictEqual(result.output, INSERT_AT_START.fix.text + TEST_CODE.replace("6 *", `${INSERT_IN_MIDDLE.fix.text}6 *`) + INSERT_AT_END.fix.text);
+                assert.strictEqual(result.messages.length, 0);
             });
 
 
             it("should ignore reversed ranges", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE, [REVERSED_RANGE]);
 
-                assert.equal(result.output, TEST_CODE);
+                assert.strictEqual(result.output, TEST_CODE);
             });
 
         });
@@ -250,32 +250,32 @@ describe("SourceCodeFixer", () => {
             it("should replace text at the end of the code", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE, [REPLACE_VAR]);
 
-                assert.equal(result.messages.length, 0);
-                assert.equal(result.output, TEST_CODE.replace("var", "let"));
+                assert.strictEqual(result.messages.length, 0);
+                assert.strictEqual(result.output, TEST_CODE.replace("var", "let"));
                 assert.isTrue(result.fixed);
             });
 
             it("should replace text at the beginning of the code", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE, [REPLACE_ID]);
 
-                assert.equal(result.messages.length, 0);
-                assert.equal(result.output, TEST_CODE.replace("answer", "foo"));
+                assert.strictEqual(result.messages.length, 0);
+                assert.strictEqual(result.output, TEST_CODE.replace("answer", "foo"));
                 assert.isTrue(result.fixed);
             });
 
             it("should replace text in the middle of the code", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE, [REPLACE_NUM]);
 
-                assert.equal(result.messages.length, 0);
-                assert.equal(result.output, TEST_CODE.replace("6", "5"));
+                assert.strictEqual(result.messages.length, 0);
+                assert.strictEqual(result.output, TEST_CODE.replace("6", "5"));
                 assert.isTrue(result.fixed);
             });
 
             it("should replace text at the beginning and end of the code", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE, [REPLACE_ID, REPLACE_VAR, REPLACE_NUM]);
 
-                assert.equal(result.messages.length, 0);
-                assert.equal(result.output, "let foo = 5 * 7;");
+                assert.strictEqual(result.messages.length, 0);
+                assert.strictEqual(result.output, "let foo = 5 * 7;");
                 assert.isTrue(result.fixed);
             });
 
@@ -286,32 +286,32 @@ describe("SourceCodeFixer", () => {
             it("should remove text at the start of the code", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE, [REMOVE_START]);
 
-                assert.equal(result.messages.length, 0);
-                assert.equal(result.output, TEST_CODE.replace("var ", ""));
+                assert.strictEqual(result.messages.length, 0);
+                assert.strictEqual(result.output, TEST_CODE.replace("var ", ""));
                 assert.isTrue(result.fixed);
             });
 
             it("should remove text in the middle of the code", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE, [REMOVE_MIDDLE]);
 
-                assert.equal(result.messages.length, 0);
-                assert.equal(result.output, TEST_CODE.replace("answer", "a"));
+                assert.strictEqual(result.messages.length, 0);
+                assert.strictEqual(result.output, TEST_CODE.replace("answer", "a"));
                 assert.isTrue(result.fixed);
             });
 
             it("should remove text towards the end of the code", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE, [REMOVE_END]);
 
-                assert.equal(result.messages.length, 0);
-                assert.equal(result.output, TEST_CODE.replace(" * 7", ""));
+                assert.strictEqual(result.messages.length, 0);
+                assert.strictEqual(result.output, TEST_CODE.replace(" * 7", ""));
                 assert.isTrue(result.fixed);
             });
 
             it("should remove text at the beginning, middle, and end of the code", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE, [REMOVE_END, REMOVE_START, REMOVE_MIDDLE]);
 
-                assert.equal(result.messages.length, 0);
-                assert.equal(result.output, "a = 6;");
+                assert.strictEqual(result.messages.length, 0);
+                assert.strictEqual(result.output, "a = 6;");
                 assert.isTrue(result.fixed);
             });
         });
@@ -321,36 +321,36 @@ describe("SourceCodeFixer", () => {
             it("should replace text at the beginning, remove text in the middle, and insert text at the end", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE, [INSERT_AT_END, REMOVE_END, REPLACE_VAR]);
 
-                assert.equal(result.output, "let answer = 6;// end");
+                assert.strictEqual(result.output, "let answer = 6;// end");
                 assert.isTrue(result.fixed);
-                assert.equal(result.messages.length, 0);
+                assert.strictEqual(result.messages.length, 0);
             });
 
             it("should only apply one fix when ranges overlap", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE, [REMOVE_MIDDLE, REPLACE_ID]);
 
-                assert.equal(result.output, TEST_CODE.replace("answer", "foo"));
-                assert.equal(result.messages.length, 1);
-                assert.equal(result.messages[0].message, "removemiddle");
+                assert.strictEqual(result.output, TEST_CODE.replace("answer", "foo"));
+                assert.strictEqual(result.messages.length, 1);
+                assert.strictEqual(result.messages[0].message, "removemiddle");
                 assert.isTrue(result.fixed);
             });
 
             it("should apply one fix when the end of one range is the same as the start of a previous range overlap", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE, [REMOVE_START, REPLACE_ID]);
 
-                assert.equal(result.output, TEST_CODE.replace("var ", ""));
-                assert.equal(result.messages.length, 1);
-                assert.equal(result.messages[0].message, "foo");
+                assert.strictEqual(result.output, TEST_CODE.replace("var ", ""));
+                assert.strictEqual(result.messages.length, 1);
+                assert.strictEqual(result.messages[0].message, "foo");
                 assert.isTrue(result.fixed);
             });
 
             it("should only apply one fix when ranges overlap and one message has no fix", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE, [REMOVE_MIDDLE, REPLACE_ID, NO_FIX]);
 
-                assert.equal(result.output, TEST_CODE.replace("answer", "foo"));
-                assert.equal(result.messages.length, 2);
-                assert.equal(result.messages[0].message, "nofix");
-                assert.equal(result.messages[1].message, "removemiddle");
+                assert.strictEqual(result.output, TEST_CODE.replace("answer", "foo"));
+                assert.strictEqual(result.messages.length, 2);
+                assert.strictEqual(result.messages[0].message, "nofix");
+                assert.strictEqual(result.messages[1].message, "removemiddle");
                 assert.isTrue(result.fixed);
             });
 
@@ -358,7 +358,7 @@ describe("SourceCodeFixer", () => {
                 const result1 = SourceCodeFixer.applyFixes(TEST_CODE, [REMOVE_MIDDLE, REPLACE_ID]);
                 const result2 = SourceCodeFixer.applyFixes(TEST_CODE, [REPLACE_ID, REMOVE_MIDDLE]);
 
-                assert.equal(result1.output, result2.output);
+                assert.strictEqual(result1.output, result2.output);
             });
         });
 
@@ -367,19 +367,19 @@ describe("SourceCodeFixer", () => {
             it("should only apply one fix when ranges overlap and one message has no fix", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE, [NO_FIX]);
 
-                assert.equal(result.output, TEST_CODE);
-                assert.equal(result.messages.length, 1);
-                assert.equal(result.messages[0].message, "nofix");
+                assert.strictEqual(result.output, TEST_CODE);
+                assert.strictEqual(result.messages.length, 1);
+                assert.strictEqual(result.messages[0].message, "nofix");
                 assert.isFalse(result.fixed);
             });
 
             it("should sort the no fix messages correctly", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE, [REPLACE_ID, NO_FIX2, NO_FIX1]);
 
-                assert.equal(result.output, TEST_CODE.replace("answer", "foo"));
-                assert.equal(result.messages.length, 2);
-                assert.equal(result.messages[0].message, "nofix1");
-                assert.equal(result.messages[1].message, "nofix2");
+                assert.strictEqual(result.output, TEST_CODE.replace("answer", "foo"));
+                assert.strictEqual(result.messages.length, 2);
+                assert.strictEqual(result.messages[0].message, "nofix1");
+                assert.strictEqual(result.messages[1].message, "nofix2");
                 assert.isTrue(result.fixed);
             });
 
@@ -390,33 +390,33 @@ describe("SourceCodeFixer", () => {
             it("should insert BOM with an insertion of '\uFEFF' at 0", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE, [INSERT_BOM]);
 
-                assert.equal(result.output, `\uFEFF${TEST_CODE}`);
+                assert.strictEqual(result.output, `\uFEFF${TEST_CODE}`);
                 assert.isTrue(result.fixed);
-                assert.equal(result.messages.length, 0);
+                assert.strictEqual(result.messages.length, 0);
             });
 
             it("should insert BOM with an insertion of '\uFEFFfoobar' at 0", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE, [INSERT_BOM_WITH_TEXT]);
 
-                assert.equal(result.output, `\uFEFF// start\n${TEST_CODE}`);
+                assert.strictEqual(result.output, `\uFEFF// start\n${TEST_CODE}`);
                 assert.isTrue(result.fixed);
-                assert.equal(result.messages.length, 0);
+                assert.strictEqual(result.messages.length, 0);
             });
 
             it("should remove BOM with a negative range", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE, [REMOVE_BOM]);
 
-                assert.equal(result.output, TEST_CODE);
+                assert.strictEqual(result.output, TEST_CODE);
                 assert.isTrue(result.fixed);
-                assert.equal(result.messages.length, 0);
+                assert.strictEqual(result.messages.length, 0);
             });
 
             it("should replace BOM with a negative range and 'foobar'", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE, [REPLACE_BOM_WITH_TEXT]);
 
-                assert.equal(result.output, `// start\n${TEST_CODE}`);
+                assert.strictEqual(result.output, `// start\n${TEST_CODE}`);
                 assert.isTrue(result.fixed);
-                assert.equal(result.messages.length, 0);
+                assert.strictEqual(result.messages.length, 0);
             });
 
         });
@@ -434,36 +434,36 @@ describe("SourceCodeFixer", () => {
             it("should insert text at the end of the code", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE_WITH_BOM, [INSERT_AT_END]);
 
-                assert.equal(result.output, `\uFEFF${TEST_CODE}${INSERT_AT_END.fix.text}`);
-                assert.equal(result.messages.length, 0);
+                assert.strictEqual(result.output, `\uFEFF${TEST_CODE}${INSERT_AT_END.fix.text}`);
+                assert.strictEqual(result.messages.length, 0);
             });
 
             it("should insert text at the beginning of the code", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE_WITH_BOM, [INSERT_AT_START]);
 
-                assert.equal(result.output, `\uFEFF${INSERT_AT_START.fix.text}${TEST_CODE}`);
-                assert.equal(result.messages.length, 0);
+                assert.strictEqual(result.output, `\uFEFF${INSERT_AT_START.fix.text}${TEST_CODE}`);
+                assert.strictEqual(result.messages.length, 0);
             });
 
             it("should insert text in the middle of the code", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE_WITH_BOM, [INSERT_IN_MIDDLE]);
 
-                assert.equal(result.output, `\uFEFF${TEST_CODE.replace("6 *", `${INSERT_IN_MIDDLE.fix.text}6 *`)}`);
-                assert.equal(result.messages.length, 0);
+                assert.strictEqual(result.output, `\uFEFF${TEST_CODE.replace("6 *", `${INSERT_IN_MIDDLE.fix.text}6 *`)}`);
+                assert.strictEqual(result.messages.length, 0);
             });
 
             it("should insert text at the beginning, middle, and end of the code", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE_WITH_BOM, [INSERT_IN_MIDDLE, INSERT_AT_START, INSERT_AT_END]);
                 const insertInMiddle = TEST_CODE.replace("6 *", `${INSERT_IN_MIDDLE.fix.text}6 *`);
 
-                assert.equal(result.output, `\uFEFF${INSERT_AT_START.fix.text}${insertInMiddle}${INSERT_AT_END.fix.text}`);
-                assert.equal(result.messages.length, 0);
+                assert.strictEqual(result.output, `\uFEFF${INSERT_AT_START.fix.text}${insertInMiddle}${INSERT_AT_END.fix.text}`);
+                assert.strictEqual(result.messages.length, 0);
             });
 
             it("should ignore reversed ranges", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE_WITH_BOM, [REVERSED_RANGE]);
 
-                assert.equal(result.output, `\uFEFF${TEST_CODE}`);
+                assert.strictEqual(result.output, `\uFEFF${TEST_CODE}`);
             });
 
         });
@@ -473,32 +473,32 @@ describe("SourceCodeFixer", () => {
             it("should replace text at the end of the code", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE_WITH_BOM, [REPLACE_VAR]);
 
-                assert.equal(result.messages.length, 0);
-                assert.equal(result.output, `\uFEFF${TEST_CODE.replace("var", "let")}`);
+                assert.strictEqual(result.messages.length, 0);
+                assert.strictEqual(result.output, `\uFEFF${TEST_CODE.replace("var", "let")}`);
                 assert.isTrue(result.fixed);
             });
 
             it("should replace text at the beginning of the code", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE_WITH_BOM, [REPLACE_ID]);
 
-                assert.equal(result.messages.length, 0);
-                assert.equal(result.output, `\uFEFF${TEST_CODE.replace("answer", "foo")}`);
+                assert.strictEqual(result.messages.length, 0);
+                assert.strictEqual(result.output, `\uFEFF${TEST_CODE.replace("answer", "foo")}`);
                 assert.isTrue(result.fixed);
             });
 
             it("should replace text in the middle of the code", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE_WITH_BOM, [REPLACE_NUM]);
 
-                assert.equal(result.messages.length, 0);
-                assert.equal(result.output, `\uFEFF${TEST_CODE.replace("6", "5")}`);
+                assert.strictEqual(result.messages.length, 0);
+                assert.strictEqual(result.output, `\uFEFF${TEST_CODE.replace("6", "5")}`);
                 assert.isTrue(result.fixed);
             });
 
             it("should replace text at the beginning and end of the code", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE_WITH_BOM, [REPLACE_ID, REPLACE_VAR, REPLACE_NUM]);
 
-                assert.equal(result.messages.length, 0);
-                assert.equal(result.output, "\uFEFFlet foo = 5 * 7;");
+                assert.strictEqual(result.messages.length, 0);
+                assert.strictEqual(result.output, "\uFEFFlet foo = 5 * 7;");
                 assert.isTrue(result.fixed);
             });
 
@@ -509,32 +509,32 @@ describe("SourceCodeFixer", () => {
             it("should remove text at the start of the code", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE_WITH_BOM, [REMOVE_START]);
 
-                assert.equal(result.messages.length, 0);
-                assert.equal(result.output, `\uFEFF${TEST_CODE.replace("var ", "")}`);
+                assert.strictEqual(result.messages.length, 0);
+                assert.strictEqual(result.output, `\uFEFF${TEST_CODE.replace("var ", "")}`);
                 assert.isTrue(result.fixed);
             });
 
             it("should remove text in the middle of the code", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE_WITH_BOM, [REMOVE_MIDDLE]);
 
-                assert.equal(result.messages.length, 0);
-                assert.equal(result.output, `\uFEFF${TEST_CODE.replace("answer", "a")}`);
+                assert.strictEqual(result.messages.length, 0);
+                assert.strictEqual(result.output, `\uFEFF${TEST_CODE.replace("answer", "a")}`);
                 assert.isTrue(result.fixed);
             });
 
             it("should remove text towards the end of the code", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE_WITH_BOM, [REMOVE_END]);
 
-                assert.equal(result.messages.length, 0);
-                assert.equal(result.output, `\uFEFF${TEST_CODE.replace(" * 7", "")}`);
+                assert.strictEqual(result.messages.length, 0);
+                assert.strictEqual(result.output, `\uFEFF${TEST_CODE.replace(" * 7", "")}`);
                 assert.isTrue(result.fixed);
             });
 
             it("should remove text at the beginning, middle, and end of the code", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE_WITH_BOM, [REMOVE_END, REMOVE_START, REMOVE_MIDDLE]);
 
-                assert.equal(result.messages.length, 0);
-                assert.equal(result.output, "\uFEFFa = 6;");
+                assert.strictEqual(result.messages.length, 0);
+                assert.strictEqual(result.output, "\uFEFFa = 6;");
                 assert.isTrue(result.fixed);
             });
         });
@@ -544,36 +544,36 @@ describe("SourceCodeFixer", () => {
             it("should replace text at the beginning, remove text in the middle, and insert text at the end", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE_WITH_BOM, [INSERT_AT_END, REMOVE_END, REPLACE_VAR]);
 
-                assert.equal(result.output, "\uFEFFlet answer = 6;// end");
+                assert.strictEqual(result.output, "\uFEFFlet answer = 6;// end");
                 assert.isTrue(result.fixed);
-                assert.equal(result.messages.length, 0);
+                assert.strictEqual(result.messages.length, 0);
             });
 
             it("should only apply one fix when ranges overlap", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE_WITH_BOM, [REMOVE_MIDDLE, REPLACE_ID]);
 
-                assert.equal(result.output, `\uFEFF${TEST_CODE.replace("answer", "foo")}`);
-                assert.equal(result.messages.length, 1);
-                assert.equal(result.messages[0].message, "removemiddle");
+                assert.strictEqual(result.output, `\uFEFF${TEST_CODE.replace("answer", "foo")}`);
+                assert.strictEqual(result.messages.length, 1);
+                assert.strictEqual(result.messages[0].message, "removemiddle");
                 assert.isTrue(result.fixed);
             });
 
             it("should apply one fix when the end of one range is the same as the start of a previous range overlap", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE_WITH_BOM, [REMOVE_START, REPLACE_ID]);
 
-                assert.equal(result.output, `\uFEFF${TEST_CODE.replace("var ", "")}`);
-                assert.equal(result.messages.length, 1);
-                assert.equal(result.messages[0].message, "foo");
+                assert.strictEqual(result.output, `\uFEFF${TEST_CODE.replace("var ", "")}`);
+                assert.strictEqual(result.messages.length, 1);
+                assert.strictEqual(result.messages[0].message, "foo");
                 assert.isTrue(result.fixed);
             });
 
             it("should only apply one fix when ranges overlap and one message has no fix", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE_WITH_BOM, [REMOVE_MIDDLE, REPLACE_ID, NO_FIX]);
 
-                assert.equal(result.output, `\uFEFF${TEST_CODE.replace("answer", "foo")}`);
-                assert.equal(result.messages.length, 2);
-                assert.equal(result.messages[0].message, "nofix");
-                assert.equal(result.messages[1].message, "removemiddle");
+                assert.strictEqual(result.output, `\uFEFF${TEST_CODE.replace("answer", "foo")}`);
+                assert.strictEqual(result.messages.length, 2);
+                assert.strictEqual(result.messages[0].message, "nofix");
+                assert.strictEqual(result.messages[1].message, "removemiddle");
                 assert.isTrue(result.fixed);
             });
 
@@ -581,7 +581,7 @@ describe("SourceCodeFixer", () => {
                 const result1 = SourceCodeFixer.applyFixes(TEST_CODE_WITH_BOM, [REMOVE_MIDDLE, REPLACE_ID]);
                 const result2 = SourceCodeFixer.applyFixes(TEST_CODE_WITH_BOM, [REPLACE_ID, REMOVE_MIDDLE]);
 
-                assert.equal(result1.output, result2.output);
+                assert.strictEqual(result1.output, result2.output);
             });
 
         });
@@ -591,9 +591,9 @@ describe("SourceCodeFixer", () => {
             it("should only apply one fix when ranges overlap and one message has no fix", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE_WITH_BOM, [NO_FIX]);
 
-                assert.equal(result.output, `\uFEFF${TEST_CODE}`);
-                assert.equal(result.messages.length, 1);
-                assert.equal(result.messages[0].message, "nofix");
+                assert.strictEqual(result.output, `\uFEFF${TEST_CODE}`);
+                assert.strictEqual(result.messages.length, 1);
+                assert.strictEqual(result.messages[0].message, "nofix");
                 assert.isFalse(result.fixed);
             });
 
@@ -604,33 +604,33 @@ describe("SourceCodeFixer", () => {
             it("should insert BOM with an insertion of '\uFEFF' at 0", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE_WITH_BOM, [INSERT_BOM]);
 
-                assert.equal(result.output, `\uFEFF${TEST_CODE}`);
+                assert.strictEqual(result.output, `\uFEFF${TEST_CODE}`);
                 assert.isTrue(result.fixed);
-                assert.equal(result.messages.length, 0);
+                assert.strictEqual(result.messages.length, 0);
             });
 
             it("should insert BOM with an insertion of '\uFEFFfoobar' at 0", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE_WITH_BOM, [INSERT_BOM_WITH_TEXT]);
 
-                assert.equal(result.output, `\uFEFF// start\n${TEST_CODE}`);
+                assert.strictEqual(result.output, `\uFEFF// start\n${TEST_CODE}`);
                 assert.isTrue(result.fixed);
-                assert.equal(result.messages.length, 0);
+                assert.strictEqual(result.messages.length, 0);
             });
 
             it("should remove BOM with a negative range", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE_WITH_BOM, [REMOVE_BOM]);
 
-                assert.equal(result.output, TEST_CODE);
+                assert.strictEqual(result.output, TEST_CODE);
                 assert.isTrue(result.fixed);
-                assert.equal(result.messages.length, 0);
+                assert.strictEqual(result.messages.length, 0);
             });
 
             it("should replace BOM with a negative range and 'foobar'", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE_WITH_BOM, [REPLACE_BOM_WITH_TEXT]);
 
-                assert.equal(result.output, `// start\n${TEST_CODE}`);
+                assert.strictEqual(result.output, `// start\n${TEST_CODE}`);
                 assert.isTrue(result.fixed);
-                assert.equal(result.messages.length, 0);
+                assert.strictEqual(result.messages.length, 0);
             });
 
         });

--- a/tests/lib/util/source-code-util.js
+++ b/tests/lib/util/source-code-util.js
@@ -137,7 +137,7 @@ describe("SourceCodeUtil", () => {
             process.chdir(fixtureDir);
             getSourceCodeOfFiles(filename, spy);
             process.chdir(originalDir);
-            assert.equal(spy.firstCall.args[0], 1);
+            assert.strictEqual(spy.firstCall.args[0], 1);
         });
 
         it("should use default options if none are provided", () => {
@@ -214,7 +214,7 @@ describe("SourceCodeUtil", () => {
             const barFile = getFixturePath("nested/bar.js");
             const sourceCode = getSourceCodeOfFiles(folder, { cwd: fixtureDir });
 
-            assert.equal(Object.keys(sourceCode).length, 2);
+            assert.strictEqual(Object.keys(sourceCode).length, 2);
             assert.instanceOf(sourceCode[fooFile], SourceCode);
             assert.instanceOf(sourceCode[barFile], SourceCode);
         });
@@ -225,7 +225,7 @@ describe("SourceCodeUtil", () => {
             const cliOptions = { extensions: [".abc"], cwd: fixtureDir };
             const sourceCode = getSourceCodeOfFiles(pattern, cliOptions);
 
-            assert.equal(Object.keys(sourceCode).length, 1);
+            assert.strictEqual(Object.keys(sourceCode).length, 1);
             assert.instanceOf(sourceCode[abcFile], SourceCode);
         });
 
@@ -243,7 +243,7 @@ describe("SourceCodeUtil", () => {
             const barFilename = getFixturePath("bar.js");
 
             getSourceCodeOfFiles([fooFilename, barFilename], { cwd: fixtureDir }, callback);
-            assert.equal(callback.callCount, 2);
+            assert.strictEqual(callback.callCount, 2);
         });
 
         it("should call callback function with total number of files with sourceCode", () => {

--- a/tests/lib/util/source-code-util.js
+++ b/tests/lib/util/source-code-util.js
@@ -146,7 +146,7 @@ describe("SourceCodeUtil", () => {
 
             getSourceCodeOfFiles(filename);
             assert(spy.called);
-            assert.deepEqual(spy.firstCall.args[1].extensions, [".js"]);
+            assert.deepStrictEqual(spy.firstCall.args[1].extensions, [".js"]);
         });
 
         it("should create an object with located filenames as keys", () => {

--- a/tests/lib/util/source-code.js
+++ b/tests/lib/util/source-code.js
@@ -47,8 +47,8 @@ describe("SourceCode", () => {
             const sourceCode = new SourceCode("foo;", ast);
 
             assert.isObject(sourceCode);
-            assert.equal(sourceCode.text, "foo;");
-            assert.equal(sourceCode.ast, ast);
+            assert.strictEqual(sourceCode.text, "foo;");
+            assert.strictEqual(sourceCode.ast, ast);
         });
 
         it("should split text into lines when called with valid data", () => {
@@ -56,9 +56,9 @@ describe("SourceCode", () => {
             const sourceCode = new SourceCode("foo;\nbar;", ast);
 
             assert.isObject(sourceCode);
-            assert.equal(sourceCode.lines.length, 2);
-            assert.equal(sourceCode.lines[0], "foo;");
-            assert.equal(sourceCode.lines[1], "bar;");
+            assert.strictEqual(sourceCode.lines.length, 2);
+            assert.strictEqual(sourceCode.lines[0], "foo;");
+            assert.strictEqual(sourceCode.lines[1], "bar;");
         });
 
         it("should throw an error when called with an AST that's missing tokens", () => {
@@ -124,11 +124,11 @@ describe("SourceCode", () => {
             });
 
             it("should has true at `hasBOM` property.", () => {
-                assert.equal(sourceCode.hasBOM, true);
+                assert.strictEqual(sourceCode.hasBOM, true);
             });
 
             it("should not has BOM in `text` property.", () => {
-                assert.equal(sourceCode.text, "console.log('hello');");
+                assert.strictEqual(sourceCode.text, "console.log('hello');");
             });
         });
 
@@ -142,11 +142,11 @@ describe("SourceCode", () => {
             });
 
             it("should has false at `hasBOM` property.", () => {
-                assert.equal(sourceCode.hasBOM, false);
+                assert.strictEqual(sourceCode.hasBOM, false);
             });
 
             it("should not has BOM in `text` property.", () => {
-                assert.equal(sourceCode.text, "console.log('hello');");
+                assert.strictEqual(sourceCode.text, "console.log('hello');");
             });
         });
 
@@ -162,7 +162,7 @@ describe("SourceCode", () => {
             it("should change the type of the first comment to \"Shebang\"", () => {
                 const firstToken = sourceCode.getAllComments()[0];
 
-                assert.equal(firstToken.type, "Shebang");
+                assert.strictEqual(firstToken.type, "Shebang");
             });
         });
 
@@ -172,7 +172,7 @@ describe("SourceCode", () => {
                 const sourceCode = new SourceCode("//comment\nconsole.log('hello');", ast);
                 const firstToken = sourceCode.getAllComments()[0];
 
-                assert.equal(firstToken.type, "Line");
+                assert.strictEqual(firstToken.type, "Line");
             });
         });
 
@@ -193,17 +193,17 @@ describe("SourceCode", () => {
             it("to be clear, check the file has UTF-8 BOM.", () => {
                 const buffer = fs.readFileSync(UTF8_FILE);
 
-                assert.equal(buffer[0], 0xEF);
-                assert.equal(buffer[1], 0xBB);
-                assert.equal(buffer[2], 0xBF);
+                assert.strictEqual(buffer[0], 0xEF);
+                assert.strictEqual(buffer[1], 0xBB);
+                assert.strictEqual(buffer[2], 0xBF);
             });
 
             it("should has true at `hasBOM` property.", () => {
-                assert.equal(sourceCode.hasBOM, true);
+                assert.strictEqual(sourceCode.hasBOM, true);
             });
 
             it("should not has BOM in `text` property.", () => {
-                assert.equal(
+                assert.strictEqual(
                     sourceCode.text,
                     "\"use strict\";\n\nconsole.log(\"This file has [0xEF, 0xBB, 0xBF] as BOM.\");\n"
                 );
@@ -237,7 +237,7 @@ describe("SourceCode", () => {
                 const sourceCode = linter.getSourceCode();
                 const jsdoc = sourceCode.getJSDocComment(node);
 
-                assert.equal(jsdoc, null);
+                assert.strictEqual(jsdoc, null);
             }
 
             const spy = sandbox.spy(assertJSDoc);
@@ -265,7 +265,7 @@ describe("SourceCode", () => {
                 const sourceCode = linter.getSourceCode();
                 const jsdoc = sourceCode.getJSDocComment(node);
 
-                assert.equal(jsdoc, null);
+                assert.strictEqual(jsdoc, null);
             }
 
             const spy = sandbox.spy(assertJSDoc);
@@ -294,7 +294,7 @@ describe("SourceCode", () => {
                     const sourceCode = linter.getSourceCode();
                     const jsdoc = sourceCode.getJSDocComment(node);
 
-                    assert.equal(jsdoc, null);
+                    assert.strictEqual(jsdoc, null);
                 }
             }
 
@@ -326,8 +326,8 @@ describe("SourceCode", () => {
                 const sourceCode = linter.getSourceCode();
                 const jsdoc = sourceCode.getJSDocComment(node);
 
-                assert.equal(jsdoc.type, "Block");
-                assert.equal(jsdoc.value, "* Documentation. ");
+                assert.strictEqual(jsdoc.type, "Block");
+                assert.strictEqual(jsdoc.value, "* Documentation. ");
             }
 
             const spy = sandbox.spy(assertJSDoc);
@@ -354,8 +354,8 @@ describe("SourceCode", () => {
                 const sourceCode = linter.getSourceCode();
                 const jsdoc = sourceCode.getJSDocComment(node);
 
-                assert.equal(jsdoc.type, "Block");
-                assert.equal(jsdoc.value, "* Desc");
+                assert.strictEqual(jsdoc.type, "Block");
+                assert.strictEqual(jsdoc.value, "* Desc");
             }
 
             const spy = sandbox.spy(assertJSDoc);
@@ -383,8 +383,8 @@ describe("SourceCode", () => {
                 const sourceCode = linter.getSourceCode();
                 const jsdoc = sourceCode.getJSDocComment(node);
 
-                assert.equal(jsdoc.type, "Block");
-                assert.equal(jsdoc.value, "* Desc");
+                assert.strictEqual(jsdoc.type, "Block");
+                assert.strictEqual(jsdoc.value, "* Desc");
             }
 
             const spy = sandbox.spy(assertJSDoc);
@@ -414,8 +414,8 @@ describe("SourceCode", () => {
                 const sourceCode = linter.getSourceCode();
                 const jsdoc = sourceCode.getJSDocComment(node);
 
-                assert.equal(jsdoc.type, "Block");
-                assert.equal(jsdoc.value, "* Desc");
+                assert.strictEqual(jsdoc.type, "Block");
+                assert.strictEqual(jsdoc.value, "* Desc");
             }
 
             const spy = sandbox.spy(assertJSDoc);
@@ -475,8 +475,8 @@ describe("SourceCode", () => {
                 const sourceCode = linter.getSourceCode();
                 const jsdoc = sourceCode.getJSDocComment(node);
 
-                assert.equal(jsdoc.type, "Block");
-                assert.equal(jsdoc.value, "* Desc");
+                assert.strictEqual(jsdoc.type, "Block");
+                assert.strictEqual(jsdoc.value, "* Desc");
             }
 
             const spy = sandbox.spy(assertJSDoc);
@@ -507,8 +507,8 @@ describe("SourceCode", () => {
                 const sourceCode = linter.getSourceCode();
                 const jsdoc = sourceCode.getJSDocComment(node);
 
-                assert.equal(jsdoc.type, "Block");
-                assert.equal(jsdoc.value, "* Desc");
+                assert.strictEqual(jsdoc.type, "Block");
+                assert.strictEqual(jsdoc.value, "* Desc");
             }
 
             const spy = sandbox.spy(assertJSDoc);
@@ -538,8 +538,8 @@ describe("SourceCode", () => {
                 const sourceCode = linter.getSourceCode();
                 const jsdoc = sourceCode.getJSDocComment(node);
 
-                assert.equal(jsdoc.type, "Block");
-                assert.equal(jsdoc.value, "* Desc");
+                assert.strictEqual(jsdoc.type, "Block");
+                assert.strictEqual(jsdoc.value, "* Desc");
             }
 
             const spy = sandbox.spy(assertJSDoc);
@@ -569,8 +569,8 @@ describe("SourceCode", () => {
                 const sourceCode = linter.getSourceCode();
                 const jsdoc = sourceCode.getJSDocComment(node);
 
-                assert.equal(jsdoc.type, "Block");
-                assert.equal(jsdoc.value, "* Desc");
+                assert.strictEqual(jsdoc.type, "Block");
+                assert.strictEqual(jsdoc.value, "* Desc");
             }
 
             const spy = sandbox.spy(assertJSDoc);
@@ -598,8 +598,8 @@ describe("SourceCode", () => {
                 const sourceCode = linter.getSourceCode();
                 const jsdoc = sourceCode.getJSDocComment(node);
 
-                assert.equal(jsdoc.type, "Block");
-                assert.equal(jsdoc.value, "* Desc");
+                assert.strictEqual(jsdoc.type, "Block");
+                assert.strictEqual(jsdoc.value, "* Desc");
             }
 
             const spy = sandbox.spy(assertJSDoc);
@@ -630,8 +630,8 @@ describe("SourceCode", () => {
                     const sourceCode = linter.getSourceCode();
                     const jsdoc = sourceCode.getJSDocComment(node);
 
-                    assert.equal(jsdoc.type, "Block");
-                    assert.equal(jsdoc.value, "* Desc");
+                    assert.strictEqual(jsdoc.type, "Block");
+                    assert.strictEqual(jsdoc.value, "* Desc");
                 }
             }
 
@@ -760,8 +760,8 @@ describe("SourceCode", () => {
                 const sourceCode = linter.getSourceCode();
                 const jsdoc = sourceCode.getJSDocComment(node);
 
-                assert.equal(jsdoc.type, "Block");
-                assert.equal(jsdoc.value, "* Merges two objects together.");
+                assert.strictEqual(jsdoc.type, "Block");
+                assert.strictEqual(jsdoc.value, "* Merges two objects together.");
             }
 
             const spy = sandbox.spy(assertJSDoc);
@@ -789,8 +789,8 @@ describe("SourceCode", () => {
                 const sourceCode = linter.getSourceCode();
                 const jsdoc = sourceCode.getJSDocComment(node);
 
-                assert.equal(jsdoc.type, "Block");
-                assert.equal(jsdoc.value, "* Merges two objects together.");
+                assert.strictEqual(jsdoc.type, "Block");
+                assert.strictEqual(jsdoc.value, "* Merges two objects together.");
             }
 
             const spy = sandbox.spy(assertJSDoc);
@@ -851,8 +851,8 @@ describe("SourceCode", () => {
                 const sourceCode = linter.getSourceCode();
                 const jsdoc = sourceCode.getJSDocComment(node);
 
-                assert.equal(jsdoc.type, "Block");
-                assert.equal(jsdoc.value, "* Merges two objects together.");
+                assert.strictEqual(jsdoc.type, "Block");
+                assert.strictEqual(jsdoc.value, "* Merges two objects together.");
             }
 
             const spy = sandbox.spy(assertJSDoc);
@@ -923,8 +923,8 @@ describe("SourceCode", () => {
                 const sourceCode = linter.getSourceCode();
                 const comments = sourceCode.getComments(node);
 
-                assert.equal(comments.leading.length, leading);
-                assert.equal(comments.trailing.length, trailing);
+                assert.strictEqual(comments.leading.length, leading);
+                assert.strictEqual(comments.trailing.length, trailing);
             }
             unusedAssertionFuncs.add(assertionFunc);
             return assertionFunc;
@@ -1600,8 +1600,8 @@ describe("SourceCode", () => {
 
             const lines = sourceCode.getLines();
 
-            assert.equal(lines[0], "a;");
-            assert.equal(lines[1], "b;");
+            assert.strictEqual(lines[0], "a;");
+            assert.strictEqual(lines[1], "b;");
         });
 
         it("should get proper lines when using \\r\\n as a line break", () => {
@@ -1611,8 +1611,8 @@ describe("SourceCode", () => {
 
             const lines = sourceCode.getLines();
 
-            assert.equal(lines[0], "a;");
-            assert.equal(lines[1], "b;");
+            assert.strictEqual(lines[0], "a;");
+            assert.strictEqual(lines[1], "b;");
         });
 
         it("should get proper lines when using \\r as a line break", () => {
@@ -1622,8 +1622,8 @@ describe("SourceCode", () => {
 
             const lines = sourceCode.getLines();
 
-            assert.equal(lines[0], "a;");
-            assert.equal(lines[1], "b;");
+            assert.strictEqual(lines[0], "a;");
+            assert.strictEqual(lines[1], "b;");
         });
 
         it("should get proper lines when using \\u2028 as a line break", () => {
@@ -1633,8 +1633,8 @@ describe("SourceCode", () => {
 
             const lines = sourceCode.getLines();
 
-            assert.equal(lines[0], "a;");
-            assert.equal(lines[1], "b;");
+            assert.strictEqual(lines[0], "a;");
+            assert.strictEqual(lines[1], "b;");
         });
 
         it("should get proper lines when using \\u2029 as a line break", () => {
@@ -1644,8 +1644,8 @@ describe("SourceCode", () => {
 
             const lines = sourceCode.getLines();
 
-            assert.equal(lines[0], "a;");
-            assert.equal(lines[1], "b;");
+            assert.strictEqual(lines[0], "a;");
+            assert.strictEqual(lines[1], "b;");
         });
     });
 
@@ -1664,8 +1664,8 @@ describe("SourceCode", () => {
                 const shebangToken = sourceCode.getAllComments()[0];
                 const shebangText = sourceCode.getText(shebangToken);
 
-                assert.equal(shebangToken.type, "Shebang");
-                assert.equal(shebangText, "#!/usr/bin/env node");
+                assert.strictEqual(shebangToken.type, "Shebang");
+                assert.strictEqual(shebangText, "#!/usr/bin/env node");
             });
         });
 
@@ -1677,19 +1677,19 @@ describe("SourceCode", () => {
         it("should retrieve all text when used without parameters", () => {
             const text = sourceCode.getText();
 
-            assert.equal(text, TEST_CODE);
+            assert.strictEqual(text, TEST_CODE);
         });
 
         it("should retrieve all text for root node", () => {
             const text = sourceCode.getText(ast);
 
-            assert.equal(text, TEST_CODE);
+            assert.strictEqual(text, TEST_CODE);
         });
 
         it("should clamp to valid range when retrieving characters before start of source", () => {
             const text = sourceCode.getText(ast, 2, 0);
 
-            assert.equal(text, TEST_CODE);
+            assert.strictEqual(text, TEST_CODE);
         });
 
         it("should retrieve all text for binary expression", () => {
@@ -1697,7 +1697,7 @@ describe("SourceCode", () => {
             const node = ast.body[0].declarations[0].init;
             const text = sourceCode.getText(node);
 
-            assert.equal(text, "6 * 7");
+            assert.strictEqual(text, "6 * 7");
         });
 
         it("should retrieve all text plus two characters before for binary expression", () => {
@@ -1705,21 +1705,21 @@ describe("SourceCode", () => {
             const node = ast.body[0].declarations[0].init;
             const text = sourceCode.getText(node, 2);
 
-            assert.equal(text, "= 6 * 7");
+            assert.strictEqual(text, "= 6 * 7");
         });
 
         it("should retrieve all text plus one character after for binary expression", () => {
             const node = ast.body[0].declarations[0].init;
             const text = sourceCode.getText(node, 0, 1);
 
-            assert.equal(text, "6 * 7;");
+            assert.strictEqual(text, "6 * 7;");
         });
 
         it("should retrieve all text plus two characters before and one character after for binary expression", () => {
             const node = ast.body[0].declarations[0].init;
             const text = sourceCode.getText(node, 2, 1);
 
-            assert.equal(text, "= 6 * 7;");
+            assert.strictEqual(text, "= 6 * 7;");
         });
 
     });
@@ -1738,34 +1738,34 @@ describe("SourceCode", () => {
         it("should retrieve a node starting at the given index", () => {
             const node = sourceCode.getNodeByRangeIndex(4);
 
-            assert.equal(node.type, "Identifier");
+            assert.strictEqual(node.type, "Identifier");
         });
 
         it("should retrieve a node containing the given index", () => {
             const node = sourceCode.getNodeByRangeIndex(6);
 
-            assert.equal(node.type, "Identifier");
+            assert.strictEqual(node.type, "Identifier");
         });
 
         it("should retrieve a node that is exactly the given index", () => {
             const node = sourceCode.getNodeByRangeIndex(13);
 
-            assert.equal(node.type, "Literal");
-            assert.equal(node.value, 6);
+            assert.strictEqual(node.type, "Literal");
+            assert.strictEqual(node.value, 6);
         });
 
         it("should retrieve a node ending with the given index", () => {
             const node = sourceCode.getNodeByRangeIndex(9);
 
-            assert.equal(node.type, "Identifier");
+            assert.strictEqual(node.type, "Identifier");
         });
 
         it("should retrieve the deepest node containing the given index", () => {
             let node = sourceCode.getNodeByRangeIndex(14);
 
-            assert.equal(node.type, "BinaryExpression");
+            assert.strictEqual(node.type, "BinaryExpression");
             node = sourceCode.getNodeByRangeIndex(3);
-            assert.equal(node.type, "VariableDeclaration");
+            assert.strictEqual(node.type, "VariableDeclaration");
         });
 
         it("should return null if the index is outside the range of any node", () => {
@@ -1780,17 +1780,17 @@ describe("SourceCode", () => {
             const node = sourceCode.getNodeByRangeIndex(14);
 
             assert.property(node, "parent");
-            assert.equal(node.parent.type, "VariableDeclarator");
+            assert.strictEqual(node.parent.type, "VariableDeclarator");
         });
 
         it("should not modify the node when attaching the parent", () => {
             let node = sourceCode.getNodeByRangeIndex(10);
 
-            assert.equal(node.type, "VariableDeclarator");
+            assert.strictEqual(node.type, "VariableDeclarator");
             node = sourceCode.getNodeByRangeIndex(4);
-            assert.equal(node.type, "Identifier");
+            assert.strictEqual(node.type, "Identifier");
             assert.property(node, "parent");
-            assert.equal(node.parent.type, "VariableDeclarator");
+            assert.strictEqual(node.parent.type, "VariableDeclarator");
             assert.notProperty(node.parent, "parent");
         });
 
@@ -1816,7 +1816,7 @@ describe("SourceCode", () => {
                 const ast = espree.parse(code, DEFAULT_CONFIG),
                     sourceCode = new SourceCode(code, ast);
 
-                assert.equal(
+                assert.strictEqual(
                     sourceCode.isSpaceBetweenTokens(
                         sourceCode.ast.tokens[0], sourceCode.ast.tokens[1]
                     ),
@@ -1840,14 +1840,14 @@ describe("SourceCode", () => {
             const sourceCode = new SourceCode(TEST_CODE, ast),
                 messages = linter.verify(sourceCode);
 
-            assert.equal(messages.length, 0);
+            assert.strictEqual(messages.length, 0);
         });
 
         it("should work when passed a SourceCode object containing ES6 syntax and config", () => {
             const sourceCode = new SourceCode("let foo = bar;", AST),
                 messages = linter.verify(sourceCode, CONFIG);
 
-            assert.equal(messages.length, 0);
+            assert.strictEqual(messages.length, 0);
         });
 
         it("should report an error when using let and blockBindings is false", () => {
@@ -1857,8 +1857,8 @@ describe("SourceCode", () => {
                     rules: { "no-unused-vars": 2 }
                 });
 
-            assert.equal(messages.length, 1);
-            assert.equal(messages[0].message, "'foo' is assigned a value but never used.");
+            assert.strictEqual(messages.length, 1);
+            assert.strictEqual(messages[0].message, "'foo' is assigned a value but never used.");
         });
     });
 

--- a/tests/lib/util/source-code.js
+++ b/tests/lib/util/source-code.js
@@ -111,7 +111,7 @@ describe("SourceCode", () => {
             const actual = sourceCode.tokensAndComments;
             const expected = [comments[0], tokens[0], tokens[1], comments[1], tokens[2]];
 
-            assert.deepEqual(actual, expected);
+            assert.deepStrictEqual(actual, expected);
         });
 
         describe("if a text has BOM,", () => {
@@ -1879,10 +1879,10 @@ describe("SourceCode", () => {
         });
 
         it("should return the location of a range index", () => {
-            assert.deepEqual(sourceCode.getLocFromIndex(5), { line: 2, column: 1 });
-            assert.deepEqual(sourceCode.getLocFromIndex(3), { line: 1, column: 3 });
-            assert.deepEqual(sourceCode.getLocFromIndex(4), { line: 2, column: 0 });
-            assert.deepEqual(sourceCode.getLocFromIndex(21), { line: 6, column: 0 });
+            assert.deepStrictEqual(sourceCode.getLocFromIndex(5), { line: 2, column: 1 });
+            assert.deepStrictEqual(sourceCode.getLocFromIndex(3), { line: 1, column: 3 });
+            assert.deepStrictEqual(sourceCode.getLocFromIndex(4), { line: 2, column: 0 });
+            assert.deepStrictEqual(sourceCode.getLocFromIndex(21), { line: 6, column: 0 });
         });
 
         it("should throw if given a bad input", () => {
@@ -1893,7 +1893,7 @@ describe("SourceCode", () => {
         });
 
         it("should not throw if given sourceCode.text.length", () => {
-            assert.deepEqual(sourceCode.getLocFromIndex(CODE.length), { line: 8, column: 0 });
+            assert.deepStrictEqual(sourceCode.getLocFromIndex(CODE.length), { line: 8, column: 0 });
         });
 
         it("should throw if given an out-of-range input", () => {

--- a/tests/lib/util/traverser.js
+++ b/tests/lib/util/traverser.js
@@ -37,7 +37,7 @@ describe("Traverser", () => {
             leave: node => exitedNodes.push(node)
         });
 
-        assert.deepEqual(enteredNodes, [fakeAst, fakeAst.body[0], fakeAst.body[1], fakeAst.body[1].foo]);
-        assert.deepEqual(exitedNodes, [fakeAst.body[0], fakeAst.body[1].foo, fakeAst.body[1], fakeAst]);
+        assert.deepStrictEqual(enteredNodes, [fakeAst, fakeAst.body[0], fakeAst.body[1], fakeAst.body[1].foo]);
+        assert.deepStrictEqual(exitedNodes, [fakeAst.body[0], fakeAst.body[1].foo, fakeAst.body[1], fakeAst]);
     });
 });

--- a/tests/performance/jshint.js
+++ b/tests/performance/jshint.js
@@ -7761,7 +7761,7 @@ Lexer.prototype = {
 					line: this.line,
 					character: this.char
 				}, checks, function () {
-					return state.directive["use strict"] && token.base === 8; 
+					return state.directive["use strict"] && token.base === 8;
 				});
 
 				this.trigger("Number", {
@@ -9585,7 +9585,7 @@ assert.fail = fail;
 // 4. Pure assertion tests whether a value is truthy, as determined
 // by !!guard.
 // assert.ok(guard, message_opt);
-// This statement is equivalent to assert.equal(true, guard,
+// This statement is equivalent to assert.strictEqual(true, guard,
 // message_opt);. To test strictly for the value true, use
 // assert.strictEqual(true, guard, message_opt);.
 
@@ -9596,10 +9596,10 @@ assert.ok = ok;
 
 // 5. The equality assertion tests shallow, coercive equality with
 // ==.
-// assert.equal(actual, expected, message_opt);
+// assert.strictEqual(actual, expected, message_opt);
 
-assert.equal = function equal(actual, expected, message) {
-  if (actual != expected) fail(actual, expected, message, '==', assert.equal);
+assert.strictEqual = function equal(actual, expected, message) {
+  if (actual != expected) fail(actual, expected, message, '==', assert.strictEqual);
 };
 
 // 6. The non-equality assertion tests for whether two objects are not equal
@@ -11209,7 +11209,7 @@ SlowBuffer.prototype.writeDoubleBE = Buffer.prototype.writeDoubleBE;
 
 	function b64ToByteArray(b64) {
 		var i, j, l, tmp, placeHolders, arr;
-	
+
 		if (b64.length % 4 > 0) {
 			throw 'Invalid string. Length must be a multiple of 4';
 		}

--- a/tests/performance/jshint.js
+++ b/tests/performance/jshint.js
@@ -7761,7 +7761,7 @@ Lexer.prototype = {
 					line: this.line,
 					character: this.char
 				}, checks, function () {
-					return state.directive["use strict"] && token.base === 8;
+					return state.directive["use strict"] && token.base === 8; 
 				});
 
 				this.trigger("Number", {
@@ -9585,7 +9585,7 @@ assert.fail = fail;
 // 4. Pure assertion tests whether a value is truthy, as determined
 // by !!guard.
 // assert.ok(guard, message_opt);
-// This statement is equivalent to assert.strictEqual(true, guard,
+// This statement is equivalent to assert.equal(true, guard,
 // message_opt);. To test strictly for the value true, use
 // assert.strictEqual(true, guard, message_opt);.
 
@@ -9596,10 +9596,10 @@ assert.ok = ok;
 
 // 5. The equality assertion tests shallow, coercive equality with
 // ==.
-// assert.strictEqual(actual, expected, message_opt);
+// assert.equal(actual, expected, message_opt);
 
-assert.strictEqual = function equal(actual, expected, message) {
-  if (actual != expected) fail(actual, expected, message, '==', assert.strictEqual);
+assert.equal = function equal(actual, expected, message) {
+  if (actual != expected) fail(actual, expected, message, '==', assert.equal);
 };
 
 // 6. The non-equality assertion tests for whether two objects are not equal
@@ -11209,7 +11209,7 @@ SlowBuffer.prototype.writeDoubleBE = Buffer.prototype.writeDoubleBE;
 
 	function b64ToByteArray(b64) {
 		var i, j, l, tmp, placeHolders, arr;
-
+	
 		if (b64.length % 4 > 0) {
 			throw 'Invalid string. Length must be a multiple of 4';
 		}

--- a/tests/templates/pr-create.md.ejs.js
+++ b/tests/templates/pr-create.md.ejs.js
@@ -37,7 +37,7 @@ describe("pr-create.md.ejs", () => {
             meta: {}
         });
 
-        assert.equal(result.trim(), "LGTM");
+        assert.strictEqual(result.trim(), "LGTM");
     });
 
     it("should mention commit message format when there's one commit and an invalid commit message is found", () => {
@@ -106,7 +106,7 @@ describe("pr-create.md.ejs", () => {
             }
         });
 
-        assert.equal(result.trim(), "LGTM");
+        assert.strictEqual(result.trim(), "LGTM");
     });
 
     it("should not mention missing issue when there's one documentation commit", () => {
@@ -129,7 +129,7 @@ describe("pr-create.md.ejs", () => {
             }
         });
 
-        assert.equal(result.trim(), "LGTM");
+        assert.strictEqual(result.trim(), "LGTM");
     });
 
     ["Breaking", "Build", "Chore", "Docs", "Fix", "New", "Update", "Upgrade"].forEach(type => {
@@ -153,7 +153,7 @@ describe("pr-create.md.ejs", () => {
                 }
             });
 
-            assert.equal(result.trim(), "LGTM");
+            assert.strictEqual(result.trim(), "LGTM");
         });
     });
 

--- a/tests/tools/eslint-fuzzer.js
+++ b/tests/tools/eslint-fuzzer.js
@@ -55,7 +55,7 @@ describe("eslint-fuzzer", function() {
                 assert.strictEqual(results.length, 1);
                 assert.strictEqual(results[0].type, "crash");
                 assert.strictEqual(results[0].text, "foo");
-                assert.deepEqual(results[0].config.rules, { "test-fuzzer-rule": 2 });
+                assert.deepStrictEqual(results[0].config.rules, { "test-fuzzer-rule": 2 });
                 assert.strictEqual(results[0].error, CRASH_BUG.stack);
             });
         });
@@ -64,7 +64,7 @@ describe("eslint-fuzzer", function() {
             it("should return an empty array", () => {
                 fakeRule = () => ({});
 
-                assert.deepEqual(fuzz({ count: 1, codeGenerator: () => "foo", checkAutofixes: false, linter }), []);
+                assert.deepStrictEqual(fuzz({ count: 1, codeGenerator: () => "foo", checkAutofixes: false, linter }), []);
             });
         });
     });
@@ -92,7 +92,7 @@ describe("eslint-fuzzer", function() {
                 assert.strictEqual(results.length, 1);
                 assert.strictEqual(results[0].type, "crash");
                 assert.strictEqual(results[0].text, "foo");
-                assert.deepEqual(results[0].config.rules, { "test-fuzzer-rule": 2 });
+                assert.deepStrictEqual(results[0].config.rules, { "test-fuzzer-rule": 2 });
                 assert.strictEqual(results[0].error, CRASH_BUG.stack);
             });
         });
@@ -125,7 +125,7 @@ describe("eslint-fuzzer", function() {
                     linter
                 });
 
-                assert.deepEqual(results, []);
+                assert.deepStrictEqual(results, []);
             });
         });
 
@@ -157,8 +157,8 @@ describe("eslint-fuzzer", function() {
                 assert.strictEqual(results.length, 1);
                 assert.strictEqual(results[0].type, "autofix");
                 assert.strictEqual(results[0].text, `foo ${disableFixableRulesComment}`);
-                assert.deepEqual(results[0].config.rules, { "test-fuzzer-rule": 2 });
-                assert.deepEqual(results[0].error, {
+                assert.deepStrictEqual(results[0].config.rules, { "test-fuzzer-rule": 2 });
+                assert.deepStrictEqual(results[0].error, {
                     ruleId: null,
                     fatal: true,
                     severity: 2,
@@ -204,8 +204,8 @@ describe("eslint-fuzzer", function() {
                 assert.strictEqual(results.length, 1);
                 assert.strictEqual(results[0].type, "autofix");
                 assert.strictEqual(results[0].text, intermediateCode);
-                assert.deepEqual(results[0].config.rules, { "test-fuzzer-rule": 2 });
-                assert.deepEqual(results[0].error, {
+                assert.deepStrictEqual(results[0].config.rules, { "test-fuzzer-rule": 2 });
+                assert.deepStrictEqual(results[0].error, {
                     ruleId: null,
                     fatal: true,
                     severity: 2,
@@ -249,7 +249,7 @@ describe("eslint-fuzzer", function() {
 
                 // TODO: (not-an-aardvark) It might be more useful to output the intermediate code here.
                 assert.strictEqual(results[0].text, `foo ${disableFixableRulesComment}`);
-                assert.deepEqual(results[0].config.rules, { "test-fuzzer-rule": 2 });
+                assert.deepStrictEqual(results[0].config.rules, { "test-fuzzer-rule": 2 });
                 assert.strictEqual(results[0].error, CRASH_BUG.stack);
             });
         });

--- a/tools/internal-testers/event-generator-tester.js
+++ b/tools/internal-testers/event-generator-tester.js
@@ -46,16 +46,16 @@ module.exports = {
     testEventGeneratorInterface(instance) {
         this.describe("should implement EventGenerator interface", () => {
             this.it("should have `emitter` property.", () => {
-                assert.equal(typeof instance.emitter, "object");
-                assert.equal(typeof instance.emitter.emit, "function");
+                assert.strictEqual(typeof instance.emitter, "object");
+                assert.strictEqual(typeof instance.emitter.emit, "function");
             });
 
             this.it("should have `enterNode` property.", () => {
-                assert.equal(typeof instance.enterNode, "function");
+                assert.strictEqual(typeof instance.enterNode, "function");
             });
 
             this.it("should have `leaveNode` property.", () => {
-                assert.equal(typeof instance.leaveNode, "function");
+                assert.strictEqual(typeof instance.leaveNode, "function");
             });
         });
     }


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates the `no-restricted-syntax` configuration to disallow `assert.equal` and `assert.notEqual` in favor of `assert.strictEqual` and `assert.notStrictEqual`. It also fixes a few places where the tests were relying on a loose equality check (e.g. comparing a single-element array to a string).

A few loose equality assertions in `RuleTester` were kept for backwards compatibility.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
