### PR TITLE
Fix: prefer-destructuring says "Use destructuring" on "super" (#9625)

### DIFF
--- a/lib/rules/prefer-destructuring.js
+++ b/lib/rules/prefer-destructuring.js
@@ -145,7 +145,7 @@ module.exports = {
          * @returns {void}
          */
         function performCheck(leftNode, rightNode, reportNode) {
-            if (rightNode.type !== "MemberExpression") {
+            if (rightNode.type !== "MemberExpression" || rightNode.object.type === "Super") {
                 return;
             }
 

--- a/tests/lib/rules/prefer-destructuring.js
+++ b/tests/lib/rules/prefer-destructuring.js
@@ -130,7 +130,8 @@ ruleTester.run("prefer-destructuring", rule, {
         {
             code: "var foo = object.foo;",
             options: [{ VariableDeclarator: { object: false }, AssignmentExpression: { object: true } }]
-        }
+        },
+        "class Foo extends Bar { static get foo() {var foo = super.foo} }"
     ],
 
     invalid: [

--- a/tests/lib/rules/prefer-destructuring.js
+++ b/tests/lib/rules/prefer-destructuring.js
@@ -131,7 +131,7 @@ ruleTester.run("prefer-destructuring", rule, {
             code: "var foo = object.foo;",
             options: [{ VariableDeclarator: { object: false }, AssignmentExpression: { object: true } }]
         },
-        "class Foo extends Bar { static get foo() {var foo = super.foo} }"
+        "class Foo extends Bar { static foo() {var foo = super.foo} }"
     ],
 
     invalid: [
@@ -276,6 +276,13 @@ ruleTester.run("prefer-destructuring", rule, {
             errors: [{
                 message: "Use object destructuring.",
                 type: "AssignmentExpression"
+            }]
+        },
+        {
+            code: "class Foo extends Bar { static foo() {var bar = super.foo.bar} }",
+            errors: [{
+                message: "Use object destructuring.",
+                type: "VariableDeclarator"
             }]
         }
     ]


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

This fixes #9625 

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
- `tests/lib/rules/prefer-destructuring.js`: I added a test to reproduce #9625 
- `lib/rules/prefer-destructuring.js`: I updated a line to fix #9625 

**Is there anything you'd like reviewers to focus on?**
No