### PR TITLE
Fix: space-in-parens crash

### DIFF
--- a/lib/rules/space-in-parens.js
+++ b/lib/rules/space-in-parens.js
@@ -45,8 +45,7 @@ module.exports = {
         const MISSING_SPACE_MESSAGE = "There must be a space inside this paren.",
             REJECTED_SPACE_MESSAGE = "There should be no spaces inside this paren.",
             ALWAYS = context.options[0] === "always",
-
-            exceptionsArrayOptions = (context.options.length === 2) ? context.options[1].exceptions : [],
+            exceptionsArrayOptions = (context.options[1] && context.options[1].exceptions) || [],
             options = {};
         let exceptions;
 

--- a/tests/lib/rules/space-in-parens.js
+++ b/tests/lib/rules/space-in-parens.js
@@ -110,7 +110,8 @@ ruleTester.run("space-in-parens", rule, {
         { code: "foo( ); bar( {bar:'baz'} ); baz( [1,2] )", options: ["never", { exceptions: ["{}", "[]", "empty"] }] },
 
         // faulty exceptions option
-        { code: "foo( { bar: 'baz' } )", options: ["always", { exceptions: [] }] }
+        { code: "foo( { bar: 'baz' } )", options: ["always", { exceptions: [] }] },
+        { code: "foo( { bar: 'baz' } )", options: ["always", {}] }
     ],
 
     invalid: [


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

**Tell us about your environment**

* **ESLint Version:** master
* **Node Version:** 8.9.1
* **npm Version:** 5.5.1

**What parser (default, Babel-ESLint, etc.) are you using?**

- default

**Please show your full configuration:**

- nothing

**What did you do? Please include the actual source code causing the issue.**

```js
/* eslint space-in-parens: [error, always, {}] */
1
```

> I couldn't get the URL of our online demo because it crashes. Please copy/paste then see devtools' console.

**What did you expect to happen?**

No errors.

**What actually happened? Please include the actual, raw output from ESLint.**

A type error was thrown.

```
Uncaught TypeError: Error while loading rule 'space-in-parens': Cannot read property 'length' of undefined
```

**What changes did you make? (Give an overview)**

This PR fixes `space-in-parens` rule not crashing.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.
