### PR TITLE
Docs: Don’t use undocumented array-style configuration for max-len

### DIFF
--- a/docs/rules/max-len.md
+++ b/docs/rules/max-len.md
@@ -30,7 +30,7 @@ This rule has a number or object option:
 Examples of **incorrect** code for this rule with the default `{ "code": 80 }` option:
 
 ```js
-/*eslint max-len: ["error", 80]*/
+/*eslint max-len: ["error", { "code": 80 }]*/
 
 var foo = { "bar": "This is a bar.", "baz": { "qux": "This is a qux" }, "difficult": "to read" };
 ```
@@ -38,7 +38,7 @@ var foo = { "bar": "This is a bar.", "baz": { "qux": "This is a qux" }, "difficu
 Examples of **correct** code for this rule with the default `{ "code": 80 }` option:
 
 ```js
-/*eslint max-len: ["error", 80]*/
+/*eslint max-len: ["error", { "code": 80 }]*/
 
 var foo = {
   "bar": "This is a bar.",
@@ -52,7 +52,7 @@ var foo = {
 Examples of **incorrect** code for this rule with the default `{ "tabWidth": 4 }` option:
 
 ```js
-/*eslint max-len: ["error", 80, 4]*/
+/*eslint max-len: ["error", { "code": 80, "tabWidth": 4 }]*/
 
 \t  \t  var foo = { "bar": "This is a bar.", "baz": { "qux": "This is a qux" } };
 ```
@@ -60,7 +60,7 @@ Examples of **incorrect** code for this rule with the default `{ "tabWidth": 4 }
 Examples of **correct** code for this rule with the default `{ "tabWidth": 4 }` option:
 
 ```js
-/*eslint max-len: ["error", 80, 4]*/
+/*eslint max-len: ["error", { "code": 80, "tabWidth": 4 }]*/
 
 \t  \t  var foo = {
 \t  \t  \t  \t  "bar": "This is a bar.",


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
I used the documented object-style configuration for the `max-len` rule in the docs, instead of the array-style `["error", 80, 4]`.

**Is there anything you'd like reviewers to focus on?**
Nothing in particular.