### PR TITLE
Chore: avoid useless catch clauses that just rethrow errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,7 @@ module.exports = {
         "eslint-plugin/report-message-format": ["error", "[^a-z].*\\.$"],
         "eslint-plugin/test-case-property-ordering": "error",
         "eslint-plugin/test-case-shorthand-strings": "error",
-        "rulesdir/multiline-comment-style": "error"
+        "rulesdir/multiline-comment-style": "error",
+        "rulesdir/no-useless-catch": "error"
     }
 };

--- a/tests/lib/testers/no-test-runners.js
+++ b/tests/lib/testers/no-test-runners.js
@@ -27,8 +27,6 @@ try {
             ]
         });
     }, /Output is incorrect\. \(' foo = bar;' == 'invalid output'\)$/);
-} catch (e) {
-    throw e;
 } finally {
     it = tmpIt;
     describe = tmpDescribe;

--- a/tests/tools/internal-rules/no-useless-catch.js
+++ b/tests/tools/internal-rules/no-useless-catch.js
@@ -1,0 +1,62 @@
+/**
+ * @fileoverview Tests for no-useless-throw rule
+ * @author Teddy Katz
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../tools/internal-rules/no-useless-catch");
+const RuleTester = require("../../../lib/testers/rule-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+new RuleTester({ parserOptions: { ecmaVersion: 6 } }).run("rulesdir/no-useless-catch", rule, {
+    valid: [
+        `
+            try {
+                foo();
+            } catch (err) {
+                console.error(err);
+            } finally {
+                foo;
+            }
+        `,
+        `
+            try {
+                foo();
+            } catch ({ err }) {
+                throw err;
+            }
+        `
+    ],
+    invalid: [
+        {
+            code: `
+                try {
+                    foo();
+                } catch (e) {
+                    throw e;
+                }
+            `,
+            errors: [{ message: "Unnecessary try/catch wrapper." }]
+        },
+        {
+            code: `
+                try {
+                    foo();
+                } catch (e) {
+                    throw e;
+                } finally {
+                    foo();
+                }
+            `,
+            errors: [{ message: "Unnecessary catch clause." }]
+        }
+    ]
+});

--- a/tools/internal-rules/no-useless-catch.js
+++ b/tools/internal-rules/no-useless-catch.js
@@ -1,0 +1,44 @@
+/**
+ * @fileoverview Reports useless `catch` clauses that just rethrow their error.
+ * @author Teddy Katz
+ */
+
+"use strict";
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "disallow unnecessary `catch` clauses",
+            category: "Internal",
+            recommended: false
+        },
+
+        schema: []
+    },
+
+    create(context) {
+        return {
+            CatchClause(node) {
+                if (
+                    node.param.type === "Identifier" &&
+                    node.body.body.length &&
+                    node.body.body[0].type === "ThrowStatement" &&
+                    node.body.body[0].argument.type === "Identifier" &&
+                    node.body.body[0].argument.name === node.param.name
+                ) {
+                    if (node.parent.finalizer) {
+                        context.report({
+                            node,
+                            message: "Unnecessary catch clause."
+                        });
+                    } else {
+                        context.report({
+                            node,
+                            message: "Unnecessary try/catch wrapper."
+                        });
+                    }
+                }
+            }
+        };
+    }
+};


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This commit removes an unnecessary `catch` clause from the codebase that just rethrows the error. It also adds an internal linting rule to avoid code like that in the future.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
