### PR TITLE
Update: require-jsdoc exceptions

### DIFF
--- a/docs/rules/require-jsdoc.md
+++ b/docs/rules/require-jsdoc.md
@@ -28,9 +28,10 @@ This rule requires JSDoc comments for specified nodes. Supported nodes:
 
 ## Options
 
-This rule has a single object option:
+This rule has the following options:
 
 * `"require"` requires JSDoc comments for the specified nodes
+* `"exceptMethods"` list any methods that should be excluded from the rule
 
 Default option settings are:
 
@@ -43,14 +44,18 @@ Default option settings are:
             "ClassDeclaration": false,
             "ArrowFunctionExpression": false,
             "FunctionExpression": false
-        }
+        },
+        "exceptMethods": []
     }]
 }
 ```
 
 ### require
 
-Examples of **incorrect** code for this rule with the `{ "require": { "FunctionDeclaration": true, "MethodDefinition": true, "ClassDeclaration": true, "ArrowFunctionExpression": true, "FunctionExpression": true } }` option:
+Examples of **incorrect** code for this rule with the `{ "require": {
+"FunctionDeclaration": true, "MethodDefinition": true, "ClassDeclaration": true,
+"ArrowFunctionExpression": true, "FunctionExpression": true }, "exceptMethods":
+[ "exceptedName" ] }` option:
 
 ```js
 /*eslint "require-jsdoc": ["error", {
@@ -92,7 +97,10 @@ var foo = {
 };
 ```
 
-Examples of **correct** code for this rule with the `{ "require": { "FunctionDeclaration": true, "MethodDefinition": true, "ClassDeclaration": true, "ArrowFunctionExpression": true, "FunctionExpression": true } }` option:
+Examples of **correct** code for this rule with the `{ "require": {
+"FunctionDeclaration": true, "MethodDefinition": true, "ClassDeclaration": true,
+"ArrowFunctionExpression": true, "FunctionExpression": true }, "exceptMethods":
+[ "exceptedName" ] }` option:
 
 ```js
 /*eslint "require-jsdoc": ["error", {
@@ -176,6 +184,19 @@ var foo = {
 };
 
 setTimeout(() => {}, 10); // since it's an anonymous arrow function
+
+var foo = function exceptedName() {};
+
+var exceptedName = () => {};
+
+class exceptedName {}
+
+/**
+ * App Class
+ **/
+class App {
+    exceptedName() {}
+}
 ```
 
 ## When Not To Use It

--- a/docs/rules/require-jsdoc.md
+++ b/docs/rules/require-jsdoc.md
@@ -32,6 +32,7 @@ This rule has the following options:
 
 * `"require"` requires JSDoc comments for the specified nodes
 * `"except"` list any methods that should be excluded from the rule
+* `"exceptPatterns"` an array of regex patterns which should be ignored
 
 Default option settings are:
 
@@ -45,7 +46,8 @@ Default option settings are:
             "ArrowFunctionExpression": false,
             "FunctionExpression": false
         },
-        "except": []
+        "except": [],
+        "exceptPatterns": [],
     }]
 }
 ```
