### PR TITLE
New: Add object options to object-property-newline for JSCS.

### DIFF
--- a/docs/developer-guide/nodejs-api.md
+++ b/docs/developer-guide/nodejs-api.md
@@ -820,9 +820,9 @@ In addition to the properties above, invalid test cases can also have the follow
     * `message` (string/regexp): The message for the error
     * `type` (string): The type of the reported AST node
     * `line` (number): The 1-based line number of the reported location
-    * `column` (number): The 0-based column number of the reported location
+    * `column` (number): The 1-based column number of the reported location
     * `endLine` (number): The 1-based line number of the end of the reported location
-    * `endColumn` (number): The 0-based column number of the end of the reported location
+    * `endColumn` (number): The 1-based column number of the end of the reported location
 
     If a string is provided as an error instead of an object, the string is used to assert the `message` of the error.
 * `output` (string, optional): Asserts the output that will be produced when using this rule for a single pass of autofixing (e.g. with the `--fix` command line flag). If this is `null`, asserts that none of the reported problems suggest autofixes.

--- a/docs/rules/keyword-spacing.md
+++ b/docs/rules/keyword-spacing.md
@@ -59,44 +59,44 @@ if (foo) {
     //...
 }
 
-// no conflict with `array-bracket-spacing`
+// Avoid conflict with `array-bracket-spacing`
 let a = [this];
 let b = [function() {}];
 
-// no conflict with `arrow-spacing`
+// Avoid conflict with `arrow-spacing`
 let a = ()=> this.foo;
 
-// no conflict with `block-spacing`
+// Avoid conflict with `block-spacing`
 {function foo() {}}
 
-// no conflict with `comma-spacing`
+// Avoid conflict with `comma-spacing`
 let a = [100,this.foo, this.bar];
 
-// not conflict with `computed-property-spacing`
+// Avoid conflict with `computed-property-spacing`
 obj[this.foo] = 0;
 
-// no conflict with `generator-star-spacing`
+// Avoid conflict with `generator-star-spacing`
 function *foo() {}
 
-// no conflict with `key-spacing`
+// Avoid conflict with `key-spacing`
 let obj = {
     foo:function() {}
 };
 
-// no conflict with `object-curly-spacing`
+// Avoid conflict with `object-curly-spacing`
 let obj = {foo: this};
 
-// no conflict with `semi-spacing`
+// Avoid conflict with `semi-spacing`
 let a = this;function foo() {}
 
-// no conflict with `space-in-parens`
+// Avoid conflict with `space-in-parens`
 (function () {})();
 
-// no conflict with `space-infix-ops`
+// Avoid conflict with `space-infix-ops`
 if ("foo"in {foo: 0}) {}
 if (10+this.foo<= this.bar) {}
 
-// no conflict with `jsx-curly-spacing`
+// Avoid conflict with `jsx-curly-spacing`
 let a = <A foo={this.foo} bar={function(){}} />
 ```
 
@@ -157,57 +157,57 @@ if (foo) {
     //...
 }
 
-// not conflict with `array-bracket-spacing`
+// Avoid conflict with `array-bracket-spacing`
 let a = [this];
 
-// not conflict with `arrow-spacing`
+// Avoid conflict with `arrow-spacing`
 let a = ()=> this.foo;
 
-// not conflict with `comma-spacing`
+// Avoid conflict with `comma-spacing`
 let a = [100, this.foo, this.bar];
 
-// not conflict with `computed-property-spacing`
+// Avoid conflict with `computed-property-spacing`
 obj[this.foo] = 0;
 
-// not conflict with `generator-star-spacing`
+// Avoid conflict with `generator-star-spacing`
 function* foo() {}
 
-// not conflict with `key-spacing`
+// Avoid conflict with `key-spacing`
 let obj = {
     foo:function() {}
 };
 
-// not conflict with `func-call-spacing`
+// Avoid conflict with `func-call-spacing`
 class A {
     constructor() {
         super();
     }
 }
 
-// not conflict with `object-curly-spacing`
+// Avoid conflict with `object-curly-spacing`
 let obj = {foo: this};
 
-// not conflict with `semi-spacing`
+// Avoid conflict with `semi-spacing`
 let a = this;function foo() {}
 
-// not conflict with `space-before-function-paren`
+// Avoid conflict with `space-before-function-paren`
 function() {}
 
-// no conflict with `space-infix-ops`
+// Avoid conflict with `space-infix-ops`
 if ("foo"in{foo: 0}) {}
 if (10+this.foo<= this.bar) {}
 
-// no conflict with `space-unary-ops`
+// Avoid conflict with `space-unary-ops`
 function* foo(a) {
     return yield+a;
 }
 
-// no conflict with `yield-star-spacing`
+// Avoid conflict with `yield-star-spacing`
 function* foo(a) {
     return yield* a;
 }
 
-// no conflict with `jsx-curly-spacing`
+// Avoid conflict with `jsx-curly-spacing`
 let a = <A foo={this.foo} bar={function(){}} />
 ```
 

--- a/docs/rules/object-property-newline.md
+++ b/docs/rules/object-property-newline.md
@@ -123,7 +123,7 @@ const newFunction = multiplier => ({
 });
 ```
 
-This object option makes the rule stricter by prohibiting one of the patterns by which you could comply with the rule. Specifically, the comma between two property specifications may not appear before the second one on the same line. The JSCS rule `requireObjectKeysOnNewLine` treats commas this way, so this object option makes ESLint compatible with JSCS in this respect.
+This object option makes the rule stricter by prohibiting one of the patterns by which you could comply with the rule. Specifically, the comma between two property specifications may not appear before the second one on the same line. The JSCS rule `requireObjectKeysOnNewLine` treats commas this way, so setting this object option to `true` makes ESLint compatible with JSCS in this respect.
 
 You can use the `comma-style` rule instead of this option to achieve partial JSCS compatibility, but not in combination with the `ignoreBracketsOfComputedNames` object option. Using the `comma-style` rule for the sole purpose of JSCS compatibility would also require you to enumerate 9 exceptions, leaving only `ObjectExpression` subject to the rule.
 

--- a/docs/rules/object-property-newline.md
+++ b/docs/rules/object-property-newline.md
@@ -177,7 +177,7 @@ b: 'p.m.',
 };
 ```
 
-The modification does not depend on whether the `allowMultiplePropertiesPerLine` object option is set to `true`. In other words, ESLint never collects all the property specifications onto a single line, even when this object option would permit that.
+The modification does not depend on whether the `allowAllPropertiesOnSameLine` object option is set to `true`. In other words, ESLint never collects all the property specifications onto a single line, even when this object option would permit that.
 
 ESLint does not correct a violation of this rule if a comment immediately precedes the second or subsequent property specification on a line, since ESLint cannot determine which line to put the comment onto.
 

