### PR TITLE
New: Add `globInputPaths` CLIEngine option (fixes #9972)

### DIFF
--- a/conf/default-cli-options.js
+++ b/conf/default-cli-options.js
@@ -26,5 +26,6 @@ module.exports = {
     cacheFile: ".eslintcache",
     fix: false,
     allowInlineConfig: true,
-    reportUnusedDisableDirectives: false
+    reportUnusedDisableDirectives: false,
+    globInputPaths: true
 };

--- a/docs/developer-guide/nodejs-api.md
+++ b/docs/developer-guide/nodejs-api.md
@@ -350,6 +350,7 @@ The `CLIEngine` is a constructor, and you can create a new instance by passing i
 * `rulePaths` - An array of directories to load custom rules from (default: empty array). Corresponds to `--rulesdir`.
 * `rules` - An object of rules to use (default: null). Corresponds to `--rule`.
 * `useEslintrc` - Set to false to disable use of `.eslintrc` files (default: true). Corresponds to `--no-eslintrc`.
+* `globInputPaths` - Set to false to skip glob resolution of input file paths to lint (default: true). If false, each input file paths is assumed to be a non-glob path to an existing file.
 
 
 

--- a/lib/util/glob-util.js
+++ b/lib/util/glob-util.js
@@ -154,11 +154,15 @@ function testFileAgainstIgnorePatterns(filename, options, isDirectPath, ignoredP
 
 /**
  * Resolves any directory patterns into glob-based patterns for easier handling.
- * @param   {string[]} patterns    File patterns (such as passed on the command line).
- * @param   {Object} options       An options object.
+ * @param   {string[]} patterns               File patterns (such as passed on the command line).
+ * @param   {Object} options                  An options object.
+ * @param   {string} [options.globInputPaths] False disables glob resolution.
  * @returns {string[]} The equivalent glob patterns and filepath strings.
  */
 function resolveFileGlobPatterns(patterns, options) {
+    if (options.globInputPaths === false) {
+        return patterns;
+    }
 
     const processPathExtensions = processPath(options);
 
@@ -171,12 +175,13 @@ const dotfilesPattern = /(?:(?:^\.)|(?:[/\\]\.))[^/\\.].*/;
  * Build a list of absolute filesnames on which ESLint will act.
  * Ignored files are excluded from the results, as are duplicates.
  *
- * @param   {string[]} globPatterns                    Glob patterns.
- * @param   {Object}   [providedOptions]               An options object.
- * @param   {string}   [providedOptions.cwd]           CWD (considered for relative filenames)
- * @param   {boolean}  [providedOptions.ignore]        False disables use of .eslintignore.
- * @param   {string}   [providedOptions.ignorePath]    The ignore file to use instead of .eslintignore.
- * @param   {string}   [providedOptions.ignorePattern] A pattern of files to ignore.
+ * @param   {string[]} globPatterns                     Glob patterns.
+ * @param   {Object}   [providedOptions]                An options object.
+ * @param   {string}   [providedOptions.cwd]            CWD (considered for relative filenames)
+ * @param   {boolean}  [providedOptions.ignore]         False disables use of .eslintignore.
+ * @param   {string}   [providedOptions.ignorePath]     The ignore file to use instead of .eslintignore.
+ * @param   {string}   [providedOptions.ignorePattern]  A pattern of files to ignore.
+ * @param   {string}   [providedOptions.globInputPaths] False disables glob resolution.
  * @returns {string[]} Resolved absolute filenames.
  */
 function listFilesToProcess(globPatterns, providedOptions) {
@@ -198,9 +203,9 @@ function listFilesToProcess(globPatterns, providedOptions) {
     const resolvedPathsByGlobPattern = resolvedGlobPatterns.map(pattern => {
         const file = path.resolve(cwd, pattern);
 
-        if (fs.existsSync(file) && fs.statSync(file).isFile()) {
+        if (options.globInputPaths === false || (fs.existsSync(file) && fs.statSync(file).isFile())) {
             const ignoredPaths = getIgnorePaths(options);
-            const fullPath = fs.realpathSync(file);
+            const fullPath = options.globInputPaths === false ? file : fs.realpathSync(file);
 
             return [{
                 filename: fullPath,

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -733,6 +733,33 @@ describe("CLIEngine", () => {
             assert.strictEqual(report.results[1].messages.length, 0);
         });
 
+        it("should resolve globs when 'globInputPaths' option is true", () => {
+            engine = new CLIEngine({
+                extensions: [".js", ".js2"],
+                ignore: false,
+                cwd: getFixturePath("..")
+            });
+
+            const report = engine.executeOnFiles(["fixtures/files/*"]);
+
+            assert.strictEqual(report.results.length, 2);
+            assert.strictEqual(report.results[0].messages.length, 0);
+            assert.strictEqual(report.results[1].messages.length, 0);
+        });
+
+        it("should not resolve globs when 'globInputPaths' option is false", () => {
+            engine = new CLIEngine({
+                extensions: [".js", ".js2"],
+                ignore: false,
+                cwd: getFixturePath(".."),
+                globInputPaths: false
+            });
+
+            assert.throws(() => {
+                engine.executeOnFiles(["fixtures/files/*"]);
+            }, `ENOENT: no such file or directory, open '${getFixturePath("..", "fixtures", "files", "*")}`);
+        });
+
         it("should report on all files passed explicitly, even if ignored by default", () => {
 
             engine = new CLIEngine({

--- a/tests/lib/util/glob-util.js
+++ b/tests/lib/util/glob-util.js
@@ -58,6 +58,17 @@ describe("globUtil", () => {
             assert.deepStrictEqual(result, ["one-js-file/**/*.js"]);
         });
 
+        it("should not convert path with globInputPaths option false", () => {
+            const patterns = ["one-js-file"];
+            const opts = {
+                cwd: getFixturePath("glob-util"),
+                globInputPaths: false
+            };
+            const result = globUtil.resolveFileGlobPatterns(patterns, opts);
+
+            assert.deepStrictEqual(result, ["one-js-file"]);
+        });
+
         it("should convert an absolute directory name with no provided extensions into a posix glob pattern", () => {
             const patterns = [getFixturePath("glob-util", "one-js-file")];
             const opts = {
@@ -151,6 +162,19 @@ describe("globUtil", () => {
             });
 
             const file1 = getFixturePath("glob-util", "one-js-file", "baz.js");
+
+            assert.isArray(result);
+            assert.deepStrictEqual(result, [{ filename: file1, ignored: false }]);
+        });
+
+        it("should return an array with a unmodified filename", () => {
+            const patterns = [getFixturePath("glob-util", "one-js-file", "**/*.js")];
+            const result = globUtil.listFilesToProcess(patterns, {
+                cwd: getFixturePath(),
+                globInputPaths: false
+            });
+
+            const file1 = getFixturePath("glob-util", "one-js-file", "**/*.js");
 
             assert.isArray(result);
             assert.deepStrictEqual(result, [{ filename: file1, ignored: false }]);


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**
[x] Add something to the core

**What changes did you make? (Give an overview)**

Add `globInputPaths` CLIEngine option.
Set to false to skip glob resolution of input file paths to lint (default: true). If false, each input file paths is assumed to be a non-glob path to an existing file.

**Is there anything you'd like reviewers to focus on?**

Should more doc be added somewhere else?

