### PR TITLE
Upgrade: eslint-plugin-node to 7.0.1

### DIFF
--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -398,6 +398,7 @@ class RuleTester {
         function assertASTDidntChange(beforeAST, afterAST) {
 
             // Feature detect the Node.js implementation and use that if available.
+            // eslint-disable-next-line node/no-unsupported-features/node-builtins
             if ((util.isDeepStrictEqual && !util.isDeepStrictEqual(beforeAST, afterAST)) || !lodash.isEqual(beforeAST, afterAST)) {
                 assert.fail(null, null, "Rule should not modify AST.");
             }

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "dateformat": "^3.0.3",
     "ejs": "^2.6.1",
     "eslint-plugin-eslint-plugin": "^1.2.0",
-    "eslint-plugin-node": "^6.0.1",
+    "eslint-plugin-node": "^7.0.1",
     "eslint-plugin-rulesdir": "^0.1.0",
     "eslint-release": "^0.11.1",
     "eslint-rule-composer": "^0.3.0",

--- a/packages/eslint-config-eslint/package.json
+++ b/packages/eslint-config-eslint/package.json
@@ -23,7 +23,7 @@
     "js-yaml": "^3.5.1"
   },
   "peerDependencies": {
-    "eslint-plugin-node": "^6.0.1"
+    "eslint-plugin-node": "^6.0.1 || ^7.0.1"
   },
   "keywords": [
     "eslintconfig",


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Other, please explain: upgrade `eslint-plugin-node` to `7.0.1` for linting our codebase.

**What changes did you make? (Give an overview)**

It has new features:

- It reports the APIs of Node.js built-in modules and globals if those are not supported on the configured Node.js versions (`^6.14.0 || ^8.10.0 || >=9.10.0`).
- It reports newly deprecated APIs.

**Is there anything you'd like reviewers to focus on?**

I'm not sure if this `util.isDeepStrictEqual()` part is needed.
That looks to do double checking for the AST if `util.isDeepStrictEqual` exists. But why?

```js
// Feature detect the Node.js implementation and use that if available.
if ((util.isDeepStrictEqual && !util.isDeepStrictEqual(beforeAST, afterAST)) || !lodash.isEqual(beforeAST, afterAST)) {
```
