### PR TITLE
Upgrade: esquery@^1.0.1 (fixes #8733)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint-scope": "^3.7.1",
     "eslint-visitor-keys": "^1.0.0",
     "espree": "^4.0.0-alpha.0",
-    "esquery": "^1.0.0",
+    "esquery": "^1.0.1",
     "esutils": "^2.0.2",
     "file-entry-cache": "^2.0.0",
     "functional-red-black-tree": "^1.0.1",

--- a/tests/lib/rules/no-restricted-syntax.js
+++ b/tests/lib/rules/no-restricted-syntax.js
@@ -37,9 +37,9 @@ ruleTester.run("no-restricted-syntax", rule, {
             code: "({ foo: 1, bar: 2 })",
             options: [{ selector: "FunctionDeclaration[params.length>2]", message: "custom error message." }]
         },
-        
+
         // https://github.com/eslint/eslint/issues/8733
-        { code: "console.log(/a/);", options: ["Literal[regex.flags=/./]"] },
+        { code: "console.log(/a/);", options: ["Literal[regex.flags=/./]"] }
     ],
     invalid: [
 
@@ -123,7 +123,7 @@ ruleTester.run("no-restricted-syntax", rule, {
             options: [{ selector: "FunctionDeclaration[params.length>2]", message: "custom message with {{selector}}" }],
             errors: [{ message: "custom message with {{selector}}", type: "FunctionDeclaration" }]
         },
-        
+
         // https://github.com/eslint/eslint/issues/8733
         {
             code: "console.log(/a/i);",

--- a/tests/lib/rules/no-restricted-syntax.js
+++ b/tests/lib/rules/no-restricted-syntax.js
@@ -98,7 +98,6 @@ ruleTester.run("no-restricted-syntax", rule, {
             options: ["FunctionDeclaration[params.length>2]"],
             errors: [{ message: "Using 'FunctionDeclaration[params.length>2]' is not allowed.", type: "FunctionDeclaration" }]
         },
-        { code: "console.log(/a/);", options: ["Literal[regex.flags=/./]"] },
 
         // object format
         {

--- a/tests/lib/rules/no-restricted-syntax.js
+++ b/tests/lib/rules/no-restricted-syntax.js
@@ -36,7 +36,10 @@ ruleTester.run("no-restricted-syntax", rule, {
         {
             code: "({ foo: 1, bar: 2 })",
             options: [{ selector: "FunctionDeclaration[params.length>2]", message: "custom error message." }]
-        }
+        },
+        
+        // https://github.com/eslint/eslint/issues/8733
+        { code: "console.log(/a/);", options: ["Literal[regex.flags=/./]"] },
     ],
     invalid: [
 
@@ -95,6 +98,7 @@ ruleTester.run("no-restricted-syntax", rule, {
             options: ["FunctionDeclaration[params.length>2]"],
             errors: [{ message: "Using 'FunctionDeclaration[params.length>2]' is not allowed.", type: "FunctionDeclaration" }]
         },
+        { code: "console.log(/a/);", options: ["Literal[regex.flags=/./]"] },
 
         // object format
         {
@@ -118,6 +122,13 @@ ruleTester.run("no-restricted-syntax", rule, {
             code: "function foo(bar, baz, qux) {}",
             options: [{ selector: "FunctionDeclaration[params.length>2]", message: "custom message with {{selector}}" }],
             errors: [{ message: "custom message with {{selector}}", type: "FunctionDeclaration" }]
+        },
+        
+        // https://github.com/eslint/eslint/issues/8733
+        {
+            code: "console.log(/a/i);",
+            options: ["Literal[regex.flags=/./]"],
+            errors: [{ message: "Using 'Literal[regex.flags=/./]' is not allowed.", type: "Literal" }]
         }
     ]
 });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

See #8733.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Upgraded esquery to ^1.0.1. This pulls in a bugfix for #8733.

**Is there anything you'd like reviewers to focus on?**

Do we want to add unit tests to the no-restricted-syntax rule to try to catch regressions here?