### PR TITLE
Fix a semicolon-less bug in padding-line-between-statements

### DIFF
--- a/lib/rules/padding-line-between-statements.js
+++ b/lib/rules/padding-line-between-statements.js
@@ -159,17 +159,20 @@ function isDirectivePrologue(node, sourceCode) {
  *
  * @param {SourceCode} sourceCode The source code to get tokens.
  * @param {ASTNode} node The node to get.
+ * @param {Object} configure The rule matches nodes
  * @returns {Token} The actual last token.
  * @private
  */
-function getActualLastToken(sourceCode, node) {
+function getActualLastToken(sourceCode, node, configure) {
     const semiToken = sourceCode.getLastToken(node);
     const prevToken = sourceCode.getTokenBefore(semiToken);
     const nextToken = sourceCode.getTokenAfter(semiToken);
+    const isUnmatchedEmptyStatement = (configure && configure.prev === "*" && node.type === "EmptyStatement");
+
     const isSemicolonLessStyle = Boolean(
         prevToken &&
         nextToken &&
-        prevToken.range[0] >= node.range[0] &&
+        (prevToken.range[0] >= node.range[0] || isUnmatchedEmptyStatement) &&
         astUtils.isSemicolonToken(semiToken) &&
         semiToken.loc.start.line !== prevToken.loc.end.line &&
         semiToken.loc.end.line === nextToken.loc.start.line
@@ -500,10 +503,16 @@ module.exports = {
                     match(nextNode, configure.next);
 
                 if (matched) {
-                    return PaddingTypes[configure.blankLine];
+                    return {
+                        type: PaddingTypes[configure.blankLine],
+                        configure
+                    };
                 }
             }
-            return PaddingTypes.any;
+            return {
+                type: PaddingTypes.any,
+                configure: null
+            };
         }
 
         /**
@@ -512,12 +521,13 @@ module.exports = {
          *
          * @param {ASTNode} prevNode The previous statement to count.
          * @param {ASTNode} nextNode The current statement to count.
+         * @param {Object} configure The rule matches nodes
          * @returns {Array<Token[]>} The array of token pairs.
          * @private
          */
-        function getPaddingLineSequences(prevNode, nextNode) {
+        function getPaddingLineSequences(prevNode, nextNode, configure) {
             const pairs = [];
-            let prevToken = getActualLastToken(sourceCode, prevNode);
+            let prevToken = getActualLastToken(sourceCode, prevNode, configure);
 
             if (nextNode.loc.start.line - prevToken.loc.end.line >= 2) {
                 do {
@@ -559,8 +569,8 @@ module.exports = {
 
             // Verify.
             if (prevNode) {
-                const type = getPaddingType(prevNode, node);
-                const paddingLines = getPaddingLineSequences(prevNode, node);
+                const { type, configure } = getPaddingType(prevNode, node);
+                const paddingLines = getPaddingLineSequences(prevNode, node, configure);
 
                 type.verify(context, prevNode, node, paddingLines);
             }

--- a/tests/lib/rules/padding-line-between-statements.js
+++ b/tests/lib/rules/padding-line-between-statements.js
@@ -551,6 +551,12 @@ ruleTester.run("padding-line-between-statements", rule, {
             ]
         },
         {
+            code: "if (true) {}\n\n// comment\n;[].map(x => \nx)",
+            options: [
+                { blankLine: "always", prev: "*", next: "multiline-expression" }
+            ]
+        },
+        {
             code: "() => {\n\tsomeArray.forEach(x => doSomething(x));\n\treturn theThing;\n}",
             options: [
                 { blankLine: "always", prev: "multiline-expression", next: "return" }


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

- [x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

**Tell us about your environment**

* **ESLint Version:** master branch, 5.0.0-rc.0
* **Node Version:** v10.3.0
* **yarn Version:** 1.7.0

**What parser (default, Babel-ESLint, etc.) are you using?**
default

**Please show your full configuration:**

Consider the following semicolon code: 
```
if (true) {}

;[].forEach(x =>{
 // Some code
});
```
The following configure
```
            options: [
                { blankLine: "always", prev: "*", next: "multiline-expression" }
            ]
```
will throws an error.

**What did you do? Please include the actual source code causing the issue.**

The problem is caused by this line of code in 
```
    const isSemicolonLessStyle = Boolean(
...
        prevToken.range[0] >= node.range[0] &&
...
    );
```
In the example, `;` is considered an emptyStatement, then `prevToken` as `{` is excluded.
  
However, it is a common practice of semi-colon that always add `;` before parens regardless of the previous statement, to prevent future code changes that mistakenly connect two lines. 

**What did you expect to happen?**
```
if (true) {}

;[].map(x =>
x);
```
shall be considered as a semicolon-less code.  If `prev='*'` is matched, then we shall let padding lines calculated between `}` and `;`.
