### PR TITLE
Fix: Allow fallthrough comment in case block (fixes #9559)

### DIFF
--- a/docs/rules/no-fallthrough.md
+++ b/docs/rules/no-fallthrough.md
@@ -124,6 +124,17 @@ switch(foo) {
     case 2:
         doSomething();
 }
+
+switch(foo) {
+    case 1: {
+        doSomething();
+        // falls through
+    }
+
+    case 2: {
+        doSomething();
+    }
+}
 ```
 
 Note that the last `case` statement in these examples does not cause a warning because there is nothing to fall through into.

--- a/lib/rules/no-fallthrough.js
+++ b/lib/rules/no-fallthrough.js
@@ -18,14 +18,20 @@ const DEFAULT_FALLTHROUGH_COMMENT = /falls?\s?through/i;
 
 /**
  * Checks whether or not a given node has a fallthrough comment.
- * @param {ASTNode} node - A SwitchCase node to get comments.
+ * @param {ASTNode} node - A SwitchCase node to get comments before.
+ * @param {ASTNode} fallthroughCase - A SwitchCase node that falls through to get comments inside.
  * @param {RuleContext} context - A rule context which stores comments.
  * @param {RegExp} fallthroughCommentPattern - A pattern to match comment to.
  * @returns {boolean} `true` if the node has a valid fallthrough comment.
  */
-function hasFallthroughComment(node, context, fallthroughCommentPattern) {
+function hasFallthroughComment(node, fallthroughCase, context, fallthroughCommentPattern) {
     const sourceCode = context.getSourceCode();
-    const comment = lodash.last(sourceCode.getCommentsBefore(node));
+
+    const beforeBlockEndToken = sourceCode.getLastToken(fallthroughCase);
+    const comment = lodash.last([
+        ...sourceCode.getCommentsBefore(beforeBlockEndToken),
+        ...sourceCode.getCommentsBefore(node)
+    ]);
 
     return Boolean(comment && fallthroughCommentPattern.test(comment.value));
 }
@@ -107,7 +113,7 @@ module.exports = {
                  * Checks whether or not there is a fallthrough comment.
                  * And reports the previous fallthrough node if that does not exist.
                  */
-                if (fallthroughCase && !hasFallthroughComment(node, context, fallthroughCommentPattern)) {
+                if (fallthroughCase && !hasFallthroughComment(node, fallthroughCase, context, fallthroughCommentPattern)) {
                     context.report({
                         message: "Expected a 'break' statement before '{{type}}'.",
                         data: { type: node.test ? "case" : "default" },

--- a/tests/lib/rules/no-fallthrough.js
+++ b/tests/lib/rules/no-fallthrough.js
@@ -55,6 +55,14 @@ ruleTester.run("no-fallthrough", rule, {
         "switch (foo) { case 0: try {} finally { break; } default: b(); }",
         "switch (foo) { case 0: try { throw 0; } catch (err) { break; } default: b(); }",
         "switch (foo) { case 0: do { throw 0; } while(a); default: b(); }",
+        "switch (foo) { case 0: {/* falls through */} default: { b(); } }",
+        "switch (foo) { case 0: {\n// falls through\n}\n\ndefault: b(); }",
+        "switch (foo) { case 0: { a();\n// falls through\n} default: b(); }",
+        "switch (foo) { case 0: { a(); break; } default: b(); }",
+        "switch (foo) { case 0: { try {throw 0;} catch (err) {break;} } default :b(); }",
+        "switch (foo) { case 0:\ncase 1: {\na();\n// falls through\n}\ndefault: b(); }",
+        "switch (foo) { case 0: { a(); } // falls through\n default: b(); }",
+        "switch (foo) { case 0: { a();\n// comment\n} // falls through\n default: b(); }",
         {
             code: "switch(foo) { case 0: a(); /* no break */ case 1: b(); }",
             options: [{
@@ -139,6 +147,41 @@ ruleTester.run("no-fallthrough", rule, {
         },
         {
             code: "switch(foo) { case 0: a(); /* falling through */ default: b() }",
+            errors: errorsDefault
+        },
+        {
+            code: "switch (foo) { case 0: {\n// falls through\na();\n} default: b(); }",
+            errors: errorsDefault
+        },
+        {
+            code: "switch (foo) { case 0: { a(); } default: b(); }",
+            errors: errorsDefault
+        },
+        {
+            code: "switch (foo) { case 0: {\na();\n} default: { b(); } }",
+            errors: errorsDefault
+        },
+        {
+            code: "switch (foo) { case 0: {\na();\n/* falls through */\n/*todo: fix readability */\n}\ndefault: b() }",
+            errors: [
+                {
+                    message: errorsDefault[0].message,
+                    type: errorsDefault[0].type,
+                    line: 6,
+                    column: 1
+                }
+            ]
+        },
+        {
+            code: "switch (foo) { case 0: {} default: b(); }",
+            errors: errorsDefault
+        },
+        {
+            code: "switch (foo) { case 0: { a(); } // comment\n default: b(); }",
+            errors: errorsDefault
+        },
+        {
+            code: "switch (foo) { case 0: { a();\n// falls through\n} // comment\n default: b(); }",
             errors: errorsDefault
         },
         {


### PR DESCRIPTION
**What is the purpose of this pull request?**

[x] Documentation update
[x] Bug fix

Reproduced and fixed issue #9559 with:
* **ESLint Version:** `v5.7.0`
* **Node Version:** `v9.4.0`

**What changes did you make?**

The rule `no-fallthrough` now gets the `fallthroughCase` passed into the function `hasFallthroughComment`. In that function, it looks for the comment directly before the fallthrough case's block in addition to directly before the current case.

Also added are corresponding tests and an example in the documentation for the switch case block.

**Is there anything you'd like reviewers to focus on?**
- The following edge cases:
```js
// Case with comment outside of the block
// - Currently these *don't error* to preserve the edge case
//   that previously didn't have unit tests
// - I can easily change this to error by not checking both comments
//   before `node` and `fallthroughCase`
switch (foo) {
    case 0: {
        a();
    } // falls through
    default: {
        b();
    }
}

// Case with comment outside of the block with a comment after
// - Currently these error to match the behavior of having a comment
//   after the fallthrough comment without a block
// - I can also change this to not error by moving the checks around
//   if erroring isn't desired
switch (foo) {
    case 0: {
        a();
        // falls through
    } // comment
    default:
        b();
}

// Cases with empty blocks
// - Currently these error
// - These look sorta like the allowed "stacking"[1] at first glance but they differ in an 
//   important way to me since the block looks like it encapsulates what case 0 and 1 do,
//   and therefore look like they don't fall through, so I didn't create special logic to allow these
switch (foo) {
    case 0: {}
    case 1: {
    }
    default: {
        b();
    }
}
```

---

fixes #9559

<details>
    <summary>[1] stacking</summary>

```js
switch(foo) {
    case 0:
    case 1:
        doSomething();
}
```

</details>