### PR TITLE
New: Add prefer-async-await rule (fixes #9649)

### DIFF
--- a/conf/eslint-recommended.js
+++ b/conf/eslint-recommended.js
@@ -230,6 +230,7 @@ module.exports = {
         "padded-blocks": "off",
         "padding-line-between-statements": "off",
         "prefer-arrow-callback": "off",
+        "prefer-async-await": "off",
         "prefer-const": "off",
         "prefer-destructuring": "off",
         "prefer-numeric-literals": "off",

--- a/docs/rules/prefer-async-await.md
+++ b/docs/rules/prefer-async-await.md
@@ -1,0 +1,48 @@
+# Prefer `async`/`await` over `.then()` (prefer-async-await)
+
+With the addition of `async`/`await` in ES2017, one can write asynchronous code
+in a synchronous-like manner.
+
+## Rule Details
+
+This rule flags `then` calls so they can be converted to use `async`/`await`.
+
+Examples of **incorrect** code for this rule:
+
+```js
+/*eslint prefer-async-await: "error"*/
+
+getData()
+  .then((data) => console.log(data))
+  .catch((error) => console.error(error))
+  .finally(() => cleanUp())
+
+dataPromise.then(function(data) { }).then(x).catch()
+```
+
+Examples of **correct** code for this rule:
+
+```js
+/*eslint prefer-async-await: "error"*/
+
+try {
+    let data = await getData();
+    console.log(data)
+} catch (error) {
+    console.error(error)
+}
+cleanUp();
+
+console.log(await getData())
+```
+
+## When Not To Use It
+
+This rule should not be enabled in environments that don't support ES2017.
+
+## Further Reading
+
+To learn more about `async`/`await`, check out the links below:
+
+- [`async function` (MDN)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function)
+- [`await` (MDN)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await)

--- a/lib/rules/prefer-async-await.js
+++ b/lib/rules/prefer-async-await.js
@@ -1,0 +1,50 @@
+/**
+ * @fileoverview Prefer async/await over .then()
+ * @author Elad Shahar
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Determine if a node is calling a `then` property
+ * @private
+ * @param {ASTNode} node - node to test
+ * @returns {boolean} True if `node` is a `then` property call
+ */
+function isThenCall(node) {
+    return node.property.type === "Identifier" &&
+           node.property.name === "then";
+}
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "require usage of async/await over .then()",
+            category: "Best Practices",
+            recommended: false,
+            url: "https://eslint.org/docs/rules/prefer-async-await"
+        },
+        schema: [],
+        messages: {
+            unexpected: "Prefer using async/await over .then()"
+        }
+    },
+
+    create(context) {
+        return {
+            MemberExpression(node) {
+                if (isThenCall(node)) {
+                    context.report({ node: node.property, messageId: "unexpected" });
+                }
+            }
+        };
+    }
+};

--- a/tests/lib/rules/prefer-async-await.js
+++ b/tests/lib/rules/prefer-async-await.js
@@ -1,0 +1,39 @@
+/**
+ * @fileoverview Tests for prefer-async-await rule.
+ * @author Elad Shahar
+ */
+
+"use strict";
+
+const rule = require("../../../lib/rules/prefer-async-await");
+const RuleTester = require("../../../lib/testers/rule-tester");
+
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2017 } });
+
+ruleTester.run("prefer-async-await", rule, {
+    valid: [
+        "async function a() { await getData(); }",
+        "async function hi() { await thing() }",
+        "async function hi() { await thing().catch() }",
+        "a = async () => (await something())"
+    ],
+    invalid: [
+        { code: "getData().then(() => {});", errors: [{ messageId: "unexpected" }] },
+        {
+            code: "function foo() { hey.then(x => {}) }",
+            errors: [{ messageId: "unexpected" }]
+        },
+        {
+            code: "function foo() { hey.then(function() { }).then() }",
+            errors: [{ messageId: "unexpected" }, { messageId: "unexpected" }]
+        },
+        {
+            code: "function foo() { hey.then(function() { }).then(x).catch() }",
+            errors: [{ messageId: "unexpected" }, { messageId: "unexpected" }]
+        },
+        {
+            code: "async function a() { hey.then(function() { }).then(function() { }) }",
+            errors: [{ messageId: "unexpected" }, { messageId: "unexpected" }]
+        }
+    ]
+});


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] New rule: fixes #9649. [Championed by](https://github.com/eslint/eslint/issues/9649#issuecomment-359363184) @mysticatea.

**What changes did you make? (Give an overview)**

This PR is a first attempt at adding a `prefer-async-await` rule. It also includes tests and the relevant documentation update.

**Is there anything you'd like reviewers to focus on?**

- This is a pretty basic implementation that just finds `.then` calls. I did not include `.catch`, `.finally`, or anything more complex. What should this PR include?
- I named this `prefer-async-await` but I'm not sure if something like `no-then` or `no-then-catch-finally` (if this is to be expanded to include more than just `then`), or something else.
- When compared to [`eslint-plugin-promise`](https://github.com/xjamundx/eslint-plugin-promise)'s [`prefer-await-to-then`](https://github.com/xjamundx/eslint-plugin-promise/blob/master/docs/rules/prefer-await-to-then.md) (as [volunteered by](https://github.com/eslint/eslint/issues/9649#issuecomment-361019153) @xjamundx), this PR's implementation fails two test cases which it reports as invalid that the `eslint-plugin-promise` returns valid for (show below). Unless I'm missing something, both of these can be rewritten with `await` to not use `then`. My implementation is also much more basic so please do point out any cases it may not handle.
  - `async function hi() { await thing().then() }`
  - `something().then(async () => await somethingElse())`
- I chose to make this not `recommended` and in the category "Best Practices" but I'm not sure if those are correct.
- All feedback welcome.
