### PR TITLE
Breaking: remove `source` property from linting messages (fixes #7358)

### DIFF
--- a/docs/developer-guide/nodejs-api.md
+++ b/docs/developer-guide/nodejs-api.md
@@ -516,8 +516,6 @@ The top-level report object has a `results` array containing all linting results
 
 The top-level report object also has `errorCount` and `warningCount` which give the exact number of errors and warnings respectively on all the files.
 
-Report message objects have a deprecated `source` property. This property **will be removed** from the linting messages returned in `messages` in an upcoming breaking release. If you depend on this property, you should now use the top-level `source` or `output` properties instead.
-
 Once you get a report object, it's up to you to determine how to output the results. Fixes will not be automatically applied to the files, even if you set `fix: true` when constructing the `CLIEngine` instance. To apply fixes to the files, call [`outputFixes`](#cliengineoutputfixes).
 
 ### CLIEngine#resolveFileGlobPatterns()

--- a/docs/developer-guide/working-with-custom-formatters.md
+++ b/docs/developer-guide/working-with-custom-formatters.md
@@ -30,8 +30,7 @@ The output of the previous command will be something like this
                 "message": "Expected { after 'if' condition.",
                 "line": 2,
                 "column": 1,
-                "nodeType": "IfStatement",
-                "source": "if (err) console.log('failed tests: ' + err);"
+                "nodeType": "IfStatement"
             },
             {
                 "ruleId": "no-process-exit",
@@ -39,8 +38,7 @@ The output of the previous command will be something like this
                 "message": "Don't use process.exit(); throw an error instead.",
                 "line": 3,
                 "column": 1,
-                "nodeType": "CallExpression",
-                "source": "process.exit(1);"
+                "nodeType": "CallExpression"
             }
         ],
         "errorCount": 2,
