### PR TITLE
Fix: incorrect error messages of no-unused-vars (fixes #9774)

### DIFF
--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -105,24 +105,19 @@ module.exports = {
          * @returns {string} The warning message to be used with this unused variable.
          */
         function getDefinedMessage(unusedVar) {
+            const defType = unusedVar.defs && unusedVar.defs[0] && unusedVar.defs[0].type;
             let type;
             let pattern;
 
-            if (config.varsIgnorePattern) {
+            if (defType === "CatchClause" && config.caughtErrorsIgnorePattern) {
+                type = "args";
+                pattern = config.caughtErrorsIgnorePattern.toString();
+            } else if (defType === "Parameter" && config.argsIgnorePattern) {
+                type = "args";
+                pattern = config.argsIgnorePattern.toString();
+            } else if (defType !== "Parameter" && config.varsIgnorePattern) {
                 type = "vars";
                 pattern = config.varsIgnorePattern.toString();
-            }
-
-            if (unusedVar.defs && unusedVar.defs[0] && unusedVar.defs[0].type) {
-                const defType = unusedVar.defs[0].type;
-
-                if (defType === "CatchClause" && config.caughtErrorsIgnorePattern) {
-                    type = "args";
-                    pattern = config.caughtErrorsIgnorePattern.toString();
-                } else if (defType === "Parameter" && config.argsIgnorePattern) {
-                    type = "args";
-                    pattern = config.argsIgnorePattern.toString();
-                }
             }
 
             const additional = type ? ` Allowed unused ${type} must match ${pattern}.` : "";

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -675,6 +675,18 @@ ruleTester.run("no-unused-vars", rule, {
                 "'a' is defined but never used.",
                 "'c' is defined but never used."
             ]
+        },
+
+        // https://github.com/eslint/eslint/issues/9774
+        {
+            code: "(function(_a) {})();",
+            options: [{ args: "all", varsIgnorePattern: "^_" }],
+            errors: [{ message: "'_a' is defined but never used." }]
+        },
+        {
+            code: "(function(_a) {})();",
+            options: [{ args: "all", caughtErrorsIgnorePattern: "^_" }],
+            errors: [{ message: "'_a' is defined but never used." }]
         }
     ]
 });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
fixes #9774.
It showed `Allowed unused vars must match {varsIgnorePattern}.` for an unused *argument* without `argsIgnorePattern` specified.

**Is there anything you'd like reviewers to focus on?**
