### PR TITLE
Fix: object-curly-newline minProperties w/default export (fixes #10101)

### DIFF
--- a/lib/rules/object-curly-newline.js
+++ b/lib/rules/object-curly-newline.js
@@ -116,7 +116,8 @@ function areLineBreaksRequired(node, options, first, last) {
     } else {
 
         // is ImportDeclaration or ExportNamedDeclaration
-        objectProperties = node.specifiers;
+        objectProperties = node.specifiers
+            .filter(s => s.type === "ImportSpecifier" || s.type === "ExportSpecifier");
     }
 
     return objectProperties.length >= options.minProperties ||

--- a/tests/lib/rules/object-curly-newline.js
+++ b/tests/lib/rules/object-curly-newline.js
@@ -493,6 +493,10 @@ ruleTester.run("object-curly-newline", rule, {
             ].join("\n"),
             options: [{ ImportDeclaration: { minProperties: 3 } }]
         },
+        {
+            code: "import DefaultExport, {a} from 'module';",
+            options: [{ ImportDeclaration: { minProperties: 2 } }]
+        },
 
         // "ExportDeclaration" ---------------------------------------------
         {
@@ -1588,6 +1592,19 @@ ruleTester.run("object-curly-newline", rule, {
             errors: [
                 { line: 1, column: 8, message: "Unexpected line break after this opening brace." },
                 { line: 3, column: 1, message: "Unexpected line break before this closing brace." }
+            ]
+        },
+        {
+            code: "import DefaultExport, {a, b} from 'module';",
+            output: [
+                "import DefaultExport, {",
+                "a, b",
+                "} from 'module';"
+            ].join("\n"),
+            options: [{ ImportDeclaration: { minProperties: 2 } }],
+            errors: [
+                { line: 1, column: 23, message: "Expected a line break after this opening brace." },
+                { line: 1, column: 28, message: "Expected a line break before this closing brace." }
             ]
         },
 


### PR DESCRIPTION
minProperties only tracks ImportSpecifier and ExportSpecifier nodes

<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

See #10101.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

The `object-curly-newline` rule used to count all `specifiers` under an `ImportDeclaration` or `ExportDeclaration` node when determining if there are enough specifiers to require line breaks. However, ImportDefaultSpecifier and ImportNamespaceSpecifier nodes are not actually part of the "object" (i.e., nodes surrounded by curly brace tokens), so they should be ignored by this rule. This change fixes the logic to only check for the count of `ImportSpecifier` or `ExportSpecifier` nodes associated with the `ImportDeclaration` or `ExportDeclaration` nodes.

**Is there anything you'd like reviewers to focus on?**

Any other unit tests I should add?