### PR TITLE
Files with no failures get a "passing" testcase

### DIFF
--- a/lib/formatters/junit.js
+++ b/lib/formatters/junit.js
@@ -39,22 +39,28 @@ module.exports = function(results) {
 
         const messages = result.messages;
 
-        output += `<testsuite package="org.eslint" time="0" tests="${messages.length}" errors="${messages.length}" name="${result.filePath}">\n`;
-        messages.forEach(message => {
-            const type = message.fatal ? "error" : "failure";
+        if (messages.length > 0) {
+            output += `<testsuite package="org.eslint" time="0" tests="${messages.length}" errors="${messages.length}" name="${result.filePath}">\n`;
+            messages.forEach(message => {
+                const type = message.fatal ? "error" : "failure";
 
-            output += `<testcase time="0" name="org.eslint.${message.ruleId || "unknown"}">`;
-            output += `<${type} message="${xmlEscape(message.message || "")}">`;
-            output += "<![CDATA[";
-            output += `line ${message.line || 0}, col `;
-            output += `${message.column || 0}, ${getMessageType(message)}`;
-            output += ` - ${xmlEscape(message.message || "")}`;
-            output += (message.ruleId ? ` (${message.ruleId})` : "");
-            output += "]]>";
-            output += `</${type}>`;
-            output += "</testcase>\n";
-        });
-        output += "</testsuite>\n";
+                output += `<testcase time="0" name="org.eslint.${message.ruleId || "unknown"}">`;
+                output += `<${type} message="${xmlEscape(message.message || "")}">`;
+                output += "<![CDATA[";
+                output += `line ${message.line || 0}, col `;
+                output += `${message.column || 0}, ${getMessageType(message)}`;
+                output += ` - ${xmlEscape(message.message || "")}`;
+                output += (message.ruleId ? ` (${message.ruleId})` : "");
+                output += "]]>";
+                output += `</${type}>`;
+                output += "</testcase>\n";
+            });
+            output += "</testsuite>\n";
+        } else {
+            output += `<testsuite package="org.eslint" time="0" tests="1" errors="0" name="${result.filePath}">\n`;
+            output += `<testcase time="0" name="${result.filePath}" />\n`;
+            output += "</testsuite>\n";
+        }
 
     });
 

--- a/tests/lib/formatters/junit.js
+++ b/tests/lib/formatters/junit.js
@@ -195,7 +195,20 @@ describe("formatter:junit", () => {
         it("should return 2 <testsuite>", () => {
             const result = formatter(code);
 
-            assert.strictEqual(result.replace(/\n/g, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><failure message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Warning - Unexpected foo. (foo)]]></failure></testcase></testsuite><testsuite package=\"org.eslint\" time=\"0\" tests=\"0\" errors=\"0\" name=\"bar.js\"></testsuite></testsuites>");
+            assert.strictEqual(result.replace(/\n/g, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><failure message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Warning - Unexpected foo. (foo)]]></failure></testcase></testsuite><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"0\" name=\"bar.js\"><testcase time=\"0\" name=\"bar.js\" /></testsuite></testsuites>");
+        });
+    });
+
+    describe("when passed a file with no errors", () => {
+        const code = [{
+            filePath: "foo.js",
+            messages: []
+        }];
+
+        it("should print a passing <testcase>", () => {
+            const result = formatter(code);
+
+            assert.strictEqual(result.replace(/\n/g, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"0\" name=\"foo.js\"><testcase time=\"0\" name=\"foo.js\" /></testsuite></testsuites>");
         });
     });
 });


### PR DESCRIPTION
This fixes JUnit parsing errors which treat no testcases as a failure (e.g. Atlassian bamboo).

<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

On files that pass, a "passing" testcase should be added. Without any passing testcases, some JUnit parsers will fail, claiming that there are no tests.

This was unofficially reported here: https://github.com/eslint/eslint/issues/16#issuecomment-284808499

This pull request ensures that a passing testcase is added to a testsuite if there are no failures.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Added empty "passing" testcase to JUnit formatter when a file has no messages.

**Is there anything you'd like reviewers to focus on?**
No