### PR TITLE
Update: add never option to quote-props rule

### DIFF
--- a/docs/rules/quote-props.md
+++ b/docs/rules/quote-props.md
@@ -44,6 +44,7 @@ String option:
 * `"as-needed"` disallows quotes around object literal property names that are not strictly required
 * `"consistent"` enforces a consistent quote style requires quotes around object literal property names
 * `"consistent-as-needed"` requires quotes around all object literal property names if any name strictly requires quotes, otherwise disallows quotes around object property names
+* `"never"` disallows quotes around any object literal property names, and also rejects instances where quotes are strictly required
 
 Object option:
 
@@ -207,6 +208,32 @@ var object1 = {
 var object2 = {
     foo: 'bar',
     baz: 42
+};
+```
+
+### never
+
+Examples of **incorrect** code for this rule with the `"never"` option:
+
+```js
+/*eslint quote-props: ["error", "never"]*/
+
+var object1 = {
+    "foo": "bar",
+    'baz': 42,
+    qux-lorem: true
+};
+
+```
+
+Examples of **correct** code for this rule with the `"never"` option:
+
+```js
+/*eslint quote-props: ["error", "never"]*/
+
+var object1 = {
+    foo: "bar",
+    baz: 42,
 };
 ```
 

--- a/lib/rules/quote-props.js
+++ b/lib/rules/quote-props.js
@@ -29,7 +29,7 @@ module.exports = {
                     type: "array",
                     items: [
                         {
-                            enum: ["always", "as-needed", "consistent", "consistent-as-needed"]
+                            enum: ["always", "as-needed", "consistent", "consistent-as-needed", "never"]
                         }
                     ],
                     minItems: 0,
@@ -39,7 +39,7 @@ module.exports = {
                     type: "array",
                     items: [
                         {
-                            enum: ["always", "as-needed", "consistent", "consistent-as-needed"]
+                            enum: ["always", "as-needed", "consistent", "consistent-as-needed", "never"]
                         },
                         {
                             type: "object",
@@ -77,6 +77,7 @@ module.exports = {
             MESSAGE_UNQUOTED = "Unquoted property '{{property}}' found.",
             MESSAGE_NUMERIC = "Unquoted number literal '{{property}}' used as key.",
             MESSAGE_RESERVED = "Unquoted reserved word '{{property}}' used as key.",
+            MESSAGE_NEVER = "Quoted property or property requiring quotes '{{property}}' found.",
             sourceCode = context.getSourceCode();
 
 
@@ -203,6 +204,24 @@ module.exports = {
         }
 
         /**
+         * Ensures that a property's key is quoted
+         * @param   {ASTNode} node Property AST node
+         * @returns {void}
+         */
+        function checkAnyQuotes(node) {
+            const key = node.key;
+
+            if (node.method || node.computed || node.shorthand || (key.type === "Literal" && typeof key.value === "string")) {
+                context.report({
+                    node,
+                    message: MESSAGE_NEVER,
+                    data: { property: key.name || key.value },
+                    fix: fixer => fixer.replaceText(key, getUnquotedKey(key))
+                });
+            }
+        }
+
+        /**
          * Ensures that an object's keys are consistently quoted, optionally checks for redundancy of quotes
          * @param   {ASTNode} node Property AST node
          * @param   {boolean} checkQuotesRedundancy Whether to check quotes' redundancy
@@ -282,6 +301,9 @@ module.exports = {
                 }
                 if (MODE === "as-needed") {
                     checkUnnecessaryQuotes(node);
+                }
+                if (MODE === "never") {
+                    checkAnyQuotes(node);
                 }
             },
             ObjectExpression(node) {

--- a/tests/lib/rules/quote-props.js
+++ b/tests/lib/rules/quote-props.js
@@ -304,5 +304,12 @@ ruleTester.run("quote-props", rule, {
         errors: [{
             message: "Unquoted property '5' found."
         }]
+    }, {
+        code: "({ foo: 0, 'bar': 0 })",
+        output: "({ foo: 0, bar: 0 })",
+        options: ["never"],
+        errors: [
+            { message: "Quoted property or property requiring quotes 'bar' found.", type: "Property" }
+        ]
     }]
 });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Added a `never` option to the `quote-props` rule to disallow all quoted object property names.

**Is there anything you'd like reviewers to focus on?**
In order to disallow all quoted property names, it is also necessary to disallow any property names that would require quotes, such as reserved words and names with dashes, etc. I only return one error for the new `never` option indicating as such. Is a more detailed error response necessary?

**What rule do you want to change?**
`quote-props`

**Does this change cause the rule to produce more or fewer warnings?**
More

**How will the change be implemented? (New option, new default behavior, etc.)?**
New option, `never`

**Please provide some example code that this change will affect:**
/*eslint quote-props: ["error", "never"]*/
```js
var object1 = {
    "foo": "bar",
    baz: 42,
    qux-lorem: true
};
```

**What does the rule currently do for this code?**
Depends on the option- if "always" will add quotes to `baz` and `qux-lorem`. If "if necessary" will only add quotes to `qux-lorem`. 

**What will the rule do after it's changed?**
Remove quotes from `foo` and throw an error because `qux-lorem` requires quotes and is thereby disallowed.