@@ -82,9 +80,6 @@ The following are the fields of the result object:
 - **line**: the line where the issue is located.
 - **column**: the column where the issue is located.
 - **nodeType**: the type of the node in the [AST](https://github.com/estree/estree/blob/master/spec.md#node-objects)
-- **source**: an extract of the code the line where the failure happened.
-
-**Please note**: the `source` property will be removed from the message object in an upcoming breaking release. If you depend on this property, you should now use the `source` or `output` properties from [the result object](#the-result-object) instead.
 
 ## Examples
 
@@ -137,8 +132,7 @@ module.exports = function ( results ) {
                 ruleId: msg.ruleId,
                 message: msg.message,
                 line: msg.line,
-                column: msg.column,
-                source: msg.source
+                column: msg.column
             };
 
             if ( msg.severity === 1 ) {
@@ -207,8 +201,7 @@ module.exports = function ( results ) {
                 ruleId: msg.ruleId,
                 message: msg.message,
                 line: msg.line,
-                column: msg.column,
-                source: msg.source
+                column: msg.column
             };
 
             if ( msg.severity === 1 ) {

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -137,7 +137,6 @@ function parseJsonConfig(string, location) {
                 ruleId: null,
                 fatal: true,
                 severity: 2,
-                source: null,
                 message: `Failed to parse JSON from '${string}': ${ex.message}`,
                 line: location.start.line,
                 column: location.start.column + 1
@@ -320,7 +319,6 @@ function getDirectiveComments(filename, ast, ruleMapper) {
                                 problems.push({
                                     ruleId: name,
                                     severity: 2,
-                                    source: null,
                                     message: err.message,
                                     line: comment.loc.start.line,
                                     column: comment.loc.start.column + 1,
@@ -546,7 +544,6 @@ function parse(text, providedParserOptions, parserName, parserMap, filePath) {
                 ruleId: null,
                 fatal: true,
                 severity: 2,
-                source: null,
                 message: ex.message,
                 line: 0,
                 column: 0
@@ -590,7 +587,6 @@ function parse(text, providedParserOptions, parserName, parserMap, filePath) {
 
         // If the message includes a leading line number, strip it:
         const message = `Parsing error: ${ex.message.replace(/^line \d+:/i, "").trim()}`;
-        const source = ex.lineNumber ? SourceCode.splitLines(text)[ex.lineNumber - 1] : null;
 
         return {
             success: false,
@@ -598,7 +594,6 @@ function parse(text, providedParserOptions, parserName, parserMap, filePath) {
                 ruleId: null,
                 fatal: true,
                 severity: 2,
-                source,
                 message,
                 line: ex.lineNumber,
                 column: ex.column

--- a/lib/report-translator.js
+++ b/lib/report-translator.js
@@ -200,7 +200,6 @@ function normalizeFixes(descriptor, sourceCode) {
  * @param {string} options.message Error message
  * @param {{start: SourceLocation, end: (SourceLocation|null)}} options.loc Start and end location
  * @param {{text: string, range: (number[]|null)}} options.fix The fix object
- * @param {string[]} options.sourceLines Source lines
  * @returns {function(...args): ReportInfo} Function that returns information about the report
  */
 function createProblem(options) {
@@ -210,8 +209,7 @@ function createProblem(options) {
         message: options.message,
         line: options.loc.start.line,
         column: options.loc.start.column + 1,
-        nodeType: options.node && options.node.type || null,
-        source: options.sourceLines[options.loc.start.line - 1] || ""
+        nodeType: options.node && options.node.type || null
     };
 
     /*
@@ -279,8 +277,7 @@ module.exports = function createReportTranslator(metadata) {
             message: normalizeMessagePlaceholders(descriptor),
             messageId: descriptor.messageId,
             loc: normalizeReportLoc(descriptor),
-            fix: normalizeFixes(descriptor, metadata.sourceCode),
-            sourceLines: metadata.sourceCode.lines
+            fix: normalizeFixes(descriptor, metadata.sourceCode)
         });
     };
 };

--- a/lib/util/apply-disable-directives.js
+++ b/lib/util/apply-disable-directives.js
@@ -94,7 +94,6 @@ function applyDirectives(options) {
             line: directive.unprocessedDirective.line,
             column: directive.unprocessedDirective.column,
             severity: 2,
-            source: null,
             nodeType: null
         }));
 

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -355,8 +355,7 @@ describe("CLIEngine", () => {
                                 column: 11,
                                 endLine: 1,
                                 endColumn: 14,
-                                nodeType: "Identifier",
-                                source: "var bar = foo"
+                                nodeType: "Identifier"
                             }
                         ],
                         errorCount: 1,
@@ -397,8 +396,7 @@ describe("CLIEngine", () => {
                                 severity: 2,
                                 message: "Parsing error: Unexpected token is",
                                 line: 1,
-                                column: 19,
-                                source: "var bar = foothis is a syntax error."
+                                column: 19
                             }
                         ],
                         errorCount: 1,
@@ -439,8 +437,7 @@ describe("CLIEngine", () => {
                                 severity: 2,
                                 message: "Parsing error: Unexpected token",
                                 line: 1,
-                                column: 10,
-                                source: "var bar ="
+                                column: 10
                             }
                         ],
                         errorCount: 1,
@@ -527,8 +524,7 @@ describe("CLIEngine", () => {
                                 severity: 2,
                                 message: "Parsing error: Unexpected token is",
                                 line: 1,
-                                column: 19,
-                                source: "var bar = foothis is a syntax error."
+                                column: 19
                             }
                         ],
                         errorCount: 1,
@@ -1398,8 +1394,7 @@ describe("CLIEngine", () => {
                                     messageId: "unexpected",
                                     nodeType: "BinaryExpression",
                                     ruleId: "eqeqeq",
-                                    severity: 2,
-                                    source: "if (msg == \"hi\") {"
+                                    severity: 2
                                 }
                             ],
                             errorCount: 1,
@@ -1419,8 +1414,7 @@ describe("CLIEngine", () => {
                                     message: "'foo' is not defined.",
                                     nodeType: "Identifier",
                                     ruleId: "no-undef",
-                                    severity: 2,
-                                    source: "var msg = \"hi\" + foo;"
+                                    severity: 2
                                 }
                             ],
                             errorCount: 1,
@@ -3038,7 +3032,6 @@ describe("CLIEngine", () => {
                                     line: 1,
                                     column: 1,
                                     severity: 2,
-                                    source: null,
                                     nodeType: null
                                 }
                             ],

--- a/tests/lib/formatters/json.js
+++ b/tests/lib/formatters/json.js
@@ -24,8 +24,7 @@ describe("formatter:json", () => {
             severity: 2,
             line: 5,
             column: 10,
-            ruleId: "foo",
-            source: "foo"
+            ruleId: "foo"
         }]
     }, {
         filePath: "bar.js",
@@ -34,8 +33,7 @@ describe("formatter:json", () => {
             severity: 1,
             line: 6,
             column: 11,
-            ruleId: "bar",
-            source: "bar"
+            ruleId: "bar"
         }]
     }];
 

--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -1627,7 +1627,6 @@ describe("Linter", () => {
                         column: 1,
                         endLine: 1,
                         endColumn: 25,
-                        source: null,
                         nodeType: null
                     }
                 ]
@@ -1646,7 +1645,6 @@ describe("Linter", () => {
                         column: 1,
                         endLine: 1,
                         endColumn: 63,
-                        source: null,
                         nodeType: null
                     }
                 ]
@@ -2703,7 +2701,6 @@ describe("Linter", () => {
             assert.strictEqual(messages.length, 1);
             assert.strictEqual(messages[0].severity, 2);
             assert.isNull(messages[0].ruleId);
-            assert.strictEqual(messages[0].source, BROKEN_TEST_CODE);
             assert.strictEqual(messages[0].line, 1);
             assert.strictEqual(messages[0].column, 4);
             assert.isTrue(messages[0].fatal);
@@ -2721,7 +2718,6 @@ describe("Linter", () => {
 
             assert.strictEqual(messages.length, 1);
             assert.strictEqual(messages[0].severity, 2);
-            assert.strictEqual(messages[0].source, inValidCode[1]);
             assert.isTrue(messages[0].fatal);
             assert.match(messages[0].message, /^Parsing error:/);
         });
@@ -2773,7 +2769,6 @@ describe("Linter", () => {
                     line: 1,
                     column: 1,
                     severity: 1,
-                    source: "var answer = 6 * 7;",
                     nodeType: null
                 }
             );
@@ -3085,7 +3080,6 @@ describe("Linter", () => {
                         line: 1,
                         column: 1,
                         severity: 2,
-                        source: null,
                         nodeType: null
                     }
                 ]
@@ -4228,7 +4222,6 @@ describe("Linter", () => {
 
                 assert.strictEqual(messages.length, 1);
                 assert.strictEqual(messages[0].severity, 2);
-                assert.isNull(messages[0].source);
                 assert.strictEqual(messages[0].message, errorPrefix + require(parser).expectedError);
             });
 

--- a/tests/lib/report-translator.js
+++ b/tests/lib/report-translator.js
@@ -61,8 +61,7 @@ describe("createReportTranslator", () => {
                     message: "foo",
                     line: 2,
                     column: 1,
-                    nodeType: "ExpressionStatement",
-                    source: "bar"
+                    nodeType: "ExpressionStatement"
                 }
             );
         });
@@ -80,8 +79,7 @@ describe("createReportTranslator", () => {
                     column: 1,
                     endLine: 1,
                     endColumn: 4,
-                    nodeType: "ExpressionStatement",
-                    source: "foo"
+                    nodeType: "ExpressionStatement"
                 }
             );
         });
@@ -105,7 +103,6 @@ describe("createReportTranslator", () => {
                     line: 2,
                     column: 1,
                     nodeType: "ExpressionStatement",
-                    source: "bar",
                     fix: {
                         range: [1, 2],
                         text: "foo"
@@ -131,7 +128,6 @@ describe("createReportTranslator", () => {
                     line: 2,
                     column: 1,
                     nodeType: "ExpressionStatement",
-                    source: "bar",
                     fix: {
                         range: [1, 2],
                         text: "foo"
@@ -187,7 +183,6 @@ describe("createReportTranslator", () => {
                     line: 2,
                     column: 1,
                     nodeType: "ExpressionStatement",
-                    source: "bar",
                     fix: {
                         range: [1, 5],
                         text: "fooo\nbar"
@@ -216,7 +211,6 @@ describe("createReportTranslator", () => {
                     line: 2,
                     column: 1,
                     nodeType: "ExpressionStatement",
-                    source: "bar",
                     fix: {
                         range: [1, 5],
                         text: "fooo\nbar"
@@ -242,7 +236,6 @@ describe("createReportTranslator", () => {
                     line: 2,
                     column: 1,
                     nodeType: "ExpressionStatement",
-                    source: "bar",
                     fix: {
                         range: [1, 2],
                         text: "foo"
@@ -268,7 +261,6 @@ describe("createReportTranslator", () => {
                     line: 2,
                     column: 1,
                     nodeType: "ExpressionStatement",
-                    source: "bar",
                     fix: {
                         range: [0, 5],
                         text: "\uFEFFfoo\nx"
@@ -300,7 +292,6 @@ describe("createReportTranslator", () => {
                     endLine: 1,
                     endColumn: 4,
                     nodeType: "ExpressionStatement",
-                    source: "foo",
                     fix: {
                         range: [-1, 5],
                         text: "foo\nx"
@@ -339,7 +330,6 @@ describe("createReportTranslator", () => {
                     line: 42,
                     column: 24,
                     nodeType: "ExpressionStatement",
-                    source: "",
                     fix: {
                         range: [1, 1],
                         text: ""
@@ -360,8 +350,7 @@ describe("createReportTranslator", () => {
                     message: "hello ExpressionStatement",
                     nodeType: "ExpressionStatement",
                     line: 1,
-                    column: 4,
-                    source: "foo"
+                    column: 4
                 }
             );
         });
@@ -375,8 +364,7 @@ describe("createReportTranslator", () => {
                     message: "hello ExpressionStatement",
                     nodeType: "ExpressionStatement",
                     line: 1,
-                    column: 4,
-                    source: "foo"
+                    column: 4
                 }
             );
         });
@@ -462,8 +450,7 @@ describe("createReportTranslator", () => {
                     message: "hello world",
                     nodeType: "ExpressionStatement",
                     line: 42,
-                    column: 14,
-                    source: ""
+                    column: 14
                 }
             );
         });
@@ -477,8 +464,7 @@ describe("createReportTranslator", () => {
                     message: "hello world",
                     nodeType: "ExpressionStatement",
                     line: 42,
-                    column: 14,
-                    source: ""
+                    column: 14
                 }
             );
         });
@@ -494,8 +480,7 @@ describe("createReportTranslator", () => {
                     line: 1,
                     column: 1,
                     endLine: 1,
-                    endColumn: 4,
-                    source: "foo"
+                    endColumn: 4
                 }
             );
         });
@@ -511,8 +496,7 @@ describe("createReportTranslator", () => {
                     line: 1,
                     column: 1,
                     endLine: 1,
-                    endColumn: 4,
-                    source: "foo"
+                    endColumn: 4
                 }
             );
         });
@@ -526,8 +510,7 @@ describe("createReportTranslator", () => {
                     message: "hello world",
                     nodeType: null,
                     line: 1,
-                    column: 1,
-                    source: "foo"
+                    column: 1
                 }
             );
         });
@@ -543,8 +526,7 @@ describe("createReportTranslator", () => {
                     line: 1,
                     column: 1,
                     endLine: 1,
-                    endColumn: 4,
-                    source: "foo"
+                    endColumn: 4
                 }
             );
         });
@@ -563,7 +545,6 @@ describe("createReportTranslator", () => {
                     column: 1,
                     endLine: 1,
                     endColumn: 4,
-                    source: "foo",
                     fix: { range: [1, 1], text: "" }
                 }
             );
@@ -589,8 +570,7 @@ describe("createReportTranslator", () => {
                     message: "hello world",
                     nodeType: null,
                     line: 1,
-                    column: 2,
-                    source: "foo"
+                    column: 2
                 }
             );
         });
@@ -604,8 +584,7 @@ describe("createReportTranslator", () => {
                     message: "hello world",
                     nodeType: null,
                     line: 1,
-                    column: 2,
-                    source: "foo"
+                    column: 2
                 }
             );
         });

--- a/tests/lib/util/apply-disable-directives.js
+++ b/tests/lib/util/apply-disable-directives.js
@@ -440,7 +440,6 @@ describe("apply-disable-directives", () => {
                         line: 1,
                         column: 5,
                         severity: 2,
-                        source: null,
                         nodeType: null
                     }
                 ]
@@ -472,7 +471,6 @@ describe("apply-disable-directives", () => {
                         line: 1,
                         column: 5,
                         severity: 2,
-                        source: null,
                         nodeType: null
                     }
                 ]
@@ -493,7 +491,6 @@ describe("apply-disable-directives", () => {
                         line: 1,
                         column: 5,
                         severity: 2,
-                        source: null,
                         nodeType: null
                     },
                     {
@@ -527,7 +524,6 @@ describe("apply-disable-directives", () => {
                         line: 1,
                         column: 5,
                         severity: 2,
-                        source: null,
                         nodeType: null
                     }
                 ]
@@ -551,7 +547,6 @@ describe("apply-disable-directives", () => {
                         line: 1,
                         column: 5,
                         severity: 2,
-                        source: null,
                         nodeType: null
                     }
                 ]
@@ -575,7 +570,6 @@ describe("apply-disable-directives", () => {
                         line: 1,
                         column: 1,
                         severity: 2,
-                        source: null,
                         nodeType: null
                     },
                     {
@@ -584,7 +578,6 @@ describe("apply-disable-directives", () => {
                         line: 2,
                         column: 1,
                         severity: 2,
-                        source: null,
                         nodeType: null
                     }
                 ]
@@ -608,7 +601,6 @@ describe("apply-disable-directives", () => {
                         line: 1,
                         column: 1,
                         severity: 2,
-                        source: null,
                         nodeType: null
                     }
                 ]
@@ -632,7 +624,6 @@ describe("apply-disable-directives", () => {
                         line: 1,
                         column: 1,
                         severity: 2,
-                        source: null,
                         nodeType: null
                     }
                 ]
@@ -667,7 +658,6 @@ describe("apply-disable-directives", () => {
                         line: 1,
                         column: 1,
                         severity: 2,
-                        source: null,
                         nodeType: null
                     }
                 ]
@@ -691,7 +681,6 @@ describe("apply-disable-directives", () => {
                         line: 2,
                         column: 1,
                         severity: 2,
-                        source: null,
                         nodeType: null
                     }
                 ]
@@ -715,7 +704,6 @@ describe("apply-disable-directives", () => {
                         line: 1,
                         column: 5,
                         severity: 2,
-                        source: null,
                         nodeType: null
                     },
                     {
@@ -744,7 +732,6 @@ describe("apply-disable-directives", () => {
                         line: 1,
                         column: 5,
                         severity: 2,
-                        source: null,
                         nodeType: null
                     },
                     {
@@ -774,7 +761,6 @@ describe("apply-disable-directives", () => {
                         line: 1,
                         column: 1,
                         severity: 2,
-                        source: null,
                         nodeType: null
                     },
                     {
@@ -783,7 +769,7 @@ describe("apply-disable-directives", () => {
                         line: 2,
                         column: 1,
                         severity: 2,
-                        source: null,
+
                         nodeType: null
                     },
                     {
@@ -809,7 +795,6 @@ describe("apply-disable-directives", () => {
                         line: 1,
                         column: 5,
                         severity: 2,
-                        source: null,
                         nodeType: null
                     }
                 ]
@@ -842,7 +827,6 @@ describe("apply-disable-directives", () => {
                         line: 1,
                         column: 5,
                         severity: 2,
-                        source: null,
                         nodeType: null
                     }
                 ]
@@ -877,7 +861,6 @@ describe("apply-disable-directives", () => {
                         line: 1,
                         column: 1,
                         severity: 2,
-                        source: null,
                         nodeType: null
                     },
                     {
@@ -886,7 +869,6 @@ describe("apply-disable-directives", () => {
                         line: 1,
                         column: 5,
                         severity: 2,
-                        source: null,
                         nodeType: null
                     }
                 ]

--- a/tests/tools/eslint-fuzzer.js
+++ b/tests/tools/eslint-fuzzer.js
@@ -162,7 +162,6 @@ describe("eslint-fuzzer", function() {
                     ruleId: null,
                     fatal: true,
                     severity: 2,
-                    source: INVALID_SYNTAX,
                     message: `Parsing error: ${expectedSyntaxError.message}`,
                     line: expectedSyntaxError.lineNumber,
                     column: expectedSyntaxError.column
@@ -209,7 +208,6 @@ describe("eslint-fuzzer", function() {
                     ruleId: null,
                     fatal: true,
                     severity: 2,
-                    source: INVALID_SYNTAX,
                     message: `Parsing error: ${expectedSyntaxError.message}`,
                     line: expectedSyntaxError.lineNumber,
                     column: expectedSyntaxError.column


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This removes the `source` property from individual linting messages, as described in https://github.com/eslint/eslint/issues/7358. The property has been deprecated since October 2016.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
