### PR TITLE
Docs: Clarifies option defaults in max-lines-per-function docs

### DIFF
--- a/docs/rules/max-lines-per-function.md
+++ b/docs/rules/max-lines-per-function.md
@@ -40,11 +40,11 @@ This rule has the following options that can be specified using an object:
 
 * `"max"` (default `50`) enforces a maximum number of lines in a function.
 
-* `"skipBlankLines": true` ignore lines made up purely of whitespace.
+* `"skipBlankLines"` (default `false`) ignore lines made up purely of whitespace.
 
-* `"skipComments": true` ignore lines containing just comments.
+* `"skipComments"` (default `false`) ignore lines containing just comments.
 
-* `"IIFEs": true` include any code included in IIFEs.
+* `"IIFEs"` (default `false`) include any code included in IIFEs.
 
 Alternatively, you may specify a single integer for the `max` option:
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

I made a change to the documentation for the `max-lines-per-function` rule to clarify the default values for the `skipComments`, `skipBlankLines` and `IIFEs` options. We originally read the `true` as a default.

I confirmed that the defaults for the three Boolean options are `false` from:

**[/lib/rules/max-lines-per-function.js:90](https://github.com/eslint/eslint/blob/0feedfdb267e110775f0a50dd5bc801c77260ae5/lib/rules/max-lines-per-function.js#L90)**
```js
let skipComments = false;
let skipBlankLines = false;
let IIFEs = false;
```
I did take a look at the documentation for about 5 other rules to see if there seemed to be a pattern for indicating defaults, but there was not a lot of consistency, so I just followed the style already established in this rule's documentation.

**Is there anything you'd like reviewers to focus on?**

If there's a desired composition pattern for this, please let me know! Thanks.
