### PR TITLE
Build: Include prerelease install info in release blog post

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -308,7 +308,22 @@ function prerelease(prereleaseId) {
     const releaseInfo = ReleaseOps.release(prereleaseId);
     const nextMajor = semver.inc(releaseInfo.version, "major");
 
-    releaseInfo.prereleaseMajorVersion = nextMajor;
+    /*
+     * Premajor release should have identical "next major version".
+     * Preminor and prepatch release will not.
+     * 5.0.0-alpha.0 --> next major = 5, current major = 5
+     * 4.4.0-alpha.0 --> next major = 5, current major = 4
+     * 4.0.1-alpha.0 --> next major = 5, current major = 4
+     */
+    if (semver.major(prereleaseId) === semver.major(nextMajor)) {
+
+        /*
+         * This prerelease is for a major release (not preminor/prepatch).
+         * Blog post generation logic needs to be aware of this (as well as
+         * know what the next major version is actually supposed to be).
+         */
+        releaseInfo.prereleaseMajorVersion = nextMajor;
+    }
 
     echo("Generating site");
 

--- a/Makefile.js
+++ b/Makefile.js
@@ -307,7 +307,7 @@ function prerelease(prereleaseId) {
 
     const releaseInfo = ReleaseOps.release(prereleaseId);
     const nextMajor = semver.inc(releaseInfo.version, "major");
-    
+
     releaseInfo.prereleaseMajorVersion = nextMajor;
 
     echo("Generating site");

--- a/Makefile.js
+++ b/Makefile.js
@@ -306,8 +306,8 @@ function release(ciRelease) {
 function prerelease(prereleaseId) {
 
     const releaseInfo = ReleaseOps.release(prereleaseId);
-
     const nextMajor = semver.inc(releaseInfo.version, "major");
+    
     releaseInfo.prereleaseMajorVersion = nextMajor;
 
     echo("Generating site");

--- a/Makefile.js
+++ b/Makefile.js
@@ -307,10 +307,13 @@ function prerelease(prereleaseId) {
 
     const releaseInfo = ReleaseOps.release(prereleaseId);
 
+    const nextMajor = semver.inc(releaseInfo.version, "major");
+    releaseInfo.prereleaseMajorVersion = nextMajor;
+
     echo("Generating site");
 
     // always write docs into the next major directory (so 2.0.0-alpha.0 writes to 2.0.0)
-    target.gensite(semver.inc(releaseInfo.version, "major"));
+    target.gensite(nextMajor);
     generateBlogPost(releaseInfo);
     publishSite(`v${releaseInfo.version}`);
     echo("Site has been published");

--- a/Makefile.js
+++ b/Makefile.js
@@ -315,7 +315,7 @@ function prerelease(prereleaseId) {
      * 4.4.0-alpha.0 --> next major = 5, current major = 4
      * 4.0.1-alpha.0 --> next major = 5, current major = 4
      */
-    if (semver.major(prereleaseId) === semver.major(nextMajor)) {
+    if (semver.major(releaseInfo.version) === semver.major(nextMajor)) {
 
         /*
          * This prerelease is for a major release (not preminor/prepatch).

--- a/templates/blogpost.md.ejs
+++ b/templates/blogpost.md.ejs
@@ -27,6 +27,31 @@ function outputList(items) {
 
 %>
 
+<% if (prereleaseMajorVersion) { %>
+## Highlights
+
+This is a summary of the major changes you need to know about for this version of ESLint.
+
+### Installing
+
+Since this is a pre-release version, you will not automatically be upgraded by npm. You must specify the `next` tag when installing:
+
+```
+npm i eslint@next --save-dev
+```
+
+You can also specify the version directly:
+
+```
+npm i eslint@<%- version %> --save-dev
+```
+
+### Migration Guide
+
+As there are a lot of changes, we've created a [migration guide](/docs/<%- prereleaseMajorVersion %>/user-guide/migrating-to-<%- prereleaseMajorVersion %>) describing the changes in great detail along with the steps you should take to address them. We expect that most users should be able to upgrade without any build changes, but the migration guide should be a useful resource if you encounter problems.
+
+<% } %>
+
 <% if (typeof changelog.breaking !== "undefined") { %>
 ## Breaking Changes
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain: Build improvement to ensure that prerelease blog posts contain installation and migration guide information.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Added some logic to ensure that if we are doing a prerelease, that the info about installation and migration guide be included to reduce manual edits after the release.

Caveat: The release type in the intro paragraph is calculated in eslint-release based solely on the commit log. I'm hoping to submit a separate PR in the near future to fix that by respecting if the current version (as of before the release process) is also a prerelease.

**Is there anything you'd like reviewers to focus on?**

I don't know how to test this (either manually or via unit tests). I'd be grateful for pointers. (Leaving as WIP/do not merge to avoid accidental merging.)