### PR TITLE
Changes rationale for Object.assign

### DIFF
--- a/docs/rules/prefer-object-spread.md
+++ b/docs/rules/prefer-object-spread.md
@@ -2,6 +2,8 @@
 
 When Object.assign is called using an object literal as the first argument, this rule requires using the object spread syntax instead. This rule also warns on cases where an `Object.assign` call is made using a single argument that is an object literal, in this case, the `Object.assign` call is not needed.
 
+Object spread is a declarative alternative which may perform better than the more dynamic, imperative `Object.assign`.
+
 ## Rule Details
 
 Examples of **incorrect** code for this rule:
@@ -44,4 +46,4 @@ Object.assign(foo, { ...baz });
 
 ## When Not To Use It
 
-When you don't care about syntactic sugar added by the object spread property.
+When object spread is not available in your codebase.


### PR DESCRIPTION
object spread is not just syntax sugar but actually performs better in browsers. The "When Not To Use It" section should therefore give a more nuanced opinion on when Object.assign is desireable.

<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Changed the "When Not To Use It" section of the `prefer-object-spread` docs.

**Is there anything you'd like reviewers to focus on?**
More concrete ideas for positive uses for `Object.assign`

