### PR TITLE
fix `Cannot read property 'match' of undefined` error

### DIFF
--- a/lib/rules/no-octal-escape.js
+++ b/lib/rules/no-octal-escape.js
@@ -25,7 +25,7 @@ module.exports = {
         return {
 
             Literal(node) {
-                if (typeof node.value !== "string") {
+                if (typeof node.value !== "string" || typeof node.raw === "undefined") {
                     return;
                 }
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
**Tell us about your environment**

* **ESLint Version:** 4.11
* **Node Version:** 8.9.1
* **npm Version:** 5.5.1

**What parser (default, Babel-ESLint, etc.) are you using?** 
bebal-eslint

**Please show your full configuration:**
```js
const path = require('path')

module.exports = {
  root: true,
  parserOptions: {
    parser: "babel-eslint",
    ecmaVersion: 2017,
    sourceType: "module"
  },
  extends: [
    'airbnb-base',
    'plugin:vue/recommended',
  ],
  // required to lint *.vue files
  plugins: [
    'html',
  ],
  // add your custom rules here
  'rules': {
    // allow paren-less arrow functions
    'arrow-parens': 0,
    // allow async-await
    'generator-star-spacing': 0,
    // allow debugger during development
    'no-debugger': process.env.NODE_ENV === 'production' ? 2 : 0,
    'comma-dangle': ['error', 'always-multiline'],
    'object-curly-spacing': ['error', 'always'],
    'camelcase': ["error"],
    'prefer-const': ['error'],
    'no-var': 'error',
    'no-console': ['error', { allow: ['warn', 'error'] }],
    'semi': ['error', 'never'],
    'import/extensions': ['error', 'always', {
      'js': 'never',
      'vue': 'never'
    }],
    'class-methods-use-this': ['error', { exceptMethods: ['render'] }],
    'function-paren-newline': 'off',
  },
  'env': {
    browser: true,
    jquery: true,
    jest: true,
  },
  settings: {
    'import/resolver': {
      webpack: {
        config: path.resolve(__dirname, './build/webpack.base.conf.js')
      },
    },
  },
}
```

**What did you do? Please include the actual source code causing the issue.**
Update eslint from 4.10.0 to 4.11.0

**What did you expect to happen?**
no type error thrown

**What actually happened? Please include the actual, raw output from ESLint.**
Error thrown for `no-octal-escape` rule
```
$ eslint --ext .js,.vue src
Cannot read property 'match' of undefined
TypeError: Cannot read property 'match' of undefined
    at Literal (/PROJECT_ROOT/node_modules/eslint/lib/rules/no-octal-escape.js:32:40)
    at listeners.(anonymous function).forEach.listener (/PROJECT_ROOT/node_modules/eslint/lib/util/safe-emitter.js:47:58)
    at Array.forEach (<anonymous>)
    at Object.emit (/PROJECT_ROOT/node_modules/eslint/lib/util/safe-emitter.js:47:38)
    at NodeEventGenerator.applySelector (/PROJECT_ROOT/node_modules/eslint/lib/util/node-event-generator.js:251:26)
    at NodeEventGenerator.applySelectors (/PROJECT_ROOT/node_modules/eslint/lib/util/node-event-generator.js:280:22)
    at NodeEventGenerator.enterNode (/PROJECT_ROOT/node_modules/eslint/lib/util/node-event-generator.js:294:14)
    at CodePathAnalyzer.enterNode (/PROJECT_ROOT/node_modules/eslint/lib/code-path-analysis/code-path-analyzer.js:608:23)
    at Traverser.enter (/PROJECT_ROOT/node_modules/eslint/lib/linter.js:959:32)
    at Traverser.__execute (/PROJECT_ROOT/node_modules/estraverse/estraverse.js:397:31)
error Command failed with exit code 1.
```

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Add a type checking for node.raw against `undefined`

**Is there anything you'd like reviewers to focus on?**
This was initially #9606, but the author has closed that issue.

I don't know if this is intended change in 4.11 that `node.raw` could be `undefined`, and what I can do is to prevent the problem surfaced

