### PR TITLE
Adjust grammar of error/warnings fixable

### DIFF
--- a/lib/formatters/stylish.js
+++ b/lib/formatters/stylish.js
@@ -89,7 +89,7 @@ module.exports = function(results) {
 
         if (fixableErrorCount > 0 || fixableWarningCount > 0) {
             output += chalk[summaryColor].bold([
-                "  ", fixableErrorCount, pluralize(" error", fixableErrorCount), ", ",
+                "  ", fixableErrorCount, pluralize(" error", fixableErrorCount), " and ",
                 fixableWarningCount, pluralize(" warning", fixableWarningCount),
                 " potentially fixable with the `--fix` option.\n"
             ].join(""));

--- a/tests/lib/formatters/stylish.js
+++ b/tests/lib/formatters/stylish.js
@@ -107,7 +107,7 @@ describe("formatter:stylish", () => {
             it("should return a string in the correct format", () => {
                 const result = formatter(code);
 
-                assert.strictEqual(result, "\nfoo.js\n  5:10  error  Unexpected foo  foo\n\n\u2716 1 problem (1 error, 0 warnings)\n  1 error, 0 warnings potentially fixable with the `--fix` option.\n");
+                assert.strictEqual(result, "\nfoo.js\n  5:10  error  Unexpected foo  foo\n\n\u2716 1 problem (1 error, 0 warnings)\n  1 error and 0 warnings potentially fixable with the `--fix` option.\n");
                 assert.strictEqual(chalkStub.yellow.bold.callCount, 0);
                 assert.strictEqual(chalkStub.red.bold.callCount, 2);
             });
@@ -146,7 +146,7 @@ describe("formatter:stylish", () => {
             it("should return a string in the correct format", () => {
                 const result = formatter(code);
 
-                assert.strictEqual(result, "\nfoo.js\n  5:10  warning  Unexpected foo  foo\n\n\u2716 1 problem (0 errors, 1 warning)\n  0 errors, 1 warning potentially fixable with the `--fix` option.\n");
+                assert.strictEqual(result, "\nfoo.js\n  5:10  warning  Unexpected foo  foo\n\n\u2716 1 problem (0 errors, 1 warning)\n  0 errors and 1 warning potentially fixable with the `--fix` option.\n");
                 assert.strictEqual(chalkStub.yellow.bold.callCount, 2);
                 assert.strictEqual(chalkStub.red.bold.callCount, 0);
             });
@@ -351,7 +351,7 @@ describe("formatter:stylish", () => {
 
             const result = formatter(code);
 
-            assert.include(result, "  1 error, 0 warnings potentially fixable with the `--fix` option.\n");
+            assert.include(result, "  1 error and 0 warnings potentially fixable with the `--fix` option.\n");
         });
 
         it("should output fixable problems message when warnings are fixable", () => {
@@ -368,7 +368,7 @@ describe("formatter:stylish", () => {
 
             const result = formatter(code);
 
-            assert.include(result, "  0 errors, 2 warnings potentially fixable with the `--fix` option.\n");
+            assert.include(result, "  0 errors and 2 warnings potentially fixable with the `--fix` option.\n");
         });
 
         it("should output the total number of fixable errors and warnings", () => {
@@ -394,7 +394,7 @@ describe("formatter:stylish", () => {
 
             const result = formatter(code);
 
-            assert.include(result, "  9 errors, 3 warnings potentially fixable with the `--fix` option.\n");
+            assert.include(result, "  9 errors and 3 warnings potentially fixable with the `--fix` option.\n");
         });
     });
 });


### PR DESCRIPTION
Changes grammar of stylish to read more intuitively.

<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Adjusting a potentially confusing CLI message. Where (when reading quickly) a user may be confused about how many errors/warnings are potentially fixable with the `--fix` option. A comma may imply a new statement whereas and continues the existing one. See below it’s not immediately clear if there are three errors or six warnings or nine.

```bash
3 errors, 6 warnings potentially fixable with the `--fix` option.
```

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Changed CLI output and to remove the comma in favour of an `and`.

**Is there anything you'd like reviewers to focus on?**
Nope.
