### PR TITLE
Chore: Simplify space-infix-ops

### DIFF
--- a/lib/rules/space-infix-ops.js
+++ b/lib/rules/space-infix-ops.js
@@ -40,25 +40,19 @@ module.exports = {
          * Returns the first token which violates the rule
          * @param {ASTNode} left - The left node of the main node
          * @param {ASTNode} right - The right node of the main node
+         * @param {string} op - The operator of the main node
          * @returns {Object} The violator token or null
          * @private
          */
-        function getFirstNonSpacedToken(left, right) {
-            const tokens = sourceCode.getTokensBetween(left, right, 1);
+        function getFirstNonSpacedToken(left, right, op) {
+            const operator = sourceCode.getTokensBetween(left, right, token => token.value === op)[0];
+            const prev = sourceCode.getTokenBefore(operator);
+            const next = sourceCode.getTokenAfter(operator);
 
-            for (let i = 1; i < tokens.length - 1; i++) {
-                const prev = tokens[i - 1];
-                const curr = tokens[i];
-                const next = tokens[i + 1];
-
-                if (curr.value === "(" || curr.value === ")") {
-                    continue;
-                }
-
-                if (!sourceCode.isSpaceBetweenTokens(prev, curr) || !sourceCode.isSpaceBetweenTokens(curr, next)) {
-                    return curr;
-                }
+            if (!sourceCode.isSpaceBetweenTokens(prev, operator) || !sourceCode.isSpaceBetweenTokens(operator, next)) {
+                return operator;
             }
+
             return null;
         }
 
@@ -104,7 +98,10 @@ module.exports = {
             const leftNode = (node.left.typeAnnotation) ? node.left.typeAnnotation : node.left;
             const rightNode = node.right;
 
-            const nonSpacedNode = getFirstNonSpacedToken(leftNode, rightNode);
+            // search for = in AssignmentPattern nodes
+            const operator = node.operator || "=";
+
+            const nonSpacedNode = getFirstNonSpacedToken(leftNode, rightNode, operator);
 
             if (nonSpacedNode) {
                 if (!(int32Hint && sourceCode.getText(node).endsWith("|0"))) {
@@ -120,8 +117,8 @@ module.exports = {
          * @private
          */
         function checkConditional(node) {
-            const nonSpacedConsequesntNode = getFirstNonSpacedToken(node.test, node.consequent);
-            const nonSpacedAlternateNode = getFirstNonSpacedToken(node.consequent, node.alternate);
+            const nonSpacedConsequesntNode = getFirstNonSpacedToken(node.test, node.consequent, "?");
+            const nonSpacedAlternateNode = getFirstNonSpacedToken(node.consequent, node.alternate, ":");
 
             if (nonSpacedConsequesntNode) {
                 report(node, nonSpacedConsequesntNode);
@@ -141,7 +138,7 @@ module.exports = {
             const rightNode = node.init;
 
             if (rightNode) {
-                const nonSpacedNode = getFirstNonSpacedToken(leftNode, rightNode);
+                const nonSpacedNode = getFirstNonSpacedToken(leftNode, rightNode, "=");
 
                 if (nonSpacedNode) {
                     report(node, nonSpacedNode);

--- a/lib/rules/space-infix-ops.js
+++ b/lib/rules/space-infix-ops.js
@@ -34,14 +34,6 @@ module.exports = {
 
     create(context) {
         const int32Hint = context.options[0] ? context.options[0].int32Hint === true : false;
-
-        const OPERATORS = [
-            "*", "/", "%", "+", "-", "<<", ">>", ">>>", "<", "<=", ">", ">=", "in",
-            "instanceof", "==", "!=", "===", "!==", "&", "^", "|", "&&", "||", "=",
-            "+=", "-=", "*=", "/=", "%=", "<<=", ">>=", ">>>=", "&=", "^=", "|=",
-            "?", ":", ",", "**"
-        ];
-
         const sourceCode = context.getSourceCode();
 
         /**
@@ -54,15 +46,17 @@ module.exports = {
         function getFirstNonSpacedToken(left, right) {
             const tokens = sourceCode.getTokensBetween(left, right, 1);
 
-            for (let i = 1, l = tokens.length - 1; i < l; ++i) {
-                const op = tokens[i];
+            for (let i = 1; i < tokens.length - 1; i++) {
+                const prev = tokens[i - 1];
+                const curr = tokens[i];
+                const next = tokens[i + 1];
 
-                if (
-                    (op.type === "Punctuator" || op.type === "Keyword") &&
-                    OPERATORS.indexOf(op.value) >= 0 &&
-                    (tokens[i - 1].range[1] >= op.range[0] || op.range[1] >= tokens[i + 1].range[0])
-                ) {
-                    return op;
+                if (curr.value === "(" || curr.value === ")") {
+                    continue;
+                }
+
+                if (!sourceCode.isSpaceBetweenTokens(prev, curr) || !sourceCode.isSpaceBetweenTokens(curr, next)) {
+                    return curr;
                 }
             }
             return null;

--- a/lib/rules/space-infix-ops.js
+++ b/lib/rules/space-infix-ops.js
@@ -45,7 +45,7 @@ module.exports = {
          * @private
          */
         function getFirstNonSpacedToken(left, right, op) {
-            const operator = sourceCode.getTokensBetween(left, right, token => token.value === op)[0];
+            const operator = sourceCode.getFirstTokenBetween(left, right, token => token.value === op);
             const prev = sourceCode.getTokenBefore(operator);
             const next = sourceCode.getTokenAfter(operator);
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

**What changes did you make? (Give an overview)**

`space-infix-ops` is a bit overcomplicated. there can be a lot of tokens between `left` and `right`, but only one of them can be an infix operator, the others must be opening and closing parens. if i'm mistaken, i'd happy to close this PR and open another one that adds those test cases :smile_cat: 

**Is there anything you'd like reviewers to focus on?**

afaik javascript engines are pretty good at caching loop invariants (so there's no need to save `tokens.length`), so i made the loop a bit more readable. i wasn't able to do performance testing (as `space-infix-ops` is not part of `eslint:recommended`, so `npm run perf` is no good), but i'd happy to tweak the implementation if someone can give me some pointer about how to do it.