### PR TITLE
Chore: add isValidThisArg in ast-utils.

### DIFF
--- a/lib/ast-utils.js
+++ b/lib/ast-utils.js
@@ -406,6 +406,31 @@ function createGlobalLinebreakMatcher() {
     return new RegExp(LINEBREAK_MATCHER.source, "g");
 }
 
+/**
+ * Checks whether or not the tokens of two given nodes are same.
+ * @param {ASTNode} left - A node 1 to compare.
+ * @param {ASTNode} right - A node 2 to compare.
+ * @param {SourceCode} sourceCode - The ESLint source code object.
+ * @returns {boolean} the source code for the given node.
+ */
+function equalTokens(left, right, sourceCode) {
+    const tokensL = sourceCode.getTokens(left);
+    const tokensR = sourceCode.getTokens(right);
+
+    if (tokensL.length !== tokensR.length) {
+        return false;
+    }
+    for (let i = 0; i < tokensL.length; ++i) {
+        if (tokensL[i].type !== tokensR[i].type ||
+            tokensL[i].value !== tokensR[i].value
+        ) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 //------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
@@ -1320,5 +1345,19 @@ module.exports = {
         }
 
         return false;
+    },
+
+    /**
+     * Checks whether or not `thisArg` is not changed by `.apply()`.
+     * @param {ASTNode|null} expectedThis - The node that is the owner of the applied function.
+     * @param {ASTNode} thisArg - The node that is given to the first argument of the `.apply()`.
+     * @param {RuleContext} context - The ESLint rule context object.
+     * @returns {boolean} Whether or not `thisArg` is not changed by `.apply()`.
+     */
+    isValidThisArg(expectedThis, thisArg, context) {
+        if (!expectedThis) {
+            return isNullOrUndefined(thisArg);
+        }
+        return equalTokens(expectedThis, thisArg, context);
     }
 };

--- a/lib/ast-utils.js
+++ b/lib/ast-utils.js
@@ -431,20 +431,6 @@ function equalTokens(left, right, sourceCode) {
     return true;
 }
 
-/**
- * Checks whether or not `thisArg` is not changed by `.apply()`.
- * @param {ASTNode|null} expectedThis - The node that is the owner of the applied function.
- * @param {ASTNode} thisArg - The node that is given to the first argument of the `.apply()`.
- * @param {RuleContext} context - The ESLint rule context object.
- * @returns {boolean} Whether or not `thisArg` is not changed by `.apply()`.
- */
-function isValidThisArg(expectedThis, thisArg, context) {
-    if (!expectedThis) {
-        return isNullOrUndefined(thisArg);
-    }
-    return equalTokens(expectedThis, thisArg, context);
-}
-
 //------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
@@ -478,7 +464,6 @@ module.exports = {
     isParenthesised,
     createGlobalLinebreakMatcher,
     equalTokens,
-    isValidThisArg,
 
     isArrowToken,
     isClosingBraceToken,

--- a/lib/ast-utils.js
+++ b/lib/ast-utils.js
@@ -431,6 +431,20 @@ function equalTokens(left, right, sourceCode) {
     return true;
 }
 
+/**
+ * Checks whether or not `thisArg` is not changed by `.apply()`.
+ * @param {ASTNode|null} expectedThis - The node that is the owner of the applied function.
+ * @param {ASTNode} thisArg - The node that is given to the first argument of the `.apply()`.
+ * @param {RuleContext} context - The ESLint rule context object.
+ * @returns {boolean} Whether or not `thisArg` is not changed by `.apply()`.
+ */
+function isValidThisArg(expectedThis, thisArg, context) {
+    if (!expectedThis) {
+        return isNullOrUndefined(thisArg);
+    }
+    return equalTokens(expectedThis, thisArg, context);
+}
+
 //------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
@@ -463,6 +477,8 @@ module.exports = {
     isArrayFromMethod,
     isParenthesised,
     createGlobalLinebreakMatcher,
+    equalTokens,
+    isValidThisArg,
 
     isArrowToken,
     isClosingBraceToken,
@@ -1345,19 +1361,5 @@ module.exports = {
         }
 
         return false;
-    },
-
-    /**
-     * Checks whether or not `thisArg` is not changed by `.apply()`.
-     * @param {ASTNode|null} expectedThis - The node that is the owner of the applied function.
-     * @param {ASTNode} thisArg - The node that is given to the first argument of the `.apply()`.
-     * @param {RuleContext} context - The ESLint rule context object.
-     * @returns {boolean} Whether or not `thisArg` is not changed by `.apply()`.
-     */
-    isValidThisArg(expectedThis, thisArg, context) {
-        if (!expectedThis) {
-            return isNullOrUndefined(thisArg);
-        }
-        return equalTokens(expectedThis, thisArg, context);
     }
 };

