### PR TITLE
Fix: eol-last allow empty-string to always pass (refs #9534)

### DIFF
--- a/lib/rules/eol-last.js
+++ b/lib/rules/eol-last.js
@@ -46,6 +46,14 @@ module.exports = {
                     CRLF = `\r${LF}`,
                     endsWithNewline = lodash.endsWith(src, LF);
 
+                /*
+                 * Empty source is always valid: No content in file so we don't
+                 * need to lint for a newline on the last line of content.
+                 */
+                if (!src.length) {
+                    return;
+                }
+
                 let mode = context.options[0] || "always",
                     appendCRLF = false;
 


### PR DESCRIPTION
Note that there are already tests asserting this behavior, but they aren't actually run in the rules. See https://github.com/eslint/eslint/issues/9534.

<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Add code to explicitly allow empty string source to pass linting in eol-last even when newline is required in config.

**Is there anything you'd like reviewers to focus on?**

Note that there is already test coverage (although the tests are not actually run in the rule due to #9534). I applied the same patch to Linter that not-an-aardvark had done in order to test the changes locally.