### PR TITLE
Upgrade: ajv@^6.0.1, still using json schema draft 04

### DIFF
--- a/lib/util/ajv.js
+++ b/lib/util/ajv.js
@@ -20,7 +20,7 @@ const ajv = new Ajv({
     validateSchema: false,
     missingRefs: "ignore",
     verbose: true,
-    schemaId: "id"
+    schemaId: "auto"
 });
 
 ajv.addMetaSchema(metaSchema);

--- a/lib/util/ajv.js
+++ b/lib/util/ajv.js
@@ -19,7 +19,8 @@ const ajv = new Ajv({
     meta: false,
     validateSchema: false,
     missingRefs: "ignore",
-    verbose: true
+    verbose: true,
+    schemaId: "id"
 });
 
 ajv.addMetaSchema(metaSchema);

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "semver": "^5.5.0",
     "strip-ansi": "^4.0.0",
     "strip-json-comments": "^2.0.1",
-    "table": "4.0.2",
+    "table": "^4.0.3",
     "text-table": "^0.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "homepage": "https://eslint.org",
   "bugs": "https://github.com/eslint/eslint/issues/",
   "dependencies": {
-    "ajv": "^5.3.0",
+    "ajv": "^6.0.1",
     "babel-code-frame": "^6.26.0",
     "chalk": "^2.1.0",
     "concat-stream": "^1.6.2",


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain: Upgrade ajv dependency (JSON schema validator)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Upgraded ajv to ^6.0.1. Also had to change the way the Ajv instance was initialized per the release notes.

**Is there anything you'd like reviewers to focus on?**

Not really.

I want to explain why I'm doing this: At work, we have to commit node modules to TFS (yes, horrible practice, but it's a company policy). And ajv@5.x had some files which had a leading `$` character in the filename, which doesn't play well with TFS. So as a result, we've been stuck on eslint@3.x because we couldn't use ajv. But ajv@6.x renamed those files. So if this is merged in and there aren't any issues, then I can finally upgrade ESLint at work.

There's absolutely no rush on my end for merging this in, so I would be okay with waiting until after the release that is coming up (soon after the time I post this) and maybe just merge this for 4.17.0, in case we want to do any extensive tests on rule schemas. That said, `npm test` does pass with this version of ajv, so we should have some confidence that this is a fairly safe change.