### PR TITLE
Docs: Move multi-str operator to new line to avoid other warning

### DIFF
--- a/docs/rules/no-multi-str.md
+++ b/docs/rules/no-multi-str.md
@@ -26,6 +26,6 @@ Examples of **correct** code for this rule:
 ```js
 /*eslint no-multi-str: "error"*/
 
-var x = "Line 1\n" +
-        "Line 2";
+var x = "Line 1\n"
+        + "Line 2";
 ```


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Moved the `+` operator in the `no-multi-str` rule example to newline since currently changing it to the current rule leads to another violation `'+' should be placed at the beginning of the line  operator-linebreak`. 


**Is there anything you'd like reviewers to focus on?**
Simple enough.