### PR TITLE
Docs: fix substitution of {{ name }}

### DIFF
--- a/docs/developer-guide/working-with-rules.md
+++ b/docs/developer-guide/working-with-rules.md
@@ -188,6 +188,7 @@ Instead of typing out messages in both the `context.report()` call and your test
 This allows you to avoid retyping error messages. It also prevents errors reported in different sections of your rule from having out-of-date messages.
 
 ```js
+{% raw %}
 // in your rule
 module.exports = {
     meta: {
@@ -236,6 +237,7 @@ ruleTester.run('my-rule', rule, {
     },
   ],
 })
+{% endraw %}
 ```
 
 ### Applying Fixes


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

The `{{ name }}` gets replaced with an empty string when rendered on the site: https://eslint.org/docs/developer-guide/working-with-rules#messageids
Based on the above example where `{{ identifier }}` is rendered properly, I'm guessing `{% raw %}` will fix that.

**Is there anything you'd like reviewers to focus on?**

I'm not 100% sure if this is the correct solution, so it should be tested first.