### PR TITLE
Upgrade globals to newest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "file-entry-cache": "^2.0.0",
     "functional-red-black-tree": "^1.0.1",
     "glob": "^7.1.2",
-    "globals": "^9.17.0",
+    "globals": "^10.2.0",
     "ignore": "^3.3.3",
     "imurmurhash": "^0.1.4",
     "inquirer": "^3.0.6",


### PR DESCRIPTION
Now PerformanceObserver is recognized as a global

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] Other, please explain: Updates dependency

**What changes did you make? (Give an overview)**
Updated included version of globals (https://github.com/sindresorhus/globals) to v10.2.0, so that ESLint won't complain about PerformanceObserver not being a global. Example (from https://github.com/ampproject/amphtml/pull/11814):
```
this.longTaskObserver_ = new PerformanceObserver(entryList => { ... });
```

**Is there anything you'd like reviewers to focus on?**
Note that globals v10.0.0 requires NodeJS 4.0. Please reject if that is a problem.


