### PR TITLE
Fix: ensure --stdin flag works when stdin is piped asynchronously

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -56,7 +56,15 @@ process.once("uncaughtException", err => {
 });
 
 if (useStdIn) {
-    process.exitCode = cli.execute(process.argv, fs.readFileSync(process.stdin.fd, "utf8"));
+
+    /*
+     * Note: `process.stdin.fd` is not used here due to https://github.com/nodejs/node/issues/7439.
+     * Accessing the `process.stdin` property seems to modify the behavior of file descriptor 0, resulting
+     * in an error when stdin is piped in asynchronously.
+     */
+    const STDIN_FILE_DESCRIPTOR = 0;
+
+    process.exitCode = cli.execute(process.argv, fs.readFileSync(STDIN_FILE_DESCRIPTOR, "utf8"));
 } else if (init) {
     const configInit = require("../lib/config/config-initializer");
 

--- a/tests/bin/eslint.js
+++ b/tests/bin/eslint.js
@@ -152,6 +152,17 @@ describe("bin/eslint.js", () => {
             }
         );
 
+        it("successfully reads from an asynchronous pipe", () => {
+            const child = runESLint(["--stdin", "--no-eslintrc"]);
+
+            child.stdin.write("var foo = bar;\n");
+            return new Promise(resolve => setTimeout(resolve, 300)).then(() => {
+                child.stdin.write("var baz = qux;\n");
+                child.stdin.end();
+
+                return assertExitCode(child, 0);
+            });
+        });
     });
 
     describe("running on files", () => {


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix

**Tell us about your environment**

* **ESLint Version:** master
* **Node Version:** 8.11.1
* **npm Version:** 5.6.0

**What parser (default, Babel-ESLint, etc.) are you using?**

N/A

**Please show your full configuration:**

N/A

**What did you do? Please include the actual source code causing the issue.**

This issue is simplest to reproduce with bash:

```bash
$ (echo 'a' && sleep 1 && echo 'b') | eslint --stdin --no-eslintrc
```

(I originally encountered this issue when using `curl` to fetch a JS file and pipe it to `eslint --stdin`.)

**What did you expect to happen?**

I expected ESLint to read stdin until the end (resulting in two lines of input), and then lint those two lines.

**What actually happened? Please include the actual, raw output from ESLint.**

An error was thrown:

```
EAGAIN: resource temporarily unavailable, read
Error: EAGAIN: resource temporarily unavailable, read
    at Object.fs.readSync (fs.js:675:18)
    at tryReadSync (fs.js:540:20)
    at Object.fs.readFileSync (fs.js:583:19)
    at Object.<anonymous> (/path/to/eslint/bin/eslint.js:59:53)
    at Module._compile (module.js:652:30)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
    at Function.Module.runMain (module.js:693:10)
```

Based on https://github.com/nodejs/node/issues/7439, this probably only occurs on macOS.

**What changes did you make? (Give an overview)**

This updates `bin/eslint.js` to avoid accessing the `process.stdin` getter, which seems to change the state of file descriptor 0.

**Is there anything you'd like reviewers to focus on?**

Should this be filed as a Node bug instead? Based on https://github.com/nodejs/node/issues/7439, it seems to at least partially be working as intended, but the behavior is somewhat surprising.
