### PR TITLE
Fix: Update dependencies version for better security

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "ignore": "^3.2.0",
     "imurmurhash": "^0.1.4",
     "inquirer": "^0.12.0",
-    "is-my-json-valid": "^2.10.0",
+    "is-my-json-valid": "^2.17.2",
     "is-resolvable": "^1.0.0",
     "js-yaml": "^3.5.1",
     "json-stable-stringify": "^1.0.0",


### PR DESCRIPTION
NSP has reported a Regular Expression Denial of Service (ReDoS) security vulnerability of the library - `is-my-json-valid` on version <1.4.1 or >=2.0.0 <2.17.2.

https://nodesecurity.io/advisories/572

This update changes eslint's minimum `is-my-json-valid` version up from 2.10.0 to 2.17.2.


[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] Other, please explain: 
Update dependencies version
