### PR TITLE
Support for more detail in `one-var`

### DIFF
--- a/lib/rules/one-var.js
+++ b/lib/rules/one-var.js
@@ -38,13 +38,7 @@ module.exports = {
                             },
                             const: {
                                 enum: ["always", "never", "consecutive"]
-                            }
-                        },
-                        additionalProperties: false
-                    },
-                    {
-                        type: "object",
-                        properties: {
+                            },
                             initialized: {
                                 enum: ["always", "never", "consecutive"]
                             },

--- a/tests/lib/rules/one-var.js
+++ b/tests/lib/rules/one-var.js
@@ -473,6 +473,10 @@ ruleTester.run("one-var", rule, {
         {
             code: "var a = 1, b = 2; var c; var d; var e = 3, f = 4;",
             options: [{ initialized: "consecutive", uninitialized: "never" }]
+        },
+        {
+            code: "const a = 1; const b = 2; let c, d; foo(); let e, f; let g = 3; let h = 4;",
+            options: [{ const: "never", initialized: "never", uninitialized: "consecutive" }]
         }
 
     ],
@@ -1519,6 +1523,28 @@ ruleTester.run("one-var", rule, {
                 type: "VariableDeclaration",
                 line: 1,
                 column: 41
+            }]
+        },
+        {
+            code: "const a = 1, b = 2; let c, d; foo(); let e; let f; let g = 3, h = 4;",
+            options: [{ const: "never", initialized: "never", uninitialized: "consecutive" }],
+            errors: [{
+                message: "Split initialized 'const' declarations into multiple statements.",
+                type: "VariableDeclaration",
+                line: 1,
+                column: 1
+            },
+            {
+                message: "Combine this with the previous 'let' statement with uninitialized variables.",
+                type: "VariableDeclaration",
+                line: 1,
+                column: 45
+            },
+            {
+                message: "Split initialized 'let' declarations into multiple statements.",
+                type: "VariableDeclaration",
+                line: 1,
+                column: 52
             }]
         }
     ]


### PR DESCRIPTION
We can now do:
```json
"one-var": [2, {
    "const": "never",
    "initialized": "never",
    "uninitialized": "consecutive"
}],
```

… where previously we were limited to:
```json
"one-var": [2, {
    "const": "never"
}],
```
… or
```json
"one-var": [2, {
    "initialized": "never",
    "uninitialized": "consecutive"
}],
```

… which meant that this unrunnable code would pass the lint:
```js
const a, b;
```

… and that finer control was not possible: #10200