### PR TITLE
Fix: allow array spread for prefer-object-spread rule (fixes #10344)

### DIFF
--- a/lib/rules/prefer-object-spread.js
+++ b/lib/rules/prefer-object-spread.js
@@ -23,6 +23,15 @@ function isObjectAssign(node) {
 }
 
 /**
+ * Helper that checks if the Object.assign call has array spread
+ * @param {ASTNode} node - The node that the rule warns on
+ * @returns {boolean} - Returns true if the Object.assign call has array spread
+ */
+function hasArraySpread(node) {
+    return node.arguments.some(arg => arg.type === "SpreadElement");
+}
+
+/**
  * Helper that checks if the node needs parentheses to be valid JS.
  * The default is to wrap the node in parentheses to avoid parsing errors.
  * @param {ASTNode} node - The node that the rule warns on
@@ -264,7 +273,8 @@ module.exports = {
                     !overWritingNativeObject &&
                     node.arguments.length > 1 &&
                     node.arguments[0].type === "ObjectExpression" &&
-                    isObjectAssign(node)
+                    isObjectAssign(node) &&
+                    !hasArraySpread(node)
                 ) {
                     context.report({
                         node,

--- a/tests/lib/rules/prefer-object-spread.js
+++ b/tests/lib/rules/prefer-object-spread.js
@@ -28,6 +28,7 @@ ruleTester.run("prefer-object-spread", rule, {
         "const bar = { ...foo }",
         "Object.assign(...foo)",
         "Object.assign(foo, { bar: baz })",
+        "Object.assign({}, ...objects)",
         "foo({ foo: 'bar' })",
         `
         const Object = {};
@@ -533,18 +534,6 @@ ruleTester.run("prefer-object-spread", rule, {
                     type: "CallExpression",
                     line: 1,
                     column: 13
-                }
-            ]
-        },
-        {
-            code: "let a = Object.assign({}, ...b)",
-            output: "let a = {...b}",
-            errors: [
-                {
-                    messageId: "useSpreadMessage",
-                    type: "CallExpression",
-                    line: 1,
-                    column: 9
                 }
             ]
         },


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
https://github.com/eslint/eslint/issues/10344

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Allow, eg:
```js
Object.assign({}, ...objects)
```

**Is there anything you'd like reviewers to focus on?**


