### PR TITLE
custom parser hook for code path analysis

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -13,7 +13,6 @@ const eslintScope = require("eslint-scope"),
     evk = require("eslint-visitor-keys"),
     levn = require("levn"),
     lodash = require("lodash"),
-    CodePathAnalyzer = require("./code-path-analysis/code-path-analyzer"),
     ConfigOps = require("./config/config-ops"),
     validator = require("./config/config-validator"),
     Environments = require("./config/environments"),
@@ -586,6 +585,7 @@ function parse(text, providedParserOptions, parserName, parserMap, filePath) {
         const parserServices = parseResult.services || {};
         const visitorKeys = parseResult.visitorKeys || evk.KEYS;
         const scopeManager = parseResult.scopeManager || analyzeScope(ast, parserOptions, visitorKeys);
+        const CodePathAnalyzer = parseResult.CodePathAnalyzer;
 
         return {
             success: true,
@@ -601,7 +601,8 @@ function parse(text, providedParserOptions, parserName, parserMap, filePath) {
                 ast,
                 parserServices,
                 scopeManager,
-                visitorKeys
+                visitorKeys,
+                CodePathAnalyzer
             })
         };
     } catch (ex) {
@@ -851,7 +852,7 @@ function runRules(sourceCode, configuredRules, ruleMapper, parserOptions, parser
         });
     });
 
-    const eventGenerator = new CodePathAnalyzer(new NodeEventGenerator(emitter));
+    const eventGenerator = new sourceCode.CodePathAnalyzer(new NodeEventGenerator(emitter));
 
     nodeQueue.forEach(traversalInfo => {
         currentNode = traversalInfo.node;

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -550,6 +550,7 @@ function parse(text, providedParserOptions, parserName, parserMap, filePath) {
         comment: true,
         eslintVisitorKeys: true,
         eslintScopeManager: true,
+        eslintCodePathAnalyzer: true,
         filePath
     });
 

--- a/lib/util/source-code.js
+++ b/lib/util/source-code.js
@@ -10,6 +10,7 @@
 
 const TokenStore = require("../token-store"),
     Traverser = require("./traverser"),
+    CodePathAnalyzer = require("../code-path-analysis/code-path-analyzer"),
     astUtils = require("../util/ast-utils"),
     lodash = require("lodash");
 
@@ -90,11 +91,12 @@ class SourceCode extends TokenStore {
      * @param {Object|null} textOrConfig.parserServices - The parser srevices.
      * @param {ScopeManager|null} textOrConfig.scopeManager - The scope of this source code.
      * @param {Object|null} textOrConfig.visitorKeys - The visitor keys to traverse AST.
+     * @param {Class|null} textOrConfig.CodePathAnalyzer - The code path analyzer class to use when traversing the AST.
      * @param {ASTNode} [astIfNoConfig] - The Program node of the AST representing the code. This AST should be created from the text that BOM was stripped.
      * @constructor
      */
     constructor(textOrConfig, astIfNoConfig) {
-        let text, ast, parserServices, scopeManager, visitorKeys;
+        let text, ast, parserServices, scopeManager, visitorKeys, CustomCodePathAnalyzer;
 
         // Process overloading.
         if (typeof textOrConfig === "string") {
@@ -106,6 +108,7 @@ class SourceCode extends TokenStore {
             parserServices = textOrConfig.parserServices;
             scopeManager = textOrConfig.scopeManager;
             visitorKeys = textOrConfig.visitorKeys;
+            CustomCodePathAnalyzer = textOrConfig.CodePathAnalyzer;
         }
 
         validate(ast);
@@ -147,6 +150,12 @@ class SourceCode extends TokenStore {
          * @type {Object}
          */
         this.visitorKeys = visitorKeys || Traverser.DEFAULT_VISITOR_KEYS;
+
+        /**
+         * The code path analyzer class to use when traversing the AST.
+         * @type {Class}
+         */
+        this.CodePathAnalyzer = CustomCodePathAnalyzer || CodePathAnalyzer;
 
         // Check the source text for the presence of a shebang since it is parsed as a standard line comment.
         const shebangMatched = this.text.match(astUtils.SHEBANG_MATCHER);

--- a/tests/fixtures/parsers/enhanced-parser-with-code-path-analyzer.js
+++ b/tests/fixtures/parsers/enhanced-parser-with-code-path-analyzer.js
@@ -1,0 +1,35 @@
+"use strict";
+
+const assert = require("assert");
+
+class Passthrough {
+    constructor(eventGenerator) {
+        this.eventGenerator = eventGenerator;
+    }
+
+    enterNode(node) {
+        this.eventGenerator.enterNode(node);
+    }
+
+    leaveNode(node) {
+        this.eventGenerator.leaveNode(node);
+    }
+
+    onLooped() {}
+}
+
+exports.parseForESLint = (code, options) => {
+    assert(code === "foo()");
+    assert(options.eslintCodePathAnalyzer === true);
+
+    const ast = { type: 'Program', comments: [], loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 5 } }, range: [ 0, 5 ], start: 0, end: 5, tokens: [ { type: 'IDENTIFIER', value: 'foo', loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 3 } }, range: [ 0, 3 ], start: 0, end: 3 }, { type: 'Punctuator', value: '(', loc: { start: { line: 1, column: 3 }, end: { line: 1, column: 4 } }, range: [ 3, 4 ], start: 3, end: 4 }, { type: 'Punctuator', value: ')', loc: { start: { line: 1, column: 4 }, end: { line: 1, column: 5 } }, range: [ 4, 5 ], start: 4, end: 5 } ], sourceType: 'module', directives: undefined, body: [ { type: 'ExpressionStatement', expression: { callee: { name: 'foo', declaration: undefined, type: 'Identifier', loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 3 } }, range: [ 0, 3 ], start: 0, end: 3, _babelType: 'Identifier' }, arguments: [], optional: false, type: 'CallExpression', loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 5 } }, range: [ 0, 5 ], start: 0, end: 5, _babelType: 'CallExpression' }, loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 5 } }, range: [ 0, 5 ], start: 0, end: 5, comments: [], _babelType: 'ExpressionStatement' } ] };
+
+    return {
+        ast,
+        CodePathAnalyzer: Passthrough,
+    };
+};
+
+exports.parse = function () {
+    throw new Error("Use parseForESLint() instead.");
+};

