### PR TITLE
Docs: Create docs landing page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,17 @@
+# Documentation
+
+Welcome to our documentation pages! What would you like to view?
+
+## [User Guide](user-guide)
+
+Intended for end users of ESLint. Contains information about core rules, configuration, command line options, formatters, and integrations,
+as well as guides for migrating from earlier versions of ESLint.
+
+## [Developer Guide](developer-guide)
+
+Intended for contributors to ESLint and people who wish to extend ESLint. Contains information about contributing to ESLint; creating custom
+rules, configurations, plugins, and formatters; and information about our architecture and Node.js API.
+
+## [Maintainer Guide](maintainer-guide)
+
+Intended for maintainers of ESLint.


### PR DESCRIPTION
The main purpose of this landing page is to allow users to view "https://eslint.org/docs", which currently is HTTP 404 on our site.

As a secondary benefit, this would also allow the landing page to be used as the launching point for Algolia's Docsearch crawler.

<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Created a docs landing page, which links to the user guide, developer guide, and maintainer guide.

**Is there anything you'd like reviewers to focus on?**

Any improvements for the text I've written in each section?