### PR TITLE
Fix: valid-jsdoc failure for missing return in interface methods (fixes #9978)

### DIFF
--- a/lib/rules/valid-jsdoc.js
+++ b/lib/rules/valid-jsdoc.js
@@ -240,6 +240,40 @@ module.exports = {
         }
 
         /**
+         * Fetches JsDoc tags from ancestor node
+         * @param {Object} jsdocNode JSDoc node
+         * @returns {Array} Collection of ancestor JsDoc tags
+         */
+        function getAncestorTags(jsdocNode) {
+            let node = jsdocNode;
+
+            while (node && node.type !== "Program") {
+                node = node.parent;
+            }
+
+            if (!node.comments.length) {
+                return [];
+            }
+
+            try {
+                return doctrine.parse(node.comments[0].value, {
+                    strict: true,
+                    unwrap: true,
+                    sloppy: true
+                }).tags;
+            } catch (ex) {
+
+                if (/braces/i.test(ex.message)) {
+                    context.report({ node, message: "JSDoc type missing brace." });
+                } else {
+                    context.report({ node, message: "JSDoc syntax error." });
+                }
+
+                return [];
+            }
+        }
+
+        /**
          * Validate the JSDoc node and output warnings if anything is wrong.
          * @param {ASTNode} node The AST node to check.
          * @returns {void}
@@ -378,6 +412,19 @@ module.exports = {
                         paramTagsByName[param.name] = param;
                     }
                 });
+
+                /**
+                 * According to JsDoc syntax there is no need to add the @interface tag to each member of the
+                 * interface (http://usejsdoc.org/tags-interface.html), therefore we have to fetch information
+                 * whether member is within interface from the ancestor node.
+                 */
+                if (node.type !== "Program") {
+                    const tags = getAncestorTags(node);
+
+                    isInterface = tags.some(tag => tag.title === "interface");
+
+                    isAbstract = isInterface || isAbstract;
+                }
 
                 if (hasReturns) {
                     if (!requireReturn && !functionData.returnPresent && (returnsTag.type === null || !isValidReturnType(returnsTag)) && !isAbstract) {

--- a/tests/lib/rules/valid-jsdoc.js
+++ b/tests/lib/rules/valid-jsdoc.js
@@ -178,6 +178,34 @@ ruleTester.run("valid-jsdoc", rule, {
                 "function Thing() {}",
             options: [{ requireReturn: true }]
         },
+        {
+            code:
+                "/**\n" +
+                " * A thing interface. \n" +
+                " * @interface\n" +
+                " */\n" +
+                "function Thing() {}" +
+                "/**\n" +
+                " * A dummy interface method.\n" +
+                " * @returns {Object} an object\n" +
+                " */\n" +
+                "Thing.prototype.dummy = function() {}",
+            options: [{ requireReturn: false }]
+        },
+        {
+            code:
+                "/**\n" +
+                " * A thing interface. \n" +
+                " * @interface\n" +
+                " */\n" +
+                "function Thing() {}" +
+                "/**\n" +
+                " * A dummy interface method.\n" +
+                " * @returns {Object} an object\n" +
+                " */\n" +
+                "Thing.prototype.dummy = function() {}",
+            options: [{ requireReturn: true }]
+        },
 
         // classes
         {


### PR DESCRIPTION
…es #9978)

<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Added lookup in ancestor nodes for possible "interface" JsDoc tag in class/interface description when checking members.

**Is there anything you'd like reviewers to focus on?**


