### PR TITLE
Fix: avoid exponential require-atomic-updates traversal (fixes #10893)

### DIFF
--- a/tests/lib/rules/require-atomic-updates.js
+++ b/tests/lib/rules/require-atomic-updates.js
@@ -129,7 +129,7 @@ ruleTester.run("require-atomic-updates", rule, {
             errors: [VARIABLE_ERROR]
         },
         {
-            code: "let foo; async function x() { foo = foo + (barrr ? baz : await amount); }",
+            code: "let foo; async function x() { foo = foo + (bar ? baz : await amount); }",
             errors: [VARIABLE_ERROR]
         },
         {

--- a/tests/lib/rules/require-atomic-updates.js
+++ b/tests/lib/rules/require-atomic-updates.js
@@ -51,12 +51,73 @@ ruleTester.run("require-atomic-updates", rule, {
         "let foo; function* x() { foo = bar + foo; }",
         "async function x() { let foo; bar(() => baz += 1); foo += await amount; }",
         "let foo; async function x() { foo = condition ? foo : await bar; }",
-        "async function x() { let foo; bar(() => { let foo; blah(foo); }); foo += await result; }"
+        "async function x() { let foo; bar(() => { let foo; blah(foo); }); foo += await result; }",
+        "let foo; async function x() { foo = foo + 1; await bar; }",
+
+
+        /*
+         * Ensure rule doesn't take exponential time in the number of branches
+         * (see https://github.com/eslint/eslint/issues/10893)
+         */
+        `
+            async function foo() {
+                if (1);
+                if (2);
+                if (3);
+                if (4);
+                if (5);
+                if (6);
+                if (7);
+                if (8);
+                if (9);
+                if (10);
+                if (11);
+                if (12);
+                if (13);
+                if (14);
+                if (15);
+                if (16);
+                if (17);
+                if (18);
+                if (19);
+                if (20);
+            }
+        `,
+        `
+            async function foo() {
+                return [
+                    1 ? a : b,
+                    2 ? a : b,
+                    3 ? a : b,
+                    4 ? a : b,
+                    5 ? a : b,
+                    6 ? a : b,
+                    7 ? a : b,
+                    8 ? a : b,
+                    9 ? a : b,
+                    10 ? a : b,
+                    11 ? a : b,
+                    12 ? a : b,
+                    13 ? a : b,
+                    14 ? a : b,
+                    15 ? a : b,
+                    16 ? a : b,
+                    17 ? a : b,
+                    18 ? a : b,
+                    19 ? a : b,
+                    20 ? a : b
+                ];
+            }
+        `
     ],
 
     invalid: [
         {
             code: "let foo; async function x() { foo += await amount; }",
+            errors: [{ messageId: "nonAtomicUpdate", data: { value: "foo" } }]
+        },
+        {
+            code: "if (1); let foo; async function x() { foo += await amount; }",
             errors: [{ messageId: "nonAtomicUpdate", data: { value: "foo" } }]
         },
         {
@@ -68,7 +129,7 @@ ruleTester.run("require-atomic-updates", rule, {
             errors: [VARIABLE_ERROR]
         },
         {
-            code: "let foo; async function x() { foo = foo + (bar ? baz : await amount); }",
+            code: "let foo; async function x() { foo = foo + (barrr ? baz : await amount); }",
             errors: [VARIABLE_ERROR]
         },
         {
@@ -137,6 +198,14 @@ ruleTester.run("require-atomic-updates", rule, {
         },
         {
             code: "async function x() { foo += await bar; }",
+            errors: [VARIABLE_ERROR]
+        },
+        {
+            code: "let foo = 0; async function x() { foo = (a ? b : foo) + await bar; if (baz); }",
+            errors: [VARIABLE_ERROR]
+        },
+        {
+            code: "let foo = 0; async function x() { foo = (a ? b ? c ? d ? foo : e : f : g : h) + await bar; if (baz); }",
             errors: [VARIABLE_ERROR]
         }
     ]


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix (https://github.com/eslint/eslint/issues/10893)
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Previously, the `require-atomic-updates` rule would traverse over every path in the control flow graph, resulting in a runtime that was exponential in the number of edges in the graph. This commit updates the rule to use a lattice-based [dataflow analysis](https://en.wikipedia.org/wiki/Data-flow_analysis) algorithm, similar to the algorithms used by optimizing compilers.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular