### PR TITLE
Fix: Correct error and test messages to fit config search path

### DIFF
--- a/messages/no-config-found.txt
+++ b/messages/no-config-found.txt
@@ -2,6 +2,6 @@ ESLint couldn't find a configuration file. To set up a configuration file for th
 
     eslint --init
 
-ESLint looked for configuration files in <%= directory %> and its ancestors.
+ESLint looked for configuration files in <%= directory %> and its ancestors. If it found none, it then looked in your home directory.
 
 If you think you already have a configuration file or if you need more help, please stop by the ESLint chat room: https://gitter.im/eslint/eslint

--- a/tests/bin/eslint.js
+++ b/tests/bin/eslint.js
@@ -122,8 +122,10 @@ describe("bin/eslint.js", () => {
             return assertExitCode(child, 1);
         });
 
-        it("gives a detailed error message if no config file is found", () => {
-            const child = runESLint(["--stdin"], { cwd: "/" }); // Assumes the root directory has no .eslintrc file
+        it("gives a detailed error message if no config file is found in / or in ~/", () => {
+
+            // Assumes the root and home directories have no .eslintrc file.
+            const child = runESLint(["--stdin"], { cwd: "/" });
 
             const exitCodePromise = assertExitCode(child, 1);
             const stdoutPromise = getOutput(child).then(output => {


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Corrected error message and test description so they no longer exclude home-directory config files from set of directories searched for config files.

**Is there anything you'd like reviewers to focus on?**
The change to the test description is intended to be temporary, pending a change of the test to make it ignore config files in the user’s home directory. If reviewers have any reservations about the idea of making that change to the test and, along with it, restoring the original description, I would appreciate their comments on that.
