### PR TITLE
Docs: no-process-exit: recommend process.exitCode

### DIFF
--- a/docs/rules/no-process-exit.md
+++ b/docs/rules/no-process-exit.md
@@ -19,6 +19,8 @@ if (somethingBadHappened) {
 
 By throwing an error in this way, other parts of the application have an opportunity to handle the error rather than stopping the application altogether. If the error bubbles all the way up to the process without being handled, then the process will exit and a non-zero exit code will returned, so the end result is the same.
 
+If you are using `process.exit()` only for specifying the exit code, you can set [`process.exitCode`](https://nodejs.org/api/process.html#process_process_exitcode) instead.
+
 ## Rule Details
 
 This rule aims to prevent the use of `process.exit()` in Node.js JavaScript. As such, it warns whenever `process.exit()` is found in code.

--- a/docs/rules/no-process-exit.md
+++ b/docs/rules/no-process-exit.md
@@ -19,7 +19,7 @@ if (somethingBadHappened) {
 
 By throwing an error in this way, other parts of the application have an opportunity to handle the error rather than stopping the application altogether. If the error bubbles all the way up to the process without being handled, then the process will exit and a non-zero exit code will returned, so the end result is the same.
 
-If you are using `process.exit()` only for specifying the exit code, you can set [`process.exitCode`](https://nodejs.org/api/process.html#process_process_exitcode) instead.
+If you are using `process.exit()` only for specifying the exit code, you can set [`process.exitCode`](https://nodejs.org/api/process.html#process_process_exitcode) (introduced in Node.js 0.11.8) instead.
 
 ## Rule Details
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Added a recommendation to use `process.exitCode` instead of `process.exit()` if the goal is only to specify the exit code.
This was my main reason for using `process.exit()` for a long time. I only found out about `process.exitCode` recently.
Until then I was suppressing many `no-process-exit` warnings since I didn't know of a better alternative.

**Is there anything you'd like reviewers to focus on?**

No