### PR TITLE
New: add "multiline" option to padding-line-between-statements (#9642)

### DIFF
--- a/docs/rules/padding-line-between-statements.md
+++ b/docs/rules/padding-line-between-statements.md
@@ -66,6 +66,7 @@ You can supply any number of configurations. If an statement pair matches multip
     - `"if"` is `if` statements.
     - `"import"` is `import` declarations.
     - `"let"` is `let` variable declarations.
+    - `"multiline"` is any multiline statement.
     - `"multiline-block-like"` is block like statements. This is the same as `block-like` type, but only the block is multiline.
     - `"return"` is `return` statements.
     - `"switch"` is `switch` statements.

--- a/lib/rules/padding-line-between-statements.js
+++ b/lib/rules/padding-line-between-statements.js
@@ -106,6 +106,15 @@ function isBlockLikeStatement(sourceCode, node) {
 }
 
 /**
+ * Check whether the given node spans multiple lines or not.
+ * @param {ASTNode} node The node to check.
+ * @returns {boolean} `true` if the node is multiline.
+ */
+function isMultilineStatement(node) {
+    return node.loc.start.line !== node.loc.end.line;
+}
+
+/**
  * Check whether the given node is a directive or not.
  * @param {ASTNode} node The node to check.
  * @param {SourceCode} sourceCode The source code object to get tokens.
@@ -353,9 +362,12 @@ const StatementTypes = {
             node.type === "ExpressionStatement" &&
             !isDirectivePrologue(node, sourceCode)
     },
+    multiline: {
+        test: node => isMultilineStatement(node)
+    },
     "multiline-block-like": {
         test: (node, sourceCode) =>
-            node.loc.start.line !== node.loc.end.line &&
+            isMultilineStatement(node) &&
             isBlockLikeStatement(sourceCode, node)
     },
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->
https://github.com/eslint/eslint/issues/9642

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Added an `isMultilineStatement(node)` function to the rule, and implemented a new `"multiline"` option that uses It. I also modified the `"multiline-block-like"` option to use the new function.

**Is there anything you'd like reviewers to focus on?**
I haven't added tests yet, I'm trying to wrap my head around how the test cases work. Any help or suggestions are welcome.

