### PR TITLE
Docs: remove links to terminated jscs.info domain

### DIFF
--- a/docs/rules/array-bracket-newline.md
+++ b/docs/rules/array-bracket-newline.md
@@ -274,7 +274,7 @@ If you don't want to enforce line breaks after opening and before closing array 
 
 ## Compatibility
 
-* **JSCS:** [validateNewlineAfterArrayElements](http://jscs.info/rule/validateNewlineAfterArrayElements)
+* **JSCS:** `validateNewlineAfterArrayElements`
 
 ## Related Rules
 

--- a/docs/rules/array-element-newline.md
+++ b/docs/rules/array-element-newline.md
@@ -290,7 +290,7 @@ If you don't want to enforce linebreaks between array elements, don't enable thi
 
 ## Compatibility
 
-* **JSCS:** [validateNewlineAfterArrayElements](http://jscs.info/rule/validateNewlineAfterArrayElements)
+* **JSCS:** `validateNewlineAfterArrayElements`
 
 ## Related Rules
 

--- a/docs/rules/capitalized-comments.md
+++ b/docs/rules/capitalized-comments.md
@@ -245,4 +245,5 @@ This rule can be disabled if you do not care about the grammatical style of comm
 
 ## Compatibility
 
-* **JSCS**: [requireCapitalizedComments](http://jscs.info/rule/requireCapitalizedComments) and [disallowCapitalizedComments](http://jscs.info/rule/disallowCapitalizedComments)
+* **JSCS**: `requireCapitalizedComments`
+* **JSCS**: `disallowCapitalizedComments`

--- a/docs/rules/func-call-spacing.md
+++ b/docs/rules/func-call-spacing.md
@@ -101,5 +101,5 @@ This rule can safely be turned off if your project does not care about enforcing
 
 ## Compatibility
 
-- **JSCS**: [disallowSpacesInCallExpression](http://jscs.info/rule/disallowSpacesInCallExpression)
-- **JSCS**: [requireSpacesInCallExpression](http://jscs.info/rule/requireSpacesInCallExpression)
+- **JSCS**: `disallowSpacesInCallExpression`
+- **JSCS**: `requireSpacesInCallExpression`

--- a/docs/rules/func-name-matching.md
+++ b/docs/rules/func-name-matching.md
@@ -137,4 +137,4 @@ Do not use this rule if you want to allow named functions to have different name
 
 ## Compatibility
 
-* **JSCS**: [requireMatchingFunctionName](http://jscs.info/rule/requireMatchingFunctionName)
+* **JSCS**: `requireMatchingFunctionName`

--- a/docs/rules/func-names.md
+++ b/docs/rules/func-names.md
@@ -107,5 +107,5 @@ Foo.prototype.bar = function() {};
 
 ## Compatibility
 
-* **JSCS**: [requireAnonymousFunctions](http://jscs.info/rule/requireAnonymousFunctions)
-* **JSCS**: [disallowAnonymousFunctions](http://jscs.info/rule/disallowAnonymousFunctions)
+* **JSCS**: `requireAnonymousFunctions`
+* **JSCS**: `disallowAnonymousFunctions`

--- a/docs/rules/indent-legacy.md
+++ b/docs/rules/indent-legacy.md
@@ -530,4 +530,4 @@ var foo = { bar: 1,
 ## Compatibility
 
 * **JSHint**: `indent`
-* **JSCS**: [validateIndentation](http://jscs.info/rule/validateIndentation)
+* **JSCS**: `validateIndentation`

--- a/docs/rules/indent.md
+++ b/docs/rules/indent.md
@@ -661,4 +661,4 @@ if (foo) {
 ## Compatibility
 
 * **JSHint**: `indent`
-* **JSCS**: [validateIndentation](http://jscs.info/rule/validateIndentation)
+* **JSCS**: `validateIndentation`

--- a/docs/rules/line-comment-position.md
+++ b/docs/rules/line-comment-position.md
@@ -103,4 +103,4 @@ If you aren't concerned about having different line comment styles, then you can
 
 ## Compatibility
 
-**JSCS**: [validateCommentPosition](http://jscs.info/rule/validateCommentPosition)
+**JSCS**: `validateCommentPosition`

--- a/docs/rules/linebreak-style.md
+++ b/docs/rules/linebreak-style.md
@@ -83,4 +83,4 @@ If you aren't concerned about having different line endings within your code, th
 
 ## Compatibility
 
-* **JSCS**: [validateLineBreaks](http://jscs.info/rule/validateLineBreaks)
+* **JSCS**: `validateLineBreaks`

--- a/docs/rules/lines-around-directive.md
+++ b/docs/rules/lines-around-directive.md
@@ -318,5 +318,5 @@ You can safely disable this rule if you do not have any strict conventions about
 
 ## Compatibility
 
-* **JSCS**: [requirePaddingNewLinesAfterUseStrict](http://jscs.info/rule/requirePaddingNewLinesAfterUseStrict)
-* **JSCS**: [disallowPaddingNewLinesAfterUseStrict](http://jscs.info/rule/disallowPaddingNewLinesAfterUseStrict)
+* **JSCS**: `requirePaddingNewLinesAfterUseStrict`
+* **JSCS**: `disallowPaddingNewLinesAfterUseStrict`

--- a/docs/rules/lines-between-class-members.md
+++ b/docs/rules/lines-between-class-members.md
@@ -105,6 +105,6 @@ If you don't want to enforce empty lines between class members, you can disable 
 * [padding-line-between-statements](padding-line-between-statements.md)
 
 ## Compatibility
- 
+
 * **JSCS**: `requirePaddingNewLinesAfterBlocks`
 * **JSCS**: `disallowPaddingNewLinesAfterBlocks`

--- a/docs/rules/lines-between-class-members.md
+++ b/docs/rules/lines-between-class-members.md
@@ -103,5 +103,8 @@ If you don't want to enforce empty lines between class members, you can disable 
 
 * [padded-blocks](padded-blocks.md)
 * [padding-line-between-statements](padding-line-between-statements.md)
-* [requirePaddingNewLinesAfterBlocks](http://jscs.info/rule/requirePaddingNewLinesAfterBlocks)
-* [disallowPaddingNewLinesAfterBlocks](http://jscs.info/rule/disallowPaddingNewLinesAfterBlocks)
+
+## Compatibility
+ 
+* **JSCS**: `requirePaddingNewLinesAfterBlocks`
+* **JSCS**: `disallowPaddingNewLinesAfterBlocks`

--- a/docs/rules/max-lines.md
+++ b/docs/rules/max-lines.md
@@ -123,4 +123,4 @@ You can turn this rule off if you are not concerned with the number of lines in 
 
 ## Compatibility
 
-* **JSCS**: [maximumNumberOfLines](http://jscs.info/rule/maximumNumberOfLines)
+* **JSCS**: `maximumNumberOfLines`

--- a/docs/rules/multiline-ternary.md
+++ b/docs/rules/multiline-ternary.md
@@ -146,4 +146,4 @@ You can safely disable this rule if you do not have any strict conventions about
 
 ## Compatibility
 
-* **JSCS**: [requireMultiLineTernary](http://jscs.info/rule/requireMultiLineTernary)
+* **JSCS**: `requireMultiLineTernary`

--- a/docs/rules/no-tabs.md
+++ b/docs/rules/no-tabs.md
@@ -38,4 +38,4 @@ If you have established a standard where having tabs is fine.
 
 ## Compatibility
 
-* **JSCS**: [disallowTabs](http://jscs.info/rule/disallowTabs)
+* **JSCS**: `disallowTabs`

--- a/docs/rules/no-useless-rename.md
+++ b/docs/rules/no-useless-rename.md
@@ -117,4 +117,4 @@ You can safely disable this rule if you do not care about redundantly renaming i
 
 ## Compatibility
 
-* **JSCS**: [disallowIdenticalDestructuringNames](http://jscs.info/rule/disallowIdenticalDestructuringNames)
+* **JSCS**: `disallowIdenticalDestructuringNames`

--- a/docs/rules/nonblock-statement-body-position.md
+++ b/docs/rules/nonblock-statement-body-position.md
@@ -155,4 +155,4 @@ If you're not concerned about consistent locations of single-line statements, yo
 
 ## Further Reading
 
-* JSCS: [requireNewlineBeforeSingleStatementsInIf](http://jscs.info/rule/requireNewlineBeforeSingleStatementsInIf)
+* JSCS: `requireNewlineBeforeSingleStatementsInIf`

--- a/docs/rules/object-curly-newline.md
+++ b/docs/rules/object-curly-newline.md
@@ -511,7 +511,8 @@ export { foo as f, bar } from 'foo-bar';
 
 ## Compatibility
 
-* **JSCS**: [requirePaddingNewLinesInObjects](http://jscs.info/rule/requirePaddingNewLinesInObjects) and [disallowPaddingNewLinesInObjects](http://jscs.info/rule/disallowPaddingNewLinesInObjects)
+* **JSCS**: `requirePaddingNewLinesInObjects`
+* **JSCS**: `disallowPaddingNewLinesInObjects`
 
 ## When Not To Use It
 

--- a/docs/rules/object-property-newline.md
+++ b/docs/rules/object-property-newline.md
@@ -260,7 +260,7 @@ You can turn this rule off if you want to decide, case-by-case, whether to place
 
 ## Compatibility
 
-- **JSCS**: This rule provides partial compatibility with [requireObjectKeysOnNewLine](http://jscs.info/rule/requireObjectKeysOnNewLine).
+- **JSCS**: This rule provides partial compatibility with `requireObjectKeysOnNewLine`.
 
 ## Related Rules
 

--- a/docs/rules/one-var.md
+++ b/docs/rules/one-var.md
@@ -536,5 +536,5 @@ function foo() {
 ## Compatibility
 
 * **JSHint**: This rule maps to the `onevar` JSHint rule, but allows `let` and `const` to be configured separately.
-* **JSCS**: This rule roughly maps to [disallowMultipleVarDecl](http://jscs.info/rule/disallowMultipleVarDecl).
-* **JSCS**: This rule option `separateRequires` roughly maps to [requireMultipleVarDecl](http://jscs.info/rule/requireMultipleVarDecl).
+* **JSCS**: This rule roughly maps to `disallowMultipleVarDecl`.
+* **JSCS**: This rule option `separateRequires` roughly maps to `requireMultipleVarDecl`.

--- a/docs/rules/prefer-numeric-literals.md
+++ b/docs/rules/prefer-numeric-literals.md
@@ -53,4 +53,4 @@ If you want to allow use of `parseInt()` or `Number.parseInt()` for binary, octa
 
 ## Compatibility
 
-* **JSCS**: [requireNumericLiterals](http://jscs.info/rule/requireNumericLiterals)
+* **JSCS**: `requireNumericLiterals`

--- a/docs/rules/sort-keys.md
+++ b/docs/rules/sort-keys.md
@@ -178,4 +178,4 @@ If you don't want to notify about properties' order, then it's safe to disable t
 
 ## Compatibility
 
-* **JSCS:** [validateOrderInObjectKeys](http://jscs.info/rule/validateOrderInObjectKeys)
+* **JSCS:** `validateOrderInObjectKeys`


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

I removed links to `jscs.info` domain, as they all lead to a site with info

```
The domain jscs.info is for sale. To purchase, call BuyDomains.com at 781-373-6841 or 844-896-7299. Click here for more details.
```

**Is there anything you'd like reviewers to focus on?**

Nope