### PR TITLE
Docs: allow offline TSC votes

### DIFF
--- a/docs/maintainer-guide/governance.md
+++ b/docs/maintainer-guide/governance.md
@@ -127,6 +127,8 @@ No binding votes on TSC agenda items can take place without a quorum of
 TSC members present in the meeting. Quorum is achieved when more than
 half of the TSC members are present.
 
+If an item is on the TSC agenda, but the TSC is unable to discuss it during a regularly-scheduled meeting (e.g. if the meeting time is taken up with discussion about other topics, or quorum is not achieved for the meeting), then a TSC member may request an offline vote on the item through another medium, such as reactions on GitHub. An offline vote is considered to be binding when a majority of TSC members have voted for a particular result, and no TSC members have expressed opposition to that result. If any TSC members have expressed opposition to a result before the vote is binding, then the offline vote is invalidated and the item should be discussed during a TSC meeting.
+
 The TSC may invite persons or representatives from certain projects to
 participate in a non-voting capacity.
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates the governance documentation to allow for offline votes on a TSC agenda item if an item is unable to be discussed during a regularly-scheduled TSC meeting.

This has the following goals:

* Formalize the policy of ":+1:s from a majority of TSC members" that we've already been informally following anyway
* Allow time-sensitive TSC agenda items to be resolved when meetings don't reach quorum
* Preserve the ability for a TSC member to object to a proposal and discuss their objections in a meeting

The requirement for offline votes that "the TSC was unable to discuss [the issue] during a regularly-scheduled meeting" is put in place to ensure that TSC members have the opportunity to object to a proposal if they disagree with it. If a TSC member is unable to attend a meeting, then typically they might not be able to voice an objection to an issue anyway (since the issue might get approved by a majority of TSC members in their absence).

**Is there anything you'd like reviewers to focus on?**

Nothing in particular, but feel free to give feedback on the general approach and whether you think this is a good idea.
