### PR TITLE
Update: addresses #9947

### DIFF
--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -18,7 +18,8 @@ const fs = require("fs"),
     pathIsInside = require("path-is-inside"),
     stripComments = require("strip-json-comments"),
     stringify = require("json-stable-stringify-without-jsonify"),
-    requireUncached = require("require-uncached");
+    requireUncached = require("require-uncached"),
+    Linter = require("../linter.js");
 
 const debug = require("debug")("eslint:config-file");
 
@@ -288,7 +289,10 @@ function writeJSConfigFile(config, filePath) {
 
     const content = `module.exports = ${stringify(config, { cmp: sortByKey, space: 4 })};`;
 
-    fs.writeFileSync(filePath, content, "utf8");
+    const linter = new Linter();
+    const lintedContent = linter.verifyAndFix(content, config).output;
+
+    fs.writeFileSync(filePath, lintedContent, "utf8");
 }
 
 /**

--- a/tests/lib/config/config-file.js
+++ b/tests/lib/config/config-file.js
@@ -1267,6 +1267,29 @@ describe("ConfigFile", () => {
                 ConfigFile.write({}, getFixturePath("yaml/.eslintrc.class"));
             }, /write to unknown file type/);
         });
+
+        it("should format file consistent with config if format is .js", () => {
+            const fakeFS = leche.fake(fs);
+
+            const singleQuoteNoSemiConfig = {
+                rules: {
+                    quotes: [2, "single"],
+                    semi: [2, "never"]
+                }
+            };
+
+            sandbox.mock(fakeFS).expects("writeFileSync").withExactArgs(
+                "dummyfile.js",
+                sinon.match(value => !(value.includes("\"") || value.includes(";"))),
+                "utf8"
+            );
+
+            const StubbedConfigFile = proxyquire("../../../lib/config/config-file", {
+                fs: fakeFS
+            });
+
+            StubbedConfigFile.write(singleQuoteNoSemiConfig, "dummyfile.js");
+        });
     });
 
 });


### PR DESCRIPTION
Format newly generated .eslintrc.js file before it is saved.

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

Slight improvement in the cli by addressing https://github.com/eslint/eslint/issues/9947

**What changes did you make? (Give an overview)**

When a user creates a new `.eslintrc.js` file via `eslint --init`, the resulting file conforms to the rules generated by the cli.

**Is there anything you'd like reviewers to focus on?**

I could not figure out how to feature test this.

It is tested by implication: a unit test confirms that when a config file is written, if that file is a `.js` config file, and rules exist in the config that is being saved, then those rules are obeyed in the resulting file.

Also note: this change uses the `Linter` class under the hood instead of the `CLIEngine`. The latter cannot be imported by the `ConfigFile` class. I tried a little and decided it made more sense to reach straight to the `Linter` instead.

