### PR TITLE
Update: support eslint-disable-* block comments (fixes #8781)

### DIFF
--- a/docs/user-guide/configuring.md
+++ b/docs/user-guide/configuring.md
@@ -394,13 +394,18 @@ You can also disable or enable specific rules for an entire file:
 alert('foo');
 ```
 
-To disable all rules on a specific line, use a line comment in one of the following formats:
+To disable all rules on a specific line, use a line or block comment in one of the following formats:
 
 ```js
 alert('foo'); // eslint-disable-line
 
 // eslint-disable-next-line
 alert('foo');
+
+/* eslint-disable-next-line */
+alert('foo');
+
+alert('foo'); /* eslint-disable-line */
 ```
 
 To disable a specific rule on a specific line:
@@ -409,6 +414,11 @@ To disable a specific rule on a specific line:
 alert('foo'); // eslint-disable-line no-alert
 
 // eslint-disable-next-line no-alert
+alert('foo');
+
+alert('foo'); /* eslint-disable-line no-alert */
+
+/* eslint-disable-next-line no-alert */
 alert('foo');
 ```
 
@@ -419,12 +429,18 @@ alert('foo'); // eslint-disable-line no-alert, quotes, semi
 
 // eslint-disable-next-line no-alert, quotes, semi
 alert('foo');
+
+alert('foo'); /* eslint-disable-line no-alert, quotes, semi */
+
+/* eslint-disable-next-line no-alert, quotes, semi */
+alert('foo');
 ```
 
 All of the above methods also work for plugin rules. For example, to disable `eslint-plugin-example`'s `rule-name` rule, combine the plugin's name (`example`) and the rule's name (`rule-name`) into `example/rule-name`:
 
 ```js
 foo(); // eslint-disable-line example/rule-name
+foo(); /* eslint-disable-line example/rule-name */
 ```
 
 **Note:** Comments that disable warnings for a portion of a file tell ESLint not to report rule violations for the disabled code. ESLint still parses the entire file, however, so disabled code still needs to be syntactically valid JavaScript.

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -307,7 +307,6 @@ function modifyConfigsFromComments(filename, ast, config, ruleMapper) {
 
         if (match) {
             value = value.slice(match.index + match[1].length);
-
             if (comment.type === "Block") {
                 switch (match[1]) {
                     case "exported":
@@ -321,6 +320,18 @@ function modifyConfigsFromComments(filename, ast, config, ruleMapper) {
 
                     case "eslint-disable":
                         [].push.apply(disableDirectives, createDisableDirectives("disable", comment.loc.start, value));
+                        break;
+
+                    case "eslint-disable-line":
+                        if (comment.loc.start.line === comment.loc.end.line) {
+                            [].push.apply(disableDirectives, createDisableDirectives("disable-line", comment.loc.start, value));
+                        }
+                        break;
+
+                    case "eslint-disable-next-line":
+                        if (comment.loc.start.line === comment.loc.end.line) {
+                            [].push.apply(disableDirectives, createDisableDirectives("disable-next-line", comment.loc.start, value));
+                        }
                         break;
 
                     case "eslint-enable":

--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -2101,8 +2101,7 @@ describe("Linter", () => {
                 ].join("\n");
                 const config = {
                     rules: {
-                        "no-alert": 1,
-                        "no-console": 1
+                        "no-alert": 1
                     }
                 };
                 const messages = linter.verify(code, config, filename);
@@ -2117,8 +2116,7 @@ describe("Linter", () => {
                 ].join("\n");
                 const config = {
                     rules: {
-                        "no-alert": 1,
-                        "no-console": 1
+                        "no-alert": 1
                     }
                 };
                 const messages = linter.verify(code, config, filename);
@@ -2168,20 +2166,17 @@ describe("Linter", () => {
             it("should ignore violations of multiple rules when specified in mixed comments", () => {
                 const code = [
                     "/* eslint-disable-next-line no-alert */ // eslint-disable-next-line quotes",
-                    "alert(\"test\");",
-                    "console.log('test');"
+                    "alert(\"test\");"
                 ].join("\n");
                 const config = {
                     rules: {
                         "no-alert": 1,
-                        quotes: [1, "single"],
-                        "no-console": 1
+                        quotes: [1, "single"]
                     }
                 };
                 const messages = linter.verify(code, config, filename);
 
-                assert.strictEqual(messages.length, 1);
-                assert.strictEqual(messages[0].ruleId, "no-console");
+                assert.strictEqual(messages.length, 0);
             });
 
             it("should ignore violations of only the specified rule on next line", () => {

--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -1931,7 +1931,7 @@ describe("Linter", () => {
                 assert.strictEqual(messages[0].ruleId, "no-alert");
             });
 
-            it("should report a violation", () => {
+            it("should report a violation if eslint-disable-line in a block comment is not on a single line", () => {
                 const code = [
                     "/* eslint-disable-line",
                     "*",
@@ -1939,7 +1939,6 @@ describe("Linter", () => {
                 ].join("\n");
                 const config = {
                     rules: {
-                        "no-alert": 1,
                         "no-console": 1
                     }
                 };
@@ -1951,18 +1950,16 @@ describe("Linter", () => {
                 assert.strictEqual(messages[0].ruleId, "no-console");
             });
 
-            it("should report a violation if block comment is not on a single line", () => {
+            it("should report a violation if eslint-disable-line in a block comment is not on a single line", () => {
                 const code = [
                     "alert('test'); /* eslint-disable-line ",
-                    "no-alert */",
-                    "console.log('test'); /* eslint-disable-line */"
+                    "no-alert */"
                 ].join("\n");
                 const config = {
                     rules: {
                         "no-alert": 1,
                         quotes: [1, "double"],
-                        semi: [1, "always"],
-                        "no-console": 1
+                        semi: [1, "always"]
                     }
                 };
 
@@ -1974,10 +1971,10 @@ describe("Linter", () => {
                 assert.strictEqual(messages[1].ruleId, "quotes");
             });
 
-            it("should not report a violation", () => {
+            it("should not report a violation for eslint-disable-line in block comment", () => {
                 const code = [
                     "alert('test'); // eslint-disable-line no-alert",
-                    "alert('test'); /*eslint-disable-line no-alert*/" // here
+                    "alert('test'); /*eslint-disable-line no-alert*/"
                 ].join("\n");
                 const config = {
                     rules: {
@@ -2052,8 +2049,7 @@ describe("Linter", () => {
                 const config = {
                     rules: {
                         "no-alert": 1,
-                        quotes: [1, "single"],
-                        "no-console": 1
+                        quotes: [1, "single"]
                     }
                 };
                 const messages = linter.verify(code, config, filename);
@@ -2081,7 +2077,7 @@ describe("Linter", () => {
                 assert.strictEqual(messages[0].ruleId, "no-console");
             });
 
-            it("should ignore violation of specified rule if comment is in block quotes", () => {
+            it("should ignore violation of specified rule if eslint-disable-next-line is a block comment", () => {
                 const code = [
                     "/* eslint-disable-next-line no-alert */",
                     "alert('test');",
@@ -2098,7 +2094,7 @@ describe("Linter", () => {
                 assert.strictEqual(messages.length, 1);
                 assert.strictEqual(messages[0].ruleId, "no-console");
             });
-            it("should ignore violation of specified rule if comment is in block quotes", () => {
+            it("should ignore violation of specified rule if eslint-disable-next-line is a block comment", () => {
                 const code = [
                     "/* eslint-disable-next-line no-alert */",
                     "alert('test');"
@@ -2248,7 +2244,7 @@ describe("Linter", () => {
                 assert.strictEqual(messages[0].ruleId, "no-console");
             });
 
-            it("should ignore violations if comment is in block quotes", () => {
+            it("should ignore violations if eslint-disable-next-line is a block comment", () => {
                 const code = [
                     "alert('test');",
                     "/* eslint-disable-next-line no-alert */",


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ X] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Updated block comments to support `eslint-disable-line` and `eslint-disable-next-line`

**Is there anything you'd like reviewers to focus on?**
Nope! 
