### PR TITLE
Fix: Adds conditional for separateRequires in one-var (fixes #10179)

### DIFF
--- a/lib/rules/one-var.js
+++ b/lib/rules/one-var.js
@@ -257,7 +257,9 @@ module.exports = {
 
             if (currentOptions.uninitialized === MODE_ALWAYS && currentOptions.initialized === MODE_ALWAYS) {
                 if (currentScope.uninitialized || currentScope.initialized) {
-                    return false;
+                    if (!hasRequires) {
+                        return false;
+                    }
                 }
             }
 
@@ -268,7 +270,9 @@ module.exports = {
             }
             if (declarationCounts.initialized > 0) {
                 if (currentOptions.initialized === MODE_ALWAYS && currentScope.initialized) {
-                    return false;
+                    if (!hasRequires) {
+                        return false;
+                    }
                 }
             }
             if (currentScope.required && hasRequires) {

--- a/tests/lib/rules/one-var.js
+++ b/tests/lib/rules/one-var.js
@@ -210,6 +210,14 @@ ruleTester.run("one-var", rule, {
             parserOptions: { env: { node: true } }
         },
         {
+            code: "var bar = 'bar'; var foo = require('foo');",
+            options: [{ separateRequires: true, var: "always" }]
+        },
+        {
+            code: "var foo = require('foo'); var bar = 'bar';",
+            options: [{ separateRequires: true, var: "always" }]
+        },
+        {
             code: "var foo = require('foo'); var bar = 'bar';",
             options: [{ separateRequires: true, var: "always" }],
             parserOptions: { env: { node: true } }
@@ -1090,6 +1098,17 @@ ruleTester.run("one-var", rule, {
                 type: "VariableDeclaration",
                 line: 1,
                 column: 25
+            }]
+        },
+        {
+            code: "var a = true; var b = false;",
+            output: "var a = true,  b = false;",
+            options: [{ separateRequires: true, var: "always" }],
+            errors: [{
+                message: "Combine this with the previous 'var' statement.",
+                type: "VariableDeclaration",
+                line: 1,
+                column: 15
             }]
         },
         {


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Added conditionals to the `hasOnlyOneStatement` based on currentScope that has requires to avoid throwing an error when it should not.

**Is there anything you'd like reviewers to focus on?**
Looking at the function `hasOnlyOneStatement`, not sure if it actually does what the JSDocs suggest it does.  Ensure the changes I added did not make the rule more brittle and to make sure the function is aligned with the JSDocs, if its not, maybe we can open a ticket helping to clarify `hasOnlyOneStatement`.

Also, docs seem a little misleading here https://eslint.org/docs/rules/one-var#var-let-and-const. The following should be split into two separate examples IMO from speaking with @not-an-aardvark for clarification.

```
/*eslint one-var: ["error", { separateRequires: true, var: "always" }]*/
/*eslint-env node*/

var foo = require("foo");
var bar = "bar";

var foo = require("foo"),
    bar = require("bar");
```
Issue this fixes: https://github.com/eslint/eslint/issues/10179

Thank you

