### PR TITLE
Fix: multiline-comment-style autofix (fixes #9485)

### DIFF
--- a/lib/rules/multiline-comment-style.js
+++ b/lib/rules/multiline-comment-style.js
@@ -66,12 +66,17 @@ module.exports = {
         /**
          * Converts a comment into separate-line form
          * @param {Token} firstComment The first comment of the group being converted
-         * @param {string[]} commentLinesList A list of lines to appear in the new starred-block comment
+         * @param {string[]} commentLinesList A list of lines to appear in the new seperate-line comment
+         * @param {boolean} needsNewLine If a new line is needed after the new seperate-line comment
          * @returns {string} A representation of the comment value in separate-line form
          */
-        function convertToSeparateLines(firstComment, commentLinesList) {
+        function convertToSeparateLines(firstComment, commentLinesList, needsNewLine) {
             const initialOffset = sourceCode.text.slice(firstComment.range[0] - firstComment.loc.start.column, firstComment.range[0]);
             const separateLines = commentLinesList.map(line => `// ${line.trim()}`);
+
+            if (needsNewLine) {
+                separateLines.push("");
+            }
 
             return separateLines.join(`\n${initialOffset}`);
         }
@@ -194,8 +199,14 @@ module.exports = {
                     const block = commentGroup[0];
                     const tokenAfter = sourceCode.getTokenAfter(block, { includeComments: true });
 
+                    /*
+                     * if the original block comment ended in the same line as a new token
+                     * a new line with offset should be added before tokenAfter
+                     */
+                    let needsNewLine = false;
+
                     if (tokenAfter && block.loc.end.line === tokenAfter.loc.start.line) {
-                        return;
+                        needsNewLine = true;
                     }
 
                     context.report({
@@ -205,7 +216,7 @@ module.exports = {
                         },
                         message: EXPECTED_LINES_ERROR,
                         fix(fixer) {
-                            return fixer.replaceText(block, convertToSeparateLines(block, commentLines.filter(line => line)));
+                            return fixer.replaceText(block, convertToSeparateLines(block, commentLines.filter(line => line), needsNewLine));
                         }
                     });
                 }

--- a/tests/lib/rules/multiline-comment-style.js
+++ b/tests/lib/rules/multiline-comment-style.js
@@ -146,13 +146,6 @@ ruleTester.run("multiline-comment-style", rule, {
         },
         {
             code: `
-                /* this is
-                   a comment */ foo;
-            `,
-            options: ["separate-lines"]
-        },
-        {
-            code: `
                 /* eslint semi: "error" */
             `,
             options: ["separate-lines"]
@@ -407,6 +400,19 @@ ruleTester.run("multiline-comment-style", rule, {
                 // bar
                 // baz
                 // qux
+            `,
+            options: ["separate-lines"],
+            errors: [{ message: EXPECTED_LINES_ERROR, line: 2 }]
+        },
+        {
+            code: `
+                /* foo
+                bar */qux;
+            `,
+            output: `
+                // foo
+                // bar
+                qux;
             `,
             options: ["separate-lines"],
             errors: [{ message: EXPECTED_LINES_ERROR, line: 2 }]


### PR DESCRIPTION
Fix the autofix for multiline-comments with seperate-lines option.

Add test present in the issue description to avoid future regressions.

Remove old test that wasn't aligned with the rule description.