### PR TITLE
Fix: ensure no-await-in-loop reports the correct node (fixes #9992)

### DIFF
--- a/lib/rules/no-await-in-loop.js
+++ b/lib/rules/no-await-in-loop.js
@@ -84,7 +84,7 @@ module.exports = {
             while (parent && !isBoundary(parent)) {
                 if (isLooped(node, parent)) {
                     context.report({
-                        node,
+                        node: awaitNode,
                         messageId: "unexpectedAwait"
                     });
                     return;

--- a/tests/lib/rules/no-await-in-loop.js
+++ b/tests/lib/rules/no-await-in-loop.js
@@ -8,7 +8,7 @@
 const rule = require("../../../lib/rules/no-await-in-loop"),
     RuleTester = require("../../../lib/testers/rule-tester");
 
-const error = { messageId: "unexpectedAwait" };
+const error = { messageId: "unexpectedAwait", type: "AwaitExpression" };
 
 const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2018 } });
 
@@ -46,7 +46,10 @@ ruleTester.run("no-await-in-loop", rule, {
         // While loops
         { code: "async function foo() { while (baz) { await bar; } }", errors: [error] },
         { code: "async function foo() { while (await foo()) {  } }", errors: [error] },
-        { code: "async function foo() { while (baz) { for await (x of xs); } }", errors: [error] },
+        {
+            code: "async function foo() { while (baz) { for await (x of xs); } }",
+            errors: [Object.assign({}, error, { type: "ForOfStatement" })]
+        },
 
         // For of loops
         { code: "async function foo() { for (var bar of baz) { await bar; } }", errors: [error] },


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (https://github.com/eslint/eslint/issues/9992)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This fixes a regression in https://github.com/eslint/eslint/commit/f012b8c7802e702a69ea8b3522cdc4c7842f038c where `no-await-in-loop` started reporting the surrounding loop node rather than the `AwaitExpression` node. As a result, some `eslint-disable` comments broke and caused more errors because they were on the wrong line.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
