### PR TITLE
Fix: Revise no-config-file test to prevent false failure.

### DIFF
--- a/docs/developer-guide/development-environment.md
+++ b/docs/developer-guide/development-environment.md
@@ -21,8 +21,6 @@ $ npm install
 
 You must be connected to the Internet for this step to work. You'll see a lot of utilities being downloaded.
 
-If you have an ESLint configuration file in your home directory (such as `~/.eslintrc.js`), either delete or rename it. This will help ensure that all the tests in Step 5 pass. It will also prevent ESLint from running with an incorrect configuration in case the configuration file in your development environment becomes misnamed, moved, or deleted.
-
 ## Step 3: Add the upstream source
 
 The *upstream source* is the main ESLint repository that active development happens on. While you won't have push access to upstream, you will have pull access, allowing you to pull in the latest code whenever you want.


### PR DESCRIPTION
Eliminate assumption that there is no config file in / or ~/ by checking for that
and expecting no-config-file-found error message and exit code 1 only if neither
directory contains a config file.

<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Revised test to pass, whether a config file exists in / or ~/ or both or neither, by making the
expected output depend on whether such a file exists there.

**Is there anything you'd like reviewers to focus on?**
Was I correct in assuming that it would not be appropriate to force config files to be absent from / and ~/ by temporarily renaming or moving them (even if the test process has permission to do so)?

