### PR TITLE
Chore: quote enable avoidEscape option in eslint-config-eslint

### DIFF
--- a/packages/eslint-config-eslint/default.yml
+++ b/packages/eslint-config-eslint/default.yml
@@ -157,7 +157,7 @@ rules:
     prefer-rest-params: "error"
     prefer-spread: "error"
     prefer-template: "error"
-    quotes: ["error", "double"]
+    quotes: ["error", "double", {avoidEscape: true}]
     quote-props: ["error", "as-needed"]
     radix: "error"
     require-jsdoc: "error"


### PR DESCRIPTION
it can be more readable to use:
```js
var s = `"hello world!"`;
```
than
```js
var s = "\"hello world!\""
```

hopefully, the option can be enabled by default?