### PR TITLE
Chore: Replace some function application with spread operators

### DIFF
--- a/lib/rules/key-spacing.js
+++ b/lib/rules/key-spacing.js
@@ -540,7 +540,7 @@ module.exports = {
             const length = properties.length,
                 widths = properties.map(getKeyWidth), // Width of keys, including quotes
                 align = alignmentOptions.on; // "value" or "colon"
-            let targetWidth = Math.max.apply(null, widths),
+            let targetWidth = Math.max(...widths),
                 beforeColon, afterColon, mode;
 
             if (alignmentOptions && length > 1) { // When aligning values within a group, use the alignment configuration.

--- a/lib/rules/no-unmodified-loop-condition.js
+++ b/lib/rules/no-unmodified-loop-condition.js
@@ -16,7 +16,6 @@ const Traverser = require("../util/traverser"),
 // Helpers
 //------------------------------------------------------------------------------
 
-const pushAll = Function.apply.bind(Array.prototype.push);
 const SENTINEL_PATTERN = /(?:(?:Call|Class|Function|Member|New|Yield)Expression|Statement|Declaration)$/;
 const LOOP_PATTERN = /^(?:DoWhile|For|While)Statement$/; // for-in/of statements don't have `test` property.
 const GROUP_PATTERN = /^(?:BinaryExpression|ConditionalExpression)$/;
@@ -356,7 +355,7 @@ module.exports = {
                 let scope;
 
                 while ((scope = queue.pop())) {
-                    pushAll(queue, scope.childScopes);
+                    queue.push(...scope.childScopes);
                     scope.variables.forEach(checkReferences);
                 }
 

--- a/lib/rules/no-useless-return.js
+++ b/lib/rules/no-useless-return.js
@@ -16,15 +16,6 @@ const astUtils = require("../ast-utils"),
 //------------------------------------------------------------------------------
 
 /**
- * Adds all elements of 2nd argument into 1st argument.
- *
- * @param {Array} array - The destination array to add.
- * @param {Array} elements - The source array to add.
- * @returns {void}
- */
-const pushAll = Function.apply.bind(Array.prototype.push);
-
-/**
  * Removes the given element from the array.
  *
  * @param {Array} array - The source array to remove.
@@ -137,7 +128,7 @@ module.exports = {
                     continue;
                 }
 
-                pushAll(uselessReturns, segmentInfoMap.get(segment).uselessReturns);
+                uselessReturns.push(...segmentInfoMap.get(segment).uselessReturns);
             }
 
             return uselessReturns;

--- a/lib/rules/prefer-const.js
+++ b/lib/rules/prefer-const.js
@@ -16,15 +16,6 @@ const DECLARATION_HOST_TYPE = /^(?:Program|BlockStatement|SwitchCase)$/;
 const DESTRUCTURING_HOST_TYPE = /^(?:VariableDeclarator|AssignmentExpression)$/;
 
 /**
- * Adds multiple items to the tail of an array.
- *
- * @param {any[]} array - A destination to add.
- * @param {any[]} values - Items to be added.
- * @returns {void}
- */
-const pushAll = Function.apply.bind(Array.prototype.push);
-
-/**
  * Checks whether a given node is located at `ForStatement.init` or not.
  *
  * @param {ASTNode} node - A node to check.
@@ -364,7 +355,7 @@ module.exports = {
 
             VariableDeclaration(node) {
                 if (node.kind === "let" && !isInitOfForStatement(node)) {
-                    pushAll(variables, context.getDeclaredVariables(node));
+                    variables.push(...context.getDeclaredVariables(node));
                 }
             }
         };

--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -140,7 +140,7 @@ const IT = Symbol("it");
  */
 function itDefaultHandler(text, method) {
     try {
-        return method.apply(this);
+        return method.call(this);
     } catch (err) {
         if (err instanceof assert.AssertionError) {
             err.message += ` (${util.inspect(err.actual)} ${err.operator} ${util.inspect(err.expected)})`;
@@ -157,7 +157,7 @@ function itDefaultHandler(text, method) {
  * @returns {any} Returned value of `method`.
  */
 function describeDefaultHandler(text, method) {
-    return method.apply(this);
+    return method.call(this);
 }
 
 class RuleTester {

--- a/lib/util/node-event-generator.js
+++ b/lib/util/node-event-generator.js
@@ -45,8 +45,8 @@ function getPossibleTypes(parsedSelector) {
         case "matches": {
             const typesForComponents = parsedSelector.selectors.map(getPossibleTypes);
 
-            if (typesForComponents.every(typesForComponent => typesForComponent)) {
-                return lodash.union.apply(null, typesForComponents);
+            if (typesForComponents.every(Boolean)) {
+                return lodash.union(...typesForComponents);
             }
             return null;
         }
@@ -63,7 +63,7 @@ function getPossibleTypes(parsedSelector) {
              * If at least one of the components could only match a particular type, the compound could only match
              * the intersection of those types.
              */
-            return lodash.intersection.apply(null, typesForComponents);
+            return lodash.intersection(...typesForComponents);
         }
 
         case "child":

--- a/tests/lib/rules/no-invalid-this.js
+++ b/tests/lib/rules/no-invalid-this.js
@@ -83,7 +83,7 @@ function extractPatterns(patterns, type) {
     }));
 
     // Flatten.
-    return Array.prototype.concat.apply([], patternsList);
+    return [].concat(...patternsList);
 }
 
 

--- a/tests/lib/testers/rule-tester.js
+++ b/tests/lib/testers/rule-tester.js
@@ -44,12 +44,12 @@ const ruleTesterTestEmitter = new EventEmitter();
 
 RuleTester.describe = function(text, method) {
     ruleTesterTestEmitter.emit("describe", text, method);
-    return method.apply(this);
+    return method.call(this);
 };
 
 RuleTester.it = function(text, method) {
     ruleTesterTestEmitter.emit("it", text, method);
-    return method.apply(this);
+    return method.call(this);
 };
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain: Just replacing some calls to `Function.prototype.apply` by using spread operators (or, in a few cases, `Function.prototype.call`.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Replaced some function application with spread operators.

**Is there anything you'd like reviewers to focus on?**

Not really.