### PR TITLE
New: Allow optional syntax sort groups for sort-imports (fixes #9713)

### DIFF
--- a/docs/rules/sort-imports.md
+++ b/docs/rules/sort-imports.md
@@ -35,11 +35,12 @@ This rule accepts an object with its properties as
 
 * `ignoreCase` (default: `false`)
 * `ignoreMemberSort` (default: `false`)
-* `memberSyntaxSortOrder` (default: `["none", "all", "multiple", "single"]`); all 4 items must be present in the array, but you can change the order:
+* `memberSyntaxSortOrder` (default: `["none", "all", "multiple", "single"]`); you can use any number of the following with "other" implicitly as the last item unless explicitly ordered:
     * `none` = import module without exported bindings.
     * `all` = import all members provided by exported bindings.
     * `multiple` = import multiple members.
     * `single` = import single member.
+    * `other` = any import type not explicitly in the order.
 
 Default option settings are:
 
@@ -158,14 +159,15 @@ Default is `false`.
 
 ### `memberSyntaxSortOrder`
 
-There are four different styles and the default member syntax sort order is:
+There are five different styles and the default member syntax sort order is:
 
 * `none` - import module without exported bindings.
 * `all` - import all members provided by exported bindings.
 * `multiple` - import multiple members.
 * `single` - import single member.
+* `other` - any import type not explicitly in the order.
 
-All four options must be specified in the array, but you can customise their order.
+Any number of options can be specified in the array in any custom order with "other" treated as the last item if not included.
 
 Examples of **incorrect** code for this rule with the default `{ "memberSyntaxSortOrder": ["none", "all", "multiple", "single"] }` option:
 
@@ -193,6 +195,43 @@ import * as foo from 'foo.js';
 import z from 'zoo.js';
 import {a, b} from 'foo.js';
 
+```
+
+Examples of **incorrect** code for this rule with the `{ "memberSyntaxSortOrder": ['all'] }` option:
+
+```js
+/*eslint sort-imports: ["error", { "memberSyntaxSortOrder": ['all'] }]*/
+
+import a from 'foo.js';
+import * as b from 'bar.js';
+```
+
+Examples of **correct** code for this rule with the `{ "memberSyntaxSortOrder": ['all'] }` option:
+
+```js
+/*eslint sort-imports: ["error", { "memberSyntaxSortOrder": ['all'] }]*/
+
+import * as b from 'bar.js';
+import a from 'foo.js';
+import {z, zoo} from 'zoo.js';
+```
+
+Examples of **correct** code for this rule with the `{ "memberSyntaxSortOrder": ['single'] }` option:
+
+```js
+/*eslint sort-imports: ["error", { "memberSyntaxSortOrder": ['single'] }]*/
+
+import a from 'foo.js';
+import * as b from 'bar.js';
+```
+
+Examples of **correct** code for this rule with the `{ "memberSyntaxSortOrder": ['other', 'all'] }` option:
+
+```js
+/*eslint sort-imports: ["error", { "memberSyntaxSortOrder": ['other', 'all'] }]*/
+
+import a from 'foo.js';
+import * as b from 'bar.js';
 ```
 
 Default is `["none", "all", "multiple", "single"]`.

--- a/lib/rules/sort-imports.js
+++ b/lib/rules/sort-imports.js
@@ -27,11 +27,11 @@ module.exports = {
                     memberSyntaxSortOrder: {
                         type: "array",
                         items: {
-                            enum: ["none", "all", "multiple", "single"]
+                            enum: ["none", "all", "multiple", "single", "other"]
                         },
                         uniqueItems: true,
-                        minItems: 4,
-                        maxItems: 4
+                        minItems: 0,
+                        maxItems: 5
                     },
                     ignoreMemberSort: {
                         type: "boolean"
@@ -84,7 +84,18 @@ module.exports = {
          * @returns {number} the declaration group by member index.
          */
         function getMemberParameterGroupIndex(node) {
-            return memberSyntaxSortOrder.indexOf(usedMemberSyntax(node));
+            let index = memberSyntaxSortOrder.indexOf(usedMemberSyntax(node));
+
+            // Use "other" index if the used syntax is not explicitly ordered
+            if (index === -1) {
+                index = memberSyntaxSortOrder.indexOf("other");
+
+                // Treat "other" as the last group if it's not enumerated
+                if (index === -1) {
+                    index = memberSyntaxSortOrder.length;
+                }
+            }
+            return index;
         }
 
         /**
@@ -125,7 +136,7 @@ module.exports = {
                                 message: "Expected '{{syntaxA}}' syntax before '{{syntaxB}}' syntax.",
                                 data: {
                                     syntaxA: memberSyntaxSortOrder[currentMemberSyntaxGroupIndex],
-                                    syntaxB: memberSyntaxSortOrder[previousMemberSyntaxGroupIndex]
+                                    syntaxB: memberSyntaxSortOrder[previousMemberSyntaxGroupIndex] || "other"
                                 }
                             });
                         }

--- a/tests/lib/rules/sort-imports.js
+++ b/tests/lib/rules/sort-imports.js
@@ -42,6 +42,46 @@ ruleTester.run("sort-imports", rule, {
                 memberSyntaxSortOrder: ["single", "multiple", "none", "all"]
             }]
         },
+        {
+            code:
+                "import A from 'bar.js';\n" +
+                "import {b, c} from 'foo.js';",
+            options: [{
+                memberSyntaxSortOrder: []
+            }]
+        },
+        {
+            code:
+                "import A from 'bar.js';\n" +
+                "import {b, c} from 'foo.js';",
+            options: [{
+                memberSyntaxSortOrder: ["single"]
+            }]
+        },
+        {
+            code:
+                "import {b, c} from 'foo.js'\n;" +
+                "import A from 'bar.js';",
+            options: [{
+                memberSyntaxSortOrder: ["multiple"]
+            }]
+        },
+        {
+            code:
+                "import A from 'bar.js';\n" +
+                "import {b, c} from 'foo.js';",
+            options: [{
+                memberSyntaxSortOrder: ["other", "multiple"]
+            }]
+        },
+        {
+            code:
+                "import A from 'bar.js';\n" +
+                "import {b, c} from 'foo.js';",
+            options: [{
+                memberSyntaxSortOrder: ["other", "single", "multiple", "none", "all"]
+            }]
+        },
         "import {a, b} from 'bar.js';\n" +
                 "import {c, d} from 'foo.js';",
         "import A from 'foo.js';\n" +
@@ -126,6 +166,27 @@ ruleTester.run("sort-imports", rule, {
         },
         {
             code:
+                "import b from 'bar.js';\n" +
+                "import * as a from 'foo.js';",
+            output: null,
+            options: [{
+                memberSyntaxSortOrder: []
+            }],
+            errors: [expectedError]
+        },
+        {
+            code:
+                "import * as a from 'foo.js';\n" +
+                "import {c, d} from 'bar.js';\n" +
+                "import b from 'baz.js';",
+            output: null,
+            options: [{
+                memberSyntaxSortOrder: ["all"]
+            }],
+            errors: [expectedError]
+        },
+        {
+            code:
                 "import a from 'foo.js';\n" +
                 "import {b, c} from 'bar.js';",
             output: null,
@@ -164,6 +225,45 @@ ruleTester.run("sort-imports", rule, {
             }],
             errors: [{
                 message: "Expected 'all' syntax before 'single' syntax.",
+                type: "ImportDeclaration"
+            }]
+        },
+        {
+            code:
+                "import b from 'bar.js';\n" +
+                "import * as a from 'foo.js';",
+            output: null,
+            options: [{
+                memberSyntaxSortOrder: ["all"]
+            }],
+            errors: [{
+                message: "Expected 'all' syntax before 'other' syntax.",
+                type: "ImportDeclaration"
+            }]
+        },
+        {
+            code:
+                "import * as a from 'foo.js';\n" +
+                "import b from 'bar.js';\n",
+            output: null,
+            options: [{
+                memberSyntaxSortOrder: ["single"]
+            }],
+            errors: [{
+                message: "Expected 'single' syntax before 'other' syntax.",
+                type: "ImportDeclaration"
+            }]
+        },
+        {
+            code:
+                "import * as a from 'foo.js';\n" +
+                "import b from 'bar.js';\n",
+            output: null,
+            options: [{
+                memberSyntaxSortOrder: ["other", "all"]
+            }],
+            errors: [{
+                message: "Expected 'other' syntax before 'all' syntax.",
                 type: "ImportDeclaration"
             }]
         },


### PR DESCRIPTION
Fix #9713
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md)) See #9713

**What changes did you make? (Give an overview)**
Changed the requirement of always 4 sort groups to allow 0 through 5 for a new "other" group. Treat a syntax as "other" if it's not explicitly listed as an option.

**Is there anything you'd like reviewers to focus on?**
The approach avoids modifying `memberSyntaxSortOrder` as it's frozen (can't just push "other" if it's missing.) Is that okay?