### PR TITLE
Fix: SourceCodeFixer apply sequential ranges (fixes #10601)

### DIFF
--- a/lib/util/source-code-fixer.js
+++ b/lib/util/source-code-fixer.js
@@ -89,7 +89,7 @@ SourceCodeFixer.applyFixes = function(sourceText, messages, shouldFix) {
         const end = fix.range[1];
 
         // Remain it as a problem if it's overlapped or it's a negative range
-        if (lastPos >= start || start > end) {
+        if (lastPos > start || start > end) {
             remainingMessages.push(problem);
             return false;
         }

--- a/tests/lib/util/source-code-fixer.js
+++ b/tests/lib/util/source-code-fixer.js
@@ -335,12 +335,11 @@ describe("SourceCodeFixer", () => {
                 assert.isTrue(result.fixed);
             });
 
-            it("should apply one fix when the end of one range is the same as the start of a previous range overlap", () => {
+            it("should apply both fixes when the end of one range is the same as the start of a next range", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE, [REMOVE_START, REPLACE_ID]);
 
-                assert.strictEqual(result.output, TEST_CODE.replace("var ", ""));
-                assert.strictEqual(result.messages.length, 1);
-                assert.strictEqual(result.messages[0].message, "foo");
+                assert.strictEqual(result.output, TEST_CODE.replace("var ", "").replace("answer", "foo"));
+                assert.strictEqual(result.messages.length, 0);
                 assert.isTrue(result.fixed);
             });
 
@@ -560,12 +559,11 @@ describe("SourceCodeFixer", () => {
                 assert.isTrue(result.fixed);
             });
 
-            it("should apply one fix when the end of one range is the same as the start of a previous range overlap", () => {
+            it("should apply both fixes when the end of one range is the same as the start of a next range", () => {
                 const result = SourceCodeFixer.applyFixes(TEST_CODE_WITH_BOM, [REMOVE_START, REPLACE_ID]);
 
-                assert.strictEqual(result.output, `\uFEFF${TEST_CODE.replace("var ", "")}`);
-                assert.strictEqual(result.messages.length, 1);
-                assert.strictEqual(result.messages[0].message, "foo");
+                assert.strictEqual(result.output, `\uFEFF${TEST_CODE.replace("var ", "").replace("answer", "foo")}`);
+                assert.strictEqual(result.messages.length, 0);
                 assert.isTrue(result.fixed);
             });
 


### PR DESCRIPTION
An end of range is not included in operations (i.e. `slice`) so it can
be equal to start of a next range.

<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Extend `SourceCodeFixer` to handle sequential ranges.

**Is there anything you'd like reviewers to focus on?**


