### PR TITLE
Fix: no-extra-parens false positive (fixes: #9755)

### DIFF
--- a/docs/rules/no-extra-parens.md
+++ b/docs/rules/no-extra-parens.md
@@ -36,6 +36,12 @@ a = (b * c);
 
 (a * b) + c;
 
+for (a in (b, c));
+
+for (a in (b));
+
+for (a of (b));
+
 typeof (a);
 
 (function(){} ? a() : b());
@@ -55,6 +61,14 @@ Examples of **correct** code for this rule with the default `"all"` option:
 (function(){}) ? a() : b();
 
 (/^a$/).test(x);
+
+for (a of (b, c));
+
+for (a of b);
+
+for (a in b, c);
+
+for (a in b);
 ```
 
 ### conditionalAssign

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -582,7 +582,7 @@ module.exports = {
                         tokensToIgnore.add(firstLeftToken);
                     }
                 }
-                if (hasExcessParens(node.right)) {
+                if (!(node.type === "ForOfStatement" && node.right.type === "SequenceExpression") && hasExcessParens(node.right)) {
                     report(node.right);
                 }
                 if (hasExcessParens(node.left)) {

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -145,7 +145,9 @@ ruleTester.run("no-extra-parens", rule, {
         "do; while(a);",
         "for(;;);",
         "for(a in b);",
+        "for(a in b, c);",
         "for(a of b);",
+        "for (a of (b, c));",
         "var a = (b, c);",
         "[]",
         "[a, b]",
@@ -1035,6 +1037,7 @@ ruleTester.run("no-extra-parens", rule, {
             "for (let.foo.bar in baz);",
             "Identifier",
             1
-        )
+        ),
+        invalid("for (a in (b, c));", "for (a in b, c);", "SequenceExpression", null)
     ]
 });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Fixes https://github.com/eslint/eslint/issues/9755 by ignoring parens for sequence expressions in for-of statements 

**Is there anything you'd like reviewers to focus on?**
Nope!

