### PR TITLE
Remove blockBindings references

### DIFF
--- a/docs/rules/no-use-before-define.md
+++ b/docs/rules/no-use-before-define.md
@@ -25,7 +25,6 @@ function g() {
 }
 var b = 1;
 
-// With blockBindings: true
 {
     alert(c);
     let c = 1;
@@ -50,9 +49,8 @@ function g() {
     return b;
 }
 
-// With blockBindings: true
 {
-    let C;
+    let c;
     c++;
 }
 ```

--- a/lib/rules/no-catch-shadow.js
+++ b/lib/rules/no-catch-shadow.js
@@ -51,7 +51,7 @@ module.exports = {
             CatchClause(node) {
                 let scope = context.getScope();
 
-                // When blockBindings is enabled, CatchClause creates its own scope
+                // When ecmaVersion >= 6, CatchClause creates its own scope
                 // so start from one upper scope to exclude the current node
                 if (scope.block === node) {
                     scope = scope.upper;

--- a/tests/lib/config/config-ops.js
+++ b/tests/lib/config/config-ops.js
@@ -218,8 +218,8 @@ describe("ConfigOps", () => {
 
         it("should combine configs when passed configs with parserOptions", () => {
             const config = [
-                { parserOptions: { ecmaFeatures: { blockBindings: true } } },
-                { parserOptions: { ecmaFeatures: { forOf: true } } }
+                { parserOptions: { ecmaFeatures: { jsx: true } } },
+                { parserOptions: { ecmaFeatures: { globalReturn: true } } }
             ];
 
             const result = ConfigOps.merge(config[0], config[1]);
@@ -227,21 +227,21 @@ describe("ConfigOps", () => {
             assert.deepStrictEqual(result, {
                 parserOptions: {
                     ecmaFeatures: {
-                        blockBindings: true,
-                        forOf: true
+                        jsx: true,
+                        globalReturn: true
                     }
                 }
             });
 
             // double-check that originals were not changed
-            assert.deepStrictEqual(config[0], { parserOptions: { ecmaFeatures: { blockBindings: true } } });
-            assert.deepStrictEqual(config[1], { parserOptions: { ecmaFeatures: { forOf: true } } });
+            assert.deepStrictEqual(config[0], { parserOptions: { ecmaFeatures: { jsx: true } } });
+            assert.deepStrictEqual(config[1], { parserOptions: { ecmaFeatures: { globalReturn: true } } });
         });
 
         it("should override configs when passed configs with the same ecmaFeatures", () => {
             const config = [
-                { parserOptions: { ecmaFeatures: { forOf: false } } },
-                { parserOptions: { ecmaFeatures: { forOf: true } } }
+                { parserOptions: { ecmaFeatures: { globalReturn: false } } },
+                { parserOptions: { ecmaFeatures: { globalReturn: true } } }
             ];
 
             const result = ConfigOps.merge(config[0], config[1]);
@@ -249,7 +249,7 @@ describe("ConfigOps", () => {
             assert.deepStrictEqual(result, {
                 parserOptions: {
                     ecmaFeatures: {
-                        forOf: true
+                        globalReturn: true
                     }
                 }
             });
@@ -342,7 +342,7 @@ describe("ConfigOps", () => {
                         smile: [1, ["hi", "bye"]]
                     },
                     parserOptions: {
-                        ecmaFeatures: { blockBindings: true }
+                        ecmaFeatures: { jsx: true }
                     },
                     env: { browser: true },
                     globals: { foo: false }
@@ -355,7 +355,7 @@ describe("ConfigOps", () => {
                         smile: [1, ["xxx", "yyy"]]
                     },
                     parserOptions: {
-                        ecmaFeatures: { forOf: true }
+                        ecmaFeatures: { globalReturn: true }
                     },
                     env: { browser: false },
                     globals: { foo: true }
@@ -367,8 +367,8 @@ describe("ConfigOps", () => {
             assert.deepStrictEqual(result, {
                 parserOptions: {
                     ecmaFeatures: {
-                        blockBindings: true,
-                        forOf: true
+                        jsx: true,
+                        globalReturn: true
                     }
                 },
                 env: {
@@ -408,7 +408,7 @@ describe("ConfigOps", () => {
                     smile: [1, ["hi", "bye"]]
                 },
                 parserOptions: {
-                    ecmaFeatures: { blockBindings: true }
+                    ecmaFeatures: { jsx: true }
                 },
                 env: { browser: true },
                 globals: { foo: false }
@@ -421,7 +421,7 @@ describe("ConfigOps", () => {
                     smile: [1, ["xxx", "yyy"]]
                 },
                 parserOptions: {
-                    ecmaFeatures: { forOf: true }
+                    ecmaFeatures: { globalReturn: true }
                 },
                 env: { browser: false },
                 globals: { foo: true }

--- a/tests/lib/util/source-code.js
+++ b/tests/lib/util/source-code.js
@@ -1850,7 +1850,7 @@ describe("SourceCode", () => {
             assert.strictEqual(messages.length, 0);
         });
 
-        it("should report an error when using let and blockBindings is false", () => {
+        it("should report an error when using let and ecmaVersion is 6", () => {
             const sourceCode = new SourceCode("let foo = bar;", AST),
                 messages = linter.verify(sourceCode, {
                     parserOptions: { ecmaVersion: 6 },


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
* Fix the typo in no-use-before-define docs (declaring variable `c` before using it `c++`), see #8368
* Remove the comment `// With blockBindings: true` in no-use-before-define docs, see #8368
* Remove references to `blockBindings` in
  * Comments
  * Test descriptions
  * Example `ecmaFeatures` used in tests


**Is there anything you'd like reviewers to focus on?**
No

