### PR TITLE
Docs: Fix examples for no-useless-escape

### DIFF
--- a/docs/rules/no-useless-escape.md
+++ b/docs/rules/no-useless-escape.md
@@ -41,8 +41,8 @@ Examples of **correct** code for this rule:
 "\371";
 "xs\u2111";
 `\``;
-`\${${foo}\}`;
-`$\{${foo}\}`;
+`\${${foo}}`;
+`$\{${foo}}`;
 /\\/g;
 /\t/g;
 /\w\$\*\^\./;


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Fix `correct` examples for `no-useless-escape`.

* https://eslint.org/docs/rules/no-useless-escape

Currently, the correct example occurs `no-useless-escape` errors.
So I've fixed the examples.

Current(copy and paste from the page)

* https://eslint.org/demo/#eyJ0ZXh0IjoiXCJcXFwiXCI7XG4nXFwnJztcblwiXFx4MTJcIjtcblwiXFx1MDBhOVwiO1xuXCJcXDM3MVwiO1xuXCJ4c1xcdTIxMTFcIjtcbmBcXGBgO1xuYFxcJHske2Zvb31cXH1gO1xuYCRcXHske2Zvb31cXH1gO1xuL1xcXFwvZztcbi9cXHQvZztcbi9cXHdcXCRcXCpcXF5cXC4vOyIsIm9wdGlvbnMiOnsicGFyc2VyT3B0aW9ucyI6eyJlY21hVmVyc2lvbiI6Niwic291cmNlVHlwZSI6InNjcmlwdCIsImVjbWFGZWF0dXJlcyI6e319LCJydWxlcyI6eyJuby11c2VsZXNzLWVzY2FwZSI6Mn0sImVudiI6e319fQ==

Fixed version

* https://eslint.org/demo/#eyJ0ZXh0IjoiXCJcXFwiXCI7XG4nXFwnJztcblwiXFx4MTJcIjtcblwiXFx1MDBhOVwiO1xuXCJcXDM3MVwiO1xuXCJ4c1xcdTIxMTFcIjtcbmBcXGBgO1xuYFxcJHske2Zvb319YDtcbmAkXFx7JHtmb299fWA7XG4vXFxcXC9nO1xuL1xcdC9nO1xuL1xcd1xcJFxcKlxcXlxcLi87Iiwib3B0aW9ucyI6eyJwYXJzZXJPcHRpb25zIjp7ImVjbWFWZXJzaW9uIjo2LCJzb3VyY2VUeXBlIjoic2NyaXB0IiwiZWNtYUZlYXR1cmVzIjp7fX0sInJ1bGVzIjp7Im5vLXVzZWxlc3MtZXNjYXBlIjoyfSwiZW52Ijp7fX19

Actually, this is a useless escape.

* https://jsfiddle.net/koba04/f1t7qr1n/

Thanks!

**Is there anything you'd like reviewers to focus on?**


