### PR TITLE
Fix: object-curly-newline for flow code

### DIFF
--- a/lib/rules/object-curly-newline.js
+++ b/lib/rules/object-curly-newline.js
@@ -88,38 +88,6 @@ function normalizeOptions(options) {
     return { ObjectExpression: value, ObjectPattern: value };
 }
 
-/**
- * Gets the closing brace of an object expression with support for flow-style type annotations
- *
- * @param {SourceCode} sourceCode - The SourceCode object for the current object node
- * @param {ASTNode} openBrace - The open brace for the object node
- *
- * @returns {ASTNode|null} The closing brace, or null if none is found
- *
- */
-function getMatchingClosingBrace(sourceCode, openBrace) {
-
-    // With flow, an object can have the form of `{ a : 3 } : { a : number }`. In this form the
-    // closing brace isn't simply the last brace. In order to find the closing brace we actually
-    // need to traverse through the node and count the braces, to find the matching pair.
-
-    let braceCount = 1;
-    let nextBrace = openBrace;
-
-    do {
-        nextBrace = sourceCode.getTokenAfter(nextBrace, token => token.value === "}" || token.value === "{");
-        if (nextBrace.value === "{") {
-            braceCount++;
-        } else {
-            braceCount--;
-        }
-        if (braceCount === 0) {
-            return nextBrace;
-        }
-    } while (nextBrace !== null);
-    return null;
-}
-
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -164,7 +132,14 @@ module.exports = {
         function check(node) {
             const options = normalizedOptions[node.type];
             const openBrace = sourceCode.getFirstToken(node, token => token.value === "{");
-            const closeBrace = getMatchingClosingBrace(sourceCode, openBrace);
+            let closeBrace;
+
+            if (node.typeAnnotation) {
+                closeBrace = sourceCode.getTokenBefore(node.typeAnnotation);
+            } else {
+                closeBrace = sourceCode.getLastToken(node);
+            }
+
             let first = sourceCode.getTokenAfter(openBrace, { includeComments: true });
             let last = sourceCode.getTokenBefore(closeBrace, { includeComments: true });
             const needsLinebreaks = (

--- a/lib/rules/object-curly-newline.js
+++ b/lib/rules/object-curly-newline.js
@@ -88,6 +88,38 @@ function normalizeOptions(options) {
     return { ObjectExpression: value, ObjectPattern: value };
 }
 
+/**
+ * Gets the closing brace of an object expression with support for flow-style type annotations
+ *
+ * @param {SourceCode} sourceCode - The SourceCode object for the current object node
+ * @param {ASTNode} openBrace - The open brace for the object node
+ *
+ * @returns {ASTNode|null} The closing brace, or null if none is found
+ *
+ */
+function getMatchingClosingBrace(sourceCode, openBrace) {
+
+    // With flow, an object can have the form of `{ a : 3 } : { a : number }`. In this form the
+    // closing brace isn't simply the last brace. In order to find the closing brace we actually
+    // need to traverse through the node and count the braces, to find the matching pair.
+
+    let braceCount = 1;
+    let nextBrace = openBrace;
+
+    do {
+        nextBrace = sourceCode.getTokenAfter(nextBrace, token => token.value === "}" || token.value === "{");
+        if (nextBrace.value === "{") {
+            braceCount++;
+        } else {
+            braceCount--;
+        }
+        if (braceCount === 0) {
+            return nextBrace;
+        }
+    } while (nextBrace !== null);
+    return null;
+}
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -132,7 +164,7 @@ module.exports = {
         function check(node) {
             const options = normalizedOptions[node.type];
             const openBrace = sourceCode.getFirstToken(node, token => token.value === "{");
-            const closeBrace = sourceCode.getLastToken(node, token => token.value === "}");
+            const closeBrace = getMatchingClosingBrace(sourceCode, openBrace);
             let first = sourceCode.getTokenAfter(openBrace, { includeComments: true });
             let last = sourceCode.getTokenBefore(closeBrace, { includeComments: true });
             const needsLinebreaks = (

--- a/lib/rules/object-curly-newline.js
+++ b/lib/rules/object-curly-newline.js
@@ -131,8 +131,8 @@ module.exports = {
          */
         function check(node) {
             const options = normalizedOptions[node.type];
-            const openBrace = sourceCode.getFirstToken(node);
-            const closeBrace = sourceCode.getLastToken(node);
+            const openBrace = sourceCode.getFirstToken(node, token => token.value === "{");
+            const closeBrace = sourceCode.getLastToken(node, token => token.value === "}");
             let first = sourceCode.getTokenAfter(openBrace, { includeComments: true });
             let last = sourceCode.getTokenBefore(closeBrace, { includeComments: true });
             const needsLinebreaks = (

--- a/tests/fixtures/parsers/object-curly-newline/flow-stub-parser-multiline-type-literal.js
+++ b/tests/fixtures/parsers/object-curly-newline/flow-stub-parser-multiline-type-literal.js
@@ -1,0 +1,821 @@
+
+/*
+  AST for:
+
+ function foo({
+ a,
+ b
+} : { a : string, b : string }) {}
+
+*/
+exports.parse = () => ({
+    "type": "Program",
+    "start": 0,
+    "end": 57,
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 5,
+            "column": 0
+        }
+    },
+    "range": [
+        0,
+        57
+    ],
+    "comments": [],
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "function",
+            "start": 0,
+            "end": 8,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 8
+                }
+            },
+            "range": [
+                0,
+                8
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "foo",
+            "start": 9,
+            "end": 12,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 9
+                },
+                "end": {
+                    "line": 1,
+                    "column": 12
+                }
+            },
+            "range": [
+                9,
+                12
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "start": 12,
+            "end": 13,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 12
+                },
+                "end": {
+                    "line": 1,
+                    "column": 13
+                }
+            },
+            "range": [
+                12,
+                13
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 13,
+            "end": 14,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 13
+                },
+                "end": {
+                    "line": 1,
+                    "column": 14
+                }
+            },
+            "range": [
+                13,
+                14
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "a",
+            "start": 16,
+            "end": 17,
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 1
+                },
+                "end": {
+                    "line": 2,
+                    "column": 2
+                }
+            },
+            "range": [
+                16,
+                17
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ",",
+            "start": 17,
+            "end": 18,
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 2
+                },
+                "end": {
+                    "line": 2,
+                    "column": 3
+                }
+            },
+            "range": [
+                17,
+                18
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "b",
+            "start": 20,
+            "end": 21,
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 1
+                },
+                "end": {
+                    "line": 3,
+                    "column": 2
+                }
+            },
+            "range": [
+                20,
+                21
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 22,
+            "end": 23,
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 0
+                },
+                "end": {
+                    "line": 4,
+                    "column": 1
+                }
+            },
+            "range": [
+                22,
+                23
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "start": 24,
+            "end": 25,
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 2
+                },
+                "end": {
+                    "line": 4,
+                    "column": 3
+                }
+            },
+            "range": [
+                24,
+                25
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 26,
+            "end": 27,
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 4
+                },
+                "end": {
+                    "line": 4,
+                    "column": 5
+                }
+            },
+            "range": [
+                26,
+                27
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "a",
+            "start": 28,
+            "end": 29,
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 6
+                },
+                "end": {
+                    "line": 4,
+                    "column": 7
+                }
+            },
+            "range": [
+                28,
+                29
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "start": 30,
+            "end": 31,
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 8
+                },
+                "end": {
+                    "line": 4,
+                    "column": 9
+                }
+            },
+            "range": [
+                30,
+                31
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "string",
+            "start": 32,
+            "end": 38,
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 10
+                },
+                "end": {
+                    "line": 4,
+                    "column": 16
+                }
+            },
+            "range": [
+                32,
+                38
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ",",
+            "start": 38,
+            "end": 39,
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 16
+                },
+                "end": {
+                    "line": 4,
+                    "column": 17
+                }
+            },
+            "range": [
+                38,
+                39
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "b",
+            "start": 40,
+            "end": 41,
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 18
+                },
+                "end": {
+                    "line": 4,
+                    "column": 19
+                }
+            },
+            "range": [
+                40,
+                41
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "start": 42,
+            "end": 43,
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 20
+                },
+                "end": {
+                    "line": 4,
+                    "column": 21
+                }
+            },
+            "range": [
+                42,
+                43
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "string",
+            "start": 44,
+            "end": 50,
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 22
+                },
+                "end": {
+                    "line": 4,
+                    "column": 28
+                }
+            },
+            "range": [
+                44,
+                50
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 51,
+            "end": 52,
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 29
+                },
+                "end": {
+                    "line": 4,
+                    "column": 30
+                }
+            },
+            "range": [
+                51,
+                52
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "start": 52,
+            "end": 53,
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 30
+                },
+                "end": {
+                    "line": 4,
+                    "column": 31
+                }
+            },
+            "range": [
+                52,
+                53
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 54,
+            "end": 55,
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 32
+                },
+                "end": {
+                    "line": 4,
+                    "column": 33
+                }
+            },
+            "range": [
+                54,
+                55
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 55,
+            "end": 56,
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 33
+                },
+                "end": {
+                    "line": 4,
+                    "column": 34
+                }
+            },
+            "range": [
+                55,
+                56
+            ]
+        }
+    ],
+    "sourceType": "module",
+    "body": [
+        {
+            "type": "FunctionDeclaration",
+            "start": 0,
+            "end": 56,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 4,
+                    "column": 34
+                }
+            },
+            "range": [
+                0,
+                56
+            ],
+            "id": {
+                "type": "Identifier",
+                "start": 9,
+                "end": 12,
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 9
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 12
+                    },
+                    "identifierName": "foo"
+                },
+                "range": [
+                    9,
+                    12
+                ],
+                "name": "foo",
+                "_babelType": "Identifier"
+            },
+            "generator": false,
+            "expression": false,
+            "async": false,
+            "params": [
+                {
+                    "type": "ObjectPattern",
+                    "start": 13,
+                    "end": 52,
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 13
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 30
+                        }
+                    },
+                    "range": [
+                        13,
+                        52
+                    ],
+                    "properties": [
+                        {
+                            "type": "Property",
+                            "start": 16,
+                            "end": 17,
+                            "loc": {
+                                "start": {
+                                    "line": 2,
+                                    "column": 1
+                                },
+                                "end": {
+                                    "line": 2,
+                                    "column": 2
+                                }
+                            },
+                            "range": [
+                                16,
+                                17
+                            ],
+                            "method": false,
+                            "computed": false,
+                            "key": {
+                                "type": "Identifier",
+                                "start": 16,
+                                "end": 17,
+                                "loc": {
+                                    "start": {
+                                        "line": 2,
+                                        "column": 1
+                                    },
+                                    "end": {
+                                        "line": 2,
+                                        "column": 2
+                                    },
+                                    "identifierName": "a"
+                                },
+                                "range": [
+                                    16,
+                                    17
+                                ],
+                                "name": "a",
+                                "_babelType": "Identifier"
+                            },
+                            "shorthand": true,
+                            "value": {
+                                "type": "Identifier",
+                                "start": 16,
+                                "end": 17,
+                                "loc": {
+                                    "start": {
+                                        "line": 2,
+                                        "column": 1
+                                    },
+                                    "end": {
+                                        "line": 2,
+                                        "column": 2
+                                    },
+                                    "identifierName": "a"
+                                },
+                                "range": [
+                                    16,
+                                    17
+                                ],
+                                "name": "a",
+                                "_babelType": "Identifier"
+                            },
+                            "kind": "init",
+                            "extra": {
+                                "shorthand": true
+                            },
+                            "_babelType": "Property"
+                        },
+                        {
+                            "type": "Property",
+                            "start": 20,
+                            "end": 21,
+                            "loc": {
+                                "start": {
+                                    "line": 3,
+                                    "column": 1
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 2
+                                }
+                            },
+                            "range": [
+                                20,
+                                21
+                            ],
+                            "method": false,
+                            "computed": false,
+                            "key": {
+                                "type": "Identifier",
+                                "start": 20,
+                                "end": 21,
+                                "loc": {
+                                    "start": {
+                                        "line": 3,
+                                        "column": 1
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "column": 2
+                                    },
+                                    "identifierName": "b"
+                                },
+                                "range": [
+                                    20,
+                                    21
+                                ],
+                                "name": "b",
+                                "_babelType": "Identifier"
+                            },
+                            "shorthand": true,
+                            "value": {
+                                "type": "Identifier",
+                                "start": 20,
+                                "end": 21,
+                                "loc": {
+                                    "start": {
+                                        "line": 3,
+                                        "column": 1
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "column": 2
+                                    },
+                                    "identifierName": "b"
+                                },
+                                "range": [
+                                    20,
+                                    21
+                                ],
+                                "name": "b",
+                                "_babelType": "Identifier"
+                            },
+                            "kind": "init",
+                            "extra": {
+                                "shorthand": true
+                            },
+                            "_babelType": "Property"
+                        }
+                    ],
+                    "typeAnnotation": {
+                        "type": "TypeAnnotation",
+                        "start": 24,
+                        "end": 52,
+                        "loc": {
+                            "start": {
+                                "line": 4,
+                                "column": 2
+                            },
+                            "end": {
+                                "line": 4,
+                                "column": 30
+                            }
+                        },
+                        "range": [
+                            24,
+                            52
+                        ],
+                        "typeAnnotation": {
+                            "type": "ObjectTypeAnnotation",
+                            "start": 26,
+                            "end": 52,
+                            "loc": {
+                                "start": {
+                                    "line": 4,
+                                    "column": 4
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 30
+                                }
+                            },
+                            "range": [
+                                26,
+                                52
+                            ],
+                            "callProperties": [],
+                            "properties": [
+                                {
+                                    "type": "ObjectTypeProperty",
+                                    "start": 28,
+                                    "end": 38,
+                                    "loc": {
+                                        "start": {
+                                            "line": 4,
+                                            "column": 6
+                                        },
+                                        "end": {
+                                            "line": 4,
+                                            "column": 16
+                                        }
+                                    },
+                                    "range": [
+                                        28,
+                                        38
+                                    ],
+                                    "static": false,
+                                    "kind": "init",
+                                    "value": {
+                                        "type": "StringTypeAnnotation",
+                                        "start": 32,
+                                        "end": 38,
+                                        "loc": {
+                                            "start": {
+                                                "line": 4,
+                                                "column": 10
+                                            },
+                                            "end": {
+                                                "line": 4,
+                                                "column": 16
+                                            }
+                                        },
+                                        "range": [
+                                            32,
+                                            38
+                                        ],
+                                        "_babelType": "StringTypeAnnotation"
+                                    },
+                                    "variance": null,
+                                    "optional": false,
+                                    "_babelType": "ObjectTypeProperty"
+                                },
+                                {
+                                    "type": "ObjectTypeProperty",
+                                    "start": 40,
+                                    "end": 50,
+                                    "loc": {
+                                        "start": {
+                                            "line": 4,
+                                            "column": 18
+                                        },
+                                        "end": {
+                                            "line": 4,
+                                            "column": 28
+                                        }
+                                    },
+                                    "range": [
+                                        40,
+                                        50
+                                    ],
+                                    "static": false,
+                                    "kind": "init",
+                                    "value": {
+                                        "type": "StringTypeAnnotation",
+                                        "start": 44,
+                                        "end": 50,
+                                        "loc": {
+                                            "start": {
+                                                "line": 4,
+                                                "column": 22
+                                            },
+                                            "end": {
+                                                "line": 4,
+                                                "column": 28
+                                            }
+                                        },
+                                        "range": [
+                                            44,
+                                            50
+                                        ],
+                                        "_babelType": "StringTypeAnnotation"
+                                    },
+                                    "variance": null,
+                                    "optional": false,
+                                    "_babelType": "ObjectTypeProperty"
+                                }
+                            ],
+                            "indexers": [],
+                            "exact": false,
+                            "_babelType": "ObjectTypeAnnotation"
+                        },
+                        "_babelType": "TypeAnnotation"
+                    },
+                    "_babelType": "ObjectPattern"
+                }
+            ],
+            "body": {
+                "type": "BlockStatement",
+                "start": 54,
+                "end": 56,
+                "loc": {
+                    "start": {
+                        "line": 4,
+                        "column": 32
+                    },
+                    "end": {
+                        "line": 4,
+                        "column": 34
+                    }
+                },
+                "range": [
+                    54,
+                    56
+                ],
+                "body": [],
+                "_babelType": "BlockStatement"
+            },
+            "_babelType": "FunctionDeclaration"
+        }
+    ]
+});
+

