### PR TITLE
Add rule padded-multilines

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+--install.no-lockfile true

--- a/conf/eslint-recommended.js
+++ b/conf/eslint-recommended.js
@@ -225,6 +225,7 @@ module.exports = {
         "operator-assignment": "off",
         "operator-linebreak": "off",
         "padded-blocks": "off",
+        "padded-multilines": "off",
         "padding-line-between-statements": "off",
         "prefer-arrow-callback": "off",
         "prefer-const": "off",

--- a/docs/rules/padded-multilines.md
+++ b/docs/rules/padded-multilines.md
@@ -1,0 +1,211 @@
+# enforce padding blank lines around blocks (padded-multilines)
+
+Some style guides require blank lines around a multilines expression,
+to improve readability by codes squeezing together. For example the blank
+lines around the while expression.
+
+```js
+function test(a) {
+    let return = [];
+
+    while ( a > 0 ) {
+        // Do something here
+        // ...
+    }
+
+    return result
+}
+```
+
+To avoid the conflict with `padded-block` rule, this rule will not enforce blank line
+when the multilines expression is preceded by a block start or followed by a block end.
+
+## Rule Details
+
+This rule enforces blank lines around multilines blocks.
+
+## Options
+
+This rule has one option, which can be an arrray of string containing `"comment"` and `"return"`
+
+Array option:
+
+* `"comment"`: When `"comment"` exists in the options, comments can exists between a blank line (or block start line) and the multilines expression
+* `"return"` : When `"return"` exists in the options, return can exists as the next line of a multilines expression
+
+
+### always
+
+Examples of **incorrect** code for this rule with the default `[]` option:
+
+```js
+/*eslint padded-multilines: ["error", []] */
+function test(a) {
+    let return = [];
+    while ( a > 0 ) {
+        // Do something here
+        // ...
+    }
+    return result
+}
+```
+
+Examples of **correct** code for this rule with the default `[]` option:
+
+```js
+function testA(a) {
+    while ( a > 0 ) {
+        // Do something here
+        // ...
+    }
+}
+
+function testB(a) {
+    let return = [];
+
+    while ( a > 0 ) {
+        // Do something here
+        // ...
+    }
+
+    return result
+}
+```
+
+### comment
+
+Examples of **incorrect** code for this rule with the `["comment"]` option:
+
+```js
+/*eslint padded-blocks: ["error", ["comment"]]*/
+function testA(a) {
+    let return = [];
+    // Line 1
+    // Line 2
+    while ( a > 0 ) {
+        // Do something here
+        // ...
+    }
+
+    return result
+}
+
+function testB(a) {
+    let return = [];
+
+    while ( a > 0 ) {
+        // Do something here
+        // ...
+    }
+    // Line 1
+    // Line 2
+    return result
+}
+```
+
+Examples of **correct** code for this rule with the `["comment"]` option:
+
+```js
+/*eslint padded-blocks: ["error", ["comment"]]*/
+function testA(a) {
+    // Line 1
+    // Line 2
+    while ( a > 0 ) {
+        // Do something here
+        // ...
+    }
+}
+
+function testB(a) {
+    let return = [];
+
+    // Line 1
+    // Line 2
+    while ( a > 0 ) {
+        // Do something here
+        // ...
+    }
+
+    return result
+}
+```
+
+### return
+
+Examples of **incorrect** code for this rule with the `["return"]` option:
+
+```js
+/*eslint padded-blocks: ["error", ["return"]]*/
+function test(a) {
+    let return = [];
+
+    while ( a > 0 ) {
+        // Do something here
+        // ...
+    }
+    // Line 1
+    // Line 2
+    return result
+}
+```
+
+```js
+/*eslint padded-blocks: ["error", ["return"]]*/
+function testA(a) {
+    while ( a > 0 ) {
+        // Do something here
+        // ...
+    }
+    return null;
+}
+
+function testB(a) {
+    let return = [];
+
+    while ( a > 0 ) {
+        // Do something here
+        // ...
+    }
+    return result
+}
+```
+
+### comment and return
+
+Examples of **correct** code for this rule with the `["comment", "return"]` option:
+
+```js
+/*eslint padded-blocks: ["error", ["comment", "return"]]*/
+function testA(a) {
+    // Line 1
+    // Line 2
+    while ( a > 0 ) {
+        // Do something here
+        // ...
+    }
+    return null;
+}
+
+function testB(a) {
+    let return = [];
+
+    // Line 1
+    // Line 2
+    while ( a > 0 ) {
+        // Do something here
+        // ...
+    }
+    return result
+}
+```
+
+## When Not To Use It
+
+You can turn this rule off if you are not concerned with the blank lines around multilines expressions.
+
+## Related Rules
+
+* [lines-between-class-members](lines-between-class-members.md)
+* [padded-blocks](padded-blocks.md)
+* [padding-line-between-statements](padding-line-between-statements.md)
+

--- a/lib/rules/padded-multilines.js
+++ b/lib/rules/padded-multilines.js
@@ -1,0 +1,228 @@
+/**
+ * @fileoverview A rule to ensure blank lines around multi-line blocks
+ * @author Jinxuan Zhu <https://github.com/zhujinxuan>
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "enforce blank lines shall around multi-line blocks",
+            category: "Stylistic Issues",
+            recommended: false,
+            url: "https://eslint.org/docs/rules/padded-multilines"
+        },
+        messages: {
+            before: "Missing blank line before a multi-lines block",
+            after: "Missing blank line after a multi-lines block"
+        },
+        fixable: "code",
+        schema: [
+            {
+                type: "string",
+                enum: ["return", "comment"]
+            },
+            {
+                type: "string",
+                enum: ["return", "comment"]
+            }
+        ]
+    },
+
+    create(context) {
+        const sourceCode = context.getSourceCode();
+        const lines = sourceCode.getLines();
+        const { options = [] } = context;
+        const hasReturn = options.includes("return");
+        const hasComment = options.includes("comment");
+
+        /**
+         * Find the previous blank line or block start
+         * @param{ASTNode} node The node to verify
+         * @returns {number} the line number of blank line or block start
+         */
+        function findBeforeBlankOrStopLineNumber(node) {
+            const { parent, loc } = node;
+            let { line } = loc.start;
+            const blockLine = parent.loc.start.line;
+
+            while (line > blockLine) {
+                const code = lines[line - 1];
+
+                if (code.trim() === "") {
+                    return line;
+                }
+                line--;
+            }
+            return blockLine;
+        }
+
+        /**
+         * Is a line filled by comment
+         * @param{number} line The line number of node
+         * @param{Array<Comment>} comments All comments before node;
+         * @returns {number|void} the line number ouside of the comment, or null if this line is not a comment
+         */
+        function isComment(line, comments) {
+            const comment = comments.find(c => {
+                const { start, end } = c.loc;
+
+                return start.line <= line && line <= end.line;
+            });
+
+            if (!comment) {
+                return null;
+            }
+
+            const { start, end } = comment.loc;
+            const code = lines[line - 1];
+
+
+            if (start.line === line) {
+                const { column } = start;
+
+                if (code.slice(0, column).trim() !== "") {
+                    return null;
+                }
+            }
+
+            if (end.line === line) {
+                const { column } = end;
+
+                if (code.slice(column).trim() !== "") {
+                    return null;
+                }
+            }
+
+            return end.line + 1;
+        }
+
+        /**
+         * Generate Report before the node
+         * @param{ASTNode} node The node to verify
+         * @returns {void}
+         */
+        function reportBefore(node) {
+            context.report({
+                node,
+                loc: node.loc.start,
+                messageId: "before",
+                fix(fixer) {
+                    return fixer.insertTextBefore(node, "\n");
+                }
+            });
+        }
+
+        /**
+         * Enforce blank like before a multi-lines block
+         * @param{ASTNode} node The node to verify
+         * @returns {void}
+         */
+        function checkBefore(node) {
+            const { loc, parent } = node;
+
+            if (parent.loc.start.line >= loc.start.line - 1) {
+                return;
+            }
+
+
+            const blankLine = findBeforeBlankOrStopLineNumber(node);
+
+            if (!hasComment) {
+                if (blankLine < loc.start.line - 1) {
+                    reportBefore(node);
+                }
+                return;
+            }
+
+            const comments = sourceCode.getCommentsBefore(node);
+
+            for (let line = blankLine + 1; line < loc.start.line;) {
+                line = isComment(line, comments);
+                if (!line) {
+                    reportBefore(node);
+                    return;
+                }
+            }
+        }
+
+        /**
+         * Generate Report after node
+         * @param{ASTNode} node The node to verify
+         * @returns {void}
+         */
+        function reportAfter(node) {
+            context.report({
+                node,
+                loc: node.loc.end,
+                messageId: "after",
+                fix(fixer) {
+                    return fixer.insertTextAfter(node, "\n");
+                }
+            });
+        }
+
+        /**
+         * Enforce blank like after a multi-lines block
+         * @param{ASTNode} node The node to verify
+         * @returns {void}
+         */
+        function checkAfter(node) {
+            const { loc, parent } = node;
+            const { line } = loc.end;
+
+            if (parent.loc.end.line <= line + 1) {
+                return;
+            }
+
+            if (lines[line - 1].trim() === "" || lines[line].trim() === "") {
+                return;
+            }
+
+            if (!hasReturn || parent.loc.end.line > line + 2) {
+                reportAfter(node);
+                return;
+            }
+
+            const token = context.getSourceCode().getTokenAfter(node);
+
+            if (token.value === "return") {
+                return;
+            }
+            reportAfter(node);
+        }
+
+        /**
+         * Enforce blank line before and after multi-line blocks
+         * @param{ASTNode} node The node to verify
+         * @returns {void}
+         */
+        function check(node) {
+            const { loc, parent } = node;
+
+            if (loc.start.line === loc.end.line) {
+                return;
+            }
+
+            if (!parent) {
+                return;
+            }
+
+            if (parent.type !== "BlockStatement") {
+                return;
+            }
+
+            checkBefore(node);
+            checkAfter(node);
+        }
+
+        return {
+            "*": check
+        };
+    }
+};

