### PR TITLE
Chore: remove concat-stream dependency

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -27,8 +27,7 @@ if (debug) {
 //------------------------------------------------------------------------------
 
 // now we can safely include the other modules that use debug
-const concat = require("concat-stream"),
-    cli = require("../lib/cli"),
+const cli = require("../lib/cli"),
     path = require("path"),
     fs = require("fs");
 
@@ -57,9 +56,7 @@ process.once("uncaughtException", err => {
 });
 
 if (useStdIn) {
-    process.stdin.pipe(concat({ encoding: "string" }, text => {
-        process.exitCode = cli.execute(process.argv, text);
-    }));
+    process.exitCode = cli.execute(process.argv, fs.readFileSync(process.stdin.fd, "utf8"));
 } else if (init) {
     const configInit = require("../lib/config/config-initializer");
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "ajv": "^5.3.0",
     "babel-code-frame": "^6.26.0",
     "chalk": "^2.1.0",
-    "concat-stream": "^1.6.2",
     "cross-spawn": "^5.1.0",
     "debug": "^3.1.0",
     "doctrine": "^2.1.0",


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

We use the `concat-stream` module to get source text from stdin when the `--stdin` flag is used. However, getting text from stdin is a one-liner without `concat-stream`, so it's not necessary to keep it as a dependency. (This is the same change as https://github.com/eslint/eslint/pull/8571.)

This is blocked on dropping support for Node 4 (https://github.com/eslint/eslint/issues/10052) because it relies on `fs.readFileSync` being able to read from a file descriptor, a capability which was initially added in Node 5.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
