### PR TITLE
Update: Add support for filename baseConfig

### DIFF
--- a/docs/developer-guide/nodejs-api.md
+++ b/docs/developer-guide/nodejs-api.md
@@ -339,7 +339,7 @@ var CLIEngine = require("eslint").CLIEngine;
 The `CLIEngine` is a constructor, and you can create a new instance by passing in the options you want to use. The available options are:
 
 * `allowInlineConfig` - Set to `false` to disable the use of configuration comments (such as `/*eslint-disable*/`). Corresponds to `--no-inline-config`.
-* `baseConfig` - Can optionally be set to a config object. This will used as a default config, and will be merged with any configuration defined in `.eslintrc.*` files, with the `.eslintrc.*` files having precedence.
+* `baseConfig` - Can optionally be set to a config object, or `string` filename to a permitted eslint configuration file. This will used as a default config, and will be merged with any configuration defined in `.eslintrc.*` files, with the `.eslintrc.*` files having precedence.
 * `cache` - Operate only on changed files (default: `false`). Corresponds to `--cache`.
 * `cacheFile` - Name of the file where the cache will be stored (default: `.eslintcache`). Corresponds to `--cache-file`. Deprecated: use `cacheLocation` instead.
 * `cacheLocation` - Name of the file or directory where the cache will be stored (default: `.eslintcache`). Corresponds to `--cache-location`.

--- a/lib/config.js
+++ b/lib/config.js
@@ -67,12 +67,15 @@ class Config {
         this.parserOptions = options.parserOptions || {};
 
         this.configCache = new ConfigCache();
-
-        this.baseConfig = options.baseConfig
-            ? ConfigOps.merge({}, ConfigFile.loadObject(options.baseConfig, this))
-            : { rules: {} };
-        this.baseConfig.filePath = "";
-        this.baseConfig.baseDirectory = this.options.cwd;
+        if (typeof options.baseConfig === "string") {
+            this.baseConfig = ConfigFile.load(options.baseConfig, this);
+        } else {
+            this.baseConfig = options.baseConfig
+                ? ConfigOps.merge({}, ConfigFile.loadObject(options.baseConfig, this))
+                : { rules: {} };
+            this.baseConfig.filePath = "";
+            this.baseConfig.baseDirectory = this.options.cwd;
+        }
 
         this.configCache.setConfig(this.baseConfig.filePath, this.baseConfig);
         this.configCache.setMergedVectorConfig(this.baseConfig.filePath, this.baseConfig);

--- a/tests/lib/config.js
+++ b/tests/lib/config.js
@@ -152,6 +152,13 @@ describe("Config", () => {
 
     describe("new Config()", () => {
 
+        it("should allow loading baseConfig from file", () => {
+            const customBaseConfig = path.resolve(__dirname, "../fixtures/config-file/bom/.eslintrc.json"),
+                configHelper = new Config({ baseConfig: customBaseConfig }, linter);
+
+            assert.strictEqual(configHelper.baseConfig.filePath, customBaseConfig);
+        });
+
         // https://github.com/eslint/eslint/issues/2380
         it("should not modify baseConfig when format is specified", () => {
             const customBaseConfig = { foo: "bar" },


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

`baseConfig` only accepts a rules object.  however, it would be friendly and desirable to offer a path to a `baseConfig` eslint configuration file in addition.  this saves the developer from having to parse the `baseConfig` rules on their own

**Is there anything you'd like reviewers to focus on?**

the whole bit!