--- a/tests/fixtures/parsers/object-curly-newline/flow-stub-parser-multiline.js
+++ b/tests/fixtures/parsers/object-curly-newline/flow-stub-parser-multiline.js
@@ -1,0 +1,591 @@
+
+/*
+  AST for:
+
+function foo({
+ a,
+ b
+} : MyType) {}
+
+*/
+exports.parse = () => ({
+    "type": "Program",
+    "start": 0,
+    "end": 37,
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 5,
+            "column": 0
+        }
+    },
+    "range": [
+        0,
+        37
+    ],
+    "comments": [],
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "function",
+            "start": 0,
+            "end": 8,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 8
+                }
+            },
+            "range": [
+                0,
+                8
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "foo",
+            "start": 9,
+            "end": 12,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 9
+                },
+                "end": {
+                    "line": 1,
+                    "column": 12
+                }
+            },
+            "range": [
+                9,
+                12
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "start": 12,
+            "end": 13,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 12
+                },
+                "end": {
+                    "line": 1,
+                    "column": 13
+                }
+            },
+            "range": [
+                12,
+                13
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 13,
+            "end": 14,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 13
+                },
+                "end": {
+                    "line": 1,
+                    "column": 14
+                }
+            },
+            "range": [
+                13,
+                14
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "a",
+            "start": 16,
+            "end": 17,
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 1
+                },
+                "end": {
+                    "line": 2,
+                    "column": 2
+                }
+            },
+            "range": [
+                16,
+                17
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ",",
+            "start": 17,
+            "end": 18,
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 2
+                },
+                "end": {
+                    "line": 2,
+                    "column": 3
+                }
+            },
+            "range": [
+                17,
+                18
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "b",
+            "start": 20,
+            "end": 21,
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 1
+                },
+                "end": {
+                    "line": 3,
+                    "column": 2
+                }
+            },
+            "range": [
+                20,
+                21
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 22,
+            "end": 23,
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 0
+                },
+                "end": {
+                    "line": 4,
+                    "column": 1
+                }
+            },
+            "range": [
+                22,
+                23
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "start": 24,
+            "end": 25,
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 2
+                },
+                "end": {
+                    "line": 4,
+                    "column": 3
+                }
+            },
+            "range": [
+                24,
+                25
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "MyType",
+            "start": 26,
+            "end": 32,
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 4
+                },
+                "end": {
+                    "line": 4,
+                    "column": 10
+                }
+            },
+            "range": [
+                26,
+                32
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "start": 32,
+            "end": 33,
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 10
+                },
+                "end": {
+                    "line": 4,
+                    "column": 11
+                }
+            },
+            "range": [
+                32,
+                33
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 34,
+            "end": 35,
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 12
+                },
+                "end": {
+                    "line": 4,
+                    "column": 13
+                }
+            },
+            "range": [
+                34,
+                35
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 35,
+            "end": 36,
+            "loc": {
+                "start": {
+                    "line": 4,
+                    "column": 13
+                },
+                "end": {
+                    "line": 4,
+                    "column": 14
+                }
+            },
+            "range": [
+                35,
+                36
+            ]
+        }
+    ],
+    "sourceType": "module",
+    "body": [
+        {
+            "type": "FunctionDeclaration",
+            "start": 0,
+            "end": 36,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 4,
+                    "column": 14
+                }
+            },
+            "range": [
+                0,
+                36
+            ],
+            "id": {
+                "type": "Identifier",
+                "start": 9,
+                "end": 12,
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 9
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 12
+                    },
+                    "identifierName": "foo"
+                },
+                "range": [
+                    9,
+                    12
+                ],
+                "name": "foo",
+                "_babelType": "Identifier"
+            },
+            "generator": false,
+            "expression": false,
+            "async": false,
+            "params": [
+                {
+                    "type": "ObjectPattern",
+                    "start": 13,
+                    "end": 32,
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 13
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 10
+                        }
+                    },
+                    "range": [
+                        13,
+                        32
+                    ],
+                    "properties": [
+                        {
+                            "type": "Property",
+                            "start": 16,
+                            "end": 17,
+                            "loc": {
+                                "start": {
+                                    "line": 2,
+                                    "column": 1
+                                },
+                                "end": {
+                                    "line": 2,
+                                    "column": 2
+                                }
+                            },
+                            "range": [
+                                16,
+                                17
+                            ],
+                            "method": false,
+                            "computed": false,
+                            "key": {
+                                "type": "Identifier",
+                                "start": 16,
+                                "end": 17,
+                                "loc": {
+                                    "start": {
+                                        "line": 2,
+                                        "column": 1
+                                    },
+                                    "end": {
+                                        "line": 2,
+                                        "column": 2
+                                    },
+                                    "identifierName": "a"
+                                },
+                                "range": [
+                                    16,
+                                    17
+                                ],
+                                "name": "a",
+                                "_babelType": "Identifier"
+                            },
+                            "shorthand": true,
+                            "value": {
+                                "type": "Identifier",
+                                "start": 16,
+                                "end": 17,
+                                "loc": {
+                                    "start": {
+                                        "line": 2,
+                                        "column": 1
+                                    },
+                                    "end": {
+                                        "line": 2,
+                                        "column": 2
+                                    },
+                                    "identifierName": "a"
+                                },
+                                "range": [
+                                    16,
+                                    17
+                                ],
+                                "name": "a",
+                                "_babelType": "Identifier"
+                            },
+                            "kind": "init",
+                            "extra": {
+                                "shorthand": true
+                            },
+                            "_babelType": "Property"
+                        },
+                        {
+                            "type": "Property",
+                            "start": 20,
+                            "end": 21,
+                            "loc": {
+                                "start": {
+                                    "line": 3,
+                                    "column": 1
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 2
+                                }
+                            },
+                            "range": [
+                                20,
+                                21
+                            ],
+                            "method": false,
+                            "computed": false,
+                            "key": {
+                                "type": "Identifier",
+                                "start": 20,
+                                "end": 21,
+                                "loc": {
+                                    "start": {
+                                        "line": 3,
+                                        "column": 1
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "column": 2
+                                    },
+                                    "identifierName": "b"
+                                },
+                                "range": [
+                                    20,
+                                    21
+                                ],
+                                "name": "b",
+                                "_babelType": "Identifier"
+                            },
+                            "shorthand": true,
+                            "value": {
+                                "type": "Identifier",
+                                "start": 20,
+                                "end": 21,
+                                "loc": {
+                                    "start": {
+                                        "line": 3,
+                                        "column": 1
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "column": 2
+                                    },
+                                    "identifierName": "b"
+                                },
+                                "range": [
+                                    20,
+                                    21
+                                ],
+                                "name": "b",
+                                "_babelType": "Identifier"
+                            },
+                            "kind": "init",
+                            "extra": {
+                                "shorthand": true
+                            },
+                            "_babelType": "Property"
+                        }
+                    ],
+                    "typeAnnotation": {
+                        "type": "TypeAnnotation",
+                        "start": 24,
+                        "end": 32,
+                        "loc": {
+                            "start": {
+                                "line": 4,
+                                "column": 2
+                            },
+                            "end": {
+                                "line": 4,
+                                "column": 10
+                            }
+                        },
+                        "range": [
+                            24,
+                            32
+                        ],
+                        "typeAnnotation": {
+                            "type": "GenericTypeAnnotation",
+                            "start": 26,
+                            "end": 32,
+                            "loc": {
+                                "start": {
+                                    "line": 4,
+                                    "column": 4
+                                },
+                                "end": {
+                                    "line": 4,
+                                    "column": 10
+                                }
+                            },
+                            "range": [
+                                26,
+                                32
+                            ],
+                            "typeParameters": null,
+                            "id": {
+                                "type": "Identifier",
+                                "start": 26,
+                                "end": 32,
+                                "loc": {
+                                    "start": {
+                                        "line": 4,
+                                        "column": 4
+                                    },
+                                    "end": {
+                                        "line": 4,
+                                        "column": 10
+                                    },
+                                    "identifierName": "MyType"
+                                },
+                                "range": [
+                                    26,
+                                    32
+                                ],
+                                "name": "MyType",
+                                "_babelType": "Identifier"
+                            },
+                            "_babelType": "GenericTypeAnnotation"
+                        },
+                        "_babelType": "TypeAnnotation"
+                    },
+                    "_babelType": "ObjectPattern"
+                }
+            ],
+            "body": {
+                "type": "BlockStatement",
+                "start": 34,
+                "end": 36,
+                "loc": {
+                    "start": {
+                        "line": 4,
+                        "column": 12
+                    },
+                    "end": {
+                        "line": 4,
+                        "column": 14
+                    }
+                },
+                "range": [
+                    34,
+                    36
+                ],
+                "body": [],
+                "_babelType": "BlockStatement"
+            },
+            "_babelType": "FunctionDeclaration"
+        }
+    ]
+});
+

