### PR TITLE
Chore: small opt to improve readability

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -209,7 +209,7 @@ class Config {
             const localConfigHierarchyCache = this.configCache.getHierarchyLocalConfigs(localConfigDirectory);
 
             if (localConfigHierarchyCache) {
-                const localConfigHierarchy = localConfigHierarchyCache.concat(configs.reverse());
+                const localConfigHierarchy = localConfigHierarchyCache.concat(configs);
 
                 this.configCache.setHierarchyLocalConfigs(searched, localConfigHierarchy);
                 return localConfigHierarchy;
@@ -232,7 +232,7 @@ class Config {
             }
 
             debug(`Using ${localConfigFile}`);
-            configs.push(localConfig);
+            configs.unshift(localConfig);
             searched.push(localConfigDirectory);
 
             // Stop traversing if a config is found with the root flag set
@@ -248,7 +248,7 @@ class Config {
             const personalConfig = this.getPersonalConfig();
 
             if (personalConfig) {
-                configs.push(personalConfig);
+                configs.unshift(personalConfig);
             } else if (!hasRules(this.options) && !this.options.baseConfig) {
 
                 // No config file, no manual configuration, and no rules, so error.
@@ -265,7 +265,7 @@ class Config {
         }
 
         // Set the caches for the parent directories
-        this.configCache.setHierarchyLocalConfigs(searched, configs.reverse());
+        this.configCache.setHierarchyLocalConfigs(searched, configs);
 
         return configs;
     }

--- a/lib/ignored-paths.js
+++ b/lib/ignored-paths.js
@@ -231,7 +231,7 @@ class IgnoredPaths {
     /**
      * Determine whether a file path is included in the default or custom ignore patterns
      * @param {string} filepath Path to check
-     * @param {string} [category=null] check 'default', 'custom' or both (null)
+     * @param {string} [category=undefined] check 'default', 'custom' or both (undefined)
      * @returns {boolean} true if the file path matches one or more patterns, false otherwise
      */
     contains(filepath, category) {
@@ -240,12 +240,11 @@ class IgnoredPaths {
         const absolutePath = path.resolve(this.options.cwd, filepath);
         const relativePath = pathUtil.getRelativePath(absolutePath, this.baseDir);
 
-        if ((typeof category === "undefined") || (category === "default")) {
-            result = result || (this.ig.default.filter([relativePath]).length === 0);
-        }
-
-        if ((typeof category === "undefined") || (category === "custom")) {
-            result = result || (this.ig.custom.filter([relativePath]).length === 0);
+        if (typeof category === "undefined") {
+            result = (this.ig.default.filter([relativePath]).length === 0) ||
+                (this.ig.custom.filter([relativePath]).length === 0);
+        } else {
+            result = (this.ig[category].filter([relativePath]).length === 0);
         }
 
         return result;


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
use `config.unshift()` to avoid calling `config.reverse()` -- more clear, and a little perf win.

**Is there anything you'd like reviewers to focus on?**
no

