### PR TITLE
Fix: parse later ES files in `eslint --init` (fixes #10003)

### DIFF
--- a/lib/config/config-initializer.js
+++ b/lib/config/config-initializer.js
@@ -256,9 +256,7 @@ function processAnswers(answers) {
         if (answers.modules) {
             config.parserOptions.sourceType = "module";
         }
-        if (answers.es6Globals) {
-            config.env.es6 = true;
-        }
+        config.env.es6 = true;
     }
 
     if (answers.commonjs) {
@@ -506,15 +504,6 @@ function promptUser() {
                 type: "confirm",
                 name: "modules",
                 message: "Are you using ES6 modules?",
-                default: false,
-                when(answers) {
-                    return answers.ecmaVersion >= 2015;
-                }
-            },
-            {
-                type: "confirm",
-                name: "es6Globals",
-                message: "Are you using ES6 globals (such as `Map` and `Set`)?",
                 default: false,
                 when(answers) {
                     return answers.ecmaVersion >= 2015;

--- a/lib/config/config-initializer.js
+++ b/lib/config/config-initializer.js
@@ -249,15 +249,18 @@ function configureRules(answers, config) {
  * @returns {Object} config object
  */
 function processAnswers(answers) {
-    let config = { rules: {}, env: {} };
+    let config = { rules: {}, env: {}, parserOptions: {} };
 
-    if (answers.es6) {
-        config.env.es6 = true;
+    config.parserOptions.ecmaVersion = answers.ecmaVersion;
+    if (answers.ecmaVersion >= 2015) {
         if (answers.modules) {
-            config.parserOptions = config.parserOptions || {};
             config.parserOptions.sourceType = "module";
         }
+        if (answers.es6Globals) {
+            config.env.es6 = true;
+        }
     }
+
     if (answers.commonjs) {
         config.env.commonjs = true;
     }
@@ -486,10 +489,18 @@ function promptUser() {
         // continue with the questions otherwise...
         return inquirer.prompt([
             {
-                type: "confirm",
-                name: "es6",
-                message: "Are you using ECMAScript 6 features?",
-                default: false
+                type: "list",
+                name: "ecmaVersion",
+                message: "Which version of ECMAScript do you use?",
+                choices: [
+                    { name: "ES3", value: 3 },
+                    { name: "ES5", value: 5 },
+                    { name: "ES2015", value: 2015 },
+                    { name: "ES2016", value: 2016 },
+                    { name: "ES2017", value: 2017 },
+                    { name: "ES2018", value: 2018 }
+                ],
+                default: 1 // This is the index in the choices list
             },
             {
                 type: "confirm",
@@ -497,7 +508,16 @@ function promptUser() {
                 message: "Are you using ES6 modules?",
                 default: false,
                 when(answers) {
-                    return answers.es6 === true;
+                    return answers.ecmaVersion >= 2015;
+                }
+            },
+            {
+                type: "confirm",
+                name: "es6Globals",
+                message: "Are you using ES6 globals (such as `Map` and `Set`)?",
+                default: false,
+                when(answers) {
+                    return answers.ecmaVersion >= 2015;
                 }
             },
             {

--- a/tests/fixtures/config-initializer/new-es-features/new-es-features.js
+++ b/tests/fixtures/config-initializer/new-es-features/new-es-features.js
@@ -1,0 +1,3 @@
+async function fn() {
+    await Promise.resolve();
+}

--- a/tests/lib/config/config-initializer.js
+++ b/tests/lib/config/config-initializer.js
@@ -123,8 +123,9 @@ describe("configInitializer", () => {
                     quotes: "single",
                     linebreak: "unix",
                     semi: true,
-                    es6: true,
+                    ecmaVersion: 2015,
                     modules: true,
+                    es6Globals: true,
                     env: ["browser"],
                     jsx: false,
                     react: false,
@@ -141,6 +142,7 @@ describe("configInitializer", () => {
                 assert.deepStrictEqual(config.rules["linebreak-style"], ["error", "unix"]);
                 assert.deepStrictEqual(config.rules.semi, ["error", "always"]);
                 assert.strictEqual(config.env.es6, true);
+                assert.strictEqual(config.parserOptions.ecmaVersion, 2015);
                 assert.strictEqual(config.parserOptions.sourceType, "module");
                 assert.strictEqual(config.env.browser, true);
                 assert.strictEqual(config.extends, "eslint:recommended");
@@ -171,9 +173,10 @@ describe("configInitializer", () => {
             });
 
             it("should not enable es6", () => {
-                answers.es6 = false;
+                answers.ecmaVersion = 5;
                 const config = init.processAnswers(answers);
 
+                assert.strictEqual(config.parserOptions.ecmaVersion, 5);
                 assert.isUndefined(config.env.es6);
             });
 
@@ -323,7 +326,7 @@ describe("configInitializer", () => {
                 answers = {
                     source: "auto",
                     patterns,
-                    es6: false,
+                    ecmaVersion: 5,
                     env: ["browser"],
                     jsx: false,
                     react: false,
@@ -361,6 +364,15 @@ describe("configInitializer", () => {
             it("should extend and not disable recommended rules", () => {
                 assert.strictEqual(config.extends, "eslint:recommended");
                 assert.notProperty(config.rules, "no-console");
+            });
+
+            it("should support new ES features if using later ES version", () => {
+                const filename = getFixturePath("new-es-features");
+
+                answers.patterns = filename;
+                answers.ecmaVersion = 2017;
+                process.chdir(fixtureDir);
+                config = init.processAnswers(answers);
             });
 
             it("should throw on fatal parsing error", () => {


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
close #10003 

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
When running `eslint --init`, the CLI will ask user the ECMAScript version and whether using es6 globals.
Note that I haven't resolved ES7+ globals. This should be in another PR.