### PR TITLE
Update: Add option `"maxConcat"` to `prefer-template` rule (fixes #10017)

### DIFF
--- a/docs/rules/prefer-template.md
+++ b/docs/rules/prefer-template.md
@@ -16,8 +16,6 @@ var str = `Hello, ${name}!`;
 
 This rule is aimed to flag usage of `+` operators with strings.
 
-## Examples
-
 Examples of **incorrect** code for this rule:
 
 ```js
@@ -39,6 +37,33 @@ var str = `Time: ${12 * 60 * 60 * 1000}`;
 
 // This is reported by `no-useless-concat`.
 var str = "Hello, " + "World!";
+```
+
+## Options
+
+This rule has an object option:
+
+* `"maxConcat"` (default: `0`) allows up to a maximum number of concatenations.
+
+
+### maxConcat
+
+Examples of **incorrect** code for this rule with the object option:
+
+```js
+/*eslint prefer-template: ["error", { "maxConcat": 1 }]*/
+
+var str = "Hello, " + name + ". Nice to meet you.";
+```
+
+Examples of **correct** code for this rule with the object option:
+
+```js
+/*eslint prefer-template: ["error", { "maxConcat": 1 }]*/
+
+var str = "Hello World!";
+var str = "Hello, " + name;
+var str = greeting + "!";
 ```
 
 ## When Not To Use It

--- a/lib/rules/prefer-template.js
+++ b/lib/rules/prefer-template.js
@@ -65,6 +65,20 @@ function hasNonStringLiteral(node) {
 }
 
 /**
+ * Counts the number of concat operations under the given node
+ * @param {ASTNode} node - A node to count.
+ * @returns {integer} the number of concat operations
+ */
+function numberOfConcats(node) {
+    if (isConcatenation(node)) {
+
+        // recurse on both operands
+        return numberOfConcats(node.left) + numberOfConcats(node.right) + 1;
+    }
+    return 0;
+}
+
+/**
  * Determines whether a given node will start with a template curly expression (`${}`) when being converted to a template literal.
  * @param {ASTNode} node The node that will be fixed to a template literal
  * @returns {boolean} `true` if the node will start with a template curly.
@@ -107,12 +121,27 @@ module.exports = {
             url: "https://eslint.org/docs/rules/prefer-template"
         },
 
-        schema: [],
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    maxConcat: {
+                        type: "integer",
+                        minimum: 0
+                    }
+                },
+                additionalProperties: false
+            }
+        ],
 
         fixable: "code"
     },
 
     create(context) {
+        const options = context.options[0] ? Object.assign({}, context.options[0]) : {};
+
+        options.maxConcat = options.maxConcat || 0;
+
         const sourceCode = context.getSourceCode();
         let done = Object.create(null);
 
@@ -211,13 +240,15 @@ module.exports = {
             done[topBinaryExpr.range[0]] = true;
 
             if (hasNonStringLiteral(topBinaryExpr)) {
-                context.report({
-                    node: topBinaryExpr,
-                    message: "Unexpected string concatenation.",
-                    fix(fixer) {
-                        return fixer.replaceText(topBinaryExpr, getTemplateLiteral(topBinaryExpr, null, null));
-                    }
-                });
+                if (!options.maxConcat || numberOfConcats(topBinaryExpr) > options.maxConcat) {
+                    context.report({
+                        node: topBinaryExpr,
+                        message: "Unexpected string concatenation.",
+                        fix(fixer) {
+                            return fixer.replaceText(topBinaryExpr, getTemplateLiteral(topBinaryExpr, null, null));
+                        }
+                    });
+                }
             }
         }
 

--- a/tests/lib/rules/prefer-template.js
+++ b/tests/lib/rules/prefer-template.js
@@ -34,7 +34,33 @@ ruleTester.run("prefer-template", rule, {
 
         // https://github.com/eslint/eslint/issues/3507
         "var foo = `foo` + `bar` + \"hoge\";",
-        "var foo = `foo` +\n    `bar` +\n    \"hoge\";"
+        "var foo = `foo` +\n    `bar` +\n    \"hoge\";",
+
+        // check for max concat
+        {
+            code: "var foo = bar + 'baz';",
+            options: [{
+                maxConcat: 1
+            }]
+        },
+        {
+            code: "var foo = bar + 'baz' + qux;",
+            options: [{
+                maxConcat: 2
+            }]
+        },
+        {
+            code: "var foo = 'hello, ' + name + '!';",
+            options: [{
+                maxConcat: 3
+            }]
+        },
+        {
+            code: "var foo = bar + 'baz' + qux + '!';",
+            options: [{
+                maxConcat: 3
+            }]
+        }
     ],
     invalid: [
         {
@@ -186,6 +212,40 @@ ruleTester.run("prefer-template", rule, {
         {
             code: "foo + 'handles unicode escapes correctly: \\x27'", // "\x27" === "'"
             output: "`${foo  }handles unicode escapes correctly: \\x27`",
+            errors
+        },
+
+        // check against max concat
+        {
+            code: "var foo = bar + 'baz';",
+            output: "var foo = `${bar  }baz`;",
+            options: [{
+                maxConcat: 0
+            }],
+            errors
+        },
+        {
+            code: "var foo = bar + 'baz' + qux;",
+            output: "var foo = `${bar  }baz${  qux}`;",
+            options: [{
+                maxConcat: 1
+            }],
+            errors
+        },
+        {
+            code: "var foo = 'hello, ' + name + '!';",
+            output: "var foo = `hello, ${  name  }!`;",
+            options: [{
+                maxConcat: 1
+            }],
+            errors
+        },
+        {
+            code: "var foo = bar + 'baz' + qux + '!';",
+            output: "var foo = `${bar  }baz${  qux  }!`;",
+            options: [{
+                maxConcat: 2
+            }],
             errors
         }
     ]


### PR DESCRIPTION

<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->
Fixes #10017 
<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Added object option `"maxConcat": integer` to `prefer-template` rule so that users can allow for simpler, short number of string concatenations.

**Is there anything you'd like reviewers to focus on?**


