### PR TITLE
Update: camelcase rule ignoreList added

### DIFF
--- a/docs/rules/camelcase.md
+++ b/docs/rules/camelcase.md
@@ -14,6 +14,7 @@ This rule has an object option:
 * `"properties": "never"` does not check property names
 * `"ignoreDestructuring": false` (default) enforces camelcase style for destructured identifiers
 * `"ignoreDestructuring": true` does not check destructured identifiers
+* `allow` (`string[]`) list of properties to accept. Accept regex.
 
 ### properties: "always"
 
@@ -149,6 +150,30 @@ var { category_id } = query;
 var { category_id = 1 } = query;
 
 var { category_id: category_id } = query;
+```
+
+## allow
+
+Examples of **correct** code for this rule with the `allow` option:
+
+```js
+/*eslint camelcase: ["error", {allow: ["UNSAFE_componentWillMount"]}]*/
+
+function UNSAFE_componentWillMount() {
+    // ...
+}
+```
+
+```js
+/*eslint camelcase: ["error", {allow: ["^UNSAFE_"]}]*/
+
+function UNSAFE_componentWillMount() {
+    // ...
+}
+
+function UNSAFE_componentWillMount() {
+    // ...
+}
 ```
 
 ## When Not To Use It

--- a/tests/lib/rules/camelcase.js
+++ b/tests/lib/rules/camelcase.js
@@ -181,6 +181,18 @@ ruleTester.run("camelcase", rule, {
         {
             code: "function foo({ trailing_ }) {}",
             parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "ignored_foo = 0;",
+            options: [{ allow: ["ignored_foo"] }]
+        },
+        {
+            code: "ignored_foo = 0; ignored_bar = 1;",
+            options: [{ allow: ["ignored_foo", "ignored_bar"] }]
+        },
+        {
+            code: "user_id = 0;",
+            options: [{ allow: ["_id$"] }]
         }
     ],
     invalid: [
@@ -541,6 +553,26 @@ ruleTester.run("camelcase", rule, {
             errors: [
                 {
                     message: "Identifier 'no_camelcased' is not in camel case.",
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
+            code: "not_ignored_foo = 0;",
+            options: [{ allow: ["ignored_bar"] }],
+            errors: [
+                {
+                    message: "Identifier 'not_ignored_foo' is not in camel case.",
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
+            code: "not_ignored_foo = 0;",
+            options: [{ allow: ["_id$"] }],
+            errors: [
+                {
+                    message: "Identifier 'not_ignored_foo' is not in camel case.",
                     type: "Identifier"
                 }
             ]


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[ ] New rule
[X] Changes an existing rule
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What rule do you want to change?**

camelcase

**Does this change cause the rule to produce more or fewer warnings?**

No, only less if used.

**How will the change be implemented? (New option, new default behavior, etc.)?**

New option to the rule.

**Please provide some example code that this change will affect:**

```js
class MyComponent extends React.Component {
  UNSAFE_componentWillMount() {
    // ...
  }
}
```

**What does the rule currently do for this code?**

It throw an error: `Identifier 'UNSAFE_componentWillMount' is not in camel case.`

**What will the rule do after it's changed?**

Using the added option: `{ ignoreList: ["UNSAFE_componentWillMount"] }` will allow this method name.

**What changes did you make? (Give an overview)**

Camel case is used, more and more, but there is still many use of underscore, basically for:
 - The `_id` for MongoDB
 - So, many people still use underscore for identifiers, like: `user_id`
 - Also, some methods of some frameworks like React have methods like `UNSAFE_componentWillMount`
 - etc.

I have seen some discussions, it seems that people is trying to find the best way to do what this update add:
 - Ignoring all variables finishing with `_id`, with the option `{ ignoreList: ["_id$"] }`
 - Ignoring all methods starting with `UNSAFE_`, with the option `{ ignoreList: ["^UNSAFE_"] }`
 - Or add some of their specific variables: `{ ignoreList: ["_main_contex_"] }`
 
Basically, it allow to ignore specific variables, and/or regexp pattern, simply.

One of the discussions, for example: https://github.com/eslint/eslint/issues/9435
 
**Also**: I've seen this PR: https://github.com/eslint/eslint/issues/10503, after my work :( But I prefer mine, do not hesitate to close this one. My bad.

**Is there anything you'd like reviewers to focus on?**

Tests, I have added some tests for my rule, but no overkill tests basically cover some already covered scenarios.