### PR TITLE
Update: Correctly indent JSXText with trailing linebreaks (fixes #9878)

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -780,6 +780,19 @@ module.exports = {
         }
 
         /**
+         * Counts the number of linebreaks that follow the last non-whitespace character in a string
+         * @param {string} string The string to check
+         * @returns {number} The number of JavaScript linebreaks that follow the last non-whitespace character,
+         * or the total number of linebreaks if the string is all whitespace.
+         */
+        function countTrailingLinebreaks(string) {
+            const trailingWhitespace = string.match(/\s*$/)[0];
+            const linebreakMatches = trailingWhitespace.match(astUtils.createGlobalLinebreakMatcher());
+
+            return linebreakMatches === null ? 0 : linebreakMatches.length;
+        }
+
+        /**
          * Check indentation for lists of elements (arrays, objects, function params)
          * @param {ASTNode[]} elements List of elements that should be offset
          * @param {Token} startToken The start token of the list that element should be aligned against, e.g. '['
@@ -836,8 +849,12 @@ module.exports = {
                 } else {
                     const previousElement = elements[index - 1];
                     const firstTokenOfPreviousElement = previousElement && getFirstToken(previousElement);
+                    const previousElementLastToken = previousElement && sourceCode.getLastToken(previousElement);
 
-                    if (previousElement && sourceCode.getLastToken(previousElement).loc.end.line > startToken.loc.end.line) {
+                    if (
+                        previousElement &&
+                        previousElementLastToken.loc.end.line - countTrailingLinebreaks(previousElementLastToken.value) > startToken.loc.end.line
+                    ) {
                         offsets.setDesiredOffsets(element.range, firstTokenOfPreviousElement, 0);
                     }
                 }

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -4607,6 +4607,16 @@ ruleTester.run("indent", rule, {
                     );
                 }
             `,
+        unIndent`
+            <div>foo
+                <div>bar</div>
+            </div>
+        `,
+        unIndent`
+            <small>Foo bar&nbsp;
+                <a>baz qux</a>.
+            </small>
+        `,
         {
             code: unIndent`
                 a(b
@@ -9135,6 +9145,32 @@ ruleTester.run("indent", rule, {
                 </div>
             `,
             errors: expectedErrors([3, 8, 6, "Block"])
+        },
+        {
+            code: unIndent`
+                <div>foo
+                <div>bar</div>
+                </div>
+            `,
+            output: unIndent`
+                <div>foo
+                    <div>bar</div>
+                </div>
+            `,
+            errors: expectedErrors([2, 4, 0, "Punctuator"])
+        },
+        {
+            code: unIndent`
+                <small>Foo bar&nbsp;
+                <a>baz qux</a>.
+                </small>
+            `,
+            output: unIndent`
+                <small>Foo bar&nbsp;
+                    <a>baz qux</a>.
+                </small>
+            `,
+            errors: expectedErrors([2, 4, 0, "Punctuator"])
         },
         {
             code: unIndent`


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (https://github.com/eslint/eslint/issues/9878)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This fixes a bug in the `indent` rule where a line comparison with the end of a token would use the end location of any trailing whitespace in the token, rather than the location of the last non-whitespace character in the token. This behavior went against user intuition for tokens with trailing whitespace.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular