### PR TITLE
Chore: Remove `esprima-fb` dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "eslint-rule-composer": "^0.1.0",
     "eslump": "1.6.0",
     "esprima": "^4.0.0",
-    "esprima-fb": "^15001.1001.0-dev-harmony-fb",
     "istanbul": "^0.4.5",
     "jsdoc": "^3.4.3",
     "karma": "^1.7.0",

--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -974,7 +974,7 @@ describe("Linter", () => {
         if (typeof window === "undefined") {
             it("should pass parser as parserPath to all rules when provided on config", () => {
 
-                const alternateParser = "esprima-fb";
+                const alternateParser = "esprima";
 
                 linter.defineRule("test-rule", sandbox.mock().withArgs(
                     sinon.match({ parserPath: alternateParser })
@@ -4209,18 +4209,18 @@ describe("Linter", () => {
 
             it("should not report an error when JSX code contains a spread operator and JSX is enabled", () => {
                 const code = "var myDivElement = <div {...this.props} />;";
-                const messages = linter.verify(code, { parser: "esprima-fb" }, "filename");
+                const messages = linter.verify(code, { parser: "esprima", parserOptions: { jsx: true } }, "filename");
 
                 assert.strictEqual(messages.length, 0);
             });
 
             it("should return an error when the custom parser can't be found", () => {
                 const code = "var myDivElement = <div {...this.props} />;";
-                const messages = linter.verify(code, { parser: "esprima-fbxyz" }, "filename");
+                const messages = linter.verify(code, { parser: "esprima-xyz" }, "filename");
 
                 assert.strictEqual(messages.length, 1);
                 assert.strictEqual(messages[0].severity, 2);
-                assert.strictEqual(messages[0].message, "Cannot find module 'esprima-fbxyz'");
+                assert.strictEqual(messages[0].message, "Cannot find module 'esprima-xyz'");
             });
 
             it("should strip leading line: prefix from parser error", () => {


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] Other, please explain:
Remove a dependency.
<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Replace `esprima-fb` usage in tests by `esprima`

**Is there anything you'd like reviewers to focus on?**
No.

