### PR TITLE
Update: added option to enforce immutables for prefer-const

### DIFF
--- a/docs/rules/prefer-const.md
+++ b/docs/rules/prefer-const.md
@@ -90,7 +90,8 @@ console.log(b);
 {
     "prefer-const": ["error", {
         "destructuring": "any",
-        "ignoreReadBeforeAssign": false
+        "ignoreReadBeforeAssign": false,
+        "constsAreConstant": false
     }]
 }
 ```
@@ -186,6 +187,44 @@ function initialize() {
 }
 ```
 
+### constsAreConstant
+
+This is an option to avoid mutating assignments.
+If `true` is specifided, this rule will notify when a non-primitive `const` is being mutated. It is recommended to pair this option with [no-param-reassign](no-param-reassign.md) so that consts are not mutated when being passed to functions.
+Default is `false`
+
+Examples of **correct** code for the `{"constsAreConstant": true}` option:
+
+```js
+/*eslint prefer-const: ["error", {"constsAreConstant": true}]*/
+/*eslint-env es6*/
+
+let timer = {};
+timer.time = new Date();
+Object.assign(timer, {
+    timezones: {...}
+});
+
+let friends = ['bob'];
+friends.push('sally');
+```
+
+Examples of **correct** code for the default `{"constsAreConst": false}` option:
+
+```js
+/*eslint prefer-const: ["error", {"constsAreConst": false}]*/
+/*eslint-env es6*/
+
+const timer = {};
+timer.time = new Date();
+Object.assign(timer, {
+    timezones: {...}
+});
+
+const friends = ['bob'];
+friends.push('sally');
+```
+
 ## When Not To Use It
 
 If you don't want to be notified about variables that are never reassigned after initial assignment, you can safely disable this rule.
@@ -194,3 +233,4 @@ If you don't want to be notified about variables that are never reassigned after
 
 * [no-var](no-var.md)
 * [no-use-before-define](no-use-before-define.md)
+* [no-param-reassign](no-param-reassign.md)

