### PR TITLE
Docs: add instructions for npm 2FA (refs #10631)

### DIFF
--- a/docs/maintainer-guide/governance.md
+++ b/docs/maintainer-guide/governance.md
@@ -93,7 +93,7 @@ A Committer is invited to become a TSC member by existing TSC members. A nominat
 
 1. Add the GitHub user to the "ESLint TSC" team
 1. Set the GitHub user to be have the "Owner" role for the ESLint organization
-1. Send welcome email with link to maintainer guide
+1. Send a welcome email with a link to the [maintainer guide](./) and the [npm 2FA guide](./npm-2fa).
 1. Add the TSC member to the README
 1. Invite to the Gitter TSC chatroom
 1. Make the TSC member an admin on the ESLint team mailing list

--- a/docs/maintainer-guide/npm-2fa.md
+++ b/docs/maintainer-guide/npm-2fa.md
@@ -1,0 +1,16 @@
+# npm two-factor authentication
+
+The `eslint` npm account has two-factor authentication (2FA) enabled. The 2FA secret is distributed using a team on [Keybase](https://keybase.io). Anyone doing a release of a package from the Jenkins server needs to have access to the 2FA secret.
+
+If you're on ESLint's TSC, you should perform the following steps to obtain the 2FA secret:
+
+1. Download the [Keybase app](https://keybase.io/download) on a smartphone.
+1. Open the app and create an account.
+1. From the app, link your Keybase username with your GitHub username. (At the time of writing, the UI for this is to tap the face icon in the bottom-left of the app, then the profile picture in the top-right, then tap "Prove your GitHub" and follow the instructions.)
+1. Mention your Keybase username in the team chatroom, and wait for someone to add you to the Keybase team.
+1. Download an authenticator app like [Google Authenticator](https://support.google.com/accounts/answer/1066447) or [Authy](https://authy.com/), if you don't have one installed already.
+1. In the Keybase app, navigate to the Keybase filesystem (at the time of writing, the UI for this is to tap the hamburger icon in the bottom-right, then tap "Files") and then navigate to `/team/eslint/auth`.
+    * If your authenticator app is downloaded on the same device as your Keybase app (this will usually be the case if you're using the Keybase mobile app), then open `npm_2fa_code.txt` and copy the contents to the clipboard. Open your authenticator app, and paste the contents as a new key (by selecting something like "Enter a provided key" or "Enter key manually").
+    * If your authenticator app is downloaded on a *different* device from your Keybase app (e.g. if you're using a Keybase desktop app), then open `npm_2fa_code.png` and scan it as a QR code from your authenticator app.
+
+You should now be able to generate 6-digit 2FA codes for the `eslint` npm account using your authenticator app.

--- a/docs/maintainer-guide/releases.md
+++ b/docs/maintainer-guide/releases.md
@@ -16,6 +16,8 @@ A two-person release team is assigned to each scheduled release. This two-person
 
 The two-person team should seek input from the whole team on the Monday following a release to double-check if a patch release is necessary.
 
+At least one member of the release team needs to have access to [eslint's two-factor authentication for npm](./npm-2fa) in order to do a release.
+
 ## Release Communication
 
 Each scheduled release should be associated with a release issue ([example](https://github.com/eslint/eslint/issues/8138)). The release issue is the source of information for the team about the status of a release. Be sure the release issue has the "release" label so that it's easy to find.
@@ -30,7 +32,9 @@ On the day of a scheduled release, the release team should follow these steps:
     * Documentation changes.
     * Small bug fixes written by a team member.
 1. Log into Jenkins and schedule a build for the "ESLint Release" job.
-1. Wait for the "ESLint Release" job to complete.
+1. Watch the console output of the build on Jenkins. At some point, the build will pause and a link will be produced with an input field for a six-digit 2FA code.
+1. Enter the current six-digit 2FA code from your authenticator app. (Also see: [npm-2fa](./npm-2fa))
+1. Continue the build and wait for it to finish.
 1. Update the release blog post with a "Highlights" section, including new rules and anything else that's important.
 1. Make a release announcement in the public chatroom.
 1. Make a release announcement on Twitter.


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

(refs #10631)

This adds a page to the maintainer guide describing how to get access to the npm 2FA secret for the `eslint` account. It also updates the release guidelines to account for the 2FA step.

**Is there anything you'd like reviewers to focus on?**

If you're on the TSC and you haven't set up Keybase yet, it might be useful to use these instructions to get set up, and point out any issues you encounter with the instructions.