--- a/lib/rules/no-useless-call.js
+++ b/lib/rules/no-useless-call.js
@@ -28,44 +28,6 @@ function isCallOrNonVariadicApply(node) {
     );
 }
 
-/**
- * Checks whether or not the tokens of two given nodes are same.
- * @param {ASTNode} left - A node 1 to compare.
- * @param {ASTNode} right - A node 2 to compare.
- * @param {SourceCode} sourceCode - The ESLint source code object.
- * @returns {boolean} the source code for the given node.
- */
-function equalTokens(left, right, sourceCode) {
-    const tokensL = sourceCode.getTokens(left);
-    const tokensR = sourceCode.getTokens(right);
-
-    if (tokensL.length !== tokensR.length) {
-        return false;
-    }
-    for (let i = 0; i < tokensL.length; ++i) {
-        if (tokensL[i].type !== tokensR[i].type ||
-            tokensL[i].value !== tokensR[i].value
-        ) {
-            return false;
-        }
-    }
-
-    return true;
-}
-
-/**
- * Checks whether or not `thisArg` is not changed by `.call()`/`.apply()`.
- * @param {ASTNode|null} expectedThis - The node that is the owner of the applied function.
- * @param {ASTNode} thisArg - The node that is given to the first argument of the `.call()`/`.apply()`.
- * @param {SourceCode} sourceCode - The ESLint source code object.
- * @returns {boolean} Whether or not `thisArg` is not changed by `.call()`/`.apply()`.
- */
-function isValidThisArg(expectedThis, thisArg, sourceCode) {
-    if (!expectedThis) {
-        return astUtils.isNullOrUndefined(thisArg);
-    }
-    return equalTokens(expectedThis, thisArg, sourceCode);
-}
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -95,7 +57,7 @@ module.exports = {
                 const expectedThis = (applied.type === "MemberExpression") ? applied.object : null;
                 const thisArg = node.arguments[0];
 
-                if (isValidThisArg(expectedThis, thisArg, sourceCode)) {
+                if (astUtils.isValidThisArg(expectedThis, thisArg, sourceCode)) {
                     context.report({ node, message: "unnecessary '.{{name}}()'.", data: { name: node.callee.property.name } });
                 }
             }

--- a/lib/rules/no-useless-call.js
+++ b/lib/rules/no-useless-call.js
@@ -29,6 +29,20 @@ function isCallOrNonVariadicApply(node) {
 }
 
 
+/**
+ * Checks whether or not `thisArg` is not changed by `.call()`/`.apply()`.
+ * @param {ASTNode|null} expectedThis - The node that is the owner of the applied function.
+ * @param {ASTNode} thisArg - The node that is given to the first argument of the `.call()`/`.apply()`.
+ * @param {SourceCode} sourceCode - The ESLint source code object.
+ * @returns {boolean} Whether or not `thisArg` is not changed by `.call()`/`.apply()`.
+ */
+function isValidThisArg(expectedThis, thisArg, sourceCode) {
+    if (!expectedThis) {
+        return astUtils.isNullOrUndefined(thisArg);
+    }
+    return astUtils.equalTokens(expectedThis, thisArg, sourceCode);
+}
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -57,7 +71,7 @@ module.exports = {
                 const expectedThis = (applied.type === "MemberExpression") ? applied.object : null;
                 const thisArg = node.arguments[0];
 
-                if (astUtils.isValidThisArg(expectedThis, thisArg, sourceCode)) {
+                if (isValidThisArg(expectedThis, thisArg, sourceCode)) {
                     context.report({ node, message: "unnecessary '.{{name}}()'.", data: { name: node.callee.property.name } });
                 }
             }

--- a/lib/rules/prefer-spread.js
+++ b/lib/rules/prefer-spread.js
@@ -28,44 +28,6 @@ function isVariadicApplyCalling(node) {
     );
 }
 
-/**
- * Checks whether or not the tokens of two given nodes are same.
- * @param {ASTNode} left - A node 1 to compare.
- * @param {ASTNode} right - A node 2 to compare.
- * @param {SourceCode} sourceCode - The ESLint source code object.
- * @returns {boolean} the source code for the given node.
- */
-function equalTokens(left, right, sourceCode) {
-    const tokensL = sourceCode.getTokens(left);
-    const tokensR = sourceCode.getTokens(right);
-
-    if (tokensL.length !== tokensR.length) {
-        return false;
-    }
-    for (let i = 0; i < tokensL.length; ++i) {
-        if (tokensL[i].type !== tokensR[i].type ||
-            tokensL[i].value !== tokensR[i].value
-        ) {
-            return false;
-        }
-    }
-
-    return true;
-}
-
-/**
- * Checks whether or not `thisArg` is not changed by `.apply()`.
- * @param {ASTNode|null} expectedThis - The node that is the owner of the applied function.
- * @param {ASTNode} thisArg - The node that is given to the first argument of the `.apply()`.
- * @param {RuleContext} context - The ESLint rule context object.
- * @returns {boolean} Whether or not `thisArg` is not changed by `.apply()`.
- */
-function isValidThisArg(expectedThis, thisArg, context) {
-    if (!expectedThis) {
-        return astUtils.isNullOrUndefined(thisArg);
-    }
-    return equalTokens(expectedThis, thisArg, context);
-}
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -97,7 +59,7 @@ module.exports = {
                 const expectedThis = (applied.type === "MemberExpression") ? applied.object : null;
                 const thisArg = node.arguments[0];
 
-                if (isValidThisArg(expectedThis, thisArg, sourceCode)) {
+                if (astUtils.isValidThisArg(expectedThis, thisArg, sourceCode)) {
                     context.report({
                         node,
                         message: "Use the spread operator instead of '.apply()'.",

--- a/lib/rules/prefer-spread.js
+++ b/lib/rules/prefer-spread.js
@@ -29,6 +29,20 @@ function isVariadicApplyCalling(node) {
 }
 
 
+/**
+ * Checks whether or not `thisArg` is not changed by `.apply()`.
+ * @param {ASTNode|null} expectedThis - The node that is the owner of the applied function.
+ * @param {ASTNode} thisArg - The node that is given to the first argument of the `.apply()`.
+ * @param {RuleContext} context - The ESLint rule context object.
+ * @returns {boolean} Whether or not `thisArg` is not changed by `.apply()`.
+ */
+function isValidThisArg(expectedThis, thisArg, context) {
+    if (!expectedThis) {
+        return astUtils.isNullOrUndefined(thisArg);
+    }
+    return astUtils.equalTokens(expectedThis, thisArg, context);
+}
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -59,7 +73,7 @@ module.exports = {
                 const expectedThis = (applied.type === "MemberExpression") ? applied.object : null;
                 const thisArg = node.arguments[0];
 
-                if (astUtils.isValidThisArg(expectedThis, thisArg, sourceCode)) {
+                if (isValidThisArg(expectedThis, thisArg, sourceCode)) {
                     context.report({
                         node,
                         message: "Use the spread operator instead of '.apply()'.",

--- a/tests/lib/ast-utils.js
+++ b/tests/lib/ast-utils.js
@@ -1198,4 +1198,22 @@ describe("ast-utils", () => {
             });
         });
     });
+
+    describe("equalTokens", () => {
+        it("should return true if tokens are equal", () => {
+            const code = "a=0;a=0;";
+            const ast = espree.parse(code, ESPREE_CONFIG);
+            const sourceCode = new SourceCode(code, ast);
+
+            assert.strictEqual(astUtils.equalTokens(ast.body[0], ast.body[1], sourceCode), true);
+        });
+
+        it("should return false if tokens are not equal", () => {
+            const code = "a=0;a=1;";
+            const ast = espree.parse(code, ESPREE_CONFIG);
+            const sourceCode = new SourceCode(code, ast);
+
+            assert.strictEqual(astUtils.equalTokens(ast.body[0], ast.body[1], sourceCode), false);
+        });
+    });
 });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
`isValidThisArg` is used both in `no-useless-call.js` and `prefer-spread.js`. placed it in ast-utils in case some other rules will use it.

**Is there anything you'd like reviewers to focus on?**


