### PR TITLE
Docs: Sync messageId examples' style with other examples

### DIFF
--- a/docs/developer-guide/working-with-rules.md
+++ b/docs/developer-guide/working-with-rules.md
@@ -204,7 +204,7 @@ module.exports = {
                         messageId: "avoidName",
                         data: {
                             name: "foo",
-                        },
+                        }
                     });
                 }
             }
@@ -214,14 +214,14 @@ module.exports = {
 
 // in the file to lint:
 
-var foo = 2
+var foo = 2;
 //  ^ error: Avoid using variables named 'foo'
 
 // In your tests:
-var rule = require('../../../lib/rules/no-insecure-random')
-var RuleTester = require('eslint').RuleTester
+var rule = require('../../../lib/rules/no-insecure-random');
+var RuleTester = require('eslint').RuleTester;
 
-var ruleTester = new RuleTester()
+var ruleTester = new RuleTester();
 ruleTester.run('my-rule', rule, {
   valid: ['bar', 'baz'],
 
@@ -231,11 +231,11 @@ ruleTester.run('my-rule', rule, {
       errors: [
         {
           messageId: 'foo',
-        },
-      ],
-    },
-  ],
-})
+        }
+      ]
+    }
+  ]
+});
 ```
 
 ### Applying Fixes


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Small changes to messageId code samples to match style of other examples on the ESLint site.

**Is there anything you'd like reviewers to focus on?**

Not really.