### PR TITLE
add bigint type to valid-typeof

### DIFF
--- a/lib/rules/valid-typeof.js
+++ b/lib/rules/valid-typeof.js
@@ -31,7 +31,7 @@ module.exports = {
 
     create(context) {
 
-        const VALID_TYPES = ["symbol", "undefined", "object", "boolean", "number", "string", "function"],
+        const VALID_TYPES = ["symbol", "undefined", "object", "boolean", "bigint", "number", "string", "function"],
             OPERATORS = ["==", "===", "!=", "!=="];
 
         const requireStringLiterals = context.options[0] && context.options[0].requireStringLiterals;


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What rule do you want to change?**
valid-typeof

**Does this change cause the rule to produce more or fewer warnings?**
fewer

**How will the change be implemented? (New option, new default behavior, etc.)?**
addition of type

**Please provide some example code that this change will affect:**

```js
typeof 10n === 'bigint'
```

**What does the rule currently do for this code?**
fails

**What will the rule do after it's changed?**
doesn't fail

**What changes did you make? (Give an overview)**
added `bigint` as a valid type for `valid-typeof` rule, no tests added because most runtimes don't have this implemented yet.

**Is there anything you'd like reviewers to focus on?**


