### PR TITLE
Fix: multiline-comment-style reports block comments followed by code

### DIFF
--- a/lib/rules/multiline-comment-style.js
+++ b/lib/rules/multiline-comment-style.js
@@ -188,6 +188,11 @@ module.exports = {
                 if (!isJSDoc(commentGroup) && commentGroup[0].type === "Block") {
                     const commentLines = getCommentLines(commentGroup);
                     const block = commentGroup[0];
+                    const tokenAfter = sourceCode.getTokenAfter(block, { includeComments: true });
+
+                    if (tokenAfter && block.loc.end.line === tokenAfter.loc.start.line) {
+                        return;
+                    }
 
                     context.report({
                         loc: {

--- a/tests/lib/rules/multiline-comment-style.js
+++ b/tests/lib/rules/multiline-comment-style.js
@@ -146,6 +146,13 @@ ruleTester.run("multiline-comment-style", rule, {
         },
         {
             code: `
+                /* this is
+                   a comment */ foo;
+            `,
+            options: ["separate-lines"]
+        },
+        {
+            code: `
                 /* eslint semi: "error" */
             `,
             options: ["separate-lines"]
@@ -322,6 +329,21 @@ ruleTester.run("multiline-comment-style", rule, {
                  * the last line of this comment
                  * is misaligned
                  */
+            `,
+            errors: [{ message: ALIGNMENT_ERROR, line: 5 }]
+        },
+        {
+            code: `
+                /*
+                 * the last line of this comment
+                 * is misaligned
+                   */ foo
+            `,
+            output: `
+                /*
+                 * the last line of this comment
+                 * is misaligned
+                 */ foo
             `,
             errors: [{ message: ALIGNMENT_ERROR, line: 5 }]
         },


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment**

* **ESLint Version:** 4.9.0
* **Node Version:** 8.7.0
* **npm Version:** 5.4.2

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

```yml
rules:
  multiline-comment-style: [error, separate-lines]
```

**What did you do? Please include the actual source code causing the issue.**

```js
/* foo
  bar */ baz;
```

**What did you expect to happen?**

I expected no error to be reported, because that comment can't safely be converted into line comments.

**What actually happened? Please include the actual, raw output from ESLint.**

ESLint autofixed the code to:

```js
// foo
// bar baz
```

In other words, the `baz` statement was incorrectly converted into a comment.

[Demo](https://eslint.org/demo/#eyJ0ZXh0IjoiLyogZXNsaW50IG11bHRpbGluZS1jb21tZW50LXN0eWxlOiBbZXJyb3IsIHNlcGFyYXRlLWxpbmVzXSAqL1xuXG4vKiBmb29cbiAgYmFyICovIGJhejsiLCJvcHRpb25zIjp7InBhcnNlck9wdGlvbnMiOnsiZWNtYVZlcnNpb24iOjYsInNvdXJjZVR5cGUiOiJtb2R1bGUiLCJlY21hRmVhdHVyZXMiOnsianN4Ijp0cnVlfX0sInJ1bGVzIjp7fSwiZW52Ijp7fX19)

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates the `multiline-comment-style` rule to ignore block comments which are followed by code on the same line when using the `separate-lines` option.

This bug was detected using the fuzzer with `npm run fuzz`, which produced 7 errors caused by this issue.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular