### PR TITLE
Update: add "always" option to no-sequences

### DIFF
--- a/docs/rules/no-sequences.md
+++ b/docs/rules/no-sequences.md
@@ -14,15 +14,26 @@ while (a = next(), a && a.length);
 
 ## Rule Details
 
-This rule forbids the use of the comma operator, with the following exceptions:
+This rule forbids unexpected usages of the comma operator.
 
-* In the initialization or update portions of a `for` statement.
-* If the expression sequence is explicitly wrapped in parentheses.
+## Options
 
-Examples of **incorrect** code for this rule:
+This rule has a string option:
+
+* `"ambiguous"` (default) report usages of the comma operator, except in some non-ambiguous cases:
+
+    * In the initialization or update portions of a `for` statement.
+    * If the expression sequence is explicitly wrapped in parentheses.
+
+* `"always"` report any usage of the comma operator.
+
+
+### ambiguous
+
+Examples of **incorrect** code for this rule with the default `"ambiguous"` option:
 
 ```js
-/*eslint no-sequences: "error"*/
+/*eslint no-sequences: ["error", "ambiguous"]*/
 
 foo = doSomething(), val;
 
@@ -41,10 +52,10 @@ while (val = foo(), val < 42);
 with (doSomething(), val) {}
 ```
 
-Examples of **correct** code for this rule:
+Examples of **correct** code for this rule with the default `"ambiguous"` option:
 
 ```js
-/*eslint no-sequences: "error"*/
+/*eslint no-sequences: ["error", "ambiguous"]*/
 
 foo = (doSomething(), val);
 
@@ -61,6 +72,21 @@ switch ((val = foo(), val)) {}
 while ((val = foo(), val < 42));
 
 // with ((doSomething(), val)) {}
+```
+
+### always
+
+All examples above are **incorrect** for this rule with the `"always"` option.
+
+The comma is still acceptable outside of its operator role. Example of **correct** code for this
+rule with the `"always"` option:
+
+```js
+/*eslint no-sequences: ["error", "always"]*/
+
+var i = 1, j = 2;
+
+foo = [doSomething(), vla];
 ```
 
 ## When Not To Use It

--- a/lib/rules/no-sequences.js
+++ b/lib/rules/no-sequences.js
@@ -23,10 +23,15 @@ module.exports = {
             recommended: false
         },
 
-        schema: []
+        schema: [
+            {
+                enum: ["ambiguous", "always"]
+            }
+        ]
     },
 
     create(context) {
+        const always = context.options[0] === "always";
         const sourceCode = context.getSourceCode();
 
         /**
@@ -82,21 +87,23 @@ module.exports = {
 
         return {
             SequenceExpression(node) {
+                if (!always) {
 
-                // Always allow sequences in for statement update
-                if (node.parent.type === "ForStatement" &&
-                        (node === node.parent.init || node === node.parent.update)) {
-                    return;
-                }
-
-                // Wrapping a sequence in extra parens indicates intent
-                if (requiresExtraParens(node)) {
-                    if (isParenthesisedTwice(node)) {
+                    // Always allow sequences in for statement update
+                    if (node.parent.type === "ForStatement" &&
+                            (node === node.parent.init || node === node.parent.update)) {
                         return;
                     }
-                } else {
-                    if (isParenthesised(node)) {
-                        return;
+
+                    // Wrapping a sequence in extra parens indicates intent
+                    if (requiresExtraParens(node)) {
+                        if (isParenthesisedTwice(node)) {
+                            return;
+                        }
+                    } else {
+                        if (isParenthesised(node)) {
+                            return;
+                        }
                     }
                 }
 

--- a/tests/lib/rules/no-sequences.js
+++ b/tests/lib/rules/no-sequences.js
@@ -49,7 +49,9 @@ ruleTester.run("no-sequences", rule, {
         "switch ((doSomething(), !!test)) {}",
         "while ((doSomething(), !!test));",
         "with ((doSomething(), val)) {}",
-        { code: "a => ((doSomething(), a))", env: { es6: true } }
+        { code: "a => ((doSomething(), a))", env: { es6: true } },
+
+        { code: "var a = 1, b = 2;", options: ["always"] }
     ],
 
     // Examples of code that should trigger the rule
@@ -61,6 +63,10 @@ ruleTester.run("no-sequences", rule, {
         { code: "switch (doSomething(), val) {}", errors: errors(22) },
         { code: "while (doSomething(), !!test);", errors: errors(21) },
         { code: "with (doSomething(), val) {}", errors: errors(20) },
-        { code: "a => (doSomething(), a)", errors: errors(20), env: { es6: true } }
+        { code: "a => (doSomething(), a)", errors: errors(20), env: { es6: true } },
+
+        { code: "var foo = (1, 2);", options: ["always"], errors: errors(13) },
+        { code: "for (i = 1, j = 2;; i++);", options: ["always"], errors: errors(11) },
+        { code: "foo(a, (b, c), d);", options: ["always"], errors: errors(10) }
     ]
 });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request?**

[x] Changes an existing rule

**What rule do you want to change?**

no-sequences

**Does this change cause the rule to produce more or fewer warnings?**

By default it produces the exact same warnings. I added an option to produce more warnings.

**How will the change be implemented? (New option, new default behavior, etc.)?**

New option.

**Please provide some example code that this change will affect:**

```js
var foo = (1, 2);
```

**What does the rule currently do for this code?**

It doesn't report anything.

**What will the rule do after it's changed?**

If the option `"always"` is used, it will report an unexpected usage of the comma operator.


**What changes did you make? (Give an overview)**

I added a `"always"` option to to the no-sequences rule so it reports all usages of the comma operator, even if they are wrapped in parenthesis or in a `for` loop. It simply removes "non-ambiguous" exceptions to the rule.

**Is there anything you'd like reviewers to focus on?**

I am not sure about the `"ambiguous"` option naming. Maybe I should make make it a boolean flag, like `{ "always": true }`?