### PR TITLE
Fix: multiline-comment-style autofixer added trailing space

### DIFF
--- a/lib/rules/multiline-comment-style.js
+++ b/lib/rules/multiline-comment-style.js
@@ -174,8 +174,12 @@ module.exports = {
                                     : MISSING_STAR_ERROR,
                                 fix(fixer) {
                                     const lineStartIndex = sourceCode.getIndexFromLoc({ line: lineNumber, column: 0 });
-                                    const commentStartIndex = lineStartIndex + lineText.match(/^\s*\*? ?/)[0].length;
-                                    const replacementText = lineNumber === block.loc.end.line ? expectedLinePrefix : `${expectedLinePrefix} `;
+                                    const linePrefixLength = lineText.match(/^\s*\*? ?/)[0].length;
+                                    const commentStartIndex = lineStartIndex + linePrefixLength;
+
+                                    const replacementText = lineNumber === block.loc.end.line || lineText.length === linePrefixLength
+                                        ? expectedLinePrefix
+                                        : `${expectedLinePrefix} `;
 
                                     return fixer.replaceTextRange([lineStartIndex, commentStartIndex], replacementText);
                                 }

--- a/tests/lib/rules/multiline-comment-style.js
+++ b/tests/lib/rules/multiline-comment-style.js
@@ -335,6 +335,40 @@ ruleTester.run("multiline-comment-style", rule, {
         {
             code: `
                 /*
+                 * the following line
+                *
+                 * is blank
+                 */
+            `,
+            output: `
+                /*
+                 * the following line
+                 *
+                 * is blank
+                 */
+            `,
+            errors: [{ message: ALIGNMENT_ERROR, line: 4 }]
+        },
+        {
+            code: `
+                /*
+                 * the following line
+                  *
+                 * is blank
+                 */
+            `,
+            output: `
+                /*
+                 * the following line
+                 *
+                 * is blank
+                 */
+            `,
+            errors: [{ message: ALIGNMENT_ERROR, line: 4 }]
+        },
+        {
+            code: `
+                /*
                  * the last line of this comment
                  * is misaligned
                    */ foo


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
**Tell us about your environment**

* **ESLint Version:** 4.9.0
* **Node Version:** 8.7.0
* **npm Version:** 5.4.2

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

```yml
rules:
  multiline-comment-style: error
```

**What did you do? Please include the actual source code causing the issue.**

```js
/*
 * foo
*
 * bar
 */
```

**What did you expect to happen?**

I expected an error to be reported for the misaligned star, and I expected the code to be autofixed to:

```js
/*
 * foo
 *
 * bar
 */
```

**What actually happened? Please include the actual, raw output from ESLint.**

The code was autofixed to:

```js
/*
 * foo
 *•
 * bar
 */
```

(`•` represents a space character.)

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates the `multiline-comment-style` autofixer to avoid adding a space after the starred-block asterisk for blank lines.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular