### PR TITLE
Update: Add NewExpression support to comma-style

### DIFF
--- a/docs/rules/comma-style.md
+++ b/docs/rules/comma-style.md
@@ -37,6 +37,7 @@ This rule also accepts an additional `exceptions` object:
     * `"ObjectExpression": true` ignores comma style in object literals
     * `"ObjectPattern": true` ignores comma style in object patterns of destructuring
     * `"VariableDeclaration": true` ignores comma style in variable declarations
+    * `"NewExpression": true` ignores comma style in the parameters of constructor expressions
 
 A way to determine the node types as defined by [ESTree](https://github.com/estree/estree) is to use the [online demo](https://eslint.org/parser).
 

--- a/lib/rules/comma-style.js
+++ b/lib/rules/comma-style.js
@@ -48,7 +48,8 @@ module.exports = {
             FunctionDeclaration: true,
             FunctionExpression: true,
             ImportDeclaration: true,
-            ObjectPattern: true
+            ObjectPattern: true,
+            NewExpression: true
         };
 
         if (context.options.length === 2 && context.options[1].hasOwnProperty("exceptions")) {
@@ -291,6 +292,11 @@ module.exports = {
         if (!exceptions.ImportDeclaration) {
             nodes.ImportDeclaration = function(node) {
                 validateComma(node, "specifiers");
+            };
+        }
+        if (!exceptions.NewExpression) {
+            nodes.NewExpression = function(node) {
+                validateComma(node, "arguments");
             };
         }
 

--- a/tests/lib/rules/comma-style.js
+++ b/tests/lib/rules/comma-style.js
@@ -40,6 +40,7 @@ ruleTester.run("comma-style", rule, {
         "var foo = [\n(bar),\nbaz\n];",
         "var foo = [\n(bar\n),\nbaz\n];",
         "var foo = [\n(\nbar\n),\nbaz\n];",
+        "new Foo(a\n,b);",
         { code: "var foo = [\n(bar\n)\n,baz\n];", options: ["first"] },
         "var foo = \n1, \nbar = [1,\n2,\n3]",
         { code: "var foo = ['apples'\n,'oranges'];", options: ["first"] },
@@ -49,6 +50,7 @@ ruleTester.run("comma-style", rule, {
         { code: "var foo = [1 \n ,2 \n, 3];", options: ["first"] },
         { code: "function foo(){return {'a': 1\n,'b': 2}}", options: ["first"] },
         { code: "function foo(){var a=[1\n, 2]}", options: ["first"] },
+        { code: "new Foo(a,\nb);", options: ["first"] },
         "f(1\n, 2);",
         "function foo(a\n, b) { return a + b; }",
         {
@@ -128,6 +130,14 @@ ruleTester.run("comma-style", rule, {
             parserOptions: {
                 ecmaVersion: 6
             }
+        },
+        {
+            code: "new Foo(a,\nb);",
+            options: ["first", {
+                exceptions: {
+                    NewExpression: true
+                }
+            }]
         },
         {
             code: "f(1\n, 2);",
@@ -211,6 +221,22 @@ ruleTester.run("comma-style", rule, {
             parserOptions: {
                 ecmaVersion: 6
             }
+        },
+        {
+            code: "new Foo(a,\nb);",
+            options: ["last", {
+                exceptions: {
+                    NewExpression: false
+                }
+            }]
+        },
+        {
+            code: "new Foo(a\n,b);",
+            options: ["last", {
+                exceptions: {
+                    NewExpression: true
+                }
+            }]
         }
     ],
 
@@ -254,6 +280,16 @@ ruleTester.run("comma-style", rule, {
                 message: BAD_LN_BRK_MSG,
                 type: "VariableDeclarator"
             }]
+        },
+        {
+            code: "new Foo(a\n,\nb);",
+            output: "new Foo(a,\nb);",
+            options: ["last", {
+                exceptions: {
+                    NewExpression: false
+                }
+            }],
+            errors: [{ message: BAD_LN_BRK_MSG }]
         },
         {
             code: "var foo = 1\n,bar = 2;",
@@ -544,6 +580,16 @@ ruleTester.run("comma-style", rule, {
             }]
         },
         {
+            code: "new Foo(a,\nb);",
+            output: "new Foo(a\n,b);",
+            options: ["first", {
+                exceptions: {
+                    NewExpression: false
+                }
+            }],
+            errors: [{ message: FIRST_MSG }]
+        },
+        {
             code: "var foo = [\n(bar\n)\n,\nbaz\n];",
             output: "var foo = [\n(bar\n),\nbaz\n];",
             errors: [{
@@ -555,6 +601,16 @@ ruleTester.run("comma-style", rule, {
             code: "[(foo),\n,\nbar]",
             output: "[(foo),,\nbar]",
             errors: [{ message: BAD_LN_BRK_MSG }]
+        },
+        {
+            code: "new Foo(a\n,b);",
+            output: "new Foo(a,\nb);",
+            options: ["last", {
+                exceptions: {
+                    NewExpression: false
+                }
+            }],
+            errors: [{ message: LAST_MSG }]
         }
     ]
 });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**What rule do you want to change?**

comma-style


**Does this change cause the rule to produce more or fewer warnings?**

more, if new option is enabled


**How will the change be implemented? (New option, new default behavior, etc.)?**

New `exceptions.NewExpression` option, which defaults to true, and can be set to false for the new behaviour.


**Please provide some example code that this change will affect:**

```js
new Date(
  2017
  ,11
  ,7)
```

**What does the rule currently do for this code?**

No errors.

**What will the rule do after it's changed?**

Gives an error that `',' should be placed last.`

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

I added a `NewExpression` exception in the same style as the existing `comma-style` exceptions (`FunctionExpression` etc.)


**Is there anything you'd like reviewers to focus on?**

