### PR TITLE
Fix: `no-unused-vars` false positive on default params (fixes #10124)

### DIFF
--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -550,7 +550,12 @@ module.exports = {
                             }
 
                             // if "args" option is "after-used", skip all but the last parameter
-                            if (config.args === "after-used" && astUtils.isFunction(def.name.parent) && !isLastInNonIgnoredParameters(variable)) {
+                            if (
+                                config.args === "after-used" &&
+                                (astUtils.isFunction(def.name.parent) ||
+                                    (def.name.parent.type === "AssignmentPattern" && astUtils.isFunction(def.name.parent.parent))) &&
+                                !isLastInNonIgnoredParameters(variable)
+                            ) {
                                 continue;
                             }
                         } else {

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -85,6 +85,7 @@ ruleTester.run("no-unused-vars", rule, {
         { code: "function g(bar, baz) { return baz; }; g();", options: [{ vars: "all" }] },
         { code: "function g(bar, baz) { return baz; }; g();", options: [{ vars: "all", args: "after-used" }] },
         { code: "function g(bar, baz) { return bar; }; g();", options: [{ vars: "all", args: "none" }] },
+        { code: "function g(bar = 1, baz) { return baz; }; g();", options: [{ vars: "all", args: "after-used" }], parserOptions: { ecmaVersion: 6 } },
         { code: "function g(bar, baz) { return 2; }; g();", options: [{ vars: "all", args: "none" }] },
         { code: "function g(bar, baz) { return bar + baz; }; g();", options: [{ vars: "local", args: "all" }] },
         { code: "var g = function(bar, baz) { return 2; }; g();", options: [{ vars: "all", args: "none" }] },


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
https://github.com/eslint/eslint/issues/10124
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Not warn when using default parameters before the last used one, for example:

```js
function g(
  bar = 1, // this
  baz
) {
  return baz;
}
```

**Is there anything you'd like reviewers to focus on?**

I'm not too familiar with ASTs, so wasn't sure if I had to perform truthy checks before accessing nested properties such as `def.name.parent.type` and `def.name.parent.parent`, and whether I need another test case where `astUtils.isFunction(def.name.parent.parent)` can return `false` (for test coverage completeness)? Also not too sure if the logic is actually sound.
