### PR TITLE
Chore: improve autofix performance (fixes #9998)

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -760,12 +760,6 @@ const BASE_TRAVERSAL_CONTEXT = Object.freeze(
 /**
  * Runs the given rules on the given SourceCode object
  * @param {TraversalParameters} traversalParameters The TraversalParameters for the given run
- * @param {Object} configuredRules The rules configuration
- * @param {function(string): Rule} ruleMapper A mapper function from rule names to rules
- * @param {Object} parserOptions The options that were passed to the parser
- * @param {string} parserName The name of the parser in the config
- * @param {Object} settings The settings that were enabled in the config
- * @param {string} filename The reported filename of the code
  * @returns {Problem[]} An array of reported problems
  */
 function runRules(traversalParameters) {

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -33,6 +33,8 @@ const eslintScope = require("eslint-scope"),
 const debug = require("debug")("eslint:linter");
 const MAX_AUTOFIX_PASSES = 10;
 const DEFAULT_PARSER_NAME = "espree";
+const DEFAULT_PREPROCESSOR = lodash.unary(Array.of);
+const DEFAULT_POSTPROCESSOR = lodash.flatten;
 
 //------------------------------------------------------------------------------
 // Typedefs
@@ -54,6 +56,17 @@ const DEFAULT_PARSER_NAME = "espree";
  * @property {number} line
  * @property {number} column
  * @property {(string|null)} ruleId
+ */
+
+/**
+ * An object containing all the resolved information necessary to run rules and produce a result
+ * @typedef {Object} TraversalParameters
+ * @property {SourceCode} sourceCode A SourceCode object containing the AST, the source text, and the scope manager/visitor keys
+ * @property {{ ruleId: string, rule: Rule, severity: (1|2), options: Array }[]} enabledRules A list of enabled rules for this text
+ * @property {Object} parserOptions The options that were passed to the parser to create this AST
+ * @property {string} parserName The name of the parser that was used in configuration
+ * @property {Object} settings The settings that were enabled in configuration
+ * @property {string} filename The filename which should be provided to rules for this source text
  */
 
 //------------------------------------------------------------------------------
@@ -239,6 +252,17 @@ function addDeclaredGlobals(globalScope, configGlobals, commentDirectives) {
 
         return true;
     });
+}
+
+/**
+ * Compares linting problems by location
+ * @param {Problem} problemA The first problem
+ * @param {Problem} problemB The second problem
+ * @returns {number} A number less than 0 if problemA occurs earlier in the file than problemB,
+ * and a number greater than 0 if problemA occurs later in the file than problemB.
+ */
+function compareLintingProblems(problemA, problemB) {
+    return problemA.line - problemB.line || problemA.column - problemB.column;
 }
 
 /**
@@ -485,6 +509,15 @@ function getRuleOptions(ruleConfig) {
 }
 
 /**
+ * Checks if a rule has the ability to autofix code
+ * @param {Rule} rule An ESLint rule
+ * @returns {boolean} true if the rule has the ability to autofix code
+ */
+function ruleIsFixable(rule) {
+    return !rule.meta || rule.meta.fixable;
+}
+
+/**
  * Analyze scope of the given AST.
  * @param {ASTNode} ast The `Program` node to analyze.
  * @param {Object} parserOptions The parser options.
@@ -726,7 +759,7 @@ const BASE_TRAVERSAL_CONTEXT = Object.freeze(
 
 /**
  * Runs the given rules on the given SourceCode object
- * @param {SourceCode} sourceCode A SourceCode object for the given text
+ * @param {TraversalParameters} traversalParameters The TraversalParameters for the given run
  * @param {Object} configuredRules The rules configuration
  * @param {function(string): Rule} ruleMapper A mapper function from rule names to rules
  * @param {Object} parserOptions The options that were passed to the parser
@@ -735,9 +768,15 @@ const BASE_TRAVERSAL_CONTEXT = Object.freeze(
  * @param {string} filename The reported filename of the code
  * @returns {Problem[]} An array of reported problems
  */
-function runRules(sourceCode, configuredRules, ruleMapper, parserOptions, parserName, settings, filename) {
+function runRules(traversalParameters) {
     const emitter = createEmitter();
     const traverser = new Traverser();
+
+    const sourceCode = traversalParameters.sourceCode;
+    const parserOptions = traversalParameters.parserOptions;
+    const parserName = traversalParameters.parserName;
+    const settings = traversalParameters.settings;
+    const filename = traversalParameters.filename;
 
     /*
      * Create a frozen object with the ruleContext properties and methods that are shared by all rules.
@@ -778,14 +817,13 @@ function runRules(sourceCode, configuredRules, ruleMapper, parserOptions, parser
 
     const lintingProblems = [];
 
-    Object.keys(configuredRules).forEach(ruleId => {
-        const severity = ConfigOps.getRuleSeverity(configuredRules[ruleId]);
+    traversalParameters.enabledRules.forEach(enabledRuleDescriptor => {
 
-        if (severity === 0) {
-            return;
-        }
+        const rule = enabledRuleDescriptor.rule;
+        const ruleId = enabledRuleDescriptor.ruleId;
+        const severity = enabledRuleDescriptor.severity;
+        const options = enabledRuleDescriptor.options;
 
-        const rule = ruleMapper(ruleId);
         const messageIds = rule.meta && rule.meta.messages;
         let reportTranslator = null;
         const ruleContext = Object.freeze(
@@ -793,7 +831,7 @@ function runRules(sourceCode, configuredRules, ruleMapper, parserOptions, parser
                 Object.create(sharedTraversalContext),
                 {
                     id: ruleId,
-                    options: getRuleOptions(configuredRules[ruleId]),
+                    options,
                     report() {
 
                         /*
@@ -811,7 +849,7 @@ function runRules(sourceCode, configuredRules, ruleMapper, parserOptions, parser
                         }
                         const problem = reportTranslator.apply(null, arguments);
 
-                        if (problem.fix && rule.meta && !rule.meta.fixable) {
+                        if (problem.fix && !ruleIsFixable(rule)) {
                             throw new Error("Fixable rules should export a `meta.fixable` property.");
                         }
                         lintingProblems.push(problem);
@@ -907,19 +945,24 @@ module.exports = class Linter {
      */
 
     /**
-     * Same as linter.verify, except without support for processors.
-     * @param {string|SourceCode} textOrSourceCode The text to parse or a SourceCode object.
-     * @param {ESLintConfig} providedConfig An ESLintConfig instance to configure everything.
-     * @param {(string|Object)} [filenameOrOptions] The optional filename of the file being checked.
-     *      If this is not set, the filename will default to '<input>' in the rule context. If
-     *      an object, then it has "filename", "saveState", and "allowInlineConfig" properties.
-     * @param {boolean} [filenameOrOptions.allowInlineConfig=true] Allow/disallow inline comments' ability to change config once it is set. Defaults to true if not supplied.
-     *      Useful if you want to validate JS without comments overriding rules.
-     * @param {boolean} [filenameOrOptions.reportUnusedDisableDirectives=false] Adds reported errors for unused
-     *      eslint-disable directives
-     * @returns {Object[]} The results as an array of messages or an empty array if no messages.
+     * Given some source text, a config object, and extra linting options,
+     * parses the source text and resolves all of the environments and globals to
+     * begin traversing the AST and running rules.
+     * @param {string|SourceCode} textOrSourceCode See `linter.verify`
+     * @param {Object|null} providedConfig See `linter.verify`
+     * @param {string|Object} filenameOrOptions See `linter.verify`
+     * @returns {({
+     *     success: true,
+     *     parameters: TraversalParameters,
+     *     disableDirectives: DisableDirective[],
+     *     reportUnusedDisableDirectives: boolean,
+     *     commentDirectiveProblems: Object[]
+     * }|{success: false, error: Object})}
+     * An object indicating whether the creation was successful. If the traversal parameters are created successfully,
+     * the `success` property will be `true` and the result will be a `TraversalParameters` object. If there
+     * was an error loading the parser or parsing the source text, the `success` property will be `false`.
      */
-    _verifyWithoutProcessors(textOrSourceCode, providedConfig, filenameOrOptions) {
+    _parseAndProcessComments(textOrSourceCode, providedConfig, filenameOrOptions) {
         const config = providedConfig || {};
         const options = normalizeVerifyOptions(filenameOrOptions);
         let text;
@@ -947,13 +990,6 @@ module.exports = class Linter {
         const settings = config.settings || {};
 
         if (!lastSourceCodes.get(this)) {
-
-            // there's no input, just exit here
-            if (text.trim().length === 0) {
-                lastSourceCodes.set(this, new SourceCode(text, blankScriptAST));
-                return [];
-            }
-
             const parseResult = parse(
                 text,
                 parserOptions,
@@ -963,7 +999,7 @@ module.exports = class Linter {
             );
 
             if (!parseResult.success) {
-                return [parseResult.error];
+                return { success: false, error: parseResult.error };
             }
 
             lastSourceCodes.set(this, parseResult.sourceCode);
@@ -999,24 +1035,29 @@ module.exports = class Linter {
         );
 
         const configuredRules = Object.assign({}, config.rules, commentDirectives.configuredRules);
+        const enabledRules = Object.keys(configuredRules)
+            .filter(ruleId => ConfigOps.getRuleSeverity(configuredRules[ruleId]) !== 0)
+            .map(ruleId => ({
+                ruleId,
+                rule: this.rules.get(ruleId),
+                severity: ConfigOps.getRuleSeverity(configuredRules[ruleId]),
+                options: getRuleOptions(configuredRules[ruleId])
+            }));
 
-        const lintingProblems = runRules(
-            sourceCode,
-            configuredRules,
-            ruleId => this.rules.get(ruleId),
-            parserOptions,
-            parserName,
-            settings,
-            options.filename
-        );
-
-        return applyDisableDirectives({
-            directives: commentDirectives.disableDirectives,
-            problems: lintingProblems
-                .concat(commentDirectives.problems)
-                .sort((problemA, problemB) => problemA.line - problemB.line || problemA.column - problemB.column),
+        return {
+            success: true,
+            parameters: {
+                sourceCode,
+                enabledRules,
+                parserOptions,
+                parserName,
+                settings,
+                filename: options.filename
+            },
+            disableDirectives: commentDirectives.disableDirectives,
+            commentDirectiveProblems: commentDirectives.problems,
             reportUnusedDisableDirectives: options.reportUnusedDisableDirectives
-        });
+        };
     }
 
     /**
@@ -1038,13 +1079,38 @@ module.exports = class Linter {
      * @returns {Object[]} The results as an array of messages or an empty array if no messages.
      */
     verify(textOrSourceCode, config, filenameOrOptions) {
-        const preprocess = filenameOrOptions && filenameOrOptions.preprocess || (rawText => [rawText]);
-        const postprocess = filenameOrOptions && filenameOrOptions.postprocess || lodash.flatten;
+        const preprocess = filenameOrOptions && filenameOrOptions.preprocess || DEFAULT_PREPROCESSOR;
+        const postprocess = filenameOrOptions && filenameOrOptions.postprocess || DEFAULT_POSTPROCESSOR;
 
         return postprocess(
-            preprocess(textOrSourceCode).map(
-                textBlock => this._verifyWithoutProcessors(textBlock, config, filenameOrOptions)
-            )
+            preprocess(textOrSourceCode).map(textBlock => {
+                const traversalParametersResult = this._parseAndProcessComments(
+                    textBlock,
+                    config,
+                    filenameOrOptions
+                );
+
+                if (!traversalParametersResult.success) {
+                    return [traversalParametersResult.error];
+                }
+
+                const traversalParameters = traversalParametersResult.parameters;
+
+                if (!traversalParameters.sourceCode.text.trim()) {
+                    lastSourceCodes.set(this, new SourceCode(traversalParameters.sourceCode.text, blankScriptAST));
+                    return [];
+                }
+
+                const lintingProblems = runRules(traversalParameters);
+
+                return applyDisableDirectives({
+                    problems: lintingProblems
+                        .concat(traversalParametersResult.commentDirectiveProblems)
+                        .sort(compareLintingProblems),
+                    directives: traversalParametersResult.disableDirectives,
+                    reportUnusedDisableDirectives: traversalParametersResult.reportUnusedDisableDirectives
+                });
+            })
         );
     }
 
@@ -1114,63 +1180,93 @@ module.exports = class Linter {
      *      SourceCodeFixer.
      */
     verifyAndFix(text, config, options) {
-        let messages = [],
-            fixedResult,
-            fixed = false,
-            passNumber = 0,
-            currentText = text;
+        const preprocess = options && options.preprocess || DEFAULT_PREPROCESSOR;
+        const postprocess = options && options.postprocess || DEFAULT_POSTPROCESSOR;
+
         const debugTextDescription = options && options.filename || `${text.slice(0, 10)}...`;
         const shouldFix = options && typeof options.fix !== "undefined" ? options.fix : true;
 
-        /**
-         * This loop continues until one of the following is true:
-         *
-         * 1. No more fixes have been applied.
-         * 2. Ten passes have been made.
-         *
-         * That means anytime a fix is successfully applied, there will be another pass.
-         * Essentially, guaranteeing a minimum of two passes.
-         */
-        do {
-            passNumber++;
+        const verify = this.verify.bind(this);
+        const parseAndProcessComments = this._parseAndProcessComments.bind(this);
 
-            debug(`Linting code for ${debugTextDescription} (pass ${passNumber})`);
-            messages = this.verify(currentText, config, options);
+        return (function runAutofixPasses(currentText, maxRemainingPasses, hasFixedAnything) {
+            debug(`Linting code for ${debugTextDescription} (pass ${MAX_AUTOFIX_PASSES - maxRemainingPasses})`);
 
-            debug(`Generating fixed text for ${debugTextDescription} (pass ${passNumber})`);
-            fixedResult = SourceCodeFixer.applyFixes(currentText, messages, shouldFix);
-
-            /*
-             * stop if there are any syntax errors.
-             * 'fixedResult.output' is a empty string.
-             */
-            if (messages.length === 1 && messages[0].fatal) {
-                break;
+            if (!shouldFix || maxRemainingPasses <= 0) {
+                return {
+                    output: currentText,
+                    messages: verify(text, config, options),
+                    fixed: hasFixedAnything
+                };
             }
 
-            // keep track if any fixes were ever applied - important for return value
-            fixed = fixed || fixedResult.fixed;
+            const textBlocks = preprocess(currentText);
+            const traversalParametersResults = textBlocks
+                .map(textBlock => parseAndProcessComments(textBlock, config, options));
 
-            // update to use the fixed output instead of the original text
-            currentText = fixedResult.output;
+            const fixableRuleProblemsByBlock = traversalParametersResults.map(traversalParametersResult => {
+                if (!traversalParametersResult.success) {
+                    return [traversalParametersResult.error];
+                }
 
-        } while (
-            fixedResult.fixed &&
-            passNumber < MAX_AUTOFIX_PASSES
-        );
+                const traversalParameters = traversalParametersResult.parameters;
 
-        /*
-         * If the last result had fixes, we need to lint again to be sure we have
-         * the most up-to-date information.
-         */
-        if (fixedResult.fixed) {
-            fixedResult.messages = this.verify(currentText, config, options);
-        }
+                if (!traversalParameters.sourceCode.text.trim()) {
+                    return [];
+                }
 
-        // ensure the last result properly reflects if fixes were done
-        fixedResult.fixed = fixed;
-        fixedResult.output = currentText;
+                const modifiedParametersWithOnlyFixableRules = Object.assign(
+                    {},
+                    traversalParameters,
+                    { enabledRules: traversalParameters.enabledRules.filter(ruleDescriptor => ruleIsFixable(ruleDescriptor.rule)) }
+                );
 
-        return fixedResult;
+                return applyDisableDirectives({
+                    problems: runRules(modifiedParametersWithOnlyFixableRules).sort(compareLintingProblems),
+                    directives: traversalParametersResult.disableDirectives,
+                    reportUnusedDisableDirectives: false
+                });
+            });
+
+            debug(`Generating fixed text for ${debugTextDescription} (pass ${MAX_AUTOFIX_PASSES - maxRemainingPasses})`);
+
+            const fixResult = SourceCodeFixer.applyFixes(currentText, postprocess(fixableRuleProblemsByBlock), shouldFix);
+
+            if (fixResult.fixed && traversalParametersResults.every(result => result.success)) {
+                return runAutofixPasses(fixResult.output, maxRemainingPasses - 1, true);
+            }
+
+            const allProblemsByBlock = traversalParametersResults.map((traversalParametersResult, index) => {
+                const fixableRuleProblems = fixableRuleProblemsByBlock[index];
+                const traversalParameters = traversalParametersResult.parameters;
+
+                if (!traversalParametersResult.success) {
+                    return fixableRuleProblems;
+                }
+
+                const unfixableRuleProblems = runRules(
+                    Object.assign(
+                        {},
+                        traversalParameters,
+                        { enabledRules: traversalParameters.enabledRules.filter(ruleDescriptor => !ruleIsFixable(ruleDescriptor.rule)) }
+                    )
+                );
+
+                return applyDisableDirectives({
+                    problems: fixableRuleProblems
+                        .concat(unfixableRuleProblems)
+                        .concat(traversalParametersResult.commentDirectiveProblems)
+                        .sort(compareLintingProblems),
+                    directives: traversalParametersResult.disableDirectives,
+                    reportUnusedDisableDirectives: traversalParametersResult.reportUnusedDisableDirectives
+                });
+            });
+
+            return {
+                messages: postprocess(allProblemsByBlock),
+                output: currentText,
+                fixed: hasFixedAnything
+            };
+        }(text, MAX_AUTOFIX_PASSES, false));
     }
 };


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates the multipass autofix logic to only run non-autofixable rules once on the last pass, rather than running them on every pass and discarding everything except the last results. ESLint now only runs autofixable rules on the first few passes, until no more fixes are possible. Afterwards, it runs all of the non-autofixable rules on the final AST by doing a second traversal, and combines their messages with the messages from the fixable rules. (See #9998 for a bit more information on how this affects the autofixing logic.)

This results in a performance improvement of about 20-25% when running autofix mode. I tested this by linting the ESLint codebase with a few rules modified (to ensure that autofixable errors are reported and fixed):

```
time eslint lib/ tests/ bin/ conf/ tools/ Makefile.js .eslintrc.js --rule 'curly: [error, multi]' --rule 'nonblock-statement-body-position: [error, beside]' --fix-dry-run
```

This increases the internal complexity of `linter`, because it needs to be able to run two sets of rules on the same AST at different times, without reparsing the source code or reprocessing all of the directive comments and environments.

**Is there anything you'd like reviewers to focus on?**

Is the performance improvement worth the additional complexity?