### PR TITLE
Update: nonblock-statement-body-position: add arrow fns (Refs: #9510)

### DIFF
--- a/docs/rules/nonblock-statement-body-position.md
+++ b/docs/rules/nonblock-statement-body-position.md
@@ -1,6 +1,6 @@
 # enforce the location of single-line statements (nonblock-statement-body-position)
 
-When writing `if`, `else`, `while`, `do-while`, and `for` statements, the body can be a single statement instead of a block. It can be useful to enforce a consistent location for these single statements.
+When writing `if`, `else`, `while`, `do-while`, `for`, and arrow functions, the body can be a single statement instead of a block. It can be useful to enforce a consistent location for these single statements.
 
 For example, some developers avoid writing code like this:
 
@@ -41,6 +41,7 @@ Additionally, the rule accepts an optional object option with an `"overrides"` k
 
 * `"beside", { "overrides": { "while": "below" } }` requires all single-line statements to appear on the same line as their parent, unless the parent is a `while` statement, in which case the single-line statement must not be on the same line.
 * `"below", { "overrides": { "do": "any" } }` disallows all single-line statements from appearing on the same line as their parent, unless the parent is a `do-while` statement, in which case the position of the single-line statement is not enforced.
+* The following block types are supported in the overrides object: `if`, `else`, `while`, `do`, `for`, and `arrowFunction`.
 
 Examples of **incorrect** code for this rule with the default `"beside"` option:
 
@@ -62,6 +63,8 @@ do
   bar();
 while (foo)
 
+(foo) =>
+  bar();
 ```
 
 Examples of **correct** code for this rule with the default `"beside"` option:
@@ -77,6 +80,12 @@ while (foo) bar();
 for (let i = 1; i < foo; i++) bar();
 
 do bar(); while (foo)
+
+(foo) => bar();
+
+(foo) => (
+  bar()
+);
 
 if (foo) { // block statements are always allowed with this rule
   bar();
@@ -98,6 +107,8 @@ while (foo) bar();
 for (let i = 1; i < foo; i++) bar();
 
 do bar(); while (foo)
+
+(foo) => bar();
 ```
 
 Examples of **correct** code for this rule with the `"below"` option:
@@ -119,6 +130,9 @@ for (let i = 1; i < foo; i++)
 do
   bar();
 while (foo)
+
+(foo) =>
+  bar();
 
 if (foo) {
   // Although the second `if` statement is on the same line as the `else`, this is a very common

--- a/lib/rules/nonblock-statement-body-position.js
+++ b/lib/rules/nonblock-statement-body-position.js
@@ -28,7 +28,8 @@ module.exports = {
                             else: POSITION_SCHEMA,
                             while: POSITION_SCHEMA,
                             do: POSITION_SCHEMA,
-                            for: POSITION_SCHEMA
+                            for: POSITION_SCHEMA,
+                            arrowFunction: POSITION_SCHEMA
                         },
                         additionalProperties: false
                     }
@@ -46,12 +47,23 @@ module.exports = {
         //----------------------------------------------------------------------
 
         /**
+         * Gets an option for the specified keyword
+         * @param {string} keywordName The name of a keyword, e.g. 'if'
+         * @returns {(string|void)} The option for the keyword, e.g. 'beside', or void if it doesn't exist
+         */
+        function getKeywordOption(keywordName) {
+            return context.options[1] &&
+                context.options[1].overrides &&
+                context.options[1].overrides[keywordName];
+        }
+
+        /**
          * Gets the applicable preference for a particular keyword
          * @param {string} keywordName The name of a keyword, e.g. 'if'
          * @returns {string} The applicable option for the keyword, e.g. 'beside'
          */
         function getOption(keywordName) {
-            return context.options[1] && context.options[1].overrides && context.options[1].overrides[keywordName] ||
+            return getKeywordOption(keywordName) ||
                 context.options[0] ||
                 "beside";
         }
@@ -102,6 +114,20 @@ module.exports = {
                 // Check the `else` node, but don't check 'else if' statements.
                 if (node.alternate && node.alternate.type !== "IfStatement") {
                     validateStatement(node.alternate, "else");
+                }
+            },
+            ArrowFunctionExpression(node) {
+                const body = node.body;
+                const tokenBefore = sourceCode.getTokenBefore(body);
+
+                // Check if the arrow function body is parenthesized
+                if (tokenBefore.value === "(") {
+                    return;
+                }
+
+                // Only warn if the arrow function override is specified
+                if (getKeywordOption("arrowFunction")) {
+                    validateStatement(node.body, "arrowFunction");
                 }
             },
             WhileStatement: node => validateStatement(node.body, "while"),

--- a/tests/lib/rules/nonblock-statement-body-position.js
+++ b/tests/lib/rules/nonblock-statement-body-position.js
@@ -32,9 +32,15 @@ ruleTester.run("nonblock-statement-body-position", rule, {
         "for (foo in bar) baz;",
         "for (foo of bar) baz;",
         "if (foo) bar; else baz;",
+        "() => foo;",
         `
             if (foo) bar(
                 baz
+            );
+        `,
+        `
+            (foo) => (
+                bar()
             );
         `,
         {
@@ -107,6 +113,13 @@ ruleTester.run("nonblock-statement-body-position", rule, {
             `,
             options: ["below"]
         },
+        {
+            code: `
+                () =>
+                    foo;
+            `,
+            options: ["below"]
+        },
 
         // 'any' option
         {
@@ -116,6 +129,17 @@ ruleTester.run("nonblock-statement-body-position", rule, {
         {
             code: `
                 if (foo)
+                    bar();
+            `,
+            options: ["any"]
+        },
+        {
+            code: "(foo) => bar();",
+            options: ["any"]
+        },
+        {
+            code: `
+                (foo) =>
                     bar();
             `,
             options: ["any"]
@@ -139,6 +163,19 @@ ruleTester.run("nonblock-statement-body-position", rule, {
                     bar();
             `,
             options: ["beside", { overrides: { while: "any" } }]
+        },
+        {
+            code: `
+                (foo) =>
+                    bar();
+            `,
+            options: ["beside", { overrides: { arrowFunction: "any" } }]
+        },
+        {
+            code: `
+                (foo) => bar();
+            `,
+            options: ["any", { overrides: { arrowFunction: "beside" } }]
         },
         {
             code: "while (foo) bar();",
@@ -335,6 +372,23 @@ ruleTester.run("nonblock-statement-body-position", rule, {
             code: "do bar(); while (foo)",
             output: "do \nbar(); while (foo)",
             options: ["any", { overrides: { do: "below" } }],
+            errors: [EXPECTED_LINEBREAK]
+        },
+        {
+            code: `
+                (foo) =>
+                    bar();
+            `,
+            output: `
+                (foo) => bar();
+            `,
+            options: ["below", { overrides: { arrowFunction: "beside" } }],
+            errors: [UNEXPECTED_LINEBREAK]
+        },
+        {
+            code: "(foo) => bar();",
+            output: "(foo) => \nbar();",
+            options: ["any", { overrides: { arrowFunction: "below" } }],
             errors: [EXPECTED_LINEBREAK]
         }
     ]


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**
- [X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))

**What changes did you make? (Give an overview)**
This is related to https://github.com/eslint/eslint/issues/9510. We would like to have a rule that prevents arrow functions with an implicit return from having a line break after `=>`.

This PR adds arrow functions to the list of statements in the [nonblock-statement-body-position](https://eslint.org/docs/rules/nonblock-statement-body-position) rule. 

This will also always allow arrow functions with a parenthesized implicit return. 
i.e. 
```js
(foo) => (
  bar()
);
```
Also updates docs and tests. 

**Is there anything you'd like reviewers to focus on?**
I'm not sure if I added the parenthesized exception in the best way and if the naming is up to par.

cc. @ljharb 
