### PR TITLE
Chore: fix incorrect comment about linter.verify return value

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -918,7 +918,7 @@ module.exports = class Linter {
      *      Useful if you want to validate JS without comments overriding rules.
      * @param {boolean} [filenameOrOptions.reportUnusedDisableDirectives=false] Adds reported errors for unused
      *      eslint-disable directives
-     * @returns {Object[]} The results as an array of messages or null if no messages.
+     * @returns {Object[]} The results as an array of messages or an empty array if no messages.
      */
     _verifyWithoutProcessors(textOrSourceCode, providedConfig, filenameOrOptions) {
         const config = providedConfig || {};
@@ -1036,7 +1036,7 @@ module.exports = class Linter {
      * @param {function(Array<Object[]>): Object[]} [filenameOrOptions.postprocess] postprocessor for report messages. If provided,
      *      this should accept an array of the message lists for each code block returned from the preprocessor,
      *      apply a mapping to the messages as appropriate, and return a one-dimensional array of messages
-     * @returns {Object[]} The results as an array of messages or null if no messages.
+     * @returns {Object[]} The results as an array of messages or an empty array if no messages.
      */
     verify(textOrSourceCode, config, filenameOrOptions) {
         const preprocess = filenameOrOptions && filenameOrOptions.preprocess || (rawText => [rawText]);


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This fixes an incorrect JSDoc comment about the return value of `linter.verify` when there are no linting problems.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular