### PR TITLE
Replaced babel-code-frame with @babel/code-frame, enabled highlightCode

### DIFF
--- a/lib/formatters/codeframe.js
+++ b/lib/formatters/codeframe.js
@@ -4,9 +4,10 @@
  */
 "use strict";
 
-const chalk = require("chalk");
-const codeFrame = require("babel-code-frame");
+const os = require("os");
 const path = require("path");
+const chalk = require("chalk");
+const codeFrame = require("@babel/code-frame");
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -63,7 +64,9 @@ function formatMessage(message, parentResult) {
 
     if (sourceCode) {
         result.push(
-            codeFrame(sourceCode, message.line, message.column, { highlightCode: false })
+            codeFrame.codeFrameColumns(sourceCode, {
+                start: { line: message.line, column: message.column }
+            }, { highlightCode: true })
         );
     }
 
@@ -102,7 +105,7 @@ function formatSummary(errors, warnings, fixableErrors, fixableWarnings) {
     let output = chalk[summaryColor].bold(`${summary.join(" and ")} found.`);
 
     if (fixableErrors || fixableWarnings) {
-        output += chalk[summaryColor].bold(`\n${fixablesSummary.join(" and ")} potentially fixable with the \`--fix\` option.`);
+        output += chalk[summaryColor].bold(`${os.EOL}${fixablesSummary.join(" and ")} potentially fixable with the \`--fix\` option.`);
     }
 
     return output;
@@ -120,18 +123,17 @@ module.exports = function(results) {
 
     const resultsWithMessages = results.filter(result => result.messages.length > 0);
 
-    let output = resultsWithMessages.reduce((resultsOutput, result) => {
-        const messages = result.messages.map(message => `${formatMessage(message, result)}\n\n`);
-
+    let output = resultsWithMessages.reduce((all, result) => {
         errors += result.errorCount;
         warnings += result.warningCount;
         fixableErrors += result.fixableErrorCount;
         fixableWarnings += result.fixableWarningCount;
 
-        return resultsOutput.concat(messages);
-    }, []).join("\n");
+        all.push.apply(all, result.messages.map(message => `${formatMessage(message, result)}${os.EOL}${os.EOL}`));
+        return all;
+    }, []).join(os.EOL);
 
-    output += "\n";
+    output += os.EOL;
     output += formatSummary(errors, warnings, fixableErrors, fixableWarnings);
 
     return (errors + warnings) > 0 ? output : "";

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
   "homepage": "https://eslint.org",
   "bugs": "https://github.com/eslint/eslint/issues/",
   "dependencies": {
+    "@babel/code-frame": "^7.0.0-beta.40",
     "ajv": "^5.3.0",
-    "babel-code-frame": "^6.22.0",
     "chalk": "^2.1.0",
     "concat-stream": "^1.6.0",
     "cross-spawn": "^5.1.0",


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] Other, please explain:

Small change to codeframe formatter. Fixes #10080

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

- Replaced babel-code-frame with `@babel/code-frame` 
- enable 1highlightCode1 option.

**Is there anything you'd like reviewers to focus on?**
Tests pass, simple enough change.