### PR TITLE
fix 'no-multiple-empty-lines'.maxEOF out by one

### DIFF
--- a/lib/rules/no-multiple-empty-lines.js
+++ b/lib/rules/no-multiple-empty-lines.js
@@ -57,9 +57,7 @@ module.exports = {
         }
 
         const sourceCode = context.getSourceCode();
-
-        // Swallow the final newline, as some editors add it automatically and we don't want it to cause an issue
-        const allLines = sourceCode.lines[sourceCode.lines.length - 1] === "" ? sourceCode.lines.slice(0, -1) : sourceCode.lines;
+        const allLines = sourceCode.lines;
         const templateLiteralLines = new Set();
 
         //--------------------------------------------------------------------------


### PR DESCRIPTION
https://github.com/airbnb/javascript/pull/1794

<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:


**What changes did you make? (Give an overview)**
Removed the code that ignores the last line of documents

**Is there anything you'd like reviewers to focus on?**
This lead to an Airbnb miss-configuration: https://github.com/airbnb/javascript/pull/1794
Also the comment removed was wrong: all text editors terminate text files with a newline by definition.

