### PR TITLE
Fix: Remove autofixer for no-debugger (fixes #10242)

### DIFF
--- a/lib/rules/no-debugger.js
+++ b/lib/rules/no-debugger.js
@@ -5,8 +5,6 @@
 
 "use strict";
 
-const astUtils = require("../ast-utils");
-
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -19,7 +17,7 @@ module.exports = {
             recommended: true,
             url: "https://eslint.org/docs/rules/no-debugger"
         },
-        fixable: "code",
+        fixable: null,
         schema: [],
         messages: {
             unexpected: "Unexpected 'debugger' statement."
@@ -32,13 +30,7 @@ module.exports = {
             DebuggerStatement(node) {
                 context.report({
                     node,
-                    messageId: "unexpected",
-                    fix(fixer) {
-                        if (astUtils.STATEMENT_LIST_PARENTS.has(node.parent.type)) {
-                            return fixer.remove(node);
-                        }
-                        return null;
-                    }
+                    messageId: "unexpected"
                 });
             }
         };

--- a/tests/lib/rules/no-debugger.js
+++ b/tests/lib/rules/no-debugger.js
@@ -24,11 +24,6 @@ ruleTester.run("no-debugger", rule, {
     ],
     invalid: [
         {
-            code: "debugger",
-            output: "",
-            errors: [{ messageId: "unexpected", type: "DebuggerStatement" }]
-        },
-        {
             code: "if (foo) debugger",
             output: null,
             errors: [{ messageId: "unexpected", type: "DebuggerStatement" }]


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (see https://github.com/eslint/eslint/issues/10242)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This removes the autofixer for `no-debugger`, as discussed in https://github.com/eslint/eslint/issues/10242.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
