### PR TITLE
New: Option to use yarn in init wizard (#9863)

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -15,6 +15,7 @@
 
 const useStdIn = (process.argv.indexOf("--stdin") > -1),
     init = (process.argv.indexOf("--init") > -1),
+    yarn = (process.argv.indexOf("--yarn") > -1),
     debug = (process.argv.indexOf("--debug") > -1);
 
 // must do this initialization *before* other requires in order to work
@@ -62,6 +63,8 @@ if (useStdIn) {
     }));
 } else if (init) {
     const configInit = require("../lib/config/config-initializer");
+
+    configInit.setCliOptions({ yarn });
 
     configInit.initializeConfig().then(() => {
         process.exitCode = 0;

--- a/lib/config/config-initializer.js
+++ b/lib/config/config-initializer.js
@@ -5,6 +5,8 @@
 
 "use strict";
 
+let cliOptions = {};
+
 //------------------------------------------------------------------------------
 // Requirements
 //------------------------------------------------------------------------------
@@ -129,7 +131,7 @@ function installModules(config, installESLint) {
 
     log.info(`Installing ${modulesToInstall.join(", ")}`);
 
-    npmUtil.installSyncSaveDev(modulesToInstall);
+    npmUtil.installSyncSaveDev(modulesToInstall, cliOptions);
 }
 
 /**
@@ -589,11 +591,21 @@ function promptUser() {
     });
 }
 
+/**
+ * Store options from command line
+ * @param   {Object} options Options object
+ * @returns {void}
+ */
+function setCliOptions(options) {
+    cliOptions = options;
+}
+
 //------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
 
 const init = {
+    setCliOptions,
     getConfigForStyleGuide,
     hasESLintVersionConflict,
     processAnswers,

--- a/lib/options.js
+++ b/lib/options.js
@@ -215,6 +215,12 @@ module.exports = optionator({
             description: "Run config initialization wizard"
         },
         {
+            option: "yarn",
+            type: "Boolean",
+            default: "false",
+            description: "Use yarn to install packages in --init wizard"
+        },
+        {
             option: "debug",
             type: "Boolean",
             default: false,

--- a/lib/util/npm-util.js
+++ b/lib/util/npm-util.js
@@ -47,20 +47,26 @@ function findPackageJson(startDir) {
 /**
  * Install node modules synchronously and save to devDependencies in package.json
  * @param   {string|string[]} packages Node module or modules to install
+ * @param   {Object}          options  Options object
  * @returns {void}
  */
-function installSyncSaveDev(packages) {
+function installSyncSaveDev(packages, options) {
     if (!Array.isArray(packages)) {
         packages = [packages];
     }
-    const npmProcess = spawn.sync("npm", ["i", "--save-dev"].concat(packages),
+
+    const yarn = options && options.yarn || false;
+    const command = yarn ? "yarn" : "npm";
+    const args = yarn ? ["add", "--dev"] : ["i", "--save-dev"];
+
+    const process = spawn.sync(command, args.concat(packages),
         { stdio: "inherit" });
-    const error = npmProcess.error;
+    const error = process.error;
 
     if (error && error.code === "ENOENT") {
         const pluralS = packages.length > 1 ? "s" : "";
 
-        log.error(`Could not execute npm. Please install the following package${pluralS} with your package manager of choice: ${packages.join(", ")}`);
+        log.error(`Could not execute ${command}. Please install the following package${pluralS} with your package manager of choice: ${packages.join(", ")}`);
     }
 }
 

--- a/tests/lib/options.js
+++ b/tests/lib/options.js
@@ -320,6 +320,14 @@ describe("options", () => {
         });
     });
 
+    describe("--yarn", () => {
+        it("should return true for --yarn when passed", () => {
+            const currentOptions = options.parse("--yarn");
+
+            assert.isTrue(currentOptions.yarn);
+        });
+    });
+
     describe("--fix", () => {
         it("should return true for --fix when passed", () => {
             const currentOptions = options.parse("--fix");

--- a/tests/lib/util/npm-util.js
+++ b/tests/lib/util/npm-util.js
@@ -179,6 +179,16 @@ describe("npmUtil", () => {
             stub.restore();
         });
 
+        it("should invoke yarn when called with yarn option", () => {
+            const stub = sandbox.stub(spawn, "sync").returns({ stdout: "" });
+
+            npmUtil.installSyncSaveDev("desired-package", { yarn: true });
+            assert(stub.calledOnce);
+            assert.strictEqual(stub.firstCall.args[0], "yarn");
+            assert.deepStrictEqual(stub.firstCall.args[1], ["add", "--dev", "desired-package"]);
+            stub.restore();
+        });
+
         it("should accept an array of packages to install", () => {
             const stub = sandbox.stub(spawn, "sync").returns({ stdout: "" });
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[x] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
PR adds a new option and passes it to a place where at the moment `npm i` is always invoked.

**Is there anything you'd like reviewers to focus on?**
Perhaps there is an easier way to pass CLI option from `bin/eslint.js` to util/npm-util.js. (Potentially util/npm-util.js could read process.args on its own but that didn't feel right).