### PR TITLE
Docs: Correct violations of “Variable Declarations” in Code Conventions

### DIFF
--- a/docs/developer-guide/nodejs-api.md
+++ b/docs/developer-guide/nodejs-api.md
@@ -706,8 +706,8 @@ Example usage:
 ```js
 "use strict";
 
-const rule = require("../../../lib/rules/my-rule");
-const RuleTester = require("eslint").RuleTester;
+const rule = require("../../../lib/rules/my-rule"),
+    RuleTester = require("eslint").RuleTester;
 
 const ruleTester = new RuleTester();
 
@@ -789,9 +789,9 @@ Example of customizing `RuleTester`:
 ```js
 "use strict";
 
-const RuleTester = require("eslint").RuleTester;
-const test = require("my-test-runner");
-const myRule = require("../../../lib/rules/my-rule");
+const RuleTester = require("eslint").RuleTester,
+    test = require("my-test-runner"),
+    myRule = require("../../../lib/rules/my-rule");
 
 RuleTester.describe = function(text, method) {
     RuleTester.it.title = text;


### PR DESCRIPTION
Violated convention is “using a single var statement with one variable per line.
All lines after the first should be indented one level”. Interpreted this as
applying to “let” and “const”, too.

<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
In 2 places in 1 document, converted a sequence of adjacent variable declaration statements to a single statement containing a sequence of declarations, to make them conform to the Code Conventions.

**Is there anything you'd like reviewers to focus on?**
This is a pilot PR, intended to discover whether corrections of this kind are desired. If so, I intend to submit more of them on other files and an update to the convention to extend it to “const” and “let”.

