### PR TITLE
Chore: use meta.messages in some rules (1/4)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,7 +31,8 @@ module.exports = {
             files: ["lib/rules/*", "tools/internal-rules/*"],
             rules: {
                 "rulesdir/no-invalid-meta": "error",
-                "rulesdir/consistent-docs-description": "error"
+                "rulesdir/consistent-docs-description": "error",
+                "rulesdir/consistent-meta-messages": "error"
             }
         }, {
             files: ["lib/rules/*"],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,8 +31,12 @@ module.exports = {
             files: ["lib/rules/*", "tools/internal-rules/*"],
             rules: {
                 "rulesdir/no-invalid-meta": "error",
-                "rulesdir/consistent-docs-description": "error",
-                "rulesdir/consistent-meta-messages": "error"
+                "rulesdir/consistent-docs-description": "error"
+
+                /*
+                 * TODO: enable it when all the rules using meta.messages
+                 * "rulesdir/consistent-meta-messages": "error"
+                 */
             }
         }, {
             files: ["lib/rules/*"],

--- a/lib/rules/for-direction.js
+++ b/lib/rules/for-direction.js
@@ -18,7 +18,10 @@ module.exports = {
             url: "https://eslint.org/docs/rules/for-direction"
         },
         fixable: null,
-        schema: []
+        schema: [],
+        messages: {
+            incorrectDirection: "The update clause in this loop moves the variable in the wrong direction."
+        }
     },
 
     create(context) {
@@ -31,7 +34,7 @@ module.exports = {
         function report(node) {
             context.report({
                 node,
-                message: "The update clause in this loop moves the variable in the wrong direction."
+                messageId: "incorrectDirection"
             });
         }
 

--- a/lib/rules/func-call-spacing.js
+++ b/lib/rules/func-call-spacing.js
@@ -57,6 +57,10 @@ module.exports = {
                     maxItems: 2
                 }
             ]
+        },
+        messages: {
+            unexpected: "Unexpected newline between function name and paren.",
+            missing: "Missing space between function name and paren."
         }
     },
 
