### PR TITLE
Fix: do not autofix octal escape sequence (fixes #10031)

### DIFF
--- a/lib/rules/prefer-template.js
+++ b/lib/rules/prefer-template.js
@@ -52,7 +52,7 @@ function isOctalEscapeSequence(node) {
         return false;
     }
 
-    const match = node.raw.match(/^([^\\]|\\[^0-7])*\\([0-3][0-7]{1,2}|[4-7][0-7]|[0-7])/);
+    const match = node.raw.match(/^([^\\]|\\([^0-7]|0[^0-7]))*\\([0-7]{1,3})/);
 
     if (match) {
 

--- a/lib/rules/prefer-template.js
+++ b/lib/rules/prefer-template.js
@@ -52,7 +52,7 @@ function isOctalEscapeSequence(node) {
         return false;
     }
 
-    const match = node.raw.match(/^([^\\]|\\([^0-7]|0[^0-7]))*\\([0-7]{1,3})/);
+    const match = node.raw.match(/^([^\\]|\\[^0-7])*\\([0-7]{1,3})/);
 
     if (match) {
 

--- a/lib/rules/prefer-template.js
+++ b/lib/rules/prefer-template.js
@@ -39,6 +39,45 @@ function getTopConcatBinaryExpression(node) {
 }
 
 /**
+ * Determines whether a given node is a octal escape sequence
+ * @param {ASTNode} node A node to check
+ * @returns {boolean} `true` if the node is an octal escape sequence
+ */
+function isOctalEscapeSequence(node) {
+
+    // No need to check TemplateLiterals – would throw error with octal escape
+    const isStringLiteral = node.type === "Literal" && typeof node.value === "string";
+
+    if (!isStringLiteral) {
+        return false;
+    }
+
+    const match = node.raw.match(/^([^\\]|\\[^0-7])*\\([0-3][0-7]{1,2}|[4-7][0-7]|[0-7])/);
+
+    if (match) {
+
+        // \0 is actually not considered an octal
+        if (match[2] !== "0" || typeof match[3] !== "undefined") {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Checks whether or not a node contains a octal escape sequence
+ * @param {ASTNode} node A node to check
+ * @returns {boolean} `true` if the node contains an octal escape sequence
+ */
+function hasOctalEscapeSequence(node) {
+    if (isConcatenation(node)) {
+        return hasOctalEscapeSequence(node.left) || hasOctalEscapeSequence(node.right);
+    }
+
+    return isOctalEscapeSequence(node);
+}
+
+/**
  * Checks whether or not a given binary expression has string literals.
  * @param {ASTNode} node - A node to check.
  * @returns {boolean} `true` if the node has string literals.
@@ -194,6 +233,22 @@ module.exports = {
         }
 
         /**
+         * Returns a fixer object that converts a non-string binary expression to a template literal
+         * @param {SourceCodeFixer} fixer The fixer object
+         * @param {ASTNode} node A node that should be converted to a template literal
+         * @returns {Object} A fix for this binary expression
+         */
+        function fixNonStringBinaryExpression(fixer, node) {
+            const topBinaryExpr = getTopConcatBinaryExpression(node.parent);
+
+            if (hasOctalEscapeSequence(topBinaryExpr)) {
+                return null;
+            }
+
+            return fixer.replaceText(topBinaryExpr, getTemplateLiteral(topBinaryExpr, null, null));
+        }
+
+        /**
          * Reports if a given node is string concatenation with non string literals.
          *
          * @param {ASTNode} node - A node to check.
@@ -216,9 +271,7 @@ module.exports = {
                 context.report({
                     node: topBinaryExpr,
                     message: "Unexpected string concatenation.",
-                    fix(fixer) {
-                        return fixer.replaceText(topBinaryExpr, getTemplateLiteral(topBinaryExpr, null, null));
-                    }
+                    fix: fixer => fixNonStringBinaryExpression(fixer, node)
                 });
             }
         }

--- a/tests/lib/rules/prefer-template.js
+++ b/tests/lib/rules/prefer-template.js
@@ -34,7 +34,8 @@ ruleTester.run("prefer-template", rule, {
 
         // https://github.com/eslint/eslint/issues/3507
         "var foo = `foo` + `bar` + \"hoge\";",
-        "var foo = `foo` +\n    `bar` +\n    \"hoge\";"
+        "var foo = `foo` +\n    `bar` +\n    \"hoge\";",
+        "var foo = `foo` + `\\0`;"
     ],
     invalid: [
         {

--- a/tests/lib/rules/prefer-template.js
+++ b/tests/lib/rules/prefer-template.js
@@ -187,6 +187,11 @@ ruleTester.run("prefer-template", rule, {
             code: "foo + 'handles unicode escapes correctly: \\x27'", // "\x27" === "'"
             output: "`${foo  }handles unicode escapes correctly: \\x27`",
             errors
+        },
+        {
+            code: "foo + 'does not autofix octal escape sequence' + '\\033'",
+            output: null,
+            errors
         }
     ]
 });

--- a/tests/lib/rules/prefer-template.js
+++ b/tests/lib/rules/prefer-template.js
@@ -26,6 +26,7 @@ const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
 ruleTester.run("prefer-template", rule, {
     valid: [
         "'use strict';",
+        "var foo = 'foo' + '\\0';",
         "var foo = 'bar';",
         "var foo = 'bar' + 'baz';",
         "var foo = foo + +'100';",
@@ -34,8 +35,7 @@ ruleTester.run("prefer-template", rule, {
 
         // https://github.com/eslint/eslint/issues/3507
         "var foo = `foo` + `bar` + \"hoge\";",
-        "var foo = `foo` +\n    `bar` +\n    \"hoge\";",
-        "var foo = `foo` + `\\0`;"
+        "var foo = `foo` +\n    `bar` +\n    \"hoge\";"
     ],
     invalid: [
         {
@@ -205,8 +205,8 @@ ruleTester.run("prefer-template", rule, {
             errors
         },
         {
-            code: "foo + '\\0 other test \\033'",
-            output: null,
+            code: "foo + '\\0'",
+            output: "`${foo  }\\0`",
             errors
         }
     ]

--- a/tests/lib/rules/prefer-template.js
+++ b/tests/lib/rules/prefer-template.js
@@ -192,6 +192,16 @@ ruleTester.run("prefer-template", rule, {
             code: "foo + 'does not autofix octal escape sequence' + '\\033'",
             output: null,
             errors
+        },
+        {
+            code: "foo + '\\n other text \\033'",
+            output: null,
+            errors
+        },
+        {
+            code: "foo + '\\\\033'",
+            output: "`${foo  }\\\\033`",
+            errors
         }
     ]
 });

--- a/tests/lib/rules/prefer-template.js
+++ b/tests/lib/rules/prefer-template.js
@@ -202,6 +202,11 @@ ruleTester.run("prefer-template", rule, {
             code: "foo + '\\\\033'",
             output: "`${foo  }\\\\033`",
             errors
+        },
+        {
+            code: "foo + '\\0 other test \\033'",
+            output: null,
+            errors
         }
     ]
 });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
https://github.com/eslint/eslint/issues/10031
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Added a check for octal escape sequences in binary expressions. The```prefer-template``` rule does not attempt to fix binary expressions that contain octal escape sequences, and returns a ```null``` fixer object if this is the case.

Also added a test that ensures that binary expressions with octal escape sequences are not auto fixed.

**Is there anything you'd like reviewers to focus on?**

