### PR TITLE
Docs: Update capitalized-comments with missing letters (fixes #10135)

### DIFF
--- a/docs/rules/capitalized-comments.md
+++ b/docs/rules/capitalized-comments.md
@@ -175,7 +175,7 @@ If the `ignoreConsecutiveComments` option is set to `true`, then comments which 
 Examples of **correct** code with `ignoreConsecutiveComments` set to `true`:
 
 ```js
-/* eslint capitalize-comments: ["error", "always", { "ignoreConsecutiveComments": true }] */
+/* eslint capitalized-comments: ["error", "always", { "ignoreConsecutiveComments": true }] */
 
 // This comment is valid since it has the correct capitalization.
 // this comment is ignored since it follows another comment,
@@ -191,7 +191,7 @@ Examples of **correct** code with `ignoreConsecutiveComments` set to `true`:
 Examples of **incorrect** code with `ignoreConsecutiveComments` set to `true`:
 
 ```js
-/* eslint capitalize-comments: ["error", "always", { "ignoreConsecutiveComments": true }] */
+/* eslint capitalized-comments: ["error", "always", { "ignoreConsecutiveComments": true }] */
 
 // this comment is invalid, but only on this line.
 // this comment does NOT get reported, since it is a consecutive comment.


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Added `d` to the end of `capitalize` to make it `capitalized` in two places.

**Is there anything you'd like reviewers to focus on?**


