### PR TITLE
Fix: Change valid-jsdoc to allow returns to be optional for async functions in the requireReturn:false case (fixes #10386)

### DIFF
--- a/lib/rules/valid-jsdoc.js
+++ b/lib/rules/valid-jsdoc.js
@@ -408,7 +408,7 @@ module.exports = {
                 if (!isOverride && !hasReturns && !hasConstructor && !isInterface &&
                     node.parent.kind !== "get" && node.parent.kind !== "constructor" &&
                     node.parent.kind !== "set" && !isTypeClass(node)) {
-                    if (requireReturn || functionData.returnPresent) {
+                    if (requireReturn || (functionData.returnPresent && !node.async)) {
                         context.report({
                             node: jsdocNode,
                             message: "Missing JSDoc @{{returns}} for function.",

--- a/tests/lib/rules/valid-jsdoc.js
+++ b/tests/lib/rules/valid-jsdoc.js
@@ -296,6 +296,17 @@ ruleTester.run("valid-jsdoc", rule, {
                 ecmaVersion: 2017
             }
         },
+        {
+            code:
+              "/**\n" +
+              " * An async function. Options do not require return.\n" +
+              " */\n" +
+              "async function a() {}",
+            options: [{ requireReturn: false }],
+            parserOptions: {
+                ecmaVersion: 2017
+            }
+        },
 
         // type validations
         {
@@ -1673,6 +1684,24 @@ ruleTester.run("valid-jsdoc", rule, {
             options: [{ requireReturn: false }],
             errors: [{
                 message: "JSDoc syntax error.",
+                type: "Block"
+            }]
+        },
+
+        // async function
+        {
+            code:
+              "/**\n" +
+              " * An async function. Options requires return.\n" +
+              " */\n" +
+              "async function a() {}",
+            output: null,
+            options: [{ requireReturn: true }],
+            parserOptions: {
+                ecmaVersion: 2017
+            },
+            errors: [{
+                message: "Missing JSDoc @returns for function.",
                 type: "Block"
             }]
         },


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
Original issue: https://github.com/eslint/eslint/issues/10386

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
For async functions with no return statements and `requireReturn:false`, allow the presence of `@returns` to be optional.

**Is there anything you'd like reviewers to focus on?**
Nothing in particular.
