### PR TITLE
Update: Allow for no lines around comments before else (fixes #10015)

### DIFF
--- a/docs/rules/lines-around-comment.md
+++ b/docs/rules/lines-around-comment.md
@@ -23,6 +23,7 @@ This rule has an object option:
 * `"allowArrayEnd": true` allows comments to appear at the end of array literals
 * `"allowClassStart": true` allows comments to appear at the start of classes
 * `"allowClassEnd": true` allows comments to appear at the end of classes
+* `"allowBeforeElse": true` allows comments to appear before else keywords
 * `"applyDefaultIgnorePatterns"` enables or disables the default comment patterns to be ignored by the rule
 * `"ignorePattern"` custom patterns to be ignored by the rule
 
@@ -432,6 +433,54 @@ const [
 
     /* what a great and wonderful day */
 ] = ["great", "not great"];
+```
+
+### allowBeforeStart
+
+Examples of **correct** code for this rule with the `{ "beforeLineComment": true, "allowBeforeElse": true }` option:
+
+```js
+/*eslint lines-around-comment: ["error", { "beforeLineComment": true, "allowBeforeElse": true }]*/
+
+let baz = true;
+
+// foo
+if(foo) {
+    call_foo();
+}
+// or bar
+else if(bar) {
+    // ...
+    call_bar();
+}
+// otherwise
+else {
+    // ...
+    call_other();
+}
+```
+
+Examples of **correct** code for this rule with the `{ "beforeBlockComment": true, "allowBeforeElse": true }` option:
+
+```js
+/*eslint lines-around-comment: ["error", { "beforeLineComment": true, "allowBeforeElse": true }]*/
+
+let baz = true;
+
+/* foo */
+if(foo) {
+    call_foo();
+}
+/* or bar */
+else if(bar) {
+    // ...
+    call_bar();
+}
+/* otherwise */
+else {
+    // ...
+    call_other();
+}
 ```
 
 

--- a/lib/rules/lines-around-comment.js
+++ b/lib/rules/lines-around-comment.js
@@ -101,6 +101,9 @@ module.exports = {
                     allowArrayEnd: {
                         type: "boolean"
                     },
+                    allowBeforeElse: {
+                        type: "boolean"
+                    },
                     ignorePattern: {
                         type: "string"
                     },
@@ -286,6 +289,26 @@ module.exports = {
         }
 
         /**
+         * Returns whether or not comments are before an else keyword or not.
+         * @param {token} token The Comment token.
+         * @returns {boolean} True if the comment is before an else keyword.
+         */
+        function isCommentBeforeElse(token) {
+            let currentToken = token;
+
+            currentToken = token;
+            do {
+                currentToken = sourceCode.getTokenAfter(currentToken, { includeComments: true });
+            } while (currentToken && astUtils.isCommentToken(currentToken));
+
+            if (currentToken && currentToken.type === "Keyword" && currentToken.value === "else") {
+                return true;
+            }
+
+            return false;
+        }
+
+        /**
          * Checks if a comment token has lines around it (ignores inline comments)
          * @param {token} token The Comment token.
          * @param {Object} opts Options to determine the newline.
@@ -319,9 +342,10 @@ module.exports = {
                 objectStartAllowed = options.allowObjectStart && isCommentAtObjectStart(token),
                 objectEndAllowed = options.allowObjectEnd && isCommentAtObjectEnd(token),
                 arrayStartAllowed = options.allowArrayStart && isCommentAtArrayStart(token),
-                arrayEndAllowed = options.allowArrayEnd && isCommentAtArrayEnd(token);
+                arrayEndAllowed = options.allowArrayEnd && isCommentAtArrayEnd(token),
+                beforeElseAllowed = options.allowBeforeElse && isCommentBeforeElse(token);
 
-            const exceptionStartAllowed = blockStartAllowed || classStartAllowed || objectStartAllowed || arrayStartAllowed;
+            const exceptionStartAllowed = blockStartAllowed || classStartAllowed || objectStartAllowed || arrayStartAllowed || beforeElseAllowed;
             const exceptionEndAllowed = blockEndAllowed || classEndAllowed || objectEndAllowed || arrayEndAllowed;
 
             // ignore top of the file and bottom of the file

--- a/tests/lib/rules/lines-around-comment.js
+++ b/tests/lib/rules/lines-around-comment.js
@@ -822,6 +822,60 @@ ruleTester.run("lines-around-comment", rule, {
             parserOptions: { ecmaVersion: 6 }
         },
 
+        // check for before else comments
+        {
+            code:
+            "if(true) {\n" +
+            "  a\n" +
+            "}\n" +
+            "// line before else\n" +
+            "else {\n" +
+            "  b\n" +
+            "}",
+            options: [{
+                allowBeforeElse: true
+            }]
+        },
+        {
+            code:
+            "if(true) {\n" +
+            "  a\n" +
+            "}\n" +
+            "/* block comment before else*/\n" +
+            "else {\n" +
+            "  b\n" +
+            "}",
+            options: [{
+                allowBeforeElse: true
+            }]
+        },
+        {
+            code:
+            "if(true) {\n" +
+            "  a\n" +
+            "}\n" +
+            "// line before else if\n" +
+            "else if(false) {\n" +
+            "  b\n" +
+            "}",
+            options: [{
+                allowBeforeElse: true
+            }]
+        },
+        {
+            code:
+            "if(true) {\n" +
+            "  a\n" +
+            "}\n" +
+            "/* block comment before else if*/\n" +
+            "else if(false) {\n" +
+            "  b\n" +
+            "}",
+            options: [{
+                allowBeforeElse: true
+            }]
+        },
+
         // ignorePattern
         {
             code:
@@ -1522,6 +1576,152 @@ ruleTester.run("lines-around-comment", rule, {
                 afterBlockComment: true
             }],
             parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: afterMessage, type: "Block", line: 4 }]
+        },
+
+        // before else comments
+        {
+            code:
+            "if(true) {\n" +
+            "  a\n" +
+            "}\n" +
+            "// line before else\n" +
+            "else {\n" +
+            "  b\n" +
+            "}",
+            output:
+            "if(true) {\n" +
+            "  a\n" +
+            "}\n" +
+            "\n" +
+            "// line before else\n" +
+            "else {\n" +
+            "  b\n" +
+            "}",
+            options: [{
+                beforeLineComment: true
+            }],
+            errors: [{ message: beforeMessage, type: "Line", line: 4 }]
+        },
+        {
+            code:
+            "if(true) {\n" +
+            "  a\n" +
+            "}\n" +
+            "/* block comment before else*/\n" +
+            "else {\n" +
+            "  b\n" +
+            "}",
+            output:
+            "if(true) {\n" +
+            "  a\n" +
+            "}\n" +
+            "\n" +
+            "/* block comment before else*/\n" +
+            "else {\n" +
+            "  b\n" +
+            "}",
+            options: [{
+                beforeBlockComment: true
+            }],
+            errors: [{ message: beforeMessage, type: "Block", line: 4 }]
+        },
+        {
+            code:
+            "if(true) {\n" +
+            "  b\n" +
+            "}\n" +
+            "// line before else\n" +
+            "else {\n" +
+            "  c\n" +
+            "}",
+            output:
+            "if(true) {\n" +
+            "  b\n" +
+            "}\n" +
+            "// line before else\n" +
+            "\n" +
+            "else {\n" +
+            "  c\n" +
+            "}",
+            options: [{
+                afterLineComment: true
+            }],
+            errors: [{ message: afterMessage, type: "Line", line: 4 }]
+        },
+        {
+            code:
+            "if(true) {\n" +
+            "  b\n" +
+            "}\n" +
+            "/* block comment before else*/\n" +
+            "else {\n" +
+            "  c\n" +
+            "}",
+            output:
+            "if(true) {\n" +
+            "  b\n" +
+            "}\n" +
+            "\n" +
+            "/* block comment before else*/\n" +
+            "\n" +
+            "else {\n" +
+            "  c\n" +
+            "}",
+            options: [{
+                afterBlockComment: true
+            }],
+            errors: [
+                { message: beforeMessage, type: "Block", line: 4 },
+                { message: afterMessage, type: "Block", line: 4 }
+            ]
+        },
+        {
+            code:
+            "if(true) {\n" +
+            "  c\n" +
+            "}\n" +
+            "// line before else\n" +
+            "else {\n" +
+            "  d\n" +
+            "}",
+            output:
+            "if(true) {\n" +
+            "  c\n" +
+            "}\n" +
+            "// line before else\n" +
+            "\n" +
+            "else {\n" +
+            "  d\n" +
+            "}",
+            options: [{
+                afterLineComment: true,
+                allowBeforeElse: true
+            }],
+            errors: [{ message: afterMessage, type: "Line", line: 4 }]
+        },
+        {
+            code:
+            "if(true) {\n" +
+            "  c\n" +
+            "}\n" +
+            "/* block comment before else*/\n" +
+            "else {\n" +
+            "  d\n" +
+            "}",
+            output:
+            "if(true) {\n" +
+            "  c\n" +
+            "}\n" +
+            "/* block comment before else*/\n" +
+            "\n" +
+            "else {\n" +
+            "  d\n" +
+            "}",
+            options: [{
+                afterBlockComment: true,
+                allowBeforeElse: true
+            }],
             errors: [{ message: afterMessage, type: "Block", line: 4 }]
         },
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
Fixes #10015 
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Add the object option `"allowBeforeElse": true` to the rule `lines-around-comment` to ignore `beforeLineComment` and `beforeBlockComment` if the token following the comment(s) is the `else` keyword.

**Is there anything you'd like reviewers to focus on?**


