### PR TITLE
Update: "off" options for "space-before-blocks" (refs #10906)

### DIFF
--- a/docs/rules/space-before-blocks.md
+++ b/docs/rules/space-before-blocks.md
@@ -17,7 +17,7 @@ This rule will enforce consistency of spacing before blocks. It is only applied 
 This rule takes one argument. If it is `"always"` then blocks must always have at least one preceding space. If `"never"`
 then all blocks should never have any preceding space. If different spacing is desired for function
 blocks, keyword blocks and classes, an optional configuration object can be passed as the rule argument to
-configure the cases separately.
+configure the cases separately. If any value in the configuration object is `"off"`, then neither style will be enforced for blocks of that kind.
 
 ( e.g. `{ "functions": "never", "keywords": "always", "classes": "always" }` )
 

--- a/lib/rules/space-before-blocks.js
+++ b/lib/rules/space-before-blocks.js
@@ -32,13 +32,13 @@ module.exports = {
                         type: "object",
                         properties: {
                             keywords: {
-                                enum: ["always", "never"]
+                                enum: ["always", "never", "off"]
                             },
                             functions: {
-                                enum: ["always", "never"]
+                                enum: ["always", "never", "off"]
                             },
                             classes: {
-                                enum: ["always", "never"]
+                                enum: ["always", "never", "off"]
                             }
                         },
                         additionalProperties: false
@@ -51,18 +51,27 @@ module.exports = {
     create(context) {
         const config = context.options[0],
             sourceCode = context.getSourceCode();
-        let checkFunctions = true,
-            checkKeywords = true,
-            checkClasses = true;
+        let alwaysFunctions = true,
+            alwaysKeywords = true,
+            alwaysClasses = true,
+            neverFunctions = false,
+            neverKeywords = false,
+            neverClasses = false;
 
         if (typeof config === "object") {
-            checkFunctions = config.functions !== "never";
-            checkKeywords = config.keywords !== "never";
-            checkClasses = config.classes !== "never";
+            alwaysFunctions = config.functions === "always";
+            alwaysKeywords = config.keywords === "always";
+            alwaysClasses = config.classes === "always";
+            neverFunctions = config.functions === "never";
+            neverKeywords = config.keywords === "never";
+            neverClasses = config.classes === "never";
         } else if (config === "never") {
-            checkFunctions = false;
-            checkKeywords = false;
-            checkClasses = false;
+            alwaysFunctions = false;
+            alwaysKeywords = false;
+            alwaysClasses = false;
+            neverFunctions = true;
+            neverKeywords = true;
+            neverClasses = true;
         }
 
         /**
@@ -88,35 +97,35 @@ module.exports = {
                 const hasSpace = sourceCode.isSpaceBetweenTokens(precedingToken, node);
                 const parent = context.getAncestors().pop();
                 let requireSpace;
+                let requireNoSpace;
 
                 if (parent.type === "FunctionExpression" || parent.type === "FunctionDeclaration") {
-                    requireSpace = checkFunctions;
+                    requireSpace = alwaysFunctions;
+                    requireNoSpace = neverFunctions;
                 } else if (node.type === "ClassBody") {
-                    requireSpace = checkClasses;
+                    requireSpace = alwaysClasses;
+                    requireNoSpace = neverClasses;
                 } else {
-                    requireSpace = checkKeywords;
+                    requireSpace = alwaysKeywords;
+                    requireNoSpace = neverKeywords;
                 }
 
-                if (requireSpace) {
-                    if (!hasSpace) {
-                        context.report({
-                            node,
-                            message: "Missing space before opening brace.",
-                            fix(fixer) {
-                                return fixer.insertTextBefore(node, " ");
-                            }
-                        });
-                    }
-                } else {
-                    if (hasSpace) {
-                        context.report({
-                            node,
-                            message: "Unexpected space before opening brace.",
-                            fix(fixer) {
-                                return fixer.removeRange([precedingToken.range[1], node.range[0]]);
-                            }
-                        });
-                    }
+                if (requireSpace && !hasSpace) {
+                    context.report({
+                        node,
+                        message: "Missing space before opening brace.",
+                        fix(fixer) {
+                            return fixer.insertTextBefore(node, " ");
+                        }
+                    });
+                } else if (requireNoSpace && hasSpace) {
+                    context.report({
+                        node,
+                        message: "Unexpected space before opening brace.",
+                        fix(fixer) {
+                            return fixer.removeRange([precedingToken.range[1], node.range[0]]);
+                        }
+                    });
                 }
             }
         }

--- a/tests/lib/rules/space-before-blocks.js
+++ b/tests/lib/rules/space-before-blocks.js
@@ -548,15 +548,15 @@ ruleTester.run("space-before-blocks", rule, {
             code: "class test { constructor(){} }",
             output: "class test{ constructor(){} }",
             options: classesNeverOthersOffArgs,
-            parserOptions: { ecmaNoVersion: 6 },
-            errors: [expectedSpacingError]
+            parserOptions: { ecmaVersion: 6 },
+            errors: [expectedNoSpacingError]
         },
         {
             code: "class test { constructor() {} }",
             output: "class test{ constructor() {} }",
             options: classesNeverOthersOffArgs,
-            parserOptions: { ecmaNoVersion: 6 },
-            errors: [expectedSpacingError]
+            parserOptions: { ecmaVersion: 6 },
+            errors: [expectedNoSpacingError]
         }
     ]
 });

--- a/tests/lib/rules/space-before-blocks.js
+++ b/tests/lib/rules/space-before-blocks.js
@@ -21,6 +21,12 @@ const ruleTester = new RuleTester(),
     functionsOnlyArgs = [{ functions: "always", keywords: "never", classes: "never" }],
     keywordOnlyArgs = [{ functions: "never", keywords: "always", classes: "never" }],
     classesOnlyArgs = [{ functions: "never", keywords: "never", classes: "always" }],
+    functionsAlwaysOthersOffArgs = [{ functions: "always", keywords: "off", classes: "off" }],
+    keywordAlwaysOthersOffArgs = [{ functions: "off", keywords: "always", classes: "off" }],
+    classesAlwaysOthersOffArgs = [{ functions: "off", keywords: "off", classes: "always" }],
+    functionsNeverOthersOffArgs = [{ functions: "never", keywords: "off", classes: "off" }],
+    keywordNeverOthersOffArgs = [{ functions: "off", keywords: "never", classes: "off" }],
+    classesNeverOthersOffArgs = [{ functions: "off", keywords: "off", classes: "never" }],
     expectedSpacingErrorMessage = "Missing space before opening brace.",
     expectedSpacingError = { message: expectedSpacingErrorMessage },
     expectedNoSpacingErrorMessage = "Unexpected space before opening brace.",
@@ -129,6 +135,54 @@ ruleTester.run("space-before-blocks", rule, {
         },
         {
             code: "class test {}",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        { code: "function a(){if(b) {}}", options: keywordAlwaysOthersOffArgs },
+        { code: "function a() {if(b) {}}", options: keywordAlwaysOthersOffArgs },
+        { code: "function a() {if(b){}}", options: functionsAlwaysOthersOffArgs },
+        { code: "function a() {if(b) {}}", options: functionsAlwaysOthersOffArgs },
+        {
+            code: "class test { constructor(){if(a){}} }",
+            options: classesAlwaysOthersOffArgs,
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "class test { constructor() {if(a){}} }",
+            options: classesAlwaysOthersOffArgs,
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "class test { constructor(){if(a) {}} }",
+            options: classesAlwaysOthersOffArgs,
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "class test { constructor() {if(a) {}} }",
+            options: classesAlwaysOthersOffArgs,
+            parserOptions: { ecmaVersion: 6 }
+        },
+        { code: "function a(){if(b){}}", options: keywordNeverOthersOffArgs },
+        { code: "function a() {if(b){}}", options: keywordNeverOthersOffArgs },
+        { code: "function a(){if(b){}}", options: functionsNeverOthersOffArgs },
+        { code: "function a(){if(b) {}}", options: functionsNeverOthersOffArgs },
+        {
+            code: "class test{ constructor(){if(a){}} }",
+            options: classesNeverOthersOffArgs,
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "class test{ constructor() {if(a){}} }",
+            options: classesNeverOthersOffArgs,
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "class test{ constructor(){if(a) {}} }",
+            options: classesNeverOthersOffArgs,
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "class test{ constructor() {if(a) {}} }",
+            options: classesNeverOthersOffArgs,
             parserOptions: { ecmaVersion: 6 }
         },
 
@@ -427,6 +481,82 @@ ruleTester.run("space-before-blocks", rule, {
             options: neverArgs,
             parserOptions: { ecmaVersion: 6 },
             errors: [expectedNoSpacingError]
+        },
+        {
+            code: "if(a){ function a(){} }",
+            output: "if(a){ function a() {} }",
+            options: functionsAlwaysOthersOffArgs,
+            errors: [expectedSpacingError]
+        },
+        {
+            code: "if(a) { function a(){} }",
+            output: "if(a) { function a() {} }",
+            options: functionsAlwaysOthersOffArgs,
+            errors: [expectedSpacingError]
+        },
+        {
+            code: "if(a){ function a(){} }",
+            output: "if(a) { function a(){} }",
+            options: keywordAlwaysOthersOffArgs,
+            errors: [expectedSpacingError]
+        },
+        {
+            code: "if(a){ function a() {} }",
+            output: "if(a) { function a() {} }",
+            options: keywordAlwaysOthersOffArgs,
+            errors: [expectedSpacingError]
+        },
+        {
+            code: "class test{ constructor(){} }",
+            output: "class test { constructor(){} }",
+            options: classesAlwaysOthersOffArgs,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [expectedSpacingError]
+        },
+        {
+            code: "class test{ constructor() {} }",
+            output: "class test { constructor() {} }",
+            options: classesAlwaysOthersOffArgs,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [expectedSpacingError]
+        },
+        {
+            code: "if(a){ function a() {} }",
+            output: "if(a){ function a(){} }",
+            options: functionsNeverOthersOffArgs,
+            errors: [expectedNoSpacingError]
+        },
+        {
+            code: "if(a) { function a() {} }",
+            output: "if(a) { function a(){} }",
+            options: functionsNeverOthersOffArgs,
+            errors: [expectedNoSpacingError]
+        },
+        {
+            code: "if(a) { function a(){} }",
+            output: "if(a){ function a(){} }",
+            options: keywordNeverOthersOffArgs,
+            errors: [expectedNoSpacingError]
+        },
+        {
+            code: "if(a) { function a() {} }",
+            output: "if(a){ function a() {} }",
+            options: keywordNeverOthersOffArgs,
+            errors: [expectedNoSpacingError]
+        },
+        {
+            code: "class test { constructor(){} }",
+            output: "class test{ constructor(){} }",
+            options: classesNeverOthersOffArgs,
+            parserOptions: { ecmaNoVersion: 6 },
+            errors: [expectedSpacingError]
+        },
+        {
+            code: "class test { constructor() {} }",
+            output: "class test{ constructor() {} }",
+            options: classesNeverOthersOffArgs,
+            parserOptions: { ecmaNoVersion: 6 },
+            errors: [expectedSpacingError]
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))

**What rule do you want to change?**

This PR modifies the behavior of the `space-before-blocks` rule.

**Does this change cause the rule to produce more or fewer warnings?**

This PR does not affect the number of warnings for existing configurations of the `space-before-blocks` rule. It allows a new configuration option which ignores whitespace for functions, classes, and/or keywords, no longer warning regardless of whether whitespace was included in the specified cases.

**How will the change be implemented? (New option, new default behavior, etc.)?**

The PR adds a new accepted value to existing options. Where previously only `"always"` and `"never"` were accepted, a third option `"off"` is now also accepted. `"off"` means that neither style of whitespace should be enforced for a certain category of blocks. Please refer to the diff for details.

**Please provide some example code that this change will affect:**

```js
function MyFunction() { ... }
class MyClass { ... }
if( ... ) { ... }
```

**What does the rule currently do for this code?**

The `space-before-blocks` rule enforces that there is either `"always"` or `"never"` whitespace between the opening brace '{' and the previous non-whitespace character, with the option to have separate enforcement for functions, classes, and keywords.

**What will the rule do after it's changed?**

The rule is able to enforce `"always"` and/or `"never"` rules for one or more of functions, classes, and keywords, and not enforce either style for the remaining cases. This is not possible with the current behavior and options.

**More info:**

Please see this issue: https://github.com/eslint/eslint/issues/10906

The behavior of the "space-before-blocks" is affected. New functionality is added. All prior tests still pass without changes, which implies that the changes are fully backwards-compatible with prior eslint configurations.

Where "always" enforces space and "never" enforces no-space, "off" does not enforce any space preference. This can be useful, for example, when enforcing one whitespace setting for "functions" but not enforcing any setting for other kinds of blocks.

It may be useful to add a similar "off" option to other rules currently only accepting "always" and "never", too, but that is outside the scope of this PR. (This is the only such change that would have an impact on my own usage of eslint.)

**TODO:**

I added to the documentation, but not in as much detail as is probably warranted. Since I don't know that something like this exists elsewhere in the docs, I was unsure with how to proceed and describe the feature in more detail. I would really appreciate some input here.

*[DONE]* Two tests fail and I do not understand why. I don't think this is related to the implementation changes; I think that I have misunderstood something in regards to writing tests which use the "class" keyword. (Why do the tests on L457 and L464 pass but two of the tests that I added do not??)

``` text
  18549 passing (48s)
  2 failing

  1) space-before-blocks
       invalid
         class test { constructor(){} }:

      AssertionError [ERR_ASSERTION]: A fatal parsing error occurred: Parsing error: The keyword 'class' is reserved
      + expected - actual

      -false
      +true

      at testInvalidTemplate (lib/testers/rule-tester.js:9:13617)
      at Context.RuleTester.it (lib/testers/rule-tester.js:9:20143)

  2) space-before-blocks
       invalid
         class test { constructor() {} }:

      AssertionError [ERR_ASSERTION]: A fatal parsing error occurred: Parsing error: The keyword 'class' is reserved
      + expected - actual

      -false
      +true

      at testInvalidTemplate (lib/testers/rule-tester.js:9:13617)
      at Context.RuleTester.it (lib/testers/rule-tester.js:9:20143)
```
