### PR TITLE
Chore: avoid modifying global state when tests fail

### DIFF
--- a/tests/lib/config/config-initializer.js
+++ b/tests/lib/config/config-initializer.js
@@ -316,6 +316,7 @@ describe("configInitializer", () => {
         describe("auto", () => {
             const completeSpy = sinon.spy();
             let config;
+            let sandbox;
 
             before(() => {
                 const patterns = [
@@ -334,23 +335,21 @@ describe("configInitializer", () => {
                     commonjs: false
                 };
 
-                const sandbox = sinon.sandbox.create();
-
+                sandbox = sinon.sandbox.create();
                 sandbox.stub(console, "log"); // necessary to replace, because of progress bar
 
                 process.chdir(fixtureDir);
+                config = init.processAnswers(answers);
+                sandbox.restore();
+            });
 
-                try {
-                    config = init.processAnswers(answers);
-                    process.chdir(originalDir);
-                } catch (err) {
+            after(() => {
+                sandbox.restore();
+            });
 
-                    // if processAnswers crashes, we need to be sure to restore cwd
-                    process.chdir(originalDir);
-                    throw err;
-                } finally {
-                    sandbox.restore(); // restore console.log()
-                }
+            afterEach(() => {
+                process.chdir(originalDir);
+                sandbox.restore();
             });
 
             it("should create a config", () => {
@@ -371,25 +370,21 @@ describe("configInitializer", () => {
             it("should throw on fatal parsing error", () => {
                 const filename = getFixturePath("parse-error");
 
-                sinon.stub(autoconfig, "extendFromRecommended");
+                sandbox.stub(autoconfig, "extendFromRecommended");
                 answers.patterns = filename;
                 process.chdir(fixtureDir);
                 assert.throws(() => {
                     config = init.processAnswers(answers);
                 }, "Parsing error: Unexpected token ;");
-                process.chdir(originalDir);
-                autoconfig.extendFromRecommended.restore();
             });
 
             it("should throw if no files are matched from patterns", () => {
-                sinon.stub(autoconfig, "extendFromRecommended");
+                sandbox.stub(autoconfig, "extendFromRecommended");
                 answers.patterns = "not-a-real-filename";
                 process.chdir(fixtureDir);
                 assert.throws(() => {
                     config = init.processAnswers(answers);
                 }, "Automatic Configuration failed.  No files were able to be parsed.");
-                process.chdir(originalDir);
-                autoconfig.extendFromRecommended.restore();
             });
         });
     });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates the tests for config-initializer to always restore `process.cwd()` back to its original location if an assertion fails. Previously, the CWD would end up incorrect if one of the assertions failed, so a large number of other tests would also fail at the same time due to the incorrect CWD.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
