### PR TITLE
Docs: Add jscs-dev.github.io links to rule names in docs

### DIFF
--- a/docs/rules/array-bracket-newline.md
+++ b/docs/rules/array-bracket-newline.md
@@ -274,7 +274,7 @@ If you don't want to enforce line breaks after opening and before closing array 
 
 ## Compatibility
 
-* **JSCS:** `validateNewlineAfterArrayElements`
+* **JSCS:** [validateNewlineAfterArrayElements](https://jscs-dev.github.io/rule/validateNewlineAfterArrayElements)
 
 ## Related Rules
 

--- a/docs/rules/array-element-newline.md
+++ b/docs/rules/array-element-newline.md
@@ -290,7 +290,7 @@ If you don't want to enforce linebreaks between array elements, don't enable thi
 
 ## Compatibility
 
-* **JSCS:** `validateNewlineAfterArrayElements`
+* **JSCS:** [validateNewlineAfterArrayElements](https://jscs-dev.github.io/rule/validateNewlineAfterArrayElements)
 
 ## Related Rules
 

--- a/docs/rules/capitalized-comments.md
+++ b/docs/rules/capitalized-comments.md
@@ -245,5 +245,5 @@ This rule can be disabled if you do not care about the grammatical style of comm
 
 ## Compatibility
 
-* **JSCS**: `requireCapitalizedComments`
-* **JSCS**: `disallowCapitalizedComments`
+* **JSCS**: [requireCapitalizedComments](https://jscs-dev.github.io/rule/requireCapitalizedComments)
+* **JSCS**: [disallowCapitalizedComments](https://jscs-dev.github.io/rule/disallowCapitalizedComments)

--- a/docs/rules/func-call-spacing.md
+++ b/docs/rules/func-call-spacing.md
@@ -101,5 +101,5 @@ This rule can safely be turned off if your project does not care about enforcing
 
 ## Compatibility
 
-- **JSCS**: `disallowSpacesInCallExpression`
-- **JSCS**: `requireSpacesInCallExpression`
+- **JSCS**: [disallowSpacesInCallExpression](https://jscs-dev.github.io/rule/disallowSpacesInCallExpression)
+- **JSCS**: [requireSpacesInCallExpression](https://jscs-dev.github.io/rule/requireSpacesInCallExpression)

--- a/docs/rules/func-name-matching.md
+++ b/docs/rules/func-name-matching.md
@@ -137,4 +137,4 @@ Do not use this rule if you want to allow named functions to have different name
 
 ## Compatibility
 
-* **JSCS**: `requireMatchingFunctionName`
+* **JSCS**: [requireMatchingFunctionName](https://jscs-dev.github.io/rule/requireMatchingFunctionName)

--- a/docs/rules/func-names.md
+++ b/docs/rules/func-names.md
@@ -107,5 +107,5 @@ Foo.prototype.bar = function() {};
 
 ## Compatibility
 
-* **JSCS**: `requireAnonymousFunctions`
-* **JSCS**: `disallowAnonymousFunctions`
+* **JSCS**: [requireAnonymousFunctions](https://jscs-dev.github.io/rule/requireAnonymousFunctions)
+* **JSCS**: [disallowAnonymousFunctions](https://jscs-dev.github.io/rule/disallowAnonymousFunctions)

--- a/docs/rules/indent-legacy.md
+++ b/docs/rules/indent-legacy.md
@@ -526,8 +526,7 @@ var foo = { bar: 1,
             baz: 2 };
 ```
 
-
 ## Compatibility
 
 * **JSHint**: `indent`
-* **JSCS**: `validateIndentation`
+* **JSCS**: [validateIndentation](https://jscs-dev.github.io/rule/validateIndentation)

--- a/docs/rules/indent.md
+++ b/docs/rules/indent.md
@@ -661,4 +661,4 @@ if (foo) {
 ## Compatibility
 
 * **JSHint**: `indent`
-* **JSCS**: `validateIndentation`
+* **JSCS**: [validateIndentation](https://jscs-dev.github.io/rule/validateIndentation)

--- a/docs/rules/line-comment-position.md
+++ b/docs/rules/line-comment-position.md
@@ -103,4 +103,4 @@ If you aren't concerned about having different line comment styles, then you can
 
 ## Compatibility
 
-**JSCS**: `validateCommentPosition`
+**JSCS**: [validateCommentPosition](https://jscs-dev.github.io/rule/validateCommentPosition)

--- a/docs/rules/linebreak-style.md
+++ b/docs/rules/linebreak-style.md
@@ -83,4 +83,4 @@ If you aren't concerned about having different line endings within your code, th
 
 ## Compatibility
 
-* **JSCS**: `validateLineBreaks`
+* **JSCS**: [validateLineBreaks](https://jscs-dev.github.io/rule/validateLineBreaks)

--- a/docs/rules/lines-around-directive.md
+++ b/docs/rules/lines-around-directive.md
@@ -318,5 +318,5 @@ You can safely disable this rule if you do not have any strict conventions about
 
 ## Compatibility
 
-* **JSCS**: `requirePaddingNewLinesAfterUseStrict`
-* **JSCS**: `disallowPaddingNewLinesAfterUseStrict`
+* **JSCS**: [requirePaddingNewLinesAfterUseStrict](https://jscs-dev.github.io/rule/requirePaddingNewLinesAfterUseStrict)
+* **JSCS**: [disallowPaddingNewLinesAfterUseStrict](https://jscs-dev.github.io/rule/disallowPaddingNewLinesAfterUseStrict)

--- a/docs/rules/lines-between-class-members.md
+++ b/docs/rules/lines-between-class-members.md
@@ -106,5 +106,5 @@ If you don't want to enforce empty lines between class members, you can disable 
 
 ## Compatibility
 
-* **JSCS**: `requirePaddingNewLinesAfterBlocks`
-* **JSCS**: `disallowPaddingNewLinesAfterBlocks`
+* [requirePaddingNewLinesAfterBlocks](https://jscs-dev.github.io/rule/requirePaddingNewLinesAfterBlocks)
+* [disallowPaddingNewLinesAfterBlocks](https://jscs-dev.github.io/rule/disallowPaddingNewLinesAfterBlocks)

--- a/docs/rules/max-lines.md
+++ b/docs/rules/max-lines.md
@@ -123,4 +123,4 @@ You can turn this rule off if you are not concerned with the number of lines in 
 
 ## Compatibility
 
-* **JSCS**: `maximumNumberOfLines`
+* **JSCS**: [maximumNumberOfLines](https://jscs-dev.github.io/rule/maximumNumberOfLines)

--- a/docs/rules/multiline-ternary.md
+++ b/docs/rules/multiline-ternary.md
@@ -146,4 +146,4 @@ You can safely disable this rule if you do not have any strict conventions about
 
 ## Compatibility
 
-* **JSCS**: `requireMultiLineTernary`
+* **JSCS**: [requireMultiLineTernary](https://jscs-dev.github.io/rule/requireMultiLineTernary)

--- a/docs/rules/no-tabs.md
+++ b/docs/rules/no-tabs.md
@@ -38,4 +38,4 @@ If you have established a standard where having tabs is fine.
 
 ## Compatibility
 
-* **JSCS**: `disallowTabs`
+* **JSCS**: [disallowTabs](https://jscs-dev.github.io/rule/disallowTabs)

--- a/docs/rules/no-useless-rename.md
+++ b/docs/rules/no-useless-rename.md
@@ -117,4 +117,4 @@ You can safely disable this rule if you do not care about redundantly renaming i
 
 ## Compatibility
 
-* **JSCS**: `disallowIdenticalDestructuringNames`
+* **JSCS**: [disallowIdenticalDestructuringNames](https://jscs-dev.github.io/rule/disallowIdenticalDestructuringNames)

--- a/docs/rules/nonblock-statement-body-position.md
+++ b/docs/rules/nonblock-statement-body-position.md
@@ -155,4 +155,4 @@ If you're not concerned about consistent locations of single-line statements, yo
 
 ## Further Reading
 
-* JSCS: `requireNewlineBeforeSingleStatementsInIf`
+* JSCS: [requireNewlineBeforeSingleStatementsInIf](https://jscs-dev.github.io/rule/requireNewlineBeforeSingleStatementsInIf)

--- a/docs/rules/object-curly-newline.md
+++ b/docs/rules/object-curly-newline.md
@@ -511,8 +511,8 @@ export { foo as f, bar } from 'foo-bar';
 
 ## Compatibility
 
-* **JSCS**: `requirePaddingNewLinesInObjects`
-* **JSCS**: `disallowPaddingNewLinesInObjects`
+* **JSCS**: [requirePaddingNewLinesInObjects](https://jscs-dev.github.io/rule/requirePaddingNewLinesInObjects)
+* **JSCS**: [disallowPaddingNewLinesInObjects](https://jscs-dev.github.io/rule/disallowPaddingNewLinesInObjects)
 
 ## When Not To Use It
 

--- a/docs/rules/object-property-newline.md
+++ b/docs/rules/object-property-newline.md
@@ -260,7 +260,7 @@ You can turn this rule off if you want to decide, case-by-case, whether to place
 
 ## Compatibility
 
-- **JSCS**: This rule provides partial compatibility with `requireObjectKeysOnNewLine`.
+- **JSCS**: This rule provides partial compatibility with [requireObjectKeysOnNewLine](https://jscs-dev.github.io/rule/requireObjectKeysOnNewLine).
 
 ## Related Rules
 

--- a/docs/rules/one-var.md
+++ b/docs/rules/one-var.md
@@ -536,5 +536,5 @@ function foo() {
 ## Compatibility
 
 * **JSHint**: This rule maps to the `onevar` JSHint rule, but allows `let` and `const` to be configured separately.
-* **JSCS**: This rule roughly maps to `disallowMultipleVarDecl`.
-* **JSCS**: This rule option `separateRequires` roughly maps to `requireMultipleVarDecl`.
+* **JSCS**: This rule roughly maps to [disallowMultipleVarDecl](https://jscs-dev.github.io/rule/disallowMultipleVarDecl).
+* **JSCS**: This rule option `separateRequires` roughly maps to [requireMultipleVarDecl](https://jscs-dev.github.io/rule/requireMultipleVarDecl).

--- a/docs/rules/prefer-numeric-literals.md
+++ b/docs/rules/prefer-numeric-literals.md
@@ -53,4 +53,4 @@ If you want to allow use of `parseInt()` or `Number.parseInt()` for binary, octa
 
 ## Compatibility
 
-* **JSCS**: `requireNumericLiterals`
+* **JSCS**: [requireNumericLiterals](https://jscs-dev.github.io/rule/requireNumericLiterals)

--- a/docs/rules/sort-keys.md
+++ b/docs/rules/sort-keys.md
@@ -178,4 +178,4 @@ If you don't want to notify about properties' order, then it's safe to disable t
 
 ## Compatibility
 
-* **JSCS:** `validateOrderInObjectKeys`
+* **JSCS:** [validateOrderInObjectKeys](https://jscs-dev.github.io/rule/validateOrderInObjectKeys)


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
I "reverted" a recent pull request that removed links for JSCS rule names spread through the docs. I have replaced them with the new jscs-dev.github.io link target.

**Is there anything you'd like reviewers to focus on?**
I am probably stepping on this guy's toes ( #10736 ) by doing this but it is a trivial change, and I hope everyone forgives me. If possible though, could I get some guidance on how to deal with the other suggested PRs? #10706 and #10737 as well as any other ones I may have missed? One of them is stuck in triage. I am merely attempting to get some of this stuff moving along through the pipes. Any help with this is appreciated. A way to consolidate all these might be even better!