--- a/tests/fixtures/parsers/object-curly-newline/flow-stub-parser-singleline-type-literal.js
+++ b/tests/fixtures/parsers/object-curly-newline/flow-stub-parser-singleline-type-literal.js
@@ -1,0 +1,818 @@
+
+/*
+  AST for:
+
+function foo({ a, b } : { a : string, b : string }) {}
+
+*/
+exports.parse = () => ({
+    "type": "Program",
+    "start": 0,
+    "end": 55,
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 2,
+            "column": 0
+        }
+    },
+    "range": [
+        0,
+        55
+    ],
+    "comments": [],
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "function",
+            "start": 0,
+            "end": 8,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 8
+                }
+            },
+            "range": [
+                0,
+                8
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "foo",
+            "start": 9,
+            "end": 12,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 9
+                },
+                "end": {
+                    "line": 1,
+                    "column": 12
+                }
+            },
+            "range": [
+                9,
+                12
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "start": 12,
+            "end": 13,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 12
+                },
+                "end": {
+                    "line": 1,
+                    "column": 13
+                }
+            },
+            "range": [
+                12,
+                13
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 13,
+            "end": 14,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 13
+                },
+                "end": {
+                    "line": 1,
+                    "column": 14
+                }
+            },
+            "range": [
+                13,
+                14
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "a",
+            "start": 15,
+            "end": 16,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 15
+                },
+                "end": {
+                    "line": 1,
+                    "column": 16
+                }
+            },
+            "range": [
+                15,
+                16
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ",",
+            "start": 16,
+            "end": 17,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 16
+                },
+                "end": {
+                    "line": 1,
+                    "column": 17
+                }
+            },
+            "range": [
+                16,
+                17
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "b",
+            "start": 18,
+            "end": 19,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 18
+                },
+                "end": {
+                    "line": 1,
+                    "column": 19
+                }
+            },
+            "range": [
+                18,
+                19
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 20,
+            "end": 21,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 20
+                },
+                "end": {
+                    "line": 1,
+                    "column": 21
+                }
+            },
+            "range": [
+                20,
+                21
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "start": 22,
+            "end": 23,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 22
+                },
+                "end": {
+                    "line": 1,
+                    "column": 23
+                }
+            },
+            "range": [
+                22,
+                23
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 24,
+            "end": 25,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 24
+                },
+                "end": {
+                    "line": 1,
+                    "column": 25
+                }
+            },
+            "range": [
+                24,
+                25
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "a",
+            "start": 26,
+            "end": 27,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 26
+                },
+                "end": {
+                    "line": 1,
+                    "column": 27
+                }
+            },
+            "range": [
+                26,
+                27
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "start": 28,
+            "end": 29,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 28
+                },
+                "end": {
+                    "line": 1,
+                    "column": 29
+                }
+            },
+            "range": [
+                28,
+                29
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "string",
+            "start": 30,
+            "end": 36,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 30
+                },
+                "end": {
+                    "line": 1,
+                    "column": 36
+                }
+            },
+            "range": [
+                30,
+                36
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ",",
+            "start": 36,
+            "end": 37,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 36
+                },
+                "end": {
+                    "line": 1,
+                    "column": 37
+                }
+            },
+            "range": [
+                36,
+                37
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "b",
+            "start": 38,
+            "end": 39,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 38
+                },
+                "end": {
+                    "line": 1,
+                    "column": 39
+                }
+            },
+            "range": [
+                38,
+                39
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "start": 40,
+            "end": 41,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 40
+                },
+                "end": {
+                    "line": 1,
+                    "column": 41
+                }
+            },
+            "range": [
+                40,
+                41
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "string",
+            "start": 42,
+            "end": 48,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 42
+                },
+                "end": {
+                    "line": 1,
+                    "column": 48
+                }
+            },
+            "range": [
+                42,
+                48
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 49,
+            "end": 50,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 49
+                },
+                "end": {
+                    "line": 1,
+                    "column": 50
+                }
+            },
+            "range": [
+                49,
+                50
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "start": 50,
+            "end": 51,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 50
+                },
+                "end": {
+                    "line": 1,
+                    "column": 51
+                }
+            },
+            "range": [
+                50,
+                51
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 52,
+            "end": 53,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 52
+                },
+                "end": {
+                    "line": 1,
+                    "column": 53
+                }
+            },
+            "range": [
+                52,
+                53
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 53,
+            "end": 54,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 53
+                },
+                "end": {
+                    "line": 1,
+                    "column": 54
+                }
+            },
+            "range": [
+                53,
+                54
+            ]
+        }
+    ],
+    "sourceType": "module",
+    "body": [
+        {
+            "type": "FunctionDeclaration",
+            "start": 0,
+            "end": 54,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 54
+                }
+            },
+            "range": [
+                0,
+                54
+            ],
+            "id": {
+                "type": "Identifier",
+                "start": 9,
+                "end": 12,
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 9
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 12
+                    },
+                    "identifierName": "foo"
+                },
+                "range": [
+                    9,
+                    12
+                ],
+                "name": "foo",
+                "_babelType": "Identifier"
+            },
+            "generator": false,
+            "expression": false,
+            "async": false,
+            "params": [
+                {
+                    "type": "ObjectPattern",
+                    "start": 13,
+                    "end": 50,
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 13
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 50
+                        }
+                    },
+                    "range": [
+                        13,
+                        50
+                    ],
+                    "properties": [
+                        {
+                            "type": "Property",
+                            "start": 15,
+                            "end": 16,
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 15
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 16
+                                }
+                            },
+                            "range": [
+                                15,
+                                16
+                            ],
+                            "method": false,
+                            "computed": false,
+                            "key": {
+                                "type": "Identifier",
+                                "start": 15,
+                                "end": 16,
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 15
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 16
+                                    },
+                                    "identifierName": "a"
+                                },
+                                "range": [
+                                    15,
+                                    16
+                                ],
+                                "name": "a",
+                                "_babelType": "Identifier"
+                            },
+                            "shorthand": true,
+                            "value": {
+                                "type": "Identifier",
+                                "start": 15,
+                                "end": 16,
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 15
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 16
+                                    },
+                                    "identifierName": "a"
+                                },
+                                "range": [
+                                    15,
+                                    16
+                                ],
+                                "name": "a",
+                                "_babelType": "Identifier"
+                            },
+                            "kind": "init",
+                            "extra": {
+                                "shorthand": true
+                            },
+                            "_babelType": "Property"
+                        },
+                        {
+                            "type": "Property",
+                            "start": 18,
+                            "end": 19,
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 18
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 19
+                                }
+                            },
+                            "range": [
+                                18,
+                                19
+                            ],
+                            "method": false,
+                            "computed": false,
+                            "key": {
+                                "type": "Identifier",
+                                "start": 18,
+                                "end": 19,
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 18
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 19
+                                    },
+                                    "identifierName": "b"
+                                },
+                                "range": [
+                                    18,
+                                    19
+                                ],
+                                "name": "b",
+                                "_babelType": "Identifier"
+                            },
+                            "shorthand": true,
+                            "value": {
+                                "type": "Identifier",
+                                "start": 18,
+                                "end": 19,
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 18
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 19
+                                    },
+                                    "identifierName": "b"
+                                },
+                                "range": [
+                                    18,
+                                    19
+                                ],
+                                "name": "b",
+                                "_babelType": "Identifier"
+                            },
+                            "kind": "init",
+                            "extra": {
+                                "shorthand": true
+                            },
+                            "_babelType": "Property"
+                        }
+                    ],
+                    "typeAnnotation": {
+                        "type": "TypeAnnotation",
+                        "start": 22,
+                        "end": 50,
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 22
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 50
+                            }
+                        },
+                        "range": [
+                            22,
+                            50
+                        ],
+                        "typeAnnotation": {
+                            "type": "ObjectTypeAnnotation",
+                            "start": 24,
+                            "end": 50,
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 24
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 50
+                                }
+                            },
+                            "range": [
+                                24,
+                                50
+                            ],
+                            "callProperties": [],
+                            "properties": [
+                                {
+                                    "type": "ObjectTypeProperty",
+                                    "start": 26,
+                                    "end": 36,
+                                    "loc": {
+                                        "start": {
+                                            "line": 1,
+                                            "column": 26
+                                        },
+                                        "end": {
+                                            "line": 1,
+                                            "column": 36
+                                        }
+                                    },
+                                    "range": [
+                                        26,
+                                        36
+                                    ],
+                                    "static": false,
+                                    "kind": "init",
+                                    "value": {
+                                        "type": "StringTypeAnnotation",
+                                        "start": 30,
+                                        "end": 36,
+                                        "loc": {
+                                            "start": {
+                                                "line": 1,
+                                                "column": 30
+                                            },
+                                            "end": {
+                                                "line": 1,
+                                                "column": 36
+                                            }
+                                        },
+                                        "range": [
+                                            30,
+                                            36
+                                        ],
+                                        "_babelType": "StringTypeAnnotation"
+                                    },
+                                    "variance": null,
+                                    "optional": false,
+                                    "_babelType": "ObjectTypeProperty"
+                                },
+                                {
+                                    "type": "ObjectTypeProperty",
+                                    "start": 38,
+                                    "end": 48,
+                                    "loc": {
+                                        "start": {
+                                            "line": 1,
+                                            "column": 38
+                                        },
+                                        "end": {
+                                            "line": 1,
+                                            "column": 48
+                                        }
+                                    },
+                                    "range": [
+                                        38,
+                                        48
+                                    ],
+                                    "static": false,
+                                    "kind": "init",
+                                    "value": {
+                                        "type": "StringTypeAnnotation",
+                                        "start": 42,
+                                        "end": 48,
+                                        "loc": {
+                                            "start": {
+                                                "line": 1,
+                                                "column": 42
+                                            },
+                                            "end": {
+                                                "line": 1,
+                                                "column": 48
+                                            }
+                                        },
+                                        "range": [
+                                            42,
+                                            48
+                                        ],
+                                        "_babelType": "StringTypeAnnotation"
+                                    },
+                                    "variance": null,
+                                    "optional": false,
+                                    "_babelType": "ObjectTypeProperty"
+                                }
+                            ],
+                            "indexers": [],
+                            "exact": false,
+                            "_babelType": "ObjectTypeAnnotation"
+                        },
+                        "_babelType": "TypeAnnotation"
+                    },
+                    "_babelType": "ObjectPattern"
+                }
+            ],
+            "body": {
+                "type": "BlockStatement",
+                "start": 52,
+                "end": 54,
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 52
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 54
+                    }
+                },
+                "range": [
+                    52,
+                    54
+                ],
+                "body": [],
+                "_babelType": "BlockStatement"
+            },
+            "_babelType": "FunctionDeclaration"
+        }
+    ]
+});
+