--- a/lib/rules/prefer-const.js
+++ b/lib/rules/prefer-const.js
@@ -74,20 +74,25 @@ function canBecomeVariableDeclaration(identifier) {
  *   exported variables are reassigned or not.
  *
  * @param {eslint-scope.Variable} variable - A variable to get.
- * @param {boolean} ignoreReadBeforeAssign -
- *      The value of `ignoreReadBeforeAssign` option.
+ * @param {Object} ruleOptions -
+ *      Object containing the values of `ignoreReadBeforeAssign` & 'constsAreConstant' option.
  * @returns {ASTNode|null}
  *      An Identifier node if the variable should change to const.
  *      Otherwise, null.
  */
-function getIdentifierIfShouldBeConst(variable, ignoreReadBeforeAssign) {
+function getIdentifierIfShouldBeConst(variable, ruleOptions) {
     if (variable.eslintUsed && variable.scope.type === "global") {
         return null;
     }
 
+    const ignoreReadBeforeAssign = ruleOptions.ignoreReadBeforeAssign;
+    const constsAreConstant = ruleOptions.constsAreConstant;
+
     // Finds the unique WriteReference.
     let writer = null;
     let isReadBeforeInit = false;
+    let isMutated = false;
+    let isAlreadyConst = false;
     const references = variable.references;
 
     for (let i = 0; i < references.length; ++i) {
@@ -102,12 +107,53 @@ function getIdentifierIfShouldBeConst(variable, ignoreReadBeforeAssign) {
             if (isReassigned) {
                 return null;
             }
-            writer = reference;
+
+            const declaredAsConst = (
+                reference.identifier &&
+                reference.identifier.parent.parent.kind === "const"
+            );
+
+            isAlreadyConst = (
+                constsAreConstant &&
+                declaredAsConst
+            );
+
+            if (!isAlreadyConst) {
+                writer = reference;
+            }
+
+        } else if (reference.isRead() && constsAreConstant) {
+            const identifier = reference.identifier;
+            const parent = identifier.parent;
+
+            const property = parent.property;
+            const argz = parent.arguments;
+            const parentType = parent.type;
+
+            if (argz && argz.length) {
+                const isArgument = argz[0].name === reference.identifier.name;
+                const isMutatingArgument = isArgument && (argz[0].parent.callee.type !== "Identifier");
+
+                if (isMutatingArgument) {
+                    isMutated = true;
+                }
+            } else if (property) {
+                const propertyType = property.type;
+
+                if (parentType === "MemberExpression" && propertyType === "Identifier") {
+                    if (!isAlreadyConst) {
+                        return null;
+                    }
+
+                    isMutated = true;
+                }
+            }
 
         } else if (reference.isRead() && writer === null) {
             if (ignoreReadBeforeAssign) {
                 return null;
             }
+
             isReadBeforeInit = true;
         }
     }
@@ -117,17 +163,24 @@ function getIdentifierIfShouldBeConst(variable, ignoreReadBeforeAssign) {
      * If the assignment cannot change to a declaration, ignore it.
      */
     const shouldBeConst = (
+        !isMutated &&
         writer !== null &&
         writer.from === variable.scope &&
         canBecomeVariableDeclaration(writer.identifier)
     );
 
+    if (isMutated) {
+        return variable.defs[0].name;
+    }
+
     if (!shouldBeConst) {
         return null;
     }
+
     if (isReadBeforeInit) {
         return variable.defs[0].name;
     }
+
     return writer.identifier;
 }
 
@@ -164,17 +217,17 @@ function getDestructuringHost(reference) {
  * destructuring.
  *
  * @param {eslint-scope.Variable[]} variables - Variables to group by destructuring.
- * @param {boolean} ignoreReadBeforeAssign -
- *      The value of `ignoreReadBeforeAssign` option.
+ * @param {Object} ruleOptions -
+ *      Object containing the values of `ignoreReadBeforeAssign` & 'constsAreConstant' option.
  * @returns {Map<ASTNode, ASTNode[]>} Grouped identifier nodes.
  */
-function groupByDestructuring(variables, ignoreReadBeforeAssign) {
+function groupByDestructuring(variables, ruleOptions) {
     const identifierMap = new Map();
 
     for (let i = 0; i < variables.length; ++i) {
         const variable = variables[i];
         const references = variable.references;
-        const identifier = getIdentifierIfShouldBeConst(variable, ignoreReadBeforeAssign);
+        const identifier = getIdentifierIfShouldBeConst(variable, ruleOptions);
         let prevId = null;
 
         for (let j = 0; j < references.length; ++j) {
@@ -243,7 +296,8 @@ module.exports = {
                 type: "object",
                 properties: {
                     destructuring: { enum: ["any", "all"] },
-                    ignoreReadBeforeAssign: { type: "boolean" }
+                    ignoreReadBeforeAssign: { type: "boolean" },
+                    constsAreConstant: { type: "boolean" }
                 },
                 additionalProperties: false
             }
@@ -255,6 +309,11 @@ module.exports = {
         const sourceCode = context.getSourceCode();
         const checkingMixedDestructuring = options.destructuring !== "all";
         const ignoreReadBeforeAssign = options.ignoreReadBeforeAssign === true;
+        const constsAreConstant = options.constsAreConstant === true;
+        const ruleOptions = {
+            constsAreConstant,
+            ignoreReadBeforeAssign
+        };
         const variables = [];
 
         /**
@@ -296,11 +355,19 @@ module.exports = {
                     nodesToReport.length === nodes.length;
 
                 nodesToReport.forEach(node => {
+                    let message = "'{{name}}' is never reassigned. Use 'const' instead.";
+                    let reDeclaration = "const";
+
+                    if (node.parent.parent.kind === "const") {
+                        message = "'{{name}}' is mutated. Use 'let' instead.";
+                        reDeclaration = "let";
+                    }
+
                     context.report({
                         node,
-                        message: "'{{name}}' is never reassigned. Use 'const' instead.",
+                        message,
                         data: node,
-                        fix: shouldFix ? fixer => fixer.replaceText(sourceCode.getFirstToken(varDeclParent), "const") : null
+                        fix: shouldFix ? fixer => fixer.replaceText(sourceCode.getFirstToken(varDeclParent), reDeclaration) : null
                     });
                 });
             }
@@ -308,11 +375,15 @@ module.exports = {
 
         return {
             "Program:exit"() {
-                groupByDestructuring(variables, ignoreReadBeforeAssign).forEach(checkGroup);
+                groupByDestructuring(variables, ruleOptions).forEach(checkGroup);
             },
 
             VariableDeclaration(node) {
                 if (node.kind === "let" && !isInitOfForStatement(node)) {
+                    pushAll(variables, context.getDeclaredVariables(node));
+                }
+
+                if (constsAreConstant && node.kind === "const" && !isInitOfForStatement(node)) {
                     pushAll(variables, context.getDeclaredVariables(node));
                 }
             }


### PR DESCRIPTION
Not sure if there is a desire for this rule as non-primitives are expected to be mutable by default but wanted to see what the community and the core team thought about it. 

It is noted in the documentation, but to make this rule more complete, it is recommended to be paired with `no-param-reassign` so the consts do not get mutated when being handed off to functions (updated the docs to reflect this). Also, I'm not wild about the name of the option `constsAreConstant` so please post recommendations if this rule seems useful.

<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

- [X] Documentation update
- [X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
- [X] Add autofixing to a rule
- [X] Add something to the core

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Added an option for the rule `prefer-consts' called `constsAreConstant`. Gives the developer an option to enforce strict rules around `consts` that should not be treated as mutable.

**Is there anything you'd like reviewers to focus on?**
`prefer-consts` is a very important rule to many devs and I did my best to not interfere with the ongoing logic within the core of the rule, so hopefully that is up to standards.

I tried to cover as many edge cases i could think of with Object an Array mutation but would be happy to fix any oversights.

