### PR TITLE
Fix: Remove extraneous linefeeds in `one-var` fixer (#10741)

### DIFF
--- a/lib/rules/one-var.js
+++ b/lib/rules/one-var.js
@@ -334,7 +334,11 @@ module.exports = {
                  *      y`
                  *      ^ afterComma
                  */
-                if (afterComma.loc.start.line > tokenAfterDeclarator.loc.end.line || afterComma.type === "Line" || afterComma.type === "Block") {
+                if (
+                    afterComma.loc.start.line > tokenAfterDeclarator.loc.end.line ||
+                    afterComma.type === "Line" ||
+                    afterComma.type === "Block"
+                ) {
                     let lastComment = afterComma;
 
                     while (lastComment.type === "Line" || lastComment.type === "Block") {
@@ -343,7 +347,7 @@ module.exports = {
 
                     return fixer.replaceTextRange(
                         [tokenAfterDeclarator.range[0], lastComment.range[0]],
-                        `;\n${sourceCode.text.slice(tokenAfterDeclarator.range[1], lastComment.range[0])}\n${declaration.kind} `
+                        `;${sourceCode.text.slice(tokenAfterDeclarator.range[1], lastComment.range[0])}${declaration.kind} `
                     );
                 }
 

--- a/tests/lib/rules/one-var.js
+++ b/tests/lib/rules/one-var.js
@@ -884,7 +884,7 @@ ruleTester.run("one-var", rule, {
         },
         {
             code: "const foo = 1,\n    bar = 2;",
-            output: "const foo = 1;\n\n    \nconst bar = 2;",
+            output: "const foo = 1;\n    const bar = 2;",
             options: [{ initialized: "never" }],
             parserOptions: { ecmaVersion: 6 },
             errors: [{
@@ -896,7 +896,7 @@ ruleTester.run("one-var", rule, {
         },
         {
             code: "var foo = 1,\n    bar = 2;",
-            output: "var foo = 1;\n\n    \nvar bar = 2;",
+            output: "var foo = 1;\n    var bar = 2;",
             options: [{ initialized: "never" }],
             errors: [{
                 message: "Split initialized 'var' declarations into multiple statements.",
@@ -907,7 +907,7 @@ ruleTester.run("one-var", rule, {
         },
         {
             code: "var foo = 1, // comment\n    bar = 2;",
-            output: "var foo = 1;\n // comment\n    \nvar bar = 2;",
+            output: "var foo = 1; // comment\n    var bar = 2;",
             options: [{ initialized: "never" }],
             errors: [{
                 message: "Split initialized 'var' declarations into multiple statements.",
@@ -929,7 +929,7 @@ ruleTester.run("one-var", rule, {
         },
         {
             code: "var f,          /* test */ l;",
-            output: "var f;\n          /* test */ \nvar l;",
+            output: "var f;          /* test */ var l;",
             options: ["never"],
             errors: [{
                 message: "Split 'var' declarations into multiple statements.",


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Resolves #10741.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Removed adding extraneous linefeeds in the fixer with input variable declarations being multiline.

**Is there anything you'd like reviewers to focus on?**

No, there isn't.
