### PR TITLE
Breaking: use an exit code of 2 for fatal config problems (fixes #9384)

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -53,7 +53,7 @@ process.once("uncaughtException", err => {
         console.error(err.stack);
     }
 
-    process.exitCode = 1;
+    process.exitCode = 2;
 });
 
 if (useStdIn) {

--- a/docs/user-guide/command-line-interface.md
+++ b/docs/user-guide/command-line-interface.md
@@ -450,3 +450,11 @@ ESLint supports `.eslintignore` files to exclude files from the linting process 
     **/vendor/*.js
 
 A more detailed breakdown of supported patterns and directories ESLint ignores by default can be found in [Configuring ESLint](configuring.md#ignoring-files-and-directories).
+
+## Exit codes
+
+ESLint will exit with one of the following exit codes:
+
+* `0`: Linting was successful and there are no linting errors. If the `--max-warnings` flag is set to `n`, the number of linting warnings is at most `n`.
+* `1`: Linting was successful and there is at least one linting error, or there are more linting warnings than allowed by the `--max-warnings` option.
+* `2`: Linting was unsuccessful due to a configuration problem or an internal error.

--- a/docs/user-guide/command-line-interface.md
+++ b/docs/user-guide/command-line-interface.md
@@ -453,7 +453,7 @@ A more detailed breakdown of supported patterns and directories ESLint ignores b
 
 ## Exit codes
 
-ESLint will exit with one of the following exit codes:
+When linting files, ESLint will exit with one of the following exit codes:
 
 * `0`: Linting was successful and there are no linting errors. If the `--max-warnings` flag is set to `n`, the number of linting warnings is at most `n`.
 * `1`: Linting was successful and there is at least one linting error, or there are more linting warnings than allowed by the `--max-warnings` option.

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -139,7 +139,7 @@ const cli = {
             currentOptions = options.parse(args);
         } catch (error) {
             log.error(error.message);
-            return 1;
+            return 2;
         }
 
         const files = currentOptions._;
@@ -153,11 +153,11 @@ const cli = {
         } else if (currentOptions.printConfig) {
             if (files.length) {
                 log.error("The --print-config option must be used with exactly one file name.");
-                return 1;
+                return 2;
             }
             if (useStdin) {
                 log.error("The --print-config option is not available for piped-in code.");
-                return 1;
+                return 2;
             }
 
             const engine = new CLIEngine(translateOptions(currentOptions));
@@ -176,12 +176,12 @@ const cli = {
 
             if (currentOptions.fix && currentOptions.fixDryRun) {
                 log.error("The --fix option and the --fix-dry-run option cannot be used together.");
-                return 1;
+                return 2;
             }
 
             if (useStdin && currentOptions.fix) {
                 log.error("The --fix option is not available for piped-in code; use --fix-dry-run instead.");
-                return 1;
+                return 2;
             }
 
             const engine = new CLIEngine(translateOptions(currentOptions));
@@ -207,7 +207,7 @@ const cli = {
 
                 return (report.errorCount || tooManyWarnings) ? 1 : 0;
             }
-            return 1;
+            return 2;
 
 
         }

--- a/tests/bin/eslint.js
+++ b/tests/bin/eslint.js
@@ -138,7 +138,7 @@ describe("bin/eslint.js", () => {
                     ["--stdin"], { cwd: "/", env: { HOME: "/" } }
                 );
 
-                const exitCodePromise = assertExitCode(child, 1);
+                const exitCodePromise = assertExitCode(child, 2);
                 const stderrPromise = getOutput(child).then(output => {
                     assert.match(
                         output.stderr,
@@ -316,7 +316,7 @@ describe("bin/eslint.js", () => {
     describe("handling crashes", () => {
         it("prints the error message to stderr in the event of a crash", () => {
             const child = runESLint(["--rule=no-restricted-syntax:[error, 'Invalid Selector [[[']", "Makefile.js"]);
-            const exitCodeAssertion = assertExitCode(child, 1);
+            const exitCodeAssertion = assertExitCode(child, 2);
             const outputAssertion = getOutput(child).then(output => {
                 const expectedSubstring = "Syntax error in selector";
 
@@ -330,7 +330,7 @@ describe("bin/eslint.js", () => {
         it("prints the error message pointing to line of code", () => {
             const invalidConfig = `${__dirname}/../fixtures/bin/.eslintrc.yml`;
             const child = runESLint(["--no-ignore", invalidConfig]);
-            const exitCodeAssertion = assertExitCode(child, 1);
+            const exitCodeAssertion = assertExitCode(child, 2);
             const outputAssertion = getOutput(child).then(output => {
                 const expectedSubstring = "Error: bad indentation of a mapping entry at line";
 

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -121,7 +121,7 @@ describe("cli", () => {
             const filePath = getFixturePath("files");
             const result = cli.execute(`--blah --another ${filePath}`);
 
-            assert.strictEqual(result, 1);
+            assert.strictEqual(result, 2);
         });
 
     });
@@ -245,7 +245,7 @@ describe("cli", () => {
             const filePath = getFixturePath("passing.js");
             const exit = cli.execute(`-f fakeformatter ${filePath}`);
 
-            assert.strictEqual(exit, 1);
+            assert.strictEqual(exit, 2);
         });
     });
 
@@ -265,14 +265,14 @@ describe("cli", () => {
             const filePath = getFixturePath("passing.js");
             const exit = cli.execute(`-f ${formatterPath} ${filePath}`);
 
-            assert.strictEqual(exit, 1);
+            assert.strictEqual(exit, 2);
         });
     });
 
     describe("when executing a file with a lint error", () => {
         it("should exit with error", () => {
             const filePath = getFixturePath("undef.js");
-            const code = `--no-ignore --config --rule no-undef:2 ${filePath}`;
+            const code = `--no-ignore --rule no-undef:2 ${filePath}`;
 
             const exit = cli.execute(code);
 
@@ -308,7 +308,7 @@ describe("cli", () => {
 
     describe("when executing with version flag", () => {
         it("should print out current version", () => {
-            cli.execute("-v");
+            assert.strictEqual(cli.execute("-v"), 0);
 
             assert.strictEqual(log.info.callCount, 1);
         });
@@ -316,7 +316,7 @@ describe("cli", () => {
 
     describe("when executing with help flag", () => {
         it("should print out help", () => {
-            cli.execute("-h");
+            assert.strictEqual(cli.execute("-h"), 0);
 
             assert.strictEqual(log.info.callCount, 1);
         });
@@ -403,7 +403,7 @@ describe("cli", () => {
             assert.throws(() => {
                 const exit = cli.execute(code);
 
-                assert.strictEqual(exit, 1);
+                assert.strictEqual(exit, 2);
             }, /Error while loading rule 'custom-rule': Cannot read property/);
         });
 
@@ -559,7 +559,7 @@ describe("cli", () => {
 
             const exit = cli.execute(code);
 
-            assert.strictEqual(exit, 1);
+            assert.strictEqual(exit, 2);
             assert.isTrue(log.info.notCalled);
             assert.isTrue(log.error.calledOnce);
         });
@@ -572,7 +572,7 @@ describe("cli", () => {
 
             const exit = cli.execute(code);
 
-            assert.strictEqual(exit, 1);
+            assert.strictEqual(exit, 2);
             assert.isTrue(log.info.notCalled);
             assert.isTrue(log.error.calledOnce);
         });
@@ -611,7 +611,7 @@ describe("cli", () => {
             const filePath = getFixturePath("passing.js");
             const exit = cli.execute(`--no-ignore --parser-options test111 ${filePath}`);
 
-            assert.strictEqual(exit, 1);
+            assert.strictEqual(exit, 2);
         });
 
         it("should exit with no error if parser is valid", () => {
@@ -862,7 +862,7 @@ describe("cli", () => {
 
             const exitCode = localCLI.execute("--fix .", "foo = bar;");
 
-            assert.strictEqual(exitCode, 1);
+            assert.strictEqual(exitCode, 2);
         });
 
     });
@@ -1020,7 +1020,7 @@ describe("cli", () => {
 
             const exitCode = localCLI.execute("--fix --fix-dry-run .", "foo = bar;");
 
-            assert.strictEqual(exitCode, 1);
+            assert.strictEqual(exitCode, 2);
         });
     });
 
@@ -1042,7 +1042,7 @@ describe("cli", () => {
 
             assert.isTrue(log.info.notCalled);
             assert.isTrue(log.error.calledOnce);
-            assert.strictEqual(exitCode, 1);
+            assert.strictEqual(exitCode, 2);
         });
 
         it("should error out when executing on text", () => {
@@ -1050,7 +1050,7 @@ describe("cli", () => {
 
             assert.isTrue(log.info.notCalled);
             assert.isTrue(log.error.calledOnce);
-            assert.strictEqual(exitCode, 1);
+            assert.strictEqual(exitCode, 2);
         });
     });
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates the CLI to use an exit code of 2 for configuration errors or crashes. As described in https://github.com/eslint/eslint/issues/9384, this is useful for integrations to distinguish between successful lint runs with errors and unsuccessful lint runs.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
