### PR TITLE
Update: Improve no-extra-parens error message

### DIFF
--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -58,7 +58,7 @@ module.exports = {
         },
 
         messages: {
-            unexpected: "Gratuitous parentheses around expression."
+            unexpected: "Unnecessary parentheses around expression."
         }
     },
 


### PR DESCRIPTION
When I encountered this error, it was not unclear to me what the
problem was or what alternative would be preferred.

The input was:

```js
return ( { foo: 1, bar: 2 }[ key ] || 0 );
```

Receiving the following in Atom's footer:

```
eslint (0|4), Gratuitous parentheses around expression., Line 165, Column 17
```

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
