### PR TITLE
Fix: OptionalCallExpression for no-unused-expressions (fixes #10939)

### DIFF
--- a/lib/rules/no-unused-expressions.js
+++ b/lib/rules/no-unused-expressions.js
@@ -111,7 +111,7 @@ module.exports = {
                 return true;
             }
 
-            return /^(?:Assignment|Call|New|Update|Yield|Await)Expression$/.test(node.type) ||
+            return /^(?:Assignment|Call|New|Update|Yield|Await|OptionalCall)Expression$/.test(node.type) ||
                 (node.type === "UnaryExpression" && ["delete", "void"].indexOf(node.operator) >= 0);
         }
 


### PR DESCRIPTION


<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:
**Tell us about your environment**

* **ESLint Version:** 5.6.1
* **Node Version:** 8.12.0
* **npm Version:** 6.4.1

**What parser (default, Babel-ESLint, etc.) are you using?** Babel-ESLint

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
{
  parser: 'babel-eslint',
  rules: {
    'no-unused-expressions': 1,
  },
}
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
function testFn() {}
testFn?.();
```

**What did you expect to happen?**
Should've been no error.

**What actually happened? Please include the actual, raw output from ESLint.**
```
2:1  error  Expected an assignment or function call and instead saw an expression  no-unused-expressions
```

**What changes did you make? (Give an overview)**
Very simple change, should be obvious.
Babylon reports OptionalCallExpressions no longer as CallExpressions but as OptionalCallExpressions.


