### PR TITLE
Fix: consistent-docs-url crashes if meta.docs isn't present

### DIFF
--- a/tests/tools/internal-rules/consistent-docs-url.js
+++ b/tests/tools/internal-rules/consistent-docs-url.js
@@ -47,6 +47,23 @@ ruleTester.run("consistent-docs-url", rule, {
             code: [
                 "module.exports = {",
                 "    meta: {",
+                "    },",
+
+                "    create: function(context) {",
+                "        return {};",
+                "    }",
+                "};"
+            ].join("\n"),
+            errors: [{
+                message: "Rule is missing a meta.docs property",
+                line: 2,
+                column: 5
+            }]
+        },
+        {
+            code: [
+                "module.exports = {",
+                "    meta: {",
                 "        docs: {}",
                 "    },",
 

--- a/tools/internal-rules/consistent-docs-url.js
+++ b/tools/internal-rules/consistent-docs-url.js
@@ -48,6 +48,14 @@ function checkMetaDocsUrl(context, exportsNode) {
     const metaDocs = metaProperty && getPropertyFromObject("docs", metaProperty.value);
     const metaDocsUrl = metaDocs && getPropertyFromObject("url", metaDocs.value);
 
+    if (!metaDocs) {
+        context.report({
+            node: metaProperty,
+            message: "Rule is missing a meta.docs property"
+        });
+        return;
+    }
+
     if (!metaDocsUrl) {
         context.report({
             node: metaDocs,


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Issue ( #10722 )

**What changes did you make? (Give an overview)**

- Added a check to report missing property if `metaDocs` is `null`

**Is there anything you'd like reviewers to focus on?**

- Changed the `checkMetaDocsUrl` function
