### PR TITLE
Docs: Incorrect link to related rule

### DIFF
--- a/docs/rules/padded-blocks.md
+++ b/docs/rules/padded-blocks.md
@@ -358,4 +358,4 @@ You can turn this rule off if you are not concerned with the consistency of padd
 ## Related Rules
 
 * [lines-between-class-members](lines-between-class-members.md)
-* [padding-line-between-statement](padding-line-between-statement.md)
+* [padding-line-between-statements](padding-line-between-statements.md)


### PR DESCRIPTION
`padding-line-between-statement` should be `padding-line-between-statements`

**What is the purpose of this pull request? (put an "X" next to item)**

[X ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Edited a linked rule to match the actual rule name. It was hitting the 404 page.

**Is there anything you'd like reviewers to focus on?**
Nope.

