### PR TITLE
Breaking: stop using fake `context._linter` property (fixes #10140)

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -779,20 +779,7 @@ function runRules(sourceCode, configuredRules, ruleMapper, parserOptions, parser
                 parserOptions,
                 parserPath: parserName,
                 parserServices: sourceCode.parserServices,
-                settings,
-
-                /**
-                 * This is used to avoid breaking rules that used to monkeypatch the `Linter#report` method
-                 * by using the `_linter` property on rule contexts.
-                 *
-                 * This should be removed in a major release after we create a better way to
-                 * lint for unused disable comments.
-                 * https://github.com/eslint/eslint/issues/9193
-                 */
-                _linter: {
-                    report() {},
-                    on: emitter.on
-                }
+                settings
             }
         )
     );
@@ -837,24 +824,6 @@ function runRules(sourceCode, configuredRules, ruleMapper, parserOptions, parser
                             throw new Error("Fixable rules should export a `meta.fixable` property.");
                         }
                         lintingProblems.push(problem);
-
-                        /*
-                         * This is used to avoid breaking rules that used monkeypatch Linter, and relied on
-                         * `linter.report` getting called with report info every time a rule reports a problem.
-                         * To continue to support this, make sure that `context._linter.report` is called every
-                         * time a problem is reported by a rule, even though `context._linter` is no longer a
-                         * `Linter` instance.
-                         *
-                         * This should be removed in a major release after we create a better way to
-                         * lint for unused disable comments.
-                         * https://github.com/eslint/eslint/issues/9193
-                         */
-                        sharedTraversalContext._linter.report( // eslint-disable-line no-underscore-dangle
-                            problem.ruleId,
-                            problem.severity,
-                            { loc: { start: { line: problem.line, column: problem.column - 1 } } },
-                            problem.message
-                        );
                     }
                 }
             )

--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -1760,31 +1760,6 @@ describe("Linter", () => {
         });
     });
 
-    describe("when evaluating rules that monkeypatch Linter", () => {
-        it("should call `context._linter.report` appropriately", () => {
-            linter.defineRule("foo", context => ({
-                Program() {
-                    context.report({ loc: { line: 5, column: 4 }, message: "foo" });
-                }
-            }));
-
-            const spy = sandbox.spy((ruleId, severity, node, message) => {
-                assert.strictEqual(ruleId, "foo");
-                assert.strictEqual(severity, 2);
-                assert.deepStrictEqual(node.loc, { start: { line: 5, column: 4 } });
-                assert.strictEqual(message, "foo");
-            });
-
-            linter.defineRule("bar", context => {
-                context._linter.report = spy; // eslint-disable-line no-underscore-dangle
-                return {};
-            });
-
-            linter.verify("foo", { rules: { foo: "error", bar: "error" } });
-            assert(spy.calledOnce);
-        });
-    });
-
     describe("when evaluating code with comments to enable and disable all reporting", () => {
         it("should report a violation", () => {
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This removes a compatibility hack for plugins that monkeypatched `linter` instances from rules with the `context._linter` property, as described in https://github.com/eslint/eslint/issues/10140.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
