### PR TITLE
Chore: avoid unnecessary filesystem accesses during config search

### DIFF
--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -567,6 +567,22 @@ function load(filePath, configContext, relativeTo) {
     return config;
 }
 
+/**
+ * Checks whether the given filename points to a file
+ * @param {string} filename A path to a file
+ * @returns {boolean} `true` if a file exists at the given location
+ */
+function isExistingFile(filename) {
+    try {
+        return fs.statSync(filename).isFile();
+    } catch (err) {
+        if (err.code === "ENOENT") {
+            return false;
+        }
+        throw err;
+    }
+}
+
 
 //------------------------------------------------------------------------------
 // Public Interface
@@ -591,14 +607,6 @@ module.exports = {
      *      or null if there is no configuration file in the directory.
      */
     getFilenameForDirectory(directory) {
-        for (let i = 0, len = CONFIG_FILES.length; i < len; i++) {
-            const filename = path.join(directory, CONFIG_FILES[i]);
-
-            if (fs.existsSync(filename) && fs.statSync(filename).isFile()) {
-                return filename;
-            }
-        }
-
-        return null;
+        return CONFIG_FILES.map(filename => path.join(directory, filename)).find(isExistingFile) || null;
     }
 };


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This avoids an unnecessary filesystem access when looking for config files by performing a `stat` syscall directly and catching an error if necessary, rather than first checking whether the file exists and then using `stat`.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular