### PR TITLE
Fix: camelcase destructure leading/trailing underscore (fixes #9700)

### DIFF
--- a/lib/rules/camelcase.js
+++ b/lib/rules/camelcase.js
@@ -109,7 +109,7 @@ module.exports = {
 
                     if (node.parent.parent && node.parent.parent.type === "ObjectPattern") {
 
-                        if (node.parent.shorthand && node.parent.value.left && isUnderscored(node.parent.value.left.name)) {
+                        if (node.parent.shorthand && node.parent.value.left && isUnderscored(name)) {
 
                             report(node);
                         }
@@ -119,7 +119,7 @@ module.exports = {
                             return;
                         }
 
-                        if (node.parent.value.name && isUnderscored(node.parent.value.name)) {
+                        if (node.parent.value.name && isUnderscored(name)) {
                             report(node);
                         }
                     }

--- a/tests/lib/rules/camelcase.js
+++ b/tests/lib/rules/camelcase.js
@@ -44,11 +44,43 @@ ruleTester.run("camelcase", rule, {
             options: [{ properties: "always" }]
         },
         {
+            code: "var o = {_leading: 1}",
+            options: [{ properties: "always" }]
+        },
+        {
+            code: "var o = {trailing_: 1}",
+            options: [{ properties: "always" }]
+        },
+        {
             code: "var o = {bar_baz: 1}",
             options: [{ properties: "never" }]
         },
         {
+            code: "var o = {_leading: 1}",
+            options: [{ properties: "never" }]
+        },
+        {
+            code: "var o = {trailing_: 1}",
+            options: [{ properties: "never" }]
+        },
+        {
             code: "obj.a_b = 2;",
+            options: [{ properties: "never" }]
+        },
+        {
+            code: "obj._a = 2;",
+            options: [{ properties: "always" }]
+        },
+        {
+            code: "obj.a_ = 2;",
+            options: [{ properties: "always" }]
+        },
+        {
+            code: "obj._a = 2;",
+            options: [{ properties: "never" }]
+        },
+        {
+            code: "obj.a_ = 2;",
             options: [{ properties: "never" }]
         },
         {
@@ -64,11 +96,35 @@ ruleTester.run("camelcase", rule, {
             parserOptions: { ecmaVersion: 6 }
         },
         {
+            code: "var { _leading } = query;",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var { trailing_ } = query;",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
             code: "import { camelCased } from \"external module\";",
             parserOptions: { ecmaVersion: 6, sourceType: "module" }
         },
         {
+            code: "import { _leading } from \"external module\";",
+            parserOptions: { ecmaVersion: 6, sourceType: "module" }
+        },
+        {
+            code: "import { trailing_ } from \"external module\";",
+            parserOptions: { ecmaVersion: 6, sourceType: "module" }
+        },
+        {
             code: "import { no_camelcased as camelCased } from \"external-module\";",
+            parserOptions: { ecmaVersion: 6, sourceType: "module" }
+        },
+        {
+            code: "import { no_camelcased as _leading } from \"external-module\";",
+            parserOptions: { ecmaVersion: 6, sourceType: "module" }
+        },
+        {
+            code: "import { no_camelcased as trailing_ } from \"external-module\";",
             parserOptions: { ecmaVersion: 6, sourceType: "module" }
         },
         {
@@ -80,11 +136,35 @@ ruleTester.run("camelcase", rule, {
             parserOptions: { ecmaVersion: 6 }
         },
         {
+            code: "function foo({ no_camelcased: _leading }) {};",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "function foo({ no_camelcased: trailing_ }) {};",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
             code: "function foo({ camelCased = 'default value' }) {};",
             parserOptions: { ecmaVersion: 6 }
         },
         {
+            code: "function foo({ _leading = 'default value' }) {};",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "function foo({ trailing_ = 'default value' }) {};",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
             code: "function foo({ camelCased }) {};",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "function foo({ _leading }) {}",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "function foo({ trailing_ }) {}",
             parserOptions: { ecmaVersion: 6 }
         }
     ],


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

See #9700.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

The camelcase rule has a subtle requirement that we keep track of both the original property/identifier name, as well as a version of the name with leading and trailing underscores stripped out. During review, we missed that the original property/identifier name was being checked in the new destructuring case.

This pull request should be followed with a chore to ensure that all underscore checks will strip leading/trailing underscores, to make future contributions to this rule easier.

**Is there anything you'd like reviewers to focus on?**

I've added a few different test cases. Have I missed anything?