### PR TITLE
Update: Create Linter.version API (fixes #9271)

### DIFF
--- a/docs/developer-guide/nodejs-api.md
+++ b/docs/developer-guide/nodejs-api.md
@@ -291,7 +291,7 @@ linter.defineParser("my-custom-parser", {
 const results = linter.verify("// some source text", { parser: "my-custom-parser" });
 ```
 
-### Linter#version
+### Linter#version/Linter.version
 
 Each instance of `Linter` has a `version` property containing the semantic version number of ESLint that the `Linter` instance is from.
 
@@ -300,6 +300,14 @@ const Linter = require("eslint").Linter;
 const linter = new Linter();
 
 linter.version; // => '4.5.0'
+```
+
+There is also a `Linter.version` property that you can read without instantiating `Linter`:
+
+```js
+const Linter = require("eslint").Linter;
+
+Linter.version; // => '4.5.0'
 ```
 
 ## linter

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -889,6 +889,15 @@ module.exports = class Linter {
     }
 
     /**
+     * Getter for package version.
+     * @static
+     * @returns {string} The version from package.json.
+     */
+    static get version() {
+        return pkg.version;
+    }
+
+    /**
      * Configuration object for the `verify` API. A JS representation of the eslintrc files.
      * @typedef {Object} ESLintConfig
      * @property {Object} rules The rule configuration to verify against.

--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -76,6 +76,14 @@ describe("Linter", () => {
         sandbox.verifyAndRestore();
     });
 
+    describe("Static Members", () => {
+        describe("version", () => {
+            it("should return same version as instance property", () => {
+                assert.strictEqual(Linter.version, linter.version);
+            });
+        });
+    });
+
     describe("when using events", () => {
         const code = TEST_CODE;
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Added `Linter.version`. I used a getter because JavaScript doesn't yet have static class properties, and otherwise, I'd need to do some hacky thing to add a property to the `Linter` constructor. I think this makes sense since `Linter.version` should not be overwritten.


**Is there anything you'd like reviewers to focus on?**

Is this what was expected?