--- a/tests/lib/rules/padded-multilines.js
+++ b/tests/lib/rules/padded-multilines.js
@@ -1,0 +1,155 @@
+/**
+ * @fileoverview Tests for padded-multilines rule.
+ * @author Jinxuan Zhu <https://github.com/zhujinxuan>
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../lib/rules/padded-multilines"),
+    RuleTester = require("../../../lib/testers/rule-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const parserOptions = {
+    ecmaVersion: 2018
+};
+
+const ruleTester = new RuleTester({ parserOptions });
+
+const valid = {
+    if: "function test(a){\n let b = a\n \nif (a.find(x => {\n if (x.checked) return true;\n return x.actual === x.expected})) {\n b = []\n }\n\n return b\n}",
+    for: "function test(a){\n let b = 0;\n \nfor (;a > 0; a-- ) {\n b++\n }\n\n return b\n}",
+    while: "function test(a){\n let b = 0;\n \nwhile (a > 0) {\n b++\n }\n\n return b\n}",
+    dowhile: "function test(a){\n let b = 0;\n \ndo {\n b++\n } while (a > 0);\n \n return b\n}",
+    call: "function test(a){\n let b = a;\n \nsetTimeout(() => {\n console.log(a)}, 1000)\n\n return b\n}"
+};
+
+const invalid = {
+    if: "function test(a){\n let b = a\n if (a.find(x => {\n if (x.checked) return true;\n return x.actual === x.expected})) {\n b = []\n }\n return b\n}",
+    for: "function test(a){\n let b = 0;\n for (;a > 0; a-- ) {\n b++\n }\n return b\n}",
+    while: "function test(a){\n let b = 0;\n while (a > 0) {\n b++\n }\n return b\n}",
+    dowhile: "function test(a){\n let b = 0;\n do {\n b++\n } while (a > 0); \n return b\n}",
+    call: "function test(a){\n let b = a;\n setTimeout(() => {\n console.log(a)}, 1000)\n return b\n}"
+};
+
+const validAllowReturn = {
+    if: "function test(a){\n let b = a\n \nif (a.find(x => {\n if (x.checked) return true;\n return x.actual === x.expected})) {\n b = []\n }\n return b\n}",
+    for: "function test(a){\n let b = 0;\n \nfor (;a > 0; a-- ) {\n b++\n }\n return b\n}",
+    while: "function test(a){\n let b = 0;\n \nwhile (a > 0) {\n b++\n }\n return b\n}",
+    dowhile: "function test(a){\n let b = 0;\n \ndo {\n b++\n } while (a > 0); \n return b\n}"
+};
+
+
+ruleTester.run("padded-multilines", rule, {
+    valid: [
+        valid.if,
+        "function test(a){\n if (a ===1) {\n b =1\n } else if (a === 2) {\n b= 2\n } \n}",
+        "function test(a){\n if (\na.find(x => {\nreturn x && x.checked})\n || \n a.find(x => {\nreturn x && x.ischecked})) {\n b =1\n } else if (a === 2) {\n b= 2\n } \n}",
+        valid.for,
+        valid.while,
+        valid.dowhile,
+        valid.call,
+        { code: "function test(a){\n let b = 0;\n \n//Line 1\n//Line2\nwhile (a > 0) {\n b++\n }\n return b\n}", options: ["comment", "return"] },
+        { code: "function test(a){\n let b = 0;\n \n/* Line 1\nLine2 */\nwhile (a > 0) {\n b++\n }\n return b\n}", options: ["comment", "return"] }
+    ],
+    invalid: [
+        {
+            code: invalid.if,
+            output: valid.if,
+            errors: [{ messageId: "before", line: 3, column: 2 }, { messageId: "after", line: 7, column: 3 }]
+        },
+        {
+            code: invalid.for,
+            output: valid.for,
+            errors: [{ messageId: "before", line: 3, column: 2 }, { messageId: "after", line: 5, columb: 3 }]
+        },
+        {
+            code: invalid.while,
+            output: valid.while,
+            errors: [{ messageId: "before", line: 3, column: 2 }, { messageId: "after", line: 5, column: 3 }]
+        },
+        {
+            code: invalid.dowhile,
+            output: valid.dowhile,
+            errors: [{ messageId: "before", line: 3, column: 2 }, { messageId: "after", line: 5, column: 18 }]
+        },
+        {
+            code: invalid.call,
+            output: valid.call,
+            errors: [{ messageId: "before", line: 3, column: 2 }, { messageId: "after", line: 4, column: 24 }]
+        },
+        {
+            code: invalid.if,
+            output: valid.if,
+            options: ["comment"],
+            errors: [{ messageId: "before", line: 3, column: 2 }, { messageId: "after", line: 7, column: 3 }]
+        },
+        {
+            code: invalid.for,
+            output: valid.for,
+            options: ["comment"],
+            errors: [{ messageId: "before", line: 3, column: 2 }, { messageId: "after", line: 5, columb: 3 }]
+        },
+        {
+            code: invalid.while,
+            output: valid.while,
+            options: ["comment"],
+            errors: [{ messageId: "before", line: 3, column: 2 }, { messageId: "after", line: 5, column: 3 }]
+        },
+        {
+            code: invalid.dowhile,
+            output: valid.dowhile,
+            options: ["comment"],
+            errors: [{ messageId: "before", line: 3, column: 2 }, { messageId: "after", line: 5, column: 18 }]
+        },
+        {
+            code: invalid.call,
+            output: valid.call,
+            options: ["comment"],
+            errors: [{ messageId: "before", line: 3, column: 2 }, { messageId: "after", line: 4, column: 24 }]
+        },
+        {
+            code: invalid.if,
+            output: validAllowReturn.if,
+            options: ["return"],
+            errors: [{ messageId: "before", line: 3, column: 2 }]
+        },
+        {
+            code: invalid.for,
+            output: validAllowReturn.for,
+            options: ["return"],
+            errors: [{ messageId: "before", line: 3, column: 2 }]
+        },
+        {
+            code: invalid.while,
+            output: validAllowReturn.while,
+            options: ["return"],
+            errors: [{ messageId: "before", line: 3, column: 2 }]
+        },
+        {
+            code: invalid.dowhile,
+            output: validAllowReturn.dowhile,
+            options: ["return"],
+            errors: [{ messageId: "before", line: 3, column: 2 }]
+        },
+        {
+            code: "function test(a){\n let b = 0;\n//Line 1\n//Line2\nwhile (a > 0) {\n b++\n }\n return b\n}",
+            output: "function test(a){\n let b = 0;\n//Line 1\n//Line2\n\nwhile (a > 0) {\n b++\n }\n return b\n}",
+            options: ["comment", "return"],
+            errors: [{ messageId: "before", line: 5, column: 1 }]
+        },
+        {
+            code: "function test(a){\n let b = 0;\n/*Line 1\nLine2*/ \nwhile (a > 0) {\n b++\n }\n return b\n}",
+            output: "function test(a){\n let b = 0;\n/*Line 1\nLine2*/ \n\nwhile (a > 0) {\n b++\n }\n return b\n}",
+            options: ["comment", "return"],
+            errors: [{ messageId: "before", line: 5, column: 1 }]
+        }
+
+    ]
+});


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

- [x] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))

**Please describe what the rule should do:**
Add blank lines around multiline expressions like `if`, `while`, `setTimeout`.  It can increase readability by preventing lines of code visually squeezing together.

**What category of rule is this? (place an "X" next to just one item)**

- [x] Enforces code style
- [ ] Warns about a potential error
- [ ] Suggests an alternate way of doing something
- [ ] Other (please specify:)

**Provide 2-3 code examples that this rule will warn about:**

```js
function test(a) {
  let result = [];
  if (a) {
    // Do something here
  }
  return result
}
```

It will be fixed as 
```js
function test(a) {
  let result = [];

  if (a) {
    // Do something here
  }

  return result
}
```

**Why should this rule be included in ESLint (instead of a plugin)?**

1. similar rules, like padded blocks, padded statements are already included in this eslint.  I think improving readability by consistent padding is one focus of eslint rules.
2. current padding statement rules force to add blank lines for one-line if functions, but do not enforce blank lines for expressions like `setTimout`, `a.forEach( callback )` and other functions.  Personally, I think it is better to enforce blank lines around all complex logics, which often occurs on multi-line expression.
3. it does not conflict with other padded rules
4. It is a general rule, and does not require additional parser config.