### PR TITLE
Update: Adds --console-format cli option

### DIFF
--- a/docs/user-guide/command-line-interface.md
+++ b/docs/user-guide/command-line-interface.md
@@ -64,6 +64,7 @@ Output:
   -o, --output-file path::String  Specify file to write report to
   -f, --format String            Use a specific output format - default: stylish
   --color, --no-color            Force enabling/disabling of color
+  --console-format               When outputing to a file, you can choose a format that will output to the terminal
 
 Inline configuration comments:
   --no-inline-config             Prevent comments from changing config or rules

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -75,14 +75,19 @@ function translateOptions(cliOptions) {
  * @param {LintResult[]} results The results to print.
  * @param {string} format The name of the formatter to use or the path to the formatter.
  * @param {string} outputFile The path for the output file.
+ * @param {strint} consoleFormat The format the output file should be output
  * @returns {boolean} True if the printing succeeds, false if not.
  * @private
  */
-function printResults(engine, results, format, outputFile) {
+function printResults(engine, results, format, outputFile, consoleFormat) {
     let formatter;
+    let consoleFormatter;
 
     try {
         formatter = engine.getFormatter(format);
+        if (consoleFormat) {
+            consoleFormatter = engine.getFormatter(consoleFormat);
+        }
     } catch (e) {
         log.error(e.message);
         return false;
@@ -91,6 +96,11 @@ function printResults(engine, results, format, outputFile) {
     const output = formatter(results);
 
     if (output) {
+        let consoleOutput = output;
+
+        if (consoleFormat && consoleFormat !== format) {
+            consoleOutput = consoleFormatter(results);
+        }
         if (outputFile) {
             const filePath = path.resolve(process.cwd(), outputFile);
 
@@ -98,7 +108,6 @@ function printResults(engine, results, format, outputFile) {
                 log.error("Cannot write to output file path, it is a directory: %s", outputFile);
                 return false;
             }
-
             try {
                 mkdirp.sync(path.dirname(filePath));
                 fs.writeFileSync(filePath, output);
@@ -106,11 +115,13 @@ function printResults(engine, results, format, outputFile) {
                 log.error("There was a problem writing the output file:\n%s", ex);
                 return false;
             }
+            if (consoleFormat) {
+                log.info(consoleOutput);
+            }
         } else {
-            log.info(output);
+            log.info(consoleOutput);
         }
     }
-
     return true;
 
 }
@@ -201,7 +212,7 @@ const cli = {
                 report.results = CLIEngine.getErrorResults(report.results);
             }
 
-            if (printResults(engine, report.results, currentOptions.format, currentOptions.outputFile)) {
+            if (printResults(engine, report.results, currentOptions.format, currentOptions.outputFile, currentOptions.consoleFormat)) {
                 const tooManyWarnings = currentOptions.maxWarnings >= 0 && report.warningCount > currentOptions.maxWarnings;
 
                 if (!report.errorCount && tooManyWarnings) {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -75,7 +75,7 @@ function translateOptions(cliOptions) {
  * @param {LintResult[]} results The results to print.
  * @param {string} format The name of the formatter to use or the path to the formatter.
  * @param {string} outputFile The path for the output file.
- * @param {strint} consoleFormat The format the output file should be output
+ * @param {string} consoleFormat The format the output file should be output
  * @returns {boolean} True if the printing succeeds, false if not.
  * @private
  */

--- a/lib/options.js
+++ b/lib/options.js
@@ -158,6 +158,11 @@ module.exports = optionator({
             description: "Specify file to write report to"
         },
         {
+            option: "console-format",
+            type: "path::String",
+            description: "Format to write to console, if a file output is specified"
+        },
+        {
             option: "format",
             alias: "f",
             type: "String",

--- a/tests/bin/eslint.js
+++ b/tests/bin/eslint.js
@@ -7,6 +7,7 @@
 
 const childProcess = require("child_process");
 const fs = require("fs");
+const sh = require("shelljs");
 const assert = require("chai").assert;
 const EXECUTABLE_PATH = require("path").resolve(`${__dirname}/../../bin/eslint.js`);
 
@@ -61,6 +62,80 @@ describe("bin/eslint.js", () => {
         forkedProcesses.add(newProcess);
         return newProcess;
     }
+    describe("reading from stdin with the --output flag", () => {
+        afterEach(() => {
+            sh.rm("-rf", "tests/output");
+        });
+
+        it("consoles out the console-format", () => {
+            const child = runESLint([
+                "--stdin",
+                "--no-eslintrc",
+                "--rule",
+                "{'no-extra-semi': 2}",
+                "--fix-dry-run",
+                "--format",
+                "junit",
+                "--o",
+                "./tests/output/eslint-output.txt",
+                "--console-format",
+                "json"
+            ]);
+
+            const expectedOutput = JSON.stringify([
+                {
+                    filePath: "<text>",
+                    messages: [],
+                    errorCount: 0,
+                    warningCount: 0,
+                    fixableErrorCount: 0,
+                    fixableWarningCount: 0,
+                    output: "var foo = bar;\n"
+                }
+            ]);
+
+            const exitCodePromise = assertExitCode(child, 0);
+            const stdoutPromise = getOutput(child).then(output => {
+
+                assert.strictEqual(output.stdout.trim(), expectedOutput);
+                assert.strictEqual(output.stderr, "");
+            });
+
+            child.stdin.write("var foo = bar;;\n");
+            child.stdin.end();
+
+            return Promise.all([exitCodePromise, stdoutPromise]);
+        });
+
+
+        it("does not output to stdout if the console format is not set", () => {
+            const child = runESLint([
+                "--stdin",
+                "--no-eslintrc",
+                "--rule",
+                "{'no-extra-semi': 2}",
+                "--fix-dry-run",
+                "--format",
+                "junit",
+                "--o",
+                "./tests/output/eslint-output.txt"
+            ]);
+
+            const expectedOutput = "";
+
+            const exitCodePromise = assertExitCode(child, 0);
+            const stdoutPromise = getOutput(child).then(output => {
+
+                assert.strictEqual(output.stdout.trim(), expectedOutput);
+                assert.strictEqual(output.stderr, "");
+            });
+
+            child.stdin.write("var foo = bar;;\n");
+            child.stdin.end();
+
+            return Promise.all([exitCodePromise, stdoutPromise]);
+        });
+    });
 
     describe("reading from stdin", () => {
         it("has exit code 0 if no linting errors are reported", () => {
@@ -105,6 +180,7 @@ describe("bin/eslint.js", () => {
 
             return Promise.all([exitCodePromise, stdoutPromise]);
         });
+
 
         it("has exit code 1 if a syntax error is thrown", () => {
             const child = runESLint(["--stdin", "--no-eslintrc"]);

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -551,6 +551,15 @@ describe("cli", () => {
             assert.isTrue(log.error.calledOnce);
         });
 
+        it("should default to saving in format when console-format is set", () => {
+            const filePath = getFixturePath("single-quoted.js");
+            const code = `--no-ignore --format junit --rule 'quotes: [1, double]' --console-format stylish --o tests/output/eslint-output.txt ${filePath}`;
+
+            cli.execute(code);
+            assert.include(fs.readFileSync("tests/output/eslint-output.txt", "utf8"), "<testsuites>");
+            assert.isTrue(log.info.calledOnce);
+        });
+
         it("should return an error if the path could not be written to", () => {
             const filePath = getFixturePath("single-quoted.js");
             const code = `--no-ignore --rule 'quotes: [1, double]' --o tests/output/eslint-output.txt ${filePath}`;


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->
Addresses issue https://github.com/eslint/eslint/issues/10707, apologies for opening this PR twice.  

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[X] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Added the `--console-format` option to the cli. It is specifically for when you want to save in one format but maintain human readable logs in another.

Biggest case for use would be in a ci environment like jenkins. It's worthwhile to save a file in junit that jenkins can consume but preferable to output logs in stylish.



