### PR TITLE
Fix: Allow project relative globs in overrides config (fixes #9740)

### DIFF
--- a/docs/user-guide/configuring.md
+++ b/docs/user-guide/configuring.md
@@ -730,6 +730,14 @@ Sometimes a more fine-controlled configuration is necessary, for example if the 
 
 ### Relative glob patterns
 
+Globs provided in the `files` or `excludedFiles` arrays can be processed in a few different ways:
+
+* Globs with a leading `./` are considered as relative to the config file location. For example, a glob pattern of `./*.js` would _only_ match `.js` files in the same directory as the config file itself.
+* Globs containing any number of `/` (though keep in mind that absolute paths are not allowed, a glob cannot _start_ with a `/`) are considered as matching paths relative to the config file location.
+* Globs without a `/` in them, are matched against the files base name. For example, a glob of `*.js` matches all `.js` files within the entire directory structure regardless of depth.
+
+Lets take a look at a few examples given the following project structure:
+
 ```
 project-root
 ├── app
@@ -740,13 +748,20 @@ project-root
 │   │   ├── bar.js
 │   │   ├── barSpec.js
 │   ├── .eslintrc.json
+│   ├── index.js
 ├── server
+│   ├── index.js
 │   ├── server.js
 │   ├── serverSpec.js
 ├── .eslintrc.json
+├── index.js
 ```
 
-The config in `app/.eslintrc.json` defines the glob pattern `**/*Spec.js`. This pattern is relative to the base directory of `app/.eslintrc.json`. So, this pattern would match `app/lib/fooSpec.js` and `app/components/barSpec.js` but **NOT** `server/serverSpec.js`. If you defined the same pattern in the `.eslintrc.json` file within in the `project-root` folder, it would match all three of the `*Spec` files.
+Assume that the config file in `app/.eslintrc.json` defines the glob pattern `**/*Spec.js`. This pattern is relative to the base directory of `app/.eslintrc.json`. So, this pattern would match `app/lib/fooSpec.js` and `app/components/barSpec.js` but **NOT** `server/serverSpec.js`.
+
+If you wanted to match all `*Spec.js` files throughout your entire heirarchy, you could instead use either `**/*Spec.js` or simply `*Spec.js` in your `project-root/.eslintrc.json` file.
+
+If you wanted to match the `project-root/index.js` file but not the `app/index.js` or `server/index.js` files, you could use a glob of `./index.js` in `project-root/.eslintrc.json`.
 
 ### Example configuration
 

--- a/lib/config/config-ops.js
+++ b/lib/config/config-ops.js
@@ -25,6 +25,50 @@ const RULE_SEVERITY_STRINGS = ["off", "warn", "error"],
     }, {}),
     VALID_SEVERITIES = [0, 1, 2, "off", "warn", "error"];
 
+const NON_PROJECT_RELATIVE_GLOB_OPTIONS = Object.freeze({ matchBase: true });
+const PROJECT_RELATIVE_GLOB_OPTIONS = Object.freeze({ });
+
+/**
+ * Determine if the provided pattern starts with `./` (and is therefore
+ * "project relative").
+ *
+ * @param {string} pattern the pattern to check
+ * @returns {boolean} true if pattern begins with `./`
+ * @private
+ */
+function isProjectRelative(pattern) {
+    return pattern.length > 2 && pattern[0] === "." && pattern[1] === "/";
+}
+
+/**
+ * Determine if the file path is matched by any of the provided patterns.
+ *
+ * Treats patterns with a leading `./` as "project relative" and opting in to
+ * project relative semantics (i.e. strip leading `./` and no `matchBase` flag
+ * to minimatch).
+ *
+ * All other patterns are matched using the default options.
+ *
+ * @param {string} filePath the file path to compare against
+ * @param {string[]} patterns an array of patterns to check
+ * @returns {boolean} true if path was matched
+ * @private
+ */
+function matchesAnyGlob(filePath, patterns) {
+    return patterns.some(pattern => {
+        let opts;
+
+        if (isProjectRelative(pattern)) {
+            opts = PROJECT_RELATIVE_GLOB_OPTIONS;
+            pattern = pattern.slice(2);
+        } else {
+            opts = NON_PROJECT_RELATIVE_GLOB_OPTIONS;
+        }
+
+        return minimatch(filePath, pattern, opts);
+    });
+}
+
 //------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
@@ -375,9 +419,6 @@ module.exports = {
             }
         });
 
-        const opts = { matchBase: true };
-
-        return patternList.some(pattern => minimatch(filePath, pattern, opts)) &&
-            !excludedPatternList.some(excludedPattern => minimatch(filePath, excludedPattern, opts));
+        return matchesAnyGlob(filePath, patternList) && !matchesAnyGlob(filePath, excludedPatternList);
     }
 };

--- a/tests/lib/config/config-ops.js
+++ b/tests/lib/config/config-ops.js
@@ -860,6 +860,15 @@ describe("ConfigOps", () => {
             });
         }
 
+        // files relative to project root
+        match("foo.js", ["./foo.js"], []);
+        match("foo.js", ["./*"], []);
+        match("foo.js", ["./**"], []);
+        match("subdir/foo.js", ["./**"], []);
+        match("subdir/foo.js", ["./subdir/**"], []);
+        match("subdir/foo.js", ["./subdir/*"], []);
+        match("subdir/foo.js", ["./subdir/foo.js"], []);
+
         // files in the project root
         match("foo.js", ["foo.js"], []);
         match("foo.js", ["*"], []);
@@ -867,9 +876,6 @@ describe("ConfigOps", () => {
         match("foo.js", ["**/*.js"], []);
         match("bar.js", ["*.js"], ["foo.js"]);
 
-        noMatch("foo.js", ["./foo.js"], []);
-        noMatch("foo.js", ["./*"], []);
-        noMatch("foo.js", ["./**"], []);
         noMatch("foo.js", ["*"], ["foo.js"]);
         noMatch("foo.js", ["*.js"], ["foo.js"]);
         noMatch("foo.js", ["**/*.js"], ["foo.js"]);
@@ -885,9 +891,6 @@ describe("ConfigOps", () => {
         match("subdir/second/foo.js", ["subdir/**"], []);
 
         noMatch("subdir/foo.js", ["./foo.js"], []);
-        noMatch("subdir/foo.js", ["./**"], []);
-        noMatch("subdir/foo.js", ["./subdir/**"], []);
-        noMatch("subdir/foo.js", ["./subdir/*"], []);
         noMatch("subdir/foo.js", ["*"], ["subdir/**"]);
         noMatch("subdir/very/deep/foo.js", ["*.js"], ["subdir/**"]);
         noMatch("subdir/second/foo.js", ["subdir/*"], []);


### PR DESCRIPTION
Prior to this change it was impossible to target files in the project root in `overrides` configuration without _also_ matching files of the same name in nested directories. This was due to the specific options passed to `minimatch` when testing the provided patterns.

After this change, it is now possible to prefix a glob with `./` to "anchor" it to the project root. This has the perceived behavior of making it possible to target `./index.js` independently of `src/index.js` (for example). Due to the fact that `./` previously _never matched_ anything (as evidendenced by the unit tests) we can be certain that this does not break any preexisting globs.

Fixes #9740.