### PR TITLE
Chore: avoid using legacy report API in no-irregular-whitespace

### DIFF
--- a/lib/rules/no-irregular-whitespace.js
+++ b/lib/rules/no-irregular-whitespace.js
@@ -81,9 +81,7 @@ module.exports = {
             const locStart = node.loc.start;
             const locEnd = node.loc.end;
 
-            errors = errors.filter(error => {
-                const errorLoc = error[1];
-
+            errors = errors.filter(({ loc: errorLoc }) => {
                 if (errorLoc.line >= locStart.line && errorLoc.line <= locEnd.line) {
                     if (errorLoc.column >= locStart.column && (errorLoc.column <= locEnd.column || errorLoc.line < locEnd.line)) {
                         return false;
@@ -157,7 +155,7 @@ module.exports = {
                         column: match.index
                     };
 
-                    errors.push([node, location, "Irregular whitespace not allowed."]);
+                    errors.push({ node, message: "Irregular whitespace not allowed.", loc: location });
                 }
             });
         }
@@ -182,7 +180,7 @@ module.exports = {
                     column: sourceLines[lineIndex].length
                 };
 
-                errors.push([node, location, "Irregular whitespace not allowed."]);
+                errors.push({ node, message: "Irregular whitespace not allowed.", loc: location });
                 lastLineIndex = lineIndex;
             }
         }
@@ -224,9 +222,7 @@ module.exports = {
                 }
 
                 // If we have any errors remaining report on them
-                errors.forEach(error => {
-                    context.report(...error);
-                });
+                errors.forEach(error => context.report(error));
             };
         } else {
             nodes.Program = noop;


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates the no-irregular-whitespace rule to avoid using the legacy multi-argument `context.report` API. We have a linting rule to enforce against using the API, but the rule wasn't enforcing it in this case.

This was originally found by @Aladdin-ADD in https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/issues/64.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
