### PR TITLE
Fix: Throw error when --ignore-path not a file (fixes #10076)

### DIFF
--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -381,6 +381,21 @@ class CLIEngine {
             providedOptions
         );
 
+        /*
+         * if an --ignore-path option is provided, ensure that the ignore
+         * file exists and is not a directory
+         */
+        if (options.ignore && options.ignorePath) {
+            try {
+                if (!fs.statSync(options.ignorePath).isFile()) {
+                    throw new Error(`${options.ignorePath} is not a file`);
+                }
+            } catch (e) {
+                e.message = `Error: Could not load file ${options.ignorePath}\nError: ${e.message}`;
+                throw e;
+            }
+        }
+
         /**
          * Stored options for this instance
          * @type {Object}

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -103,6 +103,14 @@ describe("CLIEngine", () => {
                 process.chdir(originalDir);
             }
         });
+
+        it("should report one fatal message when given a path by --ignore-path that is not a file when ignore is true.", () => {
+            assert.throws(() => {
+                const engine = new CLIEngine({ ignorePath: fixtureDir });
+
+                void (engine);
+            }, `Error: Could not load file ${fixtureDir}\nError: ${fixtureDir} is not a file`);
+        });
     });
 
     describe("executeOnText()", () => {

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -106,9 +106,8 @@ describe("CLIEngine", () => {
 
         it("should report one fatal message when given a path by --ignore-path that is not a file when ignore is true.", () => {
             assert.throws(() => {
-                const engine = new CLIEngine({ ignorePath: fixtureDir });
-
-                void (engine);
+                // eslint-disable-next-line no-new
+                new CLIEngine({ ignorePath: fixtureDir });
             }, `Error: Could not load file ${fixtureDir}\nError: ${fixtureDir} is not a file`);
         });
     });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
https://github.com/eslint/eslint/issues/10076

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
I added a conditional expression to the CLIEngine constructor that throws an error if the ignorePath file name does not point to a file. Also added a test that asserts that the CLIEngine throws an error if it is given a directory as the ignorePath.

**Is there anything you'd like reviewers to focus on?**
First pull request, so apologies for any oversights


