### PR TITLE
Update: Add autofix for `sort-vars`

### DIFF
--- a/lib/rules/sort-vars.js
+++ b/lib/rules/sort-vars.js
@@ -27,29 +27,68 @@ module.exports = {
                 },
                 additionalProperties: false
             }
-        ]
+        ],
+
+        fixable: "code"
     },
 
     create(context) {
 
         const configuration = context.options[0] || {},
-            ignoreCase = configuration.ignoreCase || false;
+            ignoreCase = configuration.ignoreCase || false,
+            sourceCode = context.getSourceCode();
 
         return {
             VariableDeclaration(node) {
                 const idDeclarations = node.declarations.filter(decl => decl.id.type === "Identifier");
+                const getSortableName = ignoreCase ? decl => decl.id.name.toLowerCase() : decl => decl.id.name;
+                const unfixable = idDeclarations.some(decl => decl.init !== null && decl.init.type !== "Literal");
+                let fixed = false;
 
                 idDeclarations.slice(1).reduce((memo, decl) => {
-                    let lastVariableName = memo.id.name,
-                        currenVariableName = decl.id.name;
+                    const lastVariableName = getSortableName(memo),
+                        currentVariableName = getSortableName(decl);
 
-                    if (ignoreCase) {
-                        lastVariableName = lastVariableName.toLowerCase();
-                        currenVariableName = currenVariableName.toLowerCase();
-                    }
+                    if (currentVariableName < lastVariableName) {
+                        if (unfixable || fixed) {
+                            context.report({
+                                node: decl,
+                                message: "Variables within the same declaration block should be sorted alphabetically."
+                            });
+                        } else {
+                            context.report({
+                                node: decl,
+                                message: "Variables within the same declaration block should be sorted alphabetically.",
+                                fix(fixer) {
+                                    return fixer.replaceTextRange(
+                                        [idDeclarations[0].range[0], idDeclarations[idDeclarations.length - 1].range[1]],
+                                        idDeclarations
 
-                    if (currenVariableName < lastVariableName) {
-                        context.report({ node: decl, message: "Variables within the same declaration block should be sorted alphabetically." });
+                                            // Clone the idDeclarations array to avoid mutating it
+                                            .slice()
+
+                                            // Sort the array into the desired order
+                                            .sort((declA, declB) => {
+                                                const aName = getSortableName(declA);
+                                                const bName = getSortableName(declB);
+
+                                                return aName > bName ? 1 : -1;
+                                            })
+
+                                            // Build a string out of the sorted list of identifier declarations and the text between the originals
+                                            .reduce((sourceText, identifier, index) => {
+                                                const textAfterIdentifier = index === idDeclarations.length - 1
+                                                    ? ""
+                                                    : sourceCode.getText().slice(idDeclarations[index].range[1], idDeclarations[index + 1].range[0]);
+
+                                                return sourceText + sourceCode.getText(identifier) + textAfterIdentifier;
+                                            }, "")
+
+                                    );
+                                }
+                            });
+                            fixed = true;
+                        }
                         return memo;
                     }
                     return decl;

--- a/lib/rules/sort-vars.js
+++ b/lib/rules/sort-vars.js
@@ -50,45 +50,41 @@ module.exports = {
                         currentVariableName = getSortableName(decl);
 
                     if (currentVariableName < lastVariableName) {
-                        if (unfixable || fixed) {
-                            context.report({
-                                node: decl,
-                                message: "Variables within the same declaration block should be sorted alphabetically."
-                            });
-                        } else {
-                            context.report({
-                                node: decl,
-                                message: "Variables within the same declaration block should be sorted alphabetically.",
-                                fix(fixer) {
-                                    return fixer.replaceTextRange(
-                                        [idDeclarations[0].range[0], idDeclarations[idDeclarations.length - 1].range[1]],
-                                        idDeclarations
-
-                                            // Clone the idDeclarations array to avoid mutating it
-                                            .slice()
-
-                                            // Sort the array into the desired order
-                                            .sort((declA, declB) => {
-                                                const aName = getSortableName(declA);
-                                                const bName = getSortableName(declB);
-
-                                                return aName > bName ? 1 : -1;
-                                            })
-
-                                            // Build a string out of the sorted list of identifier declarations and the text between the originals
-                                            .reduce((sourceText, identifier, index) => {
-                                                const textAfterIdentifier = index === idDeclarations.length - 1
-                                                    ? ""
-                                                    : sourceCode.getText().slice(idDeclarations[index].range[1], idDeclarations[index + 1].range[0]);
-
-                                                return sourceText + sourceCode.getText(identifier) + textAfterIdentifier;
-                                            }, "")
-
-                                    );
+                        context.report({
+                            node: decl,
+                            message: "Variables within the same declaration block should be sorted alphabetically.",
+                            fix(fixer) {
+                                if (unfixable || fixed) {
+                                    return null;
                                 }
-                            });
-                            fixed = true;
-                        }
+                                return fixer.replaceTextRange(
+                                    [idDeclarations[0].range[0], idDeclarations[idDeclarations.length - 1].range[1]],
+                                    idDeclarations
+
+                                        // Clone the idDeclarations array to avoid mutating it
+                                        .slice()
+
+                                        // Sort the array into the desired order
+                                        .sort((declA, declB) => {
+                                            const aName = getSortableName(declA);
+                                            const bName = getSortableName(declB);
+
+                                            return aName > bName ? 1 : -1;
+                                        })
+
+                                        // Build a string out of the sorted list of identifier declarations and the text between the originals
+                                        .reduce((sourceText, identifier, index) => {
+                                            const textAfterIdentifier = index === idDeclarations.length - 1
+                                                ? ""
+                                                : sourceCode.getText().slice(idDeclarations[index].range[1], idDeclarations[index + 1].range[0]);
+
+                                            return sourceText + sourceCode.getText(identifier) + textAfterIdentifier;
+                                        }, "")
+
+                                );
+                            }
+                        });
+                        fixed = true;
                         return memo;
                     }
                     return decl;

--- a/tests/lib/rules/sort-vars.js
+++ b/tests/lib/rules/sort-vars.js
@@ -113,33 +113,108 @@ ruleTester.run("sort-vars", rule, {
         }
     ],
     invalid: [
-        { code: "var b, a", errors: [expectedError] },
-        { code: "var b=10, a=20;", errors: [expectedError] },
-        { code: "var all=10, a = 1", errors: [expectedError] },
-        { code: "var b, c, a, d", errors: [expectedError] },
-        { code: "var c, d, a, b", errors: 2 },
-        { code: "var a, A;", errors: [expectedError] },
-        { code: "var a, B;", errors: [expectedError] },
-        { code: "var a, B, c;", errors: [expectedError] },
-        { code: "var B, a;", options: ignoreCaseArgs, errors: [expectedError] },
-        { code: "var B, A, c;", options: ignoreCaseArgs, errors: [expectedError] },
+        {
+            code: "var b, a",
+            output: "var a, b",
+            errors: [expectedError]
+        },
+        {
+            code: "var b , a",
+            output: "var a , b",
+            errors: [expectedError]
+        },
+        {
+            code: [
+                "var b,",
+                "    a;"
+            ].join("\n"),
+            output: [
+                "var a,",
+                "    b;"
+            ].join("\n"),
+            errors: [expectedError]
+        },
+        {
+            code: "var b=10, a=20;",
+            output: "var a=20, b=10;",
+            errors: [expectedError]
+        },
+        {
+            code: "var b=10, a=20, c=30;",
+            output: "var a=20, b=10, c=30;",
+            errors: [expectedError]
+        },
+        {
+            code: "var all=10, a = 1",
+            output: "var a = 1, all=10",
+            errors: [expectedError]
+        },
+        {
+            code: "var b, c, a, d",
+            output: "var a, b, c, d",
+            errors: [expectedError]
+        },
+        {
+            code: "var c, d, a, b",
+            output: "var a, b, c, d",
+            errors: 2
+        },
+        {
+            code: "var a, A;",
+            output: "var A, a;",
+            errors: [expectedError]
+        },
+        {
+            code: "var a, B;",
+            output: "var B, a;",
+            errors: [expectedError]
+        },
+        {
+            code: "var a, B, c;",
+            output: "var B, a, c;",
+            errors: [expectedError]
+        },
+        {
+            code: "var B, a;",
+            output: "var a, B;",
+            options: ignoreCaseArgs,
+            errors: [expectedError]
+        },
+        {
+            code: "var B, A, c;",
+            output: "var A, B, c;",
+            options: ignoreCaseArgs,
+            errors: [expectedError]
+        },
         {
             code: "var d, a, [b, c] = {};",
+            output: "var a, d, [b, c] = {};",
             options: ignoreCaseArgs,
             parserOptions: { ecmaVersion: 6 },
             errors: [expectedError]
         },
         {
             code: "var d, a, [b, {x: {c, e}}] = {};",
+            output: "var a, d, [b, {x: {c, e}}] = {};",
             options: ignoreCaseArgs,
             parserOptions: { ecmaVersion: 6 },
             errors: [expectedError]
         },
-
         {
             code: "var {} = 1, b, a",
+            output: "var {} = 1, a, b",
             options: ignoreCaseArgs,
             parserOptions: { ecmaVersion: 6 },
+            errors: [expectedError]
+        },
+        {
+            code: "var b=10, a=f();",
+            output: null,
+            errors: [expectedError]
+        },
+        {
+            code: "var b=10, a=b;",
+            output: null,
             errors: [expectedError]
         }
     ]

--- a/tests/lib/rules/sort-vars.js
+++ b/tests/lib/rules/sort-vars.js
@@ -216,6 +216,44 @@ ruleTester.run("sort-vars", rule, {
             code: "var b=10, a=b;",
             output: null,
             errors: [expectedError]
+        },
+        {
+            code: "var b = 0, a = `${b}`;",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [expectedError]
+        },
+        {
+            code: "var b = 0, a = `${f()}`",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [expectedError]
+        },
+        {
+            code: "var b = 0, c = b, a;",
+            output: null,
+            errors: [expectedError]
+        },
+        {
+            code: "var b = 0, c = 0, a = b + c;",
+            output: null,
+            errors: [expectedError]
+        },
+        {
+            code: "var b = f(), c, d, a;",
+            output: null,
+            errors: [expectedError]
+        },
+        {
+            code: "var b = `${f()}`, c, d, a;",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [expectedError]
+        },
+        {
+            code: "var c, a = b = 0",
+            output: null,
+            errors: [expectedError]
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [x] Add autofixing to a rule

**What changes did you make?**

The `sort-vars` rule can now automatically fix unsorted variable declarations when each variable is either unassigned or assigned to a literal value. I added the implementation for this fixer, test cases to validate that the fixer works as expected, and test cases to validate that it does not fix when a variable is assigned to a non-literal value.

In short, the fixer will convert `var c, b, a` to `var a, b, c` and `var b = 3, a = true` to `var a = true, b = 3` but **will not** fix `var b = f(), a = g()` or `var b = 5, a = b`.

**Is there anything you'd like reviewers to focus on?**

All of it, please :confused: