### PR TITLE
Build: use Node 8 in appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ version: "{build}"
 # What combinations to test
 environment:
   matrix:
-    - nodejs_version: 4
+    - nodejs_version: 8
 
 branches:
   only:


### PR DESCRIPTION
Node 8 is the latest LTS.