### PR TITLE
Update: Fix 'function' in padding-line-between-statements (fixes #10487)

### DIFF
--- a/lib/rules/padding-line-between-statements.js
+++ b/lib/rules/padding-line-between-statements.js
@@ -367,6 +367,7 @@ const StatementTypes = {
 
     block: newNodeTypeTester("BlockStatement"),
     empty: newNodeTypeTester("EmptyStatement"),
+    function: newNodeTypeTester("FunctionDeclaration"),
 
     break: newKeywordTester("break"),
     case: newKeywordTester("case"),
@@ -378,7 +379,6 @@ const StatementTypes = {
     do: newKeywordTester("do"),
     export: newKeywordTester("export"),
     for: newKeywordTester("for"),
-    function: newKeywordTester("function"),
     if: newKeywordTester("if"),
     import: newKeywordTester("import"),
     let: newKeywordTester("let"),

--- a/tests/lib/rules/padding-line-between-statements.js
+++ b/tests/lib/rules/padding-line-between-statements.js
@@ -19,7 +19,7 @@ const RuleTester = require("../../../lib/testers/rule-tester");
 const MESSAGE_NEVER = "Unexpected blank line before this statement.";
 const MESSAGE_ALWAYS = "Expected blank line before this statement.";
 
-const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2015 } });
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2017 } });
 
 ruleTester.run("padding-line-between-statements", rule, {
     valid: [
@@ -806,6 +806,13 @@ ruleTester.run("padding-line-between-statements", rule, {
         },
         {
             code: "var foo=function(){}\nfoo()",
+            options: [
+                { blankLine: "never", prev: "*", next: "*" },
+                { blankLine: "always", prev: "function", next: "*" }
+            ]
+        },
+        {
+            code: "async function foo(){}\n\nfoo()",
             options: [
                 { blankLine: "never", prev: "*", next: "*" },
                 { blankLine: "always", prev: "function", next: "*" }
@@ -3313,6 +3320,15 @@ ruleTester.run("padding-line-between-statements", rule, {
             code: "function foo(){}\nfoo()",
             output: "function foo(){}\n\nfoo()",
             options: [
+                { blankLine: "always", prev: "function", next: "*" }
+            ],
+            errors: [MESSAGE_ALWAYS]
+        },
+        {
+            code: "async function foo(){}\nfoo()",
+            output: "async function foo(){}\n\nfoo()",
+            options: [
+                { blankLine: "never", prev: "*", next: "*" },
                 { blankLine: "always", prev: "function", next: "*" }
             ],
             errors: [MESSAGE_ALWAYS]


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

See issue #10487.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

For the "function" statement type in padding-line-between-statements: Instead of relying on the `function` keyword token, just check to see if the node in question is a FunctionDeclaration. (This matches the documentation, which specifies that this statement type applies to function declarations.)

**Is there anything you'd like reviewers to focus on?**

Not really.