### PR TITLE
Fix: ESLint cache no longer stops autofix (fixes #10679)

### DIFF
--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -518,18 +518,18 @@ class CLIEngine {
             }
 
             if (options.cache) {
-
-                /*
-                 * get the descriptor for this file
-                 * with the metadata and the flag that determines if
-                 * the file has changed
-                 */
                 const cachedLintResults = lintResultCache.getCachedLintResults(fileInfo.filename);
 
                 if (cachedLintResults) {
-                    debug(`Skipping file since it hasn't changed: ${fileInfo.filename}`);
+                    const resultHadMessages = cachedLintResults.messages && cachedLintResults.messages.length;
 
-                    return cachedLintResults;
+                    if (resultHadMessages && options.fix) {
+                        debug(`Reprocessing cached file to allow autofix: ${fileInfo.filename}`);
+                    } else {
+                        debug(`Skipping file since it hasn't changed: ${fileInfo.filename}`);
+
+                        return cachedLintResults;
+                    }
                 }
             }
 

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -1473,6 +1473,31 @@ describe("CLIEngine", () => {
                 });
             });
 
+            it("should run autofix even if files are cached without autofix results", () => {
+                const baseOptions = {
+                    cwd: path.join(fixtureDir, ".."),
+                    useEslintrc: false,
+                    rules: {
+                        semi: 2,
+                        quotes: [2, "double"],
+                        eqeqeq: 2,
+                        "no-undef": 2,
+                        "space-infix-ops": 2
+                    }
+                };
+
+                engine = new CLIEngine(Object.assign({}, baseOptions, { cache: true, fix: false }));
+
+                // Do initial lint run and populate the cache file
+                engine.executeOnFiles([path.resolve(fixtureDir, `${fixtureDir}/fixmode`)]);
+
+                engine = new CLIEngine(Object.assign({}, baseOptions, { cache: true, fix: true }));
+
+                const report = engine.executeOnFiles([path.resolve(fixtureDir, `${fixtureDir}/fixmode`)]);
+
+                assert.ok(report.results.some(result => result.output));
+            });
+
         });
 
         // These tests have to do with https://github.com/eslint/eslint/issues/963


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

See issue #10679.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Changed CLIEngine so that it will not always used cached lint results. Specifically, if the cached lint result had errors and autofix has been turned on for the current CLIEngine run, CLIEngine will ignore the cached results and process the file normally.

This fixes the following scenario:
1. Run ESLint with `--cache` flag and without `--fix` flag
1. Then run ESLint with `--cache` flag and `--fix` flag

Before this change, the cached, fixless results would be returned. With this change, the cache results are ignored and the file is processed and autofixed.

**Is there anything you'd like reviewers to focus on?**

I'm realizing as I type this that maybe this could be made smarter if we look at `fixableErrorCount` and `fixableWarningCount`: if those are both 0 and the cache is still valid, then no autofix would need to be applied and we could use the cache results. Thoughts?

Other than that, are there any other test cases I should add?