### PR TITLE
Docs: fix the link to contributing page

### DIFF
--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -102,4 +102,4 @@ Because of this line, all of the rules marked "(recommended)" on the [rules page
 * Get familiar with the [command line options](command-line-interface.md).
 * Explore [ESLint integrations](integrations.md) into other tools like editors, build systems, and more.
 * Can't find just the right rule?  Make your own [custom rule](/docs/developer-guide/working-with-rules.md).
-* Make ESLint even better by [contributing](/docs/developer-guide/contributing/README.md).
+* Make ESLint even better by [contributing](/docs/developer-guide/contributing/).


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Documentation update


**What changes did you make? (Give an overview)**
fixing a link. Currently, it goes to a 404

**Is there anything you'd like reviewers to focus on?**
not really
