### PR TITLE
Update: max-params to only highlight function header

### DIFF
--- a/lib/rules/max-params.js
+++ b/lib/rules/max-params.js
@@ -53,7 +53,7 @@ module.exports = {
     },
 
     create(context) {
-
+        const sourceCode = context.getSourceCode();
         const option = context.options[0];
         let numParams = 3;
 
@@ -76,6 +76,7 @@ module.exports = {
         function checkFunction(node) {
             if (node.params.length > numParams) {
                 context.report({
+                    loc: astUtils.getFunctionHeadLoc(node, sourceCode),
                     node,
                     message: "{{name}} has too many parameters ({{count}}). Maximum allowed is {{max}}.",
                     data: {

--- a/tests/lib/rules/max-params.js
+++ b/tests/lib/rules/max-params.js
@@ -86,6 +86,20 @@ ruleTester.run("max-params", rule, {
                 message: "Function 'test' has too many parameters (3). Maximum allowed is 2.",
                 type: "FunctionDeclaration"
             }]
+        },
+
+        // Error location should not cover the entire function; just the name.
+        {
+            code: `function test(a, b, c) {
+              // Just to make it longer
+            }`,
+            options: [{ max: 2 }],
+            errors: [{
+                line: 1,
+                column: 1,
+                endLine: 1,
+                endColumn: 14
+            }]
         }
     ]
 });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Update the max-params rule to only report the location of the method header. Some tools, like Nuclide, will otherwise highlight the entire body of the method, which makes the rule visually noisy in practice.

**What rule do you want to change?**

max-params

**Does this change cause the rule to produce more or fewer warnings?**

No.

**How will the change be implemented? (New option, new default behavior, etc.)?**

New location reporting.

**Please provide some example code that this change will affect:**

```js
function foo(a, b, c, d, e, f, g) {
  // long body
  // on multiple
  // lines
}
```

**What does the rule currently do for this code?**

Highlights the entire function:

```js
function foo(a, b, c, d, e, f, g) {
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  // long body
^^^^^^^^^^^^^^
  // on multiple
^^^^^^^^^^^^^^^^
  // lines
^^^^^^^^^^
}
^
```

**What will the rule do after it's changed?**

Highlights only the function header:

```js
function foo(a, b, c, d, e, f, g) {
^^^^^^^^^^^^
  // long body
  // on multiple
  // lines
}
```

I also considered highlighting the entire params list, but it is not really
necessary, and has more noise when the function has a multi-line param list.


**Is there anything you'd like reviewers to focus on?**

It is fairly simple, just look at the test.