--- a/docs/rules/object-property-newline.md
+++ b/docs/rules/object-property-newline.md
@@ -125,7 +125,36 @@ const newFunction = multiplier => ({
 
 This object option makes the rule stricter by prohibiting one of the patterns by which you could comply with the rule. Specifically, the comma between two property specifications may not appear before the second one on the same line. The JSCS rule `requireObjectKeysOnNewLine` treats commas this way, so setting this object option to `true` makes ESLint compatible with JSCS in this respect.
 
-You can use the `comma-style` rule instead of this option to achieve partial JSCS compatibility, but not in combination with the `ignoreBracketsOfComputedNames` object option. Using the `comma-style` rule for the sole purpose of JSCS compatibility would also require you to enumerate 9 exceptions, leaving only `ObjectExpression` subject to the rule.
+You might question the need for this option in achieving JSCS compatibility, because there is another rule, `comma-style`, that regulates the placement of commas between property specifications of object literals. Why not just use that rule, with its string option `last`, together with the `ignoreBracketsOfComputedNames` option of this rule, to emulate JSCS’s `requireObjectKeysOnNewLine` rule?
+
+The answer is that you cannot accomplish this by adding `comma-style`, for at least two reasons:
+
+First the `comma-style` rule would reject a line that contains only an inter-property comma followed by the opening bracket of a computed property name, such as in
+
+```js
+const newObject = {
+  a: 0
+  , [
+    'a' + 'b'
+  ]: 1
+};
+```
+
+The `comma-style` rule would issue a `',' should be placed last` error on that line. The JSCS `requireObjectKeysOnNewLine` rule, by contrast, would permit the line, since it does not treat the `[` as part of the computed property name.
+
+Second, the `comma-style` rule would reject a line that contains only an inter-property comma, such as in
+
+```js
+const newObject = {
+  a: 0
+  ,
+  b: 1
+};
+```
+
+The `comma-style` rule would issue a `Bad line breaking before and after ','` error on that line. The JSCS `requireObjectKeysOnNewLine` rule, by contrast, would permit the line, since it does not treat the `,` as part of either the previous or the subsequent property specification.
+
+By setting this rule’s `ignoreBracketsOfComputedNames` and `noCommaFirst` both to `true`, you can emulate the JSCS `requireObjectKeysOnNewLine` rule’s acceptance of both these patterns. You are then free to use `comma-style` as you wish on the 9 other node types that it can apply to. Of course, you should not combine this rule’s `noCommaFirst` option with `comma-style`’s `last` string option unless you include `"ObjectExpression": true` as a property of the `exceptions` object in your `comma-style` invocation. Otherwise, lines of object literals that begin or end with commas would pass one test but fail the other.
 
 ### Notations
 

--- a/docs/rules/object-property-newline.md
+++ b/docs/rules/object-property-newline.md
@@ -1,6 +1,6 @@
 # enforce placing object properties on separate lines (object-property-newline)
 
-This rule permits you to restrict the locations of property specifications in object literals. You may prohibit any part of any property specification from appearing on the same line as any part of any other property specification. You may make this prohibition absolute, or, by invoking an object option, you may allow an exception, permitting an object literal to have all parts of all of its property specifications on a single line.
+This rule permits you to restrict the locations of property specifications in object literals. You may prohibit any part of any property specification from appearing on the same line as any part of any other property specification. You may make this prohibition absolute, or, by invoking an object option, you may allow an exception, permitting an object literal to have all parts of all of its property specifications on a single line. Other object options let you make the rule looser or stricter with respect to certain notations.
 
 ## Rule Details
 
@@ -24,7 +24,6 @@ const newObject = {
         {a: 3, b: 4}
     ]
 };
-
 ```
 
 Instead of those, you can comply with the rule by writing
@@ -72,19 +71,52 @@ Another benefit of this rule is specificity of diffs when a property is changed:
 +var obj = { foo: "foo", bar: "bazz", baz: "baz" };
 ```
 
-### Optional Exception
+### Optional Exceptions
 
-The rule offers one object option, `allowAllPropertiesOnSameLine` (a deprecated synonym is `allowMultiplePropertiesPerLine`). If you set it to `true`, object literals such as the first two above, with all property specifications on the same line, will be permitted, but one like
+The rule offers three object options.
+
+#### `allowMultiplePropertiesPerLine`
+
+If you set `allowAllPropertiesOnSameLine` (a deprecated synonym is `allowMultiplePropertiesPerLine`) to `true`, object literals such as the first two above, with all property specifications on the same line, will be permitted, but one like
 
 ```js
 const newObject = {
     a: 'a.m.', b: 'p.m.',
     c: 'daylight saving time'
 };
-
 ```
 
 will be prohibited, because two properties, but not all properties, appear on the same line.
+
+#### `treatComputedPropertiesLikeJSCS`
+
+If you set `treatComputedPropertiesLikeJSCS` to `true`, an object literal such as the one below will be permitted:
+
+```js
+const newObject = {
+    a: 1, [
+        process.argv[4]
+    ]: '01'
+};
+```
+
+Otherwise, this rule will prohibit it, because ESLint treats the opening bracket of a computed property name as part of the property specification. The JSCS rule `requireObjectKeysOnNewLine` does not, so this object option makes ESLint compatible with JSCS in this respect.
+
+#### `noCommaFirst`
+
+If you set `noCommaFirst` to `true`, an object literal such as the one below will be prohibited, even though all its property specifications are on separate lines:
+
+```js
+const newFunction = multiplier => ({
+    a: 2 * multiplier
+    , b: 4 * multiplier
+    , c: 8 * multiplier
+});
+```
+
+This object option makes the rule stricter by prohibiting one of the patterns by which you could comply with the rule. Specifically, the comma between two property specifications may not appear before the second one on the same line. The JSCS rule `requireObjectKeysOnNewLine` treats commas this way, so this object option makes ESLint compatible with JSCS in this respect.
+
+You can use the `comma-style` rule instead of this option to achieve partial JSCS compatibility, but not in combination with the `treatComputedPropertiesLikeJSCS` object option. Using the `comma-style` rule for the sole purpose of JSCS compatibility would also require you to enumerate 9 exceptions, leaving only `ObjectExpression` subject to the rule.
 
 ### Notations
 
@@ -122,26 +154,7 @@ const newObject = {a: [
 
 because 1 character of the specification of `a` (i.e. the trailing `]` of its value) is on the same line as the specification of `b`.
 
-The optional exception does not excuse this case, because the entire collection of property specifications spans 4 lines, not 1.
-
-### Inter-property Delimiters
-
-The comma and any whitespace that delimit property specifications are not considered parts of them. Therefore, the rule permits both of these formats:
-
-```js
-const newFunction = multiplier => ({
-    a: 2 * multiplier,
-    b: 4 * multiplier,
-    c: 8 * multiplier
-});
-const newFunction = multiplier => ({
-    a: 2 * multiplier
-    , b: 4 * multiplier
-    , c: 8 * multiplier
-});
-```
-
-(This behavior differs from that of the JSCS rule cited below, which permits the first but prohibits the second format.)
+The `allowMultiplePropertiesPerLine` object option would not excuse this case, because the entire collection of property specifications spans 4 lines, not 1.
 
 ### --fix
 
@@ -164,7 +177,7 @@ b: 'p.m.',
 };
 ```
 
-The modification does not depend on whether the object option is set to `true`. In other words, ESLint never collects all the property specifications onto a single line, even when the object option would permit that.
+The modification does not depend on whether the `allowMultiplePropertiesPerLine` object option is set to `true`. In other words, ESLint never collects all the property specifications onto a single line, even when this object option would permit that.
 
 ESLint does not correct a violation of this rule if a comment immediately precedes the second or subsequent property specification on a line, since ESLint cannot determine which line to put the comment onto.
 
@@ -172,23 +185,23 @@ As illustrated above, the `--fix` option, applied to this rule, does not comply 
 
 ## Examples
 
-Examples of **incorrect** code for this rule, with no object option or with `allowAllPropertiesOnSameLine` set to `false`:
+Examples of **incorrect** code for this rule, with all object options omitted or set to `false`:
 
 ```js
 /*eslint object-property-newline: "error"*/
 
-const obj0 = { foo: "foo", bar: "bar", baz: "baz" };
+const obj = { foo: "foo", bar: "bar", baz: "baz" };
 
-const obj1 = {
+const obj = {
     foo: "foo", bar: "bar", baz: "baz"
 };
 
-const obj2 = {
+const obj = {
     foo: "foo", bar: "bar",
     baz: "baz"
 };
 
-const obj3 = {
+const obj = {
     [process.argv[3] ? "foo" : "bar"]: 0, baz: [
         1,
         2,
@@ -199,34 +212,46 @@ const obj3 = {
 
 const a = "antidisestablishmentarianistically";
 const b = "yugoslavyalılaştırabildiklerimizdenmişsiniz";
-const obj4 = {a, b};
+const obj = {a, b};
 
 const domain = process.argv[4];
-const obj5 = {
+const obj = {
     foo: "foo", [
     domain.includes(":") ? "complexdomain" : "simpledomain"
 ]: true};
 ```
 
-Examples of **correct** code for this rule, with no object option or with `allowAllPropertiesOnSameLine` set to `false`:
+Example of additional **incorrect** code for this rule with the `{ "noCommaFirst": true }` option:
+
+```js
+/*eslint object-property-newline: ["error", { "noCommaFirst": true }]*/
+
+const obj = {
+    foo: "foo"
+    , bar: "bar"
+    , baz: "baz"
+};
+```
+
+Examples of **correct** code for this rule, with all object options omitted or set to `false`:
 
 ```js
 /*eslint object-property-newline: "error"*/
 
-const obj1 = {
+const obj = {
     foo: "foo",
     bar: "bar",
     baz: "baz"
 };
 
-const obj2 = {
+const obj = {
     foo: "foo"
     , bar: "bar"
     , baz: "baz"
 };
 
 const user = process.argv[2];
-const obj3 = {
+const obj = {
     user,
     [process.argv[3] ? "foo" : "bar"]: 0,
     baz: [
@@ -245,13 +270,25 @@ Examples of additional **correct** code for this rule with the `{ "allowAllPrope
 
 const obj = { foo: "foo", bar: "bar", baz: "baz" };
 
-const obj2 = {
+const obj = {
     foo: "foo", bar: "bar", baz: "baz"
 };
 const user = process.argv[2];
-const obj3 = {
+const obj = {
     user, [process.argv[3] ? "foo" : "bar"]: 0, baz: [1, 2, 4, 8]
 };
+```
+
+Example of additional **correct** code for this rule with the `{ "treatComputedPropertiesLikeJSCS": true }` option:
+
+```js
+/*eslint object-property-newline: ["error", { "treatComputedPropertiesLikeJSCS": true }]*/
+
+const domain = process.argv[4];
+const obj = {
+    foo: "foo", [
+    domain.includes(":") ? "complexdomain" : "simpledomain"
+]: true};
 ```
 
 ## When Not To Use It
@@ -260,7 +297,7 @@ You can turn this rule off if you want to decide, case-by-case, whether to place
 
 ## Compatibility
 
-- **JSCS**: This rule provides partial compatibility with [requireObjectKeysOnNewLine](http://jscs.info/rule/requireObjectKeysOnNewLine).
+- **JSCS**: [requireObjectKeysOnNewLine](http://jscs.info/rule/requireObjectKeysOnNewLine)
 
 ## Related Rules
 

--- a/docs/rules/object-property-newline.md
+++ b/docs/rules/object-property-newline.md
@@ -77,7 +77,16 @@ The rule offers three object options.
 
 #### `allowAllPropertiesOnSameLine`
 
-If you set `allowAllPropertiesOnSameLine` (a deprecated synonym is `allowMultiplePropertiesPerLine`) to `true`, object literals such as the first two above, with all property specifications on the same line, will be permitted, but one like
+If you set `allowAllPropertiesOnSameLine` (a deprecated synonym is `allowMultiplePropertiesPerLine`) to `true`, object literals such as
+
+```js
+const newObject = {a: 1, b: [2, {a: 3, b: 4}]};
+const newObject = {
+    a: 1, b: [2, {a: 3, b: 4}]
+};
+```
+
+that have **all** property specifications on the same line will be permitted, but one like
 
 ```js
 const newObject = {
@@ -88,9 +97,9 @@ const newObject = {
 
 will be prohibited, because two properties, but not all properties, appear on the same line.
 
-#### `treatComputedPropertiesLikeJSCS`
+#### `ignoreBracketsOfComputedProperties`
 
-If you set `treatComputedPropertiesLikeJSCS` to `true`, an object literal such as the one below will be permitted:
+If you set `ignoreBracketsOfComputedProperties` to `true`, an object literal such as the one below will be permitted:
 
 ```js
 const newObject = {
@@ -116,7 +125,7 @@ const newFunction = multiplier => ({
 
 This object option makes the rule stricter by prohibiting one of the patterns by which you could comply with the rule. Specifically, the comma between two property specifications may not appear before the second one on the same line. The JSCS rule `requireObjectKeysOnNewLine` treats commas this way, so this object option makes ESLint compatible with JSCS in this respect.
 
-You can use the `comma-style` rule instead of this option to achieve partial JSCS compatibility, but not in combination with the `treatComputedPropertiesLikeJSCS` object option. Using the `comma-style` rule for the sole purpose of JSCS compatibility would also require you to enumerate 9 exceptions, leaving only `ObjectExpression` subject to the rule.
+You can use the `comma-style` rule instead of this option to achieve partial JSCS compatibility, but not in combination with the `ignoreBracketsOfComputedProperties` object option. Using the `comma-style` rule for the sole purpose of JSCS compatibility would also require you to enumerate 9 exceptions, leaving only `ObjectExpression` subject to the rule.
 
 ### Notations
 
@@ -279,10 +288,10 @@ const obj = {
 };
 ```
 
-Example of additional **correct** code for this rule with the `{ "treatComputedPropertiesLikeJSCS": true }` option:
+Example of additional **correct** code for this rule with the `{ "ignoreBracketsOfComputedProperties": true }` option:
 
 ```js
-/*eslint object-property-newline: ["error", { "treatComputedPropertiesLikeJSCS": true }]*/
+/*eslint object-property-newline: ["error", { "ignoreBracketsOfComputedProperties": true }]*/
 
 const domain = process.argv[4];
 const obj = {

--- a/docs/rules/object-property-newline.md
+++ b/docs/rules/object-property-newline.md
@@ -109,7 +109,7 @@ const newObject = {
 };
 ```
 
-Otherwise, this rule will prohibit it, because ESLint treats the opening bracket of a computed property name as part of the property specification. The JSCS rule `requireObjectKeysOnNewLine` does not, so this object option makes ESLint compatible with JSCS in this respect.
+Otherwise, this rule will prohibit it, because ESLint treats the opening bracket of a computed property name as part of the property specification. The JSCS rule `requireObjectKeysOnNewLine` does not, so setting this object option to `true` makes ESLint compatible with JSCS in this respect.
 
 #### `noCommaFirst`
 

--- a/docs/rules/object-property-newline.md
+++ b/docs/rules/object-property-newline.md
@@ -129,7 +129,7 @@ You might question the need for this option in achieving JSCS compatibility, bec
 
 The answer is that you cannot accomplish this by adding `comma-style`, for at least two reasons:
 
-First the `comma-style` rule would reject a line that contains only an inter-property comma followed by the opening bracket of a computed property name, such as in
+First, the `comma-style` rule would reject a line that contains only an inter-property comma followed by the opening bracket of a computed property name, such as in
 
 ```js
 const newObject = {
@@ -154,7 +154,7 @@ const newObject = {
 
 The `comma-style` rule would issue a `Bad line breaking before and after ','` error on that line. The JSCS `requireObjectKeysOnNewLine` rule, by contrast, would permit the line, since it does not treat the `,` as part of either the previous or the subsequent property specification.
 
-By setting this rule’s `ignoreBracketsOfComputedNames` and `noCommaFirst` both to `true`, you can emulate the JSCS `requireObjectKeysOnNewLine` rule’s acceptance of both these patterns. You are then free to use `comma-style` as you wish on the 9 other node types that it can apply to. Of course, you should not combine this rule’s `noCommaFirst` option with `comma-style`’s `last` string option unless you include `"ObjectExpression": true` as a property of the `exceptions` object in your `comma-style` invocation. Otherwise, lines of object literals that begin or end with commas would pass one test but fail the other.
+By setting this rule’s `ignoreBracketsOfComputedNames` and `noCommaFirst` both to `true`, you can emulate the JSCS `requireObjectKeysOnNewLine` rule’s acceptance of both these patterns. You are then free to use `comma-style` as you wish on the 9 other node types that it can apply to. Of course, you should not combine this rule’s `noCommaFirst` option with `comma-style`’s `first` string option unless you include `"ObjectExpression": true` as a property of the `exceptions` object in your `comma-style` invocation. Otherwise, lines of object literals that begin or end with commas would pass one test but fail the other.
 
 ### Notations
 

--- a/docs/rules/object-property-newline.md
+++ b/docs/rules/object-property-newline.md
@@ -163,7 +163,7 @@ const newObject = {a: [
 
 because 1 character of the specification of `a` (i.e. the trailing `]` of its value) is on the same line as the specification of `b`.
 
-The `allowMultiplePropertiesPerLine` object option would not excuse this case, because the entire collection of property specifications spans 4 lines, not 1.
+The `allowAllPropertiesOnSameLine` object option would not excuse this case, because the entire collection of property specifications spans 4 lines, not 1.
 
 ### --fix
 

--- a/docs/rules/object-property-newline.md
+++ b/docs/rules/object-property-newline.md
@@ -148,7 +148,7 @@ const newObject = {
 };
 ```
 
-(This behavior differs from that of the JSCS rule cited below, which does not treat the leading `[` of a computed property name as part of that property specification. The JSCS rule prohibits the second of these formats but permits the first.)
+(This behavior differs from that of the JSCS `requireObjectKeysOnNewLine` rule, which does not treat the leading `[` of a computed property name as part of the property specification. The JSCS rule prohibits the second of these formats but permits the first.)
 
 ### Multiline Properties
 

--- a/docs/rules/object-property-newline.md
+++ b/docs/rules/object-property-newline.md
@@ -97,9 +97,9 @@ const newObject = {
 
 will be prohibited, because two properties, but not all properties, appear on the same line.
 
-#### `ignoreBracketsOfComputedProperties`
+#### `ignoreBracketsOfComputedNames`
 
-If you set `ignoreBracketsOfComputedProperties` to `true`, an object literal such as the one below will be permitted:
+If you set `ignoreBracketsOfComputedNames` to `true`, an object literal such as the one below will be permitted:
 
 ```js
 const newObject = {
@@ -125,7 +125,7 @@ const newFunction = multiplier => ({
 
 This object option makes the rule stricter by prohibiting one of the patterns by which you could comply with the rule. Specifically, the comma between two property specifications may not appear before the second one on the same line. The JSCS rule `requireObjectKeysOnNewLine` treats commas this way, so this object option makes ESLint compatible with JSCS in this respect.
 
-You can use the `comma-style` rule instead of this option to achieve partial JSCS compatibility, but not in combination with the `ignoreBracketsOfComputedProperties` object option. Using the `comma-style` rule for the sole purpose of JSCS compatibility would also require you to enumerate 9 exceptions, leaving only `ObjectExpression` subject to the rule.
+You can use the `comma-style` rule instead of this option to achieve partial JSCS compatibility, but not in combination with the `ignoreBracketsOfComputedNames` object option. Using the `comma-style` rule for the sole purpose of JSCS compatibility would also require you to enumerate 9 exceptions, leaving only `ObjectExpression` subject to the rule.
 
 ### Notations
 
@@ -288,10 +288,10 @@ const obj = {
 };
 ```
 
-Example of additional **correct** code for this rule with the `{ "ignoreBracketsOfComputedProperties": true }` option:
+Example of additional **correct** code for this rule with the `{ "ignoreBracketsOfComputedNames": true }` option:
 
 ```js
-/*eslint object-property-newline: ["error", { "ignoreBracketsOfComputedProperties": true }]*/
+/*eslint object-property-newline: ["error", { "ignoreBracketsOfComputedNames": true }]*/
 
 const domain = process.argv[4];
 const obj = {

--- a/docs/rules/object-property-newline.md
+++ b/docs/rules/object-property-newline.md
@@ -75,7 +75,7 @@ Another benefit of this rule is specificity of diffs when a property is changed:
 
 The rule offers three object options.
 
-#### `allowMultiplePropertiesPerLine`
+#### `allowAllPropertiesOnSameLine`
 
 If you set `allowAllPropertiesOnSameLine` (a deprecated synonym is `allowMultiplePropertiesPerLine`) to `true`, object literals such as the first two above, with all property specifications on the same line, will be permitted, but one like
 

--- a/lib/config/config-validator.js
+++ b/lib/config/config-validator.js
@@ -98,7 +98,8 @@ function validateRuleSchema(rule, localOptions) {
  * @param {{create: Function}|null} rule The rule that the config is being validated for
  * @param {string} ruleId The rule's unique name.
  * @param {array|number} options The given options for the rule.
- * @param {string} source The name of the configuration source to report in any errors.
+ * @param {string|null} source The name of the configuration source to report in any errors. If null or undefined,
+ * no source is prepended to the message.
  * @returns {void}
  */
 function validateRuleOptions(rule, ruleId, options, source) {
@@ -112,7 +113,13 @@ function validateRuleOptions(rule, ruleId, options, source) {
             validateRuleSchema(rule, Array.isArray(options) ? options.slice(1) : []);
         }
     } catch (err) {
-        throw new Error(`${source}:\n\tConfiguration for rule "${ruleId}" is invalid:\n${err.message}`);
+        const enhancedMessage = `Configuration for rule "${ruleId}" is invalid:\n${err.message}`;
+
+        if (typeof source === "string") {
+            throw new Error(`${source}:\n\t${enhancedMessage}`);
+        } else {
+            throw new Error(enhancedMessage);
+        }
     }
 }
 

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -340,7 +340,21 @@ function modifyConfigsFromComments(filename, ast, config, ruleMapper) {
                             Object.keys(parseResult.config).forEach(name => {
                                 const ruleValue = parseResult.config[name];
 
-                                validator.validateRuleOptions(ruleMapper(name), name, ruleValue, `${filename} line ${comment.loc.start.line}`);
+                                try {
+                                    validator.validateRuleOptions(ruleMapper(name), name, ruleValue);
+                                } catch (err) {
+                                    problems.push({
+                                        ruleId: name,
+                                        severity: 2,
+                                        source: null,
+                                        message: err.message,
+                                        line: comment.loc.start.line,
+                                        column: comment.loc.start.column + 1,
+                                        endLine: comment.loc.end.line,
+                                        endColumn: comment.loc.end.column + 1,
+                                        nodeType: null
+                                    });
+                                }
                                 commentRules[name] = ruleValue;
                             });
                         } else {

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -442,6 +442,7 @@ class OffsetStorage {
                 const offset = (
                     offsetInfo.from &&
                     offsetInfo.from.loc.start.line === token.loc.start.line &&
+                    !/^\s*?\n/.test(token.value) &&
                     !offsetInfo.force
                 ) ? 0 : offsetInfo.offset * this._indentSize;
 
@@ -836,7 +837,7 @@ module.exports = {
                     const previousElement = elements[index - 1];
                     const firstTokenOfPreviousElement = previousElement && getFirstToken(previousElement);
 
-                    if (previousElement && sourceCode.getLastToken(previousElement).loc.start.line > startToken.loc.end.line) {
+                    if (previousElement && sourceCode.getLastToken(previousElement).loc.end.line > startToken.loc.end.line) {
                         offsets.setDesiredOffsets(element.range, firstTokenOfPreviousElement, 0);
                     }
                 }

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -1094,8 +1094,8 @@ module.exports = {
                     const questionMarkToken = sourceCode.getFirstTokenBetween(node.test, node.consequent, token => token.type === "Punctuator" && token.value === "?");
                     const colonToken = sourceCode.getFirstTokenBetween(node.consequent, node.alternate, token => token.type === "Punctuator" && token.value === ":");
 
-                    const firstConsequentToken = sourceCode.getTokenAfter(questionMarkToken, { includeComments: true });
-                    const lastConsequentToken = sourceCode.getTokenBefore(colonToken, { includeComments: true });
+                    const firstConsequentToken = sourceCode.getTokenAfter(questionMarkToken);
+                    const lastConsequentToken = sourceCode.getTokenBefore(colonToken);
                     const firstAlternateToken = sourceCode.getTokenAfter(colonToken);
 
                     offsets.setDesiredOffset(questionMarkToken, firstToken, 1);

--- a/lib/rules/object-property-newline.js
+++ b/lib/rules/object-property-newline.js
@@ -65,26 +65,26 @@ module.exports = {
 
         /**
          * Returns whether a property begins with a bracket that ends its line.
-         * @param {token} myToken0 Current property’s first token.
+         * @param {token} firstToken Current property’s first token.
          * @param {sourceCode} source Current property’s sourceCode.
          * @param {number} myLine Current property’s first token’s line.
          * @returns {boolean} Whether or not the property begins with a bracket that ends its line.
          */
-        function validPerOpenBracket(myToken0, source, myLine) {
-            return myToken0.type === "Punctuator" &&
-                myToken0.value === "[" &&
-                source.getTokenAfter(myToken0).loc.start.line > myLine;
+        function validPerOpenBracket(firstToken, source, myLine) {
+            return firstToken.type === "Punctuator" &&
+                firstToken.value === "[" &&
+                source.getTokenAfter(firstToken).loc.start.line > myLine;
         }
 
         /**
          * Returns whether a comma precedes a property on the same line.
-         * @param {token} myToken0 Current property’s first token.
+         * @param {token} firstToken Current property’s first token.
          * @param {sourceCode} source Current property’s sourceCode.
          * @param {number} myLine Current property’s first token’s line.
          * @returns {boolean} Whether or not a comma precedes the property on the same line.
          */
-        function validPerLeadingComma(myToken0, source, myLine) {
-            const tokenBeforeCurrentProperty = source.getTokenBefore(myToken0);
+        function validPerLeadingComma(firstToken, source, myLine) {
+            const tokenBeforeCurrentProperty = source.getTokenBefore(firstToken);
 
             return tokenBeforeCurrentProperty.type !== "Punctuator" ||
                 tokenBeforeCurrentProperty.value !== "," ||

--- a/lib/rules/object-property-newline.js
+++ b/lib/rules/object-property-newline.js
@@ -27,6 +27,12 @@ module.exports = {
                     },
                     allowMultiplePropertiesPerLine: { // Deprecated
                         type: "boolean"
+                    },
+                    treatComputedPropertiesLikeJSCS: {
+                        type: "boolean"
+                    },
+                    noCommaFirst: {
+                        type: "boolean"
                     }
                 },
                 additionalProperties: false
@@ -41,11 +47,49 @@ module.exports = {
             Boolean(context.options[0].allowAllPropertiesOnSameLine) ||
             Boolean(context.options[0].allowMultiplePropertiesPerLine) // Deprecated
         );
-        const errorMessage = allowSameLine
+        const allowOpenBracket = context.options[0] && Boolean(context.options[0].treatComputedPropertiesLikeJSCS);
+        const denyCommaFirst = context.options[0] && Boolean(context.options[0].noCommaFirst);
+        let errorMessage = allowSameLine
             ? "Object properties must go on a new line if they aren't all on the same line."
             : "Object properties must go on a new line.";
 
+        if (allowOpenBracket) {
+            errorMessage += " The opening bracket of a computed property name may end a line on which another property appears.";
+        }
+
+        if (denyCommaFirst) {
+            errorMessage += " The comma delimiting two properties may not share a line with any of the second property.";
+        }
+
         const sourceCode = context.getSourceCode();
+
+        /**
+         * Returns whether a property begins with a bracket that ends its line.
+         * @param {token} myToken0 Current property’s first token.
+         * @param {sourceCode} source Current property’s sourceCode.
+         * @param {number} myLine Current property’s first token’s line.
+         * @returns {boolean} Whether or not the property begins with a bracket that ends its line.
+         */
+        function validPerOpenBracket(myToken0, source, myLine) {
+            return myToken0.type === "Punctuator" &&
+                myToken0.value === "[" &&
+                source.getTokenAfter(myToken0).loc.start.line > myLine;
+        }
+
+        /**
+         * Returns whether a comma precedes a property on the same line.
+         * @param {token} myToken0 Current property’s first token.
+         * @param {sourceCode} source Current property’s sourceCode.
+         * @param {number} myLine Current property’s first token’s line.
+         * @returns {boolean} Whether or not a comma precedes the property on the same line.
+         */
+        function validPerLeadingComma(myToken0, source, myLine) {
+            const tokenBeforeCurrentProperty = source.getTokenBefore(myToken0);
+
+            return tokenBeforeCurrentProperty.type !== "Punctuator" ||
+                tokenBeforeCurrentProperty.value !== "," ||
+                tokenBeforeCurrentProperty.loc.end.line !== myLine;
+        }
 
         return {
             ObjectExpression(node) {
@@ -54,7 +98,7 @@ module.exports = {
                         const firstTokenOfFirstProperty = sourceCode.getFirstToken(node.properties[0]);
                         const lastTokenOfLastProperty = sourceCode.getLastToken(node.properties[node.properties.length - 1]);
 
-                        if (firstTokenOfFirstProperty.loc.end.line === lastTokenOfLastProperty.loc.start.line) {
+                        if (firstTokenOfFirstProperty.loc.start.line === lastTokenOfLastProperty.loc.end.line) {
 
                             // All keys and values are on the same line
                             return;
@@ -63,10 +107,36 @@ module.exports = {
                 }
 
                 for (let i = 1; i < node.properties.length; i++) {
-                    const lastTokenOfPreviousProperty = sourceCode.getLastToken(node.properties[i - 1]);
-                    const firstTokenOfCurrentProperty = sourceCode.getFirstToken(node.properties[i]);
+                    const lastTokenOfPreviousProperty = sourceCode.getLastToken(node.properties[i - 1]),
+                        firstTokenOfCurrentProperty = sourceCode.getFirstToken(node.properties[i]),
+                        previousPropertyEndLine = lastTokenOfPreviousProperty.loc.end.line,
+                        currentPropertyStartLine = firstTokenOfCurrentProperty.loc.start.line,
+                        currentPropertyIsOnNewLine = previousPropertyEndLine < currentPropertyStartLine;
+                    let currentPropertyIsValid;
 
-                    if (lastTokenOfPreviousProperty.loc.end.line === firstTokenOfCurrentProperty.loc.start.line) {
+                    if (!allowOpenBracket && !denyCommaFirst) {
+                        currentPropertyIsValid = currentPropertyIsOnNewLine;
+                    } else {
+
+                        if (allowOpenBracket && !denyCommaFirst) {
+                            currentPropertyIsValid =
+                                currentPropertyIsOnNewLine ||
+                                validPerOpenBracket(firstTokenOfCurrentProperty, sourceCode, currentPropertyStartLine);
+                        } else if (!allowOpenBracket && denyCommaFirst) {
+                            currentPropertyIsValid =
+                                currentPropertyIsOnNewLine &&
+                                validPerLeadingComma(firstTokenOfCurrentProperty, sourceCode, currentPropertyStartLine);
+                        } else if (allowOpenBracket && denyCommaFirst) {
+
+                            // A line containing only “, [” is valid here.
+                            currentPropertyIsValid = validPerOpenBracket(firstTokenOfCurrentProperty, sourceCode, currentPropertyStartLine) || (
+                                currentPropertyIsOnNewLine &&
+                                validPerLeadingComma(firstTokenOfCurrentProperty, sourceCode, currentPropertyStartLine)
+                            );
+                        }
+                    }
+
+                    if (!currentPropertyIsValid) {
                         context.report({
                             node,
                             loc: firstTokenOfCurrentProperty.loc.start,

--- a/lib/rules/object-property-newline.js
+++ b/lib/rules/object-property-newline.js
@@ -28,7 +28,7 @@ module.exports = {
                     allowMultiplePropertiesPerLine: { // Deprecated
                         type: "boolean"
                     },
-                    ignoreBracketsOfComputedProperties: {
+                    ignoreBracketsOfComputedNames: {
                         type: "boolean"
                     },
                     noCommaFirst: {
@@ -47,7 +47,7 @@ module.exports = {
             Boolean(context.options[0].allowAllPropertiesOnSameLine) ||
             Boolean(context.options[0].allowMultiplePropertiesPerLine) // Deprecated
         );
-        const allowOpenBracket = context.options[0] && Boolean(context.options[0].ignoreBracketsOfComputedProperties);
+        const allowOpenBracket = context.options[0] && Boolean(context.options[0].ignoreBracketsOfComputedNames);
         const denyCommaFirst = context.options[0] && Boolean(context.options[0].noCommaFirst);
         let errorMessage = allowSameLine
             ? "Object properties must go on a new line if they aren't all on the same line."

--- a/lib/rules/object-property-newline.js
+++ b/lib/rules/object-property-newline.js
@@ -28,7 +28,7 @@ module.exports = {
                     allowMultiplePropertiesPerLine: { // Deprecated
                         type: "boolean"
                     },
-                    treatComputedPropertiesLikeJSCS: {
+                    ignoreBracketsOfComputedProperties: {
                         type: "boolean"
                     },
                     noCommaFirst: {
@@ -47,7 +47,7 @@ module.exports = {
             Boolean(context.options[0].allowAllPropertiesOnSameLine) ||
             Boolean(context.options[0].allowMultiplePropertiesPerLine) // Deprecated
         );
-        const allowOpenBracket = context.options[0] && Boolean(context.options[0].treatComputedPropertiesLikeJSCS);
+        const allowOpenBracket = context.options[0] && Boolean(context.options[0].ignoreBracketsOfComputedProperties);
         const denyCommaFirst = context.options[0] && Boolean(context.options[0].noCommaFirst);
         let errorMessage = allowSameLine
             ? "Object properties must go on a new line if they aren't all on the same line."

--- a/lib/rules/prefer-destructuring.js
+++ b/lib/rules/prefer-destructuring.js
@@ -165,8 +165,10 @@ module.exports = {
             if (shouldCheck(reportNode.type, "object")) {
                 const property = rightNode.property;
 
-                if ((property.type === "Literal" && leftNode.name === property.value) || (property.type === "Identifier" &&
-                    leftNode.name === property.name)) {
+                if (
+                    (property.type === "Literal" && leftNode.name === property.value) ||
+                    (property.type === "Identifier" && leftNode.name === property.name && !rightNode.computed)
+                ) {
                     report(reportNode, "object");
                 }
             }

--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -1615,14 +1615,42 @@ describe("Linter", () => {
     });
 
     describe("when evaluating code with invalid comments to enable rules", () => {
-        const code = "/*eslint no-alert:true*/ alert('test');";
+        it("should report a violation when the config is not a valid rule configuration", () => {
+            assert.deepStrictEqual(
+                linter.verify("/*eslint no-alert:true*/ alert('test');", {}),
+                [
+                    {
+                        severity: 2,
+                        ruleId: "no-alert",
+                        message: "Configuration for rule \"no-alert\" is invalid:\n\tSeverity should be one of the following: 0 = off, 1 = warn, 2 = error (you passed 'true').\n",
+                        line: 1,
+                        column: 1,
+                        endLine: 1,
+                        endColumn: 25,
+                        source: null,
+                        nodeType: null
+                    }
+                ]
+            );
+        });
 
-        it("should report a violation", () => {
-            const config = { rules: {} };
-
-            const fn = linter.verify.bind(linter, code, config, filename);
-
-            assert.throws(fn, "filename.js line 1:\n\tConfiguration for rule \"no-alert\" is invalid:\n\tSeverity should be one of the following: 0 = off, 1 = warn, 2 = error (you passed 'true').\n");
+        it("should report a violation when the config violates a rule's schema", () => {
+            assert.deepStrictEqual(
+                linter.verify("/* eslint no-alert: [error, {nonExistentPropertyName: true}]*/", {}),
+                [
+                    {
+                        severity: 2,
+                        ruleId: "no-alert",
+                        message: "Configuration for rule \"no-alert\" is invalid:\n\tValue [{\"nonExistentPropertyName\":true}] should NOT have more than 0 items.\n",
+                        line: 1,
+                        column: 1,
+                        endLine: 1,
+                        endColumn: 63,
+                        source: null,
+                        nodeType: null
+                    }
+                ]
+            );
         });
     });
 

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -4796,7 +4796,16 @@ ruleTester.run("indent", rule, {
                 }
             `,
             options: [4, { ignoreComments: true }]
-        }
+        },
+        unIndent`
+            const obj = {
+                foo () {
+                    return condition ? // comment
+                        1 :
+                        2
+                }
+            }
+        `
     ],
 
     invalid: [
@@ -9261,6 +9270,27 @@ ruleTester.run("indent", rule, {
             `,
             options: [4, { ignoreComments: false }],
             errors: expectedErrors([4, 4, 0, "Block"])
+        },
+        {
+            code: unIndent`
+                const obj = {
+                    foo () {
+                        return condition ? // comment
+                        1 :
+                            2
+                    }
+                }
+            `,
+            output: unIndent`
+                const obj = {
+                    foo () {
+                        return condition ? // comment
+                            1 :
+                            2
+                    }
+                }
+            `,
+            errors: expectedErrors([4, 12, 8, "Numeric"])
         }
     ]
 });

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -2831,6 +2831,13 @@ ruleTester.run("indent", rule, {
             options: [2]
         },
         unIndent`
+            foo(\`
+                bar
+            \`, {
+                baz: 1
+            });
+        `,
+        unIndent`
             function foo() {
                 \`foo\${bar}baz\${
                     qux}foo\${
@@ -3856,21 +3863,20 @@ ruleTester.run("indent", rule, {
         unIndent`
             foo(\`foo
                     \`, {
-                    ok: true
-                },
-                {
-                    ok: false
-                }
-            )
+                ok: true
+            },
+            {
+                ok: false
+            })
         `,
         unIndent`
             foo(tag\`foo
                     \`, {
-                    ok: true
-                },
-                {
-                    ok: false
-                }
+                ok: true
+            },
+            {
+                ok: false
+            }
             )
         `,
 

--- a/tests/lib/rules/object-property-newline.js
+++ b/tests/lib/rules/object-property-newline.js
@@ -573,11 +573,11 @@ ruleTester.run("object-property-newline", rule, {
             ]
         },
 
-        // treatComputedPropertiesLikeJSCS: true
+        // ignoreBracketsOfComputedProperties: true
         {
             code: "foo({\nk1: 'val1', [\nisFoo ? 'foo' : 'noo'\n]: 'val2', baz})",
             output: "foo({\nk1: 'val1', [\nisFoo ? 'foo' : 'noo'\n]: 'val2',\nbaz})",
-            options: [{ treatComputedPropertiesLikeJSCS: true }],
+            options: [{ ignoreBracketsOfComputedProperties: true }],
             parserOptions: { ecmaVersion: 6 },
             errors: [
                 {
@@ -591,7 +591,7 @@ ruleTester.run("object-property-newline", rule, {
         {
             code: "var obj = { k1: 'val1',\nk2: [\n'val2a', 'val2b', 'val2c'\n], k3: 'val3' };",
             output: "var obj = { k1: 'val1',\nk2: [\n'val2a', 'val2b', 'val2c'\n],\nk3: 'val3' };",
-            options: [{ treatComputedPropertiesLikeJSCS: true }],
+            options: [{ ignoreBracketsOfComputedProperties: true }],
             errors: [
                 {
                     message: "Object properties must go on a new line. The opening bracket of a computed property name may end a line on which another property appears.",
@@ -643,12 +643,12 @@ ruleTester.run("object-property-newline", rule, {
             ]
         },
 
-        // { treatComputedPropertiesLikeJSCS: true, noCommaFirst: true }
+        // { ignoreBracketsOfComputedProperties: true, noCommaFirst: true }
         {
             code: "var obj = {\nk1: 'val1'\n, k2: 'val2'\n, [\nbaz2\n]: 'val3'\n};",
             output: "var obj = {\nk1: 'val1'\n,\nk2: 'val2'\n, [\nbaz2\n]: 'val3'\n};",
             options: [{
-                treatComputedPropertiesLikeJSCS: true, noCommaFirst: true
+                ignoreBracketsOfComputedProperties: true, noCommaFirst: true
             }],
             parserOptions: { ecmaVersion: 6 },
             errors: [

--- a/tests/lib/rules/object-property-newline.js
+++ b/tests/lib/rules/object-property-newline.js
@@ -22,7 +22,7 @@ ruleTester.run("object-property-newline", rule, {
 
     valid: [
 
-        // default-case
+        // default case
         "var obj = {\nk1: 'val1',\nk2: 'val2',\nk3: 'val3',\nk4: 'val4'\n};",
         "var obj = {\nk1: 'val1'\n, k2: 'val2'\n, k3: 'val3'\n, k4: 'val4'\n};",
         "var obj = { k1: 'val1',\nk2: 'val2',\nk3: 'val3',\nk4: 'val4' };",
@@ -65,6 +65,7 @@ ruleTester.run("object-property-newline", rule, {
 
         // allowMultiplePropertiesPerLine: true (deprecated)
         { code: "var obj = { k1: 'val1', k2: 'val2', k3: 'val3' };", options: [{ allowMultiplePropertiesPerLine: true }] }
+
     ],
 
     invalid: [
@@ -568,6 +569,94 @@ ruleTester.run("object-property-newline", rule, {
                     type: "ObjectExpression",
                     line: 3,
                     column: 13
+                }
+            ]
+        },
+
+        // treatComputedPropertiesLikeJSCS: true
+        {
+            code: "foo({\nk1: 'val1', [\nisFoo ? 'foo' : 'noo'\n]: 'val2', baz})",
+            output: "foo({\nk1: 'val1', [\nisFoo ? 'foo' : 'noo'\n]: 'val2',\nbaz})",
+            options: [{ treatComputedPropertiesLikeJSCS: true }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    message: "Object properties must go on a new line. The opening bracket of a computed property name may end a line on which another property appears.",
+                    type: "ObjectExpression",
+                    line: 4,
+                    column: 12
+                }
+            ]
+        },
+        {
+            code: "var obj = { k1: 'val1',\nk2: [\n'val2a', 'val2b', 'val2c'\n], k3: 'val3' };",
+            output: "var obj = { k1: 'val1',\nk2: [\n'val2a', 'val2b', 'val2c'\n],\nk3: 'val3' };",
+            options: [{ treatComputedPropertiesLikeJSCS: true }],
+            errors: [
+                {
+                    message: "Object properties must go on a new line. The opening bracket of a computed property name may end a line on which another property appears.",
+                    type: "ObjectExpression",
+                    line: 4,
+                    column: 4
+                }
+            ]
+        },
+
+        // noCommaFirst: true
+        {
+            code: "var obj = {\nk1: 'val1'\n, k2: 'val2'\n, k3: 'val3'\n};",
+            output: "var obj = {\nk1: 'val1'\n,\nk2: 'val2'\n,\nk3: 'val3'\n};",
+            options: [{ noCommaFirst: true }],
+            errors: [
+                {
+                    message: "Object properties must go on a new line. The comma delimiting two properties may not share a line with any of the second property.",
+                    type: "ObjectExpression",
+                    line: 3,
+                    column: 3
+                },
+                {
+                    message: "Object properties must go on a new line. The comma delimiting two properties may not share a line with any of the second property.",
+                    type: "ObjectExpression",
+                    line: 4,
+                    column: 3
+                }
+            ]
+        },
+        {
+            code: "var obj = {\nk1: 'val1'\n, k2: 'val2'\n, [\nbaz1\n]: 'val3'\n};",
+            output: "var obj = {\nk1: 'val1'\n,\nk2: 'val2'\n,\n[\nbaz1\n]: 'val3'\n};",
+            options: [{ noCommaFirst: true }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    message: "Object properties must go on a new line. The comma delimiting two properties may not share a line with any of the second property.",
+                    type: "ObjectExpression",
+                    line: 3,
+                    column: 3
+                },
+                {
+                    message: "Object properties must go on a new line. The comma delimiting two properties may not share a line with any of the second property.",
+                    type: "ObjectExpression",
+                    line: 4,
+                    column: 3
+                }
+            ]
+        },
+
+        // { treatComputedPropertiesLikeJSCS: true, noCommaFirst: true }
+        {
+            code: "var obj = {\nk1: 'val1'\n, k2: 'val2'\n, [\nbaz2\n]: 'val3'\n};",
+            output: "var obj = {\nk1: 'val1'\n,\nk2: 'val2'\n, [\nbaz2\n]: 'val3'\n};",
+            options: [{
+                treatComputedPropertiesLikeJSCS: true, noCommaFirst: true
+            }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    message: "Object properties must go on a new line. The opening bracket of a computed property name may end a line on which another property appears. The comma delimiting two properties may not share a line with any of the second property.",
+                    type: "ObjectExpression",
+                    line: 3,
+                    column: 3
                 }
             ]
         }

--- a/tests/lib/rules/object-property-newline.js
+++ b/tests/lib/rules/object-property-newline.js
@@ -573,11 +573,11 @@ ruleTester.run("object-property-newline", rule, {
             ]
         },
 
-        // ignoreBracketsOfComputedProperties: true
+        // ignoreBracketsOfComputedNames: true
         {
             code: "foo({\nk1: 'val1', [\nisFoo ? 'foo' : 'noo'\n]: 'val2', baz})",
             output: "foo({\nk1: 'val1', [\nisFoo ? 'foo' : 'noo'\n]: 'val2',\nbaz})",
-            options: [{ ignoreBracketsOfComputedProperties: true }],
+            options: [{ ignoreBracketsOfComputedNames: true }],
             parserOptions: { ecmaVersion: 6 },
             errors: [
                 {
@@ -591,7 +591,7 @@ ruleTester.run("object-property-newline", rule, {
         {
             code: "var obj = { k1: 'val1',\nk2: [\n'val2a', 'val2b', 'val2c'\n], k3: 'val3' };",
             output: "var obj = { k1: 'val1',\nk2: [\n'val2a', 'val2b', 'val2c'\n],\nk3: 'val3' };",
-            options: [{ ignoreBracketsOfComputedProperties: true }],
+            options: [{ ignoreBracketsOfComputedNames: true }],
             errors: [
                 {
                     message: "Object properties must go on a new line. The opening bracket of a computed property name may end a line on which another property appears.",
@@ -643,12 +643,12 @@ ruleTester.run("object-property-newline", rule, {
             ]
         },
 
-        // { ignoreBracketsOfComputedProperties: true, noCommaFirst: true }
+        // { ignoreBracketsOfComputedNames: true, noCommaFirst: true }
         {
             code: "var obj = {\nk1: 'val1'\n, k2: 'val2'\n, [\nbaz2\n]: 'val3'\n};",
             output: "var obj = {\nk1: 'val1'\n,\nk2: 'val2'\n, [\nbaz2\n]: 'val3'\n};",
             options: [{
-                ignoreBracketsOfComputedProperties: true, noCommaFirst: true
+                ignoreBracketsOfComputedNames: true, noCommaFirst: true
             }],
             parserOptions: { ecmaVersion: 6 },
             errors: [

--- a/tests/lib/rules/object-property-newline.js
+++ b/tests/lib/rules/object-property-newline.js
@@ -67,11 +67,11 @@ ruleTester.run("object-property-newline", rule, {
         { code: "var obj = { k1: 'val1', k2: 'val2', k3: 'val3' };", options: [{ allowMultiplePropertiesPerLine: true }] },
 
         // ignoreBracketsOfComputedNames: true
-        { code: "var obj = { k1: 'val1', [\nk2\k]: 'val2' };", options: [{ ignoreBracketsOfComputedNames: true }], parserOptions: { ecmaVersion: 6 } },
+        { code: "var obj = { k1: 'val1', [\nk2\n]: 'val2' };", options: [{ ignoreBracketsOfComputedNames: true }], parserOptions: { ecmaVersion: 6 } },
 
         // noCommaFirst: true
         { code: "var obj = { k1: 'val1',\nk2: 'val2',\nk3: 'val3',\nk4: 'val4' };", options: [{ noCommaFirst: true }] },
-        { code: "var obj = { k1: 'val1'\n,\nk2: 'val2'\n,\nk3: 'val3'\n,\nk4: 'val4' };", options: [{ noCommaFirst: true }] }
+        { code: "var obj = { k1: 'val1'\n,\nk2: 'val2'\n,\nk3: 'val3'\n,\nk4: 'val4' };", options: [{ noCommaFirst: true }] },
 
         // { ignoreBracketsOfComputedNames: true, noCommaFirst: true }
         { code: "var obj = { k1: 'val1'\n, [\nk2 + 'prop'\n]: 'val2' };", options: [{ ignoreBracketsOfComputedNames: true }], parserOptions: { ecmaVersion: 6 } }

--- a/tests/lib/rules/object-property-newline.js
+++ b/tests/lib/rules/object-property-newline.js
@@ -64,7 +64,17 @@ ruleTester.run("object-property-newline", rule, {
         { code: "var obj = {\nk1: 'val1', k2: {e1: 'foo', e2: 'bar'}, k3: 'val2'\n};", options: [{ allowAllPropertiesOnSameLine: true }] },
 
         // allowMultiplePropertiesPerLine: true (deprecated)
-        { code: "var obj = { k1: 'val1', k2: 'val2', k3: 'val3' };", options: [{ allowMultiplePropertiesPerLine: true }] }
+        { code: "var obj = { k1: 'val1', k2: 'val2', k3: 'val3' };", options: [{ allowMultiplePropertiesPerLine: true }] },
+
+        // ignoreBracketsOfComputedNames: true
+        { code: "var obj = { k1: 'val1', [\nk2\k]: 'val2' };", options: [{ ignoreBracketsOfComputedNames: true }], parserOptions: { ecmaVersion: 6 } },
+
+        // noCommaFirst: true
+        { code: "var obj = { k1: 'val1',\nk2: 'val2',\nk3: 'val3',\nk4: 'val4' };", options: [{ noCommaFirst: true }] },
+        { code: "var obj = { k1: 'val1'\n,\nk2: 'val2'\n,\nk3: 'val3'\n,\nk4: 'val4' };", options: [{ noCommaFirst: true }] }
+
+        // { ignoreBracketsOfComputedNames: true, noCommaFirst: true }
+        { code: "var obj = { k1: 'val1'\n, [\nk2 + 'prop'\n]: 'val2' };", options: [{ ignoreBracketsOfComputedNames: true }], parserOptions: { ecmaVersion: 6 } }
 
     ],
 

--- a/tests/lib/rules/prefer-destructuring.js
+++ b/tests/lib/rules/prefer-destructuring.js
@@ -131,7 +131,9 @@ ruleTester.run("prefer-destructuring", rule, {
             code: "var foo = object.foo;",
             options: [{ VariableDeclarator: { object: false }, AssignmentExpression: { object: true } }]
         },
-        "class Foo extends Bar { static foo() {var foo = super.foo} }"
+        "class Foo extends Bar { static foo() {var foo = super.foo} }",
+        "foo = bar[foo];",
+        "var foo = bar[foo];"
     ],
 
     invalid: [


### PR DESCRIPTION
New options make the rule compatible with JSCS rule requireObjectKeysOnNewLine.
Need for noCommaFirst option, instead of comma-style, explained in the rule document. Partly fixes issue #6251.

<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
**What rule do you want to change?**
`object-property-newline`

**Does this change cause the rule to produce more or fewer warnings?**
No.

**How will the change be implemented? (New option, new default behavior, etc.)?**
2 new options.

**Please provide some example code that this change will affect:**

```js
const newObject = {
    a: 1, [
        process.argv[4]
    ]: '01'
};
```

**What does the rule currently do for this code?**
Treats it as invalid.

**What will the rule do after it's changed?**
Treat it as valid if the `treatComputedPropertiesLikeJSCS` object option is set to `true`.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Added 2 options to `object-property-newline` for compatibility with JSCS rule `requireObjectKeysOnNewLine`.

**Is there anything you'd like reviewers to focus on?**
Determine whether my judgment is correct that the `comma-style` rule cannot be relied on to achieve compatibility with the JSCS rule and therefore the `noCommaFirst` object option is appropriate. See conversation in PR #9522.

