### PR TITLE
Update: Brace style for `import` statements

### DIFF
--- a/lib/rules/brace-style.js
+++ b/lib/rules/brace-style.js
@@ -179,14 +179,14 @@ module.exports = {
                 }
             },
             ImportDeclaration(node) {
-                if (node.specifiers.length > 0 && node.specifiers[0].type == "ImportSpecifier") {
+                if (node.specifiers.length > 0 && node.specifiers[0].type === "ImportSpecifier") {
                     const openingCurly = sourceCode.getTokenBefore(node.specifiers[0]);
                     const closingCurly = sourceCode.getTokenAfter(node.specifiers[node.specifiers.length - 1]);
 
                     validateCurlyPair(openingCurly, closingCurly);
 
                     // Handle the keyword after the `import` block (before `from`)
-                    validateCurlyBeforeKeyword(closingCurly)
+                    validateCurlyBeforeKeyword(closingCurly);
                 }
             }
         };

--- a/lib/rules/brace-style.js
+++ b/lib/rules/brace-style.js
@@ -177,6 +177,17 @@ module.exports = {
                     // Handle the keyword after the `catch` block (before `finally`)
                     validateCurlyBeforeKeyword(sourceCode.getLastToken(node.handler.body));
                 }
+            },
+            ImportDeclaration(node) {
+                if (node.specifiers.length > 0 && node.specifiers[0].type == "ImportSpecifier") {
+                    const openingCurly = sourceCode.getTokenBefore(node.specifiers[0]);
+                    const closingCurly = sourceCode.getTokenAfter(node.specifiers[node.specifiers.length - 1]);
+
+                    validateCurlyPair(openingCurly, closingCurly);
+
+                    // Handle the keyword after the `import` block (before `from`)
+                    validateCurlyBeforeKeyword(closingCurly)
+                }
             }
         };
     }

--- a/tests/lib/rules/brace-style.js
+++ b/tests/lib/rules/brace-style.js
@@ -657,3 +657,128 @@ ruleTester.run("brace-style", rule, {
         }
     ]
 });
+
+const importRuleTester = new RuleTester({ parserOptions: { ecmaVersion: 6, sourceType: "module" } });
+importRuleTester.run("brace-style", rule, {
+    valid: [
+        // w/o braces rule shouldn't be active at all
+        "import a from 'module'",
+        "import 'module'",
+        "import * as a from 'module'",
+
+        // single import specifier
+        { code: "import { \n a \n} from 'module'", options: ["1tbs"] },
+        { code: "import { \n a \n}\n from 'module'", options: ["stroustrup"] },
+        { code: "import \n{\n a \n}\n from 'module'", options: ["allman"] },
+
+        // single import specifier with alias
+        { code: "import { \n a as b \n} from 'module'", options: ["1tbs"] },
+        { code: "import { \n a as b \n}\n from 'module'", options: ["stroustrup"] },
+        { code: "import \n{\n a as b \n}\n from 'module'", options: ["allman"] },
+
+        // multiple import specifiers
+        { code: "import { \n a,\n b \n} from 'module'", options: ["1tbs"] },
+        { code: "import { \n a,\n b \n}\n from 'module'", options: ["stroustrup"] },
+        { code: "import \n{\n a,\n b \n}\n from 'module'", options: ["allman"] },
+
+        // multiple import specifiers on a single line
+        { code: "import { a, b } from 'a'", options: ["1tbs", {allowSingleLine: true}] },
+        { code: "import { a, b }\n from 'a'", options: ["stroustrup", {allowSingleLine: true}] },
+        { code: "import { a, b }\n from 'a'", options: ["allman", {allowSingleLine: true}] }
+    ],
+
+    invalid: [
+        {
+            code: "import\n{\na \n} from 'module'",
+            output: "import {\na \n} from 'module'",
+            options: ["1tbs"],
+            errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }]
+        },
+        {
+            code: "import { a \n} from 'module'",
+            output: "import {\n a \n} from 'module'",
+            options: ["1tbs"],
+            errors: [{ message: BODY_MESSAGE, type: "Punctuator" }]
+        },
+        {
+            code: "import {\n a \n}\n from 'module'",
+            output: "import {\n a \n} from 'module'",
+            options: ["1tbs"],
+            errors: [{ message: CLOSE_MESSAGE, type: "Punctuator" }]
+        },
+        {
+            code: "import {\n a } from 'module'",
+            output: "import {\n a \n} from 'module'",
+            options: ["1tbs"],
+            errors: [{ message: CLOSE_MESSAGE_SINGLE, type: "Punctuator" }]
+        },
+        {
+            code: "import { a,\n b } from 'module'",
+            output: "import {\n a,\n b \n} from 'module'",
+            options: ["1tbs", {allowSingleLine: true}],
+            errors: [{ message: BODY_MESSAGE, type: "Punctuator" }, { message: CLOSE_MESSAGE_SINGLE, type: "Punctuator" }]
+        },
+
+        {
+            code: "import{\na\n}\nfrom 'module'",
+            output: "import\n{\na\n}\nfrom 'module'",
+            options: ["allman"],
+            errors: [{ message: OPEN_MESSAGE_ALLMAN, type: "Punctuator" }]
+        },
+        {
+            code: "import\n{ a \n}\nfrom 'module'",
+            output: "import\n{\n a \n}\nfrom 'module'",
+            options: ["allman"],
+            errors: [{ message: BODY_MESSAGE, type: "Punctuator" }]
+        },
+        {
+            code: "import\n{\n a }\n from 'module'",
+            output: "import\n{\n a \n}\n from 'module'",
+            options: ["allman"],
+            errors: [{ message: CLOSE_MESSAGE_SINGLE, type: "Punctuator" }]
+        },
+        {
+            code: "import\n{\n a \n}from 'module'",
+            output: "import\n{\n a \n}\nfrom 'module'",
+            options: ["allman"],
+            errors: [{ message: CLOSE_MESSAGE_STROUSTRUP_ALLMAN, type: "Punctuator" }]
+        },
+        {
+            code: "import{a,b}from 'module'",
+            output: "import{a,b}\nfrom 'module'",
+            options: ["allman", {allowSingleLine: true}],
+            errors: [{ message: CLOSE_MESSAGE_STROUSTRUP_ALLMAN, type: "Punctuator" }]
+        },
+
+        {
+            code: "import\n{\na\n}\nfrom 'module'",
+            output: "import {\na\n}\nfrom 'module'",
+            options: ["stroustrup"],
+            errors: [{ message: OPEN_MESSAGE, type: "Punctuator" }]
+        },
+        {
+            code: "import { a \n}\nfrom 'module'",
+            output: "import {\n a \n}\nfrom 'module'",
+            options: ["stroustrup"],
+            errors: [{ message: BODY_MESSAGE, type: "Punctuator" }]
+        },
+        {
+            code: "import {\n a }\n from 'module'",
+            output: "import {\n a \n}\n from 'module'",
+            options: ["stroustrup"],
+            errors: [{ message: CLOSE_MESSAGE_SINGLE, type: "Punctuator" }]
+        },
+        {
+            code: "import {\n a \n}from 'module'",
+            output: "import {\n a \n}\nfrom 'module'",
+            options: ["stroustrup"],
+            errors: [{ message: CLOSE_MESSAGE_STROUSTRUP_ALLMAN, type: "Punctuator" }]
+        },
+        {
+            code: "import{a,b}from 'module'",
+            output: "import{a,b}\nfrom 'module'",
+            options: ["stroustrup", {allowSingleLine: true}],
+            errors: [{ message: CLOSE_MESSAGE_STROUSTRUP_ALLMAN, type: "Punctuator" }]
+        }
+    ]
+});

