### PR TITLE
Docs: Wrap `Buffer()` in backticks in `no-buffer-constructor` rule description

### DIFF
--- a/lib/rules/no-buffer-constructor.js
+++ b/lib/rules/no-buffer-constructor.js
@@ -11,7 +11,7 @@
 module.exports = {
     meta: {
         docs: {
-            description: "disallow use of the Buffer() constructor",
+            description: "disallow use of the `Buffer()` constructor",
             category: "Node.js and CommonJS",
             recommended: false,
             url: "https://eslint.org/docs/rules/no-buffer-constructor"


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Wraps `Buffer()` in backticks in the `no-buffer-constructor` rule description

Adds further consistency to already backtick'd code in rule docs and descriptions:
> https://eslint.org/docs/rules/#nodejs-and-commonjs
> https://eslint.org/docs/rules/no-buffer-constructor

**Is there anything you'd like reviewers to focus on?**

Nope, just thanks, and have a great day 😄 
