### PR TITLE
Chore: remove assert.doesNotThrow in tests

### DIFF
--- a/tests/.eslintrc.yml
+++ b/tests/.eslintrc.yml
@@ -1,2 +1,8 @@
 env:
   mocha: true
+
+rules:
+  no-restricted-syntax:
+    - error
+    - selector: "CallExpression[callee.object.name='assert'][callee.property.name='doesNotThrow']"
+      message: "`assert.doesNotThrow()` should be replaced with a comment next to the code."

--- a/tests/bin/eslint.js
+++ b/tests/bin/eslint.js
@@ -221,11 +221,8 @@ describe("bin/eslint.js", () => {
                 return assertExitCode(child, 0).then(() => {
                     assert.isTrue(fs.existsSync(CACHE_PATH), "Cache file should exist at the given location");
 
-                    assert.doesNotThrow(
-                        () => JSON.parse(fs.readFileSync(CACHE_PATH, "utf8")),
-                        SyntaxError,
-                        "Cache file should contain valid JSON"
-                    );
+                    // Cache file should contain valid JSON
+                    JSON.parse(fs.readFileSync(CACHE_PATH, "utf8"));
                 });
             });
         });
@@ -289,11 +286,9 @@ describe("bin/eslint.js", () => {
 
                 return assertExitCode(child, 0).then(() => {
                     assert.isTrue(fs.existsSync(CACHE_PATH), "Cache file should exist at the given location");
-                    assert.doesNotThrow(
-                        () => JSON.parse(fs.readFileSync(CACHE_PATH, "utf8")),
-                        SyntaxError,
-                        "Cache file should contain valid JSON"
-                    );
+
+                    // Cache file should contain valid JSON
+                    JSON.parse(fs.readFileSync(CACHE_PATH, "utf8"));
                 });
             });
 

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -128,9 +128,7 @@ describe("cli", () => {
             const configPath = getFixturePath(".eslintrc");
             const filePath = getFixturePath("passing.js");
 
-            assert.doesNotThrow(() => {
-                cli.execute(`--config ${configPath} ${filePath}`);
-            });
+            cli.execute(`--config ${configPath} ${filePath}`);
         });
     });
 
@@ -141,10 +139,6 @@ describe("cli", () => {
 
             // Mock CWD
             process.eslintCwd = getFixturePath("configurations", "single-quotes");
-
-            assert.doesNotThrow(() => {
-                cli.execute(code);
-            });
 
             cli.execute(code);
 
@@ -170,11 +164,7 @@ describe("cli", () => {
             const filePath = getFixturePath("formatters");
             const code = `--config ${configPath} ${filePath}`;
 
-            let exitStatus;
-
-            assert.doesNotThrow(() => {
-                exitStatus = cli.execute(code);
-            });
+            const exitStatus = cli.execute(code);
 
             assert.strictEqual(exitStatus, 0);
         });

--- a/tests/lib/config.js
+++ b/tests/lib/config.js
@@ -1046,9 +1046,7 @@ describe("Config", () => {
                     useEslintrc: false
                 }, linter);
 
-                assert.doesNotThrow(() => {
-                    config.getConfig(filePath);
-                }, "No ESLint configuration found");
+                config.getConfig(filePath);
             });
 
             it("should not throw an error if no local config and no personal config was found but rules are specified", () => {
@@ -1067,9 +1065,7 @@ describe("Config", () => {
                     rules: { quotes: [2, "single"] }
                 }, linter);
 
-                assert.doesNotThrow(() => {
-                    config.getConfig(filePath);
-                }, "No ESLint configuration found");
+                config.getConfig(filePath);
             });
 
             it("should not throw an error if no local config and no personal config was found but baseConfig is specified", () => {
@@ -1088,9 +1084,7 @@ describe("Config", () => {
                     baseConfig: {}
                 }, linter);
 
-                assert.doesNotThrow(() => {
-                    config.getConfig(filePath);
-                }, "No ESLint configuration found");
+                config.getConfig(filePath);
             });
         });
 

