### PR TITLE
Fix: respect generator function expressions in no-constant-condition

### DIFF
--- a/lib/rules/no-constant-condition.js
+++ b/lib/rules/no-constant-condition.js
@@ -207,6 +207,8 @@ module.exports = {
             "ForStatement:exit": checkConstantConditionLoopInSet,
             FunctionDeclaration: enterFunction,
             "FunctionDeclaration:exit": exitFunction,
+            FunctionExpression: enterFunction,
+            "FunctionExpression:exit": exitFunction,
             YieldExpression: () => loopsInCurrentScope.clear()
         };
 

--- a/tests/lib/rules/no-constant-condition.js
+++ b/tests/lib/rules/no-constant-condition.js
@@ -153,6 +153,10 @@ ruleTester.run("no-constant-condition", rule, {
             errors: [{ messageId: "unexpected", type: "Literal" }]
         },
         {
+            code: "function foo() {while (true) {const bar = function*() {while (true) {yield;}}}}",
+            errors: [{ messageId: "unexpected", type: "Literal" }]
+        },
+        {
             code: "function* foo() { for (let foo = 1 + 2 + 3 + (yield); true; baz) {}}",
             errors: [{ messageId: "unexpected", type: "Literal" }]
         }


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
See #10826 for a description of the bug/environment

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Made `no-constant-condition` behave the same with respect to generator `FunctionExpression`s as it does for generator `FunctionDeclaration`s

**Is there anything you'd like reviewers to focus on?**


