### PR TITLE
Chore: fix incorrect comment in safe-emitter.js

### DIFF
--- a/lib/util/safe-emitter.js
+++ b/lib/util/safe-emitter.js
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 /**
- * An object describing an AST selector
+ * An event emitter
  * @typedef {Object} SafeEmitter
  * @property {function(eventName: string, listenerFunc: Function): void} on Adds a listener for a given event name
  * @property {function(eventName: string, arg1?: any, arg2?: any, arg3?: any)} emit Emits an event with a given name.


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This fixes an incorrect comment in `safe-emitter.js`.

When I created this comment I forgot how to declare JSDoc typedefs, so I copy-pasted a typedef from somewhere else, but I forgot to change this line.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular