### PR TITLE
Build: fix `npm run profile` script (fixes #9397)

### DIFF
--- a/tests/bench/bench.js
+++ b/tests/bench/bench.js
@@ -33,7 +33,6 @@ function benchmark(grep, times) {
 
 function run(content, times) {
     while(times--) {
-        linter.reset();
         linter.verify(content, config);
     }
 }

--- a/tests/bench/xform-rules.js
+++ b/tests/bench/xform-rules.js
@@ -3,7 +3,7 @@ module.exports = transform;
 var fs = require("fs"),
     path = require("path"),
     through = require("through");
-    
+
 var target = path.resolve(__dirname, "..", "..", "lib", "load-rules.js");
 
 
@@ -23,10 +23,14 @@ function inject() {
     var output = "module.exports = function() {\n";
     output += "    var rules = Object.create(null);\n";
 
-    fs.readdirSync(path.resolve(__dirname, "..", "..", "lib", "rules")).forEach(function(filename) {
-        var basename = path.basename(filename, ".js");
-        output += "    rules[\"" + basename + "\"] = require(\"./rules/" + basename + "\");\n";
-    });
+    fs.readdirSync(path.resolve(__dirname, "..", "..", "lib", "rules"))
+        .filter(function(filename) {
+            return filename.endsWith(".js");
+        })
+        .forEach(function(filename) {
+            var basename = path.basename(filename, ".js");
+            output += "    rules[\"" + basename + "\"] = require(\"./rules/" + basename + "\");\n";
+        });
 
     output += "\n    return rules;\n};";
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (https://github.com/eslint/eslint/issues/9397)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This fixes the `npm run profile` script in the repository.

This is actually the first time I've tried to use the script, and I'm not very familiar with the design goals (e.g. I'm not sure why it runs the benchmark in chrome rather than Node). I think having a benchmark for `Linter` is a good idea -- if we decide to keep using this, we might want to convert it to ES6 and add tests for it.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular