### PR TITLE
Update: replace stacktrace by a clear message when invalid plugins are provided (fixes #10927)

### DIFF
--- a/conf/config-schema.js
+++ b/conf/config-schema.js
@@ -10,7 +10,7 @@ const baseConfigProperties = {
     globals: { type: "object" },
     parser: { type: ["string", "null"] },
     parserOptions: { type: "object" },
-    plugins: { type: "array" },
+    plugins: { type: "array", items: { type: "string" } },
     rules: { type: "object" },
     settings: { type: "object" },
 

--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -501,6 +501,8 @@ function loadFromDisk(resolvedPath, configContext) {
 
     if (config) {
 
+        validator.validateConfigSchema(config, resolvedPath.configFullName);
+
         // ensure plugins are properly loaded first
         if (config.plugins) {
             configContext.plugins.loadAll(config.plugins);

--- a/lib/config/config-validator.js
+++ b/lib/config/config-validator.js
@@ -275,5 +275,6 @@ function validate(config, source, ruleMapper, envContext) {
 module.exports = {
     getRuleOptionsSchema,
     validate,
+    validateConfigSchema,
     validateRuleOptions
 };

--- a/tests/lib/config/config-validator.js
+++ b/tests/lib/config/config-validator.js
@@ -219,6 +219,12 @@ describe("Validator", () => {
 
                 assert.throws(fn, "Property \"plugins\" is the wrong type (expected array but got `\"react\"`).");
             });
+
+            it("should throw with an array which doesn't contains only strings", () => {
+                const fn = validator.validate.bind(null, { plugins: ["react", { foo: "bar" }] }, null, ruleMapper, linter.environments);
+
+                assert.throws(fn, "ESLint configuration in null is invalid:\n\t- Property \"plugins[1]\" is the wrong type (expected string but got `{\"foo\":\"bar\"}`).\n");
+            });
         });
 
         describe("settings", () => {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**Tell us about your environment**

* **ESLint Version:**     "eslint": "^5.6.1"
* **Node Version:** v8.10.0
* **npm Version:** 6.4.1

**What parser (default, Babel-ESLint, etc.) are you using?**

**Please show your full configuration:**

<details>
<summary>Configuration</summary>
File eslintrc.json
```js
{
  ...
  "plugins": [
    ["import"],
    [{ "node": "node"}],
    { "promise": "promise" }],
  ]
}
```

</details>

**What did you do? Please include the actual source code causing the issue.**
Provided an invalid json config file.
cf. configuration (generated with a fuzzer PyJFuzz)

**What did you expect to happen?**
A meaningful message should be displayed.

**What actually happened? Please include the actual, raw output from ESLint.**
Big exception:
```
TypeError: normalizedName.charAt is not a function
    at Object.normalizePackageName (xxx/node_modules/eslint/lib/util/naming.js:37:24)
```

**What changes did you make? (Give an overview)**
When a non-string parameter is provided to the configuration parameter "plugins",
an exception is thrown


**Is there anything you'd like reviewers to focus on?**


