### PR TITLE
Update: Add mjs to --ext default (fixes #9592)

### DIFF
--- a/conf/default-cli-options.js
+++ b/conf/default-cli-options.js
@@ -12,7 +12,7 @@ module.exports = {
     useEslintrc: true,
     envs: [],
     globals: [],
-    extensions: [".js"],
+    extensions: [".mjs", ".js"],
     ignore: true,
     ignorePath: null,
     cache: false,

--- a/docs/user-guide/command-line-interface.md
+++ b/docs/user-guide/command-line-interface.md
@@ -33,7 +33,7 @@ Basic configuration:
   --no-eslintrc                  Disable use of configuration from .eslintrc.*
   -c, --config path::String      Use this configuration, overriding .eslintrc.* config options if present
   --env [String]                 Specify environments
-  --ext [String]                 Specify JavaScript file extensions - default: .js
+  --ext [String]                 Specify JavaScript file extensions - default: mjs,js
   --global [String]              Define global variables
   --parser String                Specify the parser to be used
   --parser-options Object        Specify parser options
@@ -86,9 +86,9 @@ Options that accept array values can be specified by repeating the option or wit
 
 Example:
 
-    eslint --ext .jsx --ext .js lib/
+    eslint --ext jsx --ext js lib/
 
-    eslint --ext .jsx,.js lib/
+    eslint --ext jsx,js lib/
 
 ### Basic configuration
 
@@ -132,22 +132,22 @@ Examples:
 #### `--ext`
 
 This option allows you to specify which file extensions ESLint will use when searching for JavaScript files in the directories you specify.
-By default, it uses `.js` as the only file extension.
+By default, it uses `mjs` and `js` file extensions.
 
 Examples:
 
     # Use only .js2 extension
-    eslint . --ext .js2
+    eslint . --ext js2
 
     # Use both .js and .js2
-    eslint . --ext .js --ext .js2
+    eslint . --ext js --ext js2
 
     # Also use both .js and .js2
-    eslint . --ext .js,.js2
+    eslint . --ext js,js2
 
 **Note:** `--ext` is only used when the arguments are directories. If you use glob patterns or file names, then `--ext` is ignored.
 
-For example, `eslint lib/* --ext .js` will match all files within the `lib/` directory, regardless of extension.
+For example, `eslint lib/* --ext js` will match all files within the `lib/` directory, regardless of extension.
 
 #### `--global`
 

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -2948,9 +2948,9 @@ describe("CLIEngine", () => {
     describe("resolveFileGlobPatterns", () => {
 
         leche.withData([
-            [".", "**/*.js"],
-            ["./", "**/*.js"],
-            ["../", "../**/*.js"]
+            [".", "**/*.{mjs,js}"],
+            ["./", "**/*.{mjs,js}"],
+            ["../", "../**/*.{mjs,js}"]
         ], (input, expected) => {
 
             it(`should correctly resolve ${input} to ${expected}`, () => {

--- a/tests/lib/util/source-code-util.js
+++ b/tests/lib/util/source-code-util.js
@@ -146,7 +146,7 @@ describe("SourceCodeUtil", () => {
 
             getSourceCodeOfFiles(filename);
             assert(spy.called);
-            assert.deepStrictEqual(spy.firstCall.args[1].extensions, [".js"]);
+            assert.deepStrictEqual(spy.firstCall.args[1].extensions, [".mjs", ".js"]);
         });
 
         it("should create an object with located filenames as keys", () => {


### PR DESCRIPTION
Fixes https://github.com/eslint/eslint/issues/9592.

<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Added `mjs` the default array of file extensions used by the `--ext` CLI option and updated tests and docs accordingly, fixing https://github.com/eslint/eslint/issues/9592.

The order is `mjs,js` everywhere as that is the Node.js resolution order and the order used by tools such as Webpack.

The `.mjs` file extension is the official way to run [native ESM in Node.js](https://nodejs.org/api/esm.html).

**Is there anything you'd like reviewers to focus on?**

While updating the `--ext` docs, I removed the extension `.` from examples such as it is superfluous. For example, `eslint . --ext .js2` became `eslint . --ext js2`.

As a side note, I tried to `npm link` test the changes in a project, but got errors like `ESLint couldn't find the plugin "eslint-plugin-react".` I suppose it is looking in the wrong `node_modules` directory for plugins due to the link.
