### PR TITLE
Breaking: support @scope shorthand in plugins (fixes #9903)

### DIFF
--- a/lib/config/plugins.js
+++ b/lib/config/plugins.js
@@ -12,12 +12,6 @@ const debug = require("debug")("eslint:plugins");
 const naming = require("../util/naming");
 
 //------------------------------------------------------------------------------
-// Private
-//------------------------------------------------------------------------------
-
-const PLUGIN_NAME_PREFIX = "eslint-plugin-";
-
-//------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
 
@@ -44,10 +38,8 @@ class Plugins {
      * @returns {void}
      */
     define(pluginName, plugin) {
-        const pluginNamespace = naming.getNamespaceFromTerm(pluginName),
-            pluginNameWithoutNamespace = naming.removeNamespaceFromTerm(pluginName),
-            pluginNameWithoutPrefix = naming.removePrefixFromTerm(PLUGIN_NAME_PREFIX, pluginNameWithoutNamespace),
-            shortName = pluginNamespace + pluginNameWithoutPrefix;
+        const longName = naming.normalizePackageName(pluginName, "eslint-plugin");
+        const shortName = naming.getShorthandName(longName, "eslint-plugin");
 
         // load up environments and rules
         this._plugins[shortName] = plugin;
@@ -79,11 +71,8 @@ class Plugins {
      * @throws {Error} If the plugin cannot be loaded.
      */
     load(pluginName) {
-        const pluginNamespace = naming.getNamespaceFromTerm(pluginName),
-            pluginNameWithoutNamespace = naming.removeNamespaceFromTerm(pluginName),
-            pluginNameWithoutPrefix = naming.removePrefixFromTerm(PLUGIN_NAME_PREFIX, pluginNameWithoutNamespace),
-            shortName = pluginNamespace + pluginNameWithoutPrefix,
-            longName = pluginNamespace + PLUGIN_NAME_PREFIX + pluginNameWithoutPrefix;
+        const longName = naming.normalizePackageName(pluginName, "eslint-plugin");
+        const shortName = naming.getShorthandName(longName, "eslint-plugin");
         let plugin = null;
 
         if (pluginName.match(/\s+/)) {

--- a/lib/util/naming.js
+++ b/lib/util/naming.js
@@ -61,23 +61,28 @@ function normalizePackageName(name, prefix) {
 }
 
 /**
- * Removes the prefix from a term.
+ * Removes the prefix from a fullname.
+ * @param {string} fullname The term which may have the prefix.
  * @param {string} prefix The prefix to remove.
- * @param {string} term The term which may have the prefix.
  * @returns {string} The term without prefix.
  */
-function removePrefixFromTerm(prefix, term) {
-    return term.startsWith(prefix) ? term.slice(prefix.length) : term;
-}
+function getShorthandName(fullname, prefix) {
+    if (fullname[0] === "@") {
+        let m = new RegExp(`^(@[^/]+)/${prefix}$`).exec(fullname);
 
-/**
- * Adds a prefix to a term.
- * @param {string} prefix The prefix to add.
- * @param {string} term The term which may not have the prefix.
- * @returns {string} The term with prefix.
- */
-function addPrefixToTerm(prefix, term) {
-    return term.startsWith(prefix) ? term : `${prefix}${term}`;
+        if (m) {
+            return m[1];
+        }
+
+        m = new RegExp(`^(@[^/]+)/${prefix}-(.+)$`).exec(fullname);
+        if (m) {
+            return `${m[1]}/${m[2]}`;
+        }
+    } else if (fullname.startsWith(`${prefix}-`)) {
+        return fullname.slice(prefix.length + 1);
+    }
+
+    return fullname;
 }
 
 /**
@@ -91,23 +96,12 @@ function getNamespaceFromTerm(term) {
     return match ? match[0] : "";
 }
 
-/**
- * Removes the namespace from a term.
- * @param {string} term The term which may have the namespace.
- * @returns {string} The name of the plugin without the namespace.
- */
-function removeNamespaceFromTerm(term) {
-    return term.replace(NAMESPACE_REGEX, "");
-}
-
 //------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
 
 module.exports = {
     normalizePackageName,
-    removePrefixFromTerm,
-    addPrefixToTerm,
-    getNamespaceFromTerm,
-    removeNamespaceFromTerm
+    getShorthandName,
+    getNamespaceFromTerm
 };

--- a/lib/util/naming.js
+++ b/lib/util/naming.js
@@ -68,15 +68,15 @@ function normalizePackageName(name, prefix) {
  */
 function getShorthandName(fullname, prefix) {
     if (fullname[0] === "@") {
-        let m = new RegExp(`^(@[^/]+)/${prefix}$`).exec(fullname);
+        let matchResult = new RegExp(`^(@[^/]+)/${prefix}$`).exec(fullname);
 
-        if (m) {
-            return m[1];
+        if (matchResult) {
+            return matchResult[1];
         }
 
-        m = new RegExp(`^(@[^/]+)/${prefix}-(.+)$`).exec(fullname);
-        if (m) {
-            return `${m[1]}/${m[2]}`;
+        matchResult = new RegExp(`^(@[^/]+)/${prefix}-(.+)$`).exec(fullname);
+        if (matchResult) {
+            return `${matchResult[1]}/${matchResult[2]}`;
         }
     } else if (fullname.startsWith(`${prefix}-`)) {
         return fullname.slice(prefix.length + 1);

--- a/tests/fixtures/plugin-shorthand/basic/.eslintrc.json
+++ b/tests/fixtures/plugin-shorthand/basic/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+    "root": true,
+    "plugins": ["@scope"],
+    "rules": {
+        "@scope/rule": "error"
+    }
+}

--- a/tests/fixtures/plugin-shorthand/basic/node_modules/@scope/eslint-plugin/index.js
+++ b/tests/fixtures/plugin-shorthand/basic/node_modules/@scope/eslint-plugin/index.js
@@ -1,0 +1,22 @@
+"use strict"
+
+module.exports = {
+    configs: {
+        recommended: {
+            plugins: ["@scope"],
+            rules: { "@scope/rule": "error" }
+        }
+    },
+    rules: {
+        rule: {
+            create(context) {
+                return {
+                    Program(node) {
+                        const message = "OK"
+                        context.report({ node, message })
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/fixtures/plugin-shorthand/extends/.eslintrc.json
+++ b/tests/fixtures/plugin-shorthand/extends/.eslintrc.json
@@ -1,0 +1,4 @@
+{
+    "root": true,
+    "extends": ["plugin:@scope/recommended"]
+}

--- a/tests/fixtures/plugin-shorthand/extends/node_modules/@scope/eslint-plugin/index.js
+++ b/tests/fixtures/plugin-shorthand/extends/node_modules/@scope/eslint-plugin/index.js
@@ -1,0 +1,22 @@
+"use strict"
+
+module.exports = {
+    configs: {
+        recommended: {
+            plugins: ["@scope"],
+            rules: { "@scope/rule": "error" }
+        }
+    },
+    rules: {
+        rule: {
+            create(context) {
+                return {
+                    Program(node) {
+                        const message = "OK"
+                        context.report({node, message})
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -557,6 +557,44 @@ describe("CLIEngine", () => {
             assert.strictEqual(report.results[0].messages[0].message, expectedMsg);
         });
 
+        // @scope for @scope/eslint-plugin
+        describe("(plugin shorthand)", () => {
+            const Module = require("module");
+            let originalFindPath = null;
+
+            /* eslint-disable no-underscore-dangle */
+            before(() => {
+                originalFindPath = Module._findPath;
+                Module._findPath = function(id) {
+                    if (id === "@scope/eslint-plugin") {
+                        return path.resolve(__dirname, "../fixtures/plugin-shorthand/basic/node_modules/@scope/eslint-plugin/index.js");
+                    }
+                    return originalFindPath.apply(this, arguments);
+                };
+            });
+            after(() => {
+                Module._findPath = originalFindPath;
+            });
+            /* eslint-enable no-underscore-dangle */
+
+            it("should resolve 'plugins:[\"@scope\"]' to 'node_modules/@scope/eslint-plugin'.", () => {
+                engine = new CLIEngine({ cwd: getFixturePath("plugin-shorthand/basic") });
+                const report = engine.executeOnText("var x = 0", "index.js").results[0];
+
+                assert.strictEqual(report.filePath, getFixturePath("plugin-shorthand/basic/index.js"));
+                assert.strictEqual(report.messages[0].ruleId, "@scope/rule");
+                assert.strictEqual(report.messages[0].message, "OK");
+            });
+
+            it("should resolve 'extends:[\"plugin:@scope/recommended\"]' to 'node_modules/@scope/eslint-plugin'.", () => {
+                engine = new CLIEngine({ cwd: getFixturePath("plugin-shorthand/extends") });
+                const report = engine.executeOnText("var x = 0", "index.js").results[0];
+
+                assert.strictEqual(report.filePath, getFixturePath("plugin-shorthand/extends/index.js"));
+                assert.strictEqual(report.messages[0].ruleId, "@scope/rule");
+                assert.strictEqual(report.messages[0].message, "OK");
+            });
+        });
     });
 
     describe("executeOnFiles()", () => {

--- a/tests/lib/util/naming.js
+++ b/tests/lib/util/naming.js
@@ -36,32 +36,23 @@ describe("naming", () => {
 
     });
 
-    describe("removePrefixFromTerm()", () => {
-        it("should remove prefix when passed a term with a prefix", () => {
-            const pluginName = naming.removePrefixFromTerm("eslint-plugin-", "eslint-plugin-test");
+    describe("getShorthandName()", () => {
 
-            assert.strictEqual(pluginName, "test");
+        leche.withData([
+            ["foo", "foo"],
+            ["eslint-config-foo", "foo"],
+            ["@z", "@z"],
+            ["@z/eslint-config", "@z"],
+            ["@z/foo", "@z/foo"],
+            ["@z/eslint-config-foo", "@z/foo"]
+        ], (input, expected) => {
+            it(`should return ${expected} when passed ${input}`, () => {
+                const result = naming.getShorthandName(input, "eslint-config");
+
+                assert.strictEqual(result, expected);
+            });
         });
 
-        it("should not modify term when passed a term without a prefix", () => {
-            const pluginName = naming.removePrefixFromTerm("eslint-plugin-", "test");
-
-            assert.strictEqual(pluginName, "test");
-        });
-    });
-
-    describe("addPrefixToTerm()", () => {
-        it("should add prefix when passed a term without a prefix", () => {
-            const pluginName = naming.addPrefixToTerm("eslint-plugin-", "test");
-
-            assert.strictEqual(pluginName, "eslint-plugin-test");
-        });
-
-        it("should not modify term when passed a term with a prefix", () => {
-            const pluginName = naming.addPrefixToTerm("eslint-plugin-", "eslint-plugin-test");
-
-            assert.strictEqual(pluginName, "eslint-plugin-test");
-        });
     });
 
     describe("getNamespaceFromTerm()", () => {
@@ -69,14 +60,6 @@ describe("naming", () => {
             const namespace = naming.getNamespaceFromTerm("@namepace/eslint-plugin-test");
 
             assert.strictEqual(namespace, "@namepace/");
-        });
-    });
-
-    describe("removeNamespaceFromTerm()", () => {
-        it("should remove namepace when passed with namepace", () => {
-            const namespace = naming.removeNamespaceFromTerm("@namepace/eslint-plugin-test");
-
-            assert.strictEqual(namespace, "eslint-plugin-test");
         });
     });
 });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[X] Add something to the core
[ ] Other, please explain:

Fixes #9903.

**What changes did you make? (Give an overview)**

This is a reference implementation for #9903.
This PR changes the logic to normalize plugin names as same as shareable config's.
As the result, we can use `plugins: ["@scope"]` shorthand for `@scope/eslint-plugin` package.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.
