### PR TITLE
Upgrade: babel-code-frame to version 7

### DIFF
--- a/lib/formatters/codeframe.js
+++ b/lib/formatters/codeframe.js
@@ -5,7 +5,7 @@
 "use strict";
 
 const chalk = require("chalk");
-const codeFrame = require("babel-code-frame");
+const { codeFrameColumns } = require("@babel/code-frame");
 const path = require("path");
 
 //------------------------------------------------------------------------------
@@ -63,7 +63,7 @@ function formatMessage(message, parentResult) {
 
     if (sourceCode) {
         result.push(
-            codeFrame(sourceCode, message.line, message.column, { highlightCode: false })
+            codeFrameColumns(sourceCode, { start: { line: message.line, column: message.column } }, { highlightCode: false })
         );
     }
 

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   "homepage": "https://eslint.org",
   "bugs": "https://github.com/eslint/eslint/issues/",
   "dependencies": {
+    "@babel/code-frame": "^7.0.0",
     "ajv": "^6.5.3",
-    "babel-code-frame": "^6.26.0",
     "chalk": "^2.1.0",
     "cross-spawn": "^6.0.5",
     "debug": "^3.1.0",


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] Other, please explain:

Bumping babel-code-frame to version 7. Note I didn't touch the babel version used in the build process, only code-frame.
<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**


**Is there anything you'd like reviewers to focus on?**


