### PR TITLE
Breaking: Make require('eslint').linter non-enumerable (fixes #9270)

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -8,9 +8,22 @@
 const Linter = require("./linter");
 
 module.exports = {
-    linter: new Linter(),
     Linter,
     CLIEngine: require("./cli-engine"),
     RuleTester: require("./testers/rule-tester"),
     SourceCode: require("./util/source-code")
 };
+
+let deprecatedLinterInstance = null;
+
+Object.defineProperty(module.exports, "linter", {
+    enumerable: false,
+    configurable: false, // Don't let people bypass the warning
+    get() {
+        if (!deprecatedLinterInstance) {
+            deprecatedLinterInstance = new Linter();
+        }
+
+        return deprecatedLinterInstance;
+    }
+});

--- a/lib/api.js
+++ b/lib/api.js
@@ -18,7 +18,6 @@ let deprecatedLinterInstance = null;
 
 Object.defineProperty(module.exports, "linter", {
     enumerable: false,
-    configurable: false,
     get() {
         if (!deprecatedLinterInstance) {
             deprecatedLinterInstance = new Linter();

--- a/lib/api.js
+++ b/lib/api.js
@@ -18,7 +18,7 @@ let deprecatedLinterInstance = null;
 
 Object.defineProperty(module.exports, "linter", {
     enumerable: false,
-    configurable: false, // Don't let people bypass the warning
+    configurable: false,
     get() {
         if (!deprecatedLinterInstance) {
             deprecatedLinterInstance = new Linter();


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

#9270

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
I  made `require('eslint').linter` non-enumerable so people aren’t tempted to use it.

**Is there anything you'd like reviewers to focus on?**
Is this actually a breaking change? The ESLint API is small enough that I doubt anyone uses `Object.keys` on it, and it would be unfortunate to make this wait until v5, which would probably push the deprecation date back another major version.

