### PR TITLE
Breaking: report multiline eslint-disable-line directives (fixes #10334)

### DIFF
--- a/docs/user-guide/migrating-to-5.0.0.md
+++ b/docs/user-guide/migrating-to-5.0.0.md
@@ -13,6 +13,7 @@ The lists below are ordered roughly by the number of users each change is expect
 1. [Deprecated globals have been removed from the `node`, `browser`, and `jest` environments](#deprecated-globals)
 1. [Empty files are now linted](#empty-files)
 1. [Plugins in scoped packages are now resolvable in configs](#scoped-plugins)
+1. [Multi-line `eslint-disable-line` directives are now reported as problems](#multiline-directives)
 
 ### Breaking changes for plugin/custom rule developers
 
@@ -141,9 +142,24 @@ If you have a custom rule, you should make sure it handles empty files appropria
 
 ## <a name="scoped-plugins"></a> Plugins in scoped packages are now resolvable in configs
 
-When it encounters a plugin name in a config starting with `@`, ESLint v5 will resolve it as a [scoped npm package](https://docs.npmjs.com/misc/scope). For example, if a config contains `"plugins": ["@foo"]`, ESLint v5 will attempt to load a package called `@foo/eslint-plugin`. (On the other hand, ESLint v4 would attempt to load a package called `eslint-plugin-@foo`.) This is a breaking change because users might have been relying on ESLint finding a package at `node_modules/eslint-plugin-@foo`. However, we think it is unlikely that many users were relying on this behavior, because packages published to npm cannot contain an `@` character in the middle.
+When ESLint v5 encounters a plugin name in a config starting with `@`, the plugin will be resolved as a [scoped npm package](https://docs.npmjs.com/misc/scope). For example, if a config contains `"plugins": ["@foo"]`, ESLint v5 will attempt to load a package called `@foo/eslint-plugin`. (On the other hand, ESLint v4 would attempt to load a package called `eslint-plugin-@foo`.) This is a breaking change because users might have been relying on ESLint finding a package at `node_modules/eslint-plugin-@foo`. However, we think it is unlikely that many users were relying on this behavior, because packages published to npm cannot contain an `@` character in the middle.
 
 **To address:** If you rely on ESLint loading a package like `eslint-config-@foo`, consider renaming the package to something else.
+
+## <a name="multiline-directives"></a> Multi-line `eslint-disable-line` directives are now reported as problems
+
+`eslint-disable-line` and `eslint-disable-next-line` directive comments are only allowed to span a single line. For example, the following directive comment is invalid:
+
+```js
+alert('foo'); /* eslint-disable-line
+   no-alert */ alert('bar');
+
+// (which line is the rule disabled on?)
+```
+
+Previously, ESLint would ignore these malformed directive comments. ESLint v5 will report an error when it sees a problem like this, so that the issue can be more easily corrected.
+
+**To address:** If you see new reported errors as a result of this change, ensure that your `eslint-disable-line` directives only span a single line. Note that "block comments" (delimited by `/* */`) are still allowed to be used for directives, provided that the block comments do not contain linebreaks.
 
 ---
 

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -281,10 +281,23 @@ function getDirectiveComments(filename, ast, ruleMapper) {
 
         const directiveValue = trimmedCommentText.slice(match.index + match[1].length);
 
-        if (/^eslint-disable-(next-)?line$/.test(match[1]) && comment.loc.start.line === comment.loc.end.line) {
-            const directiveType = match[1].slice("eslint-".length);
+        if (/^eslint-disable-(next-)?line$/.test(match[1])) {
+            if (comment.loc.start.line === comment.loc.end.line) {
+                const directiveType = match[1].slice("eslint-".length);
 
-            disableDirectives.push(...createDisableDirectives(directiveType, comment.loc.start, directiveValue));
+                disableDirectives.push(...createDisableDirectives(directiveType, comment.loc.start, directiveValue));
+            } else {
+                problems.push({
+                    ruleId: null,
+                    severity: 2,
+                    message: `${match[1]} comment should not span multiple lines.`,
+                    line: comment.loc.start.line,
+                    column: comment.loc.start.column + 1,
+                    endLine: comment.loc.end.line,
+                    endColumn: comment.loc.end.column + 1,
+                    nodeType: null
+                });
+            }
         } else if (comment.type === "Block") {
             switch (match[1]) {
                 case "exported":

--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -1913,30 +1913,47 @@ describe("Linter", () => {
 
                 const messages = linter.verify(code, config, filename);
 
-                assert.strictEqual(messages.length, 1);
+                assert.strictEqual(messages.length, 2);
 
-                assert.strictEqual(messages[0].ruleId, "no-console");
+                assert.strictEqual(messages[1].ruleId, "no-console");
             });
 
-            it("should report a violation if eslint-disable-line in a block comment is not on a single line", () => {
+            it("should not disable rule and add an extra report if eslint-disable-line in a block comment is not on a single line", () => {
                 const code = [
                     "alert('test'); /* eslint-disable-line ",
                     "no-alert */"
                 ].join("\n");
                 const config = {
                     rules: {
-                        "no-alert": 1,
-                        quotes: [1, "double"],
-                        semi: [1, "always"]
+                        "no-alert": 1
                     }
                 };
 
-                const messages = linter.verify(code, config, filename);
+                const messages = linter.verify(code, config);
 
-                assert.strictEqual(messages.length, 2);
-
-                assert.strictEqual(messages[0].ruleId, "no-alert");
-                assert.strictEqual(messages[1].ruleId, "quotes");
+                assert.deepStrictEqual(messages, [
+                    {
+                        ruleId: "no-alert",
+                        severity: 1,
+                        line: 1,
+                        column: 1,
+                        endLine: 1,
+                        endColumn: 14,
+                        message: "Unexpected alert.",
+                        messageId: "unexpected",
+                        nodeType: "CallExpression"
+                    },
+                    {
+                        ruleId: null,
+                        severity: 2,
+                        message: "eslint-disable-line comment should not span multiple lines.",
+                        line: 1,
+                        column: 16,
+                        endLine: 2,
+                        endColumn: 12,
+                        nodeType: null
+                    }
+                ]);
             });
 
             it("should not report a violation for eslint-disable-line in block comment", () => {
@@ -2089,8 +2106,8 @@ describe("Linter", () => {
                 };
                 const messages = linter.verify(code, config, filename);
 
-                assert.strictEqual(messages.length, 1);
-                assert.strictEqual(messages[0].ruleId, "no-alert");
+                assert.strictEqual(messages.length, 2);
+                assert.strictEqual(messages[1].ruleId, "no-alert");
             });
 
             it("should ignore violations only of specified rule", () => {
@@ -2243,9 +2260,9 @@ describe("Linter", () => {
 
                 const messages = linter.verify(code, config, filename);
 
-                assert.strictEqual(messages.length, 1);
+                assert.strictEqual(messages.length, 2);
 
-                assert.strictEqual(messages[0].ruleId, "no-console");
+                assert.strictEqual(messages[1].ruleId, "no-console");
             });
 
             it("should not ignore violations if comment is of the type Shebang", () => {


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates `Linter` to add an error for multiline `eslint-disable-line` directives, as described in https://github.com/eslint/eslint/issues/10334.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
