### PR TITLE
Chore: Deactivate consistent-docs-url in internal rules folder

### DIFF
--- a/tools/internal-rules/.eslintrc.yml
+++ b/tools/internal-rules/.eslintrc.yml
@@ -1,4 +1,4 @@
 rules:
     rulesdir/no-invalid-meta: "error"
     rulesdir/consistent-docs-description: "error"
-    rulesdir/consistent-docs-url: "error"
+    rulesdir/consistent-docs-url: "off"

--- a/tools/internal-rules/consistent-docs-description.js
+++ b/tools/internal-rules/consistent-docs-description.js
@@ -104,7 +104,7 @@ function checkMetaDocsDescription(context, exportsNode) {
 
 module.exports = {
     meta: {
-        docs: {// eslint-disable-line rulesdir/consistent-docs-url
+        docs: {
             description: "enforce correct conventions of `meta.docs.description` property in core rules",
             category: "Internal",
             recommended: false

--- a/tools/internal-rules/consistent-docs-url.js
+++ b/tools/internal-rules/consistent-docs-url.js
@@ -75,7 +75,7 @@ function checkMetaDocsUrl(context, exportsNode) {
 
 module.exports = {
     meta: {
-        docs: {// eslint-disable-line rulesdir/consistent-docs-url
+        docs: {
             description: "enforce correct conventions of `meta.docs.url` property in core rules",
             category: "Internal",
             recommended: false

--- a/tools/internal-rules/no-invalid-meta.js
+++ b/tools/internal-rules/no-invalid-meta.js
@@ -151,7 +151,7 @@ function isCorrectExportsFormat(node) {
 
 module.exports = {
     meta: {
-        docs: {// eslint-disable-line rulesdir/consistent-docs-url
+        docs: {
             description: "enforce correct use of `meta` property in core rules",
             category: "Internal",
             recommended: false


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain: Deactivating consistent-docs-url rule on our other internal rules, since we intentionally don't document them

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Deactivated consistent-docs-url rule on our other internal rules, since we intentionally don't document those rules.

**Is there anything you'd like reviewers to focus on?**

Not really.