### PR TITLE
Fix: prefer-object-spread duplicated comma (fixes #10512, fixes #10532)

### DIFF
--- a/lib/rules/prefer-object-spread.js
+++ b/lib/rules/prefer-object-spread.js
@@ -38,14 +38,11 @@ function isModified(variable) {
  * Helper that checks if the node needs parentheses to be valid JS.
  * The default is to wrap the node in parentheses to avoid parsing errors.
  * @param {ASTNode} node - The node that the rule warns on
+ * @param {Object} sourceCode - in context sourcecode object
  * @returns {boolean} - Returns true if the node needs parentheses
  */
-function needsParens(node) {
+function needsParens(node, sourceCode) {
     const parent = node.parent;
-
-    if (!parent || !node.type) {
-        return true;
-    }
 
     switch (parent.type) {
         case "VariableDeclarator":
@@ -54,8 +51,10 @@ function needsParens(node) {
         case "CallExpression":
         case "Property":
             return false;
+        case "AssignmentExpression":
+            return parent.left === node && !isParenthesised(sourceCode, node);
         default:
-            return true;
+            return !isParenthesised(sourceCode, node);
     }
 }
 
@@ -165,7 +164,7 @@ function defineFixer(node, sourceCode) {
         yield fixer.remove(node.callee);
 
         // Replace the parens of argument list to braces.
-        if (needsParens(node)) {
+        if (needsParens(node, sourceCode)) {
             yield fixer.replaceText(leftParen, "({");
             yield fixer.replaceText(rightParen, "})");
         } else {

--- a/lib/rules/prefer-object-spread.js
+++ b/lib/rules/prefer-object-spread.js
@@ -6,21 +6,15 @@
 
 "use strict";
 
-const matchAll = require("string.prototype.matchall");
+const { CALL, ReferenceTracker, findVariable } = require("eslint-utils");
+const {
+    isCommaToken,
+    isOpeningParenToken,
+    isClosingParenToken,
+    isParenthesised
+} = require("../ast-utils");
 
-/**
- * Helper that checks if the node is an Object.assign call
- * @param {ASTNode} node - The node that the rule warns on
- * @returns {boolean} - Returns true if the node is an Object.assign call
- */
-function isObjectAssign(node) {
-    return (
-        node.callee &&
-        node.callee.type === "MemberExpression" &&
-        node.callee.object.name === "Object" &&
-        node.callee.property.name === "assign"
-    );
-}
+const ANY_SPACE = /\s/;
 
 /**
  * Helper that checks if the Object.assign call has array spread
@@ -29,6 +23,15 @@ function isObjectAssign(node) {
  */
 function hasArraySpread(node) {
     return node.arguments.some(arg => arg.type === "SpreadElement");
+}
+
+/**
+ * Check whether a given variable is modified or not.
+ * @param {eslint-scope.Variable} variable The variable object to check.
+ * @returns {boolean} `true` if the variable is modified.
+ */
+function isModified(variable) {
+    return variable && variable.references.some(ref => ref.isWrite());
 }
 
 /**
@@ -59,93 +62,92 @@ function needsParens(node) {
 /**
  * Determines if an argument needs parentheses. The default is to not add parens.
  * @param {ASTNode} node - The node to be checked.
+ * @param {Object} sourceCode - in context sourcecode object
  * @returns {boolean} True if the node needs parentheses
  */
-function argNeedsParens(node) {
-    if (!node.type) {
-        return false;
-    }
-
+function argNeedsParens(node, sourceCode) {
     switch (node.type) {
         case "AssignmentExpression":
         case "ArrowFunctionExpression":
         case "ConditionalExpression":
-            return true;
+            return !isParenthesised(sourceCode, node);
         default:
             return false;
     }
 }
 
 /**
- * Helper that adds a comma after the last non-whitespace character that is not a part of a comment.
- * @param {string} formattedArg - String of argument text
- * @param {array} comments - comments inside the argument
- * @returns {string} - argument with comma at the end of it
+ * Get the parenthesis tokens of a given ObjectExpression node.
+ * This incldues the braces of the object literal and enclosing parentheses.
+ * @param {ASTNode} node The node to get.
+ * @param {Token} leftArgumentListParen The opening paren token of the argument list.
+ * @param {SourceCode} sourceCode The source code object to get tokens.
+ * @returns {Token[]} The parenthesis tokens of the node. This is sorted by the location.
  */
-function addComma(formattedArg, comments) {
-    const nonWhitespaceCharacterRegex = /[^\s\\]/g;
-    const nonWhitespaceCharacters = Array.from(matchAll(formattedArg, nonWhitespaceCharacterRegex));
-    const commentRanges = comments.map(comment => comment.range);
-    const validWhitespaceMatches = [];
+function getParenTokens(node, leftArgumentListParen, sourceCode) {
+    const parens = [sourceCode.getFirstToken(node), sourceCode.getLastToken(node)];
+    let leftNext = sourceCode.getTokenBefore(node);
+    let rightNext = sourceCode.getTokenAfter(node);
 
-    // Create a list of indexes where non-whitespace characters exist.
-    nonWhitespaceCharacters.forEach(match => {
-        const insertIndex = match.index + match[0].length;
+    // Note: don't include the parens of the argument list.
+    while (
+        leftNext &&
+        rightNext &&
+        leftNext.range[0] > leftArgumentListParen.range[0] &&
+        isOpeningParenToken(leftNext) &&
+        isClosingParenToken(rightNext)
+    ) {
+        parens.push(leftNext, rightNext);
+        leftNext = sourceCode.getTokenBefore(leftNext);
+        rightNext = sourceCode.getTokenAfter(rightNext);
+    }
 
-        if (!commentRanges.length) {
-            validWhitespaceMatches.push(insertIndex);
-        }
-
-        // If comment ranges are found make sure that the non whitespace characters are not part of the comment.
-        commentRanges.forEach(arr => {
-            const commentStart = arr[0];
-            const commentEnd = arr[1];
-
-            if (insertIndex < commentStart || insertIndex > commentEnd) {
-                validWhitespaceMatches.push(insertIndex);
-            }
-        });
-    });
-    const insertPos = Math.max(...validWhitespaceMatches);
-    const regex = new RegExp(`^((?:.|[^/s/S]){${insertPos}}) *`);
-
-    return formattedArg.replace(regex, "$1, ");
+    return parens.sort((a, b) => a.range[0] - b.range[0]);
 }
 
 /**
- * Helper formats an argument by either removing curlies or adding a spread operator
- * @param {ASTNode|null} arg - ast node representing argument to format
- * @param {boolean} isLast - true if on the last element of the array
- * @param {Object} sourceCode - in context sourcecode object
- * @param {array} comments - comments inside checked node
- * @returns {string} - formatted argument
+ * Get the range of a given token and around whitespaces.
+ * @param {Token} token The token to get range.
+ * @param {SourceCode} sourceCode The source code object to get tokens.
+ * @returns {number} The end of the range of the token and around whitespaces.
  */
-function formatArg(arg, isLast, sourceCode, comments) {
-    const text = sourceCode.getText(arg);
-    const parens = argNeedsParens(arg);
-    const spread = arg.type === "SpreadElement" ? "" : "...";
+function getStartWithSpaces(token, sourceCode) {
+    const text = sourceCode.text;
+    let start = token.range[0];
 
-    if (arg.type === "ObjectExpression" && arg.properties.length === 0) {
-        return "";
+    // If the previous token is a line comment then skip this step to avoid commenting this token out.
+    {
+        const prevToken = sourceCode.getTokenBefore(token, { includeComments: true });
+
+        if (prevToken && prevToken.type === "Line") {
+            return start;
+        }
     }
 
-    if (arg.type === "ObjectExpression") {
-
-        /**
-         * This regex finds the opening curly brace and any following spaces and replaces it with whatever
-         * exists before the curly brace. It also does the same for the closing curly brace. This is to avoid
-         * having multiple spaces around the object expression depending on how the object properties are spaced.
-         */
-        const formattedObjectLiteral = text.replace(/^(.*){ */, "$1").replace(/ *}([^}]*)$/, "$1");
-
-        return isLast ? formattedObjectLiteral : addComma(formattedObjectLiteral, comments);
+    // Detect spaces before the token.
+    while (ANY_SPACE.test(text[start - 1] || "")) {
+        start -= 1;
     }
 
-    if (isLast) {
-        return parens ? `${spread}(${text})` : `${spread}${text}`;
+    return start;
+}
+
+/**
+ * Get the range of a given token and around whitespaces.
+ * @param {Token} token The token to get range.
+ * @param {SourceCode} sourceCode The source code object to get tokens.
+ * @returns {number} The start of the range of the token and around whitespaces.
+ */
+function getEndWithSpaces(token, sourceCode) {
+    const text = sourceCode.text;
+    let end = token.range[1];
+
+    // Detect spaces after the token.
+    while (ANY_SPACE.test(text[end] || "")) {
+        end += 1;
     }
 
-    return parens ? addComma(`${spread}(${text})`, comments) : `${spread}${addComma(text, comments)}`;
+    return end;
 }
 
 /**
@@ -154,76 +156,63 @@ function formatArg(arg, isLast, sourceCode, comments) {
  * @param {string} sourceCode - sourceCode of the Object.assign call
  * @returns {Function} autofixer - replaces the Object.assign with a spread object.
  */
-function autofixSpread(node, sourceCode) {
-    return fixer => {
-        const args = node.arguments;
-        const firstArg = args[0];
-        const lastArg = args[args.length - 1];
-        const parens = needsParens(node);
-        const comments = sourceCode.getCommentsInside(node);
-        const replaceObjectAssignStart = fixer.replaceTextRange(
-            [node.range[0], firstArg.range[0]],
-            `${parens ? "({" : "{"}`
-        );
+function defineFixer(node, sourceCode) {
+    return function *(fixer) {
+        const leftParen = sourceCode.getTokenAfter(node.callee, isOpeningParenToken);
+        const rightParen = sourceCode.getLastToken(node);
 
-        const handleArgs = args
-            .map((arg, i, arr) => formatArg(arg, i + 1 >= arr.length, sourceCode, comments))
-            .filter(arg => arg !== "," && arg !== "");
+        // Remove the callee `Object.assign`
+        yield fixer.remove(node.callee);
 
-        const insertBody = fixer.replaceTextRange([firstArg.range[0], lastArg.range[1]], handleArgs.join(""));
-        const replaceObjectAssignEnd = fixer.replaceTextRange([lastArg.range[1], node.range[1]], `${parens ? "})" : "}"}`);
+        // Replace the parens of argument list to braces.
+        if (needsParens(node)) {
+            yield fixer.replaceText(leftParen, "({");
+            yield fixer.replaceText(rightParen, "})");
+        } else {
+            yield fixer.replaceText(leftParen, "{");
+            yield fixer.replaceText(rightParen, "}");
+        }
 
-        return [
-            replaceObjectAssignStart,
-            insertBody,
-            replaceObjectAssignEnd
-        ];
+        // Process arguments.
+        for (const argNode of node.arguments) {
+            const innerParens = getParenTokens(argNode, leftParen, sourceCode);
+            const left = innerParens.shift();
+            const right = innerParens.pop();
+
+            if (argNode.type === "ObjectExpression") {
+                const maybeTrailingComma = sourceCode.getLastToken(argNode, 1);
+                const maybeArgumentComma = sourceCode.getTokenAfter(right);
+
+                /*
+                 * Make bare this object literal.
+                 * And remove spaces inside of the braces for better formatting.
+                 */
+                for (const innerParen of innerParens) {
+                    yield fixer.remove(innerParen);
+                }
+                yield fixer.removeRange([left.range[0], getEndWithSpaces(left, sourceCode)]);
+                yield fixer.removeRange([getStartWithSpaces(right, sourceCode), right.range[1]]);
+
+                // Remove the comma of this argument if it's duplication.
+                if (
+                    (argNode.properties.length === 0 || isCommaToken(maybeTrailingComma)) &&
+                    isCommaToken(maybeArgumentComma)
+                ) {
+                    yield fixer.remove(maybeArgumentComma);
+                }
+            } else {
+
+                // Make spread.
+                if (argNeedsParens(argNode, sourceCode)) {
+                    yield fixer.insertTextBefore(left, "...(");
+                    yield fixer.insertTextAfter(right, ")");
+                } else {
+                    yield fixer.insertTextBefore(left, "...");
+                }
+            }
+        }
     };
 }
-
-/**
- * Autofixes the Object.assign call with a single object literal as an argument
- * @param {ASTNode|null} node - The node that the rule warns on, i.e. the Object.assign call
- * @param {string} sourceCode - sourceCode of the Object.assign call
- * @returns {Function} autofixer - replaces the Object.assign with a object literal.
- */
-function autofixObjectLiteral(node, sourceCode) {
-    return fixer => {
-        const argument = node.arguments[0];
-        const parens = needsParens(node);
-
-        return fixer.replaceText(node, `${parens ? "(" : ""}${sourceCode.text.slice(argument.range[0], argument.range[1])}${parens ? ")" : ""}`);
-    };
-}
-
-/**
- * Check if the node has modified a given variable
- * @param {ASTNode|null} node - The node that the rule warns on, i.e. the Object.assign call
- * @returns {boolean} - true if node is an assignment, variable declaration, or import statement
- */
-function isModifier(node) {
-    if (!node.type) {
-        return false;
-    }
-
-    return node.type === "AssignmentExpression" ||
-        node.type === "VariableDeclarator" ||
-        node.type === "ImportDeclaration";
-}
-
-/**
- * Check if the node has modified a given variable
- * @param {array} references - list of reference nodes
- * @returns {boolean} - true if node is has been overwritten by an assignment or import
- */
-function modifyingObjectReference(references) {
-    return references.some(ref => (
-        ref.identifier &&
-        ref.identifier.parent &&
-        isModifier(ref.identifier.parent)
-    ));
-}
-
 
 module.exports = {
     meta: {
@@ -242,61 +231,34 @@ module.exports = {
         }
     },
 
-    create: function rule(context) {
+    create(context) {
         const sourceCode = context.getSourceCode();
-        const scope = context.getScope();
-        const objectVariable = scope.variables.filter(variable => variable.name === "Object");
-        const moduleReferences = scope.childScopes.filter(childScope => {
-            const varNamedObject = childScope.variables.filter(variable => variable.name === "Object");
-
-            return childScope.type === "module" && varNamedObject.length;
-        });
-        const references = [].concat(...objectVariable.map(variable => variable.references || []));
 
         return {
-            CallExpression(node) {
+            Program() {
+                const scope = context.getScope();
+                const tracker = new ReferenceTracker(scope);
+                const trackMap = {
+                    Object: {
+                        assign: { [CALL]: true }
+                    }
+                };
 
-                /*
-                 * If current file is either importing Object or redefining it,
-                 * we skip warning on this rule.
-                 */
-                if (moduleReferences.length || (references.length && modifyingObjectReference(references))) {
-                    return;
-                }
+                // Iterate all calls of `Object.assign` (only of the global variable `Object`).
+                for (const { node } of tracker.iterateGlobalReferences(trackMap)) {
+                    if (
+                        node.arguments.length >= 1 &&
+                        node.arguments[0].type === "ObjectExpression" &&
+                        !hasArraySpread(node) &&
+                        !isModified(findVariable(scope, "Object"))
+                    ) {
+                        const messageId = node.arguments.length === 1
+                            ? "useLiteralMessage"
+                            : "useSpreadMessage";
+                        const fix = defineFixer(node, sourceCode);
 
-                /*
-                 * The condition below is cases where Object.assign has a single argument and
-                 * that argument is an object literal. e.g. `Object.assign({ foo: bar })`.
-                 * For now, we will warn on this case and autofix it.
-                 */
-                if (
-                    node.arguments.length === 1 &&
-                    node.arguments[0].type === "ObjectExpression" &&
-                    isObjectAssign(node)
-                ) {
-                    context.report({
-                        node,
-                        messageId: "useLiteralMessage",
-                        fix: autofixObjectLiteral(node, sourceCode)
-                    });
-                }
-
-                /*
-                 * The condition below warns on `Object.assign` calls that that have
-                 * an object literal as the first argument and have a second argument
-                 * that can be spread. e.g `Object.assign({ foo: bar }, baz)`
-                 */
-                if (
-                    node.arguments.length > 1 &&
-                    node.arguments[0].type === "ObjectExpression" &&
-                    isObjectAssign(node) &&
-                    !hasArraySpread(node)
-                ) {
-                    context.report({
-                        node,
-                        messageId: "useSpreadMessage",
-                        fix: autofixSpread(node, sourceCode)
-                    });
+                        context.report({ node, messageId, fix });
+                    }
                 }
             }
         };

--- a/lib/rules/prefer-object-spread.js
+++ b/lib/rules/prefer-object-spread.js
@@ -6,7 +6,7 @@
 
 "use strict";
 
-const { CALL, ReferenceTracker, findVariable } = require("eslint-utils");
+const { CALL, ReferenceTracker } = require("eslint-utils");
 const {
     isCommaToken,
     isOpeningParenToken,
@@ -23,15 +23,6 @@ const ANY_SPACE = /\s/;
  */
 function hasArraySpread(node) {
     return node.arguments.some(arg => arg.type === "SpreadElement");
-}
-
-/**
- * Check whether a given variable is modified or not.
- * @param {eslint-scope.Variable} variable The variable object to check.
- * @returns {boolean} `true` if the variable is modified.
- */
-function isModified(variable) {
-    return variable && variable.references.some(ref => ref.isWrite());
 }
 
 /**
@@ -248,8 +239,7 @@ module.exports = {
                     if (
                         node.arguments.length >= 1 &&
                         node.arguments[0].type === "ObjectExpression" &&
-                        !hasArraySpread(node) &&
-                        !isModified(findVariable(scope, "Object"))
+                        !hasArraySpread(node)
                     ) {
                         const messageId = node.arguments.length === 1
                             ? "useLiteralMessage"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "debug": "^3.1.0",
     "doctrine": "^2.1.0",
     "eslint-scope": "^4.0.0",
-    "eslint-utils": "^1.3.0",
+    "eslint-utils": "^1.3.1",
     "eslint-visitor-keys": "^1.0.0",
     "espree": "^4.0.0",
     "esquery": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "debug": "^3.1.0",
     "doctrine": "^2.1.0",
     "eslint-scope": "^4.0.0",
+    "eslint-utils": "^1.3.0",
     "eslint-visitor-keys": "^1.0.0",
     "espree": "^4.0.0",
     "esquery": "^1.0.1",

--- a/tests/lib/rules/prefer-object-spread.js
+++ b/tests/lib/rules/prefer-object-spread.js
@@ -68,7 +68,7 @@ ruleTester.run("prefer-object-spread", rule, {
     invalid: [
         {
             code: "Object.assign({}, foo)",
-            output: "({...foo})",
+            output: "({ ...foo})",
             errors: [
                 {
                     messageId: "useSpreadMessage",
@@ -81,7 +81,7 @@ ruleTester.run("prefer-object-spread", rule, {
 
         {
             code: "Object.assign({}, { foo: 'bar' })",
-            output: "({foo: 'bar'})",
+            output: "({ foo: 'bar'})",
             errors: [
                 {
                     messageId: "useSpreadMessage",
@@ -93,7 +93,7 @@ ruleTester.run("prefer-object-spread", rule, {
         },
         {
             code: "Object.assign({}, baz, { foo: 'bar' })",
-            output: "({...baz, foo: 'bar'})",
+            output: "({ ...baz, foo: 'bar'})",
             errors: [
                 {
                     messageId: "useSpreadMessage",
@@ -105,7 +105,7 @@ ruleTester.run("prefer-object-spread", rule, {
         },
         {
             code: "Object.assign({}, { foo: 'bar', baz: 'foo' })",
-            output: "({foo: 'bar', baz: 'foo'})",
+            output: "({ foo: 'bar', baz: 'foo'})",
             errors: [
                 {
                     messageId: "useSpreadMessage",
@@ -204,7 +204,7 @@ ruleTester.run("prefer-object-spread", rule, {
         // Object shorthand
         {
             code: "Object.assign({}, { foo, bar, baz })",
-            output: "({foo, bar, baz})",
+            output: "({ foo, bar, baz})",
             errors: [
                 {
                     messageId: "useSpreadMessage",
@@ -218,7 +218,7 @@ ruleTester.run("prefer-object-spread", rule, {
         // Objects with computed properties
         {
             code: "Object.assign({}, { [bar]: 'foo' })",
-            output: "({[bar]: 'foo'})",
+            output: "({ [bar]: 'foo'})",
             errors: [
                 {
                     messageId: "useSpreadMessage",
@@ -250,11 +250,9 @@ ruleTester.run("prefer-object-spread", rule, {
                 foo: 'bar',
                 baz: "cats"
             })`,
-            output: `({...bar, 
-                // this is a bar
+            output: `({...bar, // this is a bar
                 foo: 'bar',
-                baz: "cats"
-})`,
+                baz: "cats"})`,
             errors: [
                 {
                     messageId: "useSpreadMessage",
@@ -275,15 +273,11 @@ ruleTester.run("prefer-object-spread", rule, {
                 foo: 'bar',
                 baz: "cats"
             })`,
-            output: `({
-                boo: "lol",
+            output: `({boo: "lol",
                 // I'm a comment
-                dog: "cat", 
-
-                // this is a bar
+                dog: "cat", // this is a bar
                 foo: 'bar',
-                baz: "cats"
-})`,
+                baz: "cats"})`,
             errors: [
                 {
                     messageId: "useSpreadMessage",
@@ -302,12 +296,11 @@ ruleTester.run("prefer-object-spread", rule, {
                 baz: "cats"
                 --> weird
             })`,
-            output: `const test = {...bar, 
-                <!-- html comment
+            output: `const test = {...bar, <!-- html comment
                 foo: 'bar',
                 baz: "cats"
                 --> weird
-}`,
+            }`,
             parserOptions: {
                 sourceType: "script"
             },
@@ -326,10 +319,8 @@ ruleTester.run("prefer-object-spread", rule, {
                 foo: 'bar', // inline comment
                 baz: "cats"
             })`,
-            output: `const test = {...bar, 
-                foo: 'bar', // inline comment
-                baz: "cats"
-}`,
+            output: `const test = {...bar, foo: 'bar', // inline comment
+                baz: "cats"}`,
             errors: [
                 {
                     messageId: "useSpreadMessage",
@@ -349,13 +340,11 @@ ruleTester.run("prefer-object-spread", rule, {
                 foo: 'bar',
                 baz: "cats"
             })`,
-            output: `const test = {...bar, 
-                /**
+            output: `const test = {...bar, /**
                  * foo
                  */
                 foo: 'bar',
-                baz: "cats"
-}`,
+                baz: "cats"}`,
             errors: [
                 {
                     messageId: "useSpreadMessage",
@@ -386,7 +375,7 @@ ruleTester.run("prefer-object-spread", rule, {
         },
         {
             code: "Object.assign({ foo: bar })",
-            output: "({ foo: bar })",
+            output: "({foo: bar})",
             errors: [
                 {
                     messageId: "useLiteralMessage",
@@ -404,7 +393,7 @@ ruleTester.run("prefer-object-spread", rule, {
             `,
             output: `
                 const foo = 'bar';
-                ({ foo: bar })
+                ({foo: bar})
             `,
             errors: [
                 {
@@ -423,7 +412,7 @@ ruleTester.run("prefer-object-spread", rule, {
             `,
             output: `
                 foo = 'bar';
-                ({ foo: bar })
+                ({foo: bar})
             `,
             errors: [
                 {
@@ -449,7 +438,7 @@ ruleTester.run("prefer-object-spread", rule, {
         },
         {
             code: "let a = Object.assign({}, a)",
-            output: "let a = {...a}",
+            output: "let a = { ...a}",
             errors: [
                 {
                     messageId: "useSpreadMessage",
@@ -473,7 +462,7 @@ ruleTester.run("prefer-object-spread", rule, {
         },
         {
             code: "Object.assign(  {},  a,      b,   )",
-            output: "({...a, ...b})",
+            output: "({    ...a,      ...b,   })",
             errors: [
                 {
                     messageId: "useSpreadMessage",
@@ -485,7 +474,7 @@ ruleTester.run("prefer-object-spread", rule, {
         },
         {
             code: "Object.assign({}, a ? b : {}, b => c, a = 2)",
-            output: "({...(a ? b : {}), ...(b => c), ...(a = 2)})",
+            output: "({ ...(a ? b : {}), ...(b => c), ...(a = 2)})",
             errors: [
                 {
                     messageId: "useSpreadMessage",
@@ -502,7 +491,7 @@ ruleTester.run("prefer-object-spread", rule, {
             `,
             output: `
                 const someVar = 'foo';
-                ({...(a ? b : {}), ...(b => c), ...(a = 2)})
+                ({ ...(a ? b : {}), ...(b => c), ...(a = 2)})
             `,
             errors: [
                 {
@@ -520,7 +509,7 @@ ruleTester.run("prefer-object-spread", rule, {
             `,
             output: `
                 someVar = 'foo';
-                ({...(a ? b : {}), ...(b => c), ...(a = 2)})
+                ({ ...(a ? b : {}), ...(b => c), ...(a = 2)})
             `,
             errors: [
                 {
@@ -535,7 +524,7 @@ ruleTester.run("prefer-object-spread", rule, {
         // Cases where you don't need parens around an object literal
         {
             code: "[1, 2, Object.assign({}, a)]",
-            output: "[1, 2, {...a}]",
+            output: "[1, 2, { ...a}]",
             errors: [
                 {
                     messageId: "useSpreadMessage",
@@ -547,7 +536,7 @@ ruleTester.run("prefer-object-spread", rule, {
         },
         {
             code: "const foo = Object.assign({}, a)",
-            output: "const foo = {...a}",
+            output: "const foo = { ...a}",
             errors: [
                 {
                     messageId: "useSpreadMessage",
@@ -559,7 +548,7 @@ ruleTester.run("prefer-object-spread", rule, {
         },
         {
             code: "function foo() { return Object.assign({}, a) }",
-            output: "function foo() { return {...a} }",
+            output: "function foo() { return { ...a} }",
             errors: [
                 {
                     messageId: "useSpreadMessage",
@@ -571,7 +560,7 @@ ruleTester.run("prefer-object-spread", rule, {
         },
         {
             code: "foo(Object.assign({}, a));",
-            output: "foo({...a});",
+            output: "foo({ ...a});",
             errors: [
                 {
                     messageId: "useSpreadMessage",
@@ -583,7 +572,7 @@ ruleTester.run("prefer-object-spread", rule, {
         },
         {
             code: "const x = { foo: 'bar', baz: Object.assign({}, a) }",
-            output: "const x = { foo: 'bar', baz: {...a} }",
+            output: "const x = { foo: 'bar', baz: { ...a} }",
             errors: [
                 {
                     messageId: "useSpreadMessage",
@@ -600,7 +589,7 @@ ruleTester.run("prefer-object-spread", rule, {
             `,
             output: `
                 import Foo from 'foo';
-                ({ foo: Foo });
+                ({foo: Foo});
             `,
             errors: [
                 {
@@ -618,7 +607,7 @@ ruleTester.run("prefer-object-spread", rule, {
             `,
             output: `
                 import Foo from 'foo';
-                ({...Foo});
+                ({ ...Foo});
             `,
             errors: [
                 {
@@ -636,7 +625,7 @@ ruleTester.run("prefer-object-spread", rule, {
             `,
             output: `
                 const Foo = require('foo');
-                ({ foo: Foo });
+                ({foo: Foo});
             `,
             errors: [
                 {
@@ -654,7 +643,7 @@ ruleTester.run("prefer-object-spread", rule, {
             `,
             output: `
                 import { Something as somethingelse } from 'foo';
-                ({...somethingelse});
+                ({ ...somethingelse});
             `,
             errors: [
                 {
@@ -672,7 +661,7 @@ ruleTester.run("prefer-object-spread", rule, {
             `,
             output: `
                 import { foo } from 'foo';
-                ({ foo: Foo });
+                ({foo: Foo});
             `,
             errors: [
                 {
@@ -690,7 +679,7 @@ ruleTester.run("prefer-object-spread", rule, {
             `,
             output: `
                 const Foo = require('foo');
-                ({...Foo});
+                ({ ...Foo});
             `,
             errors: [
                 {
@@ -698,6 +687,112 @@ ruleTester.run("prefer-object-spread", rule, {
                     type: "CallExpression",
                     line: 3,
                     column: 17
+                }
+            ]
+        },
+        {
+            code: `
+                const actions = Object.assign(
+                    {
+                        onChangeInput: this.handleChangeInput,
+                    },
+                    this.props.actions
+                );
+            `,
+            output: `
+                const actions = {
+                    onChangeInput: this.handleChangeInput,
+                    ...this.props.actions
+                };
+            `,
+            errors: [
+                {
+                    messageId: "useSpreadMessage",
+                    type: "CallExpression",
+                    line: 2,
+                    column: 33
+                }
+            ]
+        },
+        {
+            code: `
+                const actions = Object.assign(
+                    {
+                        onChangeInput: this.handleChangeInput, //
+                    },
+                    this.props.actions
+                );
+            `,
+            output: `
+                const actions = {
+                    onChangeInput: this.handleChangeInput, //
+                    
+                    ...this.props.actions
+                };
+            `,
+            errors: [
+                {
+                    messageId: "useSpreadMessage",
+                    type: "CallExpression",
+                    line: 2,
+                    column: 33
+                }
+            ]
+        },
+        {
+            code: `
+                const actions = Object.assign(
+                    {
+                        onChangeInput: this.handleChangeInput //
+                    },
+                    this.props.actions
+                );
+            `,
+            output: `
+                const actions = {
+                    onChangeInput: this.handleChangeInput //
+                    ,
+                    ...this.props.actions
+                };
+            `,
+            errors: [
+                {
+                    messageId: "useSpreadMessage",
+                    type: "CallExpression",
+                    line: 2,
+                    column: 33
+                }
+            ]
+        },
+        {
+            code: `
+                const actions = Object.assign(
+                    (
+                        {
+                            onChangeInput: this.handleChangeInput
+                        }
+                    ),
+                    (
+                        this.props.actions
+                    )
+                );
+            `,
+            output: `
+                const actions = {
+                    
+                            onChangeInput: this.handleChangeInput
+                        ,
+                    ...(
+                        this.props.actions
+                    )
+                };
+            `,
+            errors: [
+                {
+                    messageId: "useSpreadMessage",
+                    type: "CallExpression",
+                    line: 2,
+                    column: 33
                 }
             ]
         }

--- a/tests/lib/rules/prefer-object-spread.js
+++ b/tests/lib/rules/prefer-object-spread.js
@@ -795,6 +795,22 @@ ruleTester.run("prefer-object-spread", rule, {
                     column: 33
                 }
             ]
+        },
+        {
+            code: `
+                eventData = Object.assign({}, eventData, { outsideLocality: \`\${originLocality} - \${destinationLocality}\` })
+            `,
+            output: `
+                eventData = ({ ...eventData, outsideLocality: \`\${originLocality} - \${destinationLocality}\`})
+            `,
+            errors: [
+                {
+                    messageId: "useSpreadMessage",
+                    type: "CallExpression",
+                    line: 2,
+                    column: 29
+                }
+            ]
         }
     ]
 });

--- a/tests/lib/rules/prefer-object-spread.js
+++ b/tests/lib/rules/prefer-object-spread.js
@@ -801,7 +801,7 @@ ruleTester.run("prefer-object-spread", rule, {
                 eventData = Object.assign({}, eventData, { outsideLocality: \`\${originLocality} - \${destinationLocality}\` })
             `,
             output: `
-                eventData = ({ ...eventData, outsideLocality: \`\${originLocality} - \${destinationLocality}\`})
+                eventData = { ...eventData, outsideLocality: \`\${originLocality} - \${destinationLocality}\`}
             `,
             errors: [
                 {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix: fixes #10512, fixes #10532

**What changes did you make? (Give an overview)**

This PR fixes `prefer-object-spread` rule to generate valid code in autofix.

This PR is massive because it's hard to handle code correctly in text-based way.
The new way is token-based. Basically, it finds unnecessary tokens and removes those.

1. remove the callee (`Object.assign`).
2. replace the parentheses of the argument list to braces (`(` → `{`, `)` → `}`).
3. process arguments:
    - if it's an `ObjectExpression` node, remove braces (and enclosing parentheses), and remove trailing comma if exists.
    - otherwise, insert `...` before the argument.

I tried to make close formatting to the original, but there are some difference in spacing.

**Is there anything you'd like reviewers to focus on?**

It passes existing test cases, but tell me if you want to see other cases.
