### PR TITLE
Fix: The "../.." folder is always ignored (fixes #10675)

### DIFF
--- a/lib/ignored-paths.js
+++ b/lib/ignored-paths.js
@@ -309,7 +309,7 @@ class IgnoredPaths {
         if (this.options.dotfiles !== true) {
 
             // Ignore hidden folders.  (This cannot be ".*", or else it's not possible to unignore hidden files)
-            ig.add([".*/*", "!../"]);
+            ig.add([".*/*", "!../*"]);
         }
 
         if (this.options.ignore) {

--- a/tests/lib/ignored-paths.js
+++ b/tests/lib/ignored-paths.js
@@ -268,7 +268,7 @@ describe("IgnoredPaths", () => {
 
         it("should work when cwd is a subdirectory", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: true, ignorePath: ignoreFilePath, cwd: getFixturePath("custom-name", "subdirectory") });
-
+            
             assert.notStrictEqual(getIgnoreRules(ignoredPaths).length, countDefaultPatterns(ignoredPaths));
         });
 
@@ -644,6 +644,9 @@ describe("IgnoredPaths", () => {
             assert.isTrue(shouldIgnore(resolve("bower_components/a/b")));
             assert.isFalse(shouldIgnore(resolve(".hidden")));
             assert.isTrue(shouldIgnore(resolve(".hidden/a")));
+
+            assert.isFalse(shouldIgnore(resolve("..")));
+            assert.isFalse(shouldIgnore(resolve("../..")));
         });
 
         it("should ignore default folders when there is an ignore file without unignored defaults", () => {

--- a/tests/lib/ignored-paths.js
+++ b/tests/lib/ignored-paths.js
@@ -647,6 +647,9 @@ describe("IgnoredPaths", () => {
 
             assert.isFalse(shouldIgnore(resolve("..")));
             assert.isFalse(shouldIgnore(resolve("../..")));
+            assert.isFalse(shouldIgnore(resolve("../foo")));
+            assert.isFalse(shouldIgnore(resolve("../../..")));
+            assert.isFalse(shouldIgnore(resolve("../../foo")));
         });
 
         it("should ignore default folders when there is an ignore file without unignored defaults", () => {

--- a/tests/lib/ignored-paths.js
+++ b/tests/lib/ignored-paths.js
@@ -268,7 +268,7 @@ describe("IgnoredPaths", () => {
 
         it("should work when cwd is a subdirectory", () => {
             const ignoredPaths = new IgnoredPaths({ ignore: true, ignorePath: ignoreFilePath, cwd: getFixturePath("custom-name", "subdirectory") });
-            
+
             assert.notStrictEqual(getIgnoreRules(ignoredPaths).length, countDefaultPatterns(ignoredPaths));
         });
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ x ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

https://github.com/eslint/eslint/issues/10675

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Only the parent folder was excluded. Added '*' at end to exclude parent of parent directory.

**Is there anything you'd like reviewers to focus on?**


