### PR TITLE
Fix: Remove duplicate error message on crash (fixes #8964)

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -48,7 +48,6 @@ process.once("uncaughtException", err => {
         console.error(`\nESLint: ${pkg.version}.\n${template(err.messageData || {})}`);
     } else {
 
-        console.error(err.message);
         console.error(err.stack);
     }
 

--- a/tests/bin/eslint.js
+++ b/tests/bin/eslint.js
@@ -333,12 +333,28 @@ describe("bin/eslint.js", () => {
             return Promise.all([exitCodeAssertion, outputAssertion]);
         });
 
+        it("prints the error message exactly once to stderr in the event of a crash", () => {
+            const child = runESLint(["--rule=no-restricted-syntax:[error, 'Invalid Selector [[[']", "Makefile.js"]);
+            const exitCodeAssertion = assertExitCode(child, 2);
+            const outputAssertion = getOutput(child).then(output => {
+                const expectedSubstring = "Syntax error in selector";
+
+                assert.strictEqual(output.stdout, "");
+                assert.include(output.stderr, expectedSubstring);
+
+                // The message should appear exactly once in stderr
+                assert.strictEqual(output.stderr.indexOf(expectedSubstring), output.stderr.lastIndexOf(expectedSubstring));
+            });
+
+            return Promise.all([exitCodeAssertion, outputAssertion]);
+        });
+
         it("prints the error message pointing to line of code", () => {
             const invalidConfig = `${__dirname}/../fixtures/bin/.eslintrc.yml`;
             const child = runESLint(["--no-ignore", invalidConfig]);
             const exitCodeAssertion = assertExitCode(child, 2);
             const outputAssertion = getOutput(child).then(output => {
-                const expectedSubstring = "Error: bad indentation of a mapping entry at line";
+                const expectedSubstring = ": bad indentation of a mapping entry at line";
 
                 assert.strictEqual(output.stdout, "");
                 assert.include(output.stderr, expectedSubstring);


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Removed the extra console output that included just the error message and updated the associated tests.


**Is there anything you'd like reviewers to focus on?**

No
