### PR TITLE
Docs: Unquote booleans in lines-between-class-members docs

### DIFF
--- a/docs/rules/lines-between-class-members.md
+++ b/docs/rules/lines-between-class-members.md
@@ -44,8 +44,8 @@ String option:
 
 Object option:
 
-* `"exceptAfterSingleLine": "false"`(default) **do not** skip checking empty lines after singleline class members
-* `"exceptAfterSingleLine": "true"` skip checking empty lines after singleline class members
+* `"exceptAfterSingleLine": false`(default) **do not** skip checking empty lines after singleline class members
+* `"exceptAfterSingleLine": true` skip checking empty lines after singleline class members
 
 Examples of **incorrect** code for this rule with the string option:
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

The docs for `lines-between-class-members`' boolean `exceptAfterSingleLine` option showed `"true"` and `"false"` (notice the quotes), but the [rule's schema](https://github.com/eslint/eslint/blob/c16770d1802ba748b5c0629aa9e918f3321686c4/lib/rules/lines-between-class-members.js#L31) expects boolean literals.

**Is there anything you'd like reviewers to focus on?**

Nope