--- a/tests/fixtures/parsers/object-curly-newline/flow-stub-parser-singleline.js
+++ b/tests/fixtures/parsers/object-curly-newline/flow-stub-parser-singleline.js
@@ -1,0 +1,588 @@
+
+/*
+  AST for:
+
+function foo({ a, b } : MyType) {}
+
+*/
+exports.parse = () => ({
+    "type": "Program",
+    "start": 0,
+    "end": 35,
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 2,
+            "column": 0
+        }
+    },
+    "range": [
+        0,
+        35
+    ],
+    "comments": [],
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "function",
+            "start": 0,
+            "end": 8,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 8
+                }
+            },
+            "range": [
+                0,
+                8
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "foo",
+            "start": 9,
+            "end": 12,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 9
+                },
+                "end": {
+                    "line": 1,
+                    "column": 12
+                }
+            },
+            "range": [
+                9,
+                12
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "start": 12,
+            "end": 13,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 12
+                },
+                "end": {
+                    "line": 1,
+                    "column": 13
+                }
+            },
+            "range": [
+                12,
+                13
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 13,
+            "end": 14,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 13
+                },
+                "end": {
+                    "line": 1,
+                    "column": 14
+                }
+            },
+            "range": [
+                13,
+                14
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "a",
+            "start": 15,
+            "end": 16,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 15
+                },
+                "end": {
+                    "line": 1,
+                    "column": 16
+                }
+            },
+            "range": [
+                15,
+                16
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ",",
+            "start": 16,
+            "end": 17,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 16
+                },
+                "end": {
+                    "line": 1,
+                    "column": 17
+                }
+            },
+            "range": [
+                16,
+                17
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "b",
+            "start": 18,
+            "end": 19,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 18
+                },
+                "end": {
+                    "line": 1,
+                    "column": 19
+                }
+            },
+            "range": [
+                18,
+                19
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 20,
+            "end": 21,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 20
+                },
+                "end": {
+                    "line": 1,
+                    "column": 21
+                }
+            },
+            "range": [
+                20,
+                21
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "start": 22,
+            "end": 23,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 22
+                },
+                "end": {
+                    "line": 1,
+                    "column": 23
+                }
+            },
+            "range": [
+                22,
+                23
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "MyType",
+            "start": 24,
+            "end": 30,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 24
+                },
+                "end": {
+                    "line": 1,
+                    "column": 30
+                }
+            },
+            "range": [
+                24,
+                30
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "start": 30,
+            "end": 31,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 30
+                },
+                "end": {
+                    "line": 1,
+                    "column": 31
+                }
+            },
+            "range": [
+                30,
+                31
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 32,
+            "end": 33,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 32
+                },
+                "end": {
+                    "line": 1,
+                    "column": 33
+                }
+            },
+            "range": [
+                32,
+                33
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 33,
+            "end": 34,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 33
+                },
+                "end": {
+                    "line": 1,
+                    "column": 34
+                }
+            },
+            "range": [
+                33,
+                34
+            ]
+        }
+    ],
+    "sourceType": "module",
+    "body": [
+        {
+            "type": "FunctionDeclaration",
+            "start": 0,
+            "end": 34,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 34
+                }
+            },
+            "range": [
+                0,
+                34
+            ],
+            "id": {
+                "type": "Identifier",
+                "start": 9,
+                "end": 12,
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 9
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 12
+                    },
+                    "identifierName": "foo"
+                },
+                "range": [
+                    9,
+                    12
+                ],
+                "name": "foo",
+                "_babelType": "Identifier"
+            },
+            "generator": false,
+            "expression": false,
+            "async": false,
+            "params": [
+                {
+                    "type": "ObjectPattern",
+                    "start": 13,
+                    "end": 30,
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 13
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 30
+                        }
+                    },
+                    "range": [
+                        13,
+                        30
+                    ],
+                    "properties": [
+                        {
+                            "type": "Property",
+                            "start": 15,
+                            "end": 16,
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 15
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 16
+                                }
+                            },
+                            "range": [
+                                15,
+                                16
+                            ],
+                            "method": false,
+                            "computed": false,
+                            "key": {
+                                "type": "Identifier",
+                                "start": 15,
+                                "end": 16,
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 15
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 16
+                                    },
+                                    "identifierName": "a"
+                                },
+                                "range": [
+                                    15,
+                                    16
+                                ],
+                                "name": "a",
+                                "_babelType": "Identifier"
+                            },
+                            "shorthand": true,
+                            "value": {
+                                "type": "Identifier",
+                                "start": 15,
+                                "end": 16,
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 15
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 16
+                                    },
+                                    "identifierName": "a"
+                                },
+                                "range": [
+                                    15,
+                                    16
+                                ],
+                                "name": "a",
+                                "_babelType": "Identifier"
+                            },
+                            "kind": "init",
+                            "extra": {
+                                "shorthand": true
+                            },
+                            "_babelType": "Property"
+                        },
+                        {
+                            "type": "Property",
+                            "start": 18,
+                            "end": 19,
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 18
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 19
+                                }
+                            },
+                            "range": [
+                                18,
+                                19
+                            ],
+                            "method": false,
+                            "computed": false,
+                            "key": {
+                                "type": "Identifier",
+                                "start": 18,
+                                "end": 19,
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 18
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 19
+                                    },
+                                    "identifierName": "b"
+                                },
+                                "range": [
+                                    18,
+                                    19
+                                ],
+                                "name": "b",
+                                "_babelType": "Identifier"
+                            },
+                            "shorthand": true,
+                            "value": {
+                                "type": "Identifier",
+                                "start": 18,
+                                "end": 19,
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 18
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 19
+                                    },
+                                    "identifierName": "b"
+                                },
+                                "range": [
+                                    18,
+                                    19
+                                ],
+                                "name": "b",
+                                "_babelType": "Identifier"
+                            },
+                            "kind": "init",
+                            "extra": {
+                                "shorthand": true
+                            },
+                            "_babelType": "Property"
+                        }
+                    ],
+                    "typeAnnotation": {
+                        "type": "TypeAnnotation",
+                        "start": 22,
+                        "end": 30,
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 22
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 30
+                            }
+                        },
+                        "range": [
+                            22,
+                            30
+                        ],
+                        "typeAnnotation": {
+                            "type": "GenericTypeAnnotation",
+                            "start": 24,
+                            "end": 30,
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 24
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 30
+                                }
+                            },
+                            "range": [
+                                24,
+                                30
+                            ],
+                            "typeParameters": null,
+                            "id": {
+                                "type": "Identifier",
+                                "start": 24,
+                                "end": 30,
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 24
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 30
+                                    },
+                                    "identifierName": "MyType"
+                                },
+                                "range": [
+                                    24,
+                                    30
+                                ],
+                                "name": "MyType",
+                                "_babelType": "Identifier"
+                            },
+                            "_babelType": "GenericTypeAnnotation"
+                        },
+                        "_babelType": "TypeAnnotation"
+                    },
+                    "_babelType": "ObjectPattern"
+                }
+            ],
+            "body": {
+                "type": "BlockStatement",
+                "start": 32,
+                "end": 34,
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 32
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 34
+                    }
+                },
+                "range": [
+                    32,
+                    34
+                ],
+                "body": [],
+                "_babelType": "BlockStatement"
+            },
+            "_babelType": "FunctionDeclaration"
+        }
+    ]
+});
+

