### PR TITLE
Fix: optional chain camelcase rule fix (fixes #10848)

### DIFF
--- a/lib/rules/camelcase.js
+++ b/lib/rules/camelcase.js
@@ -6,6 +6,22 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+const MEMBER_EXPRESSIONS = ["MemberExpression", "OptionalMemberExpression"];
+
+/**
+ * Checks if expression is supported member expression.
+ *
+ * @param {string} expression - An expression to check.
+ * @returns {boolean} `true` if the expression type is supported
+ */
+function isMemberExpression(expression) {
+    return MEMBER_EXPRESSIONS.indexOf(expression) >= 0;
+}
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
@@ -110,10 +126,10 @@ module.exports = {
                  * private/protected identifiers, strip them
                  */
                 const name = node.name.replace(/^_+|_+$/g, ""),
-                    effectiveParent = (node.parent.type === "MemberExpression") ? node.parent.parent : node.parent;
+                    effectiveParent = isMemberExpression(node.parent.type) ? node.parent.parent : node.parent;
 
                 // MemberExpressions get special rules
-                if (node.parent.type === "MemberExpression") {
+                if (isMemberExpression(node.parent.type)) {
 
                     // "never" check properties
                     if (properties === "never") {
@@ -125,7 +141,7 @@ module.exports = {
                         report(node);
 
                     // Report AssignmentExpressions only if they are the left side of the assignment
-                    } else if (effectiveParent.type === "AssignmentExpression" && isUnderscored(name) && (effectiveParent.right.type !== "MemberExpression" || effectiveParent.left.type === "MemberExpression" && effectiveParent.left.property.name === node.name)) {
+                    } else if (effectiveParent.type === "AssignmentExpression" && isUnderscored(name) && (!isMemberExpression(effectiveParent.right.type) || isMemberExpression(effectiveParent.left.type) && effectiveParent.left.property.name === node.name)) {
                         report(node);
                     }
 

--- a/tests/fixtures/parsers/babel-eslint9/optional-chaining-assignment.js
+++ b/tests/fixtures/parsers/babel-eslint9/optional-chaining-assignment.js
@@ -1,0 +1,305 @@
+'use strict';
+
+/**
+ * Parser: babel-eslint v9.0.0
+ * Source code: var foo = bar?.a_b;
+ * type TransformFunction = (el: ASTElement, code: string) => string;
+ */
+
+exports.parse = () => ({
+        'type': 'Program',
+        'start': 0,
+        'end': 19,
+        'loc': {
+            'start': {
+                'line': 1,
+                'column': 0
+            },
+            'end': {
+                'line': 1,
+                'column': 19
+            }
+        },
+        'range': [
+            0,
+            19
+        ],
+        'comments': [],
+        'tokens': [
+            {
+                'type': 'Keyword',
+                'value': 'var',
+                'start': 0,
+                'end': 3,
+                'loc': {
+                    'start': {
+                        'line': 1,
+                        'column': 0
+                    },
+                    'end': {
+                        'line': 1,
+                        'column': 3
+                    }
+                },
+                'range': [
+                    0,
+                    3
+                ]
+            },
+            {
+                'type': 'Identifier',
+                'value': 'foo',
+                'start': 4,
+                'end': 7,
+                'loc': {
+                    'start': {
+                        'line': 1,
+                        'column': 4
+                    },
+                    'end': {
+                        'line': 1,
+                        'column': 7
+                    }
+                },
+                'range': [
+                    4,
+                    7
+                ]
+            },
+            {
+                'type': 'Punctuator',
+                'value': '=',
+                'start': 8,
+                'end': 9,
+                'loc': {
+                    'start': {
+                        'line': 1,
+                        'column': 8
+                    },
+                    'end': {
+                        'line': 1,
+                        'column': 9
+                    }
+                },
+                'range': [
+                    8,
+                    9
+                ]
+            },
+            {
+                'type': 'Identifier',
+                'value': 'bar',
+                'start': 10,
+                'end': 13,
+                'loc': {
+                    'start': {
+                        'line': 1,
+                        'column': 10
+                    },
+                    'end': {
+                        'line': 1,
+                        'column': 13
+                    }
+                },
+                'range': [
+                    10,
+                    13
+                ]
+            },
+            {
+                'type': 'Punctuator',
+                'value': '?.',
+                'start': 13,
+                'end': 15,
+                'loc': {
+                    'start': {
+                        'line': 1,
+                        'column': 13
+                    },
+                    'end': {
+                        'line': 1,
+                        'column': 15
+                    }
+                },
+                'range': [
+                    13,
+                    15
+                ]
+            },
+            {
+                'type': 'Identifier',
+                'value': 'a_b',
+                'start': 15,
+                'end': 18,
+                'loc': {
+                    'start': {
+                        'line': 1,
+                        'column': 15
+                    },
+                    'end': {
+                        'line': 1,
+                        'column': 18
+                    }
+                },
+                'range': [
+                    15,
+                    18
+                ]
+            },
+            {
+                'type': 'Punctuator',
+                'value': ';',
+                'start': 18,
+                'end': 19,
+                'loc': {
+                    'start': {
+                        'line': 1,
+                        'column': 18
+                    },
+                    'end': {
+                        'line': 1,
+                        'column': 19
+                    }
+                },
+                'range': [
+                    18,
+                    19
+                ]
+            }
+        ],
+        'sourceType': 'module',
+        'body': [
+            {
+                'type': 'VariableDeclaration',
+                'start': 0,
+                'end': 19,
+                'loc': {
+                    'start': {
+                        'line': 1,
+                        'column': 0
+                    },
+                    'end': {
+                        'line': 1,
+                        'column': 19
+                    }
+                },
+                'range': [
+                    0,
+                    19
+                ],
+                'declarations': [
+                    {
+                        'type': 'VariableDeclarator',
+                        'start': 4,
+                        'end': 18,
+                        'loc': {
+                            'start': {
+                                'line': 1,
+                                'column': 4
+                            },
+                            'end': {
+                                'line': 1,
+                                'column': 18
+                            }
+                        },
+                        'range': [
+                            4,
+                            18
+                        ],
+                        'id': {
+                            'type': 'Identifier',
+                            'start': 4,
+                            'end': 7,
+                            'loc': {
+                                'start': {
+                                    'line': 1,
+                                    'column': 4
+                                },
+                                'end': {
+                                    'line': 1,
+                                    'column': 7
+                                },
+                                'identifierName': 'foo'
+                            },
+                            'range': [
+                                4,
+                                7
+                            ],
+                            'name': 'foo',
+                            '_babelType': 'Identifier'
+                        },
+                        'init': {
+                            'type': 'OptionalMemberExpression',
+                            'start': 10,
+                            'end': 18,
+                            'loc': {
+                                'start': {
+                                    'line': 1,
+                                    'column': 10
+                                },
+                                'end': {
+                                    'line': 1,
+                                    'column': 18
+                                }
+                            },
+                            'range': [
+                                10,
+                                18
+                            ],
+                            'object': {
+                                'type': 'Identifier',
+                                'start': 10,
+                                'end': 13,
+                                'loc': {
+                                    'start': {
+                                        'line': 1,
+                                        'column': 10
+                                    },
+                                    'end': {
+                                        'line': 1,
+                                        'column': 13
+                                    },
+                                    'identifierName': 'bar'
+                                },
+                                'range': [
+                                    10,
+                                    13
+                                ],
+                                'name': 'bar',
+                                '_babelType': 'Identifier'
+                            },
+                            'property': {
+                                'type': 'Identifier',
+                                'start': 15,
+                                'end': 18,
+                                'loc': {
+                                    'start': {
+                                        'line': 1,
+                                        'column': 15
+                                    },
+                                    'end': {
+                                        'line': 1,
+                                        'column': 18
+                                    },
+                                    'identifierName': 'a_b'
+                                },
+                                'range': [
+                                    15,
+                                    18
+                                ],
+                                'name': 'a_b',
+                                '_babelType': 'Identifier'
+                            },
+                            'computed': false,
+                            'optional': true,
+                            '_babelType': 'OptionalMemberExpression'
+                        },
+                        '_babelType': 'VariableDeclarator'
+                    }
+                ],
+                'kind': 'var',
+                '_babelType': 'VariableDeclaration'
+            }
+        ]
+    }
+);

--- a/tests/lib/rules/camelcase.js
+++ b/tests/lib/rules/camelcase.js
@@ -10,6 +10,7 @@
 //------------------------------------------------------------------------------
 
 const rule = require("../../../lib/rules/camelcase"),
+    fixtureParser = require("../../fixtures/fixture-parser"),
     RuleTester = require("../../../lib/testers/rule-tester");
 
 //------------------------------------------------------------------------------
@@ -86,6 +87,11 @@ ruleTester.run("camelcase", rule, {
         {
             code: "var obj = {\n a_a: 1 \n};\n obj.a_b = 2;",
             options: [{ properties: "never" }]
+        },
+        {
+            code: "var foo = bar?.a_b;",
+            options: [{ properties: "never" }],
+            parser: fixtureParser("babel-eslint9/optional-chaining-assignment")
         },
         {
             code: "obj.foo_bar = function(){};",


### PR DESCRIPTION
Treat OptionalMemberExpression in similar way than MemberExpression. fixes: https://github.com/eslint/eslint/issues/10848

<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->
**What did you do? Please include the actual source code causing the issue.**

Fixed the issue with camelcase rule complaining about snake case property name when using optional chaining.

Source causing the issue:

```
var foo = bar?.a_b;
```

**What did you expect to happen?**
Eslint should not complain about the snake_case property name when using optional chaining
**What actually happened? Please include the actual, raw output from ESLint.**

`Identifier 'a_b' is not in camel case.`

**What changes did you make? (Give an overview)**
Changed camelcase rule to treat `OptionalMemberExpression` in same way as regular `MemberExpression`. 

**Is there anything you'd like reviewers to focus on?**

The fixture is generated with following code using babel-eslint 9.0.0:

```
const babelEslint = require('babel-eslint');
babelEslint.parse('var foo = bar?.a_b;');
```
