### PR TITLE
Chore: Apply memoization to config creation within glob utils

### DIFF
--- a/lib/util/glob-util.js
+++ b/lib/util/glob-util.js
@@ -91,16 +91,6 @@ function resolveFileGlobPatterns(patterns, options) {
 
 const dotfilesPattern = /(?:(?:^\.)|(?:[/\\]\.))[^/\\.].*/;
 
-const getIgnorePaths = lodash.memoize(
-    options =>
-        new IgnoredPaths(options)
-);
-
-const getNewConfig = lodash.memoize(
-    (options, dotfiles) =>
-        Object.assign({}, options, { dotfiles })
-);
-
 /**
  * Build a list of absolute filesnames on which ESLint will act.
  * Ignored files are excluded from the results, as are duplicates.
@@ -119,6 +109,13 @@ function listFilesToProcess(globPatterns, options) {
         added = {};
 
     const cwd = (options && options.cwd) || process.cwd();
+
+    const getIgnorePaths = lodash.memoize(
+        options =>
+            new IgnoredPaths(options)
+    );
+
+    const getNewConfig = (options, dotfiles) => Object.assign({}, options, { dotfiles });
 
     /**
      * Executes the linter on a file defined by the `filename`. Skips

--- a/lib/util/glob-util.js
+++ b/lib/util/glob-util.js
@@ -8,7 +8,8 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const fs = require("fs"),
+const _ = require("lodash"),
+    fs = require("fs"),
     path = require("path"),
     GlobSync = require("./glob"),
 
@@ -88,6 +89,18 @@ function resolveFileGlobPatterns(patterns, options) {
     return patterns.filter(p => p.length).map(processPathExtensions);
 }
 
+const dotfilesPattern = /(?:(?:^\.)|(?:[/\\]\.))[^/\\.].*/;
+
+const memoGetIgnorePaths = _.memoize(
+    options =>
+        new IgnoredPaths(options)
+);
+
+const memoGetNewConfig = _.memoize(
+    (options, dotfiles) =>
+        Object.assign({}, options, { dotfiles })
+);
+
 /**
  * Build a list of absolute filesnames on which ESLint will act.
  * Ignored files are excluded from the results, as are duplicates.
@@ -151,15 +164,20 @@ function listFilesToProcess(globPatterns, options) {
         const file = path.resolve(cwd, pattern);
 
         if (fs.existsSync(file) && fs.statSync(file).isFile()) {
-            const ignoredPaths = new IgnoredPaths(options);
+            const ignoredPaths = memoGetIgnorePaths(options);
 
             addFile(fs.realpathSync(file), true, ignoredPaths);
         } else {
 
             // regex to find .hidden or /.hidden patterns, but not ./relative or ../relative
-            const globIncludesDotfiles = /(?:(?:^\.)|(?:[/\\]\.))[^/\\.].*/.test(pattern);
+            const globIncludesDotfiles = dotfilesPattern.test(pattern);
+            let newOptions = options;
 
-            const ignoredPaths = new IgnoredPaths(Object.assign({}, options, { dotfiles: options.dotfiles || globIncludesDotfiles }));
+            if (!options.dotfiles) {
+                newOptions = memoGetNewConfig(options, globIncludesDotfiles);
+            }
+
+            const ignoredPaths = memoGetIgnorePaths(newOptions);
             const shouldIgnore = ignoredPaths.getIgnoredFoldersGlobChecker();
             const globOptions = {
                 nodir: true,

--- a/lib/util/glob-util.js
+++ b/lib/util/glob-util.js
@@ -111,11 +111,9 @@ function listFilesToProcess(globPatterns, options) {
     const cwd = (options && options.cwd) || process.cwd();
 
     const getIgnorePaths = lodash.memoize(
-        options =>
-            new IgnoredPaths(options)
+        optionsObj =>
+            new IgnoredPaths(optionsObj)
     );
-
-    const getNewConfig = (options, dotfiles) => Object.assign({}, options, { dotfiles });
 
     /**
      * Executes the linter on a file defined by the `filename`. Skips
@@ -171,7 +169,7 @@ function listFilesToProcess(globPatterns, options) {
             let newOptions = options;
 
             if (!options.dotfiles) {
-                newOptions = getNewConfig(options, globIncludesDotfiles);
+                newOptions = Object.assign({}, options, { dotfiles: globIncludesDotfiles });
             }
 
             const ignoredPaths = getIgnorePaths(newOptions);

--- a/lib/util/glob-util.js
+++ b/lib/util/glob-util.js
@@ -8,7 +8,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const _ = require("lodash"),
+const lodash = require("lodash"),
     fs = require("fs"),
     path = require("path"),
     GlobSync = require("./glob"),
@@ -91,12 +91,12 @@ function resolveFileGlobPatterns(patterns, options) {
 
 const dotfilesPattern = /(?:(?:^\.)|(?:[/\\]\.))[^/\\.].*/;
 
-const memoGetIgnorePaths = _.memoize(
+const getIgnorePaths = lodash.memoize(
     options =>
         new IgnoredPaths(options)
 );
 
-const memoGetNewConfig = _.memoize(
+const getNewConfig = lodash.memoize(
     (options, dotfiles) =>
         Object.assign({}, options, { dotfiles })
 );
@@ -164,7 +164,7 @@ function listFilesToProcess(globPatterns, options) {
         const file = path.resolve(cwd, pattern);
 
         if (fs.existsSync(file) && fs.statSync(file).isFile()) {
-            const ignoredPaths = memoGetIgnorePaths(options);
+            const ignoredPaths = getIgnorePaths(options);
 
             addFile(fs.realpathSync(file), true, ignoredPaths);
         } else {
@@ -174,10 +174,10 @@ function listFilesToProcess(globPatterns, options) {
             let newOptions = options;
 
             if (!options.dotfiles) {
-                newOptions = memoGetNewConfig(options, globIncludesDotfiles);
+                newOptions = getNewConfig(options, globIncludesDotfiles);
             }
 
-            const ignoredPaths = memoGetIgnorePaths(newOptions);
+            const ignoredPaths = getIgnorePaths(newOptions);
             const shouldIgnore = ignoredPaths.getIgnoredFoldersGlobChecker();
             const globOptions = {
                 nodir: true,


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

I attempted a brief review of `eslint` with performance in mind and I found (just) a few quick wins.

Running the repo's `lint` task with `--debug` I first noticed that the ignore file processing occurred multiple times in a row without significant changes.

```
2018-02-05T02:52:54.126Z eslint:cli Running on files
2018-02-05T02:52:54.131Z eslint:glob-util Creating list of files to process.
2018-02-05T02:52:54.132Z eslint:ignored-paths Looking for ignore file in ~/Projects/eslint
2018-02-05T02:52:54.132Z eslint:ignored-paths Loaded ignore file /Users/kjacobse/Projects/eslint/.eslintignore
2018-02-05T02:52:54.132Z eslint:ignored-paths Adding ~/Projects/eslint/.eslintignore
2018-02-05T02:52:54.213Z eslint:ignored-paths Looking for ignore file in ~/Projects/eslint
2018-02-05T02:52:54.213Z eslint:ignored-paths Loaded ignore file /Users/kjacobse/Projects/eslint/.eslintignore
2018-02-05T02:52:54.213Z eslint:ignored-paths Adding ~/Projects/eslint/.eslintignore
2018-02-05T02:52:54.215Z eslint:ignored-paths Looking for ignore file in~/Projects/eslint
2018-02-05T02:52:54.215Z eslint:ignored-paths Loaded ignore file /Users/kjacobse/Projects/eslint/.eslintignore
2018-02-05T02:52:54.215Z eslint:ignored-paths Adding ~/Projects/eslint/.eslintignore
2018-02-05T02:52:54.216Z eslint:ignored-paths Looking for ignore file in ~/Projects/eslint
2018-02-05T02:52:54.216Z eslint:ignored-paths Loaded ignore file /Users/kjacobse/Projects/eslint/.eslintignore
2018-02-05T02:52:54.216Z eslint:ignored-paths Adding ~/Projects/eslint/.eslintignore
2018-02-05T02:52:54.219Z eslint:cli-engine Processing ~/Projects/eslint/lib/api.js
2018-02-05T02:52:54.219Z eslint:cli-engine Linting ~/Projects/eslint/lib/api.js
2018-02-05T02:52:54.219Z eslint:config Constructing config file hierarchy for ~/Projects/eslint/lib
...
```

In this branch, the above ignored-paths steps only occur once.

Anecdotally, I have been seeing pretty consistent gains in the `perf` execution, but even bumping the runs up a lot, it's simply too noisy to post and stand behind. I can attempt some more work on this if desired.

That all said, what I have done is prevent a new object creation (due to its cost and loss of referential equality) when it's unnecessary.

Then once that has been done, since I noticed these executions are more likely to be similar than different, I included two small, memoized functions to help create this object, and get a new instance of the `IgnoredPaths` class.

**Is there anything you'd like reviewers to focus on?**
I need help testing my assumptions:
* I am assuming that downstream consumers do not need unique copies of `IgnoredPaths` class. I feel pretty good about the immediate consumer `addFile`, but I don't necessarily have enough context for the rest.
* I am also assuming that this eslint runtime has a finite shelflife -- if not this memoization in the module scope is a classic memory leak (though there also may be finite enough inputs that it also may not matter), but nonetheless, worth the discussion.

