### PR TITLE
Docs: Add rest and spread operator changes to migration guide

### DIFF
--- a/docs/user-guide/migrating-to-5.0.0.md
+++ b/docs/user-guide/migrating-to-5.0.0.md
@@ -198,17 +198,17 @@ When parsing JSX code like `<a>foo</a>`, the default parser will now give the `f
 
 ## <a name="spread-operators"></a> When using the default parser, spread operators now have type `SpreadElement`
 
-Previously, when parsing JS code like `const foo = {...data}` with the `experimentalObjectRestSpread` option enabled the default parser would set the `...data` AST node the `ExperimentalSpreadProperty` type.
+Previously, when parsing JS code like `const foo = {...data}` with the `experimentalObjectRestSpread` option enabled, the default parser would generate an `ExperimentalSpreadProperty` node type for the `...data` spread element.
 
-In ESLint v5, the default parser will now always give the `...data` AST node the `SpreadElement` type, even if the [now deprecated]](#experimental-object-rest-spread) `experimentalObjectRestSpread` option was enabled. This makes the AST compliant with the current ESTree spec.
+In ESLint v5, the default parser will now always give the `...data` AST node the `SpreadElement` type, even if the (now deprecated) [`experimentalObjectRestSpread`](#experimental-object-rest-spread) option is enabled. This makes the AST compliant with the current ESTree spec.
 
 **To address:** If you have written a custom rule that relies on spread operators having the `ExperimentalSpreadProperty` type, you should update it to also work with spread operators that have the `SpreadElement` type.
 
 ## <a name="rest-operators"></a> When using the default parser, rest operators now have type `RestElement`
 
-Previously, when parsing JS code like `const {foo, ...rest} = data` with the `experimentalObjectRestSpread` option enabled the default parser would set the `...data` AST node the `ExperimentalRestProperty` type.
+Previously, when parsing JS code like `const {foo, ...rest} = data` with the `experimentalObjectRestSpread` option enabled, the default parser would generate an `ExperimentalRestProperty` node type for the `...data` rest element.
 
-In ESLint v5, the default parser will now always give the `...data` AST node the `RestElement` type, even if the [now deprecated]](#experimental-object-rest-spread) `experimentalObjectRestSpread` option was enabled. This makes the AST compliant with the current ESTree spec.
+In ESLint v5, the default parser will now always give the `...data` AST node the `RestElement` type, even if the (now deprecated) [`experimentalObjectRestSpread`](#experimental-object-rest-spread) option is enabled. This makes the AST compliant with the current ESTree spec.
 
 **To address:** If you have written a custom rule that relies on rest operators having the `ExperimentalRestProperty` type, you should update it to also work with rest operators that have the `RestElement` type.
 

--- a/docs/user-guide/migrating-to-5.0.0.md
+++ b/docs/user-guide/migrating-to-5.0.0.md
@@ -20,6 +20,8 @@ The lists below are ordered roughly by the number of users each change is expect
 
 1. [The `parent` property of AST nodes is now set before rules start running](#parent-before-rules)
 1. [When using the default parser, text nodes in JSX elements now have type `JSXText`](#jsx-text-nodes)
+1. [When using the default parser, spread operators now have type `SpreadElement`](#spread-operators)
+1. [When using the default parser, rest operators now have type `RestElement`](#rest-operators)
 1. [The `context.getScope()` method now returns more proper scopes](#context-get-scope)
 1. [The `_linter` property on rule context objects has been removed](#no-context-linter)
 1. [`RuleTester` now uses strict equality checks in its assertions](#rule-tester-equality)
@@ -193,6 +195,22 @@ In ESLint v5, the `parent` property is set on all AST nodes before any rules hav
 When parsing JSX code like `<a>foo</a>`, the default parser will now give the `foo` AST node the `JSXText` type, rather than the `Literal` type. This makes the AST compliant with a recent update to the JSX spec.
 
 **To address:** If you have written a custom rule that relies on text nodes in JSX elements having the `Literal` type, you should update it to also work with nodes that have the `JSXText` type.
+
+## <a name="spread-operators"></a> When using the default parser, spread operators now have type `SpreadElement`
+
+Previously, when parsing JS code like `const foo = {...data}` with the `experimentalObjectRestSpread` option enabled the default parser would set the `...data` AST node the `ExperimentalSpreadProperty` type.
+
+In ESLint v5, the default parser will now always give the `...data` AST node the `SpreadElement` type, even if the [now deprecated]](#experimental-object-rest-spread) `experimentalObjectRestSpread` option was enabled. This makes the AST compliant with the current ESTree spec.
+
+**To address:** If you have written a custom rule that relies on spread operators having the `ExperimentalSpreadProperty` type, you should update it to also work with spread operators that have the `SpreadElement` type.
+
+## <a name="rest-operators"></a> When using the default parser, rest operators now have type `RestElement`
+
+Previously, when parsing JS code like `const {foo, ...rest} = data` with the `experimentalObjectRestSpread` option enabled the default parser would set the `...data` AST node the `ExperimentalRestProperty` type.
+
+In ESLint v5, the default parser will now always give the `...data` AST node the `RestElement` type, even if the [now deprecated]](#experimental-object-rest-spread) `experimentalObjectRestSpread` option was enabled. This makes the AST compliant with the current ESTree spec.
+
+**To address:** If you have written a custom rule that relies on rest operators having the `ExperimentalRestProperty` type, you should update it to also work with rest operators that have the `RestElement` type.
 
 ## <a name="context-get-scope"></a> The `context.getScope()` method now returns more proper scopes
 

--- a/docs/user-guide/migrating-to-5.0.0.md
+++ b/docs/user-guide/migrating-to-5.0.0.md
@@ -19,9 +19,9 @@ The lists below are ordered roughly by the number of users each change is expect
 ### Breaking changes for plugin/custom rule developers
 
 1. [The `parent` property of AST nodes is now set before rules start running](#parent-before-rules)
-1. [When using the default parser, text nodes in JSX elements now have type `JSXText`](#jsx-text-nodes)
 1. [When using the default parser, spread operators now have type `SpreadElement`](#spread-operators)
 1. [When using the default parser, rest operators now have type `RestElement`](#rest-operators)
+1. [When using the default parser, text nodes in JSX elements now have type `JSXText`](#jsx-text-nodes)
 1. [The `context.getScope()` method now returns more proper scopes](#context-get-scope)
 1. [The `_linter` property on rule context objects has been removed](#no-context-linter)
 1. [`RuleTester` now uses strict equality checks in its assertions](#rule-tester-equality)
@@ -190,12 +190,6 @@ In ESLint v5, the `parent` property is set on all AST nodes before any rules hav
 
 **To address:** If you have written a custom rule that enumerates all properties of an AST node, consider excluding the `parent` property or implementing cycle detection to ensure that you obtain the correct result.
 
-## <a name="jsx-text-nodes"></a> When using the default parser, text nodes in JSX elements now have type `JSXText`
-
-When parsing JSX code like `<a>foo</a>`, the default parser will now give the `foo` AST node the `JSXText` type, rather than the `Literal` type. This makes the AST compliant with a recent update to the JSX spec.
-
-**To address:** If you have written a custom rule that relies on text nodes in JSX elements having the `Literal` type, you should update it to also work with nodes that have the `JSXText` type.
-
 ## <a name="spread-operators"></a> When using the default parser, spread operators now have type `SpreadElement`
 
 Previously, when parsing JS code like `const foo = {...data}` with the `experimentalObjectRestSpread` option enabled, the default parser would generate an `ExperimentalSpreadProperty` node type for the `...data` spread element.
@@ -211,6 +205,12 @@ Previously, when parsing JS code like `const {foo, ...rest} = data` with the `ex
 In ESLint v5, the default parser will now always give the `...data` AST node the `RestElement` type, even if the (now deprecated) [`experimentalObjectRestSpread`](#experimental-object-rest-spread) option is enabled. This makes the AST compliant with the current ESTree spec.
 
 **To address:** If you have written a custom rule that relies on rest operators having the `ExperimentalRestProperty` type, you should update it to also work with rest operators that have the `RestElement` type.
+
+## <a name="jsx-text-nodes"></a> When using the default parser, text nodes in JSX elements now have type `JSXText`
+
+When parsing JSX code like `<a>foo</a>`, the default parser will now give the `foo` AST node the `JSXText` type, rather than the `Literal` type. This makes the AST compliant with a recent update to the JSX spec.
+
+**To address:** If you have written a custom rule that relies on text nodes in JSX elements having the `Literal` type, you should update it to also work with nodes that have the `JSXText` type.
 
 ## <a name="context-get-scope"></a> The `context.getScope()` method now returns more proper scopes
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

While updating `eslint-plugin-react` for the upcoming ESLint v5 I noticed some changes that were not addressed in the current [migration guide](https://eslint.org/docs/5.0.0/user-guide/migrating-to-5.0.0):

* The spread operators now always have the `SpreadElement` type, they previously had the `ExperimentalSpreadProperty` type when the `experimentalObjectRestSpread` was enabled.
* The spread operators now always have the `RestElement` type, they previously had the `ExperimentalRestProperty` type when the `experimentalObjectRestSpread` was enabled.

This is due that the backward compatibility is handled by forcing the `ecmaVersion` in https://github.com/eslint/eslint/pull/10230

This change add 2 new migration guides in the "Breaking changes for plugin/custom rule developers" section:

* When using the default parser, spread operators now have type `SpreadElement`
* When using the default parser, rest operators now have type `RestElement`

**Is there anything you'd like reviewers to focus on?**

* Plugin/custom rule developers should already have handled `SpreadElement`/`RestElement` in their plugins, but it is not always the case so I think it's worth it to add this in the migration guide.
* As stated at the top of the migration guide "The lists below are ordered roughly by the number of users each change is expected to affect, where the first items are expected to affect the most users." . I'm not sure how many plugin developers will be affected by this change, so in doubt I placed the new guides just bellow a similar change.
* English is not my primary language, so any correction is welcome 😉 