--- a/tests/lib/rules/object-curly-newline.js
+++ b/tests/lib/rules/object-curly-newline.js
@@ -9,7 +9,8 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const rule = require("../../../lib/rules/object-curly-newline"),
+const resolvePath = require("path").resolve,
+    rule = require("../../../lib/rules/object-curly-newline"),
     RuleTester = require("../../../lib/testers/rule-tester");
 
 //------------------------------------------------------------------------------
@@ -64,6 +65,26 @@ ruleTester.run("object-curly-newline", rule, {
             ].join("\n"),
             options: ["always"]
         },
+        {
+            code: [
+                "function foo({",
+                " a,",
+                " b",
+                "} : MyType) {}"
+            ].join("\n"),
+            options: ["always"],
+            parser: resolvePath(__dirname, "../../fixtures/parsers/object-curly-newline/flow-stub-parser-multiline")
+        },
+        {
+            code: [
+                "function foo({",
+                " a,",
+                " b",
+                "} : { a : string, b : string }) {}"
+            ].join("\n"),
+            options: ["always"],
+            parser: resolvePath(__dirname, "../../fixtures/parsers/object-curly-newline/flow-stub-parser-multiline-type-literal")
+        },
 
         // "never" -------------------------------------------------------------
         {
@@ -98,6 +119,16 @@ ruleTester.run("object-curly-newline", rule, {
                 "}};"
             ].join("\n"),
             options: ["never"]
+        },
+        {
+            code: "function foo({ a, b } : MyType) {}",
+            options: ["never"],
+            parser: resolvePath(__dirname, "../../fixtures/parsers/object-curly-newline/flow-stub-parser-singleline")
+        },
+        {
+            code: "function foo({ a, b } : { a : string, b : string }) {}",
+            options: ["never"],
+            parser: resolvePath(__dirname, "../../fixtures/parsers/object-curly-newline/flow-stub-parser-singleline-type-literal")
         },
 
         // "multiline" ---------------------------------------------------------
@@ -486,6 +517,34 @@ ruleTester.run("object-curly-newline", rule, {
                 { line: 3, column: 2, message: "Expected a line break before this closing brace." }
             ]
         },
+        {
+            code: "function foo({ a, b } : MyType) {}",
+            output: [
+                "function foo({",
+                " a, b ",
+                "} : MyType) {}"
+            ].join("\n"),
+            options: ["always"],
+            errors: [
+                { line: 1, column: 14, message: "Expected a line break after this opening brace." },
+                { line: 1, column: 21, message: "Expected a line break before this closing brace." }
+            ],
+            parser: resolvePath(__dirname, "../../fixtures/parsers/object-curly-newline/flow-stub-parser-singleline")
+        },
+        {
+            code: "function foo({ a, b } : { a : string, b : string }) {}",
+            output: [
+                "function foo({",
+                " a, b ",
+                "} : { a : string, b : string }) {}"
+            ].join("\n"),
+            options: ["always"],
+            errors: [
+                { line: 1, column: 14, message: "Expected a line break after this opening brace." },
+                { line: 1, column: 21, message: "Expected a line break before this closing brace." }
+            ],
+            parser: resolvePath(__dirname, "../../fixtures/parsers/object-curly-newline/flow-stub-parser-singleline-type-literal")
+        },
 
         // "never" ------------------------------------------------------------
         {
@@ -567,6 +626,42 @@ ruleTester.run("object-curly-newline", rule, {
                 { line: 1, column: 9, message: "Unexpected line break after this opening brace." },
                 { line: 5, column: 1, message: "Unexpected line break before this closing brace." }
             ]
+        },
+        {
+            code: [
+                "function foo({",
+                " a,",
+                " b",
+                "} : MyType) {}"
+            ].join("\n"),
+            output: [
+                "function foo({a,",
+                " b} : MyType) {}"
+            ].join("\n"),
+            options: ["never"],
+            errors: [
+                { line: 1, column: 14, message: "Unexpected line break after this opening brace." },
+                { line: 4, column: 1, message: "Unexpected line break before this closing brace." }
+            ],
+            parser: resolvePath(__dirname, "../../fixtures/parsers/object-curly-newline/flow-stub-parser-multiline")
+        },
+        {
+            code: [
+                "function foo({",
+                " a,",
+                " b",
+                "} : { a : string, b : string }) {}"
+            ].join("\n"),
+            output: [
+                "function foo({a,",
+                " b} : { a : string, b : string }) {}"
+            ].join("\n"),
+            options: ["never"],
+            errors: [
+                { line: 1, column: 14, message: "Unexpected line break after this opening brace." },
+                { line: 4, column: 1, message: "Unexpected line break before this closing brace." }
+            ],
+            parser: resolvePath(__dirname, "../../fixtures/parsers/object-curly-newline/flow-stub-parser-multiline-type-literal")
         },
 
         // "multiline" ---------------------------------------------------------


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

The `object-curly-newline` rule made the assumption that the last token
is always `}`. However, when an object is typed with flow this is not
the case. This causes false positives, as described in https://github.com/babel/babel-eslint/issues/513.


<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

By adding a filter to the `getLastToken` function we skip over the flow
types, and get the actual closing brace. For symmetry the same filter is
added for the open brace, though I'm not aware of any issues it would
fix.

**Is there anything you'd like reviewers to focus on?**
