### PR TITLE
Update: Add ignoreDestructing option to camelcase rule (refs #9807)

### DIFF
--- a/docs/rules/camelcase.md
+++ b/docs/rules/camelcase.md
@@ -12,8 +12,10 @@ This rule has an object option:
 
 * `"properties": "always"` (default) enforces camelcase style for property names
 * `"properties": "never"` does not check property names
+* `"ignoreDestructuring": false` (default) enforces camelcase style for destructured identifiers
+* `"ignoreDestructuring": true` does not check destructured identifiers
 
-### always
+### properties: "always"
 
 Examples of **incorrect** code for this rule with the default `{ "properties": "always" }` option:
 
@@ -95,7 +97,7 @@ var { foo: isCamelCased = 1 } = quz;
 
 ```
 
-### never
+### properties: "never"
 
 Examples of **correct** code for this rule with the `{ "properties": "never" }` option:
 
@@ -105,6 +107,48 @@ Examples of **correct** code for this rule with the `{ "properties": "never" }` 
 var obj = {
     my_pref: 1
 };
+```
+
+### ignoreDestructuring: false
+
+Examples of **incorrect** code for this rule with the default `{ "ignoreDestructuring": false }` option:
+
+```js
+/*eslint camelcase: "error"*/
+
+var { category_id } = query;
+
+var { category_id = 1 } = query;
+
+var { category_id: category_id } = query;
+
+var { category_id: category_alias } = query;
+
+var { category_id: categoryId, ...other_props } = query;
+```
+
+### ignoreDestructuring: true
+
+Examples of **incorrect** code for this rule with the `{ "ignoreDestructuring": true }` option:
+
+```js
+/*eslint camelcase: ["error", {ignoreDestructuring: true}]*/
+
+var { category_id: category_alias } = query;
+
+var { category_id, ...other_props } = query;
+```
+
+Examples of **correct** code for this rule with the `{ "ignoreDestructuring": true }` option:
+
+```js
+/*eslint camelcase: ["error", {ignoreDestructuring: true}]*/
+
+var { category_id } = query;
+
+var { category_id = 1 } = query;
+
+var { category_id: category_id } = query;
 ```
 
 ## When Not To Use It

--- a/tests/lib/rules/camelcase.js
+++ b/tests/lib/rules/camelcase.js
@@ -92,6 +92,21 @@ ruleTester.run("camelcase", rule, {
             options: [{ properties: "never" }]
         },
         {
+            code: "var { category_id } = query;",
+            options: [{ ignoreDestructuring: true }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var { category_id: category_id } = query;",
+            options: [{ ignoreDestructuring: true }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var { category_id = 1 } = query;",
+            options: [{ ignoreDestructuring: true }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
             code: "var { category_id: category } = query;",
             parserOptions: { ecmaVersion: 6 }
         },
@@ -292,12 +307,36 @@ ruleTester.run("camelcase", rule, {
             ]
         },
         {
-            code: "var { category_id: category_id } = query;",
+            code: "var { category_id: category_alias } = query;",
             parserOptions: { ecmaVersion: 6 },
             errors: [
                 {
                     messageId: "notCamelCase",
-                    data: { name: "category_id" },
+                    data: { name: "category_alias" },
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
+            code: "var { category_id: category_alias } = query;",
+            options: [{ ignoreDestructuring: true }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "notCamelCase",
+                    data: { name: "category_alias" },
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
+            code: "var { category_id: categoryId, ...other_props } = query;",
+            options: [{ ignoreDestructuring: true }],
+            parserOptions: { ecmaVersion: 2018 },
+            errors: [
+                {
+                    messageId: "notCamelCase",
+                    data: { name: "other_props" },
                     type: "Identifier"
                 }
             ]


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What rule do you want to change?**
The `camelcase` rule.

**Does this change cause the rule to produce more or fewer warnings?**
Fewer.

**How will the change be implemented? (New option, new default behavior, etc.)?**
A new option:
```js
"camelcase": [ "error", { "ignoreDestructuring": false }]
"camelcase": [ "error", { "ignoreDestructuring": true }]
```

**Please provide some example code that this change will affect:**

```js
const { foo_bar } = baz;
```

**What does the rule currently do for this code?**
The rule currently always fails for these expressions (with or without the properties: "never" config option set).

**What will the rule do after it's changed?**
If the "ignoreDestructuring": true option is set, the line of code above should pass the rule (while the rule should still be enforced for other identifiers in the source).

**What changes did you make? (Give an overview)**
The changes are in `lib/rules/camelcase.js`

**Is there anything you'd like reviewers to focus on?**
There are a couple of edge cases I mentioned on #9807, both of which are errors when `ignore_destructuring: true` is set in this change:

Creating a new identifier from a destructured assignment

```
const { category_id: category_alias } = query;
```

Creating a non-camelcased identifier for rest props:

```
const { category_id, ...other_props } = query;
```
