### PR TITLE
Chore: Remove an indirect dependency on jsonify

### DIFF
--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -24,7 +24,7 @@ const fs = require("fs"),
     fileEntryCache = require("file-entry-cache"),
     globUtil = require("./util/glob-util"),
     validator = require("./config/config-validator"),
-    stringify = require("json-stable-stringify"),
+    stringify = require("json-stable-stringify-without-jsonify"),
     hash = require("./util/hash"),
     pkg = require("../package.json");
 

--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -17,7 +17,7 @@ const fs = require("fs"),
     ModuleResolver = require("../util/module-resolver"),
     pathIsInside = require("path-is-inside"),
     stripComments = require("strip-json-comments"),
-    stringify = require("json-stable-stringify"),
+    stringify = require("json-stable-stringify-without-jsonify"),
     requireUncached = require("require-uncached");
 
 const debug = require("debug")("eslint:config-file");
@@ -29,7 +29,7 @@ const debug = require("debug")("eslint:config-file");
 /**
  * Determines sort order for object keys for json-stable-stringify
  *
- * see: https://github.com/substack/json-stable-stringify#cmp
+ * see: https://github.com/samn/json-stable-stringify#cmp
  *
  * @param   {Object} a The first comparison object ({key: akey, value: avalue})
  * @param   {Object} b The second comparison object ({key: bkey, value: bvalue})

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "inquirer": "^3.0.6",
     "is-resolvable": "^1.0.0",
     "js-yaml": "^3.9.1",
-    "json-stable-stringify": "^1.0.1",
+    "json-stable-stringify-without-jsonify": "^1.0.1",
     "levn": "^0.3.0",
     "lodash": "^4.17.4",
     "minimatch": "^3.0.2",


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] Other, please explain:

This removes an indirect dependency on jsonify which is unlicensed and not needed in supported environments.  Doesn't yet slim down the installed size as `ajv` has the same dependency. A PR in its repo is also open epoberezkin/ajv#579

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Replaced `json-stable-stringify` with `json-stable-stringify-without-jsonify`. The modules are identical except for the dependency on `jsonify`.

**Is there anything you'd like reviewers to focus on?**

An alternative would be to use nickyout/fast-stable-stringify. I chose not to do so because I'm not sure if eslint can guarantee that there's never a circular dependency.