### PR TITLE
Update: no-tabs allowIndentationTabs option (fixes #10256)

### DIFF
--- a/docs/rules/no-tabs.md
+++ b/docs/rules/no-tabs.md
@@ -9,14 +9,14 @@ This rule looks for tabs anywhere inside a file: code, comments or anything else
 Examples of **incorrect** code for this rule:
 
 ```js
-var a /t= 2;
+var a \t= 2;
 
 /**
-* /t/t it's a test function
+* \t\t it's a test function
 */
 function test(){}
 
-var x = 1; // /t test
+var x = 1; // \t test
 ```
 
 Examples of **correct** code for this rule:
@@ -32,9 +32,29 @@ function test(){}
 var x = 1; // test
 ```
 
+### Options
+
+This rule has an optional object option with the following properties:
+
+* `allowIndentationTabs` (default: false): If this is set to true, then the rule will not report tabs used for indentation.
+
+#### allowIndentationTabs
+
+Examples of **correct** code for this rule with the `allowIndentationTabs: true` option:
+
+```js
+/* eslint no-tabs: ["error", { allowIndentationTabs: true }] */
+
+function test() {
+\tdoSomething();
+}
+
+\t// comment with leading indentation tab
+```
+
 ## When Not To Use It
 
-If you have established a standard where having tabs is fine.
+If you have established a standard where having tabs is fine, then you can disable this rule.
 
 ## Compatibility
 

--- a/tests/lib/rules/no-tabs.js
+++ b/tests/lib/rules/no-tabs.js
@@ -23,7 +23,16 @@ ruleTester.run("no-tabs", rule, {
         "function test(){\n}",
         "function test(){\n" +
         "  //   sdfdsf \n" +
-        "}"
+        "}",
+
+        {
+            code: "\tdoSomething();",
+            options: [{ allowIndentationTabs: true }]
+        },
+        {
+            code: "\t// comment",
+            options: [{ allowIndentationTabs: true }]
+        }
     ],
     invalid: [
         {
@@ -31,7 +40,7 @@ ruleTester.run("no-tabs", rule, {
             errors: [{
                 message: ERROR_MESSAGE,
                 line: 1,
-                column: 18
+                column: 17
             }]
         },
         {
@@ -39,7 +48,7 @@ ruleTester.run("no-tabs", rule, {
             errors: [{
                 message: ERROR_MESSAGE,
                 line: 1,
-                column: 6
+                column: 5
             }]
         },
         {
@@ -50,7 +59,7 @@ ruleTester.run("no-tabs", rule, {
             errors: [{
                 message: ERROR_MESSAGE,
                 line: 2,
-                column: 6
+                column: 5
             }]
         },
         {
@@ -61,7 +70,7 @@ ruleTester.run("no-tabs", rule, {
             errors: [{
                 message: ERROR_MESSAGE,
                 line: 1,
-                column: 10
+                column: 9
             }]
         },
         {
@@ -73,14 +82,23 @@ ruleTester.run("no-tabs", rule, {
                 {
                     message: ERROR_MESSAGE,
                     line: 2,
-                    column: 6
+                    column: 5
                 },
                 {
                     message: ERROR_MESSAGE,
                     line: 3,
-                    column: 2
+                    column: 1
                 }
             ]
+        },
+        {
+            code: "\t// Comment with leading tab \t and inline tab",
+            options: [{ allowIndentationTabs: true }],
+            errors: [{
+                message: ERROR_MESSAGE,
+                line: 1,
+                column: 30
+            }]
         }
     ]
 });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

See #10256.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Added new option to no-tabs: `allowIndentationTabs`. This allows tabs that occur before any tokens or comments on a line.

**Is there anything you'd like reviewers to focus on?**

Any more test cases I should add?

I also noticed that the rule was reporting incorrect column locations and fixed that issue along with the existing tests. Please take a look at those changes and make sure I got them right.