### PR TITLE
Fix: fix writing config file when `source` is `prompt`

### DIFF
--- a/lib/config/config-initializer.js
+++ b/lib/config/config-initializer.js
@@ -623,7 +623,7 @@ function promptUser() {
                 const config = processAnswers(totalAnswers);
                 const modules = getModulesList(config);
 
-                return askInstallModules(modules).then(() => writeFile(config, earlyAnswers.format));
+                return askInstallModules(modules).then(() => writeFile(config, answers.format));
             });
         });
     });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
When running `eslint --init`, if the user chooses `prompt` mode, write the config file with corresponding format.


