### PR TITLE
Fix: getJSDocComment - Try using looser "Property" as a fence

### DIFF
--- a/lib/util/source-code.js
+++ b/lib/util/source-code.js
@@ -358,7 +358,7 @@ class SourceCode extends TokenStore {
                         !this.getCommentsBefore(parent).length &&
                         !/Function/.test(parent.type) &&
                         parent.type !== "MethodDefinition" &&
-                        parent.type !== "Property"
+                        !/Property/.test(parent.type)
                     ) {
                         parent = parent.parent;
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
As deeply described in this issue: https://github.com/eslint/eslint/issues/10790 there is currently an issue with using babel-supplied JS features and `getJSDocComment` which is currently making my life hard trying to add features to the `eslint-plugin-jsdoc` https://github.com/gajus/eslint-plugin-jsdoc/pull/83 (at least with certain parsers). This is an attempt to support these other tokens without forcing in this experimental syntax. All tests continue to pass, but unfortunately I wasn't able to create a test which showed this issue without adding dependencies. I can however demonstrate this working:

Working based on this branch: https://github.com/brokentone/eslint/tree/bug/babel-eslint-arrow-jsdoc-fix
Failing based on master: https://github.com/brokentone/eslint/tree/bug/babel-eslint-arrow-jsdoc

**Is there anything you'd like reviewers to focus on?**


