### PR TITLE
Chore: Adding log at beginning of unit tests in Makefile.js

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -569,6 +569,8 @@ target.test = function() {
     let errors = 0,
         lastReturn;
 
+    echo("Running unit tests");
+
     lastReturn = exec(`${getBinFile("istanbul")} cover ${MOCHA} -- -R progress -t ${MOCHA_TIMEOUT} -c ${TEST_FILES}`);
     if (lastReturn.code !== 0) {
         errors++;


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain: Added a message "Running unit tests" to help indicate to developers when `npm test` has transitioned from linting to unit tests. Not high-value but does slightly improve the developer experience.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Added message "Running unit tests" to the `test` target in `Makefile.js`. It is output after all of the lint targets but before unit tests and coverage start.

**Is there anything you'd like reviewers to focus on?**

Not really.