@@ -55,7 +57,7 @@ Default option settings are:
 Examples of **incorrect** code for this rule with the `{ "require": {
 "FunctionDeclaration": true, "MethodDefinition": true, "ClassDeclaration": true,
 "ArrowFunctionExpression": true, "FunctionExpression": true }, "except":
-[ "exceptedName" ] }` option:
+[ "exceptedName" ], exceptPatterns: ["^_(.*)"] }` option:
 
 ```js
 /*eslint "require-jsdoc": ["error", {
@@ -100,7 +102,7 @@ var foo = {
 Examples of **correct** code for this rule with the `{ "require": {
 "FunctionDeclaration": true, "MethodDefinition": true, "ClassDeclaration": true,
 "ArrowFunctionExpression": true, "FunctionExpression": true }, "except":
-[ "exceptedName" ] }` option:
+[ "exceptedName" ], exceptPatterns: [ "^_(.*)" ] }` option:
 
 ```js
 /*eslint "require-jsdoc": ["error", {
@@ -197,6 +199,8 @@ class exceptedName {}
 class App {
     exceptedName() {}
 }
+
+function _internalFunction() {}
 ```
 
 ## When Not To Use It

--- a/docs/rules/require-jsdoc.md
+++ b/docs/rules/require-jsdoc.md
@@ -31,7 +31,7 @@ This rule requires JSDoc comments for specified nodes. Supported nodes:
 This rule has the following options:
 
 * `"require"` requires JSDoc comments for the specified nodes
-* `"exceptMethods"` list any methods that should be excluded from the rule
+* `"except"` list any methods that should be excluded from the rule
 
 Default option settings are:
 
@@ -45,7 +45,7 @@ Default option settings are:
             "ArrowFunctionExpression": false,
             "FunctionExpression": false
         },
-        "exceptMethods": []
+        "except": []
     }]
 }
 ```
@@ -54,7 +54,7 @@ Default option settings are:
 
 Examples of **incorrect** code for this rule with the `{ "require": {
 "FunctionDeclaration": true, "MethodDefinition": true, "ClassDeclaration": true,
-"ArrowFunctionExpression": true, "FunctionExpression": true }, "exceptMethods":
+"ArrowFunctionExpression": true, "FunctionExpression": true }, "except":
 [ "exceptedName" ] }` option:
 
 ```js
@@ -99,7 +99,7 @@ var foo = {
 
 Examples of **correct** code for this rule with the `{ "require": {
 "FunctionDeclaration": true, "MethodDefinition": true, "ClassDeclaration": true,
-"ArrowFunctionExpression": true, "FunctionExpression": true }, "exceptMethods":
+"ArrowFunctionExpression": true, "FunctionExpression": true }, "except":
 [ "exceptedName" ] }` option:
 
 ```js

--- a/lib/rules/require-jsdoc.js
+++ b/lib/rules/require-jsdoc.js
@@ -44,8 +44,8 @@ module.exports = {
                         type: "array",
                         items: {
                             type: "string"
-                        },
-                    },
+                        }
+                    }
                 },
                 additionalProperties: false
             }
@@ -62,7 +62,7 @@ module.exports = {
             FunctionExpression: false
         };
         const options = Object.assign(DEFAULT_OPTIONS, context.options[0] && context.options[0].require || {});
-        const exceptMethods = new Set(context.options[0].exceptMethods || []);
+        const exceptMethods = new Set(context.options[0] && context.options[0].exceptMethods || []);
 
         /**
          * Report the error message
@@ -76,7 +76,7 @@ module.exports = {
         /**
          * Check if the jsdoc comment is present or not.
          * @param {ASTNode} node node to examine
-         * @param {String} name the name associated with the expression
+         * @param {string} name the name associated with the expression
          * @returns {void}
          */
         function checkJsDoc(node, name) {
@@ -91,6 +91,7 @@ module.exports = {
             FunctionDeclaration(node) {
                 if (options.FunctionDeclaration) {
                     const vars = context.getDeclaredVariables(node);
+
                     checkJsDoc(node, vars[0].name);
                 }
             },
@@ -99,13 +100,15 @@ module.exports = {
                     (options.MethodDefinition && node.parent.type === "MethodDefinition") ||
                     (options.FunctionExpression && (node.parent.type === "VariableDeclarator" || (node.parent.type === "Property" && node === node.parent.value)))
                 ) {
-                    const name = node.parent.key ? node.parent.key.name : node.parent.id.name
+                    const name = node.parent.key ? node.parent.key.name : node.parent.id.name;
+
                     checkJsDoc(node, name);
                 }
             },
             ClassDeclaration(node) {
                 if (options.ClassDeclaration) {
                     const vars = context.getDeclaredVariables(node);
+
                     checkJsDoc(node, vars[0].name);
                 }
             },

--- a/lib/rules/require-jsdoc.js
+++ b/lib/rules/require-jsdoc.js
@@ -39,7 +39,13 @@ module.exports = {
                             }
                         },
                         additionalProperties: false
-                    }
+                    },
+                    exceptMethods: {
+                        type: "array",
+                        items: {
+                            type: "string"
+                        },
+                    },
                 },
                 additionalProperties: false
             }
@@ -56,6 +62,7 @@ module.exports = {
             FunctionExpression: false
         };
         const options = Object.assign(DEFAULT_OPTIONS, context.options[0] && context.options[0].require || {});
+        const exceptMethods = new Set(context.options[0].exceptMethods || []);
 
         /**
          * Report the error message
@@ -69,12 +76,13 @@ module.exports = {
         /**
          * Check if the jsdoc comment is present or not.
          * @param {ASTNode} node node to examine
+         * @param {String} name the name associated with the expression
          * @returns {void}
          */
