### PR TITLE
Update: space-unary-ops uses astUtils.canTokensBeAdjacent (fixes #9907)

### DIFF
--- a/docs/rules/space-unary-ops.md
+++ b/docs/rules/space-unary-ops.md
@@ -59,7 +59,7 @@ This rule has three options:
 
 In this case, spacing will be disallowed after a `new` operator and required before/after a `++` operator.
 
-Examples of **incorrect** code for this rule with the `{"words": true, "nonwords": false}` option:
+Examples of **incorrect** code for this rule with the default `{"words": true, "nonwords": false}` option:
 
 ```js
 /*eslint space-unary-ops: "error"*/
@@ -87,6 +87,14 @@ foo --;
 
 function *foo() {
     yield(0)
+}
+```
+
+```js
+/*eslint space-unary-ops: "error"*/
+
+async function foo() {
+    await(bar);
 }
 ```
 
@@ -123,5 +131,13 @@ foo--;
 
 function *foo() {
     yield (0)
+}
+```
+
+```js
+/*eslint space-unary-ops: "error"*/
+
+async function foo() {
+    await (bar);
 }
 ```

--- a/lib/rules/space-unary-ops.js
+++ b/lib/rules/space-unary-ops.js
@@ -67,15 +67,6 @@ module.exports = {
         }
 
         /**
-         * Check if the node's child argument is an "ObjectExpression"
-         * @param {ASTnode} node AST node
-         * @returns {boolean} Whether or not the argument's type is "ObjectExpression"
-         */
-        function isArgumentObjectExpression(node) {
-            return node.argument && node.argument.type && node.argument.type === "ObjectExpression";
-        }
-
-        /**
          * Checks if an override exists for a given operator.
          * @param {string} operator Operator
          * @returns {boolean} Whether or not an override has been provided for the operator
@@ -125,7 +116,7 @@ module.exports = {
          * @returns {void}
          */
         function verifyWordDoesntHaveSpaces(node, firstToken, secondToken, word) {
-            if (isArgumentObjectExpression(node)) {
+            if (astUtils.canTokensBeAdjacent(firstToken, secondToken)) {
                 if (secondToken.range[0] > firstToken.range[1]) {
                     context.report({
                         node,

--- a/tests/lib/rules/space-unary-ops.js
+++ b/tests/lib/rules/space-unary-ops.js
@@ -41,6 +41,7 @@ ruleTester.run("space-unary-ops", rule, {
             code: "foo.bar --",
             options: [{ nonwords: true }]
         },
+
         {
             code: "delete foo.bar",
             options: [{ words: true }]
@@ -48,6 +49,14 @@ ruleTester.run("space-unary-ops", rule, {
         {
             code: "delete foo[\"bar\"]",
             options: [{ words: true }]
+        },
+        {
+            code: "delete foo.bar",
+            options: [{ words: false }]
+        },
+        {
+            code: "delete(foo.bar)",
+            options: [{ words: false }]
         },
 
         {
@@ -80,6 +89,14 @@ ruleTester.run("space-unary-ops", rule, {
             options: [{ words: true }]
         },
         {
+            code: "typeof (foo)",
+            options: [{ words: true }]
+        },
+        {
+            code: "typeof(foo)",
+            options: [{ words: false }]
+        },
+        {
             code: "typeof!foo",
             options: [{ words: false }]
         },
@@ -99,6 +116,14 @@ ruleTester.run("space-unary-ops", rule, {
         {
             code: "void foo",
             options: [{ words: true }]
+        },
+        {
+            code: "void foo",
+            options: [{ words: false }]
+        },
+        {
+            code: "void(foo)",
+            options: [{ words: false }]
         },
 
         {
@@ -217,12 +242,12 @@ ruleTester.run("space-unary-ops", rule, {
             options: [{ words: false, overrides: { new: false } }]
         },
         {
-            code: "function *foo () { yield (0) }",
+            code: "function *foo () { yield(0) }",
             options: [{ words: true, overrides: { yield: false } }],
             parserOptions: { ecmaVersion: 6 }
         },
         {
-            code: "function *foo () { yield (0) }",
+            code: "function *foo () { yield(0) }",
             options: [{ words: false, overrides: { yield: false } }],
             parserOptions: { ecmaVersion: 6 }
         }
@@ -248,11 +273,29 @@ ruleTester.run("space-unary-ops", rule, {
             }]
         },
         {
+            code: "delete (foo.bar)",
+            output: "delete(foo.bar)",
+            options: [{ words: false }],
+            errors: [{
+                message: "Unexpected space after unary word operator 'delete'.",
+                type: "UnaryExpression"
+            }]
+        },
+        {
             code: "new(Foo)",
             output: "new (Foo)",
             options: [{ words: true }],
             errors: [{
                 message: "Unary word operator 'new' must be followed by whitespace.",
+                type: "NewExpression"
+            }]
+        },
+        {
+            code: "new (Foo)",
+            output: "new(Foo)",
+            options: [{ words: false }],
+            errors: [{
+                message: "Unexpected space after unary word operator 'new'.",
                 type: "NewExpression"
             }]
         },
@@ -265,6 +308,15 @@ ruleTester.run("space-unary-ops", rule, {
                 type: "NewExpression"
             }]
         },
+        {
+            code: "new [foo][0]",
+            output: "new[foo][0]",
+            options: [{ words: false }],
+            errors: [{
+                message: "Unexpected space after unary word operator 'new'.",
+                type: "NewExpression"
+            }]
+        },
 
         {
             code: "typeof(foo)",
@@ -272,6 +324,33 @@ ruleTester.run("space-unary-ops", rule, {
             options: [{ words: true }],
             errors: [{
                 message: "Unary word operator 'typeof' must be followed by whitespace.",
+                type: "UnaryExpression"
+            }]
+        },
+        {
+            code: "typeof (foo)",
+            output: "typeof(foo)",
+            options: [{ words: false }],
+            errors: [{
+                message: "Unexpected space after unary word operator 'typeof'.",
+                type: "UnaryExpression"
+            }]
+        },
+        {
+            code: "typeof[foo]",
+            output: "typeof [foo]",
+            options: [{ words: true }],
+            errors: [{
+                message: "Unary word operator 'typeof' must be followed by whitespace.",
+                type: "UnaryExpression"
+            }]
+        },
+        {
+            code: "typeof [foo]",
+            output: "typeof[foo]",
+            options: [{ words: false }],
+            errors: [{
+                message: "Unexpected space after unary word operator 'typeof'.",
                 type: "UnaryExpression"
             }]
         },
@@ -322,11 +401,38 @@ ruleTester.run("space-unary-ops", rule, {
             }]
         },
         {
+            code: "void[foo];",
+            output: "void [foo];",
+            options: [{ words: true }],
+            errors: [{
+                message: "Unary word operator 'void' must be followed by whitespace.",
+                type: "UnaryExpression"
+            }]
+        },
+        {
             code: "void{a:0};",
             output: "void {a:0};",
             options: [{ words: true }],
             errors: [{
                 message: "Unary word operator 'void' must be followed by whitespace.",
+                type: "UnaryExpression"
+            }]
+        },
+        {
+            code: "void (foo)",
+            output: "void(foo)",
+            options: [{ words: false }],
+            errors: [{
+                message: "Unexpected space after unary word operator 'void'.",
+                type: "UnaryExpression"
+            }]
+        },
+        {
+            code: "void [foo]",
+            output: "void[foo]",
+            options: [{ words: false }],
+            errors: [{
+                message: "Unexpected space after unary word operator 'void'.",
                 type: "UnaryExpression"
             }]
         },
@@ -483,6 +589,18 @@ ruleTester.run("space-unary-ops", rule, {
             parserOptions: { ecmaVersion: 6 },
             errors: [{
                 message: "Unary word operator 'yield' must be followed by whitespace.",
+                type: "YieldExpression",
+                line: 1,
+                column: 19
+            }]
+        },
+        {
+            code: "function *foo() { yield (0) }",
+            output: "function *foo() { yield(0) }",
+            options: [{ words: false }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                message: "Unexpected space after unary word operator 'yield'.",
                 type: "YieldExpression",
                 line: 1,
                 column: 19


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment**

* **ESLint Version:** 4.16.x / master
* **Node Version:** 8.9.3
* **npm Version:** 4.1.1

**What parser (default, Babel-ESLint, etc.) are you using?**

Default

**Please show your full configuration:**

(See demo link below)

**What did you do? Please include the actual source code causing the issue.**

See [demo](https://eslint.org/demo/#eyJ0ZXh0IjoiLyogZXNsaW50IHNwYWNlLXVuYXJ5LW9wczogW2Vycm9yLCB7IHdvcmRzOiBmYWxzZSB9XSAqL1xyXG50eXBlb2YgKGZvby5iYXIpO1xyXG50eXBlb2YgW2Zvb107XHJcblxyXG5kZWxldGUgKGZvby5iYXIpO1xyXG5cclxudm9pZCAoZm9vLmJhcik7XHJcbnZvaWQgW2Zvb107XHJcblxyXG5uZXcgKGZvby5iYXIpO1xyXG5uZXcgW2Zvb11bMF07XHJcblxyXG4oZnVuY3Rpb24gKiAoKSB7IHlpZWxkIChmb28uYmFyKTsgfSk7XHJcbihmdW5jdGlvbiAqICgpIHsgeWllbGQgW2Zvby5iYXJdOyB9KTtcclxuXHJcbihhc3luYyBmdW5jdGlvbiAoKSB7IGF3YWl0IChmb28uYmFyKTsgfSk7XHJcbihhc3luYyBmdW5jdGlvbiAoKSB7IGF3YWl0IFtmb28uYmFyXTsgfSk7Iiwib3B0aW9ucyI6eyJwYXJzZXJPcHRpb25zIjp7ImVjbWFWZXJzaW9uIjo4LCJzb3VyY2VUeXBlIjoibW9kdWxlIiwiZWNtYUZlYXR1cmVzIjp7ImpzeCI6dHJ1ZX19LCJydWxlcyI6eyJjYW1lbGNhc2UiOjJ9LCJlbnYiOnt9fX0=).

**What did you expect to happen?**

Every UnaryExpression, NewExpression, YieldExpression, and AwaitExpression should be flagged as invalid. It is possible to remove the spaces between the unary word operator and the next token.

**What actually happened? Please include the actual, raw output from ESLint.**

No linting errors.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Changed special-case ObjectExpression check (which seemed to be used as a check for whether the next token was `{`) to instead use `astUtils.canTokensBeAdjacent`, which generalizes the logic and allows the rule to work correctly with `(` and `[` tokens.

**Is there anything you'd like reviewers to focus on?**

Not really.