### PR TITLE
Update: Fallback to no prefix when searching for eslint-config modules

### DIFF
--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -18,7 +18,8 @@ const fs = require("fs"),
     pathIsInside = require("path-is-inside"),
     stripComments = require("strip-json-comments"),
     stringify = require("json-stable-stringify-without-jsonify"),
-    requireUncached = require("require-uncached");
+    requireUncached = require("require-uncached"),
+    pathUtil = require("../util/path-util");
 
 const debug = require("debug")("eslint:config-file");
 
@@ -475,12 +476,27 @@ function resolve(filePath, relativeTo) {
     normalizedPackageName = naming.normalizePackageName(filePath, "eslint-config");
     debug(`Attempting to resolve ${normalizedPackageName}`);
 
-    return {
-        filePath: resolver.resolve(normalizedPackageName, getLookupPath(relativeTo)),
-        configFullName: filePath
-    };
+    let configDetails;
 
+    try {
+        configDetails = {
+            filePath: resolver.resolve(normalizedPackageName, getLookupPath(relativeTo)),
+            configFullName: filePath
+        };
+    } catch (e) {
+        try {
+            normalizedPackageName = filePath.indexOf("\\") > -1 ? pathUtil.convertPathToPosix(filePath) : filePath;
 
+            configDetails = {
+                filePath: resolver.resolve(normalizedPackageName, getLookupPath(relativeTo)),
+                configFullName: filePath
+            };
+        } catch (na) {
+            throw e;
+        }
+    }
+
+    return configDetails;
 }
 
 /**


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment**

* **ESLint Version:** 4.19.1
* **Node Version:** 8.10.0
* **npm Version:** 5.7.1

**What parser (default, Babel-ESLint, etc.) are you using?**
Babel-ESLint

**Please show your full configuration:**
```json
{
  "extends": "@edahlseng/linter-configuration"
}
```

**What did you do? Please include the actual source code causing the issue.**
I tried to extend configuration from a module that isn't named with a `eslint-config-` prefix.

**What did you expect to happen?**
I expected ESLint to check for a package prefixed by `eslint-config-` and then, if that failed, search for the exact package name. 

**What actually happened? Please include the actual, raw output from ESLint.**
ESLint failed to find the module, with the following error: `Cannot find module '@edahlseng/eslint-config-linter-configuration'`.

This issue was brought up about a year ago in #8644, but was closed due to inactivity.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
When resolving the file path for an ESLint config, I added a try-catch block. If the first attempt to resolve the path fails, ESLint now tries again, but without the `eslint-config-` prefix. If that still fails, then the original error is thrown.

**Is there anything you'd like reviewers to focus on?**
Nothing in particular; the total area of change is relatively small.

