### PR TITLE
Add ability to console out a specified format while saving to a file

### DIFF
--- a/docs/user-guide/command-line-interface.md
+++ b/docs/user-guide/command-line-interface.md
@@ -64,6 +64,7 @@ Output:
   -o, --output-file path::String  Specify file to write report to
   -f, --format String            Use a specific output format - default: stylish
   --color, --no-color            Force enabling/disabling of color
+  --console-format               When outputing to a file, you can choose a format that will output to the terminal
 
 Inline configuration comments:
   --no-inline-config             Prevent comments from changing config or rules

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -75,20 +75,25 @@ function translateOptions(cliOptions) {
  * @param {LintResult[]} results The results to print.
  * @param {string} format The name of the formatter to use or the path to the formatter.
  * @param {string} outputFile The path for the output file.
+ * @param {strint} consoleFormat The format the output file should be output
  * @returns {boolean} True if the printing succeeds, false if not.
  * @private
  */
-function printResults(engine, results, format, outputFile) {
+function printResults(engine, results, format, outputFile, consoleFormat) {
     let formatter;
+    let consoleFormatter;
 
     try {
         formatter = engine.getFormatter(format);
+        if (consoleFormat) {
+            consoleFormatter = engine.getFormatter(consoleFormat);
+        }
     } catch (e) {
         log.error(e.message);
         return false;
     }
 
-    const output = formatter(results);
+    let output = formatter(results);
 
     if (output) {
         if (outputFile) {
@@ -98,7 +103,6 @@ function printResults(engine, results, format, outputFile) {
                 log.error("Cannot write to output file path, it is a directory: %s", outputFile);
                 return false;
             }
-
             try {
                 mkdirp.sync(path.dirname(filePath));
                 fs.writeFileSync(filePath, output);
@@ -106,9 +110,15 @@ function printResults(engine, results, format, outputFile) {
                 log.error("There was a problem writing the output file:\n%s", ex);
                 return false;
             }
-        } else {
-            log.info(output);
         }
+
+    }
+    if (consoleFormat) {
+        output = format === consoleFormat ? output : consoleFormatter(results);
+    }
+
+    if (!outputFile || consoleFormat) {
+        log.info(output);
     }
 
     return true;
@@ -201,7 +211,7 @@ const cli = {
                 report.results = CLIEngine.getErrorResults(report.results);
             }
 
-            if (printResults(engine, report.results, currentOptions.format, currentOptions.outputFile)) {
+            if (printResults(engine, report.results, currentOptions.format, currentOptions.outputFile, currentOptions.consoleFormat)) {
                 const tooManyWarnings = currentOptions.maxWarnings >= 0 && report.warningCount > currentOptions.maxWarnings;
 
                 if (!report.errorCount && tooManyWarnings) {

--- a/lib/options.js
+++ b/lib/options.js
@@ -158,6 +158,11 @@ module.exports = optionator({
             description: "Specify file to write report to"
         },
         {
+            option: "console-format",
+            type: "path::String",
+            description: "Format to write to console, if a file output is specified"
+        },
+        {
             option: "format",
             alias: "f",
             type: "String",

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -538,6 +538,16 @@ describe("cli", () => {
             assert.isTrue(log.info.notCalled);
         });
 
+        it("should do a thing save the file in the format specified by the --output-format flag", () => {
+            const filePath = getFixturePath("single-quoted.js");
+            const code = `--no-ignore --rule 'quotes: [1, double]' --o tests/output/eslint-output.txt ${filePath} --output-format junit`;
+
+            cli.execute(code);
+
+            assert.include(fs.readFileSync("tests/output/eslint-output.txt", "utf8"), "<failure message=\"Strings must use doublequote.\">");
+            assert.isTrue(log.info.notCalled);
+        });
+
         it("should return an error if the path is a directory", () => {
             const filePath = getFixturePath("single-quoted.js");
             const code = `--no-ignore --rule 'quotes: [1, double]' --o tests/output ${filePath}`;


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[X] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Added the `--console-format` option to the cli. It is specifically for when you want to save in one format but maintain human readable logs in another.

Biggest case for use would be in a ci environment like jenkins. It's worthwhile to save a file in junit that jenkins can consume but preferable to output logs in stylish.



