### PR TITLE
Chore: Add ESLint path to plugin-missing message

### DIFF
--- a/lib/config/plugins.js
+++ b/lib/config/plugins.js
@@ -10,6 +10,7 @@
 
 const debug = require("debug")("eslint:plugins");
 const naming = require("../util/naming");
+const path = require("path");
 
 //------------------------------------------------------------------------------
 // Public Interface
@@ -100,7 +101,8 @@ class Plugins {
                     missingPluginErr.message = `Failed to load plugin ${pluginName}: ${missingPluginErr.message}`;
                     missingPluginErr.messageTemplate = "plugin-missing";
                     missingPluginErr.messageData = {
-                        pluginName: longName
+                        pluginName: longName,
+                        eslintPath: path.resolve(__dirname, "../..")
                     };
                     throw missingPluginErr;
                 }

--- a/messages/plugin-missing.txt
+++ b/messages/plugin-missing.txt
@@ -6,4 +6,6 @@ ESLint couldn't find the plugin "<%- pluginName %>". This can happen for a coupl
 
     npm i <%- pluginName %>@latest --save-dev
 
+Path to ESLint: <%- eslintPath %>
+
 If you still can't figure out the problem, please stop by https://gitter.im/eslint/eslint to chat with the team.

--- a/messages/plugin-missing.txt
+++ b/messages/plugin-missing.txt
@@ -6,6 +6,6 @@ ESLint couldn't find the plugin "<%- pluginName %>". This can happen for a coupl
 
     npm i <%- pluginName %>@latest --save-dev
 
-Path to ESLint: <%- eslintPath %>
+Path to ESLint package: <%- eslintPath %>
 
 If you still can't figure out the problem, please stop by https://gitter.im/eslint/eslint to chat with the team.


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain: Adding the path to ESLint inside the plugin-missing message.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Added ESLint path (path to the package folder) to the plugin-missing template. This should hopefully allow users or team members to spot if users are running ESLint from somewhere different than they meant to.

**Is there anything you'd like reviewers to focus on?**

* Am I missing anything? Is this approach going to work in some more unusual situations?
* Should I add some tests around this? (We have tests around errors being thrown when a plugin is not available, but not around the fact that it uses a messageTemplate/messageData for CLI users.)