### PR TITLE
Update: More detailed assert message for rule-tester

### DIFF
--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -138,7 +138,14 @@ const IT = Symbol("it");
  * @returns {any} Returned value of `method`.
  */
 function defaultHandler(text, method) {
-    return method.apply(this);
+    try {
+        return method.apply(this);
+    } catch (err) {
+        if (err instanceof assert.AssertionError) {
+            err.message = `${util.inspect(err.actual)} ${err.operator} ${util.inspect(err.expected)}`;
+        }
+        throw err;
+    }
 }
 
 class RuleTester {

--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -142,7 +142,7 @@ function itDefaultHandler(text, method) {
         return method.apply(this);
     } catch (err) {
         if (err instanceof assert.AssertionError) {
-            err.message += ` ${util.inspect(err.actual)} ${err.operator} ${util.inspect(err.expected)}`;
+            err.message += ` (${util.inspect(err.actual)} ${err.operator} ${util.inspect(err.expected)})`;
         }
         throw err;
     }

--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -131,21 +131,32 @@ const DESCRIBE = Symbol("describe");
 const IT = Symbol("it");
 
 /**
- * This is `it` or `describe` if those don't exist.
+ * This is `it` default handler if `it` don't exist.
  * @this {Mocha}
  * @param {string} text - The description of the test case.
  * @param {Function} method - The logic of the test case.
  * @returns {any} Returned value of `method`.
  */
-function defaultHandler(text, method) {
+function itDefaultHandler(text, method) {
     try {
         return method.apply(this);
     } catch (err) {
         if (err instanceof assert.AssertionError) {
-            err.message = `${util.inspect(err.actual)} ${err.operator} ${util.inspect(err.expected)}`;
+            err.message += ` ${util.inspect(err.actual)} ${err.operator} ${util.inspect(err.expected)}`;
         }
         throw err;
     }
+}
+
+/**
+ * This is `describe` default handler if `describe` don't exist.
+ * @this {Mocha}
+ * @param {string} text - The description of the test case.
+ * @param {Function} method - The logic of the test case.
+ * @returns {any} Returned value of `method`.
+ */
+function describeDefaultHandler(text, method) {
+    return method.apply(this);
 }
 
 class RuleTester {
@@ -219,7 +230,7 @@ class RuleTester {
     static get describe() {
         return (
             this[DESCRIBE] ||
-            (typeof describe === "function" ? describe : defaultHandler)
+            (typeof describe === "function" ? describe : describeDefaultHandler)
         );
     }
 
@@ -230,7 +241,7 @@ class RuleTester {
     static get it() {
         return (
             this[IT] ||
-            (typeof it === "function" ? it : defaultHandler)
+            (typeof it === "function" ? it : itDefaultHandler)
         );
     }
 

--- a/tests/lib/testers/no-test-runners.js
+++ b/tests/lib/testers/no-test-runners.js
@@ -1,0 +1,31 @@
+/**
+ * @fileoverview Tests for RuleTester without any test runner
+ * @author Weijia Wang <starkwang@126.com>
+ */
+"use strict";
+
+/* global describe, it */
+/* eslint-disable no-global-assign*/
+const assert = require("assert"),
+    RuleTester = require("../../../lib/testers/rule-tester");
+const tmpIt = it;
+const tmpDescribe = describe;
+
+it = null;
+describe = null;
+
+const ruleTester = new RuleTester();
+
+assert.throws(() => {
+    ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+        valid: [
+            "bar = baz;"
+        ],
+        invalid: [
+            { code: "var foo = bar;", output: "invalid output", errors: 1 }
+        ]
+    });
+}, /' foo = bar;' == 'invalid output'/);
+
+it = tmpIt;
+describe = tmpDescribe;

--- a/tests/lib/testers/no-test-runners.js
+++ b/tests/lib/testers/no-test-runners.js
@@ -26,7 +26,7 @@ try {
                 { code: "var foo = bar;", output: "invalid output", errors: 1 }
             ]
         });
-    }, /Output is incorrect\. ' foo = bar;' == 'invalid output'$/);
+    }, /Output is incorrect\. \(' foo = bar;' == 'invalid output'\)$/);
 } catch (e) {
     throw e;
 } finally {

--- a/tests/lib/testers/no-test-runners.js
+++ b/tests/lib/testers/no-test-runners.js
@@ -26,7 +26,7 @@ try {
                 { code: "var foo = bar;", output: "invalid output", errors: 1 }
             ]
         });
-    }, /' foo = bar;' == 'invalid output'/);
+    }, /Output is incorrect\. ' foo = bar;' == 'invalid output'$/);
 } catch (e) {
     throw e;
 } finally {

--- a/tests/lib/testers/no-test-runners.js
+++ b/tests/lib/testers/no-test-runners.js
@@ -14,18 +14,22 @@ const tmpDescribe = describe;
 it = null;
 describe = null;
 
-const ruleTester = new RuleTester();
+try {
+    const ruleTester = new RuleTester();
 
-assert.throws(() => {
-    ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
-        valid: [
-            "bar = baz;"
-        ],
-        invalid: [
-            { code: "var foo = bar;", output: "invalid output", errors: 1 }
-        ]
-    });
-}, /' foo = bar;' == 'invalid output'/);
-
-it = tmpIt;
-describe = tmpDescribe;
+    assert.throws(() => {
+        ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+            valid: [
+                "bar = baz;"
+            ],
+            invalid: [
+                { code: "var foo = bar;", output: "invalid output", errors: 1 }
+            ]
+        });
+    }, /' foo = bar;' == 'invalid output'/);
+} catch (e) {
+    throw e;
+} finally {
+    it = tmpIt;
+    describe = tmpDescribe;
+}


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[X] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
The assert message now is a little bit confused. It only tells you "`Output is incorrect.`", but doesn't specificly show the received value and the expected value.

This change is to make the assert message more detailed.

**Is there anything you'd like reviewers to focus on?**
Not yet.

