### PR TITLE
Upgrade: espree@next (fixes #10392)

### DIFF
--- a/lib/rules/no-catch-shadow.js
+++ b/lib/rules/no-catch-shadow.js
@@ -53,7 +53,7 @@ module.exports = {
 
         return {
 
-            CatchClause(node) {
+            "CatchClause[param!=null]"(node) {
                 let scope = context.getScope();
 
                 /*

--- a/lib/rules/no-shadow-restricted-names.js
+++ b/lib/rules/no-shadow-restricted-names.js
@@ -46,22 +46,13 @@ module.exports = {
             VariableDeclarator(node) {
                 checkForViolation(node.id);
             },
-            ArrowFunctionExpression(node) {
-                [].map.call(node.params, checkForViolation);
-            },
-            FunctionExpression(node) {
+            ":function"(node) {
                 if (node.id) {
                     checkForViolation(node.id);
                 }
-                [].map.call(node.params, checkForViolation);
+                node.params.forEach(checkForViolation);
             },
-            FunctionDeclaration(node) {
-                if (node.id) {
-                    checkForViolation(node.id);
-                    [].map.call(node.params, checkForViolation);
-                }
-            },
-            CatchClause(node) {
+            "CatchClause[param!=null]"(node) {
                 checkForViolation(node.param);
             }
         };

--- a/tests/lib/rules/no-catch-shadow.js
+++ b/tests/lib/rules/no-catch-shadow.js
@@ -40,6 +40,10 @@ ruleTester.run("no-catch-shadow", rule, {
         {
             code: "try {} catch (error) {}",
             env: { shelljs: false }
+        },
+        {
+            code: "try {} catch {}",
+            parserOptions: { ecmaVersion: 2019 }
         }
     ],
     invalid: [

--- a/tests/lib/rules/no-shadow-restricted-names.js
+++ b/tests/lib/rules/no-shadow-restricted-names.js
@@ -20,7 +20,11 @@ ruleTester.run("no-shadow-restricted-names", rule, {
         "!function foo(bar){ var baz; }",
         "!function(bar){ var baz; }",
         "try {} catch(e) {}",
-        { code: "export default function() {}", parserOptions: { sourceType: "module" } }
+        { code: "export default function() {}", parserOptions: { sourceType: "module" } },
+        {
+            code: "try {} catch {}",
+            parserOptions: { ecmaVersion: 2019 }
+        }
     ],
     invalid: [
         {


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

Fixes #10392.

[X] Bug fix
~~[X] Other, please explain: Upgrade `espree` to support ES2019 syntax.~~

**What changes did you make? (Give an overview)**

~~**Note**: this PR depends on `eslint/espree#upgrade-acorn-5.6` branch.~~

~~This PR upgrades `espree` to support ES2019 syntax.~~
This PR fixes the bug that it crashes on optional `catch` binding syntax in some core rules.
I searched rules with `/\.param\b/` then I fixed found two rules.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.
