### PR TITLE
Breaking: remove deprecated browser/jest/node globals (fixes #10141)

### DIFF
--- a/conf/environments.js
+++ b/conf/environments.js
@@ -19,126 +19,10 @@ module.exports = {
         globals: globals.es5
     },
     browser: {
-
-        /*
-         * For backward compatibility.
-         * Remove those on the next major release.
-         */
-        globals: Object.assign(
-            {
-                AutocompleteErrorEvent: false,
-                CDATASection: false,
-                ClientRect: false,
-                ClientRectList: false,
-                CSSAnimation: false,
-                CSSTransition: false,
-                CSSUnknownRule: false,
-                CSSViewportRule: false,
-                Debug: false,
-                DocumentTimeline: false,
-                DOMSettableTokenList: false,
-                ElementTimeControl: false,
-                FederatedCredential: false,
-                FileError: false,
-                HTMLAppletElement: false,
-                HTMLBlockquoteElement: false,
-                HTMLIsIndexElement: false,
-                HTMLKeygenElement: false,
-                HTMLLayerElement: false,
-                IDBEnvironment: false,
-                InputMethodContext: false,
-                MediaKeyError: false,
-                MediaKeyEvent: false,
-                MediaKeys: false,
-                opera: false,
-                PasswordCredential: false,
-                ReadableByteStream: false,
-                SharedKeyframeList: false,
-                showModalDialog: false,
-                SiteBoundCredential: false,
-                SVGAltGlyphDefElement: false,
-                SVGAltGlyphElement: false,
-                SVGAltGlyphItemElement: false,
-                SVGAnimateColorElement: false,
-                SVGAnimatedPathData: false,
-                SVGAnimatedPoints: false,
-                SVGColor: false,
-                SVGColorProfileElement: false,
-                SVGColorProfileRule: false,
-                SVGCSSRule: false,
-                SVGCursorElement: false,
-                SVGDocument: false,
-                SVGElementInstance: false,
-                SVGElementInstanceList: false,
-                SVGEvent: false,
-                SVGExternalResourcesRequired: false,
-                SVGFilterPrimitiveStandardAttributes: false,
-                SVGFitToViewBox: false,
-                SVGFontElement: false,
-                SVGFontFaceElement: false,
-                SVGFontFaceFormatElement: false,
-                SVGFontFaceNameElement: false,
-                SVGFontFaceSrcElement: false,
-                SVGFontFaceUriElement: false,
-                SVGGlyphElement: false,
-                SVGGlyphRefElement: false,
-                SVGHKernElement: false,
-                SVGICCColor: false,
-                SVGLangSpace: false,
-                SVGLocatable: false,
-                SVGMissingGlyphElement: false,
-                SVGPaint: false,
-                SVGPathSeg: false,
-                SVGPathSegArcAbs: false,
-                SVGPathSegArcRel: false,
-                SVGPathSegClosePath: false,
-                SVGPathSegCurvetoCubicAbs: false,
-                SVGPathSegCurvetoCubicRel: false,
-                SVGPathSegCurvetoCubicSmoothAbs: false,
-                SVGPathSegCurvetoCubicSmoothRel: false,
-                SVGPathSegCurvetoQuadraticAbs: false,
-                SVGPathSegCurvetoQuadraticRel: false,
-                SVGPathSegCurvetoQuadraticSmoothAbs: false,
-                SVGPathSegCurvetoQuadraticSmoothRel: false,
-                SVGPathSegLinetoAbs: false,
-                SVGPathSegLinetoHorizontalAbs: false,
-                SVGPathSegLinetoHorizontalRel: false,
-                SVGPathSegLinetoRel: false,
-                SVGPathSegLinetoVerticalAbs: false,
-                SVGPathSegLinetoVerticalRel: false,
-                SVGPathSegList: false,
-                SVGPathSegMovetoAbs: false,
-                SVGPathSegMovetoRel: false,
-                SVGRenderingIntent: false,
-                SVGStylable: false,
-                SVGTests: false,
-                SVGTransformable: false,
-                SVGTRefElement: false,
-                SVGURIReference: false,
-                SVGViewSpec: false,
-                SVGVKernElement: false,
-                SVGZoomAndPan: false,
-                SVGZoomEvent: false,
-                TimeEvent: false,
-                XDomainRequest: false,
-                XMLHttpRequestProgressEvent: false,
-                XPathException: false,
-                XPathNamespace: false,
-                XPathNSResolver: false
-            },
-            globals.browser
-        )
+        globals: globals.browser
     },
     node: {
-
-        /*
-         * For backward compatibility.
-         * Remove those on the next major release.
-         */
-        globals: Object.assign(
-            { arguments: false, GLOBAL: false, root: false },
-            globals.node
-        ),
+        globals: globals.node,
         parserOptions: {
             ecmaFeatures: {
                 globalReturn: true
@@ -169,15 +53,7 @@ module.exports = {
         globals: globals.jasmine
     },
     jest: {
-
-        /*
-         * For backward compatibility.
-         * Remove those on the next major release.
-         */
-        globals: Object.assign(
-            { check: false, gen: false },
-            globals.jest
-        )
+        globals: globals.jest
     },
     phantomjs: {
         globals: globals.phantomjs


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This removes deprecated globals from the `browser`, `jest`, and `node` environments, as discussed in #10141.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
