### PR TITLE
Update: upgrade `globals` to 11.0.1 (fixes #9614)

### DIFF
--- a/conf/environments.js
+++ b/conf/environments.js
@@ -17,10 +17,126 @@ const globals = require("globals");
 module.exports = {
     builtin: globals.es5,
     browser: {
-        globals: globals.browser
+
+        /*
+         * For backward compatibility.
+         * Remove those on the next major release.
+         */
+        globals: Object.assign(
+            {
+                AutocompleteErrorEvent: false,
+                CDATASection: false,
+                ClientRect: false,
+                ClientRectList: false,
+                CSSAnimation: false,
+                CSSTransition: false,
+                CSSUnknownRule: false,
+                CSSViewportRule: false,
+                Debug: false,
+                DocumentTimeline: false,
+                DOMSettableTokenList: false,
+                ElementTimeControl: false,
+                FederatedCredential: false,
+                FileError: false,
+                HTMLAppletElement: false,
+                HTMLBlockquoteElement: false,
+                HTMLIsIndexElement: false,
+                HTMLKeygenElement: false,
+                HTMLLayerElement: false,
+                IDBEnvironment: false,
+                InputMethodContext: false,
+                MediaKeyError: false,
+                MediaKeyEvent: false,
+                MediaKeys: false,
+                opera: false,
+                PasswordCredential: false,
+                ReadableByteStream: false,
+                SharedKeyframeList: false,
+                showModalDialog: false,
+                SiteBoundCredential: false,
+                SVGAltGlyphDefElement: false,
+                SVGAltGlyphElement: false,
+                SVGAltGlyphItemElement: false,
+                SVGAnimateColorElement: false,
+                SVGAnimatedPathData: false,
+                SVGAnimatedPoints: false,
+                SVGColor: false,
+                SVGColorProfileElement: false,
+                SVGColorProfileRule: false,
+                SVGCSSRule: false,
+                SVGCursorElement: false,
+                SVGDocument: false,
+                SVGElementInstance: false,
+                SVGElementInstanceList: false,
+                SVGEvent: false,
+                SVGExternalResourcesRequired: false,
+                SVGFilterPrimitiveStandardAttributes: false,
+                SVGFitToViewBox: false,
+                SVGFontElement: false,
+                SVGFontFaceElement: false,
+                SVGFontFaceFormatElement: false,
+                SVGFontFaceNameElement: false,
+                SVGFontFaceSrcElement: false,
+                SVGFontFaceUriElement: false,
+                SVGGlyphElement: false,
+                SVGGlyphRefElement: false,
+                SVGHKernElement: false,
+                SVGICCColor: false,
+                SVGLangSpace: false,
+                SVGLocatable: false,
+                SVGMissingGlyphElement: false,
+                SVGPaint: false,
+                SVGPathSeg: false,
+                SVGPathSegArcAbs: false,
+                SVGPathSegArcRel: false,
+                SVGPathSegClosePath: false,
+                SVGPathSegCurvetoCubicAbs: false,
+                SVGPathSegCurvetoCubicRel: false,
+                SVGPathSegCurvetoCubicSmoothAbs: false,
+                SVGPathSegCurvetoCubicSmoothRel: false,
+                SVGPathSegCurvetoQuadraticAbs: false,
+                SVGPathSegCurvetoQuadraticRel: false,
+                SVGPathSegCurvetoQuadraticSmoothAbs: false,
+                SVGPathSegCurvetoQuadraticSmoothRel: false,
+                SVGPathSegLinetoAbs: false,
+                SVGPathSegLinetoHorizontalAbs: false,
+                SVGPathSegLinetoHorizontalRel: false,
+                SVGPathSegLinetoRel: false,
+                SVGPathSegLinetoVerticalAbs: false,
+                SVGPathSegLinetoVerticalRel: false,
+                SVGPathSegList: false,
+                SVGPathSegMovetoAbs: false,
+                SVGPathSegMovetoRel: false,
+                SVGRenderingIntent: false,
+                SVGStylable: false,
+                SVGTests: false,
+                SVGTransformable: false,
+                SVGTRefElement: false,
+                SVGURIReference: false,
+                SVGViewSpec: false,
+                SVGVKernElement: false,
+                SVGZoomAndPan: false,
+                SVGZoomEvent: false,
+                TimeEvent: false,
+                XDomainRequest: false,
+                XMLHttpRequestProgressEvent: false,
+                XPathException: false,
+                XPathNamespace: false,
+                XPathNSResolver: false
+            },
+            globals.browser
+        )
     },
     node: {
-        globals: globals.node,
+
+        /*
+         * For backward compatibility.
+         * Remove those on the next major release.
+         */
+        globals: Object.assign(
+            { arguments: false, GLOBAL: false, root: false },
+            globals.node
+        ),
         parserOptions: {
             ecmaFeatures: {
                 globalReturn: true
@@ -51,7 +167,15 @@ module.exports = {
         globals: globals.jasmine
     },
     jest: {
-        globals: globals.jest
+
+        /*
+         * For backward compatibility.
+         * Remove those on the next major release.
+         */
+        globals: Object.assign(
+            { check: false, gen: false },
+            globals.jest
+        )
     },
     phantomjs: {
         globals: globals.phantomjs

--- a/conf/environments.js
+++ b/conf/environments.js
@@ -96,7 +96,7 @@ module.exports = {
         globals: globals.webextensions
     },
     es6: {
-        globals: globals.es6,
+        globals: globals.es2015,
         parserOptions: {
             ecmaVersion: 6
         }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "file-entry-cache": "^2.0.0",
     "functional-red-black-tree": "^1.0.1",
     "glob": "^7.1.2",
-    "globals": "^9.17.0",
+    "globals": "^11.0.1",
     "ignore": "^3.3.3",
     "imurmurhash": "^0.1.4",
     "inquirer": "^3.0.6",


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

Fixes #9614.
Closes #9555.

**What changes did you make? (Give an overview)**

This PR upgrades the dependency to `globals` package to `11.x` from `9.x` ([diff](https://github.com/sindresorhus/globals/compare/v9.17.0...v11.0.0#diff-1c916b21daa3b4eab4ea8661b409056c)).

Estimated effects:

- `no-undef` rule reports `System` variables (#9614).
- `no-shadow` and `no-redeclare` with `{builtinGlobals: true}` option no longer report `System` variables.
- `no-extend-native` rule reports about `Atomics` and `SharedBufferArray`.<br><br>
- ~~`node` environment no longer has the deprecated globals: `root`, `GLOBAL`, and `arguments`.~~
- `browser` environment is updated massively. The new globals are based on the global variables of current Chrome Canary. **EDIT:** there are not deleted variables
- `jasmine` gets `spyOnProperty` variable.
- `jest` gets `wait` variable ~~and no longer has `check` and `gen`.~~
- `greasemonkey` gets `GM` variable.

**Is there anything you'd like reviewers to focus on?**

I think we can release the changes in the next minor version because those are bug fixes.
But the diff is large a bit. What do you think?
