### PR TITLE
Fix: report no-case-declarations from declarations (fixes #10048)

### DIFF
--- a/lib/rules/no-case-declarations.js
+++ b/lib/rules/no-case-declarations.js
@@ -50,7 +50,7 @@ module.exports = {
 
                     if (isLexicalDeclaration(statement)) {
                         context.report({
-                            node,
+                            node: statement,
                             messageId: "unexpected"
                         });
                     }

--- a/tests/lib/rules/no-case-declarations.js
+++ b/tests/lib/rules/no-case-declarations.js
@@ -41,42 +41,42 @@ ruleTester.run("no-case-declarations", rule, {
         {
             code: "switch (a) { case 1: let x = 1; break; }",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ messageId: "unexpected" }]
+            errors: [{ messageId: "unexpected", type: "VariableDeclaration" }]
         },
         {
             code: "switch (a) { default: let x = 2; break; }",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ messageId: "unexpected" }]
+            errors: [{ messageId: "unexpected", type: "VariableDeclaration" }]
         },
         {
             code: "switch (a) { case 1: const x = 1; break; }",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ messageId: "unexpected" }]
+            errors: [{ messageId: "unexpected", type: "VariableDeclaration" }]
         },
         {
             code: "switch (a) { default: const x = 2; break; }",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ messageId: "unexpected" }]
+            errors: [{ messageId: "unexpected", type: "VariableDeclaration" }]
         },
         {
             code: "switch (a) { case 1: function f() {} break; }",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ messageId: "unexpected" }]
+            errors: [{ messageId: "unexpected", type: "FunctionDeclaration" }]
         },
         {
             code: "switch (a) { default: function f() {} break; }",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ messageId: "unexpected" }]
+            errors: [{ messageId: "unexpected", type: "FunctionDeclaration" }]
         },
         {
             code: "switch (a) { case 1: class C {} break; }",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ messageId: "unexpected" }]
+            errors: [{ messageId: "unexpected", type: "ClassDeclaration" }]
         },
         {
             code: "switch (a) { default: class C {} break; }",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ messageId: "unexpected" }]
+            errors: [{ messageId: "unexpected", type: "ClassDeclaration" }]
         }
     ]
 });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
`no-case-declarations` is now on the variable declaration statement instead of the SwitchCase.

**Is there anything you'd like reviewers to focus on?**


