### PR TITLE
Docs: Restore intentional spelling mistake

### DIFF
--- a/docs/rules/valid-typeof.md
+++ b/docs/rules/valid-typeof.md
@@ -20,7 +20,7 @@ Examples of **incorrect** code for this rule:
 typeof foo === "strnig"
 typeof foo == "undefimed"
 typeof bar != "nunber"
-typeof bar !== "function"
+typeof bar !== "fucntion"
 ```
 
 Examples of **correct** code for this rule:


### PR DESCRIPTION
This was accidentally removed in #9965.