### PR TITLE
Breaking: new object-curly-newline/no-self-assign default (fixes #10215)

### DIFF
--- a/docs/rules/no-self-assign.md
+++ b/docs/rules/no-self-assign.md
@@ -39,38 +39,6 @@ let foo = foo;
 
 // The default values have an effect.
 [foo = 1] = [foo];
-```
-
-## Options
-
-This rule has the option to check properties as well.
-
-```json
-{
-    "no-self-assign": ["error", {"props": false}]
-}
-```
-
-- `props` - if this is `true`, `no-self-assign` rule warns self-assignments of properties. Default is `false`.
-
-### props
-
-Examples of **incorrect** code for the `{ "props": true }` option:
-
-```js
-/*eslint no-self-assign: ["error", {"props": true}]*/
-
-// self-assignments with properties.
-obj.a = obj.a;
-obj.a.b = obj.a.b;
-obj["a"] = obj["a"];
-obj[a] = obj[a];
-```
-
-Examples of **correct** code for the `{ "props": true }` option:
-
-```js
-/*eslint no-self-assign: ["error", {"props": true}]*/
 
 // non-self-assignments with properties.
 obj.a = obj.b;
@@ -85,6 +53,32 @@ a().b = a().b
 // Known limitation: this does not support computed properties except single literal or single identifier.
 obj[a + b] = obj[a + b];
 obj["a" + "b"] = obj["a" + "b"];
+```
+
+## Options
+
+This rule has the option to check properties as well.
+
+```json
+{
+    "no-self-assign": ["error", {"props": true}]
+}
+```
+
+- `props` - if this is `true`, `no-self-assign` rule warns self-assignments of properties. Default is `true`.
+
+### props
+
+Examples of **correct** code with the `{ "props": false }` option:
+
+```js
+/*eslint no-self-assign: ["error", {"props": true}]*/
+
+// self-assignments with properties.
+obj.a = obj.a;
+obj.a.b = obj.a.b;
+obj["a"] = obj["a"];
+obj[a] = obj[a];
 ```
 
 ## When Not To Use It

--- a/docs/rules/no-self-assign.md
+++ b/docs/rules/no-self-assign.md
@@ -44,11 +44,11 @@ let foo = foo;
 obj.a = obj.b;
 obj.a.b = obj.c.b;
 obj.a.b = obj.a.c;
-obj[a] = obj["a"]
+obj[a] = obj["a"];
 
 // This ignores if there is a function call.
-obj.a().b = obj.a().b
-a().b = a().b
+obj.a().b = obj.a().b;
+a().b = a().b;
 
 // Known limitation: this does not support computed properties except single literal or single identifier.
 obj[a + b] = obj[a + b];

--- a/docs/rules/object-curly-newline.md
+++ b/docs/rules/object-curly-newline.md
@@ -15,9 +15,9 @@ This rule has either a string option:
 
 Or an object option:
 
-* `"multiline": true` (default) requires line breaks if there are line breaks inside properties or between properties
+* `"multiline": true` requires line breaks if there are line breaks inside properties or between properties
 * `"minProperties"` requires line breaks if the number of properties is at least the given integer. By default, an error will also be reported if an object contains linebreaks and has fewer properties than the given integer. However, the second behavior is disabled if the `consistent` option is set to `true`
-* `"consistent": true` requires that either both curly braces, or neither, directly enclose newlines. Note that enabling this option will also change the behavior of the `minProperties` option. (See `minProperties` above for more information)
+* `"consistent": true` (default) requires that either both curly braces, or neither, directly enclose newlines. Note that enabling this option will also change the behavior of the `minProperties` option. (See `minProperties` above for more information)
 
 You can specify different options for object literals, destructuring assignments, and named imports and exports:
 
@@ -179,7 +179,7 @@ let {k = function() {
 
 ### multiline
 
-Examples of **incorrect** code for this rule with the default `{ "multiline": true }` option:
+Examples of **incorrect** code for this rule with the `{ "multiline": true }` option:
 
 ```js
 /*eslint object-curly-newline: ["error", { "multiline": true }]*/
@@ -214,7 +214,7 @@ let {k = function() {
 }} = obj;
 ```
 
-Examples of **correct** code for this rule with the default `{ "multiline": true }` option:
+Examples of **correct** code for this rule with the `{ "multiline": true }` option:
 
 ```js
 /*eslint object-curly-newline: ["error", { "multiline": true }]*/
@@ -319,7 +319,7 @@ let {k = function() {
 
 ### consistent
 
-Examples of **incorrect** code for this rule with the `{ "consistent": true }` option:
+Examples of **incorrect** code for this rule with the default `{ "consistent": true }` option:
 
 ```js
 /*eslint object-curly-newline: ["error", { "consistent": true }]*/
@@ -354,7 +354,7 @@ let {o = function() {
 }} = obj;
 ```
 
-Examples of **correct** code for this rule with the `{ "consistent": true }` option:
+Examples of **correct** code for this rule with the default `{ "consistent": true }` option:
 
 ```js
 /*eslint object-curly-newline: ["error", { "consistent": true }]*/

--- a/docs/user-guide/migrating-to-5.0.0.md
+++ b/docs/user-guide/migrating-to-5.0.0.md
@@ -10,6 +10,7 @@ The lists below are ordered roughly by the number of users each change is expect
 1. [New rules have been added to `eslint:recommended`](#eslint-recommended-changes)
 1. [The `experimentalObjectRestSpread` option has been deprecated](#experimental-object-rest-spread)
 1. [Linting nonexistent files from the command line is now a fatal error](#nonexistent-files)
+1. [The default options for some rules have changed](#rule-default-changes)
 1. [Deprecated globals have been removed from the `node`, `browser`, and `jest` environments](#deprecated-globals)
 1. [Empty files are now linted](#empty-files)
 1. [Plugins in scoped packages are now resolvable in configs](#scoped-plugins)
@@ -111,6 +112,22 @@ Note that this also affects the [`CLIEngine.executeOnFiles()`](https://eslint.or
 **To address:** If you encounter an error about missing files after upgrading to ESLint v5, you may want to double-check that there are no typos in the paths you provide to ESLint. To make the error go away, you can simply remove the given files or globs from the list of arguments provided to ESLint on the command line.
 
 If you use a boilerplate generator that relies on this behavior (e.g. to generate a script that runs `eslint tests/` in a new project before any test files are actually present), you can work around this issue by adding a dummy file that matches the given pattern (e.g. an empty `tests/index.js` file).
+
+## <a name="rule-default-changes"></a> The default options for some rules have changed
+
+* The default options for the [`object-curly-newline`](/docs/rules/object-curly-newline) rule have changed from `{ multiline: true }` to `{ consistent: true }`.
+* The default options object for the [`no-self-assign`](/docs/rules/no-self-assign) rule has changed from `{ props: false }` to `{ props: true }`.
+
+**To address:** To restore the rule behavior from ESLint v4, you can update your config file to include the previous options:
+
+```json
+{
+  "rules": {
+    "object-curly-newline": ["error", { "multiline": true }],
+    "no-self-assign": ["error", { "props": false }]
+  }
+}
+```
 
 ## <a name="deprecated-globals"></a> Deprecated globals have been removed from the `node`, `browser`, and `jest` environments
 

--- a/lib/rules/no-self-assign.js
+++ b/lib/rules/no-self-assign.js
@@ -187,8 +187,7 @@ module.exports = {
 
     create(context) {
         const sourceCode = context.getSourceCode();
-        const options = context.options[0];
-        const props = Boolean(options && options.props);
+        const [{ props = true } = {}] = context.options;
 
         /**
          * Reports a given node as self assignments.

--- a/lib/rules/object-curly-newline.js
+++ b/lib/rules/object-curly-newline.js
@@ -64,7 +64,7 @@ function normalizeOptionValue(value) {
             consistent = Boolean(value.consistent);
         }
     } else {
-        multiline = true;
+        consistent = true;
     }
 
     return { multiline, minProperties, consistent };

--- a/tests/lib/rules/no-self-assign.js
+++ b/tests/lib/rules/no-self-assign.js
@@ -47,11 +47,26 @@ ruleTester.run("no-self-assign", rule, {
         { code: "a.b().c = a.b().c", options: [{ props: true }] },
         { code: "b().c = b().c", options: [{ props: true }] },
         { code: "a[b + 1] = a[b + 1]", options: [{ props: true }] }, // it ignores non-simple computed properties.
-        "a.b = a.b",
-        "a.b.c = a.b.c",
-        "a[b] = a[b]",
-        "a['b'] = a['b']",
-        "a[\n    'b'\n] = a[\n    'b'\n]"
+        {
+            code: "a.b = a.b",
+            options: [{ props: false }]
+        },
+        {
+            code: "a.b.c = a.b.c",
+            options: [{ props: false }]
+        },
+        {
+            code: "a[b] = a[b]",
+            options: [{ props: false }]
+        },
+        {
+            code: "a['b'] = a['b']",
+            options: [{ props: false }]
+        },
+        {
+            code: "a[\n    'b'\n] = a[\n    'b'\n]",
+            options: [{ props: false }]
+        }
     ],
     invalid: [
         { code: "a = a", errors: ["'a' is assigned to itself."] },
@@ -68,6 +83,26 @@ ruleTester.run("no-self-assign", rule, {
         { code: "({a, b} = {c, a})", parserOptions: { ecmaVersion: 6 }, errors: ["'a' is assigned to itself."] },
         { code: "({a: {b}, c: [d]} = {a: {b}, c: [d]})", parserOptions: { ecmaVersion: 6 }, errors: ["'b' is assigned to itself.", "'d' is assigned to itself."] },
         { code: "({a, b} = {a, ...x, b})", parserOptions: { ecmaVersion: 2018 }, errors: ["'b' is assigned to itself."] },
+        {
+            code: "a.b = a.b",
+            errors: ["'a.b' is assigned to itself."]
+        },
+        {
+            code: "a.b.c = a.b.c",
+            errors: ["'a.b.c' is assigned to itself."]
+        },
+        {
+            code: "a[b] = a[b]",
+            errors: ["'a[b]' is assigned to itself."]
+        },
+        {
+            code: "a['b'] = a['b']",
+            errors: ["'a['b']' is assigned to itself."]
+        },
+        {
+            code: "a[\n    'b'\n] = a[\n    'b'\n]",
+            errors: ["'a['b']' is assigned to itself."]
+        },
         { code: "a.b = a.b", options: [{ props: true }], errors: ["'a.b' is assigned to itself."] },
         { code: "a.b.c = a.b.c", options: [{ props: true }], errors: ["'a.b.c' is assigned to itself."] },
         { code: "a[b] = a[b]", options: [{ props: true }], errors: ["'a[b]' is assigned to itself."] },

--- a/tests/lib/rules/object-curly-newline.js
+++ b/tests/lib/rules/object-curly-newline.js
@@ -22,6 +22,20 @@ const ruleTester = new RuleTester({ parserOptions: { sourceType: "module" } });
 ruleTester.run("object-curly-newline", rule, {
     valid: [
 
+        // default ------------------------------------------------------------
+        [
+            "var a = {",
+            "};"
+        ].join("\n"),
+
+        [
+            "var a = {",
+            "   foo",
+            "};"
+        ].join("\n"),
+
+        "var a = { foo }",
+
         // "always" ------------------------------------------------------------
         {
             code: [
@@ -552,6 +566,18 @@ ruleTester.run("object-curly-newline", rule, {
         }
     ],
     invalid: [
+
+        // default ------------------------------------------------------------
+        {
+            code: [
+                "var a = { a",
+                "};"
+            ].join("\n"),
+            output: "var a = { a};",
+            errors: [
+                { line: 2, column: 1, message: "Unexpected line break before this closing brace." }
+            ]
+        },
 
         // "always" ------------------------------------------------------------
         {


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Changes an existing rule (see https://github.com/eslint/eslint/issues/10215)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates the default for `object-curly-newline` to `{ consistent: true }`, and updates the default for `no-self-assign` to `{ props: true }`.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
