### PR TITLE
Fix: camelcase duplicate warning bug (fixes #10801)

### DIFF
--- a/lib/rules/camelcase.js
+++ b/lib/rules/camelcase.js
@@ -145,7 +145,7 @@ module.exports = {
                         const assignmentKeyEqualsValue = node.parent.key.name === node.parent.value.name;
 
                         // prevent checking righthand side of destructured object
-                        if (!assignmentKeyEqualsValue && node.parent.key === node) {
+                        if (node.parent.key === node && node.parent.value !== node) {
                             return;
                         }
 

--- a/tests/lib/rules/camelcase.js
+++ b/tests/lib/rules/camelcase.js
@@ -353,6 +353,17 @@ ruleTester.run("camelcase", rule, {
             ]
         },
         {
+            code: "var { category_id: category_id } = query;",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "notCamelCase",
+                    data: { name: "category_id" },
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
             code: "var { category_id = 1 } = query;",
             parserOptions: { ecmaVersion: 6 },
             errors: [


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
See #10801 for description of behavior

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Fixed the logic in `lib/rules/camelcase.js`, and added a test that would've been broken before the fix

Basically, there appears to have been faulty logic introduced by #10373:

This guard (pre-#10373) was preventing reporting the `key` of a `Property`:
```
node.parent.key === node && node.parent.value !== node
```
Then #10373 replaced that guard with this:
```
!assignmentKeyEqualsValue && node.parent.key === node
```
The hole introduced in the logic is if `assignmentKeyEqualsValue` but `node.parent.key !== node.parent.value`, the `value` gets reported twice (once while visiting the `key` and once while visiting the `value`)

I believe that the only reason existing `invalid` tests like `var { category_id } = query;` weren't failing on duplicate warnings is that the default parser (`espree`?) must reuse the same `Identifier` node for the `key` and `value` of a shorthand `Property` (as opposed to the Coffeescript custom parser I'm working on, which doesn't reuse the same node, thus how I found this bug)

But then by adding an `invalid` test for `var { category_id: category_id } = query;`, you get a duplicate warning (it exposes the hole in the logic, since `assignmentKeyEqualsValue` but the `Property`'s `key` and `value` are two different `Identifier` objects)

So the fix is basically to restore the pre-#10373 guard logic so that you effectively never visit the `Property` `key`

**Is there anything you'd like reviewers to focus on?**