--- a/tests/lib/rules/brace-style.js
+++ b/tests/lib/rules/brace-style.js
@@ -659,8 +659,10 @@ ruleTester.run("brace-style", rule, {
 });
 
 const importRuleTester = new RuleTester({ parserOptions: { ecmaVersion: 6, sourceType: "module" } });
+
 importRuleTester.run("brace-style", rule, {
     valid: [
+
         // w/o braces rule shouldn't be active at all
         "import a from 'module'",
         "import 'module'",
@@ -682,9 +684,9 @@ importRuleTester.run("brace-style", rule, {
         { code: "import \n{\n a,\n b \n}\n from 'module'", options: ["allman"] },
 
         // multiple import specifiers on a single line
-        { code: "import { a, b } from 'a'", options: ["1tbs", {allowSingleLine: true}] },
-        { code: "import { a, b }\n from 'a'", options: ["stroustrup", {allowSingleLine: true}] },
-        { code: "import { a, b }\n from 'a'", options: ["allman", {allowSingleLine: true}] }
+        { code: "import { a, b } from 'a'", options: ["1tbs", { allowSingleLine: true }] },
+        { code: "import { a, b }\n from 'a'", options: ["stroustrup", { allowSingleLine: true }] },
+        { code: "import { a, b }\n from 'a'", options: ["allman", { allowSingleLine: true }] }
     ],
 
     invalid: [
@@ -715,7 +717,7 @@ importRuleTester.run("brace-style", rule, {
         {
             code: "import { a,\n b } from 'module'",
             output: "import {\n a,\n b \n} from 'module'",
-            options: ["1tbs", {allowSingleLine: true}],
+            options: ["1tbs", { allowSingleLine: true }],
             errors: [{ message: BODY_MESSAGE, type: "Punctuator" }, { message: CLOSE_MESSAGE_SINGLE, type: "Punctuator" }]
         },
 
@@ -746,7 +748,7 @@ importRuleTester.run("brace-style", rule, {
         {
             code: "import{a,b}from 'module'",
             output: "import{a,b}\nfrom 'module'",
-            options: ["allman", {allowSingleLine: true}],
+            options: ["allman", { allowSingleLine: true }],
             errors: [{ message: CLOSE_MESSAGE_STROUSTRUP_ALLMAN, type: "Punctuator" }]
         },
 
@@ -777,7 +779,7 @@ importRuleTester.run("brace-style", rule, {
         {
             code: "import{a,b}from 'module'",
             output: "import{a,b}\nfrom 'module'",
-            options: ["stroustrup", {allowSingleLine: true}],
+            options: ["stroustrup", { allowSingleLine: true }],
             errors: [{ message: CLOSE_MESSAGE_STROUSTRUP_ALLMAN, type: "Punctuator" }]
         }
     ]


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What rule do you want to change?**
brace-style

**Does this change cause the rule to produce more or fewer warnings?**
More warnings

**How will the change be implemented? (New option, new default behavior, etc.)?**
No new options, just more types of statements covered

**Please provide some example code that this change will affect:**

```js
// covers cases like this
import { a, b } from 'module';
```

**What does the rule currently do for this code?**
Currently, the rule does not process import statements.

**What will the rule do after it's changed?**
It will check if braces style in import statements with multiple specifiers is correct.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Added support for `import` statements with multiple specifiers to be checked by the rule.

**Is there anything you'd like reviewers to focus on?**
Not really sure if this somehow should be also mentioned in the docs for the rule.


