### PR TITLE
Fix: prefer-const object destructuring false positive (fixes #9108)

### DIFF
--- a/tests/lib/rules/prefer-const.js
+++ b/tests/lib/rules/prefer-const.js
@@ -69,6 +69,22 @@ ruleTester.run("prefer-const", rule, {
         "/*exported a*/ let a; function init() { a = foo(); }",
         "/*exported a*/ let a = 1",
         "let a; if (true) a = 0; foo(a);",
+        `
+        (function (a) {
+            let b;
+            ({ a, b } = obj);
+        })();
+        `,
+        `
+        (function (a) {
+            let b;
+            ([ a, b ] = obj);
+        })();
+        `,
+        "var a; { var b; ({ a, b } = obj); }",
+        "let a; { let b; ({ a, b } = obj); }",
+        "var a; { var b; ([ a, b ] = obj); }",
+        "let a; { let b; ([ a, b ] = obj); }",
 
         /*
          * The assignment is located in a different scope.


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->
close #9108

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
https://github.com/eslint/eslint/issues/9108

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Allow:
```js
(function ({ a }) {
  let b;
  ({ a, b } = obj);
})();
```
or
```js
let a;
{
  let b;
  ({ a, b } = obj);
}
```