### PR TITLE
Update: Don't ignore comments (no-trailing-spaces)

### DIFF
--- a/lib/rules/generator-star-spacing.js
+++ b/lib/rules/generator-star-spacing.js
@@ -68,7 +68,7 @@ module.exports = {
 
         /**
          * Returns resolved option definitions based on an option and defaults
-         * 
+         *
          * @param {any} option - The option object or string value
          * @param {Object} defaults - The defaults to use if options are not present
          * @returns {Object} the resolved object definition
@@ -121,7 +121,7 @@ module.exports = {
 
         /**
          * Checks the spacing between two tokens before or after the star token.
-         * 
+         *
          * @param {string} kind Either "named", "anonymous", or "method"
          * @param {string} side Either "before" or "after".
          * @param {Token} leftToken `function` keyword token if side is "before", or
@@ -161,7 +161,7 @@ module.exports = {
 
         /**
          * Enforces the spacing around the star if node is a generator function.
-         * 
+         *
          * @param {ASTNode} node A function expression or declaration node.
          * @returns {void}
          */

--- a/lib/rules/no-trailing-spaces.js
+++ b/lib/rules/no-trailing-spaces.js
@@ -49,7 +49,7 @@ module.exports = {
 
         const options = context.options[0] || {},
             skipBlankLines = options.skipBlankLines || false,
-            ignoreComments = typeof options.ignoreComments === "undefined" || options.ignoreComments;
+            ignoreComments = typeof options.ignoreComments === "boolean" && options.ignoreComments;
 
         /**
          * Report the error message

--- a/tests/lib/rules/no-trailing-spaces.js
+++ b/tests/lib/rules/no-trailing-spaces.js
@@ -72,6 +72,14 @@ ruleTester.run("no-trailing-spaces", rule, {
             options: [{ ignoreComments: true }]
         },
         {
+            code: "// Trailing comment test.",
+            options: [{ ignoreComments: false }]
+        },
+        {
+            code: "// Trailing comment test.",
+            options: []
+        },
+        {
             code: "/* \nTrailing comments test. \n*/",
             options: [{ ignoreComments: true }]
         },
@@ -482,6 +490,19 @@ ruleTester.run("no-trailing-spaces", rule, {
                     type: "Program",
                     line: 1,
                     column: 20
+                }
+            ]
+        },
+        {
+            code: "// Trailing comment default test. ",
+            output: "// Trailing comment default test.",
+            options: [],
+            errors: [
+                {
+                    message: "Trailing spaces not allowed.",
+                    type: "Program",
+                    line: 1,
+                    column: 34
                 }
             ]
         }


### PR DESCRIPTION
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))

**What rule do you want to change?**
no-trailing-spaces

**Does this change cause the rule to produce more or fewer warnings?**
More

**How will the change be implemented? (New option, new default behavior, etc.)?**
New default behavior

**Please provide some example code that this change will affect:**

```js
// Comment with trailing space 
```

**What does the rule currently do for this code?**
By default trailing spaces in comments are ignored.

**What will the rule do after it's changed?**
As specified in the docs (https://eslint.org/docs/rules/no-trailing-spaces) the comments are also checked for trailing whitespace by default.

**What changes did you make? (Give an overview)**
- Update the code to invert the check for absence of the options.ignoreComments. The variable ignoreComments will now be **false** if the option is absent, instead of **true**.
- Add test for this rule, focusssing on default behavior.
- Fix 3 instances of this error in lib/rules/generator-star-spacing.js to fix test errors.

**Is there anything you'd like reviewers to focus on?**
If my assumption is correct that the documentation described the preferred behavior.