### PR TITLE
Update: Add requireParamType option to valid-jsdoc (fixes #6753)

### DIFF
--- a/docs/rules/valid-jsdoc.md
+++ b/docs/rules/valid-jsdoc.md
@@ -163,6 +163,7 @@ This rule has an object option:
 * `"matchDescription"` specifies (as a string) a regular expression to match the description in each JSDoc comment (for example, `".+"` requires a description; this option does not apply to descriptions in parameter or return tags)
 * `"requireParamDescription": false` allows missing description in parameter tags
 * `"requireReturnDescription": false` allows missing description in return tags
+* `"requireParamType": false` allows missing type in parameter tags
 
 ### prefer
 
@@ -300,6 +301,24 @@ Example of additional **correct** code for this rule with the `"requireReturnTyp
  * @param {number} num1 The first number.
  * @param {number} num2 The second number.
  * @returns The sum of the two numbers.
+ */
+function add(num1, num2) {
+    return num1 + num2;
+}
+```
+
+### requireParamType
+
+Example of additional **correct** code for this rule with the `"requireParamType": false` option:
+
+```js
+/*eslint valid-jsdoc: ["error", { "requireParamType": false }]*/
+
+/**
+ * Add two numbers.
+ * @param num1 The first number.
+ * @param num2 The second number.
+ * @returns {number} The sum of the two numbers.
  */
 function add(num1, num2) {
     return num1 + num2;

--- a/lib/rules/valid-jsdoc.js
+++ b/lib/rules/valid-jsdoc.js
@@ -53,6 +53,9 @@ module.exports = {
                     },
                     requireReturnType: {
                         type: "boolean"
+                    },
+                    requireParamType: {
+                        type: "boolean"
                     }
                 },
                 additionalProperties: false
@@ -73,6 +76,7 @@ module.exports = {
             requireParamDescription = options.requireParamDescription !== false,
             requireReturnDescription = options.requireReturnDescription !== false,
             requireReturnType = options.requireReturnType !== false,
+            requireParamType = options.requireParamType !== false,
             preferType = options.preferType || {},
             checkPreferType = Object.keys(preferType).length !== 0;
 
@@ -351,7 +355,7 @@ module.exports = {
                 });
 
                 paramTags.forEach(param => {
-                    if (!param.type) {
+                    if (requireParamType && !param.type) {
                         context.report({
                             node: jsdocNode,
                             message: "Missing JSDoc parameter type for '{{name}}'.",

--- a/tests/lib/rules/valid-jsdoc.js
+++ b/tests/lib/rules/valid-jsdoc.js
@@ -170,6 +170,10 @@ ruleTester.run("valid-jsdoc", rule, {
             options: [{ requireReturnType: false }]
         },
         {
+            code: "/**\n* Description\n* @param p bar\n* @returns {void}*/\nFoo.bar = function(p){var t = function(){function name(){}; return name;}};",
+            options: [{ requireParamType: false }]
+        },
+        {
             code:
                 "/**\n" +
                 " * A thing interface. \n" +


### PR DESCRIPTION
This option allows to skip specyfing parameters type in JSDoc comments. It is usefull in cases, when there are other type annotations available already - i.e. Flow type.

Having types both in JSDoc and other annotation is redundant
and may cause inconsistency.

Example:
```js
/*eslint valid-jsdoc: ["error", { "requireParamTypes": false, "requireReturnType": false }]*/

/**
 * Add two numbers.
 * @param num1 The first number.
 * @param num2 The second number.
 * @returns The sum of the two numbers.
 */
function add(num1: number, num2: number): number {
    return num1 + num2;
}
```

<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**What rule do you want to change?**

valid-jsdoc

**Does this change cause the rule to produce more or fewer warnings?**

fewer

**How will the change be implemented? (New option, new default behavior, etc.)?**

new option

**Please provide some example code that this change will affect:**

The affected code examples are given in the rule documentation and commit message above.

**What does the rule currently do for this code?**

Generates `Missing JSDoc parameter type for 'param'.`


**What will the rule do after it's changed?**

Will not generate message.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Implemented new option support, documentation and test.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular. The change is trivial.
