### PR TITLE
Update: Improves the prefer-object-spread rule by removing extraneous visitors

### DIFF
--- a/lib/rules/prefer-object-spread.js
+++ b/lib/rules/prefer-object-spread.js
@@ -196,6 +196,34 @@ function autofixObjectLiteral(node, sourceCode) {
     };
 }
 
+/**
+ * Check if the node has modified a given variable
+ * @param {ASTNode|null} node - The node that the rule warns on, i.e. the Object.assign call
+ * @returns {boolean} - true if node is an assignment, variable declaration, or import statement
+ */
+function isModifier(node) {
+    if (!node.type) {
+        return false;
+    }
+
+    return node.type === "AssignmentExpression" ||
+        node.type === "VariableDeclarator" ||
+        node.type === "ImportDeclaration";
+}
+
+/**
+ * Check if the node has modified a given variable
+ * @param {array} references - list of reference nodes
+ * @returns {boolean} - true if node is has been overwritten by an assignment or import
+ */
+function modifyingObjectReference(references) {
+    return references.some(ref => (
+        ref.identifier &&
+        ref.identifier.parent &&
+        isModifier(ref.identifier.parent)
+    ));
+}
+
 
 module.exports = {
     meta: {
@@ -216,35 +244,25 @@ module.exports = {
 
     create: function rule(context) {
         const sourceCode = context.getSourceCode();
-        let overWritingNativeObject = false;
+        const scope = context.getScope();
+        const objectVariable = scope.variables.filter(variable => variable.name === "Object");
+        const moduleReferences = scope.childScopes.filter(childScope => {
+            const varNamedObject = childScope.variables.filter(variable => variable.name === "Object");
+
+            return childScope.type === "module" && varNamedObject.length;
+        });
+        const references = [].concat(...objectVariable.map(variable => variable.references || []));
 
         return {
-            VariableDeclaration(node) {
-
-                /*
-                 * If a declared variable is overwriting the native `Object`, eg. `const Object = 'something'`
-                 * we want to skip warning on them since the behavior might be different.
-                 */
-                if (node.declarations.length) {
-                    const declarationNames = node.declarations.map(dec => dec.id);
-                    const nativeObjectOverride = declarationNames.filter(identifier => identifier.name === "Object");
-
-                    if (nativeObjectOverride.length) {
-                        overWritingNativeObject = true;
-                    }
-                }
-            },
-            AssignmentExpression(node) {
-
-                /*
-                 * If an assignment is reassigning the native `Object`, eg. `Object = 'something'`
-                 * we want to skip warning on them since the behavior might be different.
-                 */
-                if (node.left.name === "Object") {
-                    overWritingNativeObject = true;
-                }
-            },
             CallExpression(node) {
+
+                /*
+                 * If current file is either importing Object or redefining it,
+                 * we skip warning on this rule.
+                 */
+                if (moduleReferences.length || (references.length && modifyingObjectReference(references))) {
+                    return;
+                }
 
                 /*
                  * The condition below is cases where Object.assign has a single argument and
@@ -252,7 +270,6 @@ module.exports = {
                  * For now, we will warn on this case and autofix it.
                  */
                 if (
-                    !overWritingNativeObject &&
                     node.arguments.length === 1 &&
                     node.arguments[0].type === "ObjectExpression" &&
                     isObjectAssign(node)
@@ -270,7 +287,6 @@ module.exports = {
                  * that can be spread. e.g `Object.assign({ foo: bar }, baz)`
                  */
                 if (
-                    !overWritingNativeObject &&
                     node.arguments.length > 1 &&
                     node.arguments[0].type === "ObjectExpression" &&
                     isObjectAssign(node) &&

--- a/tests/lib/rules/prefer-object-spread.js
+++ b/tests/lib/rules/prefer-object-spread.js
@@ -14,7 +14,8 @@ const parserOptions = {
     ecmaVersion: 2018,
     ecmaFeatures: {
         experimentalObjectRestSpread: true
-    }
+    },
+    sourceType: "module"
 };
 
 const ruleTester = new RuleTester({ parserOptions });
@@ -44,6 +45,22 @@ ruleTester.run("prefer-object-spread", rule, {
         `,
         `
         Object = {};
+        Object.assign({ foo: 'bar' });
+        `,
+        `
+        const Object = require('foo');
+        Object.assign({ foo: 'bar' });
+        `,
+        `
+        import Object from 'foo';
+        Object.assign({ foo: 'bar' });
+        `,
+        `
+        import { Something as Object } from 'foo';
+        Object.assign({ foo: 'bar' });
+        `,
+        `
+        import { Object, Array } from 'globals';
         Object.assign({ foo: 'bar' });
         `
     ],
@@ -291,6 +308,9 @@ ruleTester.run("prefer-object-spread", rule, {
                 baz: "cats"
                 --> weird
 }`,
+            parserOptions: {
+                sourceType: "script"
+            },
             errors: [
                 {
                     messageId: "useSpreadMessage",
@@ -570,6 +590,114 @@ ruleTester.run("prefer-object-spread", rule, {
                     type: "CallExpression",
                     line: 1,
                     column: 30
+                }
+            ]
+        },
+        {
+            code: `
+                import Foo from 'foo';
+                Object.assign({ foo: Foo });
+            `,
+            output: `
+                import Foo from 'foo';
+                ({ foo: Foo });
+            `,
+            errors: [
+                {
+                    messageId: "useLiteralMessage",
+                    type: "CallExpression",
+                    line: 3,
+                    column: 17
+                }
+            ]
+        },
+        {
+            code: `
+                import Foo from 'foo';
+                Object.assign({}, Foo);
+            `,
+            output: `
+                import Foo from 'foo';
+                ({...Foo});
+            `,
+            errors: [
+                {
+                    messageId: "useSpreadMessage",
+                    type: "CallExpression",
+                    line: 3,
+                    column: 17
+                }
+            ]
+        },
+        {
+            code: `
+                const Foo = require('foo');
+                Object.assign({ foo: Foo });
+            `,
+            output: `
+                const Foo = require('foo');
+                ({ foo: Foo });
+            `,
+            errors: [
+                {
+                    messageId: "useLiteralMessage",
+                    type: "CallExpression",
+                    line: 3,
+                    column: 17
+                }
+            ]
+        },
+        {
+            code: `
+                import { Something as somethingelse } from 'foo';
+                Object.assign({}, somethingelse);
+            `,
+            output: `
+                import { Something as somethingelse } from 'foo';
+                ({...somethingelse});
+            `,
+            errors: [
+                {
+                    messageId: "useSpreadMessage",
+                    type: "CallExpression",
+                    line: 3,
+                    column: 17
+                }
+            ]
+        },
+        {
+            code: `
+                import { foo } from 'foo';
+                Object.assign({ foo: Foo });
+            `,
+            output: `
+                import { foo } from 'foo';
+                ({ foo: Foo });
+            `,
+            errors: [
+                {
+                    messageId: "useLiteralMessage",
+                    type: "CallExpression",
+                    line: 3,
+                    column: 17
+                }
+            ]
+        },
+        {
+            code: `
+                const Foo = require('foo');
+                Object.assign({}, Foo);
+            `,
+            output: `
+                const Foo = require('foo');
+                ({...Foo});
+            `,
+            errors: [
+                {
+                    messageId: "useSpreadMessage",
+                    type: "CallExpression",
+                    line: 3,
+                    column: 17
                 }
             ]
         }


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
- Includes a change to stop warning if the if the file is importing `Object`. 
- Uses `context.getScope()` to determine is `Object` is being overwritten, instead of visiting every assignment and variable declaration node.
- Adds more tests


**Is there anything you'd like reviewers to focus on?**
There may be a better way to get module and scope information, not sure 🤔

cc. @ljharb @ilyavolodin 
