### PR TITLE
Chore: Add typescript-specific edge case test to space-infix-ops

### DIFF
--- a/tests/fixtures/parsers/typescript-parsers/type-alias.js
+++ b/tests/fixtures/parsers/typescript-parsers/type-alias.js
@@ -1,0 +1,155 @@
+"use strict";
+
+exports.parse = () => ({
+    type: "Program",
+    range: [0, 16],
+    loc: {
+        start: { line: 1, column: 0 },
+        end: { line: 1, column: 16 }
+    },
+    body: [
+        {
+            type: "VariableDeclaration",
+            range: [0, 16],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 16 }
+            },
+            kind: "type",
+            declarations: [
+                {
+                    type: "VariableDeclarator",
+                    id: {
+                        type: "Identifier",
+                        range: [
+                            5,
+                            8
+                        ],
+                        loc: {
+                            start: { line: 1, column: 5 },
+                            end: { line: 1, column: 8 }
+                        },
+                        name: "Foo"
+                    },
+                    init: {
+                        type: "TSTypeReference",
+                        range: [14, 15],
+                        loc: {
+                            start: { line: 1, column: 14 },
+                            end: { line: 1, column: 15 }
+                        },
+                        typeName: {
+                            type: "Identifier",
+                            range: [14, 15],
+                            loc: {
+                                start: { line: 1, column: 14 },
+                                end: { line: 1, column: 15 }
+                            },
+                            name: "T"
+                        }
+                    },
+                    range: [5, 16],
+                    loc: {
+                        start: { line: 1, column: 5 },
+                        end: { line: 1, column: 16 }
+                    },
+                    typeParameters: {
+                        type: "TSTypeParameterDeclaration",
+                        range: [8, 11],
+                        loc: {
+                            start: { line: 1, column: 8 },
+                            end: { line: 1, column: 11 }
+                        },
+                        params: [
+                            {
+                                type: "TSTypeParameter",
+                                range: [9, 10],
+                                loc: {
+                                    start: { line: 1, column: 9 },
+                                    end: { line: 1, column: 10 }
+                                },
+                                name: "T"
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    ],
+    sourceType: "script",
+    tokens: [
+        {
+            type: "Identifier",
+            value: "type",
+            range: [0, 4],
+            loc: {
+                start: { line: 1, column: 0 },
+                end: { line: 1, column: 4 }
+            }
+        },
+        {
+            type: "Identifier",
+            value: "Foo",
+            range: [5, 8],
+            loc: {
+                start: { line: 1, column: 5 },
+                end: { line: 1, column: 8 }
+            }
+        },
+        {
+            type: "Punctuator",
+            value: "<",
+            range: [8, 9],
+            loc: {
+                start: { line: 1, column: 8 },
+                end: { line: 1, column: 9 }
+            }
+        },
+        {
+            type: "Identifier",
+            value: "T",
+            range: [9, 10],
+            loc: {
+                start: { line: 1, column: 9 },
+                end: { line: 1, column: 10 }
+            }
+        },
+        {
+            type: "Punctuator",
+            value: ">",
+            range: [10, 11],
+            loc: {
+                start: { line: 1, column: 10 },
+                end: { line: 1, column: 11 }
+            }
+        },
+        {
+            type: "Punctuator",
+            value: "=",
+            range: [12, 13],
+            loc: {
+                start: { line: 1, column: 12 },
+                end: { line: 1, column: 13 }
+            }
+        },
+        {
+            type: "Identifier",
+            value: "T",
+            range: [14, 15],
+            loc: {
+                start: { line: 1, column: 14 },
+                end: { line: 1, column: 15 }
+            }
+        },
+        {
+            type: "Punctuator",
+            value: ";",
+            range: [15, 16],
+            loc: {
+                start: { line: 1, column: 15 },
+                end: { line: 1, column: 16 }
+            }
+        }
+    ],
+    comments: []
+})

--- a/tests/lib/rules/space-infix-ops.js
+++ b/tests/lib/rules/space-infix-ops.js
@@ -44,7 +44,10 @@ ruleTester.run("space-infix-ops", rule, {
         { code: "function foo(a: number = 0) { }", parserOptions: { ecmaVersion: 6 }, parser: parser("type-annotations/function-parameter-type-annotation") },
         { code: "function foo(): Bar { }", parserOptions: { ecmaVersion: 6 }, parser: parser("type-annotations/function-return-type-annotation") },
         { code: "var foo: Bar = '';", parserOptions: { ecmaVersion: 6 }, parser: parser("type-annotations/variable-declaration-init-type-annotation") },
-        { code: "const foo = function(a: number = 0): Bar { };", parserOptions: { ecmaVersion: 6 }, parser: parser("type-annotations/function-expression-type-annotation") }
+        { code: "const foo = function(a: number = 0): Bar { };", parserOptions: { ecmaVersion: 6 }, parser: parser("type-annotations/function-expression-type-annotation") },
+
+        // TypeScript Type Aliases
+        { code: "type Foo<T> = T;", parserOptions: { ecmaVersion: 6 }, parser: parser("typescript-parsers/type-alias") }
     ],
     invalid: [
         {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

**What changes did you make? (Give an overview)**

Added some edge case tests, originally part of #10923 

**Is there anything you'd like reviewers to focus on?**

 The original implementation was looking for tokens between `Foo` and `T`, and thought that `<T>` is violating the rule (as the `<` and `>` are not spaced). since #10935 the implementation is looking for a specific operator (in this case, for the `=` sign), and ignores everything else (like the type parameter).