### PR TITLE
Fix: no-invalid-regexp not understand variable for flags (fixes #10112)

### DIFF
--- a/lib/rules/no-invalid-regexp.js
+++ b/lib/rules/no-invalid-regexp.js
@@ -98,20 +98,17 @@ module.exports = {
                     return;
                 }
                 const pattern = node.arguments[0].value;
-                let flags = "";
+                let flags = isString(node.arguments[1]) ? node.arguments[1].value : "";
 
-                if (node.arguments[1]) {
-                    flags = isString(node.arguments[1]) ? node.arguments[1].value : null;
-                    if (allowedFlags) {
-                        flags = flags.replace(allowedFlags, "");
-                    }
+                if (allowedFlags) {
+                    flags = flags.replace(allowedFlags, "");
                 }
 
                 // If flags are unknown, check both are errored or not.
                 const message = validateRegExpFlags(flags) || (
-                    (flags === null)
-                        ? validateRegExpPattern(pattern, true) && validateRegExpPattern(pattern, false)
-                        : validateRegExpPattern(pattern, flags.indexOf("u") !== -1)
+                    flags
+                        ? validateRegExpPattern(pattern, flags.indexOf("u") !== -1)
+                        : validateRegExpPattern(pattern, true) && validateRegExpPattern(pattern, false)
                 );
 
                 if (message) {

--- a/tests/lib/rules/no-invalid-regexp.js
+++ b/tests/lib/rules/no-invalid-regexp.js
@@ -23,6 +23,7 @@ ruleTester.run("no-invalid-regexp", rule, {
         "new RegExp",
         "new RegExp('.', 'im')",
         "global.RegExp('\\\\')",
+        "new RegExp('.', y)",
         { code: "new RegExp('.', 'y')", options: [{ allowConstructorFlags: ["y"] }] },
         { code: "new RegExp('.', 'u')", options: [{ allowConstructorFlags: ["U"] }] },
         { code: "new RegExp('.', 'yu')", options: [{ allowConstructorFlags: ["y", "u"] }] },


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
`flags` was Initialized to `""`, but sometimes it could be `null` -- this might cause confusing.

**Is there anything you'd like reviewers to focus on?**
no. 😃 