--- a/tests/lib/config/config-validator.js
+++ b/tests/lib/config/config-validator.js
@@ -107,14 +107,11 @@ describe("Validator", () => {
     describe("validate", () => {
 
         it("should do nothing with an empty config", () => {
-            const fn = validator.validate.bind(null, {}, "tests", ruleMapper, linter.environments);
-
-            assert.doesNotThrow(fn);
+            validator.validate({}, "tests", ruleMapper, linter.environments);
         });
 
         it("should do nothing with a valid eslint config", () => {
-            const fn = validator.validate.bind(
-                null,
+            validator.validate(
                 {
                     root: true,
                     globals: { globalFoo: "bar" },
@@ -130,8 +127,6 @@ describe("Validator", () => {
                 ruleMapper,
                 linter.environments
             );
-
-            assert.doesNotThrow(fn);
         });
 
         it("should throw with an unknown property", () => {
@@ -178,9 +173,7 @@ describe("Validator", () => {
 
         describe("parser", () => {
             it("should not throw with a null value", () => {
-                const fn = validator.validate.bind(null, { parser: null }, null, ruleMapper, linter.environments);
-
-                assert.doesNotThrow(fn);
+                validator.validate({ parser: null }, null, ruleMapper, linter.environments);
             });
         });
 
@@ -211,18 +204,14 @@ describe("Validator", () => {
             });
 
             it("should do nothing with an undefined environment", () => {
-                const fn = validator.validate.bind(null, {}, null, ruleMapper, linter.environments);
-
-                assert.doesNotThrow(fn);
+                validator.validate({}, null, ruleMapper, linter.environments);
             });
 
         });
 
         describe("plugins", () => {
             it("should not throw with an empty array", () => {
-                const fn = validator.validate.bind(null, { plugins: [] }, null, ruleMapper, linter.environments);
-
-                assert.doesNotThrow(fn);
+                validator.validate({ plugins: [] }, null, ruleMapper, linter.environments);
             });
 
             it("should throw with a string", () => {
@@ -234,9 +223,7 @@ describe("Validator", () => {
 
         describe("settings", () => {
             it("should not throw with an empty object", () => {
-                const fn = validator.validate.bind(null, { settings: {} }, null, ruleMapper, linter.environments);
-
-                assert.doesNotThrow(fn);
+                validator.validate({ settings: {} }, null, ruleMapper, linter.environments);
             });
 
             it("should throw with an array", () => {
@@ -248,15 +235,11 @@ describe("Validator", () => {
 
         describe("extends", () => {
             it("should not throw with an empty array", () => {
-                const fn = validator.validate.bind(null, { extends: [] }, null, ruleMapper, linter.environments);
-
-                assert.doesNotThrow(fn);
+                validator.validate({ extends: [] }, null, ruleMapper, linter.environments);
             });
 
             it("should not throw with a string", () => {
-                const fn = validator.validate.bind(null, { extends: "react" }, null, ruleMapper, linter.environments);
-
-                assert.doesNotThrow(fn);
+                validator.validate({ extends: "react" }, null, ruleMapper, linter.environments);
             });
 
             it("should throw with an object", () => {
@@ -268,9 +251,7 @@ describe("Validator", () => {
 
         describe("parserOptions", () => {
             it("should not throw with an empty object", () => {
-                const fn = validator.validate.bind(null, { parserOptions: {} }, null, ruleMapper, linter.environments);
-
-                assert.doesNotThrow(fn);
+                validator.validate({ parserOptions: {} }, null, ruleMapper, linter.environments);
             });
 
             it("should throw with an array", () => {
@@ -283,63 +264,43 @@ describe("Validator", () => {
         describe("rules", () => {
 
             it("should do nothing with an empty rules object", () => {
-                const fn = validator.validate.bind(null, { rules: {} }, "tests", ruleMapper, linter.environments);
-
-                assert.doesNotThrow(fn);
+                validator.validate({ rules: {} }, "tests", ruleMapper, linter.environments);
             });
 
             it("should do nothing with a valid config with rules", () => {
-                const fn = validator.validate.bind(null, { rules: { "mock-rule": [2, "second"] } }, "tests", ruleMapper, linter.environments);
-
-                assert.doesNotThrow(fn);
+                validator.validate({ rules: { "mock-rule": [2, "second"] } }, "tests", ruleMapper, linter.environments);
             });
 
             it("should do nothing with a valid config when severity is off", () => {
-                const fn = validator.validate.bind(null, { rules: { "mock-rule": ["off", "second"] } }, "tests", ruleMapper, linter.environments);
-
-                assert.doesNotThrow(fn);
+                validator.validate({ rules: { "mock-rule": ["off", "second"] } }, "tests", ruleMapper, linter.environments);
             });
 
             it("should do nothing with an invalid config when severity is off", () => {
-                const fn = validator.validate.bind(null, { rules: { "mock-required-options-rule": "off" } }, "tests", ruleMapper, linter.environments);
-
-                assert.doesNotThrow(fn);
+                validator.validate({ rules: { "mock-required-options-rule": "off" } }, "tests", ruleMapper, linter.environments);
             });
 
             it("should do nothing with an invalid config when severity is an array with 'off'", () => {
-                const fn = validator.validate.bind(null, { rules: { "mock-required-options-rule": ["off"] } }, "tests", ruleMapper, linter.environments);
-
-                assert.doesNotThrow(fn);
+                validator.validate({ rules: { "mock-required-options-rule": ["off"] } }, "tests", ruleMapper, linter.environments);
             });
 
             it("should do nothing with a valid config when severity is warn", () => {
-                const fn = validator.validate.bind(null, { rules: { "mock-rule": ["warn", "second"] } }, "tests", ruleMapper, linter.environments);
-
-                assert.doesNotThrow(fn);
+                validator.validate({ rules: { "mock-rule": ["warn", "second"] } }, "tests", ruleMapper, linter.environments);
             });
 
             it("should do nothing with a valid config when severity is error", () => {
-                const fn = validator.validate.bind(null, { rules: { "mock-rule": ["error", "second"] } }, "tests", ruleMapper, linter.environments);
-
-                assert.doesNotThrow(fn);
+                validator.validate({ rules: { "mock-rule": ["error", "second"] } }, "tests", ruleMapper, linter.environments);
             });
 
             it("should do nothing with a valid config when severity is Off", () => {
-                const fn = validator.validate.bind(null, { rules: { "mock-rule": ["Off", "second"] } }, "tests", ruleMapper, linter.environments);
-
-                assert.doesNotThrow(fn);
+                validator.validate({ rules: { "mock-rule": ["Off", "second"] } }, "tests", ruleMapper, linter.environments);
             });
 
             it("should do nothing with a valid config when severity is Warn", () => {
-                const fn = validator.validate.bind(null, { rules: { "mock-rule": ["Warn", "second"] } }, "tests", ruleMapper, linter.environments);
-
-                assert.doesNotThrow(fn);
+                validator.validate({ rules: { "mock-rule": ["Warn", "second"] } }, "tests", ruleMapper, linter.environments);
             });
 
             it("should do nothing with a valid config when severity is Error", () => {
-                const fn = validator.validate.bind(null, { rules: { "mock-rule": ["Error", "second"] } }, "tests", ruleMapper, linter.environments);
-
-                assert.doesNotThrow(fn);
+                validator.validate({ rules: { "mock-rule": ["Error", "second"] } }, "tests", ruleMapper, linter.environments);
             });
 
             it("should catch invalid rule options", () => {
@@ -351,9 +312,7 @@ describe("Validator", () => {
             it("should allow for rules with no options", () => {
                 linter.defineRule("mock-no-options-rule", mockNoOptionsRule);
 
-                const fn = validator.validate.bind(null, { rules: { "mock-no-options-rule": 2 } }, "tests", ruleMapper, linter.environments);
-
-                assert.doesNotThrow(fn);
+                validator.validate({ rules: { "mock-no-options-rule": 2 } }, "tests", ruleMapper, linter.environments);
             });
 
             it("should not allow options for rules with no options", () => {
@@ -367,15 +326,11 @@ describe("Validator", () => {
 
         describe("overrides", () => {
             it("should not throw with an empty overrides array", () => {
-                const fn = validator.validate.bind(null, { overrides: [] }, "tests", ruleMapper, linter.environments);
-
-                assert.doesNotThrow(fn);
+                validator.validate({ overrides: [] }, "tests", ruleMapper, linter.environments);
             });
 
             it("should not throw with a valid overrides array", () => {
-                const fn = validator.validate.bind(null, { overrides: [{ files: "*", rules: {} }] }, "tests", ruleMapper, linter.environments);
-
-                assert.doesNotThrow(fn);
+                validator.validate({ overrides: [{ files: "*", rules: {} }] }, "tests", ruleMapper, linter.environments);
             });
 
             it("should throw if override does not specify files", () => {

--- a/tests/lib/ignored-paths.js
+++ b/tests/lib/ignored-paths.js
@@ -302,9 +302,7 @@ describe("IgnoredPaths", () => {
         it("should not throw if given a relative filename", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: true, ignorePattern: "undef.js", cwd: getFixturePath() });
 
-            assert.doesNotThrow(() => {
-                ignoredPaths.contains("undef.js");
-            });
+            ignoredPaths.contains("undef.js");
         });
 
         it("should return true for files which match an ignorePattern even if they do not exist on the filesystem", () => {

--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -3494,9 +3494,7 @@ describe("Linter", () => {
             const config = {};
 
             Object.freeze(config);
-            assert.doesNotThrow(() => {
-                linter.verify("var foo", config);
-            });
+            linter.verify("var", config);
         });
 
         it("should pass 'id' to rule contexts with the rule id", () => {
@@ -4357,9 +4355,7 @@ describe("Linter", () => {
                 })
             });
 
-            assert.doesNotThrow(() => {
-                linter.verify("0", { rules: { "test-rule": "error" } });
-            });
+            linter.verify("0", { rules: { "test-rule": "error" } });
         });
     });
 

--- a/tests/lib/testers/rule-tester.js
+++ b/tests/lib/testers/rule-tester.js
@@ -85,16 +85,13 @@ describe("RuleTester", () => {
     });
 
     it("should not throw an error when everything passes", () => {
-
-        assert.doesNotThrow(() => {
-            ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
-                valid: [
-                    "Eval(foo)"
-                ],
-                invalid: [
-                    { code: "eval(foo)", errors: [{ message: "eval sucks.", type: "CallExpression" }] }
-                ]
-            });
+        ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+            valid: [
+                "Eval(foo)"
+            ],
+            invalid: [
+                { code: "eval(foo)", errors: [{ message: "eval sucks.", type: "CallExpression" }] }
+            ]
         });
     });
 
@@ -210,44 +207,37 @@ describe("RuleTester", () => {
     });
 
     it("should not throw an error when the error is a string and it matches error message", () => {
-        assert.doesNotThrow(() => {
-            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+        ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
 
-                // Only the invalid test matters here
-                valid: [
-                    "bar = baz;"
-                ],
-                invalid: [
-                    { code: "var foo = bar;", errors: ["Bad var."] }
-                ]
-            });
+            // Only the invalid test matters here
+            valid: [
+                "bar = baz;"
+            ],
+            invalid: [
+                { code: "var foo = bar;", errors: ["Bad var."] }
+            ]
         });
     });
 
     it("should not throw an error when the error is a regex and it matches error message", () => {
-        assert.doesNotThrow(() => {
-            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
-                valid: [],
-                invalid: [
-                    { code: "var foo = bar;", errors: [/^Bad var/] }
-                ]
-            });
+        ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+            valid: [],
+            invalid: [
+                { code: "var foo = bar;", errors: [/^Bad var/] }
+            ]
         });
     });
 
     it("should not throw an error when the error is a regex in an object and it matches error message", () => {
-        assert.doesNotThrow(() => {
-            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
-                valid: [],
-                invalid: [
-                    { code: "var foo = bar;", errors: [{ message: /^Bad var/ }] }
-                ]
-            });
+        ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+            valid: [],
+            invalid: [
+                { code: "var foo = bar;", errors: [{ message: /^Bad var/ }] }
+            ]
         });
     });
 
     it("should throw an error when the expected output doesn't match", () => {
-
         assert.throws(() => {
             ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [
@@ -269,13 +259,12 @@ describe("RuleTester", () => {
             })
         };
 
-        assert.doesNotThrow(() => {
-            ruleTester.run("foo", replaceProgramWith5Rule, {
-                valid: [],
-                invalid: [
-                    { code: "var foo = bar;", output: "5", errors: 1 }
-                ]
-            });
+        // Should not throw.
+        ruleTester.run("foo", replaceProgramWith5Rule, {
+            valid: [],
+            invalid: [
+                { code: "var foo = bar;", output: "5", errors: 1 }
+            ]
         });
 
         assert.throws(() => {
@@ -289,7 +278,6 @@ describe("RuleTester", () => {
     });
 
     it("should throw an error when the expected output doesn't match and errors is just a number", () => {
-
         assert.throws(() => {
             ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
                 valid: [
@@ -303,16 +291,14 @@ describe("RuleTester", () => {
     });
 
     it("should not throw an error when the expected output is null and no errors produce output", () => {
-        assert.doesNotThrow(() => {
-            ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
-                valid: [
-                    "bar = baz;"
-                ],
-                invalid: [
-                    { code: "eval(x)", errors: 1, output: null },
-                    { code: "eval(x); eval(y);", errors: 2, output: null }
-                ]
-            });
+        ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+            valid: [
+                "bar = baz;"
+            ],
+            invalid: [
+                { code: "eval(x)", errors: 1, output: null },
+                { code: "eval(x); eval(y);", errors: 2, output: null }
+            ]
         });
     });
 
@@ -352,7 +338,6 @@ describe("RuleTester", () => {
     });
 
     it("should throw an error if invalid code specifies wrong type", () => {
-
         assert.throws(() => {
             ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [
@@ -366,7 +351,6 @@ describe("RuleTester", () => {
     });
 
     it("should throw an error if invalid code specifies wrong line", () => {
-
         assert.throws(() => {
             ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [
@@ -411,7 +395,6 @@ describe("RuleTester", () => {
     });
 
     it("should not skip column assertion if column is a falsy value", () => {
-
         assert.throws(() => {
             ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: ["Eval(foo)"],
@@ -450,7 +433,6 @@ describe("RuleTester", () => {
     });
 
     it("should throw an error if invalid code has the wrong number of errors", () => {
-
         assert.throws(() => {
             ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [
@@ -483,7 +465,6 @@ describe("RuleTester", () => {
     });
 
     it("should throw an error if invalid code has the wrong explicit number of errors", () => {
-
         assert.throws(() => {
             ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [
@@ -498,7 +479,6 @@ describe("RuleTester", () => {
 
     // https://github.com/eslint/eslint/issues/4779
     it("should throw an error if there's a parsing error and output doesn't match", () => {
-
         assert.throws(() => {
             ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [],
@@ -510,65 +490,57 @@ describe("RuleTester", () => {
     });
 
     it("should not throw an error if invalid code has at least an expected empty error object", () => {
-        assert.doesNotThrow(() => {
-            ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
-                valid: ["Eval(foo)"],
-                invalid: [{
-                    code: "eval(foo)",
-                    errors: [{}]
-                }]
-            });
+        ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+            valid: ["Eval(foo)"],
+            invalid: [{
+                code: "eval(foo)",
+                errors: [{}]
+            }]
         });
     });
 
     it("should pass-through the globals config of valid tests to the to rule", () => {
-        assert.doesNotThrow(() => {
-            ruleTester.run("no-test-global", require("../../fixtures/testers/rule-tester/no-test-global"), {
-                valid: [
-                    "var test = 'foo'",
-                    {
-                        code: "var test2 = 'bar'",
-                        globals: { test: true }
-                    }
-                ],
-                invalid: [{ code: "bar", errors: 1 }]
-            });
+        ruleTester.run("no-test-global", require("../../fixtures/testers/rule-tester/no-test-global"), {
+            valid: [
+                "var test = 'foo'",
+                {
+                    code: "var test2 = 'bar'",
+                    globals: { test: true }
+                }
+            ],
+            invalid: [{ code: "bar", errors: 1 }]
         });
     });
 
     it("should pass-through the globals config of invalid tests to the to rule", () => {
-        assert.doesNotThrow(() => {
-            ruleTester.run("no-test-global", require("../../fixtures/testers/rule-tester/no-test-global"), {
-                valid: ["var test = 'foo'"],
-                invalid: [
-                    {
-                        code: "var test = 'foo'; var foo = 'bar'",
-                        errors: 1
-                    },
-                    {
-                        code: "var test = 'foo'",
-                        globals: { foo: true },
-                        errors: [{ message: "Global variable foo should not be used." }]
-                    }
-                ]
-            });
+        ruleTester.run("no-test-global", require("../../fixtures/testers/rule-tester/no-test-global"), {
+            valid: ["var test = 'foo'"],
+            invalid: [
+                {
+                    code: "var test = 'foo'; var foo = 'bar'",
+                    errors: 1
+                },
+                {
+                    code: "var test = 'foo'",
+                    globals: { foo: true },
+                    errors: [{ message: "Global variable foo should not be used." }]
+                }
+            ]
         });
     });
 
     it("should pass-through the settings config to rules", () => {
-        assert.doesNotThrow(() => {
-            ruleTester.run("no-test-settings", require("../../fixtures/testers/rule-tester/no-test-settings"), {
-                valid: [
-                    {
-                        code: "var test = 'bar'", settings: { test: 1 }
-                    }
-                ],
-                invalid: [
-                    {
-                        code: "var test = 'bar'", settings: { "no-test": 22 }, errors: 1
-                    }
-                ]
-            });
+        ruleTester.run("no-test-settings", require("../../fixtures/testers/rule-tester/no-test-settings"), {
+            valid: [
+                {
+                    code: "var test = 'bar'", settings: { test: 1 }
+                }
+            ],
+            invalid: [
+                {
+                    code: "var test = 'bar'", settings: { "no-test": 22 }, errors: 1
+                }
+            ]
         });
     });
 
@@ -594,22 +566,20 @@ describe("RuleTester", () => {
     });
 
     it("should pass-through the options to the rule", () => {
-        assert.doesNotThrow(() => {
-            ruleTester.run("no-invalid-args", require("../../fixtures/testers/rule-tester/no-invalid-args"), {
-                valid: [
-                    {
-                        code: "var foo = 'bar'",
-                        options: [false]
-                    }
-                ],
-                invalid: [
-                    {
-                        code: "var foo = 'bar'",
-                        options: [true],
-                        errors: [{ message: "Invalid args" }]
-                    }
-                ]
-            });
+        ruleTester.run("no-invalid-args", require("../../fixtures/testers/rule-tester/no-invalid-args"), {
+            valid: [
+                {
+                    code: "var foo = 'bar'",
+                    options: [false]
+                }
+            ],
+            invalid: [
+                {
+                    code: "var foo = 'bar'",
+                    options: [true],
+                    errors: [{ message: "Invalid args" }]
+                }
+            ]
         });
     });
 
@@ -642,30 +612,26 @@ describe("RuleTester", () => {
     });
 
     it("should pass-through the parser to the rule", () => {
+        const spy = sinon.spy(ruleTester.linter, "verify");
 
-        assert.doesNotThrow(() => {
-            const spy = sinon.spy(ruleTester.linter, "verify");
-
-            ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
-                valid: [
-                    {
-                        code: "Eval(foo)"
-                    }
-                ],
-                invalid: [
-                    {
-                        code: "eval(foo)",
-                        parser: "esprima",
-                        errors: [{}]
-                    }
-                ]
-            });
-            assert.strictEqual(spy.args[1][1].parser, "esprima");
+        ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+            valid: [
+                {
+                    code: "Eval(foo)"
+                }
+            ],
+            invalid: [
+                {
+                    code: "eval(foo)",
+                    parser: "esprima",
+                    errors: [{}]
+                }
+            ]
         });
+        assert.strictEqual(spy.args[1][1].parser, "esprima");
     });
 
     it("should prevent invalid options schemas", () => {
-
         assert.throws(() => {
             ruleTester.run("no-invalid-schema", require("../../fixtures/testers/rule-tester/no-invalid-schema"), {
                 valid: [
@@ -681,7 +647,6 @@ describe("RuleTester", () => {
     });
 
     it("should prevent schema violations in options", () => {
-
         assert.throws(() => {
             ruleTester.run("no-schema-violation", require("../../fixtures/testers/rule-tester/no-schema-violation"), {
                 valid: [
@@ -697,7 +662,6 @@ describe("RuleTester", () => {
     });
 
     it("throw an error when an unknown config option is included", () => {
-
         assert.throws(() => {
             ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [
@@ -709,7 +673,6 @@ describe("RuleTester", () => {
     });
 
     it("throw an error when an invalid config value is included", () => {
-
         assert.throws(() => {
             ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
                 valid: [
@@ -725,14 +688,12 @@ describe("RuleTester", () => {
             globals: { test: true }
         });
 
-        assert.doesNotThrow(() => {
-            ruleTester.run("no-test-global", require("../../fixtures/testers/rule-tester/no-test-global"), {
-                valid: [
-                    "var test = 'foo'",
-                    "var test2 = test"
-                ],
-                invalid: [{ code: "bar", errors: 1, globals: { foo: true } }]
-            });
+        ruleTester.run("no-test-global", require("../../fixtures/testers/rule-tester/no-test-global"), {
+            valid: [
+                "var test = 'foo'",
+                "var test2 = test"
+            ],
+            invalid: [{ code: "bar", errors: 1, globals: { foo: true } }]
         });
     });
 
@@ -785,14 +746,12 @@ describe("RuleTester", () => {
         RuleTester.setDefaultConfig(config);
         ruleTester = new RuleTester();
 
-        assert.doesNotThrow(() => {
-            ruleTester.run("no-test-global", require("../../fixtures/testers/rule-tester/no-test-global"), {
-                valid: [
-                    "var test = 'foo'",
-                    "var test2 = test"
-                ],
-                invalid: [{ code: "bar", errors: 1, globals: { foo: true } }]
-            });
+        ruleTester.run("no-test-global", require("../../fixtures/testers/rule-tester/no-test-global"), {
+            valid: [
+                "var test = 'foo'",
+                "var test2 = test"
+            ],
+            invalid: [{ code: "bar", errors: 1, globals: { foo: true } }]
         });
     });
 
@@ -893,11 +852,9 @@ describe("RuleTester", () => {
             });
         }, /Avoid using variables named/);
 
-        assert.doesNotThrow(() => {
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMessageOnly, {
-                valid: [],
-                invalid: [{ code: "foo", errors: [{ message: "Avoid using variables named 'foo'." }] }]
-            });
+        ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMessageOnly, {
+            valid: [],
+            invalid: [{ code: "foo", errors: [{ message: "Avoid using variables named 'foo'." }] }]
         });
     });
 
@@ -909,11 +866,9 @@ describe("RuleTester", () => {
             });
         }, "messageId 'avoidFoo' does not match expected messageId 'unused'.");
 
-        assert.doesNotThrow(() => {
-            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMetaWithData, {
-                valid: [],
-                invalid: [{ code: "foo", errors: [{ messageId: "avoidFoo" }] }]
-            });
+        ruleTester.run("foo", require("../../fixtures/testers/rule-tester/messageId").withMetaWithData, {
+            valid: [],
+            invalid: [{ code: "foo", errors: [{ messageId: "avoidFoo" }] }]
         });
     });
     it("should assert match between resulting message output if messageId and data provided in both test and result", () => {

--- a/tests/lib/util/npm-util.js
+++ b/tests/lib/util/npm-util.js
@@ -65,9 +65,8 @@ describe("npmUtil", () => {
                 "package.json": JSON.stringify({ private: true, dependencies: {} })
             });
 
-            const fn = npmUtil.checkDevDeps.bind(null, ["some-package"]);
-
-            assert.doesNotThrow(fn);
+            // Should not throw.
+            npmUtil.checkDevDeps(["some-package"]);
         });
 
         it("should throw with message when parsing invalid package.json", () => {
@@ -128,9 +127,8 @@ describe("npmUtil", () => {
                 "package.json": JSON.stringify({ private: true, devDependencies: {} })
             });
 
-            const fn = npmUtil.checkDeps.bind(null, ["some-package"]);
-
-            assert.doesNotThrow(fn);
+            // Should not throw.
+            npmUtil.checkDeps(["some-package"]);
         });
 
         it("should throw with message when parsing invalid package.json", () => {


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

The `assert.doesNotThrow` API is not useful and just slows down the test run by
catching errors and then rethrowing in case of an error. In case
there is no error, it is a noop.
<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Removed all `assert.doesNotThrow` calls and added a eslint rule to prevent any new additions.

**Is there anything you'd like reviewers to focus on?**

The wording for the error message.

