### PR TITLE
Fix: change err report in constant condition (fixes #9398)

### DIFF
--- a/lib/rules/no-constant-condition.js
+++ b/lib/rules/no-constant-condition.js
@@ -138,7 +138,7 @@ module.exports = {
         function checkConstantConditionLoopInSet(node) {
             if (loopsInCurrentScope.has(node)) {
                 loopsInCurrentScope.delete(node);
-                context.report({ node, message: "Unexpected constant condition." });
+                context.report({ node: node.test, message: "Unexpected constant condition." });
             }
         }
 
@@ -150,7 +150,7 @@ module.exports = {
          */
         function reportIfConstant(node) {
             if (node.test && isConstant(node.test, true)) {
-                context.report({ node, message: "Unexpected constant condition." });
+                context.report({ node: node.test, message: "Unexpected constant condition." });
             }
         }
 

--- a/tests/lib/rules/no-constant-condition.js
+++ b/tests/lib/rules/no-constant-condition.js
@@ -71,90 +71,90 @@ ruleTester.run("no-constant-condition", rule, {
         "function* foo() { for (let x = yield; ; x++) { yield; }}"
     ],
     invalid: [
-        { code: "for(;true;);", errors: [{ message: "Unexpected constant condition.", type: "ForStatement" }] },
-        { code: "do{}while(true)", errors: [{ message: "Unexpected constant condition.", type: "DoWhileStatement" }] },
-        { code: "do{}while(t = -2)", errors: [{ message: "Unexpected constant condition.", type: "DoWhileStatement" }] },
-        { code: "true ? 1 : 2;", errors: [{ message: "Unexpected constant condition.", type: "ConditionalExpression" }] },
-        { code: "q = 0 ? 1 : 2;", errors: [{ message: "Unexpected constant condition.", type: "ConditionalExpression" }] },
-        { code: "(q = 0) ? 1 : 2;", errors: [{ message: "Unexpected constant condition.", type: "ConditionalExpression" }] },
-        { code: "if(-2);", errors: [{ message: "Unexpected constant condition.", type: "IfStatement" }] },
-        { code: "if(true);", errors: [{ message: "Unexpected constant condition.", type: "IfStatement" }] },
-        { code: "if({});", errors: [{ message: "Unexpected constant condition.", type: "IfStatement" }] },
-        { code: "if(0 < 1);", errors: [{ message: "Unexpected constant condition.", type: "IfStatement" }] },
-        { code: "if(0 || 1);", errors: [{ message: "Unexpected constant condition.", type: "IfStatement" }] },
-        { code: "if(a, 1);", errors: [{ message: "Unexpected constant condition.", type: "IfStatement" }] },
+        { code: "for(;true;);", errors: [{ message: "Unexpected constant condition.", type: "Literal" }] },
+        { code: "do{}while(true)", errors: [{ message: "Unexpected constant condition.", type: "Literal" }] },
+        { code: "do{}while(t = -2)", errors: [{ message: "Unexpected constant condition.", type: "AssignmentExpression" }] },
+        { code: "true ? 1 : 2;", errors: [{ message: "Unexpected constant condition.", type: "Literal" }] },
+        { code: "q = 0 ? 1 : 2;", errors: [{ message: "Unexpected constant condition.", type: "Literal" }] },
+        { code: "(q = 0) ? 1 : 2;", errors: [{ message: "Unexpected constant condition.", type: "AssignmentExpression" }] },
+        { code: "if(-2);", errors: [{ message: "Unexpected constant condition.", type: "UnaryExpression" }] },
+        { code: "if(true);", errors: [{ message: "Unexpected constant condition.", type: "Literal" }] },
+        { code: "if({});", errors: [{ message: "Unexpected constant condition.", type: "ObjectExpression" }] },
+        { code: "if(0 < 1);", errors: [{ message: "Unexpected constant condition.", type: "BinaryExpression" }] },
+        { code: "if(0 || 1);", errors: [{ message: "Unexpected constant condition.", type: "LogicalExpression" }] },
+        { code: "if(a, 1);", errors: [{ message: "Unexpected constant condition.", type: "SequenceExpression" }] },
 
-        { code: "while([]);", errors: [{ message: "Unexpected constant condition.", type: "WhileStatement" }] },
-        { code: "while(~!0);", errors: [{ message: "Unexpected constant condition.", type: "WhileStatement" }] },
-        { code: "while(x = 1);", errors: [{ message: "Unexpected constant condition.", type: "WhileStatement" }] },
-        { code: "while(function(){});", errors: [{ message: "Unexpected constant condition.", type: "WhileStatement" }] },
-        { code: "while(true);", errors: [{ message: "Unexpected constant condition.", type: "WhileStatement" }] },
-        { code: "while(() => {});", errors: [{ message: "Unexpected constant condition.", type: "WhileStatement" }] },
+        { code: "while([]);", errors: [{ message: "Unexpected constant condition.", type: "ArrayExpression" }] },
+        { code: "while(~!0);", errors: [{ message: "Unexpected constant condition.", type: "UnaryExpression" }] },
+        { code: "while(x = 1);", errors: [{ message: "Unexpected constant condition.", type: "AssignmentExpression" }] },
+        { code: "while(function(){});", errors: [{ message: "Unexpected constant condition.", type: "FunctionExpression" }] },
+        { code: "while(true);", errors: [{ message: "Unexpected constant condition.", type: "Literal" }] },
+        { code: "while(() => {});", errors: [{ message: "Unexpected constant condition.", type: "ArrowFunctionExpression" }] },
 
         // #5228 , typeof conditions
-        { code: "if(typeof x){}", errors: [{ message: "Unexpected constant condition.", type: "IfStatement" }] },
-        { code: "if(typeof 'abc' === 'string'){}", errors: [{ message: "Unexpected constant condition.", type: "IfStatement" }] },
-        { code: "if(a = typeof b){}", errors: [{ message: "Unexpected constant condition.", type: "IfStatement" }] },
-        { code: "if(a, typeof b){}", errors: [{ message: "Unexpected constant condition.", type: "IfStatement" }] },
-        { code: "if(typeof 'a' == 'string' || typeof 'b' == 'string'){}", errors: [{ message: "Unexpected constant condition.", type: "IfStatement" }] },
-        { code: "while(typeof x){}", errors: [{ message: "Unexpected constant condition.", type: "WhileStatement" }] },
+        { code: "if(typeof x){}", errors: [{ message: "Unexpected constant condition.", type: "UnaryExpression" }] },
+        { code: "if(typeof 'abc' === 'string'){}", errors: [{ message: "Unexpected constant condition.", type: "BinaryExpression" }] },
+        { code: "if(a = typeof b){}", errors: [{ message: "Unexpected constant condition.", type: "AssignmentExpression" }] },
+        { code: "if(a, typeof b){}", errors: [{ message: "Unexpected constant condition.", type: "SequenceExpression" }] },
+        { code: "if(typeof 'a' == 'string' || typeof 'b' == 'string'){}", errors: [{ message: "Unexpected constant condition.", type: "LogicalExpression" }] },
+        { code: "while(typeof x){}", errors: [{ message: "Unexpected constant condition.", type: "UnaryExpression" }] },
 
         // #5726, void conditions
-        { code: "if(1 || void x);", errors: [{ message: "Unexpected constant condition.", type: "IfStatement" }] },
-        { code: "if(void x);", errors: [{ message: "Unexpected constant condition.", type: "IfStatement" }] },
-        { code: "if(y = void x);", errors: [{ message: "Unexpected constant condition.", type: "IfStatement" }] },
-        { code: "if(x, void x);", errors: [{ message: "Unexpected constant condition.", type: "IfStatement" }] },
-        { code: "if(void x === void y);", errors: [{ message: "Unexpected constant condition.", type: "IfStatement" }] },
-        { code: "if(void x && a);", errors: [{ message: "Unexpected constant condition.", type: "IfStatement" }] },
-        { code: "if(a && void x);", errors: [{ message: "Unexpected constant condition.", type: "IfStatement" }] },
+        { code: "if(1 || void x);", errors: [{ message: "Unexpected constant condition.", type: "LogicalExpression" }] },
+        { code: "if(void x);", errors: [{ message: "Unexpected constant condition.", type: "UnaryExpression" }] },
+        { code: "if(y = void x);", errors: [{ message: "Unexpected constant condition.", type: "AssignmentExpression" }] },
+        { code: "if(x, void x);", errors: [{ message: "Unexpected constant condition.", type: "SequenceExpression" }] },
+        { code: "if(void x === void y);", errors: [{ message: "Unexpected constant condition.", type: "BinaryExpression" }] },
+        { code: "if(void x && a);", errors: [{ message: "Unexpected constant condition.", type: "LogicalExpression" }] },
+        { code: "if(a && void x);", errors: [{ message: "Unexpected constant condition.", type: "LogicalExpression" }] },
 
         // #5693
-        { code: "if(false && abc==='str'){}", errors: [{ message: "Unexpected constant condition.", type: "IfStatement" }] },
-        { code: "if(true || abc==='str'){}", errors: [{ message: "Unexpected constant condition.", type: "IfStatement" }] },
-        { code: "if(abc==='str' || true){}", errors: [{ message: "Unexpected constant condition.", type: "IfStatement" }] },
-        { code: "if(abc==='str' || true || def ==='str'){}", errors: [{ message: "Unexpected constant condition.", type: "IfStatement" }] },
-        { code: "if(false || true){}", errors: [{ message: "Unexpected constant condition.", type: "IfStatement" }] },
-        { code: "if(typeof abc==='str' || true){}", errors: [{ message: "Unexpected constant condition.", type: "IfStatement" }] },
+        { code: "if(false && abc==='str'){}", errors: [{ message: "Unexpected constant condition.", type: "LogicalExpression" }] },
+        { code: "if(true || abc==='str'){}", errors: [{ message: "Unexpected constant condition.", type: "LogicalExpression" }] },
+        { code: "if(abc==='str' || true){}", errors: [{ message: "Unexpected constant condition.", type: "LogicalExpression" }] },
+        { code: "if(abc==='str' || true || def ==='str'){}", errors: [{ message: "Unexpected constant condition.", type: "LogicalExpression" }] },
+        { code: "if(false || true){}", errors: [{ message: "Unexpected constant condition.", type: "LogicalExpression" }] },
+        { code: "if(typeof abc==='str' || true){}", errors: [{ message: "Unexpected constant condition.", type: "LogicalExpression" }] },
 
         {
             code: "function* foo(){while(true){} yield 'foo';}",
-            errors: [{ message: "Unexpected constant condition.", type: "WhileStatement" }]
+            errors: [{ message: "Unexpected constant condition.", type: "Literal" }]
         },
         {
             code: "function* foo(){while(true){if (true) {yield 'foo';}}}",
-            errors: [{ message: "Unexpected constant condition.", type: "IfStatement" }]
+            errors: [{ message: "Unexpected constant condition.", type: "Literal" }]
         },
         {
             code: "function* foo(){while(true){yield 'foo';} while(true) {}}",
-            errors: [{ message: "Unexpected constant condition.", type: "WhileStatement" }]
+            errors: [{ message: "Unexpected constant condition.", type: "Literal" }]
         },
         {
             code: "var a = function* foo(){while(true){} yield 'foo';}",
-            errors: [{ message: "Unexpected constant condition.", type: "WhileStatement" }]
+            errors: [{ message: "Unexpected constant condition.", type: "Literal" }]
         },
         {
             code: "while (true) { function* foo() {yield;}}",
-            errors: [{ message: "Unexpected constant condition.", type: "WhileStatement" }]
+            errors: [{ message: "Unexpected constant condition.", type: "Literal" }]
         },
         {
             code: "function* foo(){if (true) {yield 'foo';}}",
-            errors: [{ message: "Unexpected constant condition.", type: "IfStatement" }]
+            errors: [{ message: "Unexpected constant condition.", type: "Literal" }]
         },
         {
             code: "function* foo() {for (let foo = yield; true;) {}}",
-            errors: [{ message: "Unexpected constant condition.", type: "ForStatement" }]
+            errors: [{ message: "Unexpected constant condition.", type: "Literal" }]
         },
         {
             code: "function* foo() {for (foo = yield; true;) {}}",
-            errors: [{ message: "Unexpected constant condition.", type: "ForStatement" }]
+            errors: [{ message: "Unexpected constant condition.", type: "Literal" }]
         },
         {
             code: "function foo() {while (true) {function* bar() {while (true) {yield;}}}}",
-            errors: [{ message: "Unexpected constant condition.", type: "WhileStatement" }]
+            errors: [{ message: "Unexpected constant condition.", type: "Literal" }]
         },
         {
             code: "function* foo() { for (let foo = 1 + 2 + 3 + (yield); true; baz) {}}",
-            errors: [{ message: "Unexpected constant condition.", type: "ForStatement" }]
+            errors: [{ message: "Unexpected constant condition.", type: "Literal" }]
         }
     ]
 });

--- a/tests/lib/rules/no-constant-condition.js
+++ b/tests/lib/rules/no-constant-condition.js
@@ -158,3 +158,4 @@ ruleTester.run("no-constant-condition", rule, {
         }
     ]
 });
+

--- a/tests/lib/rules/no-constant-condition.js
+++ b/tests/lib/rules/no-constant-condition.js
@@ -158,4 +158,3 @@ ruleTester.run("no-constant-condition", rule, {
         }
     ]
 });
-


### PR DESCRIPTION

**What is the purpose of this pull request? (put an "X" next to item)**
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

**What did you do? Please include the actual source code causing the issue.**
To update the node in the report so that the error underlines in code editor linter is more accurate.

The node type in the report had to be updated as well.

**What did you expect to happen?**
For example, from the issue - with this fix, the linter looks like so
<img width="374" alt="screen shot 2017-10-13 at 11 14 49 pm" src="https://user-images.githubusercontent.com/3211873/31572120-8f161d64-b06c-11e7-81ec-2da71289dada.png">


