### PR TITLE
Chore: remove commented test for HTML formatter

### DIFF
--- a/tests/lib/formatters/html.js
+++ b/tests/lib/formatters/html.js
@@ -329,28 +329,6 @@ describe("formatter:html", () => {
         });
     });
 
-    // // Formatter doesn't use source property
-    // /*
-    // describe("when passing a single message with no source", function() {
-
-    //     var code = [{
-    //         filePath: "foo.js",
-    //         messages: [{
-    //             message: "Unexpected foo.",
-    //             severity: 2,
-    //             line: 5,
-    //             column: 10,
-    //             ruleId: "foo"
-    //         }]
-    //     }];
-
-    //     it("should return a string in HTML format with 1 issue in 1 file", function() {
-    //         var result = formatter(code);
-    //         assert.strictEqual(parseHTML(result), "");
-    //     });
-    // });
-    // */
-
     describe("when passing a single message with no rule id or message", () => {
         const code = [{
             filePath: "foo.js",


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This commit removes a test that has been commented out for 2 years and doesn't appear to work.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular