### PR TITLE
New: add max-classes-per-file rule

### DIFF
--- a/conf/eslint-recommended.js
+++ b/conf/eslint-recommended.js
@@ -65,6 +65,7 @@ module.exports = {
         "lines-around-comment": "off",
         "lines-around-directive": "off",
         "lines-between-class-members": "off",
+        "max-classes-per-file": "off",
         "max-depth": "off",
         "max-len": "off",
         "max-lines": "off",

--- a/docs/rules/max-classes-per-file.md
+++ b/docs/rules/max-classes-per-file.md
@@ -1,0 +1,39 @@
+# enforce a maximum number of classes per file (max-classes-per-file)
+
+Files containing multiple classes can often result in a less navigable
+and poorly structured codebase. Best practice is to keep each file
+limited to a single responsibility.
+
+## Rule Details
+
+This rule enforces that each file may contain only a particular number
+of classes and no more.
+
+Examples of **incorrect** code for this rule:
+
+```js
+/*eslint max-classes-per-file: "error"*/
+
+class Foo {}
+class Bar {}
+```
+
+Examples of **correct** code for this rule:
+
+```js
+/*eslint max-classes-per-file: "error"*/
+
+class Foo {}
+```
+
+## Options
+
+This rule has a numeric option (defaulted to 1) to specify the
+maximum number of classes:
+
+```js
+/*eslint max-classes-per-file: ["error", 2]*/
+
+class Foo {}
+class Bar {}
+```

--- a/docs/rules/max-classes-per-file.md
+++ b/docs/rules/max-classes-per-file.md
@@ -29,11 +29,11 @@ class Foo {}
 ## Options
 
 This rule has a numeric option (defaulted to 1) to specify the
-maximum number of classes:
+maximum number of classes.
+
+Examples of **correct** code for this rule with the numeric option set to `2`:
 
 ```js
-/*eslint max-classes-per-file: ["error", 2]*/
-
 class Foo {}
 class Bar {}
 ```

--- a/lib/rules/max-classes-per-file.js
+++ b/lib/rules/max-classes-per-file.js
@@ -52,10 +52,7 @@ module.exports = {
                     });
                 }
             },
-            ClassDeclaration() {
-                classCount++;
-            },
-            ClassExpression() {
+            "ClassDeclaration, ClassExpression"() {
                 classCount++;
             }
         };

--- a/lib/rules/max-classes-per-file.js
+++ b/lib/rules/max-classes-per-file.js
@@ -1,0 +1,63 @@
+/**
+ * @fileoverview Enforce a maximum number of classes per file
+ * @author James Garbutt <https://github.com/43081j>
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "enforce a maximum number of classes per file",
+            category: "Best Practices",
+            recommended: false,
+            url: "https://eslint.org/docs/rules/max-classes-per-file"
+        },
+        schema: [
+            {
+                type: "integer",
+                minimum: 1
+            }
+        ],
+        messages: {
+            maximumExceeded: "Number of classes per file must not exceed {{ max }}"
+        }
+    },
+    create(context) {
+
+        const maxClasses = context.options[0] || 1;
+
+        let classCount = 0;
+
+        return {
+            Program() {
+                classCount = 0;
+            },
+            "Program:exit"(node) {
+                if (classCount > maxClasses) {
+                    context.report({
+                        node,
+                        messageId: "maximumExceeded",
+                        data: {
+                            max: maxClasses
+                        }
+                    });
+                }
+            },
+            ClassDeclaration() {
+                classCount++;
+            },
+            ClassExpression() {
+                classCount++;
+            }
+        };
+    }
+};

--- a/tests/lib/rules/max-classes-per-file.js
+++ b/tests/lib/rules/max-classes-per-file.js
@@ -15,60 +15,44 @@ const rule = require("../../../lib/rules/max-classes-per-file"),
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
 
 ruleTester.run("max-classes-per-file", rule, {
     valid: [
+        "class Foo {}",
+        "var x = class {};",
+        "var x = 5;",
         {
             code: "class Foo {}",
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "var x = class {};",
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "var x = 5;",
-            parserOptions: { ecmaVersion: 6 }
-        },
-        {
-            code: "class Foo {}",
-            options: [1],
-            parserOptions: { ecmaVersion: 6 }
+            options: [1]
         },
         {
             code: "class Foo {}\nclass Bar {}",
-            options: [2],
-            parserOptions: { ecmaVersion: 6 }
+            options: [2]
         }
     ],
 
     invalid: [
         {
             code: "class Foo {}\nclass Bar {}",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ messageId: "maximumExceeded", type: "Program" }]
         },
         {
             code: "var x = class {};\nvar y = class {};",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ messageId: "maximumExceeded", type: "Program" }]
         },
         {
             code: "class Foo {}\nvar x = class {};",
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ messageId: "maximumExceeded", type: "Program" }]
         },
         {
             code: "class Foo {} class Bar {}",
             options: [1],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ messageId: "maximumExceeded", type: "Program" }]
         },
         {
             code: "class Foo {} class Bar {} class Baz {}",
             options: [2],
-            parserOptions: { ecmaVersion: 6 },
             errors: [{ messageId: "maximumExceeded", type: "Program" }]
         }
     ]

--- a/tests/lib/rules/max-classes-per-file.js
+++ b/tests/lib/rules/max-classes-per-file.js
@@ -1,0 +1,75 @@
+/**
+ * @fileoverview Tests for max-classes-per-file rule.
+ * @author James Garbutt <https://github.com/43081j>
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../lib/rules/max-classes-per-file"),
+    RuleTester = require("../../../lib/testers/rule-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("max-classes-per-file", rule, {
+    valid: [
+        {
+            code: "class Foo {}",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var x = class {};",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var x = 5;",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "class Foo {}",
+            options: [1],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "class Foo {}\nclass Bar {}",
+            options: [2],
+            parserOptions: { ecmaVersion: 6 }
+        }
+    ],
+
+    invalid: [
+        {
+            code: "class Foo {}\nclass Bar {}",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "maximumExceeded", type: "Program" }]
+        },
+        {
+            code: "var x = class {};\nvar y = class {};",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "maximumExceeded", type: "Program" }]
+        },
+        {
+            code: "class Foo {}\nvar x = class {};",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "maximumExceeded", type: "Program" }]
+        },
+        {
+            code: "class Foo {} class Bar {}",
+            options: [1],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "maximumExceeded", type: "Program" }]
+        },
+        {
+            code: "class Foo {} class Bar {} class Baz {}",
+            options: [2],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "maximumExceeded", type: "Program" }]
+        }
+    ]
+});


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))

**Please describe what the rule should do:**

Enforce a maximum number of classes per file.

**What category of rule is this? (place an "X" next to just one item)**

[x] Enforces code style

**Provide 2-3 code examples that this rule will warn about:**

```js
// incorrect with defaults
class Foo {}
class Bar {}

// correct with defaults
class Foo {}

// correct with excludeClassExpressions
class Foo {}
var Bar = class {};
```

**Why should this rule be included in ESLint (instead of a plugin)?**

It's a fairly common best practice many follow already.
