### PR TITLE
Fix: deprecation warning in RuleTester using Node v11

### DIFF
--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -397,7 +397,7 @@ class RuleTester {
          */
         function assertASTDidntChange(beforeAST, afterAST) {
             if (!lodash.isEqual(beforeAST, afterAST)) {
-                assert.fail(null, null, "Rule should not modify AST.");
+                assert.fail("Rule should not modify AST.");
             }
         }
 
@@ -551,7 +551,7 @@ class RuleTester {
                     } else {
 
                         // Message was an unexpected type
-                        assert.fail(message, null, "Error should be a string, object, or RegExp.");
+                        assert.fail(`Error should be a string, object, or RegExp, but found (${util.inspect(message)})`);
                     }
                 }
             }


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix

**Tell us about your environment**

* **ESLint Version:**
* **Node Version:**
* **npm Version:**

**What parser (default, Babel-ESLint, etc.) are you using?**

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js

```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
"use strict";
const RuleTester = require("eslint").RuleTester;
try {
    new RuleTester().run(
        "foo",
        context => (context.report(context.getSourceCode().ast, "message"), {}),
        { valid: [], invalid: [{ code: "", errors: [5] }] }
    );
} catch (err) {
    // ignore
}
```

**What did you expect to happen?**

I expected `RuleTester` to produce no output because the error was caught.

**What actually happened? Please include the actual, raw output from ESLint.**

`RuleTester` printed a deprecation warning:

> (node:49648) [DEP0094] DeprecationWarning: assert.fail() with more than one argument is deprecated. Please use assert.strictEqual() instead or only pass a message.

**What changes did you make? (Give an overview)**

This updates `RuleTester` to avoid using the deprecated multi-argument `assert.fail` API in favor of the single-argument version. The single-argument version was introduced in Node v6.12.0, so we can use it since our support only covers Node `^6.14.0`.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
