### PR TITLE
Docs: clarify defaultAssignment option, fix no-unneeded-ternary examples

### DIFF
--- a/docs/rules/no-unneeded-ternary.md
+++ b/docs/rules/no-unneeded-ternary.md
@@ -42,7 +42,7 @@ var a = x === 2 ? true : false;
 
 var a = x ? true : false;
 
-var a = foo(x ? x : 1);
+var a = f(x ? x : 1);
 ```
 
 Examples of **correct** code for this rule:

--- a/docs/rules/no-unneeded-ternary.md
+++ b/docs/rules/no-unneeded-ternary.md
@@ -41,6 +41,8 @@ Examples of **incorrect** code for this rule:
 var a = x === 2 ? true : false;
 
 var a = x ? true : false;
+
+var a = x ? x : 1;
 ```
 
 Examples of **correct** code for this rule:
@@ -55,8 +57,6 @@ var a = x !== false;
 var a = x ? "Yes" : "No";
 
 var a = x ? y : x;
-
-var a = x ? x : 1;
 ```
 
 ## Options

--- a/docs/rules/no-unneeded-ternary.md
+++ b/docs/rules/no-unneeded-ternary.md
@@ -23,10 +23,10 @@ Here is an example:
 
 ```js
 // Bad
-var foo = bar ? bar : 1;
+foo(bar ? bar : 1);
 
 // Good
-var foo = bar || 1;
+foo(bar || 1);
 ```
 
 ## Rule Details
@@ -42,7 +42,7 @@ var a = x === 2 ? true : false;
 
 var a = x ? true : false;
 
-var a = x ? x : 1;
+var a = foo(x ? x : 1);
 ```
 
 Examples of **correct** code for this rule:
@@ -57,6 +57,8 @@ var a = x !== false;
 var a = x ? "Yes" : "No";
 
 var a = x ? y : x;
+
+var a = x ? x : 1;  // Note that this is only allowed as it on the right hand side of an assignment; this type of ternary is disallowed everywhere else. See defaultAssignment option below for more details.
 ```
 
 ## Options
@@ -67,6 +69,8 @@ This rule has an object option:
 * `"defaultAssignment": false` disallows the conditional expression as a default assignment pattern
 
 ### defaultAssignment
+
+The defaultAssignment option allows expressions of the form `x ? x : expr` (where `x` is any identifier and `expr` is any expression) as the right hand side of assignments (but nowhere else).
 
 Examples of additional **incorrect** code for this rule with the `{ "defaultAssignment": false }` option:
 


### PR DESCRIPTION
The documentation for the no-unneeded-ternary rule seems to have a mistake. (https://github.com/eslint/eslint/issues/10872).

At one point, it mentions that a `||` should be used when the middle operand of the ternary is the same as the first:

```
// Bad
var foo = bar ? bar : 1;

// Good
var foo = bar || 1;
```

Later, however, it lists something seemingly identical to this as an example of correct code:

```
var a = x ? x : 1;
```

In my project, I was given a no-unneeded-ternary error for using this type of code, so the documentation seems to have an error. Either way, the documentation seems to list this sort of construct as both correct and incorrect, so one of those is probably in error.

Fixes #10872.