### PR TITLE
Fix: directives on multiline comments prefixed with `*` (Fixes #9646)

### DIFF
--- a/lib/ast-utils.js
+++ b/lib/ast-utils.js
@@ -558,13 +558,17 @@ module.exports = {
      */
     isDirectiveComment(node) {
         const comment = node.value.trim();
+        const hasAsterisk = (comment.indexOf("*") === 0);
 
         return (
             node.type === "Line" && comment.indexOf("eslint-") === 0 ||
             node.type === "Block" && (
                 comment.indexOf("global ") === 0 ||
+                (hasAsterisk && (comment.indexOf(" global") === 1 || comment.indexOf("global ") === 1) ||
                 comment.indexOf("eslint ") === 0 ||
-                comment.indexOf("eslint-") === 0
+                (hasAsterisk && (comment.indexOf(" eslint") === 1) || comment.indexOf("eslint ") === 1)) ||
+                comment.indexOf("eslint-") === 0 ||
+                (hasAsterisk && (comment.indexOf(" eslint-") === 1) || comment.indexOf("eslint-") === 1)
             )
         );
     },

--- a/tests/lib/ast-utils.js
+++ b/tests/lib/ast-utils.js
@@ -248,7 +248,10 @@ describe("ast-utils", () => {
                 "/*eslint-enable no-undef*/",
                 "/* eslint-env {\"es6\": true} */",
                 "/* eslint foo */",
-                "/*eslint bar*/"
+                "/*eslint bar*/",
+                "/*\neslint no-undef\n*/",
+                "/*\n* eslint-disable foo\n*/",
+                "/*\n*eslint-enable no-undef\n*/"
             ].join("\n");
             const ast = espree.parse(code, ESPREE_CONFIG);
             const sourceCode = new SourceCode(code, ast);


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Added verification on the ast-utils for cases where directive rule multiline comments are preceded by a `*`, which is a valid way of writing them.

**Is there anything you'd like reviewers to focus on?**

Any edge cases that I may be missing. I would also like to know if you have any particular way of addressing these long conditionals, maybe there's a standard that I don't know.


