### PR TITLE
Chore: rm unnecessary plugin in eslint-config-eslint

### DIFF
--- a/packages/eslint-config-eslint/default.yml
+++ b/packages/eslint-config-eslint/default.yml
@@ -1,10 +1,6 @@
 extends:
     - "eslint:recommended"
     - "plugin:node/recommended"
-
-plugins:
-    - "node"
-
 rules:
     array-bracket-spacing: "error"
     array-callback-return: "error"


### PR DESCRIPTION
it has been added in `node/recommended`(previous included just since it has not been released):
https://github.com/mysticatea/eslint-plugin-node/blob/master/lib/configs/recommended.json#L13

