### PR TITLE
Fix: Make max-len ignoreStrings ignore JSXText (fixes #9954)

### DIFF
--- a/lib/rules/max-len.js
+++ b/lib/rules/max-len.js
@@ -213,7 +213,7 @@ module.exports = {
          * @returns {ASTNode[]} An array of string nodes.
          */
         function getAllStrings() {
-            return sourceCode.ast.tokens.filter(token => token.type === "String");
+            return sourceCode.ast.tokens.filter(token => token.type === "String" || token.type === "JSXText");
         }
 
         /**

--- a/lib/rules/max-len.js
+++ b/lib/rules/max-len.js
@@ -213,7 +213,8 @@ module.exports = {
          * @returns {ASTNode[]} An array of string nodes.
          */
         function getAllStrings() {
-            return sourceCode.ast.tokens.filter(token => token.type === "String" || token.type === "JSXText");
+            return sourceCode.ast.tokens.filter(token => (token.type === "String" ||
+                (token.type === "JSXText" && sourceCode.getNodeByRangeIndex(token.range[0] - 1).type === "JSXAttribute")));
         }
 
         /**

--- a/tests/lib/rules/max-len.js
+++ b/tests/lib/rules/max-len.js
@@ -110,6 +110,11 @@ ruleTester.run("max-len", rule, {
             options: [29, 4, { ignoreStrings: true }]
         },
         {
+            code: "var foo = <div className=\"this is a very long string\"></div>;",
+            options: [29, 4, { ignoreStrings: true }],
+            parserOptions: { ecmaFeatures: { jsx: true } }
+        },
+        {
             code: "var foo = veryLongIdentifier;\nvar bar = `this is a very long string`;",
             options: [29, 4, { ignoreTemplateLiterals: true }],
             parserOptions

--- a/tests/lib/rules/max-len.js
+++ b/tests/lib/rules/max-len.js
@@ -558,6 +558,19 @@ ruleTester.run("max-len", rule, {
                 }
             ]
         },
+        {
+            code: "var foo = <div>this is a very very very long string</div>;",
+            options: [29, 4, { ignoreStrings: true }],
+            parserOptions: { ecmaFeatures: { jsx: true } },
+            errors: [
+                {
+                    message: "Line 1 exceeds the maximum line length of 29.",
+                    type: "Program",
+                    line: 1,
+                    column: 1
+                }
+            ]
+        },
 
         // Multi-code-point unicode glyphs
         {


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:


<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Fixes #9954.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Previously, `getAllStrings` only filter for tokens with type `String`. The filter should check if the token type is `JSXText` as well.


**Is there anything you'd like reviewers to focus on?**
Nothing in particular.

