### PR TITLE
Chore: Fixing a call to Object.assign.apply in Linter

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -465,11 +465,10 @@ function resolveParserOptions(parserName, providedOptions, enabledEnvironments) 
  * @returns {Object} The resolved globals object
  */
 function resolveGlobals(providedGlobals, enabledEnvironments) {
-    return Object.assign.apply(
-        null,
-        [{}]
-            .concat(enabledEnvironments.filter(env => env.globals).map(env => env.globals))
-            .concat(providedGlobals)
+    return Object.assign(
+        {},
+        ...enabledEnvironments.filter(env => env.globals).map(env => env.globals),
+        providedGlobals
     );
 }
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain: Change an `Object.assign.apply` call to use array spread instead.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Changed an `Object.assign.apply` call in Linter to use array spread instead.

**Is there anything you'd like reviewers to focus on?**

Not really. (I did it correctly, I hope?)