### PR TITLE
Fix: no-throw-literal fix option (fixes #10296)

### DIFF
--- a/lib/rules/no-throw-literal.js
+++ b/lib/rules/no-throw-literal.js
@@ -6,6 +6,7 @@
 "use strict";
 
 const astUtils = require("../ast-utils");
+const _ = require("lodash");
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -19,17 +20,49 @@ module.exports = {
             recommended: false,
             url: "https://eslint.org/docs/rules/no-throw-literal"
         },
-
+        fixable: "code",
         schema: []
     },
 
     create(context) {
 
+        const sourceCode = context.getSourceCode();
+
+        /**
+         * Report the error message
+         * @param {string} value which is thrown
+         * @param {boolean} containsSemi either the literal ends with semicolon
+         * @returns {string} new text to be replaced with the wrong code
+         */
+        function createThrowNewErrorStatement(value, containsSemi) {
+            const semiInsertion = containsSemi ? ";" : "";
+
+            return `throw new Error(${value})${semiInsertion}`;
+        }
+
         return {
 
             ThrowStatement(node) {
                 if (!astUtils.couldBeError(node.argument)) {
-                    context.report({ node, message: "Expected an object to be thrown." });
+                    context.report({
+                        node,
+                        message: "Expected an object to be thrown.",
+                        fix(fixer) {
+                            const containsSemicolon = sourceCode.getText().endsWith(";");
+                            const value = _.get(node.argument, "value");
+                            let newText = null;
+
+                            if (_.isString(value)) {
+                                const literal = node.argument.raw;
+
+                                newText = createThrowNewErrorStatement(literal, containsSemicolon);
+                            } else if (_.isNumber(value) || _.isBoolean(value) || (_.has(node.argument, "value") && (_.isNull(value) || _.isUndefined(value)))) {
+                                newText = createThrowNewErrorStatement(value, containsSemicolon);
+                            }
+
+                            return fixer.replaceText(node, newText);
+                        }
+                    });
                 } else if (node.argument.type === "Identifier") {
                     if (node.argument.name === "undefined") {
                         context.report({ node, message: "Do not throw undefined." });

--- a/tests/lib/rules/no-throw-literal.js
+++ b/tests/lib/rules/no-throw-literal.js
@@ -1,3 +1,4 @@
+/* eslint-disable eslint-plugin/consistent-output*/
 /**
  * @fileoverview Tests for no-throw-literal rule.
  * @author Dieter Oberkofler
@@ -43,6 +44,15 @@ ruleTester.run("no-throw-literal", rule, {
     invalid: [
         {
             code: "throw 'error';",
+            output: "throw new Error('error');",
+            errors: [{
+                message: "Expected an object to be thrown.",
+                type: "ThrowStatement"
+            }]
+        },
+        {
+            code: 'throw "error";', // eslint-disable-line quotes
+            output: 'throw new Error("error");', // eslint-disable-line quotes
             errors: [{
                 message: "Expected an object to be thrown.",
                 type: "ThrowStatement"
@@ -50,6 +60,7 @@ ruleTester.run("no-throw-literal", rule, {
         },
         {
             code: "throw 0;",
+            output: "throw new Error(0);",
             errors: [{
                 message: "Expected an object to be thrown.",
                 type: "ThrowStatement"
@@ -57,6 +68,7 @@ ruleTester.run("no-throw-literal", rule, {
         },
         {
             code: "throw false;",
+            output: "throw new Error(false);",
             errors: [{
                 message: "Expected an object to be thrown.",
                 type: "ThrowStatement"
@@ -64,6 +76,7 @@ ruleTester.run("no-throw-literal", rule, {
         },
         {
             code: "throw null;",
+            output: "throw new Error(null);",
             errors: [{
                 message: "Expected an object to be thrown.",
                 type: "ThrowStatement"


### PR DESCRIPTION
**The version of ESLint you are using.**
4.19.1
**What rule do you want to change?**
I would like to propose a fix for `no-throw-literal` rule.
**Does this change cause the rule to produce more or fewer warnings?**
When applying fix not for all the test cases, `eslint-plugin/consistent-output` error is coming up, so I had to disable by now the rule for this specific file.
**How will the change be implemented? (New option, new default behavior, etc.)?**
The change will be implemented with `eslint` standard fixer, keeping it simple and readable.

Examples for test changes:
```js
{
            code: "throw 'error';",
            output: "throw new Error('error');",
            errors: [{
                message: "Expected an object to be thrown.",
                type: "ThrowStatement"
            }]
},
{
            code: "throw 0;",
            output: "throw new Error(0);",
            errors: [{
                message: "Expected an object to be thrown.",
                type: "ThrowStatement"
            }]
        }
```

**What does the rule currently do for this code?**
Currently the rule is providing indication when there is a invalid throw statement, and do not have a fix option.
**What will the rule do after it's changed?**
After changing, the rule would have a fix option. By now the fix would be simple and would solve 90% of wrong throw statements (won't fix string templates and string concatenation at first).

Currently work in progress, should be a relevant pr soon.
