### PR TITLE
Docs: Fix typo in max-len ignorePattern example.

### DIFF
--- a/docs/rules/max-len.md
+++ b/docs/rules/max-len.md
@@ -147,7 +147,7 @@ var longRegExpLiteral = /this is a really really really really really long regul
 Examples of **correct** code for this rule with the `ignorePattern` option:
 
 ```js
-/*eslint max-len: ["error", { "ignorePattern": "^\\s*var\\s.+=\\s*require\\s*\(" }]*/
+/*eslint max-len: ["error", { "ignorePattern": "^\\s*var\\s.+=\\s*require\\s*\\(" }]*/
 
 var dep = require('really/really/really/really/really/really/really/really/long/module');
 ```


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update
[ ] Bug fix (template)
[ ] New rule (template)
[ ] Changes an existing rule (template)
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:


**What changes did you make? (Give an overview)**

Proposed change to the documentation for the `max-men` rule, specifically, the `ignorePattern` example (https://eslint.org/docs/rules/max-len#ignorepattern).

Proposed change is to add a `\` to the `ignorePattern` example to properly escape the final `(`.

The current example of `"ignorePattern": "^\\s*var\\s.+=\\s*require\\s*\("` results in an error due to the invalid escape character in the string because the final open parentheses character isn't properly escaped.

This changes the example to: `"ignorePattern": "^\\s*var\\s.+=\\s*require\\s*\\("`, which is properly escaped.


**Is there anything you'd like reviewers to focus on?**

No.