### PR TITLE
Fix: prevent crashing from JSON parsing error (fixes #10364)

### DIFF
--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -115,6 +115,11 @@ function loadJSONConfigFile(filePath) {
     } catch (e) {
         debug(`Error reading JSON file: ${filePath}`);
         e.message = `Cannot read config file: ${filePath}\nError: ${e.message}`;
+        e.messageTemplate = "failed-to-read-json";
+        e.messageData = {
+            path: filePath,
+            message: e.message
+        };
         throw e;
     }
 }

--- a/lib/ignored-paths.js
+++ b/lib/ignored-paths.js
@@ -176,6 +176,11 @@ class IgnoredPaths {
                             packageJSONOptions = JSON.parse(fs.readFileSync(packageJSONPath, "utf8"));
                         } catch (e) {
                             debug("Could not read package.json file to check eslintIgnore property");
+                            e.messageTemplate = "failed-to-read-json";
+                            e.messageData = {
+                                path: packageJSONPath,
+                                message: e.message
+                            };
                             throw e;
                         }
 

--- a/lib/util/npm-util.js
+++ b/lib/util/npm-util.js
@@ -109,8 +109,14 @@ function check(packages, opt) {
     try {
         fileJson = JSON.parse(fs.readFileSync(pkgJson, "utf8"));
     } catch (e) {
-        log.info("Could not read package.json file. Please check that the file contains valid JSON.");
-        throw new Error(e);
+        const error = new Error(e);
+
+        error.messageTemplate = "failed-to-read-json";
+        error.messageData = {
+            path: pkgJson,
+            message: e.message
+        };
+        throw error;
     }
 
     if (opt.devDependencies && typeof fileJson.devDependencies === "object") {

--- a/messages/failed-to-read-json.txt
+++ b/messages/failed-to-read-json.txt
@@ -1,0 +1,3 @@
+Failed to read JSON file at <%= path %>:
+
+<%= message %>

--- a/tests/fixtures/ignored-paths/broken-package-json/package.json
+++ b/tests/fixtures/ignored-paths/broken-package-json/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "mypackage",
+    "version": "0.0.1",
+    "eslintConfig": {
+        "env": {
+            "browser": true,
+            "node": true
+        }
+    }
+    "eslintIgnore": "hello.js"
+}

--- a/tests/lib/config/config-file.js
+++ b/tests/lib/config/config-file.js
@@ -636,7 +636,12 @@ describe("ConfigFile", () => {
 
         it("should throw error when loading invalid package.json file", () => {
             assert.throws(() => {
-                ConfigFile.load(getFixturePath("broken-package-json/package.json"), configContext);
+                try {
+                    ConfigFile.load(getFixturePath("broken-package-json/package.json"), configContext);
+                } catch (error) {
+                    assert.strictEqual(error.messageTemplate, "failed-to-read-json");
+                    throw error;
+                }
             }, /Cannot read config file/);
         });
 

--- a/tests/lib/ignored-paths.js
+++ b/tests/lib/ignored-paths.js
@@ -169,6 +169,18 @@ describe("IgnoredPaths", () => {
             assert.isTrue(ignoredPaths.contains("world.js"));
         });
 
+        it("should use correct message template if failed to parse package.json", () => {
+            assert.throw(() => {
+                try {
+                    // eslint-disable-next-line no-new
+                    new IgnoredPaths({ ignore: true, cwd: getFixturePath("broken-package-json") });
+                } catch (error) {
+                    assert.strictEqual(error.messageTemplate, "failed-to-read-json");
+                    throw error;
+                }
+            });
+        });
+
         it("should not use package.json's eslintIgnore files if specified .eslintignore file", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: true, cwd: getFixturePath() });
 

--- a/tests/lib/util/npm-util.js
+++ b/tests/lib/util/npm-util.js
@@ -71,17 +71,18 @@ describe("npmUtil", () => {
         });
 
         it("should throw with message when parsing invalid package.json", () => {
-            const logInfo = sandbox.stub(log, "info");
-
             mockFs({
                 "package.json": "{ \"not: \"valid json\" }"
             });
 
-            const fn = npmUtil.checkDevDeps.bind(null, ["some-package"]);
-
-            assert.throws(fn, "SyntaxError: Unexpected token v");
-            assert(logInfo.calledOnce);
-            assert.strictEqual(logInfo.firstCall.args[0], "Could not read package.json file. Please check that the file contains valid JSON.");
+            assert.throws(() => {
+                try {
+                    npmUtil.checkDevDeps(["some-package"]);
+                } catch (error) {
+                    assert.strictEqual(error.messageTemplate, "failed-to-read-json");
+                    throw error;
+                }
+            }, "SyntaxError: Unexpected token v");
         });
     });
 
@@ -134,18 +135,18 @@ describe("npmUtil", () => {
         });
 
         it("should throw with message when parsing invalid package.json", () => {
-            const logInfo = sandbox.stub(log, "info");
-
             mockFs({
                 "package.json": "{ \"not: \"valid json\" }"
             });
 
-            const fn = npmUtil.checkDevDeps.bind(null, ["some-package"]);
-
-            assert.throws(fn, "SyntaxError: Unexpected token v");
-            assert(logInfo.calledOnce);
-            assert.strictEqual(logInfo.firstCall.args[0], "Could not read package.json file. Please check that the file contains valid JSON.");
-            logInfo.restore();
+            assert.throws(() => {
+                try {
+                    npmUtil.checkDeps(["some-package"]);
+                } catch (error) {
+                    assert.strictEqual(error.messageTemplate, "failed-to-read-json");
+                    throw error;
+                }
+            }, "SyntaxError: Unexpected token v");
         });
     });
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
close #10364 

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Display better error message when failed to parse JSON.
