### PR TITLE
Breaking: set `parent` of AST nodes before rules run (fixes #9122)

### DIFF
--- a/docs/developer-guide/working-with-plugins.md
+++ b/docs/developer-guide/working-with-plugins.md
@@ -213,7 +213,7 @@ All nodes must have `range` property.
 * `range` (`number[]`) is an array of two numbers. Both numbers are a 0-based index which is the position in the array of source code characters. The first is the start position of the node, the second is the end position of the node. `code.slice(node.range[0], node.range[1])` must be the text of the node. This range does not include spaces/parentheses which are around the node.
 * `loc` (`SourceLocation`) must not be `null`. [The `loc` property is defined as nullable by ESTree](https://github.com/estree/estree/blob/25834f7247d44d3156030f8e8a2d07644d771fdb/es5.md#node-objects), but ESLint requires this property. On the other hand, `SourceLocation#source` property can be `undefined`. ESLint does not use the `SourceLocation#source` property.
 
-The `parent` property of all nodes must be rewriteable. ESLint sets each node's parent properties to its parent node while traversing.
+The `parent` property of all nodes must be rewriteable. ESLint sets each node's `parent` property to its parent node while traversing, before any rules have access to the AST.
 
 #### The `Program` node:
 

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -672,13 +672,13 @@ function createRuleListeners(rule, ruleContext) {
  * from the root node and going inwards to the parent node.
  */
 function getAncestors(node) {
-    if (node.parent) {
-        const parentAncestors = getAncestors(node.parent);
+    const ancestorsStartingAtParent = [];
 
-        parentAncestors.push(node.parent);
-        return parentAncestors;
+    for (let ancestor = node.parent; ancestor; ancestor = ancestor.parent) {
+        ancestorsStartingAtParent.push(ancestor);
     }
-    return [];
+
+    return ancestorsStartingAtParent.reverse();
 }
 
 // methods that exist on SourceCode object

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -665,6 +665,22 @@ function createRuleListeners(rule, ruleContext) {
     }
 }
 
+/**
+ * Gets all the ancestors of a given node
+ * @param {ASTNode} node The node
+ * @returns {ASTNode[]} All the ancestor nodes in the AST, not including the provided node, starting
+ * from the root node and going inwards to the parent node.
+ */
+function getAncestors(node) {
+    if (node.parent) {
+        const parentAncestors = getAncestors(node.parent);
+
+        parentAncestors.push(node.parent);
+        return parentAncestors;
+    }
+    return [];
+}
+
 // methods that exist on SourceCode object
 const DEPRECATED_SOURCECODE_PASSTHROUGHS = {
     getSource: "getText",
@@ -716,7 +732,19 @@ const BASE_TRAVERSAL_CONTEXT = Object.freeze(
  */
 function runRules(sourceCode, configuredRules, ruleMapper, parserOptions, parserName, settings, filename) {
     const emitter = createEmitter();
-    const traverser = new Traverser();
+    const nodeQueue = [];
+    let currentNode = sourceCode.ast;
+
+    Traverser.traverse(sourceCode.ast, {
+        enter(node, parent) {
+            node.parent = parent;
+            nodeQueue.push({ isEntering: true, node });
+        },
+        leave(node) {
+            nodeQueue.push({ isEntering: false, node });
+        },
+        visitorKeys: sourceCode.visitorKeys
+    });
 
     /*
      * Create a frozen object with the ruleContext properties and methods that are shared by all rules.
@@ -727,12 +755,12 @@ function runRules(sourceCode, configuredRules, ruleMapper, parserOptions, parser
         Object.assign(
             Object.create(BASE_TRAVERSAL_CONTEXT),
             {
-                getAncestors: () => traverser.parents(),
+                getAncestors: () => getAncestors(currentNode),
                 getDeclaredVariables: sourceCode.scopeManager.getDeclaredVariables.bind(sourceCode.scopeManager),
                 getFilename: () => filename,
-                getScope: () => getScope(sourceCode.scopeManager, traverser.current(), parserOptions.ecmaVersion),
+                getScope: () => getScope(sourceCode.scopeManager, currentNode, parserOptions.ecmaVersion),
                 getSourceCode: () => sourceCode,
-                markVariableAsUsed: name => markVariableAsUsed(sourceCode.scopeManager, traverser.current(), parserOptions, name),
+                markVariableAsUsed: name => markVariableAsUsed(sourceCode.scopeManager, currentNode, parserOptions, name),
                 parserOptions,
                 parserPath: parserName,
                 parserServices: sourceCode.parserServices,
@@ -832,21 +860,14 @@ function runRules(sourceCode, configuredRules, ruleMapper, parserOptions, parser
 
     const eventGenerator = new CodePathAnalyzer(new NodeEventGenerator(emitter));
 
-    /*
-     * Each node has a type property. Whenever a particular type of
-     * node is found, an event is fired. This allows any listeners to
-     * automatically be informed that this type of node has been found
-     * and react accordingly.
-     */
-    traverser.traverse(sourceCode.ast, {
-        enter(node, parent) {
-            node.parent = parent;
-            eventGenerator.enterNode(node);
-        },
-        leave(node) {
-            eventGenerator.leaveNode(node);
-        },
-        visitorKeys: sourceCode.visitorKeys
+    nodeQueue.forEach(traversalInfo => {
+        currentNode = traversalInfo.node;
+
+        if (traversalInfo.isEntering) {
+            eventGenerator.enterNode(currentNode);
+        } else {
+            eventGenerator.leaveNode(currentNode);
+        }
     });
 
     return lintingProblems;

--- a/lib/util/source-code.js
+++ b/lib/util/source-code.js
@@ -386,15 +386,13 @@ class SourceCode extends TokenStore {
      * @public
      */
     getNodeByRangeIndex(index) {
-        let result = null,
-            resultParent = null;
+        let result = null;
 
         Traverser.traverse(this.ast, {
             visitorKeys: this.visitorKeys,
-            enter(node, parent) {
+            enter(node) {
                 if (node.range[0] <= index && index < node.range[1]) {
                     result = node;
-                    resultParent = parent;
                 } else {
                     this.skip();
                 }
@@ -406,7 +404,7 @@ class SourceCode extends TokenStore {
             }
         });
 
-        return result ? Object.assign({ parent: resultParent }, result) : null;
+        return result;
     }
 
     /**

--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -118,6 +118,21 @@ describe("Linter", () => {
             linter.verify("foo", { rules: { checker: "error", "no-undef": "error" } });
             assert(spy.notCalled);
         });
+
+        it("has all the `parent` properties on nodes when the rule listeners are created", () => {
+            linter.defineRule("checker", context => {
+                const ast = context.getSourceCode().ast;
+
+                assert.strictEqual(ast.body[0].parent, ast);
+                assert.strictEqual(ast.body[0].expression.parent, ast.body[0]);
+                assert.strictEqual(ast.body[0].expression.left.parent, ast.body[0].expression);
+                assert.strictEqual(ast.body[0].expression.right.parent, ast.body[0].expression);
+
+                return {};
+            });
+
+            linter.verify("foo + bar", { rules: { checker: "error" } });
+        });
     });
 
     describe("context.getSourceLines()", () => {
@@ -450,43 +465,6 @@ describe("Linter", () => {
             linter.verify(code, config);
             assert(spy.calledOnce);
         });
-
-        it("should attach the node's parent", () => {
-            const config = { rules: { checker: "error" } };
-            const spy = sandbox.spy(context => {
-                const node = context.getNodeByRangeIndex(14);
-
-                assert.property(node, "parent");
-                assert.strictEqual(node.parent.type, "VariableDeclarator");
-                return {};
-            });
-
-            linter.defineRule("checker", spy);
-            linter.verify(code, config);
-            assert(spy.calledOnce);
-        });
-
-        it("should not modify the node when attaching the parent", () => {
-            const config = { rules: { checker: "error" } };
-            const spy = sandbox.spy(context => {
-                const node1 = context.getNodeByRangeIndex(10);
-
-                assert.strictEqual(node1.type, "VariableDeclarator");
-
-                const node2 = context.getNodeByRangeIndex(4);
-
-                assert.strictEqual(node2.type, "Identifier");
-                assert.property(node2, "parent");
-                assert.strictEqual(node2.parent.type, "VariableDeclarator");
-                assert.notProperty(node2.parent, "parent");
-                return {};
-            });
-
-            linter.defineRule("checker", spy);
-            linter.verify(code, config);
-            assert(spy.calledOnce);
-        });
-
     });
 
 

--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -120,7 +120,7 @@ describe("Linter", () => {
         });
 
         it("has all the `parent` properties on nodes when the rule listeners are created", () => {
-            linter.defineRule("checker", context => {
+            const spy = sandbox.spy(context => {
                 const ast = context.getSourceCode().ast;
 
                 assert.strictEqual(ast.body[0].parent, ast);
@@ -131,7 +131,10 @@ describe("Linter", () => {
                 return {};
             });
 
+            linter.defineRule("checker", spy);
+
             linter.verify("foo + bar", { rules: { checker: "error" } });
+            assert(spy.calledOnce);
         });
     });
 

--- a/tests/lib/util/source-code.js
+++ b/tests/lib/util/source-code.js
@@ -16,7 +16,6 @@ const fs = require("fs"),
     leche = require("leche"),
     Linter = require("../../../lib/linter"),
     SourceCode = require("../../../lib/util/source-code"),
-    Traverser = require("../../../lib/util/traverser"),
     astUtils = require("../../../lib/ast-utils");
 
 //------------------------------------------------------------------------------
@@ -1791,44 +1790,6 @@ describe("SourceCode", () => {
             node = sourceCode.getNodeByRangeIndex(-99);
             assert.isNull(node);
         });
-
-        it("should attach the node's parent", () => {
-            const node = sourceCode.getNodeByRangeIndex(14);
-
-            assert.property(node, "parent");
-            assert.strictEqual(node.parent.type, "VariableDeclarator");
-        });
-
-        it("should not modify the node when attaching the parent", () => {
-            let node = sourceCode.getNodeByRangeIndex(10);
-
-            assert.strictEqual(node.type, "VariableDeclarator");
-            node = sourceCode.getNodeByRangeIndex(4);
-            assert.strictEqual(node.type, "Identifier");
-            assert.property(node, "parent");
-            assert.strictEqual(node.parent.type, "VariableDeclarator");
-            assert.notProperty(node.parent, "parent");
-        });
-
-        it("should use visitorKeys", () => {
-            const text = "a + b";
-            const ast = espree.parse(text, DEFAULT_CONFIG);
-
-            // no traverse BinaryExpression#left
-            sourceCode = new SourceCode({
-                text,
-                ast,
-                parserServices: null,
-                scopeManager: null,
-                visitorKeys: Object.assign({}, Traverser.DEFAULT_VISITOR_KEYS, {
-                    BinaryExpression: ["right"]
-                })
-            });
-            const node = sourceCode.getNodeByRangeIndex(0);
-
-            assert.strictEqual(node.type, "BinaryExpression"); // This is Identifier if 'BinaryExpression#left' was traversed.
-        });
-
     });
 
     describe("isSpaceBetweenTokens()", () => {


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Add something to the core

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates `linter` to perform a traversal before rules run in order to set the `parent` property, and store all the traversed nodes in a queue to invoke the listeners afterwards. (See https://github.com/eslint/eslint/issues/9122 for more information.)

This was originally merged in https://github.com/eslint/eslint/commit/1488b511f3be3220d6f187f48c8b22075c6bbd30, but was reverted because it broke a couple of rules. The issue was re-accepted as a breaking change.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