-        function checkJsDoc(node) {
+        function checkJsDoc(node, name) {
             const jsdocComment = source.getJSDocComment(node);
 
-            if (!jsdocComment) {
+            if (!jsdocComment && !exceptMethods.has(name)) {
                 report(node);
             }
         }
@@ -82,7 +90,8 @@ module.exports = {
         return {
             FunctionDeclaration(node) {
                 if (options.FunctionDeclaration) {
-                    checkJsDoc(node);
+                    const vars = context.getDeclaredVariables(node);
+                    checkJsDoc(node, vars[0].name);
                 }
             },
             FunctionExpression(node) {
@@ -90,17 +99,19 @@ module.exports = {
                     (options.MethodDefinition && node.parent.type === "MethodDefinition") ||
                     (options.FunctionExpression && (node.parent.type === "VariableDeclarator" || (node.parent.type === "Property" && node === node.parent.value)))
                 ) {
-                    checkJsDoc(node);
+                    const name = node.parent.key ? node.parent.key.name : node.parent.id.name
+                    checkJsDoc(node, name);
                 }
             },
             ClassDeclaration(node) {
                 if (options.ClassDeclaration) {
-                    checkJsDoc(node);
+                    const vars = context.getDeclaredVariables(node);
+                    checkJsDoc(node, vars[0].name);
                 }
             },
             ArrowFunctionExpression(node) {
                 if (options.ArrowFunctionExpression && node.parent.type === "VariableDeclarator") {
-                    checkJsDoc(node);
+                    checkJsDoc(node, node.parent.id.name);
                 }
             }
         };

--- a/lib/rules/require-jsdoc.js
+++ b/lib/rules/require-jsdoc.js
@@ -40,7 +40,7 @@ module.exports = {
                         },
                         additionalProperties: false
                     },
-                    exceptMethods: {
+                    except: {
                         type: "array",
                         items: {
                             type: "string"
@@ -62,7 +62,7 @@ module.exports = {
             FunctionExpression: false
         };
         const options = Object.assign(DEFAULT_OPTIONS, context.options[0] && context.options[0].require || {});
-        const exceptMethods = new Set(context.options[0] && context.options[0].exceptMethods || []);
+        const except = new Set(context.options[0] && context.options[0].except || []);
 
         /**
          * Report the error message
@@ -82,7 +82,7 @@ module.exports = {
         function checkJsDoc(node, name) {
             const jsdocComment = source.getJSDocComment(node);
 
-            if (!jsdocComment && !exceptMethods.has(name)) {
+            if (!jsdocComment && !except.has(name)) {
                 report(node);
             }
         }

--- a/lib/rules/require-jsdoc.js
+++ b/lib/rules/require-jsdoc.js
@@ -45,6 +45,12 @@ module.exports = {
                         items: {
                             type: "string"
                         }
+                    },
+                    exceptPatterns: {
+                        type: "array",
+                        items: {
+                            type: "string"
+                        }
                     }
                 },
                 additionalProperties: false
@@ -62,7 +68,8 @@ module.exports = {
             FunctionExpression: false
         };
         const options = Object.assign(DEFAULT_OPTIONS, context.options[0] && context.options[0].require || {});
-        const except = new Set(context.options[0] && context.options[0].except || []);
+        const exceptStrings = new Set(context.options[0] && context.options[0].except || []);
+        const exceptPatterns = (context.options[0] && context.options[0].exceptPatterns || []).map(pattern => new RegExp(pattern));
 
         /**
          * Report the error message
@@ -74,6 +81,20 @@ module.exports = {
         }
 
         /**
+         * Check if the function name is excepted
+         * @param {string} name the name associated with the expression
+         * @returns {boolean} is true if the name is an exception
+         */
+        function isNameAnException(name) {
+            const normalException = exceptStrings.has(name);
+            const patternException = exceptPatterns.reduce((isException, pattern) =>
+                isException || pattern.test(name)
+            , false);
+
+            return normalException || patternException;
+        }
+
+        /**
          * Check if the jsdoc comment is present or not.
          * @param {ASTNode} node node to examine
          * @param {string} name the name associated with the expression
@@ -82,7 +103,7 @@ module.exports = {
         function checkJsDoc(node, name) {
             const jsdocComment = source.getJSDocComment(node);
 
-            if (!jsdocComment && !except.has(name)) {
+            if (!jsdocComment && !isNameAnException(name)) {
                 report(node);
             }
         }

--- a/tests/lib/rules/require-jsdoc.js
+++ b/tests/lib/rules/require-jsdoc.js
@@ -225,6 +225,39 @@ ruleTester.run("require-jsdoc", rule, {
                 }
             }],
             parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var exceptedFunction = function() {};",
+            options: [{
+                require: {
+                    FunctionExpression: true
+                },
+                exceptMethods: ["exceptedFunction"]
+            }],
+        },
+        {
+            code:
+            "class ExceptedClass extends Component {\n" +
+            "    exceptedMethod(xs) {}\n" +
+            "}",
+            options: [{
+                require: {
+                    MethodDefinition: true,
+                    ClassDeclaration: true
+                },
+                exceptMethods: ["exceptedMethod", "ExceptedClass"]
+            }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var exceptedArrowfunction = () => {}",
+            options: [{
+                require: {
+                    ArrowFunctionExpression: true,
+                },
+                exceptMethods: ["exceptedArrowfunction"]
+            }],
+            parserOptions: { ecmaVersion: 6 }
         }
     ],
 
@@ -412,6 +445,7 @@ ruleTester.run("require-jsdoc", rule, {
                 message: "Missing JSDoc comment.",
                 type: "FunctionExpression"
             }]
-        }
+        },
+        
     ]
 });

--- a/tests/lib/rules/require-jsdoc.js
+++ b/tests/lib/rules/require-jsdoc.js
@@ -258,6 +258,16 @@ ruleTester.run("require-jsdoc", rule, {
                 except: ["exceptedArrowfunction"]
             }],
             parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var _exceptedArrowfunction = () => {}",
+            options: [{
+                require: {
+                    ArrowFunctionExpression: true
+                },
+                exceptPatterns: ["^_(.*)"]
+            }],
+            parserOptions: { ecmaVersion: 6 }
         }
     ],
 

--- a/tests/lib/rules/require-jsdoc.js
+++ b/tests/lib/rules/require-jsdoc.js
@@ -232,7 +232,7 @@ ruleTester.run("require-jsdoc", rule, {
                 require: {
                     FunctionExpression: true
                 },
-                exceptMethods: ["exceptedFunction"]
+                except: ["exceptedFunction"]
             }]
         },
         {
@@ -245,7 +245,7 @@ ruleTester.run("require-jsdoc", rule, {
                     MethodDefinition: true,
                     ClassDeclaration: true
                 },
-                exceptMethods: ["exceptedMethod", "ExceptedClass"]
+                except: ["exceptedMethod", "ExceptedClass"]
             }],
             parserOptions: { ecmaVersion: 6 }
         },
@@ -255,7 +255,7 @@ ruleTester.run("require-jsdoc", rule, {
                 require: {
                     ArrowFunctionExpression: true
                 },
-                exceptMethods: ["exceptedArrowfunction"]
+                except: ["exceptedArrowfunction"]
             }],
             parserOptions: { ecmaVersion: 6 }
         }

--- a/tests/lib/rules/require-jsdoc.js
+++ b/tests/lib/rules/require-jsdoc.js
@@ -233,7 +233,7 @@ ruleTester.run("require-jsdoc", rule, {
                     FunctionExpression: true
                 },
                 exceptMethods: ["exceptedFunction"]
-            }],
+            }]
         },
         {
             code:
@@ -253,7 +253,7 @@ ruleTester.run("require-jsdoc", rule, {
             code: "var exceptedArrowfunction = () => {}",
             options: [{
                 require: {
-                    ArrowFunctionExpression: true,
+                    ArrowFunctionExpression: true
                 },
                 exceptMethods: ["exceptedArrowfunction"]
             }],
@@ -445,7 +445,6 @@ ruleTester.run("require-jsdoc", rule, {
                 message: "Missing JSDoc comment.",
                 type: "FunctionExpression"
             }]
-        },
-        
+        }
     ]
 });


### PR DESCRIPTION
As discussed in #10910 :
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Hey guys,

I want to start adopting require-jsdoc for internal use at the company I'm working with. The problem is that it either flags any function or none at all; meaning that even oft-repeated functions need a docblock. To be more specific, we'd like to opt-out of the rule if the function has a certain name, ie. `mapStateToProps` or `render`. We believe this will enforce a pattern of creating thoughtful comments, without having to create a docblock for recurring pieces of code.

I am perfectly willing to do a pull request for this one, if it all sounds good to you.

**What rule do you want to change?**
require-jsdoc

**Does this change cause the rule to produce more or fewer warnings?**
Fewer

**How will the change be implemented? (New option, new default behavior, etc.)?**
New option

**Please provide some example code that this change will affect:**

<!-- Put your code examples here -->
Config 
```
"require-jsdoc": ["error", {
    "require": {
        "FunctionDeclaration": true,
        "MethodDefinition": false,
        "ClassDeclaration": false,
        "ArrowFunctionExpression": false,
        "FunctionExpression": false
    },
    "exceptMethods": [
      "mapDispatchToProps"
    ]
}]
```

Code:
```js
function mapDispatchToProps() {
  return {};
}

function otherFunctionName () {
  return {};
}
```

**What does the rule currently do for this code?**
Throws errors for both `mapDispatchToProps` and `otherFunctionName`.

**What will the rule do after it's changed?**
Only throw an error for `otherFunctionName`.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
* Added the `exceptMethod` parameter in the schema
* Passed function names along to the report function
* Inserted a check if the function name is included in exceptMethods

**Is there anything you'd like reviewers to focus on?**
I'm not sure if exceptMethods is the right name for this parameter, but I'm open to suggestions.