### PR TITLE
Update: fix false negative in no-use-before-define (fixes #10227)

### DIFF
--- a/lib/rules/no-use-before-define.js
+++ b/lib/rules/no-use-before-define.js
@@ -219,49 +219,14 @@ module.exports = {
                     data: reference.identifier
                 });
             });
+
+            scope.childScopes.forEach(findVariablesInScope);
         }
 
-        /**
-         * Validates variables inside of a node's scope.
-         * @param {ASTNode} node The node to check.
-         * @returns {void}
-         * @private
-         */
-        function findVariables() {
-            const scope = context.getScope();
-
-            findVariablesInScope(scope);
-        }
-
-        const ruleDefinition = {
-            "Program:exit"(node) {
-                const scope = context.getScope(),
-                    ecmaFeatures = context.parserOptions.ecmaFeatures || {};
-
-                findVariablesInScope(scope);
-
-                // both Node.js and Modules have an extra scope
-                if (ecmaFeatures.globalReturn || node.sourceType === "module") {
-                    findVariablesInScope(scope.childScopes[0]);
-                }
+        return {
+            Program() {
+                findVariablesInScope(context.getScope());
             }
         };
-
-        if (context.parserOptions.ecmaVersion >= 6) {
-            ruleDefinition["BlockStatement:exit"] =
-                ruleDefinition["SwitchStatement:exit"] = findVariables;
-
-            ruleDefinition["ArrowFunctionExpression:exit"] = function(node) {
-                if (node.body.type !== "BlockStatement") {
-                    findVariables();
-                }
-            };
-        } else {
-            ruleDefinition["FunctionExpression:exit"] =
-                ruleDefinition["FunctionDeclaration:exit"] =
-                ruleDefinition["ArrowFunctionExpression:exit"] = findVariables;
-        }
-
-        return ruleDefinition;
     }
 };

--- a/tests/lib/rules/no-use-before-define.js
+++ b/tests/lib/rules/no-use-before-define.js
@@ -137,12 +137,14 @@ ruleTester.run("no-use-before-define", rule, {
             errors: ["'x' was used before it was defined."]
         },
         {
-            code: "with (x); let x = {}",
+            code: "with (obj) x; let x = {}",
             parserOptions: { ecmaVersion: 2015 },
             errors: ["'x' was used before it was defined."]
         },
+
+        // WithStatements.
         {
-            code: "with (obj) x; let x = {}",
+            code: "with (x); let x = {}",
             parserOptions: { ecmaVersion: 2015 },
             errors: ["'x' was used before it was defined."]
         },

--- a/tests/lib/rules/no-use-before-define.js
+++ b/tests/lib/rules/no-use-before-define.js
@@ -113,6 +113,53 @@ ruleTester.run("no-use-before-define", rule, {
             code: "foo; var foo;",
             options: [{ variables: false }],
             errors: [{ message: "'foo' was used before it was defined.", type: "Identifier" }]
+        },
+
+        // https://github.com/eslint/eslint/issues/10227
+        {
+            code: "for (let x = x;;); let x = 0",
+            parserOptions: { ecmaVersion: 2015 },
+            errors: ["'x' was used before it was defined."]
+        },
+        {
+            code: "for (let x in xs); let xs = []",
+            parserOptions: { ecmaVersion: 2015 },
+            errors: ["'xs' was used before it was defined."]
+        },
+        {
+            code: "for (let x of xs); let xs = []",
+            parserOptions: { ecmaVersion: 2015 },
+            errors: ["'xs' was used before it was defined."]
+        },
+        {
+            code: "try {} catch ({message = x}) {} let x = ''",
+            parserOptions: { ecmaVersion: 2015 },
+            errors: ["'x' was used before it was defined."]
+        },
+        {
+            code: "with (x); let x = {}",
+            parserOptions: { ecmaVersion: 2015 },
+            errors: ["'x' was used before it was defined."]
+        },
+        {
+            code: "with (obj) x; let x = {}",
+            parserOptions: { ecmaVersion: 2015 },
+            errors: ["'x' was used before it was defined."]
+        },
+        {
+            code: "with (obj) { x } let x = {}",
+            parserOptions: { ecmaVersion: 2015 },
+            errors: ["'x' was used before it was defined."]
+        },
+        {
+            code: "with (obj) { if (a) { x } } let x = {}",
+            parserOptions: { ecmaVersion: 2015 },
+            errors: ["'x' was used before it was defined."]
+        },
+        {
+            code: "with (obj) { (() => { if (a) { x } })() } let x = {}",
+            parserOptions: { ecmaVersion: 2015 },
+            errors: ["'x' was used before it was defined."]
         }
     ]
 });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix: #10227

**What changes did you make? (Give an overview)**

This PR does:

- fixes many false negatives of `no-use-before-define` rule.
- remove the accesses to `parserOptions` from the rule.
- adds several lacking tests to the rule.

**Is there anything you'd like reviewers to focus on?**

The tests for `CatchClause` and `WithStatement` were lacking.
Please check the added tests to make a consensus.