### PR TITLE
Update no-octal-escape.js (Cannot read property 'match' of undefined)

### DIFF
--- a/lib/rules/no-octal-escape.js
+++ b/lib/rules/no-octal-escape.js
@@ -25,7 +25,7 @@ module.exports = {
         return {
 
             Literal(node) {
-                if (typeof node.value !== "string") {
+                if (typeof node.value !== "string" || node.raw === undefined) {
                     return;
                 }
 


### PR DESCRIPTION
```
ERROR in ./src/index.js
Module build failed: TypeError: Cannot read property 'match' of undefined
    at Literal (/Users/user/data/projects/public/node_modules/eslint/lib/rules/no-octal-escape.js:34:40)
    at listeners.(anonymous function).forEach.listener (/Users/user/data/projects/public/node_modules/eslint/lib/util/safe-emitter.js:47:58)
    at Array.forEach (<anonymous>)
    at Object.emit (/Users/user/data/projects/public/node_modules/eslint/lib/util/safe-emitter.js:47:38)
    at NodeEventGenerator.applySelector (/Users/user/data/projects/public/node_modules/eslint/lib/util/node-event-generator.js:251:26)
    at NodeEventGenerator.applySelectors (/Users/user/data/projects/public/node_modules/eslint/lib/util/node-event-generator.js:280:22)
    at NodeEventGenerator.enterNode (/Users/user/data/projects/public/node_modules/eslint/lib/util/node-event-generator.js:294:14)
    at CodePathAnalyzer.enterNode (/Users/user/data/projects/public/node_modules/eslint/lib/code-path-analysis/code-path-analyzer.js:606:23)
    at Traverser.enter (/Users/user/data/projects/public/node_modules/eslint/lib/linter.js:955:32)
    at Traverser.__execute (/Users/user/data/projects/public/node_modules/estraverse/estraverse.js:397:31)
```
