### PR TITLE
Docs: add another example for when not to use no-await-in-loop

### DIFF
--- a/docs/rules/no-await-in-loop.md
+++ b/docs/rules/no-await-in-loop.md
@@ -70,5 +70,6 @@ async function foo(things) {
 
 In many cases the iterations of a loop are not actually independent of each-other. For example, the
 output of one iteration might be used as the input to another. Or, loops may be used to retry
-asynchronous operations that were unsuccessful. In such cases it makes sense to use `await` within a
+asynchronous operations that were unsuccessful. Or, loops may be used to prevent your code from sending
+an excessive amount of requests in parallel. In such cases it makes sense to use `await` within a
 loop and it is recommended to disable the rule via a standard ESLint disable comment.


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Re: https://github.com/vkarpov15/mastering-async-await-issues/issues/1, I added another example of another case when you would want to avoid the `no-await-in-loop` rule. I'd like to make sure eslint users are informed of all the cases when this rule shouldn't apply.

**Is there anything you'd like reviewers to focus on?**

Thanks for all your work on eslint!
