### PR TITLE
Chore: refactor parser-loading out of linter.verify

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -513,13 +513,16 @@ function analyzeScope(ast, parserOptions, visitorKeys) {
  * as possible
  * @param {string} text The text to parse.
  * @param {Object} providedParserOptions Options to pass to the parser
- * @param {Object} parser The parser module
+ * @param {string} parserName The name of the parser
+ * @param {Map<string, Object>} parserMap A map from names to loaded parsers
  * @param {string} filePath The path to the file being parsed.
  * @returns {{success: false, error: Problem}|{success: true, sourceCode: SourceCode}}
  * An object containing the AST and parser services if parsing was successful, or the error if parsing failed
  * @private
  */
-function parse(text, providedParserOptions, parser, filePath) {
+function parse(text, providedParserOptions, parserName, parserMap, filePath) {
+
+
     const textToParse = stripUnicodeBOM(text).replace(astUtils.SHEBANG_MATCHER, (match, captured) => `//${captured}`);
     const parserOptions = Object.assign({}, providedParserOptions, {
         loc: true,
@@ -531,6 +534,25 @@ function parse(text, providedParserOptions, parser, filePath) {
         eslintScopeManager: true,
         filePath
     });
+
+    let parser;
+
+    try {
+        parser = parserMap.get(parserName) || require(parserName);
+    } catch (ex) {
+        return {
+            success: false,
+            error: {
+                ruleId: null,
+                fatal: true,
+                severity: 2,
+                source: null,
+                message: ex.message,
+                line: 0,
+                column: 0
+            }
+        };
+    }
 
     /*
      * Check for parsing errors first. If there's a parsing error, nothing
@@ -853,6 +875,7 @@ function runRules(sourceCode, configuredRules, ruleMapper, parserOptions, parser
 }
 
 const lastSourceCodes = new WeakMap();
+const loadedParserMaps = new WeakMap();
 
 //------------------------------------------------------------------------------
 // Public Interface
@@ -866,10 +889,10 @@ module.exports = class Linter {
 
     constructor() {
         lastSourceCodes.set(this, null);
+        loadedParserMaps.set(this, new Map());
         this.version = pkg.version;
 
         this.rules = new Rules();
-        this._parsers = new Map();
         this.environments = new Environments();
     }
 
@@ -932,25 +955,11 @@ module.exports = class Linter {
                 return [];
             }
 
-            let parser;
-
-            try {
-                parser = this._parsers.get(parserName) || require(parserName);
-            } catch (ex) {
-                return [{
-                    ruleId: null,
-                    fatal: true,
-                    severity: 2,
-                    source: null,
-                    message: ex.message,
-                    line: 0,
-                    column: 0
-                }];
-            }
             const parseResult = parse(
                 text,
                 parserOptions,
-                parser,
+                parserName,
+                loadedParserMaps.get(this),
                 options.filename
             );
 
@@ -1084,7 +1093,7 @@ module.exports = class Linter {
      * @returns {void}
      */
     defineParser(parserId, parserModule) {
-        this._parsers.set(parserId, parserModule);
+        loadedParserMaps.get(this).set(parserId, parserModule);
     }
 
     /**


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This is a refactoring that moves the logic for loading parsers out of `linter._verifyWithoutProcessors` and into the `parse` function, for the purpose of simplifying `linter._verifyWithoutProcessors`.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
