### PR TITLE
Update: no-magic-numbers should ignore parseFloat (fixes #10445)

### DIFF
--- a/docs/rules/no-magic-numbers.md
+++ b/docs/rules/no-magic-numbers.md
@@ -78,6 +78,18 @@ var data = ['foo', 'bar', 'baz'];
 var dataLast = data[2];
 ```
 
+### ignoreRadixes
+
+A boolean to specify if radixes of `parseInt` and `parseFloat` are considered okay. `true` by default.
+
+Examples of **incorrect** code for the `{ "ignoreRadixes": false }` option:
+
+```js
+/*eslint no-magic-numbers: ["error", { "ignoreRadixes": false }]*/
+
+var price = parseInt('100', 10);
+```
+
 ### enforceConst
 
 A boolean to specify if we should check for the const keyword in variable declaration of numbers. `false` by default.

--- a/lib/rules/no-magic-numbers.js
+++ b/lib/rules/no-magic-numbers.js
@@ -36,6 +36,9 @@ module.exports = {
                 },
                 ignoreArrayIndexes: {
                     type: "boolean"
+                },
+                ignoreRadixes: {
+                    type: "boolean"
                 }
             },
             additionalProperties: false
@@ -47,7 +50,8 @@ module.exports = {
             detectObjects = !!config.detectObjects,
             enforceConst = !!config.enforceConst,
             ignore = config.ignore || [],
-            ignoreArrayIndexes = !!config.ignoreArrayIndexes;
+            ignoreArrayIndexes = !!config.ignoreArrayIndexes,
+            ignoreRadixes = "ignoreRadixes" in config ? !!config.ignoreRadixes : true;
 
         /**
          * Returns whether the node is number literal
@@ -69,16 +73,26 @@ module.exports = {
 
         /**
          * Returns whether the number should be ignored when used as a radix within parseInt() or Number.parseInt()
+         * or the parseFloat equivalents.
          * @param {ASTNode} parent - the non-"UnaryExpression" parent
          * @param {ASTNode} node - the node literal being evaluated
          * @returns {boolean} true if the number should be ignored
          */
-        function shouldIgnoreParseInt(parent, node) {
-            return parent.type === "CallExpression" && node === parent.arguments[1] &&
-                (parent.callee.name === "parseInt" ||
-                parent.callee.type === "MemberExpression" &&
-                parent.callee.object.name === "Number" &&
-                parent.callee.property.name === "parseInt");
+        function shouldIgnoreRadix(parent, node) {
+            if (!ignoreRadixes || !(parent.type === "CallExpression" && node === parent.arguments[1])) {
+                return false;
+            }
+
+            if (parent.callee.name === "parseInt" || parent.callee.name === "parseFloat") {
+                return true;
+            }
+
+            if (parent.callee.type === "MemberExpression" && parent.callee.object.name === "Number" &&
+                (parent.callee.property.name === "parseInt" || parent.callee.property.name === "parseFloat")) {
+                return true;
+            }
+
+            return false;
         }
 
         /**
@@ -126,7 +140,7 @@ module.exports = {
                 }
 
                 if (shouldIgnoreNumber(value) ||
-                    shouldIgnoreParseInt(parent, fullNumberNode) ||
+                    shouldIgnoreRadix(parent, fullNumberNode) ||
                     shouldIgnoreArrayIndexes(parent) ||
                     shouldIgnoreJSXNumbers(parent)) {
                     return;

--- a/tests/lib/rules/no-magic-numbers.js
+++ b/tests/lib/rules/no-magic-numbers.js
@@ -23,6 +23,9 @@ ruleTester.run("no-magic-numbers", rule, {
         "var x = parseInt(y, 10);",
         "var x = parseInt(y, -10);",
         "var x = Number.parseInt(y, 10);",
+        "var x = parseFloat(y, 10);",
+        "var x = parseFloat(y, -10);",
+        "var x = Number.parseFloat(y, 10);",
         {
             code: "const foo = 42;",
             env: { es6: true }
@@ -78,6 +81,60 @@ ruleTester.run("no-magic-numbers", rule, {
         }
     ],
     invalid: [
+        {
+            code: "var x = parseInt(y, 10);",
+            options: [{
+                ignoreRadixes: false
+            }],
+            errors: [
+                { message: "No magic number: 10." }
+            ]
+        },
+        {
+            code: "var x = parseInt(y, -10);",
+            options: [{
+                ignoreRadixes: false
+            }],
+            errors: [
+                { message: "No magic number: -10." }
+            ]
+        },
+        {
+            code: "var x = Number.parseInt(y, 10);",
+            options: [{
+                ignoreRadixes: false
+            }],
+            errors: [
+                { message: "No magic number: 10." }
+            ]
+        },
+        {
+            code: "var x = parseFloat(y, 10);",
+            options: [{
+                ignoreRadixes: false
+            }],
+            errors: [
+                { message: "No magic number: 10." }
+            ]
+        },
+        {
+            code: "var x = parseFloat(y, -10);",
+            options: [{
+                ignoreRadixes: false
+            }],
+            errors: [
+                { message: "No magic number: -10." }
+            ]
+        },
+        {
+            code: "var x = Number.parseFloat(y, 10);",
+            options: [{
+                ignoreRadixes: false
+            }],
+            errors: [
+                { message: "No magic number: 10." }
+            ]
+        },
         {
             code: "var foo = 42",
             options: [{


### PR DESCRIPTION
Previous work was done to allow `parseInt` (refs #4171), but `parseFloat`
seems to have been forgotten.

This commit also adds a new `ignoreRadixes` option, which reasonably defaults
to true for backward compatibility, to make this behavior configurable.

<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update
[x] Changes an existing rule (see #10445 for details)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Added the `ignoreRadixes` options to the `no-magic-numbers` rule, which defaults to `true`, so the change is backward compatible.

Ignored `parseFloat` on top of `parseInt` for similar reasons as the ones exposed in #4167.

**Is there anything you'd like reviewers to focus on?**

Nope. Just want to point out that I "exploded" the large _return-condition_ into multiple ifs and returns because it was becoming a bit too complicated.

