### PR TITLE
Update: Fix incorrect default value for position

### DIFF
--- a/lib/rules/line-comment-position.js
+++ b/lib/rules/line-comment-position.js
@@ -59,7 +59,7 @@ module.exports = {
             above = !options || options === "above";
 
         } else {
-            above = options.position === "above";
+            above = !options.position || options.position === "above";
             ignorePattern = options.ignorePattern;
 
             if (options.hasOwnProperty("applyDefaultIgnorePatterns")) {

--- a/tests/lib/rules/line-comment-position.js
+++ b/tests/lib/rules/line-comment-position.js
@@ -76,6 +76,10 @@ ruleTester.run("line-comment-position", rule, {
         {
             code: "// pragma valid comment\n1 + 1;",
             options: [{ position: "beside", ignorePattern: "pragma|linter" }]
+        },
+        {
+            code: "// above\n1 + 1; // ignored",
+            options: [{ ignorePattern: "ignored" }]
         }
     ],
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment**

* **ESLint Version:** 5.2.0
* **Node Version:** v8.9.4
* **npm Version:** 5.6.0

**What parser (default, Babel-ESLint, etc.) are you using?** default

**Please show your full configuration:**

```js
{
    "env": {
        "browser": true,
        "es6": true,
        "greasemonkey": true
    },
    "extends": "eslint:recommended",
    "globals": {
        "player": false,
        "PLAYER_STATE": false
    },
    "rules": {
        "line-comment-position": [
            "error", {
                "ignorePattern": "fall\\-through"
            }
        ]
    }
}
```

**What did you do? Please include the actual source code causing the issue.**

```js
var playerState = player.getPlayerState();

// This should not trigger an error
switch (playerState) {
    case PLAYER_STATE.Unstarted: // fall-through
    case PLAYER_STATE.Ended: // fall-through
    case PLAYER_STATE.Paused: // fall-through
    case PLAYER_STATE.Buffering: // fall-through
    case PLAYER_STATE.VideoCued: {
        player.playVideo();

        break;
    }
}
```

**What did you expect to happen?**

Not throw an error.

**What actually happened? Please include the actual, raw output from ESLint.**

```
.../scripts/Main/main.js
  3:1  error  Expected comment to be beside code  line-comment-position

✖ 1 problem (1 error, 0 warnings)
```

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

I ensured that the current documentation is correct regarding the `line-comment-position` rule. It states that the `above` `position` is the default value, but specifying the `ignorePattern` (or `applyDefaultIgnorePatterns` for that matter) caused the `position` to default to `beside` instead. The change is merely copied and adapted from 3 lines above it.

**Is there anything you'd like reviewers to focus on?**