@@ -116,7 +120,7 @@ module.exports = {
                 context.report({
                     node,
                     loc: lastCalleeToken.loc.start,
-                    message: "Unexpected space between function name and paren.",
+                    messageId: "unexpected",
                     fix(fixer) {
 
                         /*
@@ -134,7 +138,7 @@ module.exports = {
                 context.report({
                     node,
                     loc: lastCalleeToken.loc.start,
-                    message: "Missing space between function name and paren.",
+                    messageId: "missing",
                     fix(fixer) {
                         return fixer.insertTextBefore(parenToken, " ");
                     }
@@ -143,7 +147,7 @@ module.exports = {
                 context.report({
                     node,
                     loc: lastCalleeToken.loc.start,
-                    message: "Unexpected newline between function name and paren.",
+                    messageId: "unexpected",
                     fix(fixer) {
                         return fixer.replaceTextRange([prevToken.range[1], parenToken.range[0]], " ");
                     }

--- a/lib/rules/func-name-matching.js
+++ b/lib/rules/func-name-matching.js
@@ -87,6 +87,12 @@ module.exports = {
                 additionalItems: false,
                 items: [optionsObject]
             }]
+        },
+        messages: {
+            matchProperty: "Function name `{{funcName}}` should match property name `{{name}}`",
+            matchVariable: "Function name `{{funcName}}` should match variable name `{{name}}`",
+            notMatchProperty: "Function name `{{funcName}}` should not match property name `{{name}}`",
+            notMatchVariable: "Function name `{{funcName}}` should not match variable name `{{name}}`"
         }
     },
 
@@ -132,20 +138,20 @@ module.exports = {
          * @returns {void}
          */
         function report(node, name, funcName, isProp) {
-            let message;
+            let messageId;
 
             if (nameMatches === "always" && isProp) {
-                message = "Function name `{{funcName}}` should match property name `{{name}}`";
+                messageId = "matchProperty";
             } else if (nameMatches === "always") {
-                message = "Function name `{{funcName}}` should match variable name `{{name}}`";
+                messageId = "matchVariable";
             } else if (isProp) {
-                message = "Function name `{{funcName}}` should not match property name `{{name}}`";
+                messageId = "notMatchProperty";
             } else {
-                message = "Function name `{{funcName}}` should not match variable name `{{name}}`";
+                messageId = "notMatchVariable";
             }
             context.report({
                 node,
-                message,
+                messageId,
                 data: {
                     name,
                     funcName

--- a/lib/rules/func-names.js
+++ b/lib/rules/func-names.js
@@ -37,7 +37,11 @@ module.exports = {
             {
                 enum: ["always", "as-needed", "never"]
             }
-        ]
+        ],
+        messages: {
+            unnamed: "Unexpected unnamed {{name}}.",
+            named: "Unexpected named {{name}}."
+        }
     },
 
     create(context) {
@@ -96,7 +100,7 @@ module.exports = {
                     if (hasName) {
                         context.report({
                             node,
-                            message: "Unexpected named {{name}}.",
+                            messageId: "named",
                             data: { name }
                         });
                     }
@@ -104,7 +108,7 @@ module.exports = {
                     if (!hasName && (asNeeded ? !hasInferredName(node) : !isObjectOrClassMethod(node))) {
                         context.report({
                             node,
-                            message: "Unexpected unnamed {{name}}.",
+                            messageId: "unnamed",
                             data: { name }
                         });
                     }

--- a/lib/rules/func-style.js
+++ b/lib/rules/func-style.js
@@ -30,7 +30,11 @@ module.exports = {
                 },
                 additionalProperties: false
             }
-        ]
+        ],
+        messages: {
+            expression: "Expected a function expression.",
+            declaration: "Expected a function declaration."
+        }
     },
 
     create(context) {
@@ -45,7 +49,7 @@ module.exports = {
                 stack.push(false);
 
                 if (!enforceDeclarations && node.parent.type !== "ExportDefaultDeclaration") {
-                    context.report({ node, message: "Expected a function expression." });
+                    context.report({ node, messageId: "expression" });
                 }
             },
             "FunctionDeclaration:exit"() {
@@ -56,7 +60,7 @@ module.exports = {
                 stack.push(false);
 
                 if (enforceDeclarations && node.parent.type === "VariableDeclarator") {
-                    context.report({ node: node.parent, message: "Expected a function declaration." });
+                    context.report({ node: node.parent, messageId: "declaration" });
                 }
             },
             "FunctionExpression:exit"() {
@@ -79,7 +83,7 @@ module.exports = {
                 const hasThisExpr = stack.pop();
 
                 if (enforceDeclarations && !hasThisExpr && node.parent.type === "VariableDeclarator") {
-                    context.report({ node: node.parent, message: "Expected a function declaration." });
+                    context.report({ node: node.parent, messageId: "declaration" });
                 }
             };
         }

--- a/lib/rules/function-paren-newline.js
+++ b/lib/rules/function-paren-newline.js
@@ -41,7 +41,13 @@ module.exports = {
                     }
                 ]
             }
-        ]
+        ],
+        messages: {
+            expectedBefore: "Expected newline before ')'.",
+            expectedAfter: "Expected newline after '('.",
+            unexpectedBefore: "Unexpected newline before '('.",
+            unexpectedAfter: "Unexpected newline after ')'."
+        }
     },
 
     create(context) {
@@ -99,7 +105,7 @@ module.exports = {
             if (hasLeftNewline && !needsNewlines) {
                 context.report({
                     node: leftParen,
-                    message: "Unexpected newline after '('.",
+                    messageId: "unexpectedAfter",
                     fix(fixer) {
                         return sourceCode.getText().slice(leftParen.range[1], tokenAfterLeftParen.range[0]).trim()
 
@@ -111,7 +117,7 @@ module.exports = {
             } else if (!hasLeftNewline && needsNewlines) {
                 context.report({
                     node: leftParen,
-                    message: "Expected a newline after '('.",
+                    messageId: "expectedAfter",
                     fix: fixer => fixer.insertTextAfter(leftParen, "\n")
                 });
             }
@@ -119,7 +125,7 @@ module.exports = {
             if (hasRightNewline && !needsNewlines) {
                 context.report({
                     node: rightParen,
-                    message: "Unexpected newline before ')'.",
+                    messageId: "unexpectedBefore",
                     fix(fixer) {
                         return sourceCode.getText().slice(tokenBeforeRightParen.range[1], rightParen.range[0]).trim()
 
@@ -131,7 +137,7 @@ module.exports = {
             } else if (!hasRightNewline && needsNewlines) {
                 context.report({
                     node: rightParen,
-                    message: "Expected a newline before ')'.",
+                    messageId: "expectedBefore",
                     fix: fixer => fixer.insertTextBefore(rightParen, "\n")
                 });
             }

--- a/lib/rules/generator-star-spacing.js
+++ b/lib/rules/generator-star-spacing.js
@@ -57,8 +57,10 @@ module.exports = {
             }
         ],
         messages: {
-            missing: "Missing space {{side}} *.",
-            unexpected: "Unexpected space {{side}} *."
+            missingBefore: "Missing space before *.",
+            missingAfter: "Missing space after *.",
+            unexpectedBefore: "Unexpected space before *.",
+            unexpectedAfter: "Unexpected space after *."
         }
     },
 
@@ -124,6 +126,15 @@ module.exports = {
         }
 
         /**
+         * capitalize a given string.
+         * @param {string} str the given string.
+         * @returns {string} the capitalized string.
+         */
+        function capitalize(str) {
+            return str[0].toUpperCase() + str.slice(1);
+        }
+
+        /**
          * Checks the spacing between two tokens before or after the star token.
          *
          * @param {string} kind Either "named", "anonymous", or "method"
@@ -139,15 +150,11 @@ module.exports = {
                 const after = leftToken.value === "*";
                 const spaceRequired = modes[kind][side];
                 const node = after ? leftToken : rightToken;
-                const messageId = spaceRequired ? "missing" : "unexpected";
-
-                // const message = "{{type}} space {{side}} *.";
-                const data = { side };
+                const messageId = `${spaceRequired ? "missing" : "unexpected"}${capitalize(side)}`;
 
                 context.report({
                     node,
                     messageId,
-                    data,
                     fix(fixer) {
                         if (spaceRequired) {
                             if (after) {

--- a/lib/rules/generator-star-spacing.js
+++ b/lib/rules/generator-star-spacing.js
@@ -55,7 +55,11 @@ module.exports = {
                     }
                 ]
             }
-        ]
+        ],
+        messages: {
+            missing: "Missing space {{side}} *.",
+            unexpected: "Unexpected space {{side}} *."
+        }
     },
 
     create(context) {
@@ -135,16 +139,14 @@ module.exports = {
                 const after = leftToken.value === "*";
                 const spaceRequired = modes[kind][side];
                 const node = after ? leftToken : rightToken;
-                const type = spaceRequired ? "Missing" : "Unexpected";
-                const message = "{{type}} space {{side}} *.";
-                const data = {
-                    type,
-                    side
-                };
+                const messageId = spaceRequired ? "missing" : "unexpected";
+
+                // const message = "{{type}} space {{side}} *.";
+                const data = { side };
 
                 context.report({
                     node,
-                    message,
+                    messageId,
                     data,
                     fix(fixer) {
                         if (spaceRequired) {

--- a/lib/rules/getter-return.js
+++ b/lib/rules/getter-return.js
@@ -61,7 +61,11 @@ module.exports = {
                 },
                 additionalProperties: false
             }
-        ]
+        ],
+        messages: {
+            expected: "Expected to return a value in {{name}}.",
+            expectedAlways: "Expected {{name}} to always return a value."
+        }
     },
 
     create(context) {
@@ -93,9 +97,7 @@ module.exports = {
                 context.report({
                     node,
                     loc: getId(node).loc.start,
-                    message: funcInfo.hasReturn
-                        ? "Expected {{name}} to always return a value."
-                        : "Expected to return a value in {{name}}.",
+                    messageId: funcInfo.hasReturn ? "expectedAlways" : "expected",
                     data: {
                         name: astUtils.getFunctionNameWithKind(funcInfo.node)
                     }
@@ -161,7 +163,7 @@ module.exports = {
                     if (!options.allowImplicit && !node.argument) {
                         context.report({
                             node,
-                            message: "Expected to return a value in {{name}}.",
+                            messageId: "expected",
                             data: {
                                 name: astUtils.getFunctionNameWithKind(funcInfo.node)
                             }

--- a/lib/rules/no-magic-numbers.js
+++ b/lib/rules/no-magic-numbers.js
@@ -39,7 +39,11 @@ module.exports = {
                 }
             },
             additionalProperties: false
-        }]
+        }],
+        messages: {
+            useConst: "Number constants declarations must use 'const'.",
+            noMagic: "No magic number: {{raw}}."
+        }
     },
 
     create(context) {
@@ -136,7 +140,7 @@ module.exports = {
                     if (enforceConst && parent.parent.kind !== "const") {
                         context.report({
                             node: fullNumberNode,
-                            message: "Number constants declarations must use 'const'."
+                            messageId: "useConst"
                         });
                     }
                 } else if (
@@ -145,7 +149,7 @@ module.exports = {
                 ) {
                     context.report({
                         node: fullNumberNode,
-                        message: "No magic number: {{raw}}.",
+                        messageId: "noMagic",
                         data: {
                             raw
                         }

--- a/tests/lib/rules/for-direction.js
+++ b/tests/lib/rules/for-direction.js
@@ -17,6 +17,7 @@ const RuleTester = require("../../../lib/testers/rule-tester");
 //------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester();
+const incorrectDirection = { messageId: "incorrectDirection" };
 
 ruleTester.run("for-direction", rule, {
     valid: [
@@ -52,17 +53,17 @@ ruleTester.run("for-direction", rule, {
     invalid: [
 
         // test if '++', '--'
-        { code: "for(var i = 0; i < 10; i--){}", errors: [{ message: "The update clause in this loop moves the variable in the wrong direction." }] },
-        { code: "for(var i = 0; i <= 10; i--){}", errors: [{ message: "The update clause in this loop moves the variable in the wrong direction." }] },
-        { code: "for(var i = 10; i > 10; i++){}", errors: [{ message: "The update clause in this loop moves the variable in the wrong direction." }] },
-        { code: "for(var i = 10; i >= 0; i++){}", errors: [{ message: "The update clause in this loop moves the variable in the wrong direction." }] },
+        { code: "for(var i = 0; i < 10; i--){}", errors: [incorrectDirection] },
+        { code: "for(var i = 0; i <= 10; i--){}", errors: [incorrectDirection] },
+        { code: "for(var i = 10; i > 10; i++){}", errors: [incorrectDirection] },
+        { code: "for(var i = 10; i >= 0; i++){}", errors: [incorrectDirection] },
 
         // test if '+=', '-='
-        { code: "for(var i = 0; i < 10; i-=1){}", errors: [{ message: "The update clause in this loop moves the variable in the wrong direction." }] },
-        { code: "for(var i = 0; i <= 10; i-=1){}", errors: [{ message: "The update clause in this loop moves the variable in the wrong direction." }] },
-        { code: "for(var i = 10; i > 10; i+=1){}", errors: [{ message: "The update clause in this loop moves the variable in the wrong direction." }] },
-        { code: "for(var i = 10; i >= 0; i+=1){}", errors: [{ message: "The update clause in this loop moves the variable in the wrong direction." }] },
-        { code: "for (var i = 0; i < MAX; i -= STEP_SIZE);", errors: [{ message: "The update clause in this loop moves the variable in the wrong direction." }] },
-        { code: "for (var i = 0; i > MIN; i += STEP_SIZE);", errors: [{ message: "The update clause in this loop moves the variable in the wrong direction." }] }
+        { code: "for(var i = 0; i < 10; i-=1){}", errors: [incorrectDirection] },
+        { code: "for(var i = 0; i <= 10; i-=1){}", errors: [incorrectDirection] },
+        { code: "for(var i = 10; i > 10; i+=1){}", errors: [incorrectDirection] },
+        { code: "for(var i = 10; i >= 0; i+=1){}", errors: [incorrectDirection] },
+        { code: "for (var i = 0; i < MAX; i -= STEP_SIZE);", errors: [incorrectDirection] },
+        { code: "for (var i = 0; i > MIN; i += STEP_SIZE);", errors: [incorrectDirection] }
     ]
 });

--- a/tests/lib/rules/func-call-spacing.js
+++ b/tests/lib/rules/func-call-spacing.js
@@ -207,59 +207,59 @@ ruleTester.run("func-call-spacing", rule, {
         {
             code: "f ();",
             output: "f();",
-            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression" }]
+            errors: [{ messageId: "unexpected", type: "CallExpression" }]
         },
         {
             code: "f (a, b);",
             output: "f(a, b);",
-            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression" }]
+            errors: [{ messageId: "unexpected", type: "CallExpression" }]
         },
         {
             code: "f.b ();",
             output: "f.b();",
-            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression", column: 3 }]
+            errors: [{ messageId: "unexpected", type: "CallExpression", column: 3 }]
         },
         {
             code: "f.b().c ();",
             output: "f.b().c();",
-            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression", column: 7 }]
+            errors: [{ messageId: "unexpected", type: "CallExpression", column: 7 }]
         },
         {
             code: "f() ()",
             output: "f()()",
-            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression" }]
+            errors: [{ messageId: "unexpected", type: "CallExpression" }]
         },
         {
             code: "(function() {} ())",
             output: "(function() {}())",
-            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression" }]
+            errors: [{ messageId: "unexpected", type: "CallExpression" }]
         },
         {
             code: "var f = new Foo ()",
             output: "var f = new Foo()",
-            errors: [{ message: "Unexpected space between function name and paren.", type: "NewExpression" }]
+            errors: [{ messageId: "unexpected", type: "NewExpression" }]
         },
         {
             code: "f ( (0) )",
             output: "f( (0) )",
-            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression" }]
+            errors: [{ messageId: "unexpected", type: "CallExpression" }]
         },
         {
             code: "f(0) (1)",
             output: "f(0)(1)",
-            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression" }]
+            errors: [{ messageId: "unexpected", type: "CallExpression" }]
         },
         {
             code: "(f) (0)",
             output: "(f)(0)",
-            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression" }]
+            errors: [{ messageId: "unexpected", type: "CallExpression" }]
         },
         {
             code: "f ();\n t   ();",
             output: "f();\n t();",
             errors: [
-                { message: "Unexpected space between function name and paren.", type: "CallExpression" },
-                { message: "Unexpected space between function name and paren.", type: "CallExpression" }
+                { messageId: "unexpected", type: "CallExpression" },
+                { messageId: "unexpected", type: "CallExpression" }
             ]
         },
 
@@ -267,27 +267,27 @@ ruleTester.run("func-call-spacing", rule, {
         {
             code: "f\n();",
             output: null, // no change
-            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression" }]
+            errors: [{ messageId: "unexpected", type: "CallExpression" }]
         },
         {
             code: "f\r();",
             output: null, // no change
-            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression" }]
+            errors: [{ messageId: "unexpected", type: "CallExpression" }]
         },
         {
             code: "f\u2028();",
             output: null, // no change
-            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression" }]
+            errors: [{ messageId: "unexpected", type: "CallExpression" }]
         },
         {
             code: "f\u2029();",
             output: null, // no change
-            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression" }]
+            errors: [{ messageId: "unexpected", type: "CallExpression" }]
         },
         {
             code: "f\r\n();",
             output: null, // no change
-            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression" }]
+            errors: [{ messageId: "unexpected", type: "CallExpression" }]
         },
 
         // "never"
@@ -295,69 +295,69 @@ ruleTester.run("func-call-spacing", rule, {
             code: "f ();",
             output: "f();",
             options: ["never"],
-            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression" }]
+            errors: [{ messageId: "unexpected", type: "CallExpression" }]
         },
         {
             code: "f (a, b);",
             output: "f(a, b);",
             options: ["never"],
-            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression" }]
+            errors: [{ messageId: "unexpected", type: "CallExpression" }]
         },
         {
             code: "f.b ();",
             output: "f.b();",
             options: ["never"],
-            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression", column: 3 }]
+            errors: [{ messageId: "unexpected", type: "CallExpression", column: 3 }]
         },
         {
             code: "f.b().c ();",
             output: "f.b().c();",
             options: ["never"],
-            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression", column: 7 }]
+            errors: [{ messageId: "unexpected", type: "CallExpression", column: 7 }]
         },
         {
             code: "f() ()",
             output: "f()()",
             options: ["never"],
-            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression" }]
+            errors: [{ messageId: "unexpected", type: "CallExpression" }]
         },
         {
             code: "(function() {} ())",
             output: "(function() {}())",
             options: ["never"],
-            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression" }]
+            errors: [{ messageId: "unexpected", type: "CallExpression" }]
         },
         {
             code: "var f = new Foo ()",
             output: "var f = new Foo()",
             options: ["never"],
-            errors: [{ message: "Unexpected space between function name and paren.", type: "NewExpression" }]
+            errors: [{ messageId: "unexpected", type: "NewExpression" }]
         },
         {
             code: "f ( (0) )",
             output: "f( (0) )",
             options: ["never"],
-            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression" }]
+            errors: [{ messageId: "unexpected", type: "CallExpression" }]
         },
         {
             code: "f(0) (1)",
             output: "f(0)(1)",
             options: ["never"],
-            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression" }]
+            errors: [{ messageId: "unexpected", type: "CallExpression" }]
         },
         {
             code: "(f) (0)",
             output: "(f)(0)",
             options: ["never"],
-            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression" }]
+            errors: [{ messageId: "unexpected", type: "CallExpression" }]
         },
         {
             code: "f ();\n t   ();",
             output: "f();\n t();",
             options: ["never"],
             errors: [
-                { message: "Unexpected space between function name and paren.", type: "CallExpression" },
-                { message: "Unexpected space between function name and paren.", type: "CallExpression" }
+                { messageId: "unexpected", type: "CallExpression" },
+                { messageId: "unexpected", type: "CallExpression" }
             ]
         },
 
@@ -368,7 +368,7 @@ ruleTester.run("func-call-spacing", rule, {
             options: ["never"],
             errors: [
                 {
-                    message: "Unexpected space between function name and paren.",
+                    messageId: "unexpected",
                     type: "CallExpression"
                 }
             ]
@@ -383,7 +383,7 @@ ruleTester.run("func-call-spacing", rule, {
             options: ["never"],
             errors: [
                 {
-                    message: "Unexpected space between function name and paren.",
+                    messageId: "unexpected",
                     type: "CallExpression",
                     line: 2,
                     column: 23
@@ -399,7 +399,7 @@ ruleTester.run("func-call-spacing", rule, {
             options: ["never"],
             errors: [
                 {
-                    message: "Unexpected space between function name and paren.",
+                    messageId: "unexpected",
                     type: "CallExpression",
                     line: 1,
                     column: 9
@@ -415,7 +415,7 @@ ruleTester.run("func-call-spacing", rule, {
             options: ["never"],
             errors: [
                 {
-                    message: "Unexpected space between function name and paren.",
+                    messageId: "unexpected",
                     type: "CallExpression",
                     line: 1,
                     column: 9
@@ -428,7 +428,7 @@ ruleTester.run("func-call-spacing", rule, {
             options: ["never"],
             errors: [
                 {
-                    message: "Unexpected space between function name and paren.",
+                    messageId: "unexpected",
                     type: "CallExpression"
                 }
             ]
@@ -439,7 +439,7 @@ ruleTester.run("func-call-spacing", rule, {
             options: ["never"],
             errors: [
                 {
-                    message: "Unexpected space between function name and paren.",
+                    messageId: "unexpected",
                     type: "CallExpression"
                 }
             ]
@@ -450,7 +450,7 @@ ruleTester.run("func-call-spacing", rule, {
             options: ["never"],
             errors: [
                 {
-                    message: "Unexpected space between function name and paren.",
+                    messageId: "unexpected",
                     type: "CallExpression"
                 }
             ]
@@ -461,7 +461,7 @@ ruleTester.run("func-call-spacing", rule, {
             options: ["never"],
             errors: [
                 {
-                    message: "Unexpected space between function name and paren.",
+                    messageId: "unexpected",
                     type: "CallExpression"
                 }
             ]
@@ -472,133 +472,133 @@ ruleTester.run("func-call-spacing", rule, {
             code: "f();",
             output: "f ();",
             options: ["always"],
-            errors: [{ message: "Missing space between function name and paren.", type: "CallExpression" }]
+            errors: [{ messageId: "missing", type: "CallExpression" }]
         },
         {
             code: "f\n();",
             output: "f ();",
             options: ["always"],
-            errors: [{ message: "Unexpected newline between function name and paren.", type: "CallExpression" }]
+            errors: [{ messageId: "unexpected", type: "CallExpression" }]
         },
         {
             code: "f(a, b);",
             output: "f (a, b);",
             options: ["always"],
-            errors: [{ message: "Missing space between function name and paren.", type: "CallExpression" }]
+            errors: [{ messageId: "missing", type: "CallExpression" }]
         },
         {
             code: "f\n(a, b);",
             output: "f (a, b);",
             options: ["always"],
-            errors: [{ message: "Unexpected newline between function name and paren.", type: "CallExpression" }]
+            errors: [{ messageId: "unexpected", type: "CallExpression" }]
         },
         {
             code: "f.b();",
             output: "f.b ();",
             options: ["always"],
-            errors: [{ message: "Missing space between function name and paren.", type: "CallExpression", column: 3 }]
+            errors: [{ messageId: "missing", type: "CallExpression", column: 3 }]
         },
         {
             code: "f.b\n();",
             output: "f.b ();",
             options: ["always"],
-            errors: [{ message: "Unexpected newline between function name and paren.", type: "CallExpression", column: 3 }]
+            errors: [{ messageId: "unexpected", type: "CallExpression", column: 3 }]
         },
         {
             code: "f.b().c ();",
             output: "f.b ().c ();",
             options: ["always"],
-            errors: [{ message: "Missing space between function name and paren.", type: "CallExpression", column: 3 }]
+            errors: [{ messageId: "missing", type: "CallExpression", column: 3 }]
         },
         {
             code: "f.b\n().c ();",
             output: "f.b ().c ();",
             options: ["always"],
-            errors: [{ message: "Unexpected newline between function name and paren.", type: "CallExpression", column: 3 }]
+            errors: [{ messageId: "unexpected", type: "CallExpression", column: 3 }]
         },
         {
             code: "f() ()",
             output: "f () ()",
             options: ["always"],
-            errors: [{ message: "Missing space between function name and paren.", type: "CallExpression" }]
+            errors: [{ messageId: "missing", type: "CallExpression" }]
         },
         {
             code: "f\n() ()",
             output: "f () ()",
             options: ["always"],
-            errors: [{ message: "Unexpected newline between function name and paren.", type: "CallExpression" }]
+            errors: [{ messageId: "unexpected", type: "CallExpression" }]
         },
         {
             code: "f\n()()",
             output: "f () ()",
             options: ["always"],
             errors: [
-                { message: "Unexpected newline between function name and paren.", type: "CallExpression" },
-                { message: "Missing space between function name and paren.", type: "CallExpression" }
+                { messageId: "unexpected", type: "CallExpression" },
+                { messageId: "missing", type: "CallExpression" }
             ]
         },
         {
             code: "(function() {}())",
             output: "(function() {} ())",
             options: ["always"],
-            errors: [{ message: "Missing space between function name and paren.", type: "CallExpression" }]
+            errors: [{ messageId: "missing", type: "CallExpression" }]
         },
         {
             code: "var f = new Foo()",
             output: "var f = new Foo ()",
             options: ["always"],
-            errors: [{ message: "Missing space between function name and paren.", type: "NewExpression" }]
+            errors: [{ messageId: "missing", type: "NewExpression" }]
         },
         {
             code: "f( (0) )",
             output: "f ( (0) )",
             options: ["always"],
-            errors: [{ message: "Missing space between function name and paren.", type: "CallExpression" }]
+            errors: [{ messageId: "missing", type: "CallExpression" }]
         },
         {
             code: "f(0) (1)",
             output: "f (0) (1)",
             options: ["always"],
-            errors: [{ message: "Missing space between function name and paren.", type: "CallExpression" }]
+            errors: [{ messageId: "missing", type: "CallExpression" }]
         },
         {
             code: "(f)(0)",
             output: "(f) (0)",
             options: ["always"],
-            errors: [{ message: "Missing space between function name and paren.", type: "CallExpression" }]
+            errors: [{ messageId: "missing", type: "CallExpression" }]
         },
         {
             code: "f();\n t();",
             output: "f ();\n t ();",
             options: ["always"],
             errors: [
-                { message: "Missing space between function name and paren.", type: "CallExpression" },
-                { message: "Missing space between function name and paren.", type: "CallExpression" }
+                { messageId: "missing", type: "CallExpression" },
+                { messageId: "missing", type: "CallExpression" }
             ]
         },
         {
             code: "f\r();",
             output: "f ();",
             options: ["always"],
-            errors: [{ message: "Unexpected newline between function name and paren.", type: "CallExpression" }]
+            errors: [{ messageId: "unexpected", type: "CallExpression" }]
         },
         {
             code: "f\u2028();",
             output: "f ();",
             options: ["always"],
-            errors: [{ message: "Unexpected newline between function name and paren.", type: "CallExpression" }]
+            errors: [{ messageId: "unexpected", type: "CallExpression" }]
         },
         {
             code: "f\u2029();",
             output: "f ();",
             options: ["always"],
-            errors: [{ message: "Unexpected newline between function name and paren.", type: "CallExpression" }]
+            errors: [{ messageId: "unexpected", type: "CallExpression" }]
         },
         {
             code: "f\r\n();",
             output: "f ();",
             options: ["always"],
-            errors: [{ message: "Unexpected newline between function name and paren.", type: "CallExpression" }]
+            errors: [{ messageId: "unexpected", type: "CallExpression" }]
         },
 
         // "always", "allowNewlines": true
@@ -607,69 +607,69 @@ ruleTester.run("func-call-spacing", rule, {
             output: "f ();",
             options: ["always", { allowNewlines: true }],
             errors: [
-                { message: "Missing space between function name and paren.", type: "CallExpression" }]
+                { messageId: "missing", type: "CallExpression" }]
         },
         {
             code: "f(a, b);",
             output: "f (a, b);",
             options: ["always", { allowNewlines: true }],
-            errors: [{ message: "Missing space between function name and paren.", type: "CallExpression" }]
+            errors: [{ messageId: "missing", type: "CallExpression" }]
         },
         {
             code: "f.b();",
             output: "f.b ();",
             options: ["always", { allowNewlines: true }],
-            errors: [{ message: "Missing space between function name and paren.", type: "CallExpression", column: 3 }]
+            errors: [{ messageId: "missing", type: "CallExpression", column: 3 }]
         },
         {
             code: "f.b().c ();",
             output: "f.b ().c ();",
             options: ["always", { allowNewlines: true }],
-            errors: [{ message: "Missing space between function name and paren.", type: "CallExpression", column: 3 }]
+            errors: [{ messageId: "missing", type: "CallExpression", column: 3 }]
         },
         {
             code: "f() ()",
             output: "f () ()",
             options: ["always", { allowNewlines: true }],
-            errors: [{ message: "Missing space between function name and paren.", type: "CallExpression" }]
+            errors: [{ messageId: "missing", type: "CallExpression" }]
         },
         {
             code: "(function() {}())",
             output: "(function() {} ())",
             options: ["always", { allowNewlines: true }],
-            errors: [{ message: "Missing space between function name and paren.", type: "CallExpression" }]
+            errors: [{ messageId: "missing", type: "CallExpression" }]
         },
         {
             code: "var f = new Foo()",
             output: "var f = new Foo ()",
             options: ["always", { allowNewlines: true }],
-            errors: [{ message: "Missing space between function name and paren.", type: "NewExpression" }]
+            errors: [{ messageId: "missing", type: "NewExpression" }]
         },
         {
             code: "f( (0) )",
             output: "f ( (0) )",
             options: ["always", { allowNewlines: true }],
-            errors: [{ message: "Missing space between function name and paren.", type: "CallExpression" }]
+            errors: [{ messageId: "missing", type: "CallExpression" }]
         },
         {
             code: "f(0) (1)",
             output: "f (0) (1)",
             options: ["always", { allowNewlines: true }],
-            errors: [{ message: "Missing space between function name and paren.", type: "CallExpression" }]
+            errors: [{ messageId: "missing", type: "CallExpression" }]
         },
         {
             code: "(f)(0)",
             output: "(f) (0)",
             options: ["always", { allowNewlines: true }],
-            errors: [{ message: "Missing space between function name and paren.", type: "CallExpression" }]
+            errors: [{ messageId: "missing", type: "CallExpression" }]
         },
         {
             code: "f();\n t();",
             output: "f ();\n t ();",
             options: ["always", { allowNewlines: true }],
             errors: [
-                { message: "Missing space between function name and paren.", type: "CallExpression" },
-                { message: "Missing space between function name and paren.", type: "CallExpression" }
+                { messageId: "missing", type: "CallExpression" },
+                { messageId: "missing", type: "CallExpression" }
             ]
         }
     ]

--- a/tests/lib/rules/func-name-matching.js
+++ b/tests/lib/rules/func-name-matching.js
@@ -263,63 +263,63 @@ ruleTester.run("func-name-matching", rule, {
             options: ["always"],
             parserOptions: { ecmaVersion: 6 },
             errors: [
-                { message: "Function name `bar` should match variable name `foo`" }
+                { messageId: "matchVariable", data: { funcName: "bar", name: "foo" } }
             ]
         },
         {
             code: "let foo = function bar() {};",
             parserOptions: { ecmaVersion: 6 },
             errors: [
-                { message: "Function name `bar` should match variable name `foo`" }
+                { messageId: "matchVariable", data: { funcName: "bar", name: "foo" } }
             ]
         },
         {
             code: "foo = function bar() {};",
             parserOptions: { ecmaVersion: 6 },
             errors: [
-                { message: "Function name `bar` should match variable name `foo`" }
+                { messageId: "matchVariable", data: { funcName: "bar", name: "foo" } }
             ]
         },
         {
             code: "obj.foo = function bar() {};",
             parserOptions: { ecmaVersion: 6 },
             errors: [
-                { message: "Function name `bar` should match property name `foo`" }
+                { messageId: "matchProperty", data: { funcName: "bar", name: "foo" } }
             ]
         },
         {
             code: "obj.bar.foo = function bar() {};",
             parserOptions: { ecmaVersion: 6 },
             errors: [
-                { message: "Function name `bar` should match property name `foo`" }
+                { messageId: "matchProperty", data: { funcName: "bar", name: "foo" } }
             ]
         },
         {
             code: "obj['foo'] = function bar() {};",
             parserOptions: { ecmaVersion: 6 },
             errors: [
-                { message: "Function name `bar` should match property name `foo`" }
+                { messageId: "matchProperty", data: { funcName: "bar", name: "foo" } }
             ]
         },
         {
             code: "let obj = {foo: function bar() {}};",
             parserOptions: { ecmaVersion: 6 },
             errors: [
-                { message: "Function name `bar` should match property name `foo`" }
+                { messageId: "matchProperty", data: { funcName: "bar", name: "foo" } }
             ]
         },
         {
             code: "let obj = {'foo': function bar() {}};",
             parserOptions: { ecmaVersion: 6 },
             errors: [
-                { message: "Function name `bar` should match property name `foo`" }
+                { messageId: "matchProperty", data: { funcName: "bar", name: "foo" } }
             ]
         },
         {
             code: "({['foo']: function bar() {}})",
             parserOptions: { ecmaVersion: 6 },
             errors: [
-                { message: "Function name `bar` should match property name `foo`" }
+                { messageId: "matchProperty", data: { funcName: "bar", name: "foo" } }
             ]
         },
         {
@@ -327,7 +327,7 @@ ruleTester.run("func-name-matching", rule, {
             options: [{ includeCommonJSModuleExports: true }],
             parserOptions: { ecmaVersion: 6 },
             errors: [
-                { message: "Function name `foo` should match property name `exports`" }
+                { messageId: "matchProperty", data: { funcName: "foo", name: "exports" } }
             ]
         },
         {
@@ -335,7 +335,7 @@ ruleTester.run("func-name-matching", rule, {
             options: ["always", { includeCommonJSModuleExports: true }],
             parserOptions: { ecmaVersion: 6 },
             errors: [
-                { message: "Function name `foo` should match property name `exports`" }
+                { messageId: "matchProperty", data: { funcName: "foo", name: "exports" } }
             ]
         },
         {
@@ -343,7 +343,7 @@ ruleTester.run("func-name-matching", rule, {
             options: ["never", { includeCommonJSModuleExports: true }],
             parserOptions: { ecmaVersion: 6 },
             errors: [
-                { message: "Function name `exports` should not match property name `exports`" }
+                { messageId: "notMatchProperty", data: { funcName: "exports", name: "exports" } }
             ]
         },
         {
@@ -351,7 +351,7 @@ ruleTester.run("func-name-matching", rule, {
             options: [{ includeCommonJSModuleExports: true }],
             parserOptions: { ecmaVersion: 6 },
             errors: [
-                { message: "Function name `foo` should match property name `exports`" }
+                { messageId: "matchProperty", data: { funcName: "foo", name: "exports" } }
             ]
         },
         {
@@ -359,7 +359,7 @@ ruleTester.run("func-name-matching", rule, {
             options: ["always", { includeCommonJSModuleExports: true }],
             parserOptions: { ecmaVersion: 6 },
             errors: [
-                { message: "Function name `foo` should match property name `exports`" }
+                { messageId: "matchProperty", data: { funcName: "foo", name: "exports" } }
             ]
         },
         {
@@ -367,84 +367,84 @@ ruleTester.run("func-name-matching", rule, {
             options: ["never", { includeCommonJSModuleExports: true }],
             parserOptions: { ecmaVersion: 6 },
             errors: [
-                { message: "Function name `exports` should not match property name `exports`" }
+                { messageId: "notMatchProperty", data: { funcName: "exports", name: "exports" } }
             ]
         },
         {
             code: "var foo = function foo(name) {};",
             options: ["never"],
             errors: [
-                { message: "Function name `foo` should not match variable name `foo`" }
+                { messageId: "notMatchVariable", data: { funcName: "foo", name: "foo" } }
             ]
         },
         {
             code: "obj.foo = function foo(name) {};",
             options: ["never"],
             errors: [
-                { message: "Function name `foo` should not match property name `foo`" }
+                { messageId: "notMatchProperty", data: { funcName: "foo", name: "foo" } }
             ]
         },
         {
             code: "Object.defineProperty(foo, 'bar', { value: function baz() {} })",
             options: ["always", { considerPropertyDescriptor: true }],
             errors: [
-                { message: "Function name `baz` should match property name `bar`" }
+                { messageId: "matchProperty", data: { funcName: "baz", name: "bar" } }
             ]
         },
         {
             code: "Object.defineProperties(foo, { bar: { value: function baz() {} } })",
             options: ["always", { considerPropertyDescriptor: true }],
             errors: [
-                { message: "Function name `baz` should match property name `bar`" }
+                { messageId: "matchProperty", data: { funcName: "baz", name: "bar" } }
             ]
         },
         {
             code: "Object.create(proto, { bar: { value: function baz() {} } })",
             options: ["always", { considerPropertyDescriptor: true }],
             errors: [
-                { message: "Function name `baz` should match property name `bar`" }
+                { messageId: "matchProperty", data: { funcName: "baz", name: "bar" } }
             ]
         },
         {
             code: "var obj = { value: function foo(name) {} }",
             options: ["always", { considerPropertyDescriptor: true }],
             errors: [
-                { message: "Function name `foo` should match property name `value`" }
+                { messageId: "matchProperty", data: { funcName: "foo", name: "value" } }
             ]
         },
         {
             code: "Object.defineProperty(foo, 'bar', { value: function bar() {} })",
             options: ["never", { considerPropertyDescriptor: true }],
             errors: [
-                { message: "Function name `bar` should not match property name `bar`" }
+                { messageId: "notMatchProperty", data: { funcName: "bar", name: "bar" } }
             ]
         },
         {
             code: "Object.defineProperties(foo, { bar: { value: function bar() {} } })",
             options: ["never", { considerPropertyDescriptor: true }],
             errors: [
-                { message: "Function name `bar` should not match property name `bar`" }
+                { messageId: "notMatchProperty", data: { funcName: "bar", name: "bar" } }
             ]
         },
         {
             code: "Object.create(proto, { bar: { value: function bar() {} } })",
             options: ["never", { considerPropertyDescriptor: true }],
             errors: [
-                { message: "Function name `bar` should not match property name `bar`" }
+                { messageId: "notMatchProperty", data: { funcName: "bar", name: "bar" } }
             ]
         },
         {
             code: "Reflect.defineProperty(foo, 'bar', { value: function baz() {} })",
             options: ["always", { considerPropertyDescriptor: true }],
             errors: [
-                { message: "Function name `baz` should match property name `bar`" }
+                { messageId: "matchProperty", data: { funcName: "baz", name: "bar" } }
             ]
         },
         {
             code: "Reflect.defineProperty(foo, 'bar', { value: function bar() {} })",
             options: ["never", { considerPropertyDescriptor: true }],
             errors: [
-                { message: "Function name `bar` should not match property name `bar`" }
+                { messageId: "notMatchProperty", data: { funcName: "bar", name: "bar" } }
             ]
         }
     ]

--- a/tests/lib/rules/func-names.js
+++ b/tests/lib/rules/func-names.js
@@ -17,6 +17,7 @@ const rule = require("../../../lib/rules/func-names"),
 //------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester();
+const unnamedError = { messageId: "unnamed", type: "FunctionExpression" };
 
 ruleTester.run("func-names", rule, {
     valid: [
@@ -130,73 +131,73 @@ ruleTester.run("func-names", rule, {
     invalid: [
         {
             code: "Foo.prototype.bar = function() {};",
-            errors: [{ message: "Unexpected unnamed function.", type: "FunctionExpression" }]
+            errors: [unnamedError]
         },
         {
             code: "(function(){}())",
-            errors: [{ message: "Unexpected unnamed function.", type: "FunctionExpression" }]
+            errors: [unnamedError]
         },
         {
             code: "f(function(){})",
-            errors: [{ message: "Unexpected unnamed function.", type: "FunctionExpression" }]
+            errors: [unnamedError]
         },
         {
             code: "var a = new Date(function() {});",
-            errors: [{ message: "Unexpected unnamed function.", type: "FunctionExpression" }]
+            errors: [unnamedError]
         },
         {
             code: "var test = function(d, e, f) {};",
-            errors: [{ message: "Unexpected unnamed function.", type: "FunctionExpression" }]
+            errors: [unnamedError]
         },
         {
             code: "new function() {}",
-            errors: [{ message: "Unexpected unnamed function.", type: "FunctionExpression" }]
+            errors: [unnamedError]
         },
         {
             code: "Foo.prototype.bar = function() {};",
             options: ["as-needed"],
-            errors: [{ message: "Unexpected unnamed function.", type: "FunctionExpression" }]
+            errors: [unnamedError]
         },
         {
             code: "(function(){}())",
             options: ["as-needed"],
-            errors: [{ message: "Unexpected unnamed function.", type: "FunctionExpression" }]
+            errors: [unnamedError]
         },
         {
             code: "f(function(){})",
             options: ["as-needed"],
-            errors: [{ message: "Unexpected unnamed function.", type: "FunctionExpression" }]
+            errors: [unnamedError]
         },
         {
             code: "var a = new Date(function() {});",
             options: ["as-needed"],
-            errors: [{ message: "Unexpected unnamed function.", type: "FunctionExpression" }]
+            errors: [unnamedError]
         },
         {
             code: "new function() {}",
             options: ["as-needed"],
-            errors: [{ message: "Unexpected unnamed function.", type: "FunctionExpression" }]
+            errors: [unnamedError]
         },
         {
             code: "var {foo} = function(){};",
             options: ["as-needed"],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "Unexpected unnamed function.", type: "FunctionExpression" }]
+            errors: [unnamedError]
         },
         {
             code: "var x = function foo() {};",
             options: ["never"],
-            errors: [{ message: "Unexpected named function 'foo'.", type: "FunctionExpression" }]
+            errors: [{ messageId: "named", data: { name: "function 'foo'" }, type: "FunctionExpression" }]
         },
         {
             code: "Foo.prototype.bar = function foo() {};",
             options: ["never"],
-            errors: [{ message: "Unexpected named function 'foo'.", type: "FunctionExpression" }]
+            errors: [{ messageId: "named", data: { name: "function 'foo'" }, type: "FunctionExpression" }]
         },
         {
             code: "({foo: function foo() {}})",
             options: ["never"],
-            errors: [{ message: "Unexpected named method 'foo'.", type: "FunctionExpression" }]
+            errors: [{ messageId: "named", data: { name: "method 'foo'" }, type: "FunctionExpression" }]
         }
     ]
 });

--- a/tests/lib/rules/func-style.js
+++ b/tests/lib/rules/func-style.js
@@ -90,7 +90,7 @@ ruleTester.run("func-style", rule, {
             options: ["declaration"],
             errors: [
                 {
-                    message: "Expected a function declaration.",
+                    messageId: "declaration",
                     type: "VariableDeclarator"
                 }
             ]
@@ -101,7 +101,7 @@ ruleTester.run("func-style", rule, {
             parserOptions: { ecmaVersion: 6 },
             errors: [
                 {
-                    message: "Expected a function declaration.",
+                    messageId: "declaration",
                     type: "VariableDeclarator"
                 }
             ]
@@ -112,7 +112,7 @@ ruleTester.run("func-style", rule, {
             parserOptions: { ecmaVersion: 6 },
             errors: [
                 {
-                    message: "Expected a function declaration.",
+                    messageId: "declaration",
                     type: "VariableDeclarator"
                 }
             ]
@@ -122,7 +122,7 @@ ruleTester.run("func-style", rule, {
             options: ["expression"],
             errors: [
                 {
-                    message: "Expected a function expression.",
+                    messageId: "expression",
                     type: "FunctionDeclaration"
                 }
             ]

--- a/tests/lib/rules/function-paren-newline.js
+++ b/tests/lib/rules/function-paren-newline.js
@@ -16,10 +16,10 @@ const RuleTester = require("../../../lib/testers/rule-tester");
 // Tests
 //------------------------------------------------------------------------------
 
-const LEFT_MISSING_ERROR = { message: "Expected a newline after '('.", type: "Punctuator" };
-const LEFT_UNEXPECTED_ERROR = { message: "Unexpected newline after '('.", type: "Punctuator" };
-const RIGHT_MISSING_ERROR = { message: "Expected a newline before ')'.", type: "Punctuator" };
-const RIGHT_UNEXPECTED_ERROR = { message: "Unexpected newline before ')'.", type: "Punctuator" };
+const LEFT_MISSING_ERROR = { messageId: "expectedAfter", type: "Punctuator" };
+const LEFT_UNEXPECTED_ERROR = { messageId: "unexpectedAfter", type: "Punctuator" };
+const RIGHT_MISSING_ERROR = { messageId: "expectedBefore", type: "Punctuator" };
+const RIGHT_UNEXPECTED_ERROR = { messageId: "unexpectedBefore", type: "Punctuator" };
 
 const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
 

--- a/tests/lib/rules/generator-star-spacing.js
+++ b/tests/lib/rules/generator-star-spacing.js
@@ -18,6 +18,11 @@ const rule = require("../../../lib/rules/generator-star-spacing"),
 
 const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2018 } });
 
+const missingBeforeError = {messageId: "missing", data: {side: "before"}, type: "Punctuator"};
+const missingAfterError = {messageId: "missing", data: {side: "after"}, type: "Punctuator"};
+const unexpectedBeforeError = {messageId: "unexpected", data: {side: "before"}, type: "Punctuator"};
+const unexpectedAfterError = {messageId: "unexpected", data: {side: "after"}, type: "Punctuator"};
+
 ruleTester.run("generator-star-spacing", rule, {
 
     valid: [
@@ -487,67 +492,37 @@ ruleTester.run("generator-star-spacing", rule, {
         {
             code: "function*foo(){}",
             output: "function *foo(){}",
-            errors: [{
-                message: "Missing space before *.",
-                type: "Punctuator"
-            }]
+            errors: [missingBeforeError]
         },
         {
             code: "function* foo(arg1, arg2){}",
             output: "function *foo(arg1, arg2){}",
-            errors: [{
-                message: "Missing space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Unexpected space after *.",
-                type: "Punctuator"
-            }]
+            errors: [missingBeforeError, unexpectedAfterError]
         },
         {
             code: "var foo = function*foo(){};",
             output: "var foo = function *foo(){};",
-            errors: [{
-                message: "Missing space before *.",
-                type: "Punctuator"
-            }]
+            errors: [missingBeforeError]
         },
         {
             code: "var foo = function* (){};",
             output: "var foo = function *(){};",
-            errors: [{
-                message: "Missing space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Unexpected space after *.",
-                type: "Punctuator"
-            }]
+            errors: [missingBeforeError, unexpectedAfterError]
         },
         {
             code: "var foo = {* foo(){} };",
             output: "var foo = {*foo(){} };",
-            errors: [{
-                message: "Unexpected space after *.",
-                type: "Punctuator"
-            }]
+            errors: [unexpectedAfterError]
         },
         {
             code: "class Foo {* foo(){} }",
             output: "class Foo {*foo(){} }",
-            errors: [{
-                message: "Unexpected space after *.",
-                type: "Punctuator"
-            }]
+            errors: [unexpectedAfterError]
         },
         {
             code: "class Foo { static* foo(){} }",
             output: "class Foo { static *foo(){} }",
-            errors: [{
-                message: "Missing space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Unexpected space after *.",
-                type: "Punctuator"
-            }]
+            errors: [missingBeforeError, unexpectedAfterError]
         },
 
         // "before"
@@ -555,79 +530,49 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "function*foo(){}",
             output: "function *foo(){}",
             options: ["before"],
-            errors: [{
-                message: "Missing space before *.",
-                type: "Punctuator"
-            }]
+            errors: [missingBeforeError]
         },
         {
             code: "function* foo(arg1, arg2){}",
             output: "function *foo(arg1, arg2){}",
             options: ["before"],
-            errors: [{
-                message: "Missing space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Unexpected space after *.",
-                type: "Punctuator"
-            }]
+            errors: [missingBeforeError, unexpectedAfterError]
         },
         {
             code: "var foo = function*foo(){};",
             output: "var foo = function *foo(){};",
             options: ["before"],
-            errors: [{
-                message: "Missing space before *.",
-                type: "Punctuator"
-            }]
+            errors: [missingBeforeError]
         },
         {
             code: "var foo = function* (){};",
             output: "var foo = function *(){};",
             options: ["before"],
-            errors: [{
-                message: "Missing space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Unexpected space after *.",
-                type: "Punctuator"
-            }]
+            errors: [missingBeforeError, unexpectedAfterError]
         },
         {
             code: "var foo = {* foo(){} };",
             output: "var foo = {*foo(){} };",
             options: ["before"],
-            errors: [{
-                message: "Unexpected space after *.",
-                type: "Punctuator"
-            }]
+            errors: [unexpectedAfterError]
         },
         {
             code: "class Foo {* foo(){} }",
             output: "class Foo {*foo(){} }",
             options: ["before"],
-            errors: [{
-                message: "Unexpected space after *.",
-                type: "Punctuator"
-            }]
+            errors: [unexpectedAfterError]
         },
         {
             code: "var foo = {* [ foo ](){} };",
             output: "var foo = {*[ foo ](){} };",
             options: ["before"],
-            errors: [{
-                message: "Unexpected space after *.",
-                type: "Punctuator"
-            }]
+            errors: [unexpectedAfterError]
         },
         {
             code: "class Foo {* [ foo ](){} }",
             output: "class Foo {*[ foo ](){} }",
             options: ["before"],
-            errors: [{
-                message: "Unexpected space after *.",
-                type: "Punctuator"
-            }]
+            errors: [unexpectedAfterError]
         },
 
         // "after"
@@ -635,94 +580,55 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "function*foo(){}",
             output: "function* foo(){}",
             options: ["after"],
-            errors: [{
-                message: "Missing space after *.",
-                type: "Punctuator"
-            }]
+            errors: [missingAfterError]
         },
         {
             code: "function *foo(arg1, arg2){}",
             output: "function* foo(arg1, arg2){}",
             options: ["after"],
-            errors: [{
-                message: "Unexpected space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Missing space after *.",
-                type: "Punctuator"
-            }]
+            errors: [unexpectedBeforeError, missingAfterError]
         },
         {
             code: "var foo = function *foo(){};",
             output: "var foo = function* foo(){};",
             options: ["after"],
-            errors: [{
-                message: "Unexpected space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Missing space after *.",
-                type: "Punctuator"
-            }]
+            errors: [unexpectedBeforeError, missingAfterError]
         },
         {
             code: "var foo = function *(){};",
             output: "var foo = function* (){};",
             options: ["after"],
-            errors: [{
-                message: "Unexpected space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Missing space after *.",
-                type: "Punctuator"
-            }]
+            errors: [unexpectedBeforeError, missingAfterError]
         },
         {
             code: "var foo = { *foo(){} };",
             output: "var foo = { * foo(){} };",
             options: ["after"],
-            errors: [{
-                message: "Missing space after *.",
-                type: "Punctuator"
-            }]
+            errors: [missingAfterError]
         },
         {
             code: "class Foo { *foo(){} }",
             output: "class Foo { * foo(){} }",
             options: ["after"],
-            errors: [{
-                message: "Missing space after *.",
-                type: "Punctuator"
-            }]
+            errors: [missingAfterError]
         },
         {
             code: "class Foo { static *foo(){} }",
             output: "class Foo { static* foo(){} }",
             options: ["after"],
-            errors: [{
-                message: "Unexpected space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Missing space after *.",
-                type: "Punctuator"
-            }]
+            errors: [unexpectedBeforeError, missingAfterError]
         },
         {
             code: "var foo = { *[foo](){} };",
             output: "var foo = { * [foo](){} };",
             options: ["after"],
-            errors: [{
-                message: "Missing space after *.",
-                type: "Punctuator"
-            }]
+            errors: [missingAfterError]
         },
         {
             code: "class Foo { *[foo](){} }",
             output: "class Foo { * [foo](){} }",
             options: ["after"],
-            errors: [{
-                message: "Missing space after *.",
-                type: "Punctuator"
-            }]
+            errors: [missingAfterError]
         },
 
         // "both"
@@ -730,97 +636,55 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "function*foo(){}",
             output: "function * foo(){}",
             options: ["both"],
-            errors: [{
-                message: "Missing space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Missing space after *.",
-                type: "Punctuator"
-            }]
+            errors: [missingBeforeError, missingAfterError]
         },
         {
             code: "function*foo(arg1, arg2){}",
             output: "function * foo(arg1, arg2){}",
             options: ["both"],
-            errors: [{
-                message: "Missing space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Missing space after *.",
-                type: "Punctuator"
-            }]
+            errors: [missingBeforeError, missingAfterError]
         },
         {
             code: "var foo = function*foo(){};",
             output: "var foo = function * foo(){};",
             options: ["both"],
-            errors: [{
-                message: "Missing space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Missing space after *.",
-                type: "Punctuator"
-            }]
+            errors: [missingBeforeError, missingAfterError]
         },
         {
             code: "var foo = function*(){};",
             output: "var foo = function * (){};",
             options: ["both"],
-            errors: [{
-                message: "Missing space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Missing space after *.",
-                type: "Punctuator"
-            }]
+            errors: [missingBeforeError, missingAfterError]
         },
         {
             code: "var foo = {*foo(){} };",
             output: "var foo = {* foo(){} };",
             options: ["both"],
-            errors: [{
-                message: "Missing space after *.",
-                type: "Punctuator"
-            }]
+            errors: [missingAfterError]
         },
         {
             code: "class Foo {*foo(){} }",
             output: "class Foo {* foo(){} }",
             options: ["both"],
-            errors: [{
-                message: "Missing space after *.",
-                type: "Punctuator"
-            }]
+            errors: [missingAfterError]
         },
         {
             code: "class Foo { static*foo(){} }",
             output: "class Foo { static * foo(){} }",
             options: ["both"],
-            errors: [{
-                message: "Missing space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Missing space after *.",
-                type: "Punctuator"
-            }]
+            errors: [missingBeforeError, missingAfterError]
         },
         {
             code: "var foo = {*[foo](){} };",
             output: "var foo = {* [foo](){} };",
             options: ["both"],
-            errors: [{
-                message: "Missing space after *.",
-                type: "Punctuator"
-            }]
+            errors: [missingAfterError]
         },
         {
             code: "class Foo {*[foo](){} }",
             output: "class Foo {* [foo](){} }",
             options: ["both"],
-            errors: [{
-                message: "Missing space after *.",
-                type: "Punctuator"
-            }]
+            errors: [missingAfterError]
         },
 
         // "neither"
@@ -828,97 +692,55 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "function * foo(){}",
             output: "function*foo(){}",
             options: ["neither"],
-            errors: [{
-                message: "Unexpected space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Unexpected space after *.",
-                type: "Punctuator"
-            }]
+            errors: [unexpectedBeforeError, unexpectedAfterError]
         },
         {
             code: "function * foo(arg1, arg2){}",
             output: "function*foo(arg1, arg2){}",
             options: ["neither"],
-            errors: [{
-                message: "Unexpected space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Unexpected space after *.",
-                type: "Punctuator"
-            }]
+            errors: [unexpectedBeforeError, unexpectedAfterError]
         },
         {
             code: "var foo = function * foo(){};",
             output: "var foo = function*foo(){};",
             options: ["neither"],
-            errors: [{
-                message: "Unexpected space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Unexpected space after *.",
-                type: "Punctuator"
-            }]
+            errors: [unexpectedBeforeError, unexpectedAfterError]
         },
         {
             code: "var foo = function * (){};",
             output: "var foo = function*(){};",
             options: ["neither"],
-            errors: [{
-                message: "Unexpected space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Unexpected space after *.",
-                type: "Punctuator"
-            }]
+            errors: [unexpectedBeforeError, unexpectedAfterError]
         },
         {
             code: "var foo = { * foo(){} };",
             output: "var foo = { *foo(){} };",
             options: ["neither"],
-            errors: [{
-                message: "Unexpected space after *.",
-                type: "Punctuator"
-            }]
+            errors: [unexpectedAfterError]
         },
         {
             code: "class Foo { * foo(){} }",
             output: "class Foo { *foo(){} }",
             options: ["neither"],
-            errors: [{
-                message: "Unexpected space after *.",
-                type: "Punctuator"
-            }]
+            errors: [unexpectedAfterError]
         },
         {
             code: "class Foo { static * foo(){} }",
             output: "class Foo { static*foo(){} }",
             options: ["neither"],
-            errors: [{
-                message: "Unexpected space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Unexpected space after *.",
-                type: "Punctuator"
-            }]
+            errors: [unexpectedBeforeError, unexpectedAfterError]
         },
         {
             code: "var foo = { * [ foo ](){} };",
             output: "var foo = { *[ foo ](){} };",
             options: ["neither"],
-            errors: [{
-                message: "Unexpected space after *.",
-                type: "Punctuator"
-            }]
+            errors: [unexpectedAfterError]
         },
         {
             code: "class Foo { * [ foo ](){} }",
             output: "class Foo { *[ foo ](){} }",
             options: ["neither"],
-            errors: [{
-                message: "Unexpected space after *.",
-                type: "Punctuator"
-            }]
+            errors: [unexpectedAfterError]
         },
 
         // {"before": true, "after": false}
@@ -926,61 +748,37 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "function*foo(){}",
             output: "function *foo(){}",
             options: [{ before: true, after: false }],
-            errors: [{
-                message: "Missing space before *.",
-                type: "Punctuator"
-            }]
+            errors: [missingBeforeError]
         },
         {
             code: "function* foo(arg1, arg2){}",
             output: "function *foo(arg1, arg2){}",
             options: [{ before: true, after: false }],
-            errors: [{
-                message: "Missing space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Unexpected space after *.",
-                type: "Punctuator"
-            }]
+            errors: [missingBeforeError, unexpectedAfterError]
         },
         {
             code: "var foo = function*foo(){};",
             output: "var foo = function *foo(){};",
             options: [{ before: true, after: false }],
-            errors: [{
-                message: "Missing space before *.",
-                type: "Punctuator"
-            }]
+            errors: [missingBeforeError]
         },
         {
             code: "var foo = function* (){};",
             output: "var foo = function *(){};",
             options: [{ before: true, after: false }],
-            errors: [{
-                message: "Missing space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Unexpected space after *.",
-                type: "Punctuator"
-            }]
+            errors: [missingBeforeError, unexpectedAfterError]
         },
         {
             code: "var foo = {* foo(){} };",
             output: "var foo = {*foo(){} };",
             options: [{ before: true, after: false }],
-            errors: [{
-                message: "Unexpected space after *.",
-                type: "Punctuator"
-            }]
+            errors: [unexpectedAfterError]
         },
         {
             code: "class Foo {* foo(){} }",
             output: "class Foo {*foo(){} }",
             options: [{ before: true, after: false }],
-            errors: [{
-                message: "Unexpected space after *.",
-                type: "Punctuator"
-            }]
+            errors: [unexpectedAfterError]
         },
 
         // {"before": false, "after": true}
@@ -988,76 +786,43 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "function*foo(){}",
             output: "function* foo(){}",
             options: [{ before: false, after: true }],
-            errors: [{
-                message: "Missing space after *.",
-                type: "Punctuator"
-            }]
+            errors: [missingAfterError]
         },
         {
             code: "function *foo(arg1, arg2){}",
             output: "function* foo(arg1, arg2){}",
             options: [{ before: false, after: true }],
-            errors: [{
-                message: "Unexpected space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Missing space after *.",
-                type: "Punctuator"
-            }]
+            errors: [unexpectedBeforeError, missingAfterError]
         },
         {
             code: "var foo = function *foo(){};",
             output: "var foo = function* foo(){};",
             options: [{ before: false, after: true }],
-            errors: [{
-                message: "Unexpected space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Missing space after *.",
-                type: "Punctuator"
-            }]
+            errors: [unexpectedBeforeError, missingAfterError]
         },
         {
             code: "var foo = function *(){};",
             output: "var foo = function* (){};",
             options: [{ before: false, after: true }],
-            errors: [{
-                message: "Unexpected space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Missing space after *.",
-                type: "Punctuator"
-            }]
+            errors: [unexpectedBeforeError, missingAfterError]
         },
         {
             code: "var foo = { *foo(){} };",
             output: "var foo = { * foo(){} };",
             options: [{ before: false, after: true }],
-            errors: [{
-                message: "Missing space after *.",
-                type: "Punctuator"
-            }]
+            errors: [missingAfterError]
         },
         {
             code: "class Foo { *foo(){} }",
             output: "class Foo { * foo(){} }",
             options: [{ before: false, after: true }],
-            errors: [{
-                message: "Missing space after *.",
-                type: "Punctuator"
-            }]
+            errors: [missingAfterError]
         },
         {
             code: "class Foo { static *foo(){} }",
             output: "class Foo { static* foo(){} }",
             options: [{ before: false, after: true }],
-            errors: [{
-                message: "Unexpected space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Missing space after *.",
-                type: "Punctuator"
-            }]
+            errors: [unexpectedBeforeError, missingAfterError]
         },
 
         // {"before": true, "after": true}
@@ -1065,79 +830,43 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "function*foo(){}",
             output: "function * foo(){}",
             options: [{ before: true, after: true }],
-            errors: [{
-                message: "Missing space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Missing space after *.",
-                type: "Punctuator"
-            }]
+            errors: [missingBeforeError, missingAfterError]
         },
         {
             code: "function*foo(arg1, arg2){}",
             output: "function * foo(arg1, arg2){}",
             options: [{ before: true, after: true }],
-            errors: [{
-                message: "Missing space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Missing space after *.",
-                type: "Punctuator"
-            }]
+            errors: [missingBeforeError, missingAfterError]
         },
         {
             code: "var foo = function*foo(){};",
             output: "var foo = function * foo(){};",
             options: [{ before: true, after: true }],
-            errors: [{
-                message: "Missing space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Missing space after *.",
-                type: "Punctuator"
-            }]
+            errors: [missingBeforeError, missingAfterError]
         },
         {
             code: "var foo = function*(){};",
             output: "var foo = function * (){};",
             options: [{ before: true, after: true }],
-            errors: [{
-                message: "Missing space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Missing space after *.",
-                type: "Punctuator"
-            }]
+            errors: [missingBeforeError, missingAfterError]
         },
         {
             code: "var foo = {*foo(){} };",
             output: "var foo = {* foo(){} };",
             options: [{ before: true, after: true }],
-            errors: [{
-                message: "Missing space after *.",
-                type: "Punctuator"
-            }]
+            errors: [missingAfterError]
         },
         {
             code: "class Foo {*foo(){} }",
             output: "class Foo {* foo(){} }",
             options: [{ before: true, after: true }],
-            errors: [{
-                message: "Missing space after *.",
-                type: "Punctuator"
-            }]
+            errors: [missingAfterError]
         },
         {
             code: "class Foo { static*foo(){} }",
             output: "class Foo { static * foo(){} }",
             options: [{ before: true, after: true }],
-            errors: [{
-                message: "Missing space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Missing space after *.",
-                type: "Punctuator"
-            }]
+            errors: [missingBeforeError, missingAfterError]
         },
 
         // {"before": false, "after": false}
@@ -1145,79 +874,43 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "function * foo(){}",
             output: "function*foo(){}",
             options: [{ before: false, after: false }],
-            errors: [{
-                message: "Unexpected space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Unexpected space after *.",
-                type: "Punctuator"
-            }]
+            errors: [unexpectedBeforeError, unexpectedAfterError]
         },
         {
             code: "function * foo(arg1, arg2){}",
             output: "function*foo(arg1, arg2){}",
             options: [{ before: false, after: false }],
-            errors: [{
-                message: "Unexpected space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Unexpected space after *.",
-                type: "Punctuator"
-            }]
+            errors: [unexpectedBeforeError, unexpectedAfterError]
         },
         {
             code: "var foo = function * foo(){};",
             output: "var foo = function*foo(){};",
             options: [{ before: false, after: false }],
-            errors: [{
-                message: "Unexpected space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Unexpected space after *.",
-                type: "Punctuator"
-            }]
+            errors: [unexpectedBeforeError, unexpectedAfterError]
         },
         {
             code: "var foo = function * (){};",
             output: "var foo = function*(){};",
             options: [{ before: false, after: false }],
-            errors: [{
-                message: "Unexpected space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Unexpected space after *.",
-                type: "Punctuator"
-            }]
+            errors: [unexpectedBeforeError, unexpectedAfterError]
         },
         {
             code: "var foo = { * foo(){} };",
             output: "var foo = { *foo(){} };",
             options: [{ before: false, after: false }],
-            errors: [{
-                message: "Unexpected space after *.",
-                type: "Punctuator"
-            }]
+            errors: [unexpectedAfterError]
         },
         {
             code: "class Foo { * foo(){} }",
             output: "class Foo { *foo(){} }",
             options: [{ before: false, after: false }],
-            errors: [{
-                message: "Unexpected space after *.",
-                type: "Punctuator"
-            }]
+            errors: [unexpectedAfterError]
         },
         {
             code: "class Foo { static * foo(){} }",
             output: "class Foo { static*foo(){} }",
             options: [{ before: false, after: false }],
-            errors: [{
-                message: "Unexpected space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Unexpected space after *.",
-                type: "Punctuator"
-            }]
+            errors: [unexpectedBeforeError, unexpectedAfterError]
         },
 
         // full configurability
@@ -1225,67 +918,37 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "function*foo(){}",
             output: "function * foo(){}",
             options: [{ before: false, after: false, named: "both" }],
-            errors: [{
-                message: "Missing space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Missing space after *.",
-                type: "Punctuator"
-            }]
+            errors: [missingBeforeError, missingAfterError]
         },
         {
             code: "var foo = function*(){};",
             output: "var foo = function * (){};",
             options: [{ before: false, after: false, anonymous: "both" }],
-            errors: [{
-                message: "Missing space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Missing space after *.",
-                type: "Punctuator"
-            }]
+            errors: [missingBeforeError, missingAfterError]
         },
         {
             code: "class Foo { *foo(){} }",
             output: "class Foo { * foo(){} }",
             options: [{ before: false, after: false, method: "both" }],
-            errors: [{
-                message: "Missing space after *.",
-                type: "Punctuator"
-            }]
+            errors: [missingAfterError]
         },
         {
             code: "var foo = { *foo(){} }",
             output: "var foo = { * foo(){} }",
             options: [{ before: false, after: false, method: "both" }],
-            errors: [{
-                message: "Missing space after *.",
-                type: "Punctuator"
-            }]
+            errors: [missingAfterError]
         },
         {
             code: "var foo = { bar: function*() {} }",
             output: "var foo = { bar: function * () {} }",
             options: [{ before: false, after: false, anonymous: "both" }],
-            errors: [{
-                message: "Missing space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Missing space after *.",
-                type: "Punctuator"
-            }]
+            errors: [missingBeforeError, missingAfterError]
         },
         {
             code: "class Foo { static*foo(){} }",
             output: "class Foo { static * foo(){} }",
             options: [{ before: false, after: false, method: "both" }],
-            errors: [{
-                message: "Missing space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Missing space after *.",
-                type: "Punctuator"
-            }]
+            errors: [missingBeforeError, missingAfterError]
         },
 
         // default to top level "before"
@@ -1293,10 +956,7 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "function*foo(){}",
             output: "function *foo(){}",
             options: [{ method: "both" }],
-            errors: [{
-                message: "Missing space before *.",
-                type: "Punctuator"
-            }]
+            errors: [missingBeforeError]
         },
 
         // don't apply unrelated override
@@ -1304,13 +964,7 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "function * foo(){}",
             output: "function*foo(){}",
             options: [{ before: false, after: false, method: "both" }],
-            errors: [{
-                message: "Unexpected space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Unexpected space after *.",
-                type: "Punctuator"
-            }]
+            errors: [unexpectedBeforeError, unexpectedAfterError]
         },
 
         // ensure using object-type override works
@@ -1318,13 +972,7 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "function*foo(){}",
             output: "function * foo(){}",
             options: [{ before: false, after: false, named: { before: true, after: true } }],
-            errors: [{
-                message: "Missing space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Missing space after *.",
-                type: "Punctuator"
-            }]
+            errors: [missingBeforeError, missingAfterError]
         },
 
         // unspecified option uses default
@@ -1332,10 +980,7 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "function*foo(){}",
             output: "function *foo(){}",
             options: [{ before: false, after: false, named: { before: true } }],
-            errors: [{
-                message: "Missing space before *.",
-                type: "Punctuator"
-            }]
+            errors: [missingBeforeError]
         },
 
         // async generators
@@ -1343,73 +988,37 @@ ruleTester.run("generator-star-spacing", rule, {
             code: "({ async * foo(){} })",
             output: "({ async*foo(){} })",
             options: [{ before: false, after: false }],
-            errors: [{
-                message: "Unexpected space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Unexpected space after *.",
-                type: "Punctuator"
-            }]
+            errors: [unexpectedBeforeError, unexpectedAfterError]
         },
         {
             code: "({ async*foo(){} })",
             output: "({ async * foo(){} })",
             options: [{ before: true, after: true }],
-            errors: [{
-                message: "Missing space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Missing space after *.",
-                type: "Punctuator"
-            }]
+            errors: [missingBeforeError, missingAfterError]
         },
         {
             code: "class Foo { async * foo(){} }",
             output: "class Foo { async*foo(){} }",
             options: [{ before: false, after: false }],
-            errors: [{
-                message: "Unexpected space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Unexpected space after *.",
-                type: "Punctuator"
-            }]
+            errors: [unexpectedBeforeError, unexpectedAfterError]
         },
         {
             code: "class Foo { async*foo(){} }",
             output: "class Foo { async * foo(){} }",
             options: [{ before: true, after: true }],
-            errors: [{
-                message: "Missing space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Missing space after *.",
-                type: "Punctuator"
-            }]
+            errors: [missingBeforeError, missingAfterError]
         },
         {
             code: "class Foo { static async * foo(){} }",
             output: "class Foo { static async*foo(){} }",
             options: [{ before: false, after: false }],
-            errors: [{
-                message: "Unexpected space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Unexpected space after *.",
-                type: "Punctuator"
-            }]
+            errors: [unexpectedBeforeError, unexpectedAfterError]
         },
         {
             code: "class Foo { static async*foo(){} }",
             output: "class Foo { static async * foo(){} }",
             options: [{ before: true, after: true }],
-            errors: [{
-                message: "Missing space before *.",
-                type: "Punctuator"
-            }, {
-                message: "Missing space after *.",
-                type: "Punctuator"
-            }]
+            errors: [missingBeforeError, missingAfterError]
         }
 
     ]

--- a/tests/lib/rules/generator-star-spacing.js
+++ b/tests/lib/rules/generator-star-spacing.js
@@ -18,10 +18,10 @@ const rule = require("../../../lib/rules/generator-star-spacing"),
 
 const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2018 } });
 
-const missingBeforeError = {messageId: "missing", data: {side: "before"}, type: "Punctuator"};
-const missingAfterError = {messageId: "missing", data: {side: "after"}, type: "Punctuator"};
-const unexpectedBeforeError = {messageId: "unexpected", data: {side: "before"}, type: "Punctuator"};
-const unexpectedAfterError = {messageId: "unexpected", data: {side: "after"}, type: "Punctuator"};
+const missingBeforeError = { messageId: "missingBefore", type: "Punctuator" };
+const missingAfterError = { messageId: "missingAfter", type: "Punctuator" };
+const unexpectedBeforeError = { messageId: "unexpectedBefore", type: "Punctuator" };
+const unexpectedAfterError = { messageId: "unexpectedAfter", type: "Punctuator" };
 
 ruleTester.run("generator-star-spacing", rule, {
 

--- a/tests/lib/rules/getter-return.js
+++ b/tests/lib/rules/getter-return.js
@@ -17,8 +17,8 @@ const RuleTester = require("../../../lib/testers/rule-tester");
 //------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
-const expectedError = {messageId: "expected", data: {name: "getter 'bar'"}};
-const expectedAlwaysError = {messageId: "expectedAlways", data: {name: "getter 'bar'"}};
+const expectedError = { messageId: "expected", data: { name: "getter 'bar'" } };
+const expectedAlwaysError = { messageId: "expectedAlways", data: { name: "getter 'bar'" } };
 const options = [{ allowImplicit: true }];
 
 ruleTester.run("getter-return", rule, {
@@ -105,13 +105,13 @@ ruleTester.run("getter-return", rule, {
          * test object.defineProperty(s)
          * option: {allowImplicit: false}
          */
-        { code: "Object.defineProperty(foo, \"bar\", { get: function (){}});", errors: [{messageId: "expected", data: {name: "method 'get'"}}] },
-        { code: "Object.defineProperty(foo, \"bar\", { get: () => {}});", errors: [{messageId: "expected", data: {name: "arrow function 'get'"}}] },
-        { code: "Object.defineProperty(foo, \"bar\", { get: function (){if(bar) {return true;}}});", errors: [{ messageId: "expectedAlways"}] },
-        { code: "Object.defineProperty(foo, \"bar\", { get: function (){ ~function () { return true; }()}});", errors: [{messageId: "expected"}] },
-        { code: "Object.defineProperties(foo, { bar: { get: function () {}} });", options, errors: [{messageId: "expected"}] },
+        { code: "Object.defineProperty(foo, \"bar\", { get: function (){}});", errors: [{ messageId: "expected", data: { name: "method 'get'" } }] },
+        { code: "Object.defineProperty(foo, \"bar\", { get: () => {}});", errors: [{ messageId: "expected", data: { name: "arrow function 'get'" } }] },
+        { code: "Object.defineProperty(foo, \"bar\", { get: function (){if(bar) {return true;}}});", errors: [{ messageId: "expectedAlways" }] },
+        { code: "Object.defineProperty(foo, \"bar\", { get: function (){ ~function () { return true; }()}});", errors: [{ messageId: "expected" }] },
+        { code: "Object.defineProperties(foo, { bar: { get: function () {}} });", options, errors: [{ messageId: "expected" }] },
         { code: "Object.defineProperties(foo, { bar: { get: function (){if(bar) {return true;}}}});", options, errors: [{ messageId: "expectedAlways" }] },
-        { code: "Object.defineProperties(foo, { bar: { get: function () {~function () { return true; }()}} });", options, errors: [{messageId: "expected"}] },
+        { code: "Object.defineProperties(foo, { bar: { get: function () {~function () { return true; }()}} });", options, errors: [{ messageId: "expected" }] },
 
         // option: {allowImplicit: true}
         { code: "Object.defineProperty(foo, \"bar\", { get: function (){}});", options, errors: [{ messageId: "expected" }] }

--- a/tests/lib/rules/getter-return.js
+++ b/tests/lib/rules/getter-return.js
@@ -17,11 +17,8 @@ const RuleTester = require("../../../lib/testers/rule-tester");
 //------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
-
-// data is not working, so specify a name: "getter 'bar'"
-const name = "getter 'bar'";
-const noReturnMessage = `Expected to return a value in ${name}.`;
-const noLastReturnMessage = `Expected ${name} to always return a value.`;
+const expectedError = {messageId: "expected", data: {name: "getter 'bar'"}};
+const expectedAlwaysError = {messageId: "expectedAlways", data: {name: "getter 'bar'"}};
 const options = [{ allowImplicit: true }];
 
 ruleTester.run("getter-return", rule, {
@@ -84,39 +81,39 @@ ruleTester.run("getter-return", rule, {
          * test obj: get
          * option: {allowImplicit: false}
          */
-        { code: "var foo = { get bar() {} };", errors: [{ message: noReturnMessage }] },
-        { code: "var foo = { get bar(){if(baz) {return true;}} };", errors: [{ message: noLastReturnMessage }] },
-        { code: "var foo = { get bar() { ~function () {return true;}} };", errors: [{ message: noReturnMessage }] },
+        { code: "var foo = { get bar() {} };", errors: [expectedError] },
+        { code: "var foo = { get bar(){if(baz) {return true;}} };", errors: [expectedAlwaysError] },
+        { code: "var foo = { get bar() { ~function () {return true;}} };", errors: [expectedError] },
 
         // option: {allowImplicit: true}
-        { code: "var foo = { get bar() {} };", options, errors: [{ message: noReturnMessage }] },
-        { code: "var foo = { get bar() {if (baz) {return;}} };", options, errors: [{ message: noLastReturnMessage }] },
+        { code: "var foo = { get bar() {} };", options, errors: [expectedError] },
+        { code: "var foo = { get bar() {if (baz) {return;}} };", options, errors: [expectedAlwaysError] },
 
         /*
          * test class: get
          * option: {allowImplicit: false}
          */
-        { code: "class foo { get bar(){} }", errors: [{ message: noReturnMessage }] },
-        { code: "class foo { get bar(){ if (baz) { return true; }}}", errors: [{ noLastReturnMessage }] },
-        { code: "class foo { get bar(){ ~function () { return true; }()}}", errors: [{ noLastReturnMessage }] },
+        { code: "class foo { get bar(){} }", errors: [expectedError] },
+        { code: "class foo { get bar(){ if (baz) { return true; }}}", errors: [expectedAlwaysError] },
+        { code: "class foo { get bar(){ ~function () { return true; }()}}", errors: [expectedError] },
 
         // option: {allowImplicit: true}
-        { code: "class foo { get bar(){} }", options, errors: [{ message: noReturnMessage }] },
-        { code: "class foo { get bar(){if (baz) {return true;} } }", options, errors: [{ message: noLastReturnMessage }] },
+        { code: "class foo { get bar(){} }", options, errors: [expectedError] },
+        { code: "class foo { get bar(){if (baz) {return true;} } }", options, errors: [expectedAlwaysError] },
 
         /*
          * test object.defineProperty(s)
          * option: {allowImplicit: false}
          */
-        { code: "Object.defineProperty(foo, \"bar\", { get: function (){}});", errors: [{ noReturnMessage }] },
-        { code: "Object.defineProperty(foo, \"bar\", { get: () => {}});", errors: [{ noReturnMessage }] },
-        { code: "Object.defineProperty(foo, \"bar\", { get: function (){if(bar) {return true;}}});", errors: [{ message: "Expected method 'get' to always return a value." }] },
-        { code: "Object.defineProperty(foo, \"bar\", { get: function (){ ~function () { return true; }()}});", errors: [{ noReturnMessage }] },
-        { code: "Object.defineProperties(foo, { bar: { get: function () {}} });", options, errors: [{ noReturnMessage }] },
-        { code: "Object.defineProperties(foo, { bar: { get: function (){if(bar) {return true;}}}});", options, errors: [{ message: "Expected method 'get' to always return a value." }] },
-        { code: "Object.defineProperties(foo, { bar: { get: function () {~function () { return true; }()}} });", options, errors: [{ noReturnMessage }] },
+        { code: "Object.defineProperty(foo, \"bar\", { get: function (){}});", errors: [{messageId: "expected", data: {name: "method 'get'"}}] },
+        { code: "Object.defineProperty(foo, \"bar\", { get: () => {}});", errors: [{messageId: "expected", data: {name: "arrow function 'get'"}}] },
+        { code: "Object.defineProperty(foo, \"bar\", { get: function (){if(bar) {return true;}}});", errors: [{ messageId: "expectedAlways"}] },
+        { code: "Object.defineProperty(foo, \"bar\", { get: function (){ ~function () { return true; }()}});", errors: [{messageId: "expected"}] },
+        { code: "Object.defineProperties(foo, { bar: { get: function () {}} });", options, errors: [{messageId: "expected"}] },
+        { code: "Object.defineProperties(foo, { bar: { get: function (){if(bar) {return true;}}}});", options, errors: [{ messageId: "expectedAlways" }] },
+        { code: "Object.defineProperties(foo, { bar: { get: function () {~function () { return true; }()}} });", options, errors: [{messageId: "expected"}] },
 
         // option: {allowImplicit: true}
-        { code: "Object.defineProperty(foo, \"bar\", { get: function (){}});", options, errors: [{ message: "Expected to return a value in method 'get'." }] }
+        { code: "Object.defineProperty(foo, \"bar\", { get: function (){}});", options, errors: [{ messageId: "expected" }] }
     ]
 });

--- a/tests/lib/rules/no-magic-numbers.js
+++ b/tests/lib/rules/no-magic-numbers.js
@@ -83,37 +83,35 @@ ruleTester.run("no-magic-numbers", rule, {
             options: [{
                 enforceConst: true
             }],
-            errors: [{
-                message: "Number constants declarations must use 'const'."
-            }],
+            errors: [{ messageId: "useConst" }],
             env: { es6: true }
         },
         {
             code: "var foo = 0 + 1;",
             errors: [
-                { message: "No magic number: 0." },
-                { message: "No magic number: 1." }
+                { messageId: "noMagic", data: { raw: "0" } },
+                { messageId: "noMagic", data: { raw: "1" } }
             ]
         },
         {
             code: "a = a + 5;",
             errors: [
-                { message: "No magic number: 5." }
+                { messageId: "noMagic", data: { raw: "5" } }
             ]
         },
         {
             code: "a += 5;",
             errors: [
-                { message: "No magic number: 5." }
+                { messageId: "noMagic", data: { raw: "5" } }
             ]
         },
         {
             code: "var foo = 0 + 1 + -2 + 2;",
             errors: [
-                { message: "No magic number: 0." },
-                { message: "No magic number: 1." },
-                { message: "No magic number: -2." },
-                { message: "No magic number: 2." }
+                { messageId: "noMagic", data: { raw: "0" } },
+                { messageId: "noMagic", data: { raw: "1" } },
+                { messageId: "noMagic", data: { raw: "-2" } },
+                { messageId: "noMagic", data: { raw: "2" } }
             ]
         },
         {
@@ -122,7 +120,7 @@ ruleTester.run("no-magic-numbers", rule, {
                 ignore: [0, 1]
             }],
             errors: [
-                { message: "No magic number: 2." }
+                { messageId: "noMagic", data: { raw: "2" } }
             ]
         },
         {
@@ -131,14 +129,14 @@ ruleTester.run("no-magic-numbers", rule, {
                 detectObjects: true
             }],
             errors: [
-                { message: "No magic number: 10." }
+                { messageId: "noMagic", data: { raw: "10" } }
             ]
         }, {
             code: "console.log(0x1A + 0x02); console.log(071);",
             errors: [
-                { message: "No magic number: 0x1A." },
-                { message: "No magic number: 0x02." },
-                { message: "No magic number: 071." }
+                { messageId: "noMagic", data: { raw: "0x1A" } },
+                { messageId: "noMagic", data: { raw: "0x02" } },
+                { messageId: "noMagic", data: { raw: "071" } }
             ]
         }, {
             code: "var stats = {avg: 42};",
@@ -146,13 +144,13 @@ ruleTester.run("no-magic-numbers", rule, {
                 detectObjects: true
             }],
             errors: [
-                { message: "No magic number: 42." }
+                { messageId: "noMagic", data: { raw: "42" } }
             ]
         }, {
             code: "var colors = {}; colors.RED = 2; colors.YELLOW = 3; colors.BLUE = 4 + 5;",
             errors: [
-                { message: "No magic number: 4." },
-                { message: "No magic number: 5." }
+                { messageId: "noMagic", data: { raw: "4" } },
+                { messageId: "noMagic", data: { raw: "5" } }
             ]
         },
         {
@@ -164,7 +162,7 @@ ruleTester.run("no-magic-numbers", rule, {
         {
             code: "function getNegativeSecondsInMinute() {return -60;}",
             errors: [
-                { message: "No magic number: -60." }
+                { messageId: "noMagic", data: { raw: "-60" } }
             ]
         },
         {
@@ -192,12 +190,12 @@ ruleTester.run("no-magic-numbers", rule, {
                   "setTimeout(func, 10);\n" +
                 "}\n",
             errors: [
-                { message: "No magic number: 10.", line: 7 },
-                { message: "No magic number: 10.", line: 7 },
-                { message: "No magic number: 24.", line: 11 },
-                { message: "No magic number: 1000.", line: 15 },
-                { message: "No magic number: 0.", line: 19 },
-                { message: "No magic number: 10.", line: 22 }
+                { messageId: "noMagic", data: { raw: "10" }, line: 7 },
+                { messageId: "noMagic", data: { raw: "10" }, line: 7 },
+                { messageId: "noMagic", data: { raw: "24" }, line: 11 },
+                { messageId: "noMagic", data: { raw: "1000" }, line: 15 },
+                { messageId: "noMagic", data: { raw: "0" }, line: 19 },
+                { messageId: "noMagic", data: { raw: "10" }, line: 22 }
             ],
             env: { es6: true }
         },
@@ -205,7 +203,7 @@ ruleTester.run("no-magic-numbers", rule, {
             code: "var data = ['foo', 'bar', 'baz']; var third = data[3];",
             options: [{}],
             errors: [{
-                message: "No magic number: 3.", line: 1
+                messageId: "noMagic", data: { raw: "3" }, line: 1
             }]
         },
         {
@@ -216,18 +214,18 @@ ruleTester.run("no-magic-numbers", rule, {
                 }
             },
             errors: [
-                { message: "No magic number: 1.", line: 1 },
-                { message: "No magic number: 2.", line: 1 },
-                { message: "No magic number: 3.", line: 1 }
+                { messageId: "noMagic", data: { raw: "1" }, line: 1 },
+                { messageId: "noMagic", data: { raw: "2" }, line: 1 },
+                { messageId: "noMagic", data: { raw: "3" }, line: 1 }
             ]
         },
         {
             code: "var min, max, mean; min = 1; max = 10; mean = 4;",
             options: [{}],
             errors: [
-                { message: "No magic number: 1.", line: 1 },
-                { message: "No magic number: 10.", line: 1 },
-                { message: "No magic number: 4.", line: 1 }
+                { messageId: "noMagic", data: { raw: "1" }, line: 1 },
+                { messageId: "noMagic", data: { raw: "10" }, line: 1 },
+                { messageId: "noMagic", data: { raw: "4" }, line: 1 }
             ]
         }
     ]

--- a/tests/tools/internal-rules/consistent-meta-messages.js
+++ b/tests/tools/internal-rules/consistent-meta-messages.js
@@ -1,0 +1,38 @@
+/**
+ * @fileoverview Tests for consistent-meta-messages rule.
+ * @author 薛定谔的猫<hh_2013@foxmail.com>
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../tools/internal-rules/consistent-meta-messages");
+const RuleTester = require("../../../lib/testers/rule-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("consistent-meta-messages", rule, {
+    valid: [
+        `module.exports = {
+            meta: {
+                messages: {unexpected: "an error occurs."}
+            }
+        };`
+    ],
+    invalid: [
+        {
+            code: `
+            module.exports = {
+                meta: {}
+            };`,
+            errors: [{ messageId: "expectedMessages" }]
+        }
+    ]
+});

--- a/tools/internal-rules/consistent-meta-messages.js
+++ b/tools/internal-rules/consistent-meta-messages.js
@@ -66,21 +66,14 @@ module.exports = {
         },
         schema: [],
         messages: {
-            expectedMessages: "expected `meta.messages` property"
+            expectedMessages: "Expected `meta.messages` property"
         }
     },
 
     create(context) {
         return {
-            AssignmentExpression(node) {
-                if (node.left &&
-                    node.right &&
-                    node.left.type === "MemberExpression" &&
-                    node.left.object.name === "module" &&
-                    node.left.property.name === "exports") {
-
-                    checkMetaMessages(context, node.right);
-                }
+            "AssignmentExpression[left.object.name='module'][left.property.name='exports']"(node) {
+                checkMetaMessages(context, node.right);
             }
         };
     }

--- a/tools/internal-rules/consistent-meta-messages.js
+++ b/tools/internal-rules/consistent-meta-messages.js
@@ -1,0 +1,87 @@
+/**
+ * @fileoverview A rule to enforce using `meta.messages` property in core rules
+ * @author 薛定谔的猫<hh_2013@foxmail.com>
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Gets the property of the Object node passed in that has the name specified.
+ *
+ * @param {string} property Name of the property to return.
+ * @param {ASTNode} node The ObjectExpression node.
+ * @returns {ASTNode} The Property node or null if not found.
+ */
+function getPropertyFromObject(property, node) {
+    const properties = node.properties;
+
+    for (let i = 0; i < properties.length; i++) {
+        if (properties[i].key.name === property) {
+            return properties[i];
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Verifies that the meta.messages property is present.
+ * TODO: check it has the correct value
+ * @param {RuleContext} context The ESLint rule context.
+ * @param {ASTNode} exportsNode ObjectExpression node that the rule exports.
+ * @returns {void}
+ */
+function checkMetaMessages(context, exportsNode) {
+    if (exportsNode.type !== "ObjectExpression") {
+
+        // if the exported node is not the correct format, "internal-no-invalid-meta" will already report this.
+        return;
+    }
+
+    const metaProperty = getPropertyFromObject("meta", exportsNode);
+    const messages = metaProperty && getPropertyFromObject("messages", metaProperty.value);
+
+    if (!messages) {
+        context.report({
+            node: metaProperty,
+            messageId: "expectedMessages"
+        });
+    }
+}
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "enforce using `meta.messages` property in core rules",
+            category: "Internal",
+            recommended: false
+        },
+        schema: [],
+        messages: {
+            expectedMessages: "expected `meta.messages` property"
+        }
+    },
+
+    create(context) {
+        return {
+            AssignmentExpression(node) {
+                if (node.left &&
+                    node.right &&
+                    node.left.type === "MemberExpression" &&
+                    node.left.object.name === "module" &&
+                    node.left.property.name === "exports") {
+
+                    checkMetaMessages(context, node.right);
+                }
+            }
+        };
+    }
+};


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
+ add a interal rule: consistent-meta-messages
+ use messages in some rules

**Is there anything you'd like reviewers to focus on?**

Not all the rules have to be changed in just one PR, I plan to separate it to 3~4 PR. temporally disabled the rule, and will enable it when all the changes finished.