### PR TITLE
Docs: suggest deleting branches after merging PRs

### DIFF
--- a/docs/maintainer-guide/pullrequests.md
+++ b/docs/maintainer-guide/pullrequests.md
@@ -69,6 +69,8 @@ Otherwise, team members should observe a waiting period before merging a pull re
 
 The waiting period ensures that other team members have a chance to review the pull request before it is merged.
 
+If the pull request was created from a branch on the `eslint/eslint` repository (as opposed to a fork), delete the branch after merging the pull request. (GitHub will display a "Delete branch" button after the pull request is merged.)
+
 **Note:** You should not merge your own pull request unless you're received feedback from at least one other team member.
 
 ## When to Close a Pull Request


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates the maintainer guide to recommend deleting the git branch after merging a PR. (It seems like we usually already do this, but I think we should document it to make the recommendation more official.)

**Is there anything you'd like reviewers to focus on?**

Nothing in particular