### PR TITLE
Chore: fix redundant equality check

### DIFF
--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -396,9 +396,7 @@ class RuleTester {
          * @private
          */
         function assertASTDidntChange(beforeAST, afterAST) {
-
-            // Feature detect the Node.js implementation and use that if available.
-            if ((util.isDeepStrictEqual && !util.isDeepStrictEqual(beforeAST, afterAST)) || !lodash.isEqual(beforeAST, afterAST)) {
+            if (!lodash.isEqual(beforeAST, afterAST)) {
                 assert.fail(null, null, "Rule should not modify AST.");
             }
         }


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Other, please explain: improve performance.

**What changes did you make? (Give an overview)**

This PR removes a redundant equality check which was found in #10612.

```js
!util.isDeepStrictEqual(beforeAST, afterAST) || !lodash.isEqual(beforeAST, afterAST)
```

fixed to:

```js
!lodash.isEqual(beforeAST, afterAST)
```

As the result, `mocha --reporter progress tests/lib/rules/*.js` in our codebase gets 15% faster.
`lodash.isEqual` looks faster than `util.isDeepStrictEqual`.
See details: https://gist.github.com/mysticatea/1045687663c17f2a9f1488e92d9b3038

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.

