### PR TITLE
Chore: Adding debug logs on successful plugin loads

### DIFF
--- a/lib/config/plugins.js
+++ b/lib/config/plugins.js
@@ -122,13 +122,22 @@ class Plugins {
 
             // This step is costly, so skip if debug is disabled
             if (debug.enabled) {
-                try {
-                    const version = require(`${longName}/package.json`).version;
+                const resolvedPath = require.resolve(longName);
 
-                    debug(`Loaded plugin ${pluginName} (${longName}@${version})`);
+                let version = null;
+
+                try {
+                    version = require(`${longName}/package.json`).version;
                 } catch (e) {
-                    debug(`Loaded plugin ${pluginName} (${longName}, version unknown)`);
+
+                    // Do nothing
                 }
+
+                const loadedPluginAndVersion = version
+                    ? `${longName}@${version}`
+                    : `${longName}, version unknown`;
+
+                debug(`Loaded plugin ${pluginName} (${loadedPluginAndVersion}) (from ${resolvedPath})`);
             }
 
             this.define(pluginName, plugin);

--- a/lib/config/plugins.js
+++ b/lib/config/plugins.js
@@ -120,6 +120,17 @@ class Plugins {
                 throw pluginLoadErr;
             }
 
+            // This step is costly, so skip if debug is disabled
+            if (debug.enabled) {
+                try {
+                    const version = require(`${longName}/package.json`).version;
+
+                    debug(`Loaded plugin ${pluginName} (${longName}@${version})`);
+                } catch (e) {
+                    debug(`Loaded plugin ${pluginName} (${longName}, version unknown)`);
+                }
+            }
+
             this.define(pluginName, plugin);
         }
     }


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain: Adding some debug logs for successful plugin loads, to help users detect if plugin versions don't match expectations.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Added some debug logging to lib/config/plugins.js on successful plugin load. These statements note the plugin name (as specified in config), the resolved plugin name, and the version of the loaded plugin (if we can determine it).

This logic is only executed if debug is actually enabled. This is because the most reliable way I know of for finding a plugin version is to `require` the `package.json` file within the plugin package and read the `version` property. There's no point in resolving, loading, and reading that file if debug isn't enabled, hence the extra if check.

**Is there anything you'd like reviewers to focus on?**

* Is there a better way for me to read a package version?
* Should I add any unit tests for this change? If so, any tips for getting started?
* Anything else I should consider adding to the debug statements? Is there a better way to present the information?

Example output when running `DEBUG=eslint:plugins node ./bin/eslint.js lib` (from root of ESLint project):

```
2018-03-19T18:00:03.314Z eslint:plugins Loaded plugin eslint-plugin (eslint-plugin-eslint-plugin@1.2.0)
2018-03-19T18:00:03.365Z eslint:plugins Loaded plugin node (eslint-plugin-node@5.1.0)
2018-03-19T18:00:03.366Z eslint:plugins Loaded plugin rulesdir (eslint-plugin-rulesdir@0.1.0)
```

(Note: Looks a bit different than when run on console due to output redirect. Just ignore the timestamps.)

--------

Inspired by #10090. This output could be useful for users who expect a certain plugin version to be loaded, but they get a different version due to either global/local mismatching or npm/yarn shenanigans.