### PR TITLE
Update: re-enable experimentalObjectRestSpread (fixes #9990)

### DIFF
--- a/lib/config/config-validator.js
+++ b/lib/config/config-validator.js
@@ -210,7 +210,8 @@ const emitDeprecationWarning = lodash.memoize((source, errorCode) => {
 
     process.emitWarning(
         `${message} (found in "${rel}")`,
-        { code: errorCode, type: "DeprecationWarning" }
+        "DeprecationWarning",
+        errorCode
     );
 });
 

--- a/lib/config/config-validator.js
+++ b/lib/config/config-validator.js
@@ -9,7 +9,8 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const ajv = require("../util/ajv"),
+const path = require("path"),
+    ajv = require("../util/ajv"),
     lodash = require("lodash"),
     configSchema = require("../../conf/config-schema.js"),
     util = require("util");
@@ -194,18 +195,16 @@ function formatErrors(errors) {
  * for each unique file path, but repeated invocations with the same file path have no effect.
  * No warnings are emitted if the `--no-deprecation` or `--no-warnings` Node runtime flags are active.
  * @param {string} source The name of the configuration source to report the warning for.
+ * @param {string} message The warning message to show.
  * @returns {void}
  */
-const emitEcmaFeaturesWarning = lodash.memoize(source => {
+const emitDeprecationWarning = lodash.memoize((source, message) => {
+    const rel = path.relative(process.cwd(), source);
 
-    /*
-     * util.deprecate seems to be the only way to emit a warning in Node 4.x while respecting the --no-warnings flag.
-     * (In Node 6+, process.emitWarning could be used instead.)
-     */
-    util.deprecate(
-        () => {},
-        `[eslint] The 'ecmaFeatures' config file property is deprecated, and has no effect. (found in ${source})`
-    )();
+    process.emitWarning(
+        `${message} (found in "${rel}")`,
+        { code: "ESLint", type: "DeprecationWarning" }
+    );
 });
 
 /**
@@ -221,8 +220,17 @@ function validateConfigSchema(config, source) {
         throw new Error(`ESLint configuration in ${source} is invalid:\n${formatErrors(validateSchema.errors)}`);
     }
 
-    if (Object.prototype.hasOwnProperty.call(config, "ecmaFeatures")) {
-        emitEcmaFeaturesWarning(source);
+    if (Object.hasOwnProperty.call(config, "ecmaFeatures")) {
+        emitDeprecationWarning(source, "The 'ecmaFeatures' config file property is deprecated, and has no effect.");
+    }
+
+    if (
+        (config.parser || "espree") === "espree" &&
+        config.parserOptions &&
+        config.parserOptions.ecmaFeatures &&
+        config.parserOptions.ecmaFeatures.experimentalObjectRestSpread
+    ) {
+        emitDeprecationWarning(source, "The 'parserOptions.ecmaFeatures.experimentalObjectRestSpread' option is deprecated. Use 'parserOptions.ecmaVersion' instead.");
     }
 }
 

--- a/lib/config/config-validator.js
+++ b/lib/config/config-validator.js
@@ -22,6 +22,12 @@ const ruleValidators = new WeakMap();
 //------------------------------------------------------------------------------
 let validateSchema;
 
+// Defitions for deprecation warnings.
+const deprecationWarningMessages = Object.freeze({
+    ESLINT_LEGACY_ECMAFEATURES: "The 'ecmaFeatures' config file property is deprecated, and has no effect.",
+    ESLINT_LEGACY_OBJECT_REST_SPREAD: "The 'parserOptions.ecmaFeatures.experimentalObjectRestSpread' option is deprecated. Use 'parserOptions.ecmaVersion' instead."
+});
+
 /**
  * Gets a complete options schema for a rule.
  * @param {{create: Function, schema: (Array|null)}} rule A new-style rule object
@@ -195,15 +201,16 @@ function formatErrors(errors) {
  * for each unique file path, but repeated invocations with the same file path have no effect.
  * No warnings are emitted if the `--no-deprecation` or `--no-warnings` Node runtime flags are active.
  * @param {string} source The name of the configuration source to report the warning for.
- * @param {string} message The warning message to show.
+ * @param {string} errorCode The warning message to show.
  * @returns {void}
  */
-const emitDeprecationWarning = lodash.memoize((source, message) => {
+const emitDeprecationWarning = lodash.memoize((source, errorCode) => {
     const rel = path.relative(process.cwd(), source);
+    const message = deprecationWarningMessages[errorCode];
 
     process.emitWarning(
         `${message} (found in "${rel}")`,
-        { code: "ESLint", type: "DeprecationWarning" }
+        { code: errorCode, type: "DeprecationWarning" }
     );
 });
 
@@ -221,7 +228,7 @@ function validateConfigSchema(config, source) {
     }
 
     if (Object.hasOwnProperty.call(config, "ecmaFeatures")) {
-        emitDeprecationWarning(source, "The 'ecmaFeatures' config file property is deprecated, and has no effect.");
+        emitDeprecationWarning(source, "ESLINT_LEGACY_ECMAFEATURES");
     }
 
     if (
@@ -230,7 +237,7 @@ function validateConfigSchema(config, source) {
         config.parserOptions.ecmaFeatures &&
         config.parserOptions.ecmaFeatures.experimentalObjectRestSpread
     ) {
-        emitDeprecationWarning(source, "The 'parserOptions.ecmaFeatures.experimentalObjectRestSpread' option is deprecated. Use 'parserOptions.ecmaVersion' instead.");
+        emitDeprecationWarning(source, "ESLINT_LEGACY_OBJECT_REST_SPREAD");
     }
 }
 

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -929,7 +929,9 @@ module.exports = class Linter {
         const settings = config.settings || {};
 
         // TODO: For backward compatibility. Will remove on v6.0.0.
-        if (parserOptions.ecmaFeatures &&
+        if (
+            parserName === DEFAULT_PARSER_NAME &&
+            parserOptions.ecmaFeatures &&
             parserOptions.ecmaFeatures.experimentalObjectRestSpread &&
             (!parserOptions.ecmaVersion || parserOptions.ecmaVersion < 9)
         ) {
@@ -1011,19 +1013,6 @@ module.exports = class Linter {
                 .sort((problemA, problemB) => problemA.line - problemB.line || problemA.column - problemB.column),
             reportUnusedDisableDirectives: options.reportUnusedDisableDirectives
         });
-
-        // TODO: For backward compatibility. Will remove on v6.0.0.
-        if (parserOptions.ecmaFeatures && parserOptions.ecmaFeatures.experimentalObjectRestSpread) {
-            lintingProblems.push({
-                ruleId: null,
-                fatal: false,
-                severity: 1,
-                message: "'parserOptions.ecmaFeatures.experimentalObjectRestSpread' has been deprecated. Use 'parserOptions.ecmaVersion' instead.",
-                line: 0,
-                column: 0
-            });
-            lintingProblems.sort((a, b) => a.line - b.line || a.column - b.column);
-        }
 
         return lintingProblems;
     }

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -928,6 +928,14 @@ module.exports = class Linter {
         const parserName = config.parser || DEFAULT_PARSER_NAME;
         const settings = config.settings || {};
 
+        // TODO: For backward compatibility. Will remove on v6.0.0.
+        if (parserOptions.ecmaFeatures &&
+            parserOptions.ecmaFeatures.experimentalObjectRestSpread &&
+            (!parserOptions.ecmaVersion || parserOptions.ecmaVersion < 9)
+        ) {
+            parserOptions.ecmaVersion = 9;
+        }
+
         if (!lastSourceCodes.get(this)) {
             const parseResult = parse(
                 text,
@@ -996,13 +1004,28 @@ module.exports = class Linter {
             throw err;
         }
 
-        return applyDisableDirectives({
+        lintingProblems = applyDisableDirectives({
             directives: commentDirectives.disableDirectives,
             problems: lintingProblems
                 .concat(commentDirectives.problems)
                 .sort((problemA, problemB) => problemA.line - problemB.line || problemA.column - problemB.column),
             reportUnusedDisableDirectives: options.reportUnusedDisableDirectives
         });
+
+        // TODO: For backward compatibility. Will remove on v6.0.0.
+        if (parserOptions.ecmaFeatures && parserOptions.ecmaFeatures.experimentalObjectRestSpread) {
+            lintingProblems.push({
+                ruleId: null,
+                fatal: false,
+                severity: 1,
+                message: "'parserOptions.ecmaFeatures.experimentalObjectRestSpread' has been deprecated. Use 'parserOptions.ecmaVersion' instead.",
+                line: 0,
+                column: 0
+            });
+            lintingProblems.sort((a, b) => a.line - b.line || a.column - b.column);
+        }
+
+        return lintingProblems;
     }
 
     /**

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -1006,15 +1006,13 @@ module.exports = class Linter {
             throw err;
         }
 
-        lintingProblems = applyDisableDirectives({
+        return applyDisableDirectives({
             directives: commentDirectives.disableDirectives,
             problems: lintingProblems
                 .concat(commentDirectives.problems)
                 .sort((problemA, problemB) => problemA.line - problemB.line || problemA.column - problemB.column),
             reportUnusedDisableDirectives: options.reportUnusedDisableDirectives
         });
-
-        return lintingProblems;
     }
 
     /**

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -410,11 +410,12 @@ function normalizeVerifyOptions(providedOptions) {
 
 /**
  * Combines the provided parserOptions with the options from environments
+ * @param {string} parserName The parser name which uses this options.
  * @param {Object} providedOptions The provided 'parserOptions' key in a config
  * @param {Environment[]} enabledEnvironments The environments enabled in configuration and with inline comments
  * @returns {Object} Resulting parser options after merge
  */
-function resolveParserOptions(providedOptions, enabledEnvironments) {
+function resolveParserOptions(parserName, providedOptions, enabledEnvironments) {
     const parserOptionsFromEnv = enabledEnvironments
         .filter(env => env.parserOptions)
         .reduce((parserOptions, env) => ConfigOps.merge(parserOptions, env.parserOptions), {});
@@ -430,6 +431,16 @@ function resolveParserOptions(providedOptions, enabledEnvironments) {
     }
 
     mergedParserOptions.ecmaVersion = normalizeEcmaVersion(mergedParserOptions.ecmaVersion, isModule);
+
+    // TODO: For backward compatibility. Will remove on v6.0.0.
+    if (
+        parserName === DEFAULT_PARSER_NAME &&
+        mergedParserOptions.ecmaFeatures &&
+        mergedParserOptions.ecmaFeatures.experimentalObjectRestSpread &&
+        (!mergedParserOptions.ecmaVersion || mergedParserOptions.ecmaVersion < 9)
+    ) {
+        mergedParserOptions.ecmaVersion = 9;
+    }
 
     return mergedParserOptions;
 }
@@ -923,20 +934,10 @@ module.exports = class Linter {
             .map(envName => this.environments.get(envName))
             .filter(env => env);
 
-        const parserOptions = resolveParserOptions(config.parserOptions || {}, enabledEnvs);
-        const configuredGlobals = resolveGlobals(config.globals || {}, enabledEnvs);
         const parserName = config.parser || DEFAULT_PARSER_NAME;
+        const parserOptions = resolveParserOptions(parserName, config.parserOptions || {}, enabledEnvs);
+        const configuredGlobals = resolveGlobals(config.globals || {}, enabledEnvs);
         const settings = config.settings || {};
-
-        // TODO: For backward compatibility. Will remove on v6.0.0.
-        if (
-            parserName === DEFAULT_PARSER_NAME &&
-            parserOptions.ecmaFeatures &&
-            parserOptions.ecmaFeatures.experimentalObjectRestSpread &&
-            (!parserOptions.ecmaVersion || parserOptions.ecmaVersion < 9)
-        ) {
-            parserOptions.ecmaVersion = 9;
-        }
 
         if (!lastSourceCodes.get(this)) {
             const parseResult = parse(

--- a/tests/fixtures/config-file/experimental-object-rest-spread/another-parser/.eslintrc.yml
+++ b/tests/fixtures/config-file/experimental-object-rest-spread/another-parser/.eslintrc.yml
@@ -1,0 +1,6 @@
+root: true
+
+parser: ./parser.js
+parserOptions:
+  ecmaFeatures:
+    experimentalObjectRestSpread: true

--- a/tests/fixtures/config-file/experimental-object-rest-spread/another-parser/parser.js
+++ b/tests/fixtures/config-file/experimental-object-rest-spread/another-parser/parser.js
@@ -1,0 +1,1 @@
+module.exports.parse = () => ({ type: "Program", body: [] })

--- a/tests/fixtures/config-file/experimental-object-rest-spread/basic/.eslintrc.yml
+++ b/tests/fixtures/config-file/experimental-object-rest-spread/basic/.eslintrc.yml
@@ -1,0 +1,5 @@
+root: true
+
+parserOptions:
+  ecmaFeatures:
+    experimentalObjectRestSpread: true

--- a/tests/fixtures/config-file/experimental-object-rest-spread/extends/.eslintrc.yml
+++ b/tests/fixtures/config-file/experimental-object-rest-spread/extends/.eslintrc.yml
@@ -1,0 +1,4 @@
+root: true
+
+extends:
+  - ./common.yml

--- a/tests/fixtures/config-file/experimental-object-rest-spread/extends/common.yml
+++ b/tests/fixtures/config-file/experimental-object-rest-spread/extends/common.yml
@@ -1,0 +1,3 @@
+parserOptions:
+  ecmaFeatures:
+    experimentalObjectRestSpread: true

--- a/tests/fixtures/config-file/experimental-object-rest-spread/subdir/.eslintrc.yml
+++ b/tests/fixtures/config-file/experimental-object-rest-spread/subdir/.eslintrc.yml
@@ -1,0 +1,5 @@
+root: true
+
+parserOptions:
+  ecmaFeatures:
+    experimentalObjectRestSpread: true

--- a/tests/fixtures/config-file/experimental-object-rest-spread/subdir/lib/.eslintrc.yml
+++ b/tests/fixtures/config-file/experimental-object-rest-spread/subdir/lib/.eslintrc.yml
@@ -1,0 +1,2 @@
+rules:
+  no-undef: off

--- a/tests/lib/config.js
+++ b/tests/lib/config.js
@@ -1371,7 +1371,9 @@ describe("Config", () => {
             let warning = null;
 
             function onWarning(w) { // eslint-disable-line require-jsdoc
-                warning = w;
+                if (typeof w.code === "string" && w.code.startsWith("ESLINT_")) {
+                    warning = w;
+                }
             }
 
             beforeEach(() => {

--- a/tests/lib/config.js
+++ b/tests/lib/config.js
@@ -1371,7 +1371,9 @@ describe("Config", () => {
             let warning = null;
 
             function onWarning(w) { // eslint-disable-line require-jsdoc
-                if (typeof w.code === "string" && w.code.startsWith("ESLINT_")) {
+
+                // Node.js 6.x does not have 'w.code' property.
+                if (!w.hasOwnProperty("code") || typeof w.code === "string" && w.code.startsWith("ESLINT_")) {
                     warning = w;
                 }
             }

--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -3503,7 +3503,6 @@ describe("Linter", () => {
         });
     });
 
-
     describe("Variables and references", () => {
         const code = [
             "a;",

--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -3499,50 +3499,10 @@ describe("Linter", () => {
                 { parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } } }
             );
 
-            assert(messages.length === 1);
-            assert(messages[0].fatal !== true);
-            assert(messages[0].severity === 1);
-            assert(messages[0].message === "'parserOptions.ecmaFeatures.experimentalObjectRestSpread' has been deprecated. Use 'parserOptions.ecmaVersion' instead.");
-            assert(messages[0].line === 0);
-            assert(messages[0].column === 0);
-        });
-
-        it("should sort messages by locations", () => {
-            linter.defineRule("report", context => ({
-                Program() {
-                    context.report({
-                        loc: { line: 1, column: 1 },
-                        message: "(1,1)"
-                    });
-                    context.report({
-                        loc: { line: 0, column: 1 },
-                        message: "(0,1)"
-                    });
-                    context.report({
-                        loc: { line: 1, column: 0 },
-                        message: "(1,0)"
-                    });
-                }
-            }));
-            const messages = linter.verify(
-                "async function* f() { let {a, ...rest} = { a, ...obj }; }",
-                {
-                    parserOptions: { ecmaFeatures: { experimentalObjectRestSpread: true } },
-                    rules: { report: "error" }
-                }
-            );
-
-            assert(messages.length === 4);
-            assert(messages[0].line === 0);
-            assert(messages[0].column === 0);
-            assert(messages[1].line === 0);
-            assert(messages[1].column === 2);
-            assert(messages[2].line === 1);
-            assert(messages[2].column === 1);
-            assert(messages[3].line === 1);
-            assert(messages[3].column === 2);
+            assert(messages.length === 0);
         });
     });
+
 
     describe("Variables and references", () => {
         const code = [


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Other, please explain: fixes #9990

**What changes did you make? (Give an overview)**

1. If `parserOptions.ecmaFeatures.experimentalObjectRestSpread` is given and `parserOptions.ecmaVersion` is less than `9`, `linter` enables `parserOptions.ecmaVersion: 9` for backward compatibility.
2. If `parserOptions.ecmaFeatures.experimentalObjectRestSpread` is given, `linter` generates a deprecation warning to show the deprecation.

**Is there anything you'd like reviewers to focus on?**

I make the deprecation warning is as a message with `severity: 1`. Should it be with another way?
