### PR TITLE
Fix: no-invalid-meta crashes for non Object values (fixes #10750)

### DIFF
--- a/tests/tools/internal-rules/no-invalid-meta.js
+++ b/tests/tools/internal-rules/no-invalid-meta.js
@@ -129,6 +129,24 @@ ruleTester.run("no-invalid-meta", rule, {
         {
             code: [
                 "module.exports = {",
+                "    meta: [],",
+
+                "    create: function(context) {",
+                "        return {",
+                "            Program: function(node) {}",
+                "        };",
+                "    }",
+                "};"
+            ].join("\n"),
+            errors: [{
+                message: "Rule is missing a meta.docs property.",
+                line: 2,
+                column: 5
+            }]
+        },
+        {
+            code: [
+                "module.exports = {",
                 "    meta: {",
                 "        schema: []",
                 "    },",

--- a/tools/internal-rules/consistent-docs-description.js
+++ b/tools/internal-rules/consistent-docs-description.js
@@ -25,6 +25,12 @@ const ALLOWED_FIRST_WORDS = [
 function getPropertyFromObject(property, node) {
     const properties = node.properties;
 
+    if (!Array.isArray(properties)) {
+
+        // if properties is not an array, "internal-no-invalid-meta" will already report this.
+        return null;
+    }
+
     for (let i = 0; i < properties.length; i++) {
         if (properties[i].key.name === property) {
             return properties[i];

--- a/tools/internal-rules/consistent-docs-url.js
+++ b/tools/internal-rules/consistent-docs-url.js
@@ -21,6 +21,12 @@ const path = require("path");
 function getPropertyFromObject(property, node) {
     const properties = node.properties;
 
+    if (!Array.isArray(properties)) {
+
+        // if properties is not an array, "internal-no-invalid-meta" will already report this.
+        return null;
+    }
+
     for (let i = 0; i < properties.length; i++) {
         if (properties[i].key.name === property) {
             return properties[i];

--- a/tools/internal-rules/no-invalid-meta.js
+++ b/tools/internal-rules/no-invalid-meta.js
@@ -19,6 +19,11 @@
 function getPropertyFromObject(property, node) {
     const properties = node.properties;
 
+    if (!Array.isArray(properties)) {
+
+        return null;
+    }
+
     for (let i = 0; i < properties.length; i++) {
         if (properties[i].key.name === property) {
             return properties[i];


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Issue ( #10750 )

**What changes did you make? (Give an overview)**

- Added a check to prevent `getPropertyFromObject` trying to access the `length` property of `undefined`

**Is there anything you'd like reviewers to focus on?**

- Changed the `getPropertyFromObject` function across all internal rule files.
