### PR TITLE
Fix: Junit formatter handles better warnings/errors (fixes #10266)

### DIFF
--- a/lib/formatters/junit.js
+++ b/lib/formatters/junit.js
@@ -40,7 +40,7 @@ module.exports = function(results) {
         const messages = result.messages;
 
         if (messages.length > 0) {
-            output += `<testsuite package="org.eslint" time="0" tests="${messages.length}" errors="${messages.length}" name="${result.filePath}">\n`;
+            output += `<testsuite package="org.eslint" time="0" tests="${messages.length}" errors="${result.errorCount}" warnings="${result.warningCount}" name="${result.filePath}">\n`;
             messages.forEach(message => {
                 const type = message.fatal ? "error" : "failure";
 


### PR DESCRIPTION
Now uses warningCount+errorCount in warnings/errors xml attrs

<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
I've change the behaviour of warnings/errors counter of this formatter.
Typical case: eslint output 2 warnings in a file.

Before, formatter output was something like that:
```
<testsuite package="org.eslint" time="0" tests="2" errors="2" name="/usr/app/PATH_TO_THE_TESTED_FILE.js">[...]
```

Now, formatter will be able to output something like that:
```
<testsuite package="org.eslint" time="0" tests="2" errors="0" warnings="2" name="/usr/app/PATH_TO_THE_TESTED_FILE.js">[...]
```

So now, it truly handles warns. 

**Is there anything you'd like reviewers to focus on?**
No