--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -4608,6 +4608,33 @@ describe("Linter", () => {
                 });
             });
 
+            describe("if a parser provides 'CodePathAnalyzer'", () => {
+                let codePathStartFired = false;
+                let programFired = false;
+
+                beforeEach(() => {
+                    const parser = path.join(parserFixtures, "enhanced-parser-with-code-path-analyzer.js");
+
+                    linter.defineRule("save-code-path-start", () => ({
+                        onCodePathStart() {
+                            codePathStartFired = true;
+                        },
+                        Program() {
+                            programFired = true;
+                        }
+                    }));
+                    linter.verify("foo()", { parser, rules: { "save-code-path-start": 2 } });
+                });
+
+                it("should fire program event", () => {
+                    assert(programFired);
+                });
+
+                it("should not fire code path events", () => {
+                    assert(!codePathStartFired);
+                });
+            });
+
             it("should not pass any default parserOptions to the parser", () => {
                 const parser = path.join(parserFixtures, "throws-with-options.js");
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[X] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

As I mentioned in #10801, I'm working on a custom parser for Coffeescript (in [eslint-plugin-coffeescript](https://github.com/helixbass/eslint-plugin-coffeescript))

Overall, the integration has been going nicely, I'm successfully using the `visitorKeys` and `scopeManager` custom parser hooks

But I ran into another need that's not currently exposed as a custom parser hook: Coffeescript requires some slightly different code path analysis (eg `switch` cases implicitly break, `and`/`or`/`?` logical operators, differently structured `for` loops)

So this PR adds a `CodePathAnalyzer` custom parser hook

I looked through #8755 for reference. It seemed most appropriate to store the custom `CodePathAnalyzer` in the `SourceCode` object along with the other custom parser hooks

I'm assuming I'll also need to try and provide a monkeypatching fallback (a la `babel-eslint`) when running against a version of ESLint that doesn't support this new custom parser hook. But it's working nicely running against this branch, I'm successfully using a customized version of ESLint's `CodePathAnalyzer` (and friends)

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Exposed an additional custom parser hook `CodePathAnalyzer`

**Is there anything you'd like reviewers to focus on?**
What I'm aware of as potential todos:
- the commit messages on this branch aren't currently using the recommended format, given that there are currently a few small commits I wasn't sure how you'd prefer this branch to look?
- presumably the "working with custom parsers" docs would have to be updated to describe this additional hook, the version in which it was added, and the presence of the `eslintCodePathAnalyzer` flag to indicate that it's supported (like the other custom parser hooks)

