### PR TITLE
Chore: regex.test => string.startsWith to improve readability

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -978,7 +978,7 @@ target.checkGitCommit = function() {
     }
 
     // Only check non-release messages
-    if (!semver.valid(commitMsgs[0]) && !/^Revert /.test(commitMsgs[0])) {
+    if (!semver.valid(commitMsgs[0]) && !commitMsgs[0].startsWith("Revert")) {
         if (commitMsgs[0].split(/\r?\n/)[0].length > 72) {
             echo(" - First line of commit message must not exceed 72 characters");
             failed = true;

--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -240,8 +240,8 @@ function processFile(filename, configHelper, options, linter) {
 function createIgnoreResult(filePath, baseDir) {
     let message;
     const isHidden = /^\./.test(path.basename(filePath));
-    const isInNodeModules = baseDir && /^node_modules/.test(path.relative(baseDir, filePath));
-    const isInBowerComponents = baseDir && /^bower_components/.test(path.relative(baseDir, filePath));
+    const isInNodeModules = baseDir && path.relative(baseDir, filePath).startsWith("node_modules");
+    const isInBowerComponents = baseDir && path.relative(baseDir, filePath).startsWith("bower_components");
 
     if (isHidden) {
         message = "File ignored by default.  Use a negated ignore pattern (like \"--ignore-pattern '!<relative/path/to/filename>'\") to override.";


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:
`string.startsWith` has a better readability.