### PR TITLE
Docs: Fixed typo in key-spacing rule doc

### DIFF
--- a/docs/rules/key-spacing.md
+++ b/docs/rules/key-spacing.md
@@ -16,7 +16,7 @@ This rule has an object option:
 * `"afterColon": true (default) | false`
     * `true`: requires at least one space between the colon and the value in object literals.
     * `false`: disallows spaces between the colon and the value in object literals.
-* `"mode": "strict" (default) | "miniumum"`
+* `"mode": "strict" (default) | "minimum"`
     * `"strict"`: enforces exactly one space before or after colons in object literals.
     * `"minimum"`: enforces one or more spaces before or after colons in object literals.
 * `"align": "value" | "colon"`


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Fixed typo in the list of allowed string values for `mode` option in the rule `key-spacing` (said `"miniumum"` instead of `"minimum"`).

