### PR TITLE
New: Adds prefer-object-spread rule (refs: #7230)

### DIFF
--- a/conf/eslint-recommended.js
+++ b/conf/eslint-recommended.js
@@ -229,6 +229,7 @@ module.exports = {
         "prefer-const": "off",
         "prefer-destructuring": "off",
         "prefer-numeric-literals": "off",
+        "prefer-object-spread": "off",
         "prefer-promise-reject-errors": "off",
         "prefer-reflect": "off",
         "prefer-rest-params": "off",

--- a/docs/rules/prefer-object-spread.md
+++ b/docs/rules/prefer-object-spread.md
@@ -35,7 +35,7 @@ Object.assign(...foo);
 // Any Object.assign call without an object literal as the first argument
 Object.assign(foo, { bar: baz });
 
-Object.assign(foo, Object.assign({ bar: 'foo' }));
+Object.assign(foo, Object.assign(bar));
 
 Object.assign(foo, { bar, baz })
 

--- a/docs/rules/prefer-object-spread.md
+++ b/docs/rules/prefer-object-spread.md
@@ -1,0 +1,50 @@
+# Prefer use of an object spread over `Object.assign` (prefer-object-spread)
+
+When Object.assign is called using an object literal the first argument, this rule requires using the object spread syntax instead.
+
+**Please note:** This rule can only be used when using an `ecmaVersion` of 2018 or higher, 9 or higher, or when using an `ecmaVersion` of 2015-2017 or 5-8 with the `experimentalObjectRestSpread` parser option enabled.
+
+## Rule Details
+
+The following patterns are considered errors:
+
+```js
+
+Object.assign({}, foo)
+
+Object.assign({}, {foo: 'bar'})
+
+Object.assign({ foo: 'bar'}, baz)
+
+Object.assign({ foo: 'bar' }, Object.assign({ bar: 'foo' }))
+
+Object.assign({}, { foo, bar, baz })
+
+Object.assign({}, { ...baz })
+
+```
+
+The following patterns are not errors:
+
+```js
+
+Object.assign(...foo);
+
+// Any Object.assign call without an object literal as the first argument
+Object.assign(foo, { bar: baz });
+
+Object.assign(foo, Object.assign({ bar: 'foo' }));
+
+Object.assign(foo, { bar, baz })
+
+Object.assign(foo, { ...baz });
+
+// Object.assign with a single argument that is an object literal
+Object.assign({});
+
+Object.assign({ foo: bar });
+```
+
+## When Not To Use It
+
+When you don't care about syntactic sugar added by the object spread property.

--- a/docs/rules/prefer-object-spread.md
+++ b/docs/rules/prefer-object-spread.md
@@ -1,6 +1,6 @@
 # Prefer use of an object spread over `Object.assign` (prefer-object-spread)
 
-When Object.assign is called using an object literal the first argument, this rule requires using the object spread syntax instead.
+When Object.assign is called using an object literal the first argument, this rule requires using the object spread syntax instead. This rule also warns on cases where an `Object.assign` call is made using a single argument that is an object literal, in this case, the `Object.assign` call is not needed.
 
 **Please note:** This rule can only be used when using an `ecmaVersion` of 2018 or higher, 9 or higher, or when using an `ecmaVersion` of 2015-2017 or 5-8 with the `experimentalObjectRestSpread` parser option enabled.
 
@@ -22,6 +22,10 @@ Object.assign({}, { foo, bar, baz })
 
 Object.assign({}, { ...baz })
 
+// Object.assign with a single argument that is an object literal
+Object.assign({});
+
+Object.assign({ foo: bar });
 ```
 
 The following patterns are not errors:
@@ -38,11 +42,6 @@ Object.assign(foo, Object.assign({ bar: 'foo' }));
 Object.assign(foo, { bar, baz })
 
 Object.assign(foo, { ...baz });
-
-// Object.assign with a single argument that is an object literal
-Object.assign({});
-
-Object.assign({ foo: bar });
 ```
 
 ## When Not To Use It

--- a/docs/rules/prefer-object-spread.md
+++ b/docs/rules/prefer-object-spread.md
@@ -2,8 +2,6 @@
 
 When Object.assign is called using an object literal the first argument, this rule requires using the object spread syntax instead. This rule also warns on cases where an `Object.assign` call is made using a single argument that is an object literal, in this case, the `Object.assign` call is not needed.
 
-**Please note:** This rule can only be used when using an `ecmaVersion` of 2018 or higher, 9 or higher, or when using an `ecmaVersion` of 2015-2017 or 5-8 with the `experimentalObjectRestSpread` parser option enabled.
-
 ## Rule Details
 
 The following patterns are considered errors:

--- a/docs/rules/prefer-object-spread.md
+++ b/docs/rules/prefer-object-spread.md
@@ -1,10 +1,10 @@
 # Prefer use of an object spread over `Object.assign` (prefer-object-spread)
 
-When Object.assign is called using an object literal the first argument, this rule requires using the object spread syntax instead. This rule also warns on cases where an `Object.assign` call is made using a single argument that is an object literal, in this case, the `Object.assign` call is not needed.
+When Object.assign is called using an object literal as the first argument, this rule requires using the object spread syntax instead. This rule also warns on cases where an `Object.assign` call is made using a single argument that is an object literal, in this case, the `Object.assign` call is not needed.
 
 ## Rule Details
 
-The following patterns are considered errors:
+Examples of **incorrect** code for this rule:
 
 ```js
 
@@ -26,7 +26,7 @@ Object.assign({});
 Object.assign({ foo: bar });
 ```
 
-The following patterns are not errors:
+Examples of **correct** code for this rule:
 
 ```js
 

--- a/lib/rules/prefer-object-spread.js
+++ b/lib/rules/prefer-object-spread.js
@@ -104,6 +104,21 @@ function autofixSpread(node, sourceCode) {
     };
 }
 
+/**
+ * Autofixes the Object.assign call with a single object literal as an argument
+ * @param {ASTNode|null} node - The node that the rule warns on, i.e. the Object.assign call
+ * @param {string} sourceCode - sourceCode of the Object.assign call
+ * @returns {Function} autofixer - replaces the Object.assign with a object literal.
+ */
+function autofixObjectLiteral(node, sourceCode) {
+    return fixer => {
+        const argument = node.arguments[0];
+
+        return fixer.replaceText(node, sourceCode.text.slice(argument.range[0], argument.range[1]));
+    };
+}
+
+
 module.exports = {
     meta: {
         docs: {
@@ -125,6 +140,28 @@ module.exports = {
                 const hasSpreadElement = node.arguments.length &&
                     node.arguments.some(x => x.type === "SpreadElement");
 
+                /*
+                 * The condition below is cases where Object.assign has a single argument and
+                 * that argument is an object literal. e.g. `Object.assign({ foo: bar })`.
+                 * For now, we will warn on this case and autofix it.
+                 */
+                if (
+                    node.arguments.length === 1 &&
+                    node.arguments[0].type === "ObjectExpression"
+                ) {
+                    context.report({
+                        node,
+                        message:
+                            "Use an object literal instead of `Object.assign`.",
+                        fix: autofixObjectLiteral(node, sourceCode)
+                    });
+                }
+
+                /*
+                 * The condition below warns on `Object.assign` calls that that have
+                 * an object literal as the first argument and have a second argument
+                 * that can be spread. e.g `Object.assign({ foo: bar }, baz)`
+                 */
                 if (
                     node.arguments.length > 1 &&
                     node.arguments[0].type === "ObjectExpression" &&

--- a/lib/rules/prefer-object-spread.js
+++ b/lib/rules/prefer-object-spread.js
@@ -207,8 +207,34 @@ module.exports = {
 
     create: function rule(context) {
         const sourceCode = context.getSourceCode();
+        let overWritingNativeObject = false;
 
         return {
+            VariableDeclaration(node) {
+
+                /*
+                 * If a declared variable is overwriting the native `Object`, eg. `const Object = 'something'`
+                 * we want to skip warning on them since the behavior might be different.
+                 */
+                if (node.declarations.length) {
+                    const declarationNames = node.declarations.map(dec => dec.id);
+                    const nativeObjectOverride = declarationNames.filter(identifier => identifier.name === "Object");
+
+                    if (nativeObjectOverride.length) {
+                        overWritingNativeObject = true;
+                    }
+                }
+            },
+            AssignmentExpression(node) {
+
+                /*
+                 * If an assignment is reassigning the native `Object`, eg. `Object = 'something'`
+                 * we want to skip warning on them since the behavior might be different.
+                 */
+                if (node.left.name === "Object") {
+                    overWritingNativeObject = true;
+                }
+            },
             CallExpression(node) {
 
                 /*
@@ -217,8 +243,10 @@ module.exports = {
                  * For now, we will warn on this case and autofix it.
                  */
                 if (
+                    !overWritingNativeObject &&
                     node.arguments.length === 1 &&
-                    node.arguments[0].type === "ObjectExpression"
+                    node.arguments[0].type === "ObjectExpression" &&
+                    isObjectAssign(node)
                 ) {
                     context.report({
                         node,
@@ -233,9 +261,10 @@ module.exports = {
                  * that can be spread. e.g `Object.assign({ foo: bar }, baz)`
                  */
                 if (
+                    !overWritingNativeObject &&
                     node.arguments.length > 1 &&
                     node.arguments[0].type === "ObjectExpression" &&
-                    isObjectAssign
+                    isObjectAssign(node)
                 ) {
                     context.report({
                         node,

--- a/lib/rules/prefer-object-spread.js
+++ b/lib/rules/prefer-object-spread.js
@@ -1,0 +1,143 @@
+/**
+ * @fileoverview Prefers object spread property over Object.assign
+ * @author Sharmila Jesupaul
+ * See LICENSE file in root directory for full license.
+ */
+
+"use strict";
+
+// Helpers
+/**
+ * Helper that returns the last element in an array
+ * @param {array} arr - array that you are searching in
+ * @returns {string} - Returns the last element in an array of string arguments
+ */
+function tail(arr) {
+    return arr[arr.length - 1];
+}
+
+/**
+ * Helper that strips the curlie braces from a stringified object, returning only the contents
+ * @param {string} objectString - Source code of an object literal
+ * @returns {string} - Returns the object with the curly braces stripped
+ */
+function stripCurlies(objectString) {
+    return objectString.slice(1, -1);
+}
+
+/**
+ * Helper that checks if the node is an Object.assign call
+ * @param {ASTNode} node - The node that the rule warns on
+ * @returns {boolean} - Returns true if the node is an Object.assign call
+ */
+function isObjectAssign(node) {
+    return (
+        node.callee &&
+        node.callee.type === "MemberExpression" &&
+        node.callee.object.name === "Object" &&
+        node.callee.property.name === "assign"
+    );
+}
+
+/**
+ * Autofixer that parses arguments that are passed into the Object.assign call, and returns a formatted object spread.
+ * @param {array} args - The node that the rule warns on, i.e. the Object.assign call
+ * @param {string} sourceCode - sourceCode of the Object.assign call
+ * @returns {array} formatted args - replaces the Object.assign with a spread object.
+ */
+function parseArgs(args, sourceCode) {
+    const mapped = args.map((arg, i) => {
+
+        // If the the argument is an empty object
+        if (arg.type === "ObjectExpression" && arg.properties.length === 0) {
+            return "";
+        }
+
+        // if the argument is another object.assign call run this function for all of it's arguments
+        if (isObjectAssign(arg)) {
+            return parseArgs(arg.arguments, sourceCode);
+        }
+
+        const next = args[i + 1] || {};
+
+        // if the argument is an object with properties
+        if (arg.type === "ObjectExpression") {
+            const trimmedObject = stripCurlies(sourceCode.getText(arg)).trim();
+
+            return next.range && next.range[0] ? `${trimmedObject}, ` : trimmedObject;
+        }
+
+        return next.range && next.range[0]
+            ? `...${sourceCode.getText(arg)}, `
+            : `...${sourceCode.getText(arg)}`;
+    });
+
+    return [].concat.apply([], mapped);
+}
+
+/**
+ * Autofixes the Object.assign call to use an object spread instead.
+ * @param {ASTNode|null} node - The node that the rule warns on, i.e. the Object.assign call
+ * @param {string} sourceCode - sourceCode of the Object.assign call
+ * @returns {Function} autofixer - replaces the Object.assign with a spread object.
+ */
+function autofixSpread(node, sourceCode) {
+    return fixer => {
+        const args = node.arguments;
+
+        const processedArgs = parseArgs(args, sourceCode).join("");
+
+        const lastArg = tail(args);
+        const firstArg = args[0];
+
+        const funcEnd = sourceCode.text
+            .slice(lastArg.range[1], node.range[1])
+            .split(")")[0];
+        const funcStart = tail(
+            sourceCode.text.slice(node.range[0], firstArg.range[0]).split("(")
+        );
+
+        return fixer.replaceText(
+            node,
+            `{${funcStart}${processedArgs}${funcEnd}}`
+        );
+    };
+}
+
+module.exports = {
+    meta: {
+        docs: {
+            description:
+                "disallow using Object.assign with an object literal as the first argument and prefer the use of object spread instead.",
+            category: "ECMAScript 6",
+            recommended: false,
+            url: "https://eslint.org/docs/rules/prefer-object-spread"
+        },
+        schema: [],
+        fixable: "code"
+    },
+
+    create: function rule(context) {
+        return {
+            CallExpression: node => {
+                const message = "Use an object spread instead of `Object.assign()` eg: `{ ...foo }`";
+                const sourceCode = context.getSourceCode();
+                const hasSpreadElement = node.arguments.length &&
+                    node.arguments.some(x => x.type === "SpreadElement");
+
+                if (
+                    node.arguments.length > 1 &&
+                    node.arguments[0].type === "ObjectExpression" &&
+                    isObjectAssign &&
+                    !hasSpreadElement
+                ) {
+                    context.report({
+                        node,
+                        message,
+                        fix: autofixSpread(node, sourceCode)
+                    });
+                }
+            }
+        };
+    }
+};

--- a/lib/rules/prefer-object-spread.js
+++ b/lib/rules/prefer-object-spread.js
@@ -5,8 +5,10 @@
  */
 
 "use strict";
+let globalContext;
 
 // Helpers
+
 /**
  * Helper that returns the last element in an array
  * @param {array} arr - array that you are searching in
@@ -14,15 +16,6 @@
  */
 function tail(arr) {
     return arr[arr.length - 1];
-}
-
-/**
- * Helper that strips the curlie braces from a stringified object, returning only the contents
- * @param {string} objectString - Source code of an object literal
- * @returns {string} - Returns the object with the curly braces stripped
- */
-function stripCurlies(objectString) {
-    return objectString.slice(1, -1);
 }
 
 /**
@@ -40,42 +33,6 @@ function isObjectAssign(node) {
 }
 
 /**
- * Autofixer that parses arguments that are passed into the Object.assign call, and returns a formatted object spread.
- * @param {array} args - The node that the rule warns on, i.e. the Object.assign call
- * @param {string} sourceCode - sourceCode of the Object.assign call
- * @returns {array} formatted args - replaces the Object.assign with a spread object.
- */
-function parseArgs(args, sourceCode) {
-    const mapped = args.map((arg, i) => {
-
-        // If the the argument is an empty object
-        if (arg.type === "ObjectExpression" && arg.properties.length === 0) {
-            return "";
-        }
-
-        // if the argument is another object.assign call run this function for all of it's arguments
-        if (isObjectAssign(arg)) {
-            return parseArgs(arg.arguments, sourceCode);
-        }
-
-        const next = args[i + 1] || {};
-
-        // if the argument is an object with properties
-        if (arg.type === "ObjectExpression") {
-            const trimmedObject = stripCurlies(sourceCode.getText(arg)).trim();
-
-            return next.range && next.range[0] ? `${trimmedObject}, ` : trimmedObject;
-        }
-
-        return next.range && next.range[0]
-            ? `...${sourceCode.getText(arg)}, `
-            : `...${sourceCode.getText(arg)}`;
-    });
-
-    return [].concat.apply([], mapped);
-}
-
-/**
  * Autofixes the Object.assign call to use an object spread instead.
  * @param {ASTNode|null} node - The node that the rule warns on, i.e. the Object.assign call
  * @param {string} sourceCode - sourceCode of the Object.assign call
@@ -84,23 +41,41 @@ function parseArgs(args, sourceCode) {
 function autofixSpread(node, sourceCode) {
     return fixer => {
         const args = node.arguments;
-
-        const processedArgs = parseArgs(args, sourceCode).join("");
-
-        const lastArg = tail(args);
         const firstArg = args[0];
+        const lastToken = tail(globalContext.getTokens(firstArg));
+        const spreadArgs = args.map((arg, i) => {
+            const name = arg.name || sourceCode.getText(arg);
 
-        const funcEnd = sourceCode.text
-            .slice(lastArg.range[1], node.range[1])
-            .split(")")[0];
-        const funcStart = tail(
-            sourceCode.text.slice(node.range[0], firstArg.range[0]).split("(")
+            if (i === 0) {
+                return "";
+            }
+
+            if (args.length - 1 === i) {
+                return `...${name}`;
+            }
+
+            return `...${name},`;
+        });
+
+        const insertSpreads = fixer.insertTextBefore(lastToken, `${
+            node.arguments[0].properties && node.arguments[0].properties.length
+                ? ","
+                : ""
+        }${spreadArgs.join("")}`);
+
+        const removeObjectAssignStart = fixer.removeRange(
+            [node.range[0], firstArg.range[0]],
+            ""
         );
 
-        return fixer.replaceText(
-            node,
-            `{${funcStart}${processedArgs}${funcEnd}}`
-        );
+        const allOtherArgumentsRange = [firstArg.range[1], node.range[1]];
+        const removeRemainingArguments = fixer.removeRange(allOtherArgumentsRange, "");
+
+        return [
+            removeObjectAssignStart,
+            insertSpreads,
+            removeRemainingArguments
+        ];
     };
 }
 
@@ -124,18 +99,22 @@ module.exports = {
         docs: {
             description:
                 "disallow using Object.assign with an object literal as the first argument and prefer the use of object spread instead.",
-            category: "ECMAScript 6",
+            category: "Stylistic Issues",
             recommended: false,
             url: "https://eslint.org/docs/rules/prefer-object-spread"
         },
         schema: [],
-        fixable: "code"
+        fixable: "code",
+        messages: {
+            useSpreadMessage: "Use an object spread instead of `Object.assign()` eg: `{ ...foo }`",
+            useLiteralMessage: "Use an object literal instead of `Object.assign`."
+        }
     },
 
     create: function rule(context) {
+        globalContext = context;
         return {
-            CallExpression: node => {
-                const message = "Use an object spread instead of `Object.assign()` eg: `{ ...foo }`";
+            CallExpression(node) {
                 const sourceCode = context.getSourceCode();
                 const hasSpreadElement = node.arguments.length &&
                     node.arguments.some(x => x.type === "SpreadElement");
@@ -151,8 +130,7 @@ module.exports = {
                 ) {
                     context.report({
                         node,
-                        message:
-                            "Use an object literal instead of `Object.assign`.",
+                        messageId: "useLiteralMessage",
                         fix: autofixObjectLiteral(node, sourceCode)
                     });
                 }
@@ -170,7 +148,7 @@ module.exports = {
                 ) {
                     context.report({
                         node,
-                        message,
+                        messageId: "useSpreadMessage",
                         fix: autofixSpread(node, sourceCode)
                     });
                 }

--- a/lib/rules/prefer-object-spread.js
+++ b/lib/rules/prefer-object-spread.js
@@ -200,8 +200,8 @@ module.exports = {
         schema: [],
         fixable: "code",
         messages: {
-            useSpreadMessage: "Use an object spread instead of `Object.assign()` eg: `{ ...foo }`",
-            useLiteralMessage: "Use an object literal instead of `Object.assign`."
+            useSpreadMessage: "Use an object spread instead of `Object.assign` eg: `{ ...foo }`",
+            useLiteralMessage: "Use an object literal instead of `Object.assign`. eg: `{ foo: bar }`"
         }
     },
 

--- a/lib/rules/prefer-object-spread.js
+++ b/lib/rules/prefer-object-spread.js
@@ -5,18 +5,8 @@
  */
 
 "use strict";
-let globalContext;
 
-// Helpers
-
-/**
- * Helper that returns the last element in an array
- * @param {array} arr - array that you are searching in
- * @returns {string} - Returns the last element in an array of string arguments
- */
-function tail(arr) {
-    return arr[arr.length - 1];
-}
+const matchAll = require("string.prototype.matchall");
 
 /**
  * Helper that checks if the node is an Object.assign call
@@ -33,6 +23,132 @@ function isObjectAssign(node) {
 }
 
 /**
+ * Helper that checks if the node needs parentheses to be valid JS.
+ * The default is to wrap the node in parentheses to avoid parsing errors.
+ * @param {ASTNode} node - The node that the rule warns on
+ * @returns {boolean} - Returns true if the node needs parentheses
+ */
+function needsParens(node) {
+    const parent = node.parent;
+
+    if (!parent || !node.type) {
+        return true;
+    }
+
+    switch (parent.type) {
+        case "VariableDeclarator":
+        case "ArrayExpression":
+        case "ReturnStatement":
+        case "CallExpression":
+        case "Property":
+            return false;
+        default:
+            return true;
+    }
+}
+
+/**
+ * Determines if an argument needs parentheses. The default is to not add parens.
+ * @param {ASTNode} node - The node to be checked.
+ * @returns {boolean} True if the node needs parentheses
+ */
+function argNeedsParens(node) {
+    if (!node.type) {
+        return false;
+    }
+
+    switch (node.type) {
+        case "AssignmentExpression":
+        case "ArrowFunctionExpression":
+        case "ConditionalExpression":
+            return true;
+        default:
+            return false;
+    }
+}
+
+/**
+ * Helper that adds a comma after the last non-whitespace character that is not a part of a comment.
+ * @param {string} arg - String of argument text
+ * @returns {string} - argument with comma at the end of it
+ */
+function addComma(arg) {
+    const nonWhitespaceCharacterRegex = /[^\s\\]/g;
+    const commentRegex = /(\/\*[\w'\s\r\n*]*\*\/)|(\/\/[\w\s']*)|(<![-\-\s\w>/]*>)/g;
+
+    const commentMatches = Array.from(matchAll(arg, commentRegex));
+    const nonWhitespaceCharacters = Array.from(matchAll(arg, nonWhitespaceCharacterRegex));
+    const commentRanges = [];
+
+    // Create a ranges of starting and ending indicies for comments found
+    commentMatches.forEach(match => {
+        const start = match.index;
+        const end = start + match[0].length;
+
+        commentRanges.push([start, end]);
+    });
+
+    const validWhitespaceMatches = [];
+
+    // Create a list of indexes where non-whitespace characters exist.
+    nonWhitespaceCharacters.forEach(match => {
+        const insertIndex = match.index + match[0].length;
+
+        if (!commentRanges.length) {
+            validWhitespaceMatches.push(insertIndex);
+        }
+
+        // If comment ranges are found make sure that the non whitespace characters are not part of the comment.
+        commentRanges.forEach(arr => {
+            const commentStart = arr[0];
+            const commentEnd = arr[1];
+
+            if (insertIndex < commentStart || insertIndex > commentEnd) {
+                validWhitespaceMatches.push(insertIndex);
+            }
+        });
+    });
+    const insertPos = Math.max.apply(Math, validWhitespaceMatches);
+    const regex = new RegExp(`^((?:.|[^/s/S]){${insertPos}}) *`);
+
+    return arg.replace(regex, "$1, ");
+}
+
+/**
+ * Helper formats an argument by either removing curlies or adding a spread operator
+ * @param {ASTNode|null} arg - ast node representing argument to format
+ * @param {boolean} isLast - true if on the last element of the array
+ * @param {Object} sourceCode - in context sourcecode object
+ * @returns {string} - formatted argument
+ */
+function formatArg(arg, isLast, sourceCode) {
+    const text = sourceCode.getText(arg);
+    const parens = argNeedsParens(arg);
+
+    if (arg.type === "ObjectExpression" && arg.properties.length === 0) {
+        return "";
+    }
+
+    if (arg.type === "ObjectExpression") {
+
+        /**
+         * This regex finds the opening curly brace and any following spaces and replaces it with whatever
+         * exists before the curly brace. It also does the same for the closing curly brace. This is to avoid
+         * having multiple spaces around the object expression depending on how the object properties are spaced.
+         */
+        const formattedObjectLiteral = text.replace(/^(.*){ */, "$1").replace(/ *}([^}]*)$/, "$1");
+
+        return isLast ? formattedObjectLiteral : addComma(formattedObjectLiteral);
+    }
+
+    if (isLast) {
+        return parens ? `...(${text})` : `...${text}`;
+    }
+
+    return parens ? addComma(`...(${text})`) : `...${addComma(text)}`;
+}
+
+/**
  * Autofixes the Object.assign call to use an object spread instead.
  * @param {ASTNode|null} node - The node that the rule warns on, i.e. the Object.assign call
  * @param {string} sourceCode - sourceCode of the Object.assign call
@@ -42,39 +158,24 @@ function autofixSpread(node, sourceCode) {
     return fixer => {
         const args = node.arguments;
         const firstArg = args[0];
-        const lastToken = tail(globalContext.getTokens(firstArg));
-        const spreadArgs = args.map((arg, i) => {
-            const name = arg.name || sourceCode.getText(arg);
-
-            if (i === 0) {
-                return "";
-            }
-
-            if (args.length - 1 === i) {
-                return `...${name}`;
-            }
-
-            return `...${name},`;
-        });
-
-        const insertSpreads = fixer.insertTextBefore(lastToken, `${
-            node.arguments[0].properties && node.arguments[0].properties.length
-                ? ","
-                : ""
-        }${spreadArgs.join("")}`);
-
-        const removeObjectAssignStart = fixer.removeRange(
+        const lastArg = args[args.length - 1];
+        const parens = needsParens(node);
+        const replaceObjectAssignStart = fixer.replaceTextRange(
             [node.range[0], firstArg.range[0]],
-            ""
+            `${parens ? "({" : "{"}`
         );
 
-        const allOtherArgumentsRange = [firstArg.range[1], node.range[1]];
-        const removeRemainingArguments = fixer.removeRange(allOtherArgumentsRange, "");
+        const handleArgs = args
+            .map((arg, i, arr) => formatArg(arg, i + 1 >= arr.length, sourceCode))
+            .filter(arg => arg !== "," && arg !== "");
+
+        const insertBody = fixer.replaceTextRange([firstArg.range[0], lastArg.range[1]], handleArgs.join(""));
+        const replaceObjectAssignEnd = fixer.replaceTextRange([lastArg.range[1], node.range[1]], `${parens ? "})" : "}"}`);
 
         return [
-            removeObjectAssignStart,
-            insertSpreads,
-            removeRemainingArguments
+            replaceObjectAssignStart,
+            insertBody,
+            replaceObjectAssignEnd
         ];
     };
 }
@@ -88,8 +189,9 @@ function autofixSpread(node, sourceCode) {
 function autofixObjectLiteral(node, sourceCode) {
     return fixer => {
         const argument = node.arguments[0];
+        const parens = needsParens(node);
 
-        return fixer.replaceText(node, sourceCode.text.slice(argument.range[0], argument.range[1]));
+        return fixer.replaceText(node, `${parens ? "(" : ""}${sourceCode.text.slice(argument.range[0], argument.range[1])}${parens ? ")" : ""}`);
     };
 }
 
@@ -112,7 +214,6 @@ module.exports = {
     },
 
     create: function rule(context) {
-        globalContext = context;
         return {
             CallExpression(node) {
                 const sourceCode = context.getSourceCode();

--- a/lib/rules/prefer-object-spread.js
+++ b/lib/rules/prefer-object-spread.js
@@ -69,25 +69,14 @@ function argNeedsParens(node) {
 
 /**
  * Helper that adds a comma after the last non-whitespace character that is not a part of a comment.
- * @param {string} arg - String of argument text
+ * @param {string} formattedArg - String of argument text
+ * @param {array} comments - comments inside the argument
  * @returns {string} - argument with comma at the end of it
  */
-function addComma(arg) {
+function addComma(formattedArg, comments) {
     const nonWhitespaceCharacterRegex = /[^\s\\]/g;
-    const commentRegex = /(\/\*[\w'\s\r\n*]*\*\/)|(\/\/[\w\s']*)|(<![-\-\s\w>/]*>)/g;
-
-    const commentMatches = Array.from(matchAll(arg, commentRegex));
-    const nonWhitespaceCharacters = Array.from(matchAll(arg, nonWhitespaceCharacterRegex));
-    const commentRanges = [];
-
-    // Create a ranges of starting and ending indicies for comments found
-    commentMatches.forEach(match => {
-        const start = match.index;
-        const end = start + match[0].length;
-
-        commentRanges.push([start, end]);
-    });
-
+    const nonWhitespaceCharacters = Array.from(matchAll(formattedArg, nonWhitespaceCharacterRegex));
+    const commentRanges = comments.map(comment => comment.range);
     const validWhitespaceMatches = [];
 
     // Create a list of indexes where non-whitespace characters exist.
@@ -111,7 +100,7 @@ function addComma(arg) {
     const insertPos = Math.max.apply(Math, validWhitespaceMatches);
     const regex = new RegExp(`^((?:.|[^/s/S]){${insertPos}}) *`);
 
-    return arg.replace(regex, "$1, ");
+    return formattedArg.replace(regex, "$1, ");
 }
 
 /**
@@ -119,11 +108,13 @@ function addComma(arg) {
  * @param {ASTNode|null} arg - ast node representing argument to format
  * @param {boolean} isLast - true if on the last element of the array
  * @param {Object} sourceCode - in context sourcecode object
+ * @param {array} comments - comments inside checked node
  * @returns {string} - formatted argument
  */
-function formatArg(arg, isLast, sourceCode) {
+function formatArg(arg, isLast, sourceCode, comments) {
     const text = sourceCode.getText(arg);
     const parens = argNeedsParens(arg);
+    const spread = arg.type === "SpreadElement" ? "" : "...";
 
     if (arg.type === "ObjectExpression" && arg.properties.length === 0) {
         return "";
@@ -138,14 +129,14 @@ function formatArg(arg, isLast, sourceCode) {
          */
         const formattedObjectLiteral = text.replace(/^(.*){ */, "$1").replace(/ *}([^}]*)$/, "$1");
 
-        return isLast ? formattedObjectLiteral : addComma(formattedObjectLiteral);
+        return isLast ? formattedObjectLiteral : addComma(formattedObjectLiteral, comments);
     }
 
     if (isLast) {
-        return parens ? `...(${text})` : `...${text}`;
+        return parens ? `${spread}(${text})` : `${spread}${text}`;
     }
 
-    return parens ? addComma(`...(${text})`) : `...${addComma(text)}`;
+    return parens ? addComma(`${spread}(${text})`, comments) : `${spread}${addComma(text, comments)}`;
 }
 
 /**
@@ -160,13 +151,14 @@ function autofixSpread(node, sourceCode) {
         const firstArg = args[0];
         const lastArg = args[args.length - 1];
         const parens = needsParens(node);
+        const comments = sourceCode.getCommentsInside(node);
         const replaceObjectAssignStart = fixer.replaceTextRange(
             [node.range[0], firstArg.range[0]],
             `${parens ? "({" : "{"}`
         );
 
         const handleArgs = args
-            .map((arg, i, arr) => formatArg(arg, i + 1 >= arr.length, sourceCode))
+            .map((arg, i, arr) => formatArg(arg, i + 1 >= arr.length, sourceCode, comments))
             .filter(arg => arg !== "," && arg !== "");
 
         const insertBody = fixer.replaceTextRange([firstArg.range[0], lastArg.range[1]], handleArgs.join(""));
@@ -214,11 +206,10 @@ module.exports = {
     },
 
     create: function rule(context) {
+        const sourceCode = context.getSourceCode();
+
         return {
             CallExpression(node) {
-                const sourceCode = context.getSourceCode();
-                const hasSpreadElement = node.arguments.length &&
-                    node.arguments.some(x => x.type === "SpreadElement");
 
                 /*
                  * The condition below is cases where Object.assign has a single argument and
@@ -244,8 +235,7 @@ module.exports = {
                 if (
                     node.arguments.length > 1 &&
                     node.arguments[0].type === "ObjectExpression" &&
-                    isObjectAssign &&
-                    !hasSpreadElement
+                    isObjectAssign
                 ) {
                     context.report({
                         node,

--- a/lib/rules/prefer-object-spread.js
+++ b/lib/rules/prefer-object-spread.js
@@ -97,7 +97,7 @@ function addComma(formattedArg, comments) {
             }
         });
     });
-    const insertPos = Math.max.apply(Math, validWhitespaceMatches);
+    const insertPos = Math.max(...validWhitespaceMatches);
     const regex = new RegExp(`^((?:.|[^/s/S]){${insertPos}}) *`);
 
     return formattedArg.replace(regex, "$1, ");

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "regexpp": "^1.1.0",
     "require-uncached": "^1.0.3",
     "semver": "^5.5.0",
+    "string.prototype.matchall": "^2.0.0",
     "strip-ansi": "^4.0.0",
     "strip-json-comments": "^2.0.1",
     "table": "4.0.2",

--- a/tests/lib/rules/prefer-object-spread.js
+++ b/tests/lib/rules/prefer-object-spread.js
@@ -17,8 +17,8 @@ const parserOptions = {
     }
 };
 
-const defaultErrorMessage =
-    "Use an object spread instead of `Object.assign()` eg: `{ ...foo }`";
+const defaultErrorMessage = "Use an object spread instead of `Object.assign()` eg: `{ ...foo }`";
+const useObjLiteralErrorMessage = "Use an object literal instead of `Object.assign`.";
 const ruleTester = new RuleTester();
 
 ruleTester.run("prefer-object-spread", rule, {
@@ -187,6 +187,32 @@ ruleTester.run("prefer-object-spread", rule, {
             errors: [
                 {
                     message: defaultErrorMessage,
+                    type: "CallExpression"
+                }
+            ]
+        },
+
+        /*
+         * This is a special case where Object.assign is called with a single argument
+         * and that argument is an object expression. In this case we warn and display
+         * a message to use an object literal instead.
+         */
+        {
+            code: "Object.assign({})",
+            output: "{}",
+            errors: [
+                {
+                    message: useObjLiteralErrorMessage,
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "Object.assign({ foo: bar })",
+            output: "{ foo: bar }",
+            errors: [
+                {
+                    message: useObjLiteralErrorMessage,
                     type: "CallExpression"
                 }
             ]

--- a/tests/lib/rules/prefer-object-spread.js
+++ b/tests/lib/rules/prefer-object-spread.js
@@ -25,7 +25,6 @@ ruleTester.run("prefer-object-spread", rule, {
         "let a = Object.assign(a, b)",
         "Object.assign(a, b)",
         "let a = Object.assign(b, { c: 1 })",
-        "let a = Object.assign({}, ...b)",
         "const bar = { ...foo }",
         "Object.assign(...foo)",
         "Object.assign(foo, { bar: baz })"
@@ -38,17 +37,22 @@ ruleTester.run("prefer-object-spread", rule, {
             errors: [
                 {
                     messageId: "useSpreadMessage",
-                    type: "CallExpression"
+                    type: "CallExpression",
+                    line: 1,
+                    column: 1
                 }
             ]
         },
+
         {
             code: "Object.assign({}, { foo: 'bar' })",
             output: "({foo: 'bar'})",
             errors: [
                 {
                     messageId: "useSpreadMessage",
-                    type: "CallExpression"
+                    type: "CallExpression",
+                    line: 1,
+                    column: 1
                 }
             ]
         },
@@ -58,7 +62,9 @@ ruleTester.run("prefer-object-spread", rule, {
             errors: [
                 {
                     messageId: "useSpreadMessage",
-                    type: "CallExpression"
+                    type: "CallExpression",
+                    line: 1,
+                    column: 1
                 }
             ]
         },
@@ -68,7 +74,9 @@ ruleTester.run("prefer-object-spread", rule, {
             errors: [
                 {
                     messageId: "useSpreadMessage",
-                    type: "CallExpression"
+                    type: "CallExpression",
+                    line: 1,
+                    column: 1
                 }
             ]
         },
@@ -78,7 +86,9 @@ ruleTester.run("prefer-object-spread", rule, {
             errors: [
                 {
                     messageId: "useSpreadMessage",
-                    type: "CallExpression"
+                    type: "CallExpression",
+                    line: 1,
+                    column: 1
                 }
             ]
         },
@@ -90,12 +100,13 @@ ruleTester.run("prefer-object-spread", rule, {
             errors: [
                 {
                     messageId: "useSpreadMessage",
-                    type: "CallExpression"
+                    type: "CallExpression",
+                    line: 1,
+                    column: 1
                 }
             ]
         },
 
-        // TODO: Handle nested Object.assign calls
         {
             code:
                 "Object.assign({ foo: 'bar' }, Object.assign({ bar: 'foo' }, baz))",
@@ -103,11 +114,15 @@ ruleTester.run("prefer-object-spread", rule, {
             errors: [
                 {
                     messageId: "useSpreadMessage",
-                    type: "CallExpression"
+                    type: "CallExpression",
+                    line: 1,
+                    column: 1
                 },
                 {
                     messageId: "useSpreadMessage",
-                    type: "CallExpression"
+                    type: "CallExpression",
+                    line: 1,
+                    column: 31
                 }
             ]
         },
@@ -118,15 +133,21 @@ ruleTester.run("prefer-object-spread", rule, {
             errors: [
                 {
                     messageId: "useSpreadMessage",
-                    type: "CallExpression"
+                    type: "CallExpression",
+                    line: 1,
+                    column: 1
                 },
                 {
                     messageId: "useSpreadMessage",
-                    type: "CallExpression"
+                    type: "CallExpression",
+                    line: 1,
+                    column: 31
                 },
                 {
                     messageId: "useSpreadMessage",
-                    type: "CallExpression"
+                    type: "CallExpression",
+                    line: 1,
+                    column: 61
                 }
             ]
         },
@@ -138,7 +159,9 @@ ruleTester.run("prefer-object-spread", rule, {
             errors: [
                 {
                     messageId: "useSpreadMessage",
-                    type: "CallExpression"
+                    type: "CallExpression",
+                    line: 1,
+                    column: 1
                 }
             ]
         },
@@ -150,7 +173,9 @@ ruleTester.run("prefer-object-spread", rule, {
             errors: [
                 {
                     messageId: "useSpreadMessage",
-                    type: "CallExpression"
+                    type: "CallExpression",
+                    line: 1,
+                    column: 1
                 }
             ]
         },
@@ -162,7 +187,9 @@ ruleTester.run("prefer-object-spread", rule, {
             errors: [
                 {
                     messageId: "useSpreadMessage",
-                    type: "CallExpression"
+                    type: "CallExpression",
+                    line: 1,
+                    column: 1
                 }
             ]
         },
@@ -174,7 +201,9 @@ ruleTester.run("prefer-object-spread", rule, {
             errors: [
                 {
                     messageId: "useSpreadMessage",
-                    type: "CallExpression"
+                    type: "CallExpression",
+                    line: 1,
+                    column: 1
                 }
             ]
         },
@@ -194,7 +223,9 @@ ruleTester.run("prefer-object-spread", rule, {
             errors: [
                 {
                     messageId: "useSpreadMessage",
-                    type: "CallExpression"
+                    type: "CallExpression",
+                    line: 1,
+                    column: 1
                 }
             ]
         },
@@ -221,7 +252,9 @@ ruleTester.run("prefer-object-spread", rule, {
             errors: [
                 {
                     messageId: "useSpreadMessage",
-                    type: "CallExpression"
+                    type: "CallExpression",
+                    line: 1,
+                    column: 1
                 }
             ]
         },
@@ -243,7 +276,9 @@ ruleTester.run("prefer-object-spread", rule, {
             errors: [
                 {
                     messageId: "useSpreadMessage",
-                    type: "CallExpression"
+                    type: "CallExpression",
+                    line: 1,
+                    column: 14
                 }
             ]
         },
@@ -260,7 +295,9 @@ ruleTester.run("prefer-object-spread", rule, {
             errors: [
                 {
                     messageId: "useSpreadMessage",
-                    type: "CallExpression"
+                    type: "CallExpression",
+                    line: 1,
+                    column: 14
                 }
             ]
         },
@@ -284,7 +321,9 @@ ruleTester.run("prefer-object-spread", rule, {
             errors: [
                 {
                     messageId: "useSpreadMessage",
-                    type: "CallExpression"
+                    type: "CallExpression",
+                    line: 1,
+                    column: 14
                 }
             ]
         },
@@ -301,7 +340,9 @@ ruleTester.run("prefer-object-spread", rule, {
             errors: [
                 {
                     messageId: "useLiteralMessage",
-                    type: "CallExpression"
+                    type: "CallExpression",
+                    line: 1,
+                    column: 1
                 }
             ]
         },
@@ -311,7 +352,9 @@ ruleTester.run("prefer-object-spread", rule, {
             errors: [
                 {
                     messageId: "useLiteralMessage",
-                    type: "CallExpression"
+                    type: "CallExpression",
+                    line: 1,
+                    column: 1
                 }
             ]
         },
@@ -322,7 +365,9 @@ ruleTester.run("prefer-object-spread", rule, {
             errors: [
                 {
                     messageId: "useLiteralMessage",
-                    type: "CallExpression"
+                    type: "CallExpression",
+                    line: 1,
+                    column: 9
                 }
             ]
         },
@@ -332,7 +377,9 @@ ruleTester.run("prefer-object-spread", rule, {
             errors: [
                 {
                     messageId: "useSpreadMessage",
-                    type: "CallExpression"
+                    type: "CallExpression",
+                    line: 1,
+                    column: 9
                 }
             ]
         },
@@ -342,7 +389,9 @@ ruleTester.run("prefer-object-spread", rule, {
             errors: [
                 {
                     messageId: "useSpreadMessage",
-                    type: "CallExpression"
+                    type: "CallExpression",
+                    line: 1,
+                    column: 9
                 }
             ]
         },
@@ -352,7 +401,9 @@ ruleTester.run("prefer-object-spread", rule, {
             errors: [
                 {
                     messageId: "useSpreadMessage",
-                    type: "CallExpression"
+                    type: "CallExpression",
+                    line: 1,
+                    column: 1
                 }
             ]
         },
@@ -362,7 +413,9 @@ ruleTester.run("prefer-object-spread", rule, {
             errors: [
                 {
                     messageId: "useSpreadMessage",
-                    type: "CallExpression"
+                    type: "CallExpression",
+                    line: 1,
+                    column: 1
                 }
             ]
         },
@@ -374,7 +427,9 @@ ruleTester.run("prefer-object-spread", rule, {
             errors: [
                 {
                     messageId: "useSpreadMessage",
-                    type: "CallExpression"
+                    type: "CallExpression",
+                    line: 1,
+                    column: 8
                 }
             ]
         },
@@ -384,7 +439,21 @@ ruleTester.run("prefer-object-spread", rule, {
             errors: [
                 {
                     messageId: "useSpreadMessage",
-                    type: "CallExpression"
+                    type: "CallExpression",
+                    line: 1,
+                    column: 13
+                }
+            ]
+        },
+        {
+            code: "let a = Object.assign({}, ...b)",
+            output: "let a = {...b}",
+            errors: [
+                {
+                    messageId: "useSpreadMessage",
+                    type: "CallExpression",
+                    line: 1,
+                    column: 9
                 }
             ]
         },
@@ -394,7 +463,9 @@ ruleTester.run("prefer-object-spread", rule, {
             errors: [
                 {
                     messageId: "useSpreadMessage",
-                    type: "CallExpression"
+                    type: "CallExpression",
+                    line: 1,
+                    column: 25
                 }
             ]
         },
@@ -404,7 +475,9 @@ ruleTester.run("prefer-object-spread", rule, {
             errors: [
                 {
                     messageId: "useSpreadMessage",
-                    type: "CallExpression"
+                    type: "CallExpression",
+                    line: 1,
+                    column: 5
                 }
             ]
         },
@@ -414,7 +487,9 @@ ruleTester.run("prefer-object-spread", rule, {
             errors: [
                 {
                     messageId: "useSpreadMessage",
-                    type: "CallExpression"
+                    type: "CallExpression",
+                    line: 1,
+                    column: 30
                 }
             ]
         }

--- a/tests/lib/rules/prefer-object-spread.js
+++ b/tests/lib/rules/prefer-object-spread.js
@@ -1,0 +1,195 @@
+/**
+ * @fileoverview Prefers object spread property over Object.assign
+ * @author Sharmila Jesupaul
+ * See LICENSE file in root directory for full license.
+ */
+
+"use strict";
+
+const rule = require("../../../lib/rules/prefer-object-spread");
+
+const RuleTester = require("../../../lib/testers/rule-tester");
+
+const parserOptions = {
+    ecmaVersion: 6,
+    ecmaFeatures: {
+        experimentalObjectRestSpread: true
+    }
+};
+
+const defaultErrorMessage =
+    "Use an object spread instead of `Object.assign()` eg: `{ ...foo }`";
+const ruleTester = new RuleTester();
+
+ruleTester.run("prefer-object-spread", rule, {
+    valid: [
+        {
+            code: "const bar = { ...foo }",
+            parserOptions
+        },
+        {
+            code: "Object.assign(...foo)",
+            parserOptions
+        },
+        {
+            code: "Object.assign(foo, { bar: baz })",
+            parserOptions
+        }
+    ],
+
+    invalid: [
+        {
+            code: "Object.assign({}, foo)",
+            output: "{...foo}",
+            errors: [
+                {
+                    message: defaultErrorMessage,
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "Object.assign({}, { foo: 'bar' })",
+            output: "{foo: 'bar'}",
+            errors: [
+                {
+                    message: defaultErrorMessage,
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "Object.assign({}, baz, { foo: 'bar' })",
+            output: "{...baz, foo: 'bar'}",
+            errors: [
+                {
+                    message: defaultErrorMessage,
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "Object.assign({}, { foo: 'bar', baz: 'foo' })",
+            output: "{foo: 'bar', baz: 'foo'}",
+            errors: [
+                {
+                    message: defaultErrorMessage,
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "Object.assign({ foo: 'bar' }, baz)",
+            output: "{foo: 'bar', ...baz}",
+            errors: [
+                {
+                    message: defaultErrorMessage,
+                    type: "CallExpression"
+                }
+            ]
+        },
+
+        // Many args
+        {
+            code: "Object.assign({ foo: 'bar' }, cats, dogs, trees, birds)",
+            output: "{foo: 'bar', ...cats, ...dogs, ...trees, ...birds}",
+            parserOptions,
+            errors: [
+                {
+                    message: defaultErrorMessage,
+                    type: "CallExpression"
+                }
+            ]
+        },
+
+        // Nested Object.assign calls
+        {
+            code:
+                "Object.assign({ foo: 'bar' }, Object.assign({ bar: 'foo' }, baz))",
+            output: "{foo: 'bar', bar: 'foo', ...baz}",
+            parserOptions,
+            errors: [
+                {
+                    message: defaultErrorMessage,
+                    type: "CallExpression"
+                },
+                {
+                    message: defaultErrorMessage,
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code:
+                "Object.assign({ foo: 'bar' }, Object.assign({ bar: 'foo' }, Object.assign({}, { superNested: 'butwhy' })))",
+            output: "{foo: 'bar', bar: 'foo', superNested: 'butwhy'}",
+            parserOptions,
+            errors: [
+                {
+                    message: defaultErrorMessage,
+                    type: "CallExpression"
+                },
+                {
+                    message: defaultErrorMessage,
+                    type: "CallExpression"
+                },
+                {
+                    message: defaultErrorMessage,
+                    type: "CallExpression"
+                }
+            ]
+        },
+
+        // Mix spread in argument
+        {
+            code: "Object.assign({ foo: 'bar', ...bar }, baz)",
+            output: "{foo: 'bar', ...bar, ...baz}",
+            parserOptions,
+            errors: [
+                {
+                    message: defaultErrorMessage,
+                    type: "CallExpression"
+                }
+            ]
+        },
+
+        // Object shorthand
+        {
+            code: "Object.assign({}, { foo, bar, baz })",
+            output: "{foo, bar, baz}",
+            parserOptions,
+            errors: [
+                {
+                    message: defaultErrorMessage,
+                    type: "CallExpression"
+                }
+            ]
+        },
+
+        // Objects with computed properties
+        {
+            code: "Object.assign({}, { [bar]: 'foo' })",
+            output: "{[bar]: 'foo'}",
+            parserOptions,
+            errors: [
+                {
+                    message: defaultErrorMessage,
+                    type: "CallExpression"
+                }
+            ]
+        },
+
+        // Objects with spread properties
+        {
+            code: "Object.assign({ ...bar }, { ...baz })",
+            output: "{...bar, ...baz}",
+            parserOptions,
+            errors: [
+                {
+                    message: defaultErrorMessage,
+                    type: "CallExpression"
+                }
+            ]
+        }
+    ]
+});

--- a/tests/lib/rules/prefer-object-spread.js
+++ b/tests/lib/rules/prefer-object-spread.js
@@ -27,7 +27,24 @@ ruleTester.run("prefer-object-spread", rule, {
         "let a = Object.assign(b, { c: 1 })",
         "const bar = { ...foo }",
         "Object.assign(...foo)",
-        "Object.assign(foo, { bar: baz })"
+        "Object.assign(foo, { bar: baz })",
+        "foo({ foo: 'bar' })",
+        `
+        const Object = {};
+        Object.assign({}, foo);
+        `,
+        `
+        Object = {};
+        Object.assign({}, foo);
+        `,
+        `
+        const Object = {};
+        Object.assign({ foo: 'bar' });
+        `,
+        `
+        Object = {};
+        Object.assign({ foo: 'bar' });
+        `
     ],
 
     invalid: [
@@ -360,6 +377,44 @@ ruleTester.run("prefer-object-spread", rule, {
         },
 
         {
+            code: `
+                const foo = 'bar';
+                Object.assign({ foo: bar })
+            `,
+            output: `
+                const foo = 'bar';
+                ({ foo: bar })
+            `,
+            errors: [
+                {
+                    messageId: "useLiteralMessage",
+                    type: "CallExpression",
+                    line: 3,
+                    column: 17
+                }
+            ]
+        },
+
+        {
+            code: `
+                foo = 'bar';
+                Object.assign({ foo: bar })
+            `,
+            output: `
+                foo = 'bar';
+                ({ foo: bar })
+            `,
+            errors: [
+                {
+                    messageId: "useLiteralMessage",
+                    type: "CallExpression",
+                    line: 3,
+                    column: 17
+                }
+            ]
+        },
+
+        {
             code: "let a = Object.assign({})",
             output: "let a = {}",
             errors: [
@@ -416,6 +471,42 @@ ruleTester.run("prefer-object-spread", rule, {
                     type: "CallExpression",
                     line: 1,
                     column: 1
+                }
+            ]
+        },
+        {
+            code: `
+                const someVar = 'foo';
+                Object.assign({}, a ? b : {}, b => c, a = 2)
+            `,
+            output: `
+                const someVar = 'foo';
+                ({...(a ? b : {}), ...(b => c), ...(a = 2)})
+            `,
+            errors: [
+                {
+                    messageId: "useSpreadMessage",
+                    type: "CallExpression",
+                    line: 3,
+                    column: 17
+                }
+            ]
+        },
+        {
+            code: `
+                someVar = 'foo';
+                Object.assign({}, a ? b : {}, b => c, a = 2)
+            `,
+            output: `
+                someVar = 'foo';
+                ({...(a ? b : {}), ...(b => c), ...(a = 2)})
+            `,
+            errors: [
+                {
+                    messageId: "useSpreadMessage",
+                    type: "CallExpression",
+                    line: 3,
+                    column: 17
                 }
             ]
         },


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

- [X] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
This is a follow up to #7230, we implemented `prefer-object-spread` internally at @airbnb.
The rule requires that you use an object spread over an `Object.assign` call with multiple arguments and an object literal as the first argument.

We also warn on cases where an `Object.assign` call is made using a single argument that is an object literal, in this case, the `Object.assign` is not needed (7f7f97d).

The following patterns are considered errors:

```js

Object.assign({}, foo)

Object.assign({}, {foo: 'bar'})

Object.assign({ foo: 'bar'}, baz)

Object.assign({ foo: 'bar' }, Object.assign({ bar: 'foo' }))

Object.assign({}, { foo, bar, baz })

Object.assign({}, { ...baz })

// Object.assign with a single argument that is an object literal
Object.assign({});

Object.assign({ foo: bar });
```

The following patterns are not errors:

```js

Object.assign(...foo);

// Any Object.assign call without an object literal as the first argument
Object.assign(foo, { bar: baz });

Object.assign(foo, Object.assign({ bar: 'foo' }));

Object.assign(foo, { bar, baz })

Object.assign(foo, { ...baz });
```

**Is there anything you'd like reviewers to focus on?**

I made 2 commits in this PR
1.  6e3e035 handles the general use case where `Object.assign` is called using an object literal and an additional argument, which can be changed to use object spread.
2. 7f7f97d warns on cases where `Object.assign` has a single argument that is an object literal. In this case, you can use the object literal directly. (i.e. `Object.assign({})` -> `{}`)

I left the second part in its own commit because I wasn't sure if it would fit into the scope of this rule.

cc. @ljharb 