### PR TITLE
Breaking: require rules to provide report messages (fixes #10011)

### DIFF
--- a/lib/report-translator.js
+++ b/lib/report-translator.js
@@ -114,15 +114,6 @@ function normalizeReportLoc(descriptor) {
 }
 
 /**
- * Interpolates data placeholders in report messages
- * @param {MessageDescriptor} descriptor The report message descriptor.
- * @returns {string} The interpolated message for the descriptor
- */
-function normalizeMessagePlaceholders(descriptor) {
-    return interpolate(descriptor.message, descriptor.data);
-}
-
-/**
  * Compares items in a fixes array by range.
  * @param {Fix} a The first message.
  * @param {Fix} b The second message.
@@ -255,6 +246,8 @@ module.exports = function createReportTranslator(metadata) {
 
         assertValidNodeInfo(descriptor);
 
+        let computedMessage;
+
         if (descriptor.messageId) {
             if (!metadata.messageIds) {
                 throw new TypeError("context.report() called with a messageId, but no messages were present in the rule metadata.");
@@ -268,7 +261,11 @@ module.exports = function createReportTranslator(metadata) {
             if (!messages || !Object.prototype.hasOwnProperty.call(messages, id)) {
                 throw new TypeError(`context.report() called with a messageId of '${id}' which is not present in the 'messages' config: ${JSON.stringify(messages, null, 2)}`);
             }
-            descriptor.message = messages[id];
+            computedMessage = messages[id];
+        } else if (descriptor.message) {
+            computedMessage = descriptor.message;
+        } else {
+            throw new TypeError("Missing `message` property in report() call; add a message that describes the linting problem.");
         }
 
 
@@ -276,7 +273,7 @@ module.exports = function createReportTranslator(metadata) {
             ruleId: metadata.ruleId,
             severity: metadata.severity,
             node: descriptor.node,
-            message: normalizeMessagePlaceholders(descriptor),
+            message: interpolate(computedMessage, descriptor.data),
             messageId: descriptor.messageId,
             loc: normalizeReportLoc(descriptor),
             fix: normalizeFixes(descriptor, metadata.sourceCode),

--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -870,6 +870,20 @@ describe("Linter", () => {
             sinon.assert.calledTwice(spyLiteral);
             sinon.assert.calledOnce(spyBinaryExpression);
         });
+
+        it("should throw an error if a rule reports a problem without a message", () => {
+            linter.defineRule("invalid-report", context => ({
+                Program(node) {
+                    context.report({ node });
+                }
+            }));
+
+            assert.throws(
+                () => linter.verify("foo", { rules: { "invalid-report": "error" } }),
+                TypeError,
+                "Missing `message` property in report() call; add a message that describes the linting problem."
+            );
+        });
     });
 
     describe("when config has shared settings for rules", () => {

--- a/tests/lib/report-translator.js
+++ b/tests/lib/report-translator.js
@@ -168,6 +168,15 @@ describe("createReportTranslator", () => {
                 /^context\.report\(\) called with a messageId of '[^']+' which is not present in the 'messages' config:/
             );
         });
+        it("should throw when no message is provided", () => {
+            const reportDescriptor = { node };
+
+            assert.throws(
+                () => translateReport(reportDescriptor),
+                TypeError,
+                "Missing `message` property in report() call; add a message that describes the linting problem."
+            );
+        });
     });
     describe("combining autofixes", () => {
         it("should merge fixes to one if 'fix' function returns an array of fixes.", () => {


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates ESLint core to throw an error when a rule reports a problem without providing a report message, as described in https://github.com/eslint/eslint/issues/10011.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular