### PR TITLE
Chore: resolve the relative configuration file by the strategy how node resolves a .js module

### DIFF
--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -150,10 +150,11 @@ function loadLegacyConfigFile(filePath) {
  */
 function loadJSConfigFile(filePath) {
     debug(`Loading JS config file: ${filePath}`);
+
     try {
         return requireUncached(filePath);
     } catch (e) {
-        debug(`Error reading JavaScript file: ${filePath}`);
+        debug(`Error resolving JavaScript file: ${filePath}`);
         e.message = `Cannot read config file: ${filePath}\nError: ${e.message}`;
         throw e;
     }
@@ -452,10 +453,16 @@ function applyExtends(config, configContext, filePath, relativeTo) {
  */
 function resolve(filePath, relativeTo) {
     if (isFilePath(filePath)) {
-        const fullPath = path.resolve(relativeTo || "", filePath);
+        let fullPath = path.resolve(relativeTo || "", filePath);
+
+        try {
+            fullPath = require.resolve(filePath);
+            // eslint-disable-next-line no-empty
+        } catch (error) {}
 
         return { filePath: fullPath, configFullName: fullPath };
     }
+
     let normalizedPackageName;
 
     if (filePath.startsWith("plugin:")) {
@@ -472,6 +479,7 @@ function resolve(filePath, relativeTo) {
             configFullName
         };
     }
+
     normalizedPackageName = naming.normalizePackageName(filePath, "eslint-config");
     debug(`Attempting to resolve ${normalizedPackageName}`);
 
@@ -479,8 +487,6 @@ function resolve(filePath, relativeTo) {
         filePath: resolver.resolve(normalizedPackageName, getLookupPath(relativeTo)),
         configFullName: filePath
     };
-
-
 }
 
 /**

--- a/tests/fixtures/config-file/js/.eslintrc.resolvable.js
+++ b/tests/fixtures/config-file/js/.eslintrc.resolvable.js
@@ -1,0 +1,3 @@
+module.exports = {
+    extends: "./node_modules/resolvable"
+}

--- a/tests/fixtures/config-file/js/.eslintrc.unresolvable.js
+++ b/tests/fixtures/config-file/js/.eslintrc.unresolvable.js
@@ -1,0 +1,3 @@
+module.exports = {
+    extends: "./node_modules/non-exist-module"
+}

--- a/tests/fixtures/config-file/js/node_modules/resolvable/index.js
+++ b/tests/fixtures/config-file/js/node_modules/resolvable/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+    rules: {}
+};

--- a/tests/lib/config/config-file.js
+++ b/tests/lib/config/config-file.js
@@ -481,6 +481,16 @@ describe("ConfigFile", () => {
             });
         });
 
+        it("should load file by the strategy of how `require()` resolve a js file", () => {
+            assert.doesNotThrow(() => {
+                ConfigFile.load(getFixturePath("js/.eslintrc.resolvable.js"), configContext);
+            });
+
+            assert.throws(() => {
+                ConfigFile.load(getFixturePath("js/.eslintrc.unresolvable.js"), configContext);
+            });
+        });
+
         it("should load information from a legacy file", () => {
             const configFilePath = getFixturePath("legacy/.eslintrc");
             const config = ConfigFile.load(configFilePath, configContext);


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ X ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)** 

As the test shows, when I want to extend the eslint configuration through an irregular way, not a configuration package name, but a particular file path target to the configuration file. But I'm lazy that not want to write down the full path of the target configuration. I want the eslint find it in the way how node resolves a module.

**Is there anything you'd like reviewers to focus on?**

I'm not sure will this be conflicted with something else, but the tests passed except an error like this:

![image](https://user-images.githubusercontent.com/10795207/39661541-b2e6a01a-5085-11e8-94a3-223acf2b79e1.png)

So, I think it' okay with the current implementation, if I missed something, please check it and tell me, thanks ~

