### PR TITLE
New: Add the exclude function name option.

### DIFF
--- a/lib/rules/max-lines-per-function.js
+++ b/lib/rules/max-lines-per-function.js
@@ -178,7 +178,7 @@ module.exports = {
         function processFunction(funcNode) {
             const node = isEmbedded(funcNode) ? funcNode.parent : funcNode;
             const name = astUtils.getFunctionNameWithKind(funcNode);
-            
+
             if ((!IIFEs && isIIFE(node)) || (!excludeFunctions && excludeFunctions.indexOf(name) !== -1)) {
                 return;
             }

--- a/lib/rules/max-lines-per-function.js
+++ b/lib/rules/max-lines-per-function.js
@@ -29,6 +29,9 @@ const OPTIONS_SCHEMA = {
         },
         IIFEs: {
             type: "boolean"
+        },
+        excludeFunctions: {
+            type: "array"
         }
     },
     additionalProperties: false
@@ -90,6 +93,7 @@ module.exports = {
         let skipComments = false;
         let skipBlankLines = false;
         let IIFEs = false;
+        let excludeFunctions = false;
 
         if (typeof option === "object") {
             if (typeof option.max === "number") {
@@ -103,6 +107,9 @@ module.exports = {
             }
             if (typeof option.IIFEs === "boolean") {
                 IIFEs = option.IIFEs;
+            }
+             if (typeof option.excludeFunctions === "array") {
+                excludeFunctions = option.excludeFunctions;
             }
         } else if (typeof option === "number") {
             maxLines = option;
@@ -170,8 +177,10 @@ module.exports = {
          */
         function processFunction(funcNode) {
             const node = isEmbedded(funcNode) ? funcNode.parent : funcNode;
-
-            if (!IIFEs && isIIFE(node)) {
+            const name = astUtils.getFunctionNameWithKind(funcNode);
+            
+            if ((!IIFEs && isIIFE(node))
+                || (!excludeFunctions && excludeFunctions.indexOf(name) !== -1)) {
                 return;
             }
             let lineCount = 0;
@@ -195,8 +204,6 @@ module.exports = {
             }
 
             if (lineCount > maxLines) {
-                const name = astUtils.getFunctionNameWithKind(funcNode);
-
                 context.report({
                     node,
                     message: "{{name}} has too many lines ({{lineCount}}). Maximum allowed is {{maxLines}}.",

--- a/lib/rules/max-lines-per-function.js
+++ b/lib/rules/max-lines-per-function.js
@@ -31,7 +31,7 @@ const OPTIONS_SCHEMA = {
             type: "boolean"
         },
         excludeFunctions: {
-            type: "array"
+            type: "object"
         }
     },
     additionalProperties: false
@@ -179,7 +179,7 @@ module.exports = {
             const node = isEmbedded(funcNode) ? funcNode.parent : funcNode;
             const name = astUtils.getFunctionNameWithKind(funcNode);
 
-            if ((!IIFEs && isIIFE(node)) || (!excludeFunctions && excludeFunctions.indexOf(name) !== -1)) {
+            if ((!IIFEs && isIIFE(node)) || (excludeFunctions && excludeFunctions.indexOf(name) !== -1)) {
                 return;
             }
             let lineCount = 0;

--- a/lib/rules/max-lines-per-function.js
+++ b/lib/rules/max-lines-per-function.js
@@ -108,7 +108,7 @@ module.exports = {
             if (typeof option.IIFEs === "boolean") {
                 IIFEs = option.IIFEs;
             }
-             if (typeof option.excludeFunctions === "array") {
+            if (typeof option.excludeFunctions === "object") {
                 excludeFunctions = option.excludeFunctions;
             }
         } else if (typeof option === "number") {
@@ -179,8 +179,7 @@ module.exports = {
             const node = isEmbedded(funcNode) ? funcNode.parent : funcNode;
             const name = astUtils.getFunctionNameWithKind(funcNode);
             
-            if ((!IIFEs && isIIFE(node))
-                || (!excludeFunctions && excludeFunctions.indexOf(name) !== -1)) {
+            if ((!IIFEs && isIIFE(node)) || (!excludeFunctions && excludeFunctions.indexOf(name) !== -1)) {
                 return;
             }
             let lineCount = 0;


### PR DESCRIPTION
Sometime, we need to declare some functions name to exclude. For example a "render" function in JSX can be huge. (rendering forms, etc..)

<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Just added the "excludeFunctions" option which allow to skip max-lines-per-function for specific function names. 

**Is there anything you'd like reviewers to focus on?**
No

