### PR TITLE
Chore: Update issue templates with new format

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -1,0 +1,54 @@
+---
+name: Bug report
+about: Report an issue with ESLint or rules bundled with ESLint
+
+---
+
+<!--
+    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
+
+    This template is for bug reports. If you are here for another reason, please see below:
+
+    1. To propose a new rule: https://eslint.org/docs/developer-guide/contributing/new-rules
+    2. To request a rule change: https://eslint.org/docs/developer-guide/contributing/rule-changes
+    3. To request a change that is not a bug fix, rule change, or new rule: https://eslint.org/docs/developer-guide/contributing/changes
+    4. If you have any questions, please stop by our chatroom: https://gitter.im/eslint/eslint
+
+    Note that leaving sections blank will make it difficult for us to troubleshoot and we may have to close the issue.
+-->
+
+**Tell us about your environment**
+
+* **ESLint Version:**
+* **Node Version:**
+* **npm Version:**
+
+**What parser (default, Babel-ESLint, etc.) are you using?**
+
+**Please show your full configuration:**
+
+<details>
+<summary>Configuration</summary>
+
+<!-- Paste your configuration below: -->
+```js
+
+```
+
+</details>
+
+**What did you do? Please include the actual source code causing the issue, as well as the command that you used to run ESLint.**
+
+<!-- Paste the source code below: -->
+```js
+
+```
+
+<!-- Paste the command you used to run ESLint: -->
+```bash
+
+```
+
+**What did you expect to happen?**
+
+**What actually happened? Please include the actual, raw output from ESLint.**

--- a/.github/ISSUE_TEMPLATE/CHANGE.md
+++ b/.github/ISSUE_TEMPLATE/CHANGE.md
@@ -1,3 +1,9 @@
+---
+name: Non-rule change request
+about: Request a change that is not a bug fix, rule change, or new rule
+
+---
+
 <!--
     ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
 
@@ -11,15 +17,9 @@
     Note that leaving sections blank will make it difficult for us to troubleshoot and we may have to close the issue.
 -->
 
-**Tell us about your environment**
+**The version of ESLint you are using.**
 
-* **ESLint Version:**
-* **Node Version:**
-* **npm Version:**
+**The problem you want to solve.**
 
-**What did you do?**
-
-**What happened?**
-
-**What did you expect to happen?**
+**Your take on the correct solution to problem.**
 

--- a/.github/ISSUE_TEMPLATE/NEW_RULE.md
+++ b/.github/ISSUE_TEMPLATE/NEW_RULE.md
@@ -1,3 +1,9 @@
+---
+name: New rule proposal
+about: Propose a new rule to be added to ESLint
+
+---
+
 <!--
     ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
 

--- a/.github/ISSUE_TEMPLATE/RULE_CHANGE.md
+++ b/.github/ISSUE_TEMPLATE/RULE_CHANGE.md
@@ -1,3 +1,9 @@
+---
+name: Rule change request
+about: Request a change to an existing rule
+
+---
+
 <!--
     ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:
Github introduced issue type selector, but the format needs to be updated to follow their guidelines. I tried using their UI, but it only supports up to 3 types, and we need 4. So modified those template manually.
<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Updated issue templates

**Is there anything you'd like reviewers to focus on?**
Do we still need to links to other templates in the comments?

