### PR TITLE
Chore: avoid code duplication in rule severity checking

### DIFF
--- a/lib/config/config-ops.js
+++ b/lib/config/config-ops.js
@@ -240,14 +240,7 @@ module.exports = {
      * @returns {boolean} True if the rule represents an error, false if not.
      */
     isErrorSeverity(ruleConfig) {
-
-        let severity = Array.isArray(ruleConfig) ? ruleConfig[0] : ruleConfig;
-
-        if (typeof severity === "string") {
-            severity = RULE_SEVERITY[severity.toLowerCase()] || 0;
-        }
-
-        return (typeof severity === "number" && severity === 2);
+        return module.exports.getRuleSeverity(ruleConfig) === 2;
     },
 
     /**


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This removes code from `ConfigOps.isErrorSeverity` that was already present in `ConfigOps.getRuleSeverity`.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
