### PR TITLE
Update: Allow the noun version of fall through too

### DIFF
--- a/lib/rules/no-fallthrough.js
+++ b/lib/rules/no-fallthrough.js
@@ -14,7 +14,7 @@ const lodash = require("lodash");
 // Helpers
 //------------------------------------------------------------------------------
 
-const DEFAULT_FALLTHROUGH_COMMENT = /falls?\s?through/i;
+const DEFAULT_FALLTHROUGH_COMMENT = /fall(?:s?\s?|-)through/i;
 
 /**
  * Checks whether or not a given node has a fallthrough comment.


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**What rule do you want to change?**

`no-fallthrough`

**Does this change cause the rule to produce more or fewer warnings?**

Fewer for default options.

**How will the change be implemented? (New option, new default behavior, etc.)?**

Updating a default regex.

**Please provide some example code that this change will affect:**

```js
switch (someVariable) {
    case someValue:
        // fall-through
    case otherValue:
        break;
}
```

[Demo](https://eslint.org/demo/#eyJ0ZXh0Ijoic3dpdGNoIChzb21lVmFyaWFibGUpIHtcbiAgY2FzZSBzb21lVmFsdWU6XG4gICAgLy8gZmFsbC10aHJvdWdoXG4gIGNhc2Ugb3RoZXJWYWx1ZTpcbiAgICBicmVhaztcbn1cbiIsIm9wdGlvbnMiOnsicGFyc2VyT3B0aW9ucyI6eyJlY21hVmVyc2lvbiI6NSwic291cmNlVHlwZSI6InNjcmlwdCIsImVjbWFGZWF0dXJlcyI6e319LCJydWxlcyI6eyJuby1mYWxsdGhyb3VnaCI6Mn0sImVudiI6e319fQ==)

**What does the rule currently do for this code?**

Fails with `4:3 - Expected a 'break' statement before 'case'. (no-fallthrough)`.

**What will the rule do after it's changed?**

Pass.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

It was currently only accepting the [verb](https://en.wiktionary.org/wiki/fall_through) (https://regex101.com/r/odtJoM/1/), and it now accepts the [noun](https://en.wiktionary.org/wiki/fall-through) too (https://regex101.com/r/EqRFZ7/1/).

**Is there anything you'd like reviewers to focus on?**


