### PR TITLE
Update: add `beforeStatementContinuationChars` to semi (fixes #9521)

### DIFF
--- a/docs/rules/semi.md
+++ b/docs/rules/semi.md
@@ -72,6 +72,7 @@ Object option (when `"always"`):
 
 Object option (when `"never"`):
 
+* `"beforeStatementContinuationChars": "any"` (default) ignores semicolons (or lacking semicolon) at the end of statements if the next line starts with `[`, `(`, `/`, `+`, or `-`.
 * `"beforeStatementContinuationChars": "always"` requires semicolons at the end of statements if the next line starts with `[`, `(`, `/`, `+`, or `-`.
 * `"beforeStatementContinuationChars": "never"` disallows semicolons as the end of statements if it doesn't make ASI hazard even if the next line starts with `[`, `(`, `/`, `+`, or `-`.
 
@@ -128,6 +129,16 @@ object.method = function() {
 
 var name = "ESLint"
 
+;(function() {
+    // ...
+})()
+
+import a from "a"
+(function() {
+    // ...
+})()
+
+import b from "b"
 ;(function() {
     // ...
 })()

--- a/docs/rules/semi.md
+++ b/docs/rules/semi.md
@@ -72,8 +72,8 @@ Object option (when `"always"`):
 
 Object option (when `"never"`):
 
-* `"beforeUnreliableLineButSafe": "always"` requires semicolons at the end of statements if the next line starts with `[`, `(`, `/`, `+`, or `-`.
-* `"beforeUnreliableLineButSafe": "never"` disallows semicolons as the end of statements if it doesn't make ASI hazard even if the next line starts with `[`, `(`, `/`, `+`, or `-`.
+* `"beforeStatementContinuationChars": "always"` requires semicolons at the end of statements if the next line starts with `[`, `(`, `/`, `+`, or `-`.
+* `"beforeStatementContinuationChars": "never"` disallows semicolons as the end of statements if it doesn't make ASI hazard even if the next line starts with `[`, `(`, `/`, `+`, or `-`.
 
 ### always
 
@@ -145,12 +145,12 @@ if (foo) { bar() }
 if (foo) { bar(); baz() }
 ```
 
-#### beforeUnreliableLineButSafe
+#### beforeStatementContinuationChars
 
-Examples of additional **incorrect** code for this rule with the `"never", { "beforeUnreliableLineButSafe": "always" }` options:
+Examples of additional **incorrect** code for this rule with the `"never", { "beforeStatementContinuationChars": "always" }` options:
 
 ```js
-/*eslint semi: ["error", "never", { "beforeUnreliableLineButSafe": "always"}] */
+/*eslint semi: ["error", "never", { "beforeStatementContinuationChars": "always"}] */
 import a from "a"
 
 (function() {
@@ -158,10 +158,10 @@ import a from "a"
 })()
 ```
 
-Examples of additional **incorrect** code for this rule with the `"never", { "beforeUnreliableLineButSafe": "never" }` options:
+Examples of additional **incorrect** code for this rule with the `"never", { "beforeStatementContinuationChars": "never" }` options:
 
 ```js
-/*eslint semi: ["error", "never", { "beforeUnreliableLineButSafe": "never"}] */
+/*eslint semi: ["error", "never", { "beforeStatementContinuationChars": "never"}] */
 import a from "a"
 
 ;(function() {

--- a/docs/rules/semi.md
+++ b/docs/rules/semi.md
@@ -66,9 +66,14 @@ String option:
 * `"always"` (default) requires semicolons at the end of statements
 * `"never"` disallows semicolons as the end of statements (except to disambiguate statements beginning with `[`, `(`, `/`, `+`, or `-`)
 
-Object option:
+Object option (when `"always"`):
 
 * `"omitLastInOneLineBlock": true` ignores the last semicolon in a block in which its braces (and therefore the content of the block) are in the same line
+
+Object option (when `"never"`):
+
+* `"beforeUnreliableLineButSafe": "always"` requires semicolons at the end of statements if the next line starts with `[`, `(`, `/`, `+`, or `-`.
+* `"beforeUnreliableLineButSafe": "never"` disallows semicolons as the end of statements if it doesn't make ASI hazard even if the next line starts with `[`, `(`, `/`, `+`, or `-`.
 
 ### always
 
@@ -138,6 +143,30 @@ Examples of additional **correct** code for this rule with the `"always", { "omi
 if (foo) { bar() }
 
 if (foo) { bar(); baz() }
+```
+
+#### beforeUnreliableLineButSafe
+
+Examples of additional **incorrect** code for this rule with the `"never", { "beforeUnreliableLineButSafe": "always" }` options:
+
+```js
+/*eslint semi: ["error", "never", { "beforeUnreliableLineButSafe": "always"}] */
+import a from "a"
+
+(function() {
+    // ...
+})()
+```
+
+Examples of additional **incorrect** code for this rule with the `"never", { "beforeUnreliableLineButSafe": "never" }` options:
+
+```js
+/*eslint semi: ["error", "never", { "beforeUnreliableLineButSafe": "never"}] */
+import a from "a"
+
+;(function() {
+    // ...
+})()
 ```
 
 ## When Not To Use It

--- a/lib/rules/semi.js
+++ b/lib/rules/semi.js
@@ -32,10 +32,19 @@ module.exports = {
                     items: [
                         {
                             enum: ["never"]
+                        },
+                        {
+                            type: "object",
+                            properties: {
+                                beforeUnreliableLineButSafe: {
+                                    enum: ["always", "any", "never"]
+                                }
+                            },
+                            additionalProperties: false
                         }
                     ],
                     minItems: 0,
-                    maxItems: 1
+                    maxItems: 2
                 },
                 {
                     type: "array",
@@ -62,9 +71,10 @@ module.exports = {
 
         const OPT_OUT_PATTERN = /^[-[(/+`]/; // One of [(/+-`
         const options = context.options[1];
-        const never = context.options[0] === "never",
-            exceptOneLine = options && options.omitLastInOneLineBlock === true,
-            sourceCode = context.getSourceCode();
+        const never = context.options[0] === "never";
+        const exceptOneLine = Boolean(options && options.omitLastInOneLineBlock);
+        const beforeUnreliableLineButSafe = (options && options.beforeUnreliableLineButSafe) || "any";
+        const sourceCode = context.getSourceCode();
 
         //--------------------------------------------------------------------------
         // Helpers
@@ -114,29 +124,115 @@ module.exports = {
         }
 
         /**
-         * Check if a semicolon is unnecessary, only true if:
-         *   - next token is on a new line and is not one of the opt-out tokens
-         *   - next token is a valid statement divider
-         * @param {Token} lastToken last token of current node.
-         * @returns {boolean} whether the semicolon is unnecessary.
+         * Check whether a given semicolon token is redandant.
+         * @param {Token} semiToken A semicolon token to check.
+         * @returns {boolean} `true` if the next token is `;` or `}`.
          */
-        function isUnnecessarySemicolon(lastToken) {
-            if (!astUtils.isSemicolonToken(lastToken)) {
+        function isRedundantSemi(semiToken) {
+            const nextToken = sourceCode.getTokenAfter(semiToken);
+
+            return (
+                !nextToken ||
+                astUtils.isClosingBraceToken(nextToken) ||
+                astUtils.isSemicolonToken(nextToken)
+            );
+        }
+
+        /**
+         * Check whether a given token is the closing brace of an arrow function.
+         * @param {Token} lastToken A token to check.
+         * @returns {boolean} `true` if the token is the closing brace of an arrow function.
+         */
+        function isEndOfArrowBlock(lastToken) {
+            if (!astUtils.isClosingBraceToken(lastToken)) {
+                return false;
+            }
+            const node = sourceCode.getNodeByRangeIndex(lastToken.range[0]);
+
+            return (
+                node.type === "BlockStatement" &&
+                node.parent.type === "ArrowFunctionExpression"
+            );
+        }
+
+        /**
+         * Check whether a given node is on the same line with the next token.
+         * @param {Node} node A statement node to check.
+         * @returns {boolean} `true` if the node is on the same line with the next token.
+         */
+        function isOnSameLineWithNextToken(node) {
+            const prevToken = sourceCode.getLastToken(node, 1);
+            const nextToken = sourceCode.getTokenAfter(node);
+
+            return !!nextToken && astUtils.isTokenOnSameLine(prevToken, nextToken);
+        }
+
+        /**
+         * Check whether a given node can connect the next line if the next line is unreliable.
+         * @param {Node} node A statement node to check.
+         * @returns {boolean} `true` if the node can connect the next line.
+         */
+        function maybeAsiHazardAfter(node) {
+            const t = node.type;
+
+            if (t === "DoWhileStatement" ||
+                t === "BreakStatement" ||
+                t === "ContinueStatement" ||
+                t === "DebuggerStatement" ||
+                t === "ImportDeclaration" ||
+                t === "ExportAllDeclaration"
+            ) {
+                return false;
+            }
+            if (t === "ReturnStatement") {
+                return Boolean(node.argument);
+            }
+            if (t === "ExportNamedDeclaration") {
+                return Boolean(node.declaration);
+            }
+            if (isEndOfArrowBlock(sourceCode.getLastToken(node, 1))) {
                 return false;
             }
 
-            const nextToken = sourceCode.getTokenAfter(lastToken);
+            return true;
+        }
 
-            if (!nextToken) {
-                return true;
+        /**
+         * Check whether a given token can connect the previous statement.
+         * @param {Token} token A token to check.
+         * @returns {boolean} `true` if the token is one of `[`, `(`, `/`, `+`, `-`, ```, `++`, and `--`.
+         */
+        function maybeAsiHazardBefore(token) {
+            return (
+                Boolean(token) &&
+                OPT_OUT_PATTERN.test(token.value) &&
+                token.value !== "++" &&
+                token.value !== "--"
+            );
+        }
+
+        /**
+         * Check if the semicolon of a given node is unnecessary, only true if:
+         *   - next token is a valid statement divider (`;` or `}`).
+         *   - next token is on a new line and the node is not connectable to the new line.
+         * @param {Node} node A statement node to check.
+         * @returns {boolean} whether the semicolon is unnecessary.
+         */
+        function canRemoveSemicolon(node) {
+            if (isRedundantSemi(sourceCode.getLastToken(node))) {
+                return true; // `;;` or `;}`
+            }
+            if (isOnSameLineWithNextToken(node)) {
+                return false; // One liner.
+            }
+            if (beforeUnreliableLineButSafe === "never" && !maybeAsiHazardAfter(node)) {
+                return true; // ASI works. This statement doesn't connect to the next.
+            }
+            if (!maybeAsiHazardBefore(sourceCode.getTokenAfter(node))) {
+                return true; // ASI works. The next token doesn't connect to this statement.
             }
 
-            const lastTokenLine = lastToken.loc.end.line;
-            const nextTokenLine = nextToken.loc.start.line;
-            const isOptOutToken = OPT_OUT_PATTERN.test(nextToken.value) && nextToken.value !== "++" && nextToken.value !== "--";
-            const isDivider = (astUtils.isClosingBraceToken(nextToken) || astUtils.isSemicolonToken(nextToken));
-
-            return (lastTokenLine !== nextTokenLine && !isOptOutToken) || isDivider;
+            return false;
         }
 
         /**
@@ -145,16 +241,17 @@ module.exports = {
          * @returns {boolean} whether the node is in a one-liner block statement.
          */
         function isOneLinerBlock(node) {
+            const parent = node.parent;
             const nextToken = sourceCode.getTokenAfter(node);
 
             if (!nextToken || nextToken.value !== "}") {
                 return false;
             }
-
-            const parent = node.parent;
-
-            return parent && parent.type === "BlockStatement" &&
-              parent.loc.start.line === parent.loc.end.line;
+            return (
+                !!parent &&
+                parent.type === "BlockStatement" &&
+                parent.loc.start.line === parent.loc.end.line
+            );
         }
 
         /**
@@ -163,21 +260,21 @@ module.exports = {
          * @returns {void}
          */
         function checkForSemicolon(node) {
-            const lastToken = sourceCode.getLastToken(node);
+            const isSemi = astUtils.isSemicolonToken(sourceCode.getLastToken(node));
 
             if (never) {
-                if (isUnnecessarySemicolon(lastToken)) {
+                if (isSemi && canRemoveSemicolon(node)) {
                     report(node, true);
+                } else if (!isSemi && beforeUnreliableLineButSafe === "always" && maybeAsiHazardBefore(sourceCode.getTokenAfter(node))) {
+                    report(node);
                 }
             } else {
-                if (!astUtils.isSemicolonToken(lastToken)) {
-                    if (!exceptOneLine || !isOneLinerBlock(node)) {
-                        report(node);
-                    }
-                } else {
-                    if (exceptOneLine && isOneLinerBlock(node)) {
-                        report(node, true);
-                    }
+                const oneLinerBlock = (exceptOneLine && isOneLinerBlock(node));
+
+                if (isSemi && oneLinerBlock) {
+                    report(node, true);
+                } else if (!isSemi && !oneLinerBlock) {
+                    report(node);
                 }
             }
         }
@@ -188,9 +285,7 @@ module.exports = {
          * @returns {void}
          */
         function checkForSemicolonForVariableDeclaration(node) {
-            const ancestors = context.getAncestors(),
-                parentIndex = ancestors.length - 1,
-                parent = ancestors[parentIndex];
+            const parent = node.parent;
 
             if ((parent.type !== "ForStatement" || parent.init !== node) &&
                 (!/^For(?:In|Of)Statement/.test(parent.type) || parent.left !== node)

--- a/lib/rules/semi.js
+++ b/lib/rules/semi.js
@@ -36,7 +36,7 @@ module.exports = {
                         {
                             type: "object",
                             properties: {
-                                beforeUnreliableLineButSafe: {
+                                beforeStatementContinuationChars: {
                                     enum: ["always", "any", "never"]
                                 }
                             },
@@ -73,7 +73,7 @@ module.exports = {
         const options = context.options[1];
         const never = context.options[0] === "never";
         const exceptOneLine = Boolean(options && options.omitLastInOneLineBlock);
-        const beforeUnreliableLineButSafe = (options && options.beforeUnreliableLineButSafe) || "any";
+        const beforeStatementContinuationChars = (options && options.beforeStatementContinuationChars) || "any";
         const sourceCode = context.getSourceCode();
 
         //--------------------------------------------------------------------------
@@ -225,7 +225,7 @@ module.exports = {
             if (isOnSameLineWithNextToken(node)) {
                 return false; // One liner.
             }
-            if (beforeUnreliableLineButSafe === "never" && !maybeAsiHazardAfter(node)) {
+            if (beforeStatementContinuationChars === "never" && !maybeAsiHazardAfter(node)) {
                 return true; // ASI works. This statement doesn't connect to the next.
             }
             if (!maybeAsiHazardBefore(sourceCode.getTokenAfter(node))) {
@@ -265,7 +265,7 @@ module.exports = {
             if (never) {
                 if (isSemi && canRemoveSemicolon(node)) {
                     report(node, true);
-                } else if (!isSemi && beforeUnreliableLineButSafe === "always" && maybeAsiHazardBefore(sourceCode.getTokenAfter(node))) {
+                } else if (!isSemi && beforeStatementContinuationChars === "always" && maybeAsiHazardBefore(sourceCode.getTokenAfter(node))) {
                     report(node);
                 }
             } else {

--- a/tests/lib/rules/semi.js
+++ b/tests/lib/rules/semi.js
@@ -104,21 +104,21 @@ ruleTester.run("semi", rule, {
                 do; while(a);
                 [1,2,3].forEach(doSomething)
             `,
-            options: ["never", { beforeUnreliableLineButSafe: "any" }]
+            options: ["never", { beforeStatementContinuationChars: "any" }]
         },
         {
             code: `
                 do; while(a)
                 [1,2,3].forEach(doSomething)
             `,
-            options: ["never", { beforeUnreliableLineButSafe: "any" }]
+            options: ["never", { beforeStatementContinuationChars: "any" }]
         },
         {
             code: `
                 import a from "a";
                 [1,2,3].forEach(doSomething)
             `,
-            options: ["never", { beforeUnreliableLineButSafe: "always" }],
+            options: ["never", { beforeStatementContinuationChars: "always" }],
             parserOptions: { sourceType: "module" }
         },
         {
@@ -126,7 +126,7 @@ ruleTester.run("semi", rule, {
                 export {a};
                 [a] = b
             `,
-            options: ["never", { beforeUnreliableLineButSafe: "always" }],
+            options: ["never", { beforeStatementContinuationChars: "always" }],
             parserOptions: { sourceType: "module" }
         },
         {
@@ -136,7 +136,7 @@ ruleTester.run("semi", rule, {
                     ({a} = b)
                 }
             `,
-            options: ["never", { beforeUnreliableLineButSafe: "always" }],
+            options: ["never", { beforeStatementContinuationChars: "always" }],
             parserOptions: { ecmaVersion: 2015 }
         },
         {
@@ -146,7 +146,7 @@ ruleTester.run("semi", rule, {
                     +i
                 }
             `,
-            options: ["never", { beforeUnreliableLineButSafe: "always" }]
+            options: ["never", { beforeStatementContinuationChars: "always" }]
         },
         {
             code: `
@@ -155,21 +155,21 @@ ruleTester.run("semi", rule, {
                     [1,2,3].forEach(doSomething)
                 }
             `,
-            options: ["never", { beforeUnreliableLineButSafe: "always" }]
+            options: ["never", { beforeStatementContinuationChars: "always" }]
         },
         {
             code: `
                 do; while(a);
                 [1,2,3].forEach(doSomething)
             `,
-            options: ["never", { beforeUnreliableLineButSafe: "always" }]
+            options: ["never", { beforeStatementContinuationChars: "always" }]
         },
         {
             code: `
                 const f = () => {};
                 [1,2,3].forEach(doSomething)
             `,
-            options: ["never", { beforeUnreliableLineButSafe: "always" }],
+            options: ["never", { beforeStatementContinuationChars: "always" }],
             parserOptions: { ecmaVersion: 2015 }
         },
         {
@@ -177,7 +177,7 @@ ruleTester.run("semi", rule, {
                 import a from "a"
                 [1,2,3].forEach(doSomething)
             `,
-            options: ["never", { beforeUnreliableLineButSafe: "never" }],
+            options: ["never", { beforeStatementContinuationChars: "never" }],
             parserOptions: { sourceType: "module" }
         },
         {
@@ -185,7 +185,7 @@ ruleTester.run("semi", rule, {
                 export {a}
                 [a] = b
             `,
-            options: ["never", { beforeUnreliableLineButSafe: "never" }],
+            options: ["never", { beforeStatementContinuationChars: "never" }],
             parserOptions: { sourceType: "module" }
         },
         {
@@ -195,7 +195,7 @@ ruleTester.run("semi", rule, {
                     ({a} = b)
                 }
             `,
-            options: ["never", { beforeUnreliableLineButSafe: "never" }],
+            options: ["never", { beforeStatementContinuationChars: "never" }],
             parserOptions: { ecmaVersion: 2015 }
         },
         {
@@ -205,7 +205,7 @@ ruleTester.run("semi", rule, {
                     +i
                 }
             `,
-            options: ["never", { beforeUnreliableLineButSafe: "never" }]
+            options: ["never", { beforeStatementContinuationChars: "never" }]
         },
         {
             code: `
@@ -214,21 +214,21 @@ ruleTester.run("semi", rule, {
                     [1,2,3].forEach(doSomething)
                 }
             `,
-            options: ["never", { beforeUnreliableLineButSafe: "never" }]
+            options: ["never", { beforeStatementContinuationChars: "never" }]
         },
         {
             code: `
                 do; while(a)
                 [1,2,3].forEach(doSomething)
             `,
-            options: ["never", { beforeUnreliableLineButSafe: "never" }]
+            options: ["never", { beforeStatementContinuationChars: "never" }]
         },
         {
             code: `
                 const f = () => {}
                 [1,2,3].forEach(doSomething)
             `,
-            options: ["never", { beforeUnreliableLineButSafe: "never" }],
+            options: ["never", { beforeStatementContinuationChars: "never" }],
             parserOptions: { ecmaVersion: 2015 }
         }
     ],
@@ -332,7 +332,7 @@ ruleTester.run("semi", rule, {
                 import a from "a";
                 [1,2,3].forEach(doSomething)
             `,
-            options: ["never", { beforeUnreliableLineButSafe: "always" }],
+            options: ["never", { beforeStatementContinuationChars: "always" }],
             parserOptions: { sourceType: "module" },
             errors: ["Missing semicolon."]
         },
@@ -345,7 +345,7 @@ ruleTester.run("semi", rule, {
                 export {a};
                 [a] = b
             `,
-            options: ["never", { beforeUnreliableLineButSafe: "always" }],
+            options: ["never", { beforeStatementContinuationChars: "always" }],
             parserOptions: { sourceType: "module" },
             errors: ["Missing semicolon."]
         },
@@ -362,7 +362,7 @@ ruleTester.run("semi", rule, {
                     ({a} = b)
                 }
             `,
-            options: ["never", { beforeUnreliableLineButSafe: "always" }],
+            options: ["never", { beforeStatementContinuationChars: "always" }],
             parserOptions: { ecmaVersion: 2015 },
             errors: ["Missing semicolon."]
         },
@@ -379,7 +379,7 @@ ruleTester.run("semi", rule, {
                    +i
                 }
             `,
-            options: ["never", { beforeUnreliableLineButSafe: "always" }],
+            options: ["never", { beforeStatementContinuationChars: "always" }],
             errors: ["Missing semicolon."]
         },
         {
@@ -395,7 +395,7 @@ ruleTester.run("semi", rule, {
                     [1,2,3].forEach(doSomething)
                 }
             `,
-            options: ["never", { beforeUnreliableLineButSafe: "always" }],
+            options: ["never", { beforeStatementContinuationChars: "always" }],
             errors: ["Missing semicolon."]
         },
         {
@@ -407,7 +407,7 @@ ruleTester.run("semi", rule, {
                 do; while(a);
                 [1,2,3].forEach(doSomething)
             `,
-            options: ["never", { beforeUnreliableLineButSafe: "always" }],
+            options: ["never", { beforeStatementContinuationChars: "always" }],
             errors: ["Missing semicolon."]
         },
         {
@@ -419,7 +419,7 @@ ruleTester.run("semi", rule, {
                 const f = () => {};
                 [1,2,3].forEach(doSomething)
             `,
-            options: ["never", { beforeUnreliableLineButSafe: "always" }],
+            options: ["never", { beforeStatementContinuationChars: "always" }],
             parserOptions: { ecmaVersion: 2015 },
             errors: ["Missing semicolon."]
         },
@@ -432,7 +432,7 @@ ruleTester.run("semi", rule, {
                 import a from "a"
                 [1,2,3].forEach(doSomething)
             `,
-            options: ["never", { beforeUnreliableLineButSafe: "never" }],
+            options: ["never", { beforeStatementContinuationChars: "never" }],
             parserOptions: { sourceType: "module" },
             errors: ["Extra semicolon."]
         },
@@ -445,7 +445,7 @@ ruleTester.run("semi", rule, {
                 export {a}
                 [a] = b
             `,
-            options: ["never", { beforeUnreliableLineButSafe: "never" }],
+            options: ["never", { beforeStatementContinuationChars: "never" }],
             parserOptions: { sourceType: "module" },
             errors: ["Extra semicolon."]
         },
@@ -462,7 +462,7 @@ ruleTester.run("semi", rule, {
                     ({a} = b)
                 }
             `,
-            options: ["never", { beforeUnreliableLineButSafe: "never" }],
+            options: ["never", { beforeStatementContinuationChars: "never" }],
             parserOptions: { ecmaVersion: 2015 },
             errors: ["Extra semicolon."]
         },
@@ -479,7 +479,7 @@ ruleTester.run("semi", rule, {
                     +i
                 }
             `,
-            options: ["never", { beforeUnreliableLineButSafe: "never" }],
+            options: ["never", { beforeStatementContinuationChars: "never" }],
             errors: ["Extra semicolon."]
         },
         {
@@ -495,7 +495,7 @@ ruleTester.run("semi", rule, {
                     [1,2,3].forEach(doSomething)
                 }
             `,
-            options: ["never", { beforeUnreliableLineButSafe: "never" }],
+            options: ["never", { beforeStatementContinuationChars: "never" }],
             errors: ["Extra semicolon."]
         },
         {
@@ -507,7 +507,7 @@ ruleTester.run("semi", rule, {
                 do; while(a)
                 [1,2,3].forEach(doSomething)
             `,
-            options: ["never", { beforeUnreliableLineButSafe: "never" }],
+            options: ["never", { beforeStatementContinuationChars: "never" }],
             errors: ["Extra semicolon."]
         },
         {
@@ -519,7 +519,7 @@ ruleTester.run("semi", rule, {
                 const f = () => {}
                 [1,2,3].forEach(doSomething)
             `,
-            options: ["never", { beforeUnreliableLineButSafe: "never" }],
+            options: ["never", { beforeStatementContinuationChars: "never" }],
             parserOptions: { ecmaVersion: 2015 },
             errors: ["Extra semicolon."]
         },
@@ -532,7 +532,7 @@ ruleTester.run("semi", rule, {
                 import a from "a"
                 [1,2,3].forEach(doSomething)
             `,
-            options: ["never", { beforeUnreliableLineButSafe: "never" }],
+            options: ["never", { beforeStatementContinuationChars: "never" }],
             parserOptions: { sourceType: "module" },
             errors: ["Extra semicolon."]
         },
@@ -545,7 +545,7 @@ ruleTester.run("semi", rule, {
                 export {a}
                 [1,2,3].forEach(doSomething)
             `,
-            options: ["never", { beforeUnreliableLineButSafe: "never" }],
+            options: ["never", { beforeStatementContinuationChars: "never" }],
             parserOptions: { sourceType: "module" },
             errors: ["Extra semicolon."]
         },
@@ -562,7 +562,7 @@ ruleTester.run("semi", rule, {
                     [1,2,3].forEach(doSomething)
                 }
             `,
-            options: ["never", { beforeUnreliableLineButSafe: "never" }],
+            options: ["never", { beforeStatementContinuationChars: "never" }],
             errors: ["Extra semicolon."]
         },
         {
@@ -578,7 +578,7 @@ ruleTester.run("semi", rule, {
                     [1,2,3].forEach(doSomething)
                 }
             `,
-            options: ["never", { beforeUnreliableLineButSafe: "never" }],
+            options: ["never", { beforeStatementContinuationChars: "never" }],
             errors: ["Extra semicolon."]
         },
         {
@@ -594,7 +594,7 @@ ruleTester.run("semi", rule, {
                     [1,2,3].forEach(doSomething)
                 }
             `,
-            options: ["never", { beforeUnreliableLineButSafe: "never" }],
+            options: ["never", { beforeStatementContinuationChars: "never" }],
             errors: ["Extra semicolon."]
         },
         {
@@ -606,7 +606,7 @@ ruleTester.run("semi", rule, {
                 do; while(a)
                 [1,2,3].forEach(doSomething)
             `,
-            options: ["never", { beforeUnreliableLineButSafe: "never" }],
+            options: ["never", { beforeStatementContinuationChars: "never" }],
             errors: ["Extra semicolon."]
         },
         {
@@ -618,7 +618,7 @@ ruleTester.run("semi", rule, {
                 const f = () => {}
                 [1,2,3].forEach(doSomething)
             `,
-            options: ["never", { beforeUnreliableLineButSafe: "never" }],
+            options: ["never", { beforeStatementContinuationChars: "never" }],
             parserOptions: { ecmaVersion: 2015 },
             errors: ["Extra semicolon."]
         }

--- a/tests/lib/rules/semi.js
+++ b/tests/lib/rules/semi.js
@@ -96,7 +96,141 @@ ruleTester.run("semi", rule, {
 
         // https://github.com/eslint/eslint/issues/7782
         { code: "var a = b;\n/foo/.test(c)", options: ["never"] },
-        { code: "var a = b;\n`foo`", options: ["never"], parserOptions: { ecmaVersion: 6 } }
+        { code: "var a = b;\n`foo`", options: ["never"], parserOptions: { ecmaVersion: 6 } },
+
+        // https://github.com/eslint/eslint/issues/9521
+        {
+            code: `
+                do; while(a);
+                [1,2,3].forEach(doSomething)
+            `,
+            options: ["never", { beforeUnreliableLineButSafe: "any" }]
+        },
+        {
+            code: `
+                do; while(a)
+                [1,2,3].forEach(doSomething)
+            `,
+            options: ["never", { beforeUnreliableLineButSafe: "any" }]
+        },
+        {
+            code: `
+                import a from "a";
+                [1,2,3].forEach(doSomething)
+            `,
+            options: ["never", { beforeUnreliableLineButSafe: "always" }],
+            parserOptions: { sourceType: "module" }
+        },
+        {
+            code: `
+                export {a};
+                [a] = b
+            `,
+            options: ["never", { beforeUnreliableLineButSafe: "always" }],
+            parserOptions: { sourceType: "module" }
+        },
+        {
+            code: `
+                function wrap() {
+                    return;
+                    ({a} = b)
+                }
+            `,
+            options: ["never", { beforeUnreliableLineButSafe: "always" }],
+            parserOptions: { ecmaVersion: 2015 }
+        },
+        {
+            code: `
+                while (true) {
+                    break;
+                    +i
+                }
+            `,
+            options: ["never", { beforeUnreliableLineButSafe: "always" }]
+        },
+        {
+            code: `
+                while (true) {
+                    continue;
+                    [1,2,3].forEach(doSomething)
+                }
+            `,
+            options: ["never", { beforeUnreliableLineButSafe: "always" }]
+        },
+        {
+            code: `
+                do; while(a);
+                [1,2,3].forEach(doSomething)
+            `,
+            options: ["never", { beforeUnreliableLineButSafe: "always" }]
+        },
+        {
+            code: `
+                const f = () => {};
+                [1,2,3].forEach(doSomething)
+            `,
+            options: ["never", { beforeUnreliableLineButSafe: "always" }],
+            parserOptions: { ecmaVersion: 2015 }
+        },
+        {
+            code: `
+                import a from "a"
+                [1,2,3].forEach(doSomething)
+            `,
+            options: ["never", { beforeUnreliableLineButSafe: "never" }],
+            parserOptions: { sourceType: "module" }
+        },
+        {
+            code: `
+                export {a}
+                [a] = b
+            `,
+            options: ["never", { beforeUnreliableLineButSafe: "never" }],
+            parserOptions: { sourceType: "module" }
+        },
+        {
+            code: `
+                function wrap() {
+                    return
+                    ({a} = b)
+                }
+            `,
+            options: ["never", { beforeUnreliableLineButSafe: "never" }],
+            parserOptions: { ecmaVersion: 2015 }
+        },
+        {
+            code: `
+                while (true) {
+                    break
+                    +i
+                }
+            `,
+            options: ["never", { beforeUnreliableLineButSafe: "never" }]
+        },
+        {
+            code: `
+                while (true) {
+                    continue
+                    [1,2,3].forEach(doSomething)
+                }
+            `,
+            options: ["never", { beforeUnreliableLineButSafe: "never" }]
+        },
+        {
+            code: `
+                do; while(a)
+                [1,2,3].forEach(doSomething)
+            `,
+            options: ["never", { beforeUnreliableLineButSafe: "never" }]
+        },
+        {
+            code: `
+                const f = () => {}
+                [1,2,3].forEach(doSomething)
+            `,
+            options: ["never", { beforeUnreliableLineButSafe: "never" }],
+            parserOptions: { ecmaVersion: 2015 }
+        }
     ],
     invalid: [
         { code: "import * as utils from './utils'", output: "import * as utils from './utils';", parserOptions: { sourceType: "module" }, errors: [{ message: "Missing semicolon.", type: "ImportDeclaration", column: 33 }] },
@@ -186,6 +320,307 @@ ruleTester.run("semi", rule, {
                 "Extra semicolon.",
                 "Unnecessary semicolon."
             ]
+        },
+
+        // https://github.com/eslint/eslint/issues/9521
+        {
+            code: `
+                import a from "a"
+                [1,2,3].forEach(doSomething)
+            `,
+            output: `
+                import a from "a";
+                [1,2,3].forEach(doSomething)
+            `,
+            options: ["never", { beforeUnreliableLineButSafe: "always" }],
+            parserOptions: { sourceType: "module" },
+            errors: ["Missing semicolon."]
+        },
+        {
+            code: `
+                export {a}
+                [a] = b
+            `,
+            output: `
+                export {a};
+                [a] = b
+            `,
+            options: ["never", { beforeUnreliableLineButSafe: "always" }],
+            parserOptions: { sourceType: "module" },
+            errors: ["Missing semicolon."]
+        },
+        {
+            code: `
+                function wrap() {
+                    return
+                    ({a} = b)
+                }
+            `,
+            output: `
+                function wrap() {
+                    return;
+                    ({a} = b)
+                }
+            `,
+            options: ["never", { beforeUnreliableLineButSafe: "always" }],
+            parserOptions: { ecmaVersion: 2015 },
+            errors: ["Missing semicolon."]
+        },
+        {
+            code: `
+                while (true) {
+                    break
+                   +i
+                }
+            `,
+            output: `
+                while (true) {
+                    break;
+                   +i
+                }
+            `,
+            options: ["never", { beforeUnreliableLineButSafe: "always" }],
+            errors: ["Missing semicolon."]
+        },
+        {
+            code: `
+                while (true) {
+                    continue
+                    [1,2,3].forEach(doSomething)
+                }
+            `,
+            output: `
+                while (true) {
+                    continue;
+                    [1,2,3].forEach(doSomething)
+                }
+            `,
+            options: ["never", { beforeUnreliableLineButSafe: "always" }],
+            errors: ["Missing semicolon."]
+        },
+        {
+            code: `
+                do; while(a)
+                [1,2,3].forEach(doSomething)
+            `,
+            output: `
+                do; while(a);
+                [1,2,3].forEach(doSomething)
+            `,
+            options: ["never", { beforeUnreliableLineButSafe: "always" }],
+            errors: ["Missing semicolon."]
+        },
+        {
+            code: `
+                const f = () => {}
+                [1,2,3].forEach(doSomething)
+            `,
+            output: `
+                const f = () => {};
+                [1,2,3].forEach(doSomething)
+            `,
+            options: ["never", { beforeUnreliableLineButSafe: "always" }],
+            parserOptions: { ecmaVersion: 2015 },
+            errors: ["Missing semicolon."]
+        },
+        {
+            code: `
+                import a from "a";
+                [1,2,3].forEach(doSomething)
+            `,
+            output: `
+                import a from "a"
+                [1,2,3].forEach(doSomething)
+            `,
+            options: ["never", { beforeUnreliableLineButSafe: "never" }],
+            parserOptions: { sourceType: "module" },
+            errors: ["Extra semicolon."]
+        },
+        {
+            code: `
+                export {a};
+                [a] = b
+            `,
+            output: `
+                export {a}
+                [a] = b
+            `,
+            options: ["never", { beforeUnreliableLineButSafe: "never" }],
+            parserOptions: { sourceType: "module" },
+            errors: ["Extra semicolon."]
+        },
+        {
+            code: `
+                function wrap() {
+                    return;
+                    ({a} = b)
+                }
+            `,
+            output: `
+                function wrap() {
+                    return
+                    ({a} = b)
+                }
+            `,
+            options: ["never", { beforeUnreliableLineButSafe: "never" }],
+            parserOptions: { ecmaVersion: 2015 },
+            errors: ["Extra semicolon."]
+        },
+        {
+            code: `
+                while (true) {
+                    break;
+                    +i
+                }
+            `,
+            output: `
+                while (true) {
+                    break
+                    +i
+                }
+            `,
+            options: ["never", { beforeUnreliableLineButSafe: "never" }],
+            errors: ["Extra semicolon."]
+        },
+        {
+            code: `
+                while (true) {
+                    continue;
+                    [1,2,3].forEach(doSomething)
+                }
+            `,
+            output: `
+                while (true) {
+                    continue
+                    [1,2,3].forEach(doSomething)
+                }
+            `,
+            options: ["never", { beforeUnreliableLineButSafe: "never" }],
+            errors: ["Extra semicolon."]
+        },
+        {
+            code: `
+                do; while(a);
+                [1,2,3].forEach(doSomething)
+            `,
+            output: `
+                do; while(a)
+                [1,2,3].forEach(doSomething)
+            `,
+            options: ["never", { beforeUnreliableLineButSafe: "never" }],
+            errors: ["Extra semicolon."]
+        },
+        {
+            code: `
+                const f = () => {};
+                [1,2,3].forEach(doSomething)
+            `,
+            output: `
+                const f = () => {}
+                [1,2,3].forEach(doSomething)
+            `,
+            options: ["never", { beforeUnreliableLineButSafe: "never" }],
+            parserOptions: { ecmaVersion: 2015 },
+            errors: ["Extra semicolon."]
+        },
+        {
+            code: `
+                import a from "a"
+                ;[1,2,3].forEach(doSomething)
+            `,
+            output: `
+                import a from "a"
+                [1,2,3].forEach(doSomething)
+            `,
+            options: ["never", { beforeUnreliableLineButSafe: "never" }],
+            parserOptions: { sourceType: "module" },
+            errors: ["Extra semicolon."]
+        },
+        {
+            code: `
+                export {a}
+                ;[1,2,3].forEach(doSomething)
+            `,
+            output: `
+                export {a}
+                [1,2,3].forEach(doSomething)
+            `,
+            options: ["never", { beforeUnreliableLineButSafe: "never" }],
+            parserOptions: { sourceType: "module" },
+            errors: ["Extra semicolon."]
+        },
+        {
+            code: `
+                function wrap() {
+                    return
+                    ;[1,2,3].forEach(doSomething)
+                }
+            `,
+            output: `
+                function wrap() {
+                    return
+                    [1,2,3].forEach(doSomething)
+                }
+            `,
+            options: ["never", { beforeUnreliableLineButSafe: "never" }],
+            errors: ["Extra semicolon."]
+        },
+        {
+            code: `
+                while (true) {
+                    break
+                    ;[1,2,3].forEach(doSomething)
+                }
+            `,
+            output: `
+                while (true) {
+                    break
+                    [1,2,3].forEach(doSomething)
+                }
+            `,
+            options: ["never", { beforeUnreliableLineButSafe: "never" }],
+            errors: ["Extra semicolon."]
+        },
+        {
+            code: `
+                while (true) {
+                    continue
+                    ;[1,2,3].forEach(doSomething)
+                }
+            `,
+            output: `
+                while (true) {
+                    continue
+                    [1,2,3].forEach(doSomething)
+                }
+            `,
+            options: ["never", { beforeUnreliableLineButSafe: "never" }],
+            errors: ["Extra semicolon."]
+        },
+        {
+            code: `
+                do; while(a)
+                ;[1,2,3].forEach(doSomething)
+            `,
+            output: `
+                do; while(a)
+                [1,2,3].forEach(doSomething)
+            `,
+            options: ["never", { beforeUnreliableLineButSafe: "never" }],
+            errors: ["Extra semicolon."]
+        },
+        {
+            code: `
+                const f = () => {}
+                ;[1,2,3].forEach(doSomething)
+            `,
+            output: `
+                const f = () => {}
+                [1,2,3].forEach(doSomething)
+            `,
+            options: ["never", { beforeUnreliableLineButSafe: "never" }],
+            parserOptions: { ecmaVersion: 2015 },
+            errors: ["Extra semicolon."]
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Changes an existing rule: fixes #9521.

**What changes did you make? (Give an overview)**

This PR adds a new option `beforeUnreliableLineButSafe` to `semi` rule. This option specifies the behavior about semicolons (or lacking semicolons) which satisfy the following two condition:

1. The semicolon (or lacking semicolon) is followed by the tokens which can make ASI hazard (`[`, `(`, `+`, `-`, or `` ` ``).
2. But the semicolon (or lacking semicolon) does not make ASI hazard because the next token does not connect to the previous statement.

For example:

```js
import a from "a"
[1,2,3].forEach(doSomething)
```

The option can be one of three values:

- `{ beforeUnreliableLineButSafe: "any" }` ignores the semicolons (or lacking semicolon). This is the default. This is the current behavior.
- `{ beforeUnreliableLineButSafe: "always" }` requires the semicolons.
- `{ beforeUnreliableLineButSafe: "never" }` disallow the semicolons.

**Is there anything you'd like reviewers to focus on?**

The option name `beforeUnreliableLineButSafe` is not the best name. Does somebody have a better idea? 
