### PR TITLE
Update: use meta.docs.url in HTML formatter

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -88,7 +88,7 @@ function printResults(engine, results, format, outputFile) {
         return false;
     }
 
-    const output = formatter(results);
+    const output = formatter(results, engine.getRules());
 
     if (output) {
         if (outputFile) {

--- a/lib/formatters/html-template-message.html
+++ b/lib/formatters/html-template-message.html
@@ -3,6 +3,6 @@
     <td class="clr-<%= severityNumber %>"><%= severityName %></td>
     <td><%- message %></td>
     <td>
-        <a href="https://eslint.org/docs/rules/<%= ruleId %>" target="_blank"><%= ruleId %></a>
+        <a href="<%= url %>" target="_blank"><%= ruleId %></a>
     </td>
 </tr>

--- a/lib/formatters/html.js
+++ b/lib/formatters/html.js
@@ -62,9 +62,10 @@ function renderColor(totalErrors, totalWarnings) {
  * Get HTML (table rows) describing the messages.
  * @param {Array} messages Messages.
  * @param {int} parentIndex Index of the parent HTML row.
+ * @param {Map} rules Rules.
  * @returns {string} HTML (table rows) describing the messages.
  */
-function renderMessages(messages, parentIndex) {
+function renderMessages(messages, parentIndex, rules) {
 
     /**
      * Get HTML (table row) describing a message.
@@ -82,30 +83,32 @@ function renderMessages(messages, parentIndex) {
             severityNumber: message.severity,
             severityName: message.severity === 1 ? "Warning" : "Error",
             message: message.message,
-            ruleId: message.ruleId
+            ruleId: message.ruleId,
+            url: rules.get(message.ruleId).meta.docs.url
         });
     }).join("\n");
 }
 
 /**
  * @param {Array} results Test results.
+ * @param {Set} rules Rules.
  * @returns {string} HTML string describing the results.
  */
-function renderResults(results) {
+function renderResults(results, rules) {
     return lodash.map(results, (result, index) => resultTemplate({
         index,
         color: renderColor(result.errorCount, result.warningCount),
         filePath: result.filePath,
         summary: renderSummary(result.errorCount, result.warningCount)
 
-    }) + renderMessages(result.messages, index)).join("\n");
+    }) + renderMessages(result.messages, index, rules)).join("\n");
 }
 
 //------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
 
-module.exports = function(results) {
+module.exports = function(results, rules) {
     let totalErrors,
         totalWarnings;
 
@@ -122,6 +125,6 @@ module.exports = function(results) {
         date: new Date(),
         reportColor: renderColor(totalErrors, totalWarnings),
         reportSummary: renderSummary(totalErrors, totalWarnings),
-        results: renderResults(results)
+        results: renderResults(results, rules)
     });
 };

--- a/lib/formatters/html.js
+++ b/lib/formatters/html.js
@@ -75,6 +75,7 @@ function renderMessages(messages, parentIndex, rules) {
     return lodash.map(messages, message => {
         const lineNumber = message.line || 0;
         const columnNumber = message.column || 0;
+        const meta = rules.get(message.ruleId).meta;
 
         return messageTemplate({
             parentIndex,
@@ -84,7 +85,7 @@ function renderMessages(messages, parentIndex, rules) {
             severityName: message.severity === 1 ? "Warning" : "Error",
             message: message.message,
             ruleId: message.ruleId,
-            url: rules.get(message.ruleId).meta.docs.url
+            url: meta && meta.docs && meta.docs.url
         });
     }).join("\n");
 }

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -55,6 +55,7 @@ describe("cli", () => {
         fakeCLIEngine.prototype = leche.fake(CLIEngine.prototype);
         sandbox.stub(fakeCLIEngine.prototype, "executeOnFiles").returns({});
         sandbox.stub(fakeCLIEngine.prototype, "getFormatter").returns(sinon.spy());
+        sandbox.stub(fakeCLIEngine.prototype, "getRules").returns(new Map());
 
         const localCLI = proxyquire("../../lib/cli", {
             "./cli-engine": fakeCLIEngine,
@@ -706,6 +707,7 @@ describe("cli", () => {
                 }]
             });
             sandbox.stub(fakeCLIEngine.prototype, "getFormatter").returns(() => "done");
+            sandbox.stub(fakeCLIEngine.prototype, "getRules").returns(new Map());
             fakeCLIEngine.outputFixes = sandbox.stub();
 
             localCLI = proxyquire("../../lib/cli", {
@@ -728,6 +730,7 @@ describe("cli", () => {
                 results: []
             });
             sandbox.stub(fakeCLIEngine.prototype, "getFormatter").returns(() => "done");
+            sandbox.stub(fakeCLIEngine.prototype, "getRules").returns(new Map());
             fakeCLIEngine.outputFixes = sandbox.stub();
 
             localCLI = proxyquire("../../lib/cli", {
@@ -764,6 +767,7 @@ describe("cli", () => {
                 results: []
             });
             sandbox.stub(fakeCLIEngine.prototype, "getFormatter").returns(() => "done");
+            sandbox.stub(fakeCLIEngine.prototype, "getRules").returns(new Map());
             fakeCLIEngine.outputFixes = sandbox.mock().once();
 
             localCLI = proxyquire("../../lib/cli", {
@@ -800,6 +804,7 @@ describe("cli", () => {
             fakeCLIEngine.prototype = leche.fake(CLIEngine.prototype);
             sandbox.stub(fakeCLIEngine.prototype, "executeOnFiles").returns(report);
             sandbox.stub(fakeCLIEngine.prototype, "getFormatter").returns(() => "done");
+            sandbox.stub(fakeCLIEngine.prototype, "getRules").returns(new Map());
             fakeCLIEngine.outputFixes = sandbox.mock().withExactArgs(report);
 
             localCLI = proxyquire("../../lib/cli", {
@@ -836,6 +841,7 @@ describe("cli", () => {
             fakeCLIEngine.prototype = leche.fake(CLIEngine.prototype);
             sandbox.stub(fakeCLIEngine.prototype, "executeOnFiles").returns(report);
             sandbox.stub(fakeCLIEngine.prototype, "getFormatter").returns(() => "done");
+            sandbox.stub(fakeCLIEngine.prototype, "getRules").returns(new Map());
             fakeCLIEngine.getErrorResults = sandbox.stub().returns([]);
             fakeCLIEngine.outputFixes = sandbox.mock().withExactArgs(report);
 
@@ -887,6 +893,7 @@ describe("cli", () => {
                 results: []
             });
             sandbox.stub(fakeCLIEngine.prototype, "getFormatter").returns(() => "done");
+            sandbox.stub(fakeCLIEngine.prototype, "getRules").returns(new Map());
             fakeCLIEngine.outputFixes = sandbox.mock().never();
 
             localCLI = proxyquire("../../lib/cli", {
@@ -923,6 +930,7 @@ describe("cli", () => {
             fakeCLIEngine.prototype = leche.fake(CLIEngine.prototype);
             sandbox.stub(fakeCLIEngine.prototype, "executeOnFiles").returns(report);
             sandbox.stub(fakeCLIEngine.prototype, "getFormatter").returns(() => "done");
+            sandbox.stub(fakeCLIEngine.prototype, "getRules").returns(new Map());
             fakeCLIEngine.outputFixes = sandbox.mock().never();
 
             localCLI = proxyquire("../../lib/cli", {
@@ -959,6 +967,7 @@ describe("cli", () => {
             fakeCLIEngine.prototype = leche.fake(CLIEngine.prototype);
             sandbox.stub(fakeCLIEngine.prototype, "executeOnFiles").returns(report);
             sandbox.stub(fakeCLIEngine.prototype, "getFormatter").returns(() => "done");
+            sandbox.stub(fakeCLIEngine.prototype, "getRules").returns(new Map());
             fakeCLIEngine.getErrorResults = sandbox.stub().returns([]);
             fakeCLIEngine.outputFixes = sandbox.mock().never();
 
@@ -996,6 +1005,7 @@ describe("cli", () => {
             fakeCLIEngine.prototype = leche.fake(CLIEngine.prototype);
             sandbox.stub(fakeCLIEngine.prototype, "executeOnText").returns(report);
             sandbox.stub(fakeCLIEngine.prototype, "getFormatter").returns(() => "done");
+            sandbox.stub(fakeCLIEngine.prototype, "getRules").returns(new Map());
             fakeCLIEngine.outputFixes = sandbox.mock().never();
 
             localCLI = proxyquire("../../lib/cli", {

--- a/tests/lib/formatters/html.js
+++ b/tests/lib/formatters/html.js
@@ -57,7 +57,21 @@ function checkContentRow($, row, args) {
     assert($(row.find("td")[1]).hasClass(args.color), "Check that severity color is correct");
     assert.strictEqual($(row.find("td")[2]).html(), args.message, "Check that message is correct");
     assert.strictEqual($(row.find("td")[3]).find("a").text(), args.ruleId, "Check that ruleId is correct");
+    assert.strictEqual($(row.find("td")[3]).find("a").attr("href"), "http://example.com/docs/some-rule", "Check that URL is correct");
 }
+
+const RULES = {
+    get() {
+        return {
+            meta: {
+                docs: {
+                    url: "http://example.com/docs/some-rule"
+                }
+            }
+        };
+    }
+};
+
 
 //------------------------------------------------------------------------------
 // Tests
@@ -81,7 +95,7 @@ describe("formatter:html", () => {
         }];
 
         it("should return a string in HTML format with 1 issue in 1 file and styled accordingly", () => {
-            const result = formatter(code);
+            const result = formatter(code, RULES);
             const $ = cheerio.load(result);
 
             // Check overview
@@ -112,7 +126,7 @@ describe("formatter:html", () => {
         }];
 
         it("should return a string in HTML format with 1 issue in 1 file and styled accordingly", () => {
-            const result = formatter(code);
+            const result = formatter(code, RULES);
             const $ = cheerio.load(result);
 
             // Check overview
@@ -143,7 +157,7 @@ describe("formatter:html", () => {
         }];
 
         it("should return a string in HTML format with 1 issue in 1 file and styled accordingly", () => {
-            const result = formatter(code);
+            const result = formatter(code, RULES);
             const $ = cheerio.load(result);
 
             // Check overview
@@ -167,7 +181,7 @@ describe("formatter:html", () => {
         }];
 
         it("should return a string in HTML format with 0 issues in 1 file and styled accordingly", () => {
-            const result = formatter(code);
+            const result = formatter(code, RULES);
             const $ = cheerio.load(result);
 
             // Check overview
@@ -202,7 +216,7 @@ describe("formatter:html", () => {
         }];
 
         it("should return a string in HTML format with 2 issues in 1 file and styled accordingly", () => {
-            const result = formatter(code);
+            const result = formatter(code, RULES);
             const $ = cheerio.load(result);
 
             // Check overview
@@ -245,7 +259,7 @@ describe("formatter:html", () => {
         }];
 
         it("should return a string in HTML format with 2 issues in 2 files and styled accordingly", () => {
-            const result = formatter(code);
+            const result = formatter(code, RULES);
             const $ = cheerio.load(result);
 
             // Check overview
@@ -289,7 +303,7 @@ describe("formatter:html", () => {
         }];
 
         it("should return a string in HTML format with 2 issues in 2 files and styled accordingly", () => {
-            const result = formatter(code);
+            const result = formatter(code, RULES);
             const $ = cheerio.load(result);
 
             // Check overview
@@ -322,7 +336,7 @@ describe("formatter:html", () => {
         }];
 
         it("should return a string in HTML format with 1 issue in 1 file", () => {
-            const result = formatter(code);
+            const result = formatter(code, RULES);
             const $ = cheerio.load(result);
 
             checkContentRow($, $("tr")[1], { group: "f-0", lineCol: "5:10", color: "clr-2", message: "Unexpected &lt;&amp;&quot;&apos;&gt; foo.", ruleId: "foo" });
@@ -342,7 +356,7 @@ describe("formatter:html", () => {
         }];
 
         it("should return a string in HTML format with 1 issue in 1 file", () => {
-            const result = formatter(code);
+            const result = formatter(code, RULES);
             const $ = cheerio.load(result);
 
             checkContentRow($, $("tr")[1], { group: "f-0", lineCol: "5:10", color: "clr-2", message: "", ruleId: "" });
@@ -364,7 +378,7 @@ describe("formatter:html", () => {
         }];
 
         it("should return a string in HTML format with 1 issue in 1 file and styled accordingly", () => {
-            const result = formatter(code);
+            const result = formatter(code, RULES);
             const $ = cheerio.load(result);
 
             checkContentRow($, $("tr")[1], { group: "f-0", lineCol: "0:0", color: "clr-2", message: "Unexpected foo.", ruleId: "foo" });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

In the HTML formatter, use the documentation URL from `meta.docs.url` instead of assuming every rule is a core rule. 


<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

- Changed the HTML formatter template so that "http://eslint.org/docs/rules/" is no longer hard-coded.
- Instead, look up the URL from the rule's meta (`meta.doc.url`)
- Pass the list of rules from cli.js to the formatter to make the above possible
- Update unit tests
- Add a check in the unit test that the URL is correct

**Is there anything you'd like reviewers to focus on?**

There may be a better way to mock the rules in the unit test. 
