### PR TITLE
New: prompt users before installing dependencies

### DIFF
--- a/lib/config/config-initializer.js
+++ b/lib/config/config-initializer.js
@@ -106,11 +106,6 @@ function getModulesList(config, installESLint) {
         );
     }
 
-    // If no modules, return empty array.
-    if (Object.keys(modules).length === 0) {
-        return [];
-    }
-
     if (installESLint === false) {
         delete modules.eslint;
     } else {

--- a/lib/config/config-initializer.js
+++ b/lib/config/config-initializer.js
@@ -82,12 +82,12 @@ function getPeerDependencies(moduleName) {
 getPeerDependencies.cache = new Map();
 
 /**
- * Synchronously install necessary plugins, configs, parsers, etc. based on the config
+ * Return necessary plugins, configs, parsers, etc. based on the config
  * @param   {Object} config  config object
  * @param   {boolean} [installESLint=true]  If `false` is given, it does not install eslint.
- * @returns {void}
+ * @returns {string[]} An array of modules to be installed.
  */
-function installModules(config, installESLint) {
+function getModulesList(config, installESLint) {
     const modules = {};
 
     // Create a list of modules which should be installed based on config
@@ -106,9 +106,9 @@ function installModules(config, installESLint) {
         );
     }
 
-    // If no modules, do nothing.
+    // If no modules, return empty array.
     if (Object.keys(modules).length === 0) {
-        return;
+        return [];
     }
 
     if (installESLint === false) {
@@ -124,12 +124,7 @@ function installModules(config, installESLint) {
         }
     }
 
-    // Install packages
-    const modulesToInstall = Object.keys(modules).map(name => `${name}@${modules[name]}`);
-
-    log.info(`Installing ${modulesToInstall.join(", ")}`);
-
-    npmUtil.installSyncSaveDev(modulesToInstall);
+    return Object.keys(modules).map(name => `${name}@${modules[name]}`);
 }
 
 /**
@@ -282,8 +277,6 @@ function processAnswers(answers) {
         config.rules.semi = ["error", answers.semi ? "always" : "never"];
     }
 
-    installModules(config);
-
     if (answers.source === "auto") {
         config = configureRules(answers, config);
         config = autoconfig.extendFromRecommended(config);
@@ -296,10 +289,9 @@ function processAnswers(answers) {
 /**
  * process user's style guide of choice and return an appropriate config object.
  * @param {string} guide name of the chosen style guide
- * @param {boolean} [installESLint=true]  If `false` is given, it does not install eslint.
  * @returns {Object} config object
  */
-function getConfigForStyleGuide(guide, installESLint) {
+function getConfigForStyleGuide(guide) {
     const guides = {
         google: { extends: "google" },
         airbnb: { extends: "airbnb" },
@@ -310,8 +302,6 @@ function getConfigForStyleGuide(guide, installESLint) {
     if (!guides[guide]) {
         throw new Error("You referenced an unsupported guide.");
     }
-
-    installModules(guides[guide], installESLint);
 
     return guides[guide];
 }
@@ -380,7 +370,50 @@ function hasESLintVersionConflict(answers) {
     return true;
 }
 
-/* istanbul ignore next: no need to test inquirer*/
+/**
+ * Install modules.
+ * @param   {string[]} modules Modules to be installed.
+ * @returns {void}
+ */
+function installModules(modules) {
+    log.info(`Installing ${modules.join(", ")}`);
+    npmUtil.installSyncSaveDev(modules);
+}
+
+/* istanbul ignore next: no need to test inquirer */
+/**
+ * Ask user to install modules.
+ * @param   {string[]} modules Array of modules to be installed.
+ * @param   {boolean} packageJsonExists Indicates if package.json is existed.
+ * @returns {Promise} Answer that indicates if user wants to install.
+ */
+function askInstallModules(modules, packageJsonExists) {
+
+    // If no modules, do nothing.
+    if (modules.length === 0) {
+        return Promise.resolve();
+    }
+
+    log.info("The config that you've selected requires the following dependencies:\n");
+    log.info(modules.join(" "));
+    return inquirer.prompt([
+        {
+            type: "confirm",
+            name: "executeInstallation",
+            message: "Would you like to install them now with npm?",
+            default: true,
+            when() {
+                return modules.length && packageJsonExists;
+            }
+        }
+    ]).then(({ executeInstallation }) => {
+        if (executeInstallation) {
+            installModules(modules);
+        }
+    });
+}
+
+/* istanbul ignore next: no need to test inquirer */
 /**
  * Ask use a few questions on command prompt
  * @returns {Promise} The promise with the result of the prompt
@@ -477,10 +510,10 @@ function promptUser() {
             }
 
             const config = getConfigForStyleGuide(earlyAnswers.styleguide, earlyAnswers.installESLint);
+            const modules = getModulesList(config);
 
-            writeFile(config, earlyAnswers.format);
-
-            return void 0;
+            return askInstallModules(modules, earlyAnswers.packageJsonExists)
+                .then(() => writeFile(config, earlyAnswers.format));
         }
 
         // continue with the questions otherwise...
@@ -539,10 +572,9 @@ function promptUser() {
 
                 const config = processAnswers(combinedAnswers);
 
-                installModules(config);
-                writeFile(config, earlyAnswers.format);
+                const modules = getModulesList(config);
 
-                return void 0;
+                return askInstallModules(modules).then(() => writeFile(config, earlyAnswers.format));
             }
 
             // continue with the style questions otherwise...
@@ -585,9 +617,9 @@ function promptUser() {
                 const totalAnswers = Object.assign({}, earlyAnswers, secondAnswers, answers);
 
                 const config = processAnswers(totalAnswers);
+                const modules = getModulesList(config);
 
-                installModules(config);
-                writeFile(config, answers.format);
+                return askInstallModules(modules).then(() => writeFile(config, earlyAnswers.format));
             });
         });
     });
@@ -599,7 +631,9 @@ function promptUser() {
 
 const init = {
     getConfigForStyleGuide,
+    getModulesList,
     hasESLintVersionConflict,
+    installModules,
     processAnswers,
     /* istanbul ignore next */initializeConfig() {
         return promptUser();

--- a/tests/lib/config/config-initializer.js
+++ b/tests/lib/config/config-initializer.js
@@ -200,26 +200,34 @@ describe("configInitializer", () => {
         describe("guide", () => {
             it("should support the google style guide", () => {
                 const config = init.getConfigForStyleGuide("google");
+                const modules = init.getModulesList(config);
 
                 assert.deepStrictEqual(config, { extends: "google", installedESLint: true });
+                assert.include(modules, "eslint-config-google@latest");
             });
 
             it("should support the airbnb style guide", () => {
                 const config = init.getConfigForStyleGuide("airbnb");
+                const modules = init.getModulesList(config);
 
                 assert.deepStrictEqual(config, { extends: "airbnb", installedESLint: true });
+                assert.include(modules, "eslint-config-airbnb@latest");
             });
 
             it("should support the airbnb base style guide", () => {
                 const config = init.getConfigForStyleGuide("airbnb-base");
+                const modules = init.getModulesList(config);
 
                 assert.deepStrictEqual(config, { extends: "airbnb-base", installedESLint: true });
+                assert.include(modules, "eslint-config-airbnb-base@latest");
             });
 
             it("should support the standard style guide", () => {
                 const config = init.getConfigForStyleGuide("standard");
+                const modules = init.getModulesList(config);
 
                 assert.deepStrictEqual(config, { extends: "standard", installedESLint: true });
+                assert.include(modules, "eslint-config-standard@latest");
             });
 
             it("should throw when encountering an unsupported style guide", () => {
@@ -229,19 +237,25 @@ describe("configInitializer", () => {
             });
 
             it("should install required sharable config", () => {
-                init.getConfigForStyleGuide("google");
+                const config = init.getConfigForStyleGuide("google");
+
+                init.installModules(init.getModulesList(config));
                 assert(npmInstallStub.calledOnce);
                 assert(npmInstallStub.firstCall.args[0].some(name => name.startsWith("eslint-config-google@")));
             });
 
             it("should install ESLint if not installed locally", () => {
-                init.getConfigForStyleGuide("google");
+                const config = init.getConfigForStyleGuide("google");
+
+                init.installModules(init.getModulesList(config));
                 assert(npmInstallStub.calledOnce);
                 assert(npmInstallStub.firstCall.args[0].some(name => name.startsWith("eslint@")));
             });
 
             it("should install peerDependencies of the sharable config", () => {
-                init.getConfigForStyleGuide("airbnb");
+                const config = init.getConfigForStyleGuide("airbnb");
+
+                init.installModules(init.getModulesList(config));
 
                 assert(npmFetchPeerDependenciesStub.calledOnce);
                 assert(npmFetchPeerDependenciesStub.firstCall.args[0] === "eslint-config-airbnb@latest");


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->
close #9918 

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:
Change CLI behavior.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
https://github.com/eslint/eslint/issues/9918
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
After user answered a series of questions, ESLint will compute and collect what npm modules should be installed. Then, show these modules to user and ask user if he/she wants to install it:
![image](https://user-images.githubusercontent.com/17216317/40066883-a863c0ae-5897-11e8-9af6-078abafe9e15.png)
If user chooses "yes", ESLint will spawn `npm install` and write ESLint config file. If user chooses "no", it just writes config file.

**Is there anything you'd like reviewers to focus on?**


 