### PR TITLE
Chore: Use json5 for parsing json configs

### DIFF
--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -17,6 +17,7 @@ const fs = require("fs"),
     naming = require("../util/naming"),
     pathIsInside = require("path-is-inside"),
     stripComments = require("strip-json-comments"),
+    JSON5 = require("json5"),
     stringify = require("json-stable-stringify-without-jsonify"),
     requireUncached = require("require-uncached");
 
@@ -111,7 +112,7 @@ function loadJSONConfigFile(filePath) {
     debug(`Loading JSON config file: ${filePath}`);
 
     try {
-        return JSON.parse(stripComments(readFile(filePath)));
+        return JSON5.parse(readFile(filePath));
     } catch (e) {
         debug(`Error reading JSON file: ${filePath}`);
         e.message = `Cannot read config file: ${filePath}\nError: ${e.message}`;

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "is-resolvable": "^1.0.0",
     "js-yaml": "^3.9.1",
     "json-stable-stringify-without-jsonify": "^1.0.1",
+    "json5": "^0.5.1",
     "levn": "^0.3.0",
     "lodash": "^4.17.4",
     "minimatch": "^3.0.2",

--- a/tests/fixtures/eslintrc/.eslintrc
+++ b/tests/fixtures/eslintrc/.eslintrc
@@ -1,5 +1,5 @@
 {
     "rules": {
-        "quotes": [2, "single"]
+        "quotes": [2, "single"],
     }
 }


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

json5 allow comments (like with the strip-comments package) but also trailing commas for example.

`.babelrc` supports json5 among others

It makes it easier to write an `.eslintrc`
<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**


**Is there anything you'd like reviewers to focus on?**


