### PR TITLE
Fix: prefer-const when using destructuring assign (fixes #8308)

### DIFF
--- a/docs/rules/prefer-const.md
+++ b/docs/rules/prefer-const.md
@@ -84,8 +84,8 @@ let predicate;
 [object.type, predicate] = foo();
 
 // `a` is only assigned once but cannot be separately declared as `const`
-let a; 
-const b = {}; 
+let a;
+const b = {};
 ({ a, c: b.c } = func());
 
 // suggest to use `no-var` rule.

--- a/docs/rules/prefer-const.md
+++ b/docs/rules/prefer-const.md
@@ -79,6 +79,15 @@ for (let i = 0, end = 10; i < end; ++i) {
     console.log(a);
 }
 
+// `predicate` is only assigned once but cannot be separately declared as `const`
+let predicate;
+[object.type, predicate] = foo();
+
+// `a` is only assigned once but cannot be separately declared as `const`
+let a; 
+const b = {}; 
+({ a, c: b.c } = func());
+
 // suggest to use `no-var` rule.
 var b = 3;
 console.log(b);

--- a/lib/rules/prefer-const.js
+++ b/lib/rules/prefer-const.js
@@ -98,6 +98,47 @@ function getDestructuringHost(reference) {
 }
 
 /**
+ * Determines if a destructuring assignment node contains
+ * any MemberExpression nodes. This is used to determine if a
+ * variable that is only written once using destructuring can be
+ * safely converted into a const declaration.
+ * @param {ASTNode} node The ObjectPattern or ArrayPattern node to check.
+ * @returns {boolean} True if the destructuring pattern contains
+ *      a MemberExpression, false if not.
+ */
+function hasMemberExpressionAssignment(node) {
+    switch (node.type) {
+        case "ObjectPattern":
+            return node.properties.some(prop => {
+                if (prop) {
+                    return hasMemberExpressionAssignment(prop.value);
+                }
+
+                return false;
+            });
+
+        case "ArrayPattern":
+            return node.elements.some(element => {
+                if (element) {
+                    return hasMemberExpressionAssignment(element);
+                }
+
+                return false;
+            });
+
+        case "AssignmentPattern":
+            return hasMemberExpressionAssignment(node.left);
+
+        case "MemberExpression":
+            return true;
+
+        // no default
+    }
+
+    return false;
+}
+
+/**
  * Gets an identifier node of a given variable.
  *
  * If the initialization exists or one or more reading references exist before
@@ -160,19 +201,8 @@ function getIdentifierIfShouldBeConst(variable, ignoreReadBeforeAssign) {
                         .map(prop => prop.value.name)
                         .some(name => isOuterVariableInDestructing(name, variable.scope));
 
-                    hasNonIdentifiers = properties.some(prop => {
-                        if (prop) {
-                            let value = prop.value;
+                    hasNonIdentifiers = hasMemberExpressionAssignment(leftNode);
 
-                            if (prop.value.type === "AssignmentPattern") {
-                                value = prop.value.left;
-                            }
-
-                            return value.type !== "Identifier";
-                        }
-
-                        return false;
-                    });
                 } else if (leftNode.type === "ArrayPattern") {
                     const elements = leftNode.elements;
 
@@ -180,20 +210,7 @@ function getIdentifierIfShouldBeConst(variable, ignoreReadBeforeAssign) {
                         .map(element => element && element.name)
                         .some(name => isOuterVariableInDestructing(name, variable.scope));
 
-                    hasNonIdentifiers = elements.some(element => {
-                        if (element) {
-                            let value = element;
-
-                            if (value.type === "AssignmentPattern") {
-                                value = value.left;
-                            }
-
-                            return value.type !== "Identifier";
-                        }
-
-                        return false;
-
-                    });
+                    hasNonIdentifiers = hasMemberExpressionAssignment(leftNode);
                 }
 
                 if (hasOuterVariables || hasNonIdentifiers) {

--- a/lib/rules/prefer-const.js
+++ b/lib/rules/prefer-const.js
@@ -57,6 +57,7 @@ function canBecomeVariableDeclaration(identifier) {
  * @returns {boolean} Indicates if the variable is from outer scope or function parameters.
  */
 function isOuterVariableInDestructing(name, initScope) {
+
     if (initScope.through.find(ref => ref.resolved && ref.resolved.name === name)) {
         return true;
     }
@@ -148,7 +149,8 @@ function getIdentifierIfShouldBeConst(variable, ignoreReadBeforeAssign) {
 
             if (destructuringHost !== null && destructuringHost.left !== void 0) {
                 const leftNode = destructuringHost.left;
-                let hasOuterVariables = false;
+                let hasOuterVariables = false,
+                    hasNonIdentifiers = false;
 
                 if (leftNode.type === "ObjectPattern") {
                     const properties = leftNode.properties;
@@ -157,16 +159,47 @@ function getIdentifierIfShouldBeConst(variable, ignoreReadBeforeAssign) {
                         .filter(prop => prop.value)
                         .map(prop => prop.value.name)
                         .some(name => isOuterVariableInDestructing(name, variable.scope));
+
+                    hasNonIdentifiers = properties.some(prop => {
+                        if (prop) {
+                            let value = prop.value;
+
+                            if (prop.value.type === "AssignmentPattern") {
+                                value = prop.value.left;
+                            }
+
+                            return value.type !== "Identifier";
+                        }
+
+                        return false;
+                    });
                 } else if (leftNode.type === "ArrayPattern") {
                     const elements = leftNode.elements;
 
                     hasOuterVariables = elements
                         .map(element => element && element.name)
                         .some(name => isOuterVariableInDestructing(name, variable.scope));
+
+                    hasNonIdentifiers = elements.some(element => {
+                        if (element) {
+                            let value = element;
+
+                            if (value.type === "AssignmentPattern") {
+                                value = value.left;
+                            }
+
+                            return value.type !== "Identifier";
+                        }
+
+                        return false;
+
+                    });
                 }
-                if (hasOuterVariables) {
+
+                if (hasOuterVariables || hasNonIdentifiers) {
                     return null;
                 }
+
             }
 
             writer = reference;
@@ -192,9 +225,11 @@ function getIdentifierIfShouldBeConst(variable, ignoreReadBeforeAssign) {
     if (!shouldBeConst) {
         return null;
     }
+
     if (isReadBeforeInit) {
         return variable.defs[0].name;
     }
+
     return writer.identifier;
 }
 
@@ -295,7 +330,7 @@ module.exports = {
     create(context) {
         const options = context.options[0] || {};
         const sourceCode = context.getSourceCode();
-        const checkingMixedDestructuring = options.destructuring !== "all";
+        const shouldMatchAnyDestructuredVariable = options.destructuring !== "all";
         const ignoreReadBeforeAssign = options.ignoreReadBeforeAssign === true;
         const variables = [];
 
@@ -316,7 +351,7 @@ module.exports = {
         function checkGroup(nodes) {
             const nodesToReport = nodes.filter(Boolean);
 
-            if (nodes.length && (checkingMixedDestructuring || nodesToReport.length === nodes.length)) {
+            if (nodes.length && (shouldMatchAnyDestructuredVariable || nodesToReport.length === nodes.length)) {
                 const varDeclParent = findUp(nodes[0], "VariableDeclaration", parentNode => parentNode.type.endsWith("Statement"));
                 const shouldFix = varDeclParent &&
 

--- a/lib/rules/prefer-const.js
+++ b/lib/rules/prefer-const.js
@@ -111,10 +111,14 @@ function hasMemberExpressionAssignment(node) {
         case "ObjectPattern":
             return node.properties.some(prop => {
                 if (prop) {
-                    const nodeToCheck = (prop.type === "RestElement")
-                        ? prop.argument : prop.value;
 
-                    return hasMemberExpressionAssignment(nodeToCheck);
+                    /*
+                     * Spread elements have an argument property while
+                     * others have a value property. Because different
+                     * parsers use different node types for spread elements,
+                     * we just check if there is an argument property.
+                     */
+                    return hasMemberExpressionAssignment(prop.argument || prop.value);
                 }
 
                 return false;

--- a/lib/rules/prefer-const.js
+++ b/lib/rules/prefer-const.js
@@ -111,7 +111,10 @@ function hasMemberExpressionAssignment(node) {
         case "ObjectPattern":
             return node.properties.some(prop => {
                 if (prop) {
-                    return hasMemberExpressionAssignment(prop.value);
+                    const nodeToCheck = (prop.type === "RestElement")
+                        ? prop.argument : prop.value;
+
+                    return hasMemberExpressionAssignment(nodeToCheck);
                 }
 
                 return false;

--- a/tests/lib/rules/prefer-const.js
+++ b/tests/lib/rules/prefer-const.js
@@ -117,6 +117,16 @@ ruleTester.run("prefer-const", rule, {
             parser: fixtureParser("babel-eslint5/destructuring-object-spread")
         },
 
+        // https://github.com/eslint/eslint/issues/8308
+        {
+            code: "let predicate; [typeNode.returnType, predicate] = foo();",
+            parserOptions: { ecmaVersion: 2018 }
+        },
+        {
+            code: "let a; const b = {}; ({ a, c: b.c } = func());",
+            parserOptions: { ecmaVersion: 2018 }
+        },
+
         // ignoreReadBeforeAssign
         {
             code: "let x; function foo() { bar(x); } x = 0;",

--- a/tests/lib/rules/prefer-const.js
+++ b/tests/lib/rules/prefer-const.js
@@ -117,12 +117,13 @@ ruleTester.run("prefer-const", rule, {
             parser: fixtureParser("babel-eslint5/destructuring-object-spread")
         },
 
-        // // https://github.com/eslint/eslint/issues/8308
+        // https://github.com/eslint/eslint/issues/8308
         {
             code: "let predicate; [typeNode.returnType, predicate] = foo();",
             parserOptions: { ecmaVersion: 2018 }
         },
         {
+            // intentionally testing empty slot in destructuring assignment
             code: "let predicate; [typeNode.returnType,, predicate] = foo();",
             parserOptions: { ecmaVersion: 2018 }
         },
@@ -155,7 +156,7 @@ ruleTester.run("prefer-const", rule, {
             parserOptions: { ecmaVersion: 2018 }
         },
 
-        // // ignoreReadBeforeAssign
+        // ignoreReadBeforeAssign
         {
             code: "let x; function foo() { bar(x); } x = 0;",
             options: [{ ignoreReadBeforeAssign: true }]

--- a/tests/lib/rules/prefer-const.js
+++ b/tests/lib/rules/prefer-const.js
@@ -123,6 +123,7 @@ ruleTester.run("prefer-const", rule, {
             parserOptions: { ecmaVersion: 2018 }
         },
         {
+
             // intentionally testing empty slot in destructuring assignment
             code: "let predicate; [typeNode.returnType,, predicate] = foo();",
             parserOptions: { ecmaVersion: 2018 }

--- a/tests/lib/rules/prefer-const.js
+++ b/tests/lib/rules/prefer-const.js
@@ -123,6 +123,10 @@ ruleTester.run("prefer-const", rule, {
             parserOptions: { ecmaVersion: 2018 }
         },
         {
+            code: "let predicate; [typeNode.returnType, ...predicate] = foo();",
+            parserOptions: { ecmaVersion: 2018 }
+        },
+        {
 
             // intentionally testing empty slot in destructuring assignment
             code: "let predicate; [typeNode.returnType,, predicate] = foo();",
@@ -150,6 +154,10 @@ ruleTester.run("prefer-const", rule, {
         },
         {
             code: "let predicate; [, {foo:typeNode.returnType, predicate}] = foo();",
+            parserOptions: { ecmaVersion: 2018 }
+        },
+        {
+            code: "let predicate; [, {foo:typeNode.returnType, ...predicate}] = foo();",
             parserOptions: { ecmaVersion: 2018 }
         },
         {
@@ -425,6 +433,22 @@ ruleTester.run("prefer-const", rule, {
         // https://github.com/eslint/eslint/issues/8308
         {
             code: "let predicate; [, {foo:returnType, predicate}] = foo();",
+            output: null,
+            parserOptions: { ecmaVersion: 2018 },
+            errors: [
+                { message: "'predicate' is never reassigned. Use 'const' instead.", type: "Identifier" }
+            ]
+        },
+        {
+            code: "let predicate; [, {foo:returnType, predicate}, ...bar ] = foo();",
+            output: null,
+            parserOptions: { ecmaVersion: 2018 },
+            errors: [
+                { message: "'predicate' is never reassigned. Use 'const' instead.", type: "Identifier" }
+            ]
+        },
+        {
+            code: "let predicate; [, {foo:returnType, ...predicate} ] = foo();",
             output: null,
             parserOptions: { ecmaVersion: 2018 },
             errors: [

--- a/tests/lib/rules/prefer-const.js
+++ b/tests/lib/rules/prefer-const.js
@@ -117,9 +117,37 @@ ruleTester.run("prefer-const", rule, {
             parser: fixtureParser("babel-eslint5/destructuring-object-spread")
         },
 
-        // https://github.com/eslint/eslint/issues/8308
+        // // https://github.com/eslint/eslint/issues/8308
         {
             code: "let predicate; [typeNode.returnType, predicate] = foo();",
+            parserOptions: { ecmaVersion: 2018 }
+        },
+        {
+            code: "let predicate; [typeNode.returnType,, predicate] = foo();",
+            parserOptions: { ecmaVersion: 2018 }
+        },
+        {
+            code: "let predicate; [typeNode.returnType=5, predicate] = foo();",
+            parserOptions: { ecmaVersion: 2018 }
+        },
+        {
+            code: "let predicate; [[typeNode.returnType=5], predicate] = foo();",
+            parserOptions: { ecmaVersion: 2018 }
+        },
+        {
+            code: "let predicate; [[typeNode.returnType, predicate]] = foo();",
+            parserOptions: { ecmaVersion: 2018 }
+        },
+        {
+            code: "let predicate; [typeNode.returnType, [predicate]] = foo();",
+            parserOptions: { ecmaVersion: 2018 }
+        },
+        {
+            code: "let predicate; [, [typeNode.returnType, predicate]] = foo();",
+            parserOptions: { ecmaVersion: 2018 }
+        },
+        {
+            code: "let predicate; [, {foo:typeNode.returnType, predicate}] = foo();",
             parserOptions: { ecmaVersion: 2018 }
         },
         {
@@ -127,7 +155,7 @@ ruleTester.run("prefer-const", rule, {
             parserOptions: { ecmaVersion: 2018 }
         },
 
-        // ignoreReadBeforeAssign
+        // // ignoreReadBeforeAssign
         {
             code: "let x; function foo() { bar(x); } x = 0;",
             options: [{ ignoreReadBeforeAssign: true }]
@@ -390,6 +418,17 @@ ruleTester.run("prefer-const", rule, {
                 { message: "'y' is never reassigned. Use 'const' instead.", type: "Identifier" },
                 { message: "'z' is never reassigned. Use 'const' instead.", type: "Identifier" }
             ]
+        },
+
+        // https://github.com/eslint/eslint/issues/8308
+        {
+            code: "let predicate; [, {foo:returnType, predicate}] = foo();",
+            output: null,
+            parserOptions: { ecmaVersion: 2018 },
+            errors: [
+                { message: "'predicate' is never reassigned. Use 'const' instead.", type: "Identifier" }
+            ]
         }
+
     ]
 });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Changed `prefer-const` so that it considers destructuring assignment with an object property to disqualify using `const` for variables used in the same destructuring assignment.


**Is there anything you'd like reviewers to focus on?**

Is this the correct approach? It seems like the key to fixing this bug was to consider object properties in destructuring assignment to be the key factor in determining if a variable should be declared with `const`. I'm not 100% this is the correct assumption, so please double-check that.
