### PR TITLE
Fix: sort-keys in an object that contains spread (fixes #10261)

### DIFF
--- a/docs/rules/sort-keys.md
+++ b/docs/rules/sort-keys.md
@@ -52,6 +52,9 @@ let obj = {a: 1, [c + d]: 3, b: 2};
 let obj = {a: 1, ["c" + "d"]: 3, b: 2};
 let obj = {a: 1, [`${c}`]: 3, b: 2};
 let obj = {a: 1, [tag`c`]: 3, b: 2};
+
+// This rule ignores objects that have a spread operator in them.
+let obj = {b: 1, ...c, a: 2};
 ```
 
 ## Options

--- a/lib/rules/sort-keys.js
+++ b/lib/rules/sort-keys.js
@@ -125,7 +125,7 @@ module.exports = {
             },
 
             Property(node) {
-                if (node.parent.type === "ObjectPattern") {
+                if (node.parent.type === "ObjectPattern" || node.parent.properties.some(n => n.type === "SpreadElement")) {
                     return;
                 }
 

--- a/tests/lib/rules/sort-keys.js
+++ b/tests/lib/rules/sort-keys.js
@@ -35,6 +35,7 @@ ruleTester.run("sort-keys", rule, {
 
         // ignore spread properties.
         { code: "var obj = {a:1, ...z, b:1}", options: [], parserOptions: { ecmaVersion: 2018 } },
+        { code: "var obj = {b:1, ...z, a:1}", options: [], parserOptions: { ecmaVersion: 2018 } },
 
         // ignore destructuring patterns.
         { code: "let {a, b} = {}", options: [], parserOptions: { ecmaVersion: 6 } },
@@ -155,17 +156,6 @@ ruleTester.run("sort-keys", rule, {
             code: "var obj = {a:1, b:3, [a]: -1, c:2}",
             parserOptions: { ecmaVersion: 6 },
             errors: ["Expected object keys to be in ascending order. 'a' should be before 'b'."]
-        },
-
-        // ignore spred properties.
-        {
-            code: "var obj = {b:1, ...z, a:1}",
-            parserOptions: {
-                ecmaVersion: 2018
-            },
-            errors: [
-                "Expected object keys to be in ascending order. 'a' should be before 'b'."
-            ]
         },
 
         // nested


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
I caused the linter to ignore any key-ordering in an object that contains a spread operator. Previously, it would verify that any keys that were not themselves spread operators were in the correct order, but this caused issues when the spread operator was between other keys as illustrated in https://eslint.org/docs/developer-guide/contributing/pull-requests

**Is there anything you'd like reviewers to focus on?**
This is my first pull request to this project, so any feedback would be welcomed. Since this does remove a test, I would also like to have a second set of eyes verify that the original test was indeed accidental and should have been reversed.