### PR TITLE
Fix: edge-cases of semi-style

### DIFF
--- a/lib/rules/semi-style.js
+++ b/lib/rules/semi-style.js
@@ -25,6 +25,82 @@ const SELECTOR = `:matches(${
     ].join(",")
 })`;
 
+/**
+ * Get the child node list of a given node.
+ * This returns `Program#body`, `BlockStatement#body`, or `SwitchCase#consequent`.
+ * This is used to check whether a node is the first/last child.
+ * @param {Node} node A node to get child node list.
+ * @returns {Node[]|null} The child node list.
+ */
+function getChildren(node) {
+    const t = node.type;
+
+    if (t === "BlockStatement" || t === "Program") {
+        return node.body;
+    }
+    if (t === "SwitchCase") {
+        return node.consequent;
+    }
+    return null;
+}
+
+/**
+ * Check whether a given node is the first statement in the parent block.
+ * @param {Node} node A node to check.
+ * @returns {boolean} `true` if the node is the first statement in the parent block.
+ */
+function isFirstChild(node) {
+    const nodeList = getChildren(node.parent);
+
+    return nodeList !== null && nodeList[0] === node;
+}
+
+/**
+ * Check whether a given node is the last statement in the parent block.
+ * @param {Node} node A node to check.
+ * @returns {boolean} `true` if the node is the last statement in the parent block.
+ */
+function isLastChild(node) {
+    const t = node.parent.type;
+
+    if (t === "IfStatement" && node.parent.consequent === node && node.parent.alternate) { // before `else` keyword.
+        return true;
+    }
+    if (t === "DoWhileStatement") { // before `while` keyword.
+        return true;
+    }
+    const nodeList = getChildren(node.parent);
+
+    return nodeList !== null && nodeList[nodeList.length - 1] === node; // before `}` or etc.
+}
+
+/**
+ * Check whether a given node is a dangling semi. For example:
+ *
+ *     while (a)
+ *         ;
+ *
+ * @param {Node} node A node to check.
+ * @returns {boolean} `true` if the node is the last statement in the parent block.
+ */
+function isDanglingEmptyStatement(node) {
+    if (node.type !== "EmptyStatement") {
+        return false;
+    }
+    const t = node.parent.type;
+
+    return (
+        t === "DoWhileStatement" ||
+        t === "ForInStatement" ||
+        t === "ForOfStatement" ||
+        t === "ForStatement" ||
+        t === "IfStatement" ||
+        t === "LabeledStatement" ||
+        t === "WhileStatement" ||
+        t === "WithStatement"
+    );
+}
+
 module.exports = {
     meta: {
         docs: {
@@ -39,23 +115,6 @@ module.exports = {
     create(context) {
         const sourceCode = context.getSourceCode();
         const option = context.options[0] || "last";
-
-        /**
-         * Check whether comments exist between the given 2 tokens.
-         * @param {Token} left The left token to check.
-         * @param {Token} right The right token to check.
-         * @returns {boolean} `true` if comments exist between the given 2 tokens.
-         */
-        function commentsExistBetween(left, right) {
-            return sourceCode.getFirstTokenBetween(
-                left,
-                right,
-                {
-                    includeComments: true,
-                    filter: astUtils.isCommentToken
-                }
-            ) !== null;
-        }
 
         /**
          * Check the given semicolon token.
@@ -79,7 +138,7 @@ module.exports = {
                             : "the beginning of the next line"
                     },
                     fix(fixer) {
-                        if (prevToken && nextToken && commentsExistBetween(prevToken, nextToken)) {
+                        if (prevToken && nextToken && sourceCode.commentsExistBetween(prevToken, nextToken)) {
                             return null;
                         }
 
@@ -95,6 +154,16 @@ module.exports = {
 
         return {
             [SELECTOR](node) {
+                if (option === "last" && node.type === "EmptyStatement" && isFirstChild(node)) {
+                    return;
+                }
+                if (option === "first" && isLastChild(node)) {
+                    return;
+                }
+                if (isDanglingEmptyStatement(node)) {
+                    return;
+                }
+
                 const lastToken = sourceCode.getLastToken(node);
 
                 if (astUtils.isSemicolonToken(lastToken)) {

--- a/lib/rules/semi-style.js
+++ b/lib/rules/semi-style.js
@@ -18,7 +18,7 @@ const astUtils = require("../ast-utils");
 const SELECTOR = `:matches(${
     [
         "BreakStatement", "ContinueStatement", "DebuggerStatement",
-        "DoWhileStatement", "EmptyStatement", "ExportAllDeclaration",
+        "DoWhileStatement", "ExportAllDeclaration",
         "ExportDefaultDeclaration", "ExportNamedDeclaration",
         "ExpressionStatement", "ImportDeclaration", "ReturnStatement",
         "ThrowStatement", "VariableDeclaration"
@@ -45,17 +45,6 @@ function getChildren(node) {
 }
 
 /**
- * Check whether a given node is the first statement in the parent block.
- * @param {Node} node A node to check.
- * @returns {boolean} `true` if the node is the first statement in the parent block.
- */
-function isFirstChild(node) {
-    const nodeList = getChildren(node.parent);
-
-    return nodeList !== null && nodeList[0] === node;
-}
-
-/**
  * Check whether a given node is the last statement in the parent block.
  * @param {Node} node A node to check.
  * @returns {boolean} `true` if the node is the last statement in the parent block.
@@ -72,33 +61,6 @@ function isLastChild(node) {
     const nodeList = getChildren(node.parent);
 
     return nodeList !== null && nodeList[nodeList.length - 1] === node; // before `}` or etc.
-}
-
-/**
- * Check whether a given node is a dangling semi. For example:
- *
- *     while (a)
- *         ;
- *
- * @param {Node} node A node to check.
- * @returns {boolean} `true` if the node is the last statement in the parent block.
- */
-function isDanglingEmptyStatement(node) {
-    if (node.type !== "EmptyStatement") {
-        return false;
-    }
-    const t = node.parent.type;
-
-    return (
-        t === "DoWhileStatement" ||
-        t === "ForInStatement" ||
-        t === "ForOfStatement" ||
-        t === "ForStatement" ||
-        t === "IfStatement" ||
-        t === "LabeledStatement" ||
-        t === "WhileStatement" ||
-        t === "WithStatement"
-    );
 }
 
 module.exports = {
@@ -154,13 +116,7 @@ module.exports = {
 
         return {
             [SELECTOR](node) {
-                if (option === "last" && node.type === "EmptyStatement" && isFirstChild(node)) {
-                    return;
-                }
                 if (option === "first" && isLastChild(node)) {
-                    return;
-                }
-                if (isDanglingEmptyStatement(node)) {
                     return;
                 }
 

--- a/tests/lib/rules/semi-style.js
+++ b/tests/lib/rules/semi-style.js
@@ -27,18 +27,103 @@ ruleTester.run("semi-style", rule, {
         "for(a;\nb;\nc);",
         "for((a\n);\n(b\n);\n(c));",
         "if(a)foo;\nbar",
+        { code: ";", options: ["last"] },
         { code: ";foo;bar;baz;", options: ["last"] },
         { code: "foo;\nbar;", options: ["last"] },
         { code: "for(a;b;c);", options: ["last"] },
         { code: "for(a;\nb;\nc);", options: ["last"] },
         { code: "for((a\n);\n(b\n);\n(c));", options: ["last"] },
         { code: "if(a)foo;\nbar", options: ["last"] },
+        { code: ";", options: ["first"] },
         { code: ";foo;bar;baz;", options: ["first"] },
         { code: "foo\n;bar;", options: ["first"] },
         { code: "for(a;b;c);", options: ["first"] },
         { code: "for(a;\nb;\nc);", options: ["first"] },
         { code: "for((a\n);\n(b\n);\n(c));", options: ["first"] },
-        { code: "if(a)foo\n;bar", options: ["first"] }
+
+        // edge cases
+        {
+            code: `
+                {
+                    ;
+                }
+            `,
+            options: ["first"]
+        },
+        {
+            code: `
+                while (a)
+                    ;
+                foo
+            `,
+            options: ["first"]
+        },
+        {
+            code: `
+                do
+                    ;
+                while (a)
+            `,
+            options: ["first"]
+        },
+        {
+            code: `
+                do
+                    foo;
+                while (a)
+            `,
+            options: ["first"]
+        },
+        {
+            code: `
+                if (a)
+                    foo;
+                else
+                    bar
+            `,
+            options: ["first"]
+        },
+        {
+            code: `
+                if (a)
+                    foo
+                ;bar
+            `,
+            options: ["first"]
+        },
+        {
+            code: `
+                {
+                    ;
+                }
+            `,
+            options: ["last"]
+        },
+        {
+            code: `
+                switch (a) {
+                    case 1:
+                        ;foo
+                }
+            `,
+            options: ["last"]
+        },
+        {
+            code: `
+                while (a)
+                    ;
+                foo
+            `,
+            options: ["last"]
+        },
+        {
+            code: `
+                do
+                    ;
+                while (a)
+            `,
+            options: ["last"]
+        }
     ],
     invalid: [
         {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix

**Tell us about your environment**

* **ESLint Version:** 4.10.0
* **Node Version:** 8.9.0
* **npm Version:** 5.5.1

**What parser (default, Babel-ESLint, etc.) are you using?**

- default

**Please show your full configuration:**

- nothing

**What did you do? Please include the actual source code causing the issue.**

> [The online demo for `"first"` option](https://eslint.org/demo/#eyJ0ZXh0IjoiLyplc2xpbnQgc2VtaS1zdHlsZTogW2Vycm9yLCBmaXJzdF0gKi9cclxuXHJcbntcclxuXHQ7IC8vIFNob3VsZCBiZSBpZ25vcmVkLiBJdCdzIHJlcG9ydGVkIGJ5IGBuby1leHRyYS1zZW1pYC5cclxufVxyXG5cclxud2hpbGUgKGEpXHJcblx0OyAvLyBTaG91bGQgYmUgaWdub3JlZCB0byBrZWVwIHRoZSBpbmRlbnRlZCBsb29wIGJvZHkuXHJcbmZvb1xyXG5cclxuZG9cclxuXHQ7IC8vIFNob3VsZCBiZSBpZ25vcmVkIHRvIGtlZXAgdGhlIGluZGVudGVkIGxvb3AgYm9keS5cclxud2hpbGUgKGEpXHJcblxyXG5kb1xyXG5cdGZvbzsgLy8gU2hvdWxkIGJlIGlnbm9yZWQgaW5zdGVhZCBvZiBtYWtpbmcgYDt3aGlsZWAuXHJcbndoaWxlIChhKVxyXG5cclxuaWYgKGEpXHJcblx0Zm9vOyAvLyBTaG91bGQgYmUgaWdub3JlZCBpbnN0ZWFkIG9mIG1ha2luZyBgO2Vsc2VgLlxyXG5lbHNlXHJcblx0YmFyXHJcbiIsIm9wdGlvbnMiOnsicGFyc2VyT3B0aW9ucyI6eyJlY21hVmVyc2lvbiI6OCwic291cmNlVHlwZSI6Im1vZHVsZSIsImVjbWFGZWF0dXJlcyI6e319LCJydWxlcyI6e30sImVudiI6e319fQ==)

```js
/*eslint semi-style: [error, first] */

{
	; // Should be ignored. It's reported by `no-extra-semi`.
}

while (a)
	; // Should be ignored to keep the indented loop body.
foo

do
	; // Should be ignored to keep the indented loop body.
while (a)

do
	foo; // Should be ignored instead of making `;while`.
while (a)

if (a)
	foo; // Should be ignored instead of making `;else`.
else
	bar
```

> [The online demo for `"last"` option](https://eslint.org/demo/#eyJ0ZXh0IjoiLyplc2xpbnQgc2VtaS1zdHlsZTogW2Vycm9yLCBsYXN0XSAqL1xyXG5cclxue1xyXG5cdDsgLy8gU2hvdWxkIGJlIGlnbm9yZWQuIEl0J3MgcmVwb3J0ZWQgYnkgYG5vLWV4dHJhLXNlbWlgLlxyXG59XHJcblxyXG5zd2l0Y2ggKGEpIHtcclxuXHRjYXNlIDE6XHJcblx0XHQ7Zm9vIC8vIFNob3VsZCBiZSBpZ25vcmVkLiBJdCdzIHJlcG9ydGVkIGJ5IGBuby1leHRyYS1zZW1pYC5cclxufVxyXG5cclxud2hpbGUgKGEpXHJcblx0OyAvLyBTaG91bGQgYmUgaWdub3JlZCB0byBrZWVwIHRoZSBpbmRlbnRlZCBsb29wIGJvZHkuXHJcbmZvb1xyXG5cclxuZG9cclxuXHQ7IC8vIFNob3VsZCBiZSBpZ25vcmVkIHRvIGtlZXAgdGhlIGluZGVudGVkIGxvb3AgYm9keS5cclxud2hpbGUgKGEpXHJcbiIsIm9wdGlvbnMiOnsicGFyc2VyT3B0aW9ucyI6eyJlY21hVmVyc2lvbiI6OCwic291cmNlVHlwZSI6Im1vZHVsZSIsImVjbWFGZWF0dXJlcyI6e319LCJydWxlcyI6e30sImVudiI6e319fQ==)

```js
/*eslint semi-style: [error, last] */

{
	; // Should be ignored. It's reported by `no-extra-semi`.
}

switch (a) {
	case 1:
		;foo // Should be ignored. It's reported by `no-extra-semi`.
}

while (a)
	; // Should be ignored to keep the indented loop body.
foo

do
	; // Should be ignored to keep the indented loop body.
while (a)
```

**What did you expect to happen?**

No errors.

**What actually happened? Please include the actual, raw output from ESLint.**

Several errors are reported. See the demo pages.

**What changes did you make? (Give an overview)**

This PR fixes those false positives. Now the rule ignores semicolons at the first/last in a block/clause.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.
