### PR TITLE
Update: fix indent bug with binary operators/ignoredNodes (fixes #9882)

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -1043,7 +1043,6 @@ module.exports = {
                 offsets.ignoreToken(operator);
                 offsets.ignoreToken(tokenAfterOperator);
                 offsets.setDesiredOffset(tokenAfterOperator, operator, 0);
-                offsets.setDesiredOffsets([tokenAfterOperator.range[1], node.range[1]], tokenAfterOperator, 1);
             },
 
             "BlockStatement, ClassBody"(node) {

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -4696,6 +4696,15 @@ ruleTester.run("indent", rule, {
         },
         {
             code: unIndent`
+                foo &&
+                <Bar
+                >
+                </Bar>
+            `,
+            options: [4, { ignoredNodes: ["JSXElement", "JSXOpeningElement"] }]
+        },
+        {
+            code: unIndent`
                 (function($) {
                 $(function() {
                     foo;


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (https://github.com/eslint/eslint/issues/9882)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates the `indent` rule to avoid setting the offset of the right-hand side of a `BinaryExpression` to depend on the token after the operator, which was unnecessary and could cause problems when the right-hand side of the expression was ignored.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular