### PR TITLE
Update: iife statement type for padding-line-between-statements (fixes #10853)

### DIFF
--- a/docs/rules/padding-line-between-statements.md
+++ b/docs/rules/padding-line-between-statements.md
@@ -20,9 +20,9 @@ function foo() {
 
 ## Rule Details
 
-This rule does nothing if no configuration.
+This rule does nothing if no configurations are provided.
 
-A configuration is an object which has 3 properties; `blankLine`, `prev` and `next`. For example, `{ blankLine: "always", prev: "var", next: "return" }` means "it requires one or more blank lines between a variable declaration and a `return` statement."
+A configuration is an object which has 3 properties; `blankLine`, `prev` and `next`. For example, `{ blankLine: "always", prev: "var", next: "return" }` means "one or more blank lines are required between a variable declaration and a `return` statement."
 You can supply any number of configurations. If a statement pair matches multiple configurations, the last matched configuration will be used.
 
 ```json
@@ -46,11 +46,11 @@ You can supply any number of configurations. If a statement pair matches multipl
 - `STATEMENT_TYPE` is one of the following, or an array of the following.
     - `"*"` is wildcard. This matches any statements.
     - `"block"` is lonely blocks.
-    - `"block-like"` is block like statements. This matches statements that the last token is the closing brace of blocks; e.g. `{ }`, `if (a) { }`, and `while (a) { }`.
+    - `"block-like"` is block like statements. This matches statements that the last token is the closing brace of blocks; e.g. `{ }`, `if (a) { }`, and `while (a) { }`. Also matches immediately invoked function expression statements.
     - `"break"` is `break` statements.
     - `"case"` is `case` labels.
-    - `"cjs-export"` is `export` statements of CommonJS; e.g. `module.exports = 0`, `module.exports.foo = 1`, and `exports.foo = 2`. This is the special cases of assignment.
-    - `"cjs-import"` is `import` statements of CommonJS; e.g. `const foo = require("foo")`. This is the special cases of variable declarations.
+    - `"cjs-export"` is `export` statements of CommonJS; e.g. `module.exports = 0`, `module.exports.foo = 1`, and `exports.foo = 2`. This is a special case of assignment.
+    - `"cjs-import"` is `import` statements of CommonJS; e.g. `const foo = require("foo")`. This is a special case of variable declarations.
     - `"class"` is `class` declarations.
     - `"const"` is `const` variable declarations.
     - `"continue"` is `continue` statements.
@@ -64,6 +64,7 @@ You can supply any number of configurations. If a statement pair matches multipl
     - `"for"` is `for` loop families. This matches all statements that the first token is `for` keyword.
     - `"function"` is function declarations.
     - `"if"` is `if` statements.
+    - `"iife"` is immediately invoked function expression statements. This matches calls on a function expression, optionally prefixed with a unary operator.
     - `"import"` is `import` declarations.
     - `"let"` is `let` variable declarations.
     - `"multiline-block-like"` is block like statements. This is the same as `block-like` type, but only if the block is multiline.

--- a/lib/rules/padding-line-between-statements.js
+++ b/lib/rules/padding-line-between-statements.js
@@ -353,6 +353,9 @@ const StatementTypes = {
             node.type === "ExpressionStatement" &&
             !isDirectivePrologue(node, sourceCode)
     },
+    iife: {
+        test: isIIFEStatement
+    },
     "multiline-block-like": {
         test: (node, sourceCode) =>
             node.loc.start.line !== node.loc.end.line &&

--- a/tests/lib/rules/padding-line-between-statements.js
+++ b/tests/lib/rules/padding-line-between-statements.js
@@ -853,6 +853,35 @@ ruleTester.run("padding-line-between-statements", rule, {
         },
 
         //----------------------------------------------------------------------
+        // iife
+        //----------------------------------------------------------------------
+
+        {
+            code: "(function(){\n})()\n\nvar a = 2;",
+            options: [
+                { blankLine: "always", prev: "iife", next: "*" }
+            ]
+        },
+        {
+            code: "+(function(){\n})()\n\nvar a = 2;",
+            options: [
+                { blankLine: "always", prev: "iife", next: "*" }
+            ]
+        },
+        {
+            code: "(function(){\n})()\nvar a = 2;",
+            options: [
+                { blankLine: "never", prev: "iife", next: "*" }
+            ]
+        },
+        {
+            code: "+(function(){\n})()\nvar a = 2;",
+            options: [
+                { blankLine: "never", prev: "iife", next: "*" }
+            ]
+        },
+
+        //----------------------------------------------------------------------
         // import
         //----------------------------------------------------------------------
 
@@ -3372,6 +3401,43 @@ ruleTester.run("padding-line-between-statements", rule, {
         },
 
         //----------------------------------------------------------------------
+        // iife
+        //----------------------------------------------------------------------
+
+        {
+            code: "(function(){\n})()\n\nvar a = 2;",
+            output: "(function(){\n})()\nvar a = 2;",
+            options: [
+                { blankLine: "never", prev: "iife", next: "*" }
+            ],
+            errors: [MESSAGE_NEVER]
+        },
+        {
+            code: "+(function(){\n})()\n\nvar a = 2;",
+            output: "+(function(){\n})()\nvar a = 2;",
+            options: [
+                { blankLine: "never", prev: "iife", next: "*" }
+            ],
+            errors: [MESSAGE_NEVER]
+        },
+        {
+            code: "(function(){\n})()\nvar a = 2;",
+            output: "(function(){\n})()\n\nvar a = 2;",
+            options: [
+                { blankLine: "always", prev: "iife", next: "*" }
+            ],
+            errors: [MESSAGE_ALWAYS]
+        },
+        {
+            code: "+(function(){\n})()\nvar a = 2;",
+            output: "+(function(){\n})()\n\nvar a = 2;",
+            options: [
+                { blankLine: "always", prev: "iife", next: "*" }
+            ],
+            errors: [MESSAGE_ALWAYS]
+        },
+
+        //----------------------------------------------------------------------
         // import
         //----------------------------------------------------------------------
 
@@ -4242,6 +4308,14 @@ ruleTester.run("padding-line-between-statements", rule, {
         {
             code: "(function(){\n})()\n\nvar a = 2;",
             output: "(function(){\n})()\nvar a = 2;",
+            options: [
+                { blankLine: "never", prev: "block-like", next: "*" }
+            ],
+            errors: [MESSAGE_NEVER]
+        },
+        {
+            code: "+(function(){\n})()\n\nvar a = 2;",
+            output: "+(function(){\n})()\nvar a = 2;",
             options: [
                 { blankLine: "never", prev: "block-like", next: "*" }
             ],


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

See #10853.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Added "iife" statement type to `padding-line-between-statements` rule.

**Is there anything you'd like reviewers to focus on?**

* Any issues with the documentation changes I've added?
* Are there any more tests I should add?
