### PR TITLE
Fix: allow no tokens after `return` keyword (fixes #10372)

### DIFF
--- a/lib/rules/arrow-body-style.js
+++ b/lib/rules/arrow-body-style.js
@@ -124,6 +124,8 @@ module.exports = {
                         messageId = "unexpectedEmptyBlock";
                     } else if (blockBody.length > 1) {
                         messageId = "unexpectedOtherBlock";
+                    } else if (blockBody[0].argument === null) {
+                        messageId = "unexpectedSingleBlock";
                     } else if (astUtils.isOpeningBraceToken(sourceCode.getFirstToken(blockBody[0], { skip: 1 }))) {
                         messageId = "unexpectedObjectBlock";
                     } else {

--- a/tests/lib/rules/arrow-body-style.js
+++ b/tests/lib/rules/arrow-body-style.js
@@ -163,6 +163,19 @@ ruleTester.run("arrow-body-style", rule, {
             ]
         },
         {
+            code: "var foo = () => { return };",
+            output: null, // not fixed
+            options: ["as-needed", { requireReturnForObjectLiteral: true }],
+            errors: [
+                {
+                    line: 1,
+                    column: 17,
+                    type: "ArrowFunctionExpression",
+                    messageId: "unexpectedSingleBlock"
+                }
+            ]
+        },
+        {
             code: "var foo = () => { return; };",
             output: null, // not fixed
             options: ["as-needed", { requireReturnForObjectLiteral: true }],


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
close #10372 
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Allow:
```js
test = () => { return }
```

**Is there anything you'd like reviewers to focus on?**


