### PR TITLE
New: Adds implicit-arrow-linebreak rule (refs #9510)

### DIFF
--- a/conf/eslint-recommended.js
+++ b/conf/eslint-recommended.js
@@ -53,6 +53,7 @@ module.exports = {
         "id-blacklist": "off",
         "id-length": "off",
         "id-match": "off",
+        "implicit-arrow-linebreak": "off",
         indent: "off",
         "indent-legacy": "off",
         "init-declarations": "off",

--- a/docs/rules/implicit-arrow-linebreak.md
+++ b/docs/rules/implicit-arrow-linebreak.md
@@ -1,0 +1,101 @@
+# Enforce the location of arrow function bodies with implicit returns (implicit-arrow-linebreak)
+
+An arrow function body can contain an implicit return as an expression instead of a block body. It can be useful to enforce a consistent location for the implicitly returned expression.
+
+## Rule Details
+
+This rule aims to enforce a consistent location for an arrow function containing an implicit return.
+
+See Also:
+
+- [`brace-style`](https://eslint.org/docs/rules/brace-style) which enforces this behavior for arrow functions with block bodies.
+
+### Options
+
+This rule accepts a string option:
+
+- `"beside"` (default) disallows a newline before an arrow function body.
+- `"below"` requires a newline before an arrow function body.
+
+Examples of **incorrect** code for this rule with the default `"beside"` option:
+
+```js
+/* eslint arrow-linebreak: ["error", "beside"] */
+
+(foo) =>
+  bar;
+
+(foo) =>
+  (bar);
+
+(foo) =>
+  bar =>
+    baz;
+
+(foo) =>
+(
+  bar()
+);
+```
+
+Examples of **correct** code for this rule with the default `"beside"` option:
+
+```js
+/* eslint arrow-linebreak: ["error", "beside"] */
+
+(foo) => bar;
+
+(foo) => (bar);
+
+(foo) => bar => baz;
+
+(foo) => (
+  bar()
+);
+
+// functions with block bodies allowed with this rule using any style
+// to enforce a consistent location for this case, see the rule: `brace-style`
+(foo) => {
+  return bar();
+}
+
+(foo) =>
+{
+  return bar();
+}
+```
+
+Examples of **incorrect** code for this rule with the `"below"` option:
+
+```js
+/* eslint arrow-linebreak: ["error", "below"] */
+
+(foo) => bar;
+
+(foo) => (bar);
+
+(foo) => bar => baz;
+```
+
+Examples of **correct** code for this rule with the `"below"` option:
+
+```js
+/* eslint arrow-linebreak: ["error", "below"] */
+
+
+(foo) =>
+  bar;
+
+(foo) =>
+  (bar);
+
+(foo) =>
+  bar =>
+    baz;
+```
+
+## When Not To Use It
+
+If you're not concerned about consistent locations of implicitly returned arrow function expressions, you should not turn on this rule.
+
+You can also disable this rule if you are using the `"always"` option for the [`arrow-body-style`](https://eslint.org/docs/rules/arrow-body-style), since this will disable the use of implicit returns in arrow functions.

--- a/docs/rules/implicit-arrow-linebreak.md
+++ b/docs/rules/implicit-arrow-linebreak.md
@@ -20,7 +20,7 @@ This rule accepts a string option:
 Examples of **incorrect** code for this rule with the default `"beside"` option:
 
 ```js
-/* eslint arrow-linebreak: ["error", "beside"] */
+/* eslint implicit-arrow-linebreak: ["error", "beside"] */
 
 (foo) =>
   bar;
@@ -41,7 +41,7 @@ Examples of **incorrect** code for this rule with the default `"beside"` option:
 Examples of **correct** code for this rule with the default `"beside"` option:
 
 ```js
-/* eslint arrow-linebreak: ["error", "beside"] */
+/* eslint implicit-arrow-linebreak: ["error", "beside"] */
 
 (foo) => bar;
 
@@ -68,7 +68,7 @@ Examples of **correct** code for this rule with the default `"beside"` option:
 Examples of **incorrect** code for this rule with the `"below"` option:
 
 ```js
-/* eslint arrow-linebreak: ["error", "below"] */
+/* eslint implicit-arrow-linebreak: ["error", "below"] */
 
 (foo) => bar;
 
@@ -80,7 +80,7 @@ Examples of **incorrect** code for this rule with the `"below"` option:
 Examples of **correct** code for this rule with the `"below"` option:
 
 ```js
-/* eslint arrow-linebreak: ["error", "below"] */
+/* eslint implicit-arrow-linebreak: ["error", "below"] */
 
 
 (foo) =>

--- a/lib/rules/implicit-arrow-linebreak.js
+++ b/lib/rules/implicit-arrow-linebreak.js
@@ -1,0 +1,86 @@
+/**
+ * @fileoverview enforce the location of arrow function bodies
+ * @author Sharmila Jesupaul
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+module.exports = {
+    meta: {
+        docs: {
+            description: "enforce the location of arrow function bodies",
+            category: "Stylistic Issues",
+            recommended: false
+        },
+        fixable: "whitespace",
+        schema: [
+            {
+                enum: ["beside", "below"]
+            }
+        ]
+    },
+
+    create(context) {
+        const sourceCode = context.getSourceCode();
+
+        //----------------------------------------------------------------------
+        // Helpers
+        //----------------------------------------------------------------------
+        /**
+         * Gets the applicable preference for a particular keyword
+         * @returns {string} The applicable option for the keyword, e.g. 'beside'
+         */
+        function getOption() {
+            return context.options[0] || "beside";
+        }
+
+        /**
+         * Validates the location of an arrow function body
+         * @param {ASTNode} node The arrow function body
+         * @param {string} keywordName The applicable keyword name for the arrow function body
+         * @returns {void}
+         */
+        function validateExpression(node) {
+            const option = getOption();
+
+            let tokenBefore = sourceCode.getTokenBefore(node.body);
+            const hasParens = tokenBefore.value === "(";
+
+            if (node.type === "BlockStatement") {
+                return;
+            }
+
+            let fixerTarget = node.body;
+
+            if (hasParens) {
+
+                // Gets the first token before the function body that is not an open paren
+                tokenBefore = sourceCode.getTokenBefore(node.body, token => token.value !== "(");
+                fixerTarget = sourceCode.getTokenAfter(tokenBefore);
+            }
+
+            if (tokenBefore.loc.end.line === fixerTarget.loc.start.line && option === "below") {
+                context.report({
+                    node: fixerTarget,
+                    message: "Expected a linebreak before this expression.",
+                    fix: fixer => fixer.insertTextBefore(fixerTarget, "\n")
+                });
+            } else if (tokenBefore.loc.end.line !== fixerTarget.loc.start.line && option === "beside") {
+                context.report({
+                    node: fixerTarget,
+                    message: "Expected no linebreak before this expression.",
+                    fix: fixer => fixer.replaceTextRange([tokenBefore.range[1], fixerTarget.range[0]], " ")
+                });
+            }
+        }
+
+        //----------------------------------------------------------------------
+        // Public
+        //----------------------------------------------------------------------
+        return {
+            ArrowFunctionExpression: node => validateExpression(node)
+        };
+    }
+};

--- a/tests/lib/rules/implicit-arrow-linebreak.js
+++ b/tests/lib/rules/implicit-arrow-linebreak.js
@@ -1,0 +1,173 @@
+/**
+ * @fileoverview enforce the location of arrow function bodies
+ * @author Sharmila Jesupaul
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../lib/rules/implicit-arrow-linebreak");
+const RuleTester = require("../../../lib/testers/rule-tester");
+
+const EXPECTED_LINEBREAK = { message: "Expected a linebreak before this expression." };
+const UNEXPECTED_LINEBREAK = { message: "Expected no linebreak before this expression." };
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
+
+ruleTester.run("arrow-linebreak", rule, {
+
+    valid: [
+
+        // always valid
+        `(foo) => {
+            bar
+        }`,
+
+        // 'beside' option
+        "() => bar;",
+        "() => (bar);",
+        "() => bar => baz;",
+        "() => ((((bar))));",
+        `(foo) => (
+            bar
+        )`,
+        {
+            code: "(foo) => bar();",
+            options: ["beside"]
+        },
+
+        // 'below' option
+        {
+            code: `
+                (foo) =>
+                    (
+                        bar
+                    )
+            `,
+            options: ["below"]
+        }, {
+            code: `
+                () =>
+                    ((((bar))));
+            `,
+            options: ["below"]
+        }, {
+            code: `
+                () =>
+                    bar();
+            `,
+            options: ["below"]
+        }, {
+            code: `
+                () =>
+                    (bar);
+            `,
+            options: ["below"]
+        }, {
+            code: `
+                () =>
+                    bar =>
+                        baz;
+            `,
+            options: ["below"]
+        }
+    ],
+
+    invalid: [
+
+        // 'beside' option
+        {
+            code: `
+                (foo) =>
+                    bar();
+            `,
+            output: `
+                (foo) => bar();
+            `,
+            errors: [UNEXPECTED_LINEBREAK]
+        }, {
+            code: `
+                () =>
+                    (bar);
+            `,
+            output: `
+                () => (bar);
+            `,
+            errors: [UNEXPECTED_LINEBREAK]
+        }, {
+            code: `
+                () =>
+                    bar =>
+                        baz;
+            `,
+            output: `
+                () => bar => baz;
+            `,
+            errors: [UNEXPECTED_LINEBREAK, UNEXPECTED_LINEBREAK]
+        }, {
+            code: `
+                () =>
+                    ((((bar))));
+            `,
+            output: `
+                () => ((((bar))));
+            `,
+            errors: [UNEXPECTED_LINEBREAK]
+        }, {
+            code: `
+                (foo) =>
+                    (
+                        bar
+                    )
+            `,
+            output: `
+                (foo) => (
+                        bar
+                    )
+            `,
+            errors: [UNEXPECTED_LINEBREAK]
+        },
+
+        // 'below' option
+        {
+            code: "(foo) => bar();",
+            output: "(foo) => \nbar();",
+            options: ["below"],
+            errors: [EXPECTED_LINEBREAK]
+        }, {
+            code: "(foo) => bar => baz;",
+            output: "(foo) => \nbar => \nbaz;",
+            options: ["below"],
+            errors: [EXPECTED_LINEBREAK, EXPECTED_LINEBREAK]
+        }, {
+            code: "(foo) => (bar);",
+            output: "(foo) => \n(bar);",
+            options: ["below"],
+            errors: [EXPECTED_LINEBREAK]
+        }, {
+            code: "(foo) => (((bar)));",
+            output: "(foo) => \n(((bar)));",
+            options: ["below"],
+            errors: [EXPECTED_LINEBREAK]
+        }, {
+            code: `
+                (foo) => (
+                    bar
+                )
+            `,
+            output: `
+                (foo) => \n(
+                    bar
+                )
+            `,
+            options: ["below"],
+            errors: [EXPECTED_LINEBREAK]
+        }
+    ]
+});

--- a/tests/lib/rules/implicit-arrow-linebreak.js
+++ b/tests/lib/rules/implicit-arrow-linebreak.js
@@ -20,7 +20,7 @@ const UNEXPECTED_LINEBREAK = { message: "Expected no linebreak before this expre
 
 const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
 
-ruleTester.run("arrow-linebreak", rule, {
+ruleTester.run("implicit-arrow-linebreak", rule, {
 
     valid: [
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**
- [X] adds a new rule 

**What changes did you make? (Give an overview)**
Introduces a new rule enforcing the location of arrow function bodies with implicit returns. Also adds tests and docs.
Refs: #9510 & #6067 

**Is there anything you'd like reviewers to focus on?**
I think this rule gets a little less intuitive when it comes to function bodies surrounded by parentheses. 

I would like to make sure that this rule never warns on a case where parentheses are used to surround a multiline body, like this: 
```js
(foo) => (
  bar
);
```
However, currently, it does warn on cases like: 
```js
// incorrect code for "beside" option
(foo) => 
  (bar);

// incorrect code for "below" option
(foo) => (bar)
```
I'm not sure if that's the best way to handle this 🤔

cc. @ljharb, @not-an-aardvark  
more discussion: https://github.com/eslint/eslint/pull/9623.