### PR TITLE
Fix: do not fail on unknown operators from custom parsers (fixes #10475)

### DIFF
--- a/tests/fixtures/parsers/unknown-operators/unknown-logical-operator.js
+++ b/tests/fixtures/parsers/unknown-operators/unknown-logical-operator.js
@@ -1,0 +1,166 @@
+/**
+ * The output AST has been modified to represent an unknown operator
+ * (replaced ?? with %%)
+ *
+ * Parser: babel-eslint v8.2.3
+ * Source code:
+ * null ?? 'foo'
+ */
+
+exports.parse = () => ({
+    type: "Program",
+    start: 0,
+    end: 13,
+    loc: {
+        start: {
+            line: 1,
+            column: 0
+        },
+        end: {
+            line: 1,
+            column: 13
+        }
+    },
+    range: [0, 13],
+    comments: [],
+    tokens: [
+        {
+            type: "Null",
+            value: "null",
+            start: 0,
+            end: 4,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 0
+                },
+                end: {
+                    line: 1,
+                    column: 4
+                }
+            },
+            range: [0, 4]
+        },
+        {
+            type: {
+                label: "%%",
+                beforeExpr: true,
+                startsExpr: false,
+                rightAssociative: false,
+                isLoop: false,
+                isAssign: false,
+                prefix: false,
+                postfix: false,
+                binop: 1,
+                updateContext: null
+            },
+            value: "%%",
+            start: 5,
+            end: 7,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 5
+                },
+                end: {
+                    line: 1,
+                    column: 7
+                }
+            },
+            range: [5, 7]
+        },
+        {
+            type: "String",
+            value: "'foo'",
+            start: 8,
+            end: 13,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 8
+                },
+                end: {
+                    line: 1,
+                    column: 13
+                }
+            },
+            range: [8, 13]
+        }
+    ],
+    sourceType: "script",
+    body: [
+        {
+            type: "ExpressionStatement",
+            start: 0,
+            end: 13,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 0
+                },
+                end: {
+                    line: 1,
+                    column: 13
+                }
+            },
+            range: [0, 13],
+            expression: {
+                type: "LogicalExpression",
+                start: 0,
+                end: 13,
+                loc: {
+                    start: {
+                        line: 1,
+                        column: 0
+                    },
+                    end: {
+                        line: 1,
+                        column: 13
+                    }
+                },
+                range: [0, 13],
+                left: {
+                    type: "Literal",
+                    start: 0,
+                    end: 4,
+                    loc: {
+                        start: {
+                            line: 1,
+                            column: 0
+                        },
+                        end: {
+                            line: 1,
+                            column: 4
+                        }
+                    },
+                    range: [0, 4],
+                    value: null,
+                    raw: "null",
+                    _babelType: "Literal"
+                },
+                operator: "%%",
+                right: {
+                    type: "Literal",
+                    start: 8,
+                    end: 13,
+                    loc: {
+                        start: {
+                            line: 1,
+                            column: 8
+                        },
+                        end: {
+                            line: 1,
+                            column: 13
+                        }
+                    },
+                    range: [8, 13],
+                    value: "foo",
+                    raw: "'foo'",
+                    _babelType: "Literal"
+                },
+                _babelType: "LogicalExpression"
+            },
+            _babelType: "ExpressionStatement"
+        }
+    ]
+});

--- a/tests/fixtures/parsers/unknown-operators/unknown-logical-operator.js
+++ b/tests/fixtures/parsers/unknown-operators/unknown-logical-operator.js
@@ -3,6 +3,7 @@
  * (replaced ?? with %%)
  *
  * Parser: babel-eslint v8.2.3
+ * (with this fix for tokens: https://github.com/babel/babel-eslint/pull/632)
  * Source code:
  * null ?? 'foo'
  */
@@ -42,18 +43,7 @@ exports.parse = () => ({
             range: [0, 4]
         },
         {
-            type: {
-                label: "%%",
-                beforeExpr: true,
-                startsExpr: false,
-                rightAssociative: false,
-                isLoop: false,
-                isAssign: false,
-                prefix: false,
-                postfix: false,
-                binop: 1,
-                updateContext: null
-            },
+            type: "Punctuator",
             value: "%%",
             start: 5,
             end: 7,

--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -4470,6 +4470,16 @@ describe("Linter", () => {
                 assert.strictEqual(messages[0].message, "Cannot find module 'esprima-xyz'");
             });
 
+            it("should not throw or report errors when the custom parser returns unrecognized operators (https://github.com/eslint/eslint/issues/10475)", () => {
+                const code = "null %% 'foo'";
+                const parser = path.join(parserFixtures, "unknown-operators", "unknown-logical-operator.js");
+
+                // This shouldn't throw
+                const messages = linter.verify(code, { parser }, filename, true);
+
+                assert.strictEqual(messages.length, 0);
+            });
+
             it("should strip leading line: prefix from parser error", () => {
                 const parser = path.join(parserFixtures, "line-error.js");
                 const messages = linter.verify(";", { parser }, "filename");


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[X] Add something to the core
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

I modified the code path analysis code to explicitly check the operator of the logical expressions in order to create new code paths. This will allow users to use a custom parser that adds a new operator (like `??`) without breaking the code. The error users see now is

```
Error: unreachable
      at CodePathState.popChoiceContext (node_modules/eslint/lib/code-path-analysis/code-path-state.js:444:23)
      at processCodePathToExit (node_modules/eslint/lib/code-path-analysis/code-path-analyzer.js:434:19)
      at CodePathAnalyzer.leaveNode (node_modules/eslint/lib/code-path-analysis/code-path-analyzer.js:627:9)
      at Traverser.leave (node_modules/eslint/lib/linter.js:959:32)
      at Traverser.__execute (node_modules/estraverse/estraverse.js:397:31)
      at Traverser.traverse (node_modules/estraverse/estraverse.js:491:28)
      at Traverser.traverse (node_modules/eslint/lib/util/traverser.js:31:22)
      at Linter._verifyWithoutProcessors (node_modules/eslint/lib/linter.js:953:19)
      at preprocess.map.textBlock (node_modules/eslint/lib/linter.js:994:35)
      at Array.map (<anonymous>)
      at Linter.verify (node_modules/eslint/lib/linter.js:993:42)
      ...
```

Fixes #10475 (see for more details) and provides a more generic solution to #10399 (which is against the ESLint policy about providing support for pre-Stage 3 proposals).
