### PR TITLE
Update: config-validator should validate overrides

### DIFF
--- a/lib/config/config-validator.js
+++ b/lib/config/config-validator.js
@@ -254,6 +254,11 @@ function validate(config, source, ruleMapper, envContext) {
     validateConfigSchema(config, source);
     validateRules(config.rules, source, ruleMapper);
     validateEnvironment(config.env, source, envContext);
+
+    for (const override of config.overrides || []) {
+        validateRules(override.rules, source, ruleMapper);
+        validateEnvironment(override.env, source, envContext);
+    }
 }
 
 //------------------------------------------------------------------------------

--- a/tests/lib/config/config-validator.js
+++ b/tests/lib/config/config-validator.js
@@ -407,6 +407,40 @@ describe("Validator", () => {
 
                 assert.throws(fn, "ESLint configuration in tests is invalid:\n\t- Unexpected top-level property \"overrides[0].root\".\n");
             });
+
+            describe("env", () => {
+
+                it("should catch invalid environments", () => {
+                    const fn = validator.validate.bind(null, { overrides: [{ files: "*", env: { browser: true, invalid: true } }] }, null, ruleMapper, linter.environments);
+
+                    assert.throws(fn, "Environment key \"invalid\" is unknown\n");
+                });
+
+                it("should catch disabled invalid environments", () => {
+                    const fn = validator.validate.bind(null, { overrides: [{ files: "*", env: { browser: true, invalid: false } }] }, null, ruleMapper, linter.environments);
+
+                    assert.throws(fn, "Environment key \"invalid\" is unknown\n");
+                });
+
+            });
+
+            describe("rules", () => {
+
+                it("should catch invalid rule options", () => {
+                    const fn = validator.validate.bind(null, { overrides: [{ files: "*", rules: { "mock-rule": [3, "third"] } }] }, "tests", ruleMapper, linter.environments);
+
+                    assert.throws(fn, "tests:\n\tConfiguration for rule \"mock-rule\" is invalid:\n\tSeverity should be one of the following: 0 = off, 1 = warn, 2 = error (you passed '3').\n");
+                });
+
+                it("should not allow options for rules with no options", () => {
+                    linter.defineRule("mock-no-options-rule", mockNoOptionsRule);
+
+                    const fn = validator.validate.bind(null, { overrides: [{ files: "*", rules: { "mock-no-options-rule": [2, "extra"] } }] }, "tests", ruleMapper, linter.environments);
+
+                    assert.throws(fn, "tests:\n\tConfiguration for rule \"mock-no-options-rule\" is invalid:\n\tValue [\"extra\"] should NOT have more than 0 items.\n");
+                });
+            });
+
         });
 
     });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix

**What changes did you make? (Give an overview)**

This PR fixes a bug that ESLint overlooks invalid `env` and `rules` option values in the `overrides` option. This is important to catch invalid rule options.

This might be a breaking change since it can throw new error on invalid configs.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.
