### PR TITLE
Fix: do not autofix object-shorthand with comments (fixes #10038)

### DIFF
--- a/lib/rules/object-shorthand.js
+++ b/lib/rules/object-shorthand.js
@@ -233,6 +233,10 @@ module.exports = {
             const keyText = sourceCode.text.slice(firstKeyToken.range[0], lastKeyToken.range[1]);
             let keyPrefix = "";
 
+            if (sourceCode.getCommentsBefore(sourceCode.getFirstToken(node.value)).length > 0) {
+                return null;
+            }
+
             if (node.value.async) {
                 keyPrefix += "async ";
             }

--- a/lib/rules/object-shorthand.js
+++ b/lib/rules/object-shorthand.js
@@ -233,7 +233,7 @@ module.exports = {
             const keyText = sourceCode.text.slice(firstKeyToken.range[0], lastKeyToken.range[1]);
             let keyPrefix = "";
 
-            if (sourceCode.getCommentsBefore(sourceCode.getFirstToken(node.value)).length > 0) {
+            if (sourceCode.commentsExistBetween(lastKeyToken, node.value)) {
                 return null;
             }
 

--- a/tests/lib/rules/object-shorthand.js
+++ b/tests/lib/rules/object-shorthand.js
@@ -428,6 +428,11 @@ ruleTester.run("object-shorthand", rule, {
             errors: [METHOD_ERROR]
         },
         {
+            code: "var x = {\n  f: /* comment */ function() {\n  }\n  }",
+            output: null,
+            errors: [METHOD_ERROR]
+        },
+        {
             code: "var x = {y: function() {}}",
             output: "var x = {y() {}}",
             errors: [METHOD_ERROR]

--- a/tests/lib/rules/object-shorthand.js
+++ b/tests/lib/rules/object-shorthand.js
@@ -433,6 +433,11 @@ ruleTester.run("object-shorthand", rule, {
             errors: [METHOD_ERROR]
         },
         {
+            code: "var x = {\n f /* comment */: function() {\n  }\n  }",
+            output: null,
+            errors: [METHOD_ERROR]
+        },
+        {
             code: "var x = {y: function() {}}",
             output: "var x = {y() {}}",
             errors: [METHOD_ERROR]


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
https://github.com/eslint/eslint/issues/10038
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
I added a check in the ```makeFunctionShorthand``` function that returns a null fixer if there is a comment between a functionExpression property key and value, since the comment cannot be auto fixed without changing its position. 
```javascript
if (sourceCode.getCommentsBefore(sourceCode.getFirstToken(node.value)).length > 0) {
    return null;
}
```
I also added a test that would fail without this check.

**Is there anything you'd like reviewers to focus on?**
I wasn't absolutely sure about where to add the check, I chose the makeFunctionShorthand helper because it returns a ```fixer``` object and this was an autofix bug. 
