### PR TITLE
Update: Ignore type aliases in space-infix-ops (fixes #10922)

### DIFF
--- a/lib/rules/space-infix-ops.js
+++ b/lib/rules/space-infix-ops.js
@@ -35,6 +35,8 @@ module.exports = {
     create(context) {
         const int32Hint = context.options[0] ? context.options[0].int32Hint === true : false;
 
+        const DECLARATION_KINDS = ["var", "let", "const"];
+
         const OPERATORS = [
             "*", "/", "%", "+", "-", "<<", ">>", ">>>", "<", "<=", ">", ">=", "in",
             "instanceof", "==", "!=", "===", "!==", "&", "^", "|", "&&", "||", "=",
@@ -143,6 +145,9 @@ module.exports = {
          * @private
          */
         function checkVar(node) {
+            if (DECLARATION_KINDS.indexOf(node.parent.kind) < 0) {
+                return;
+            }
             const leftNode = (node.id.typeAnnotation) ? node.id.typeAnnotation : node.id;
             const rightNode = node.init;
 

--- a/tests/fixtures/parsers/typescript-parsers/type-alias.js
+++ b/tests/fixtures/parsers/typescript-parsers/type-alias.js
@@ -1,0 +1,155 @@
+"use strict";
+
+exports.parse = () => ({
+    type: "Program",
+    range: [0, 16],
+    loc: {
+        start: { line: 1, column: 0 },
+        end: { line: 1, column: 16 }
+    },
+    body: [
+        {
+            type: "VariableDeclaration",
+            range: [0, 16],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 16 }
+            },
+            kind: "type",
+            declarations: [
+                {
+                    type: "VariableDeclarator",
+                    id: {
+                        type: "Identifier",
+                        range: [
+                            5,
+                            8
+                        ],
+                        loc: {
+                            start: { line: 1, column: 5 },
+                            end: { line: 1, column: 8 }
+                        },
+                        name: "Foo"
+                    },
+                    init: {
+                        type: "TSTypeReference",
+                        range: [14, 15],
+                        loc: {
+                            start: { line: 1, column: 14 },
+                            end: { line: 1, column: 15 }
+                        },
+                        typeName: {
+                            type: "Identifier",
+                            range: [14, 15],
+                            loc: {
+                                start: { line: 1, column: 14 },
+                                end: { line: 1, column: 15 }
+                            },
+                            name: "T"
+                        }
+                    },
+                    range: [5, 16],
+                    loc: {
+                        start: { line: 1, column: 5 },
+                        end: { line: 1, column: 16 }
+                    },
+                    typeParameters: {
+                        type: "TSTypeParameterDeclaration",
+                        range: [8, 11],
+                        loc: {
+                            start: { line: 1, column: 8 },
+                            end: { line: 1, column: 11 }
+                        },
+                        params: [
+                            {
+                                type: "TSTypeParameter",
+                                range: [9, 10],
+                                loc: {
+                                    start: { line: 1, column: 9 },
+                                    end: { line: 1, column: 10 }
+                                },
+                                name: "T"
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    ],
+    sourceType: "script",
+    tokens: [
+        {
+            type: "Identifier",
+            value: "type",
+            range: [0, 4],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 4 }
+            }
+        },
+        {
+            type: "Identifier",
+            value: "Foo",
+            range: [5, 8],
+            loc: {
+                start: { line: 1, column: 5 },
+                end: { line: 1, column: 8 }
+            }
+        },
+        {
+            type: "Punctuator",
+            value: "<",
+            range: [8, 9],
+            loc: {
+                start: { line: 1, column: 8 },
+                end: { line: 1, column: 9 }
+            }
+        },
+        {
+            type: "Identifier",
+            value: "T",
+            range: [9, 10],
+            loc: {
+                start: { line: 1, column: 9 },
+                end: { line: 1, column: 10 }
+            }
+        },
+        {
+            type: "Punctuator",
+            value: ">",
+            range: [10, 11],
+            loc: {
+                start: { line: 1, column: 10 },
+                end: { line: 1, column: 11 }
+            }
+        },
+        {
+            type: "Punctuator",
+            value: "=",
+            range: [12, 13],
+            loc: {
+                start: { line: 1, column: 12 },
+                end: { line: 1, column: 13 }
+            }
+        },
+        {
+            type: "Identifier",
+            value: "T",
+            range: [14, 15],
+            loc: {
+                start: { line: 1, column: 14 },
+                end: { line: 1, column: 15 }
+            }
+        },
+        {
+            type: "Punctuator",
+            value: ";",
+            range: [15, 16],
+            loc: {
+                start: { line: 1, column: 15 },
+                end: { line: 1, column: 16 }
+            }
+        }
+    ],
+    comments: []
+})

--- a/tests/lib/rules/space-infix-ops.js
+++ b/tests/lib/rules/space-infix-ops.js
@@ -38,7 +38,10 @@ ruleTester.run("space-infix-ops", rule, {
         { code: "function foo(a: number = 0) { }", parserOptions: { ecmaVersion: 6 }, parser: parser("type-annotations/function-parameter-type-annotation") },
         { code: "function foo(): Bar { }", parserOptions: { ecmaVersion: 6 }, parser: parser("type-annotations/function-return-type-annotation") },
         { code: "var foo: Bar = '';", parserOptions: { ecmaVersion: 6 }, parser: parser("type-annotations/variable-declaration-init-type-annotation") },
-        { code: "const foo = function(a: number = 0): Bar { };", parserOptions: { ecmaVersion: 6 }, parser: parser("type-annotations/function-expression-type-annotation") }
+        { code: "const foo = function(a: number = 0): Bar { };", parserOptions: { ecmaVersion: 6 }, parser: parser("type-annotations/function-expression-type-annotation") },
+
+        // TypeScript Type Aliases
+        { code: "type Foo<T> = T;", parserOptions: { ecmaVersion: 6 }, parser: parser("typescript-parsers/type-alias") }
     ],
     invalid: [
         {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What rule do you want to change?**

`space-infix-ops`

**Does this change cause the rule to produce more or fewer warnings?**

No change for javascript, no more false positives for typescript.

**How will the change be implemented? (New option, new default behavior, etc.)?**

Disable the rule for `VariableDeclarator`s where the parent node is a `VariableDeclaration` with a non-standard `kind` (not `var`, `let`, or `const`). After this, [`eslint-plugin-typescript`](https://github.com/nzakas/eslint-plugin-typescript) can implement the rule for typescript type aliases [(which are represented as variable declarations, with `kind: 'type'`)](https://github.com/JamesHenry/typescript-estree/blob/c165bd334751fcd954c6f699d15647c97e785794/lib/convert.js#L2111-L2146).

**Please provide some example code that this change will affect:**

```js
type Foo<T> = T;
```

**What does the rule currently do for this code?**

It reports a violation, as after `Foo` the `<` is not surrounded by whitespaces.

**What will the rule do after it's changed?**

It'll ignore typescript type aliases, so a plugin can handle the non-standard syntax.

**What changes did you make? (Give an overview)**

`space-infix-ops` will ignore non-standard declarations (everything that's not `var`, `let`, or `const`). a possible fix for #10922 

**Is there anything you'd like reviewers to focus on?**

:man_shrugging: 