### PR TITLE
Update: Add sort-imports ignoreDeclarationSort (fixes #11019)

### DIFF
--- a/docs/rules/sort-imports.md
+++ b/docs/rules/sort-imports.md
@@ -142,7 +142,7 @@ Default is `false`.
 
 Ignores the sorting of import declaration statements.
 
-Examples of **incorrect** code for this rule with the default `{ "ignoreMemberSort": false }` option:
+Examples of **incorrect** code for this rule with the default `{ "ignoreDeclarationSort": false }` option:
 
 ```js
 /*eslint sort-imports: ["error", { "ignoreDeclarationSort": false }]*/
@@ -150,7 +150,7 @@ import 'foo.js'
 import 'bar.js'
 ```
 
-Examples of **correct** code for this rule with the `{ "ignoreMemberSort": true }` option:
+Examples of **correct** code for this rule with the `{ "ignoreDeclarationSort": true }` option:
 
 ```js
 /*eslint sort-imports: ["error", { "ignoreDeclarationSort": true }]*/

--- a/docs/rules/sort-imports.md
+++ b/docs/rules/sort-imports.md
@@ -34,6 +34,7 @@ The `--fix` option on the command line automatically fixes some problems reporte
 This rule accepts an object with its properties as
 
 * `ignoreCase` (default: `false`)
+* `ignoreDeclarationSort` (default: `false`)
 * `ignoreMemberSort` (default: `false`)
 * `memberSyntaxSortOrder` (default: `["none", "all", "multiple", "single"]`); all 4 items must be present in the array, but you can change the order:
     * `none` = import module without exported bindings.
@@ -47,6 +48,7 @@ Default option settings are:
 {
     "sort-imports": ["error", {
         "ignoreCase": false,
+        "ignoreDeclarationSort": false,
         "ignoreMemberSort": false,
         "memberSyntaxSortOrder": ["none", "all", "multiple", "single"]
     }]
@@ -132,6 +134,34 @@ Examples of **correct** code for this rule with the `{ "ignoreCase": true }` opt
 import a from 'foo.js';
 import B from 'bar.js';
 import c from 'baz.js';
+```
+
+Default is `false`.
+
+### `ignoreDeclarationSort`
+
+Ignores the sorting of import declaration statements.
+
+Examples of **incorrect** code for this rule with the default `{ "ignoreMemberSort": false }` option:
+
+```js
+/*eslint sort-imports: ["error", { "ignoreDeclarationSort": false }]*/
+import 'foo.js'
+import 'bar.js'
+```
+
+Examples of **correct** code for this rule with the `{ "ignoreMemberSort": true }` option:
+
+```js
+/*eslint sort-imports: ["error", { "ignoreDeclarationSort": true }]*/
+import 'foo.js'
+import 'bar.js'
+```
+
+```js
+/*eslint sort-imports: ["error", { "ignoreDeclarationSort": true }]*/
+import 'bar.js'
+import 'foo.js'
 ```
 
 Default is `false`.

--- a/lib/rules/sort-imports.js
+++ b/lib/rules/sort-imports.js
@@ -34,6 +34,9 @@ module.exports = {
                         minItems: 4,
                         maxItems: 4
                     },
+                    ignoreDeclarationSort: {
+                        type: "boolean"
+                    },
                     ignoreMemberSort: {
                         type: "boolean"
                     }
@@ -49,6 +52,7 @@ module.exports = {
 
         const configuration = context.options[0] || {},
             ignoreCase = configuration.ignoreCase || false,
+            ignoreDeclarationSort = configuration.ignoreDeclarationSort || false,
             ignoreMemberSort = configuration.ignoreMemberSort || false,
             memberSyntaxSortOrder = configuration.memberSyntaxSortOrder || ["none", "all", "multiple", "single"],
             sourceCode = context.getSourceCode();
@@ -103,44 +107,48 @@ module.exports = {
 
         return {
             ImportDeclaration(node) {
-                if (previousDeclaration) {
-                    const currentMemberSyntaxGroupIndex = getMemberParameterGroupIndex(node),
-                        previousMemberSyntaxGroupIndex = getMemberParameterGroupIndex(previousDeclaration);
-                    let currentLocalMemberName = getFirstLocalMemberName(node),
-                        previousLocalMemberName = getFirstLocalMemberName(previousDeclaration);
+                if (!ignoreDeclarationSort) {
+                    if (previousDeclaration) {
+                        const currentMemberSyntaxGroupIndex = getMemberParameterGroupIndex(node),
+                            previousMemberSyntaxGroupIndex = getMemberParameterGroupIndex(previousDeclaration);
+                        let currentLocalMemberName = getFirstLocalMemberName(node),
+                            previousLocalMemberName = getFirstLocalMemberName(previousDeclaration);
 
-                    if (ignoreCase) {
-                        previousLocalMemberName = previousLocalMemberName && previousLocalMemberName.toLowerCase();
-                        currentLocalMemberName = currentLocalMemberName && currentLocalMemberName.toLowerCase();
+                        if (ignoreCase) {
+                            previousLocalMemberName = previousLocalMemberName && previousLocalMemberName.toLowerCase();
+                            currentLocalMemberName = currentLocalMemberName && currentLocalMemberName.toLowerCase();
+                        }
+
+                        /*
+                         * When the current declaration uses a different member syntax,
+                         * then check if the ordering is correct.
+                         * Otherwise, make a default string compare (like rule sort-vars to be consistent) of the first used local member name.
+                         */
+                        if (currentMemberSyntaxGroupIndex !== previousMemberSyntaxGroupIndex) {
+                            if (currentMemberSyntaxGroupIndex < previousMemberSyntaxGroupIndex) {
+                                context.report({
+                                    node,
+                                    message: "Expected '{{syntaxA}}' syntax before '{{syntaxB}}' syntax.",
+                                    data: {
+                                        syntaxA: memberSyntaxSortOrder[currentMemberSyntaxGroupIndex],
+                                        syntaxB: memberSyntaxSortOrder[previousMemberSyntaxGroupIndex]
+                                    }
+                                });
+                            }
+                        } else {
+                            if (previousLocalMemberName &&
+                                currentLocalMemberName &&
+                                currentLocalMemberName < previousLocalMemberName
+                            ) {
+                                context.report({
+                                    node,
+                                    message: "Imports should be sorted alphabetically."
+                                });
+                            }
+                        }
                     }
 
-                    /*
-                     * When the current declaration uses a different member syntax,
-                     * then check if the ordering is correct.
-                     * Otherwise, make a default string compare (like rule sort-vars to be consistent) of the first used local member name.
-                     */
-                    if (currentMemberSyntaxGroupIndex !== previousMemberSyntaxGroupIndex) {
-                        if (currentMemberSyntaxGroupIndex < previousMemberSyntaxGroupIndex) {
-                            context.report({
-                                node,
-                                message: "Expected '{{syntaxA}}' syntax before '{{syntaxB}}' syntax.",
-                                data: {
-                                    syntaxA: memberSyntaxSortOrder[currentMemberSyntaxGroupIndex],
-                                    syntaxB: memberSyntaxSortOrder[previousMemberSyntaxGroupIndex]
-                                }
-                            });
-                        }
-                    } else {
-                        if (previousLocalMemberName &&
-                            currentLocalMemberName &&
-                            currentLocalMemberName < previousLocalMemberName
-                        ) {
-                            context.report({
-                                node,
-                                message: "Imports should be sorted alphabetically."
-                            });
-                        }
-                    }
+                    previousDeclaration = node;
                 }
 
                 if (!ignoreMemberSort) {
@@ -189,8 +197,6 @@ module.exports = {
                         });
                     }
                 }
-
-                previousDeclaration = node;
             }
         };
     }

--- a/tests/lib/rules/sort-imports.js
+++ b/tests/lib/rules/sort-imports.js
@@ -62,6 +62,14 @@ ruleTester.run("sort-imports", rule, {
         },
         "import {a, b, c, d} from 'foo.js';",
         {
+            code:
+                "import a from 'foo.js';\n" +
+                "import B from 'bar.js';",
+            options: [{
+                ignoreDeclarationSort: true
+            }]
+        },
+        {
             code: "import {b, A, C, d} from 'foo.js';",
             options: [{
                 ignoreMemberSort: true
@@ -170,6 +178,21 @@ ruleTester.run("sort-imports", rule, {
         {
             code: "import {b, a, d, c} from 'foo.js';",
             output: "import {a, b, c, d} from 'foo.js';",
+            errors: [{
+                message: "Member 'a' of the import declaration should be sorted alphabetically.",
+                type: "ImportSpecifier"
+            }]
+        },
+        {
+            code:
+                "import {b, a, d, c} from 'foo.js';\n" +
+                "import {e, f, g, h} from 'bar.js';",
+            output:
+                "import {a, b, c, d} from 'foo.js';\n" +
+                "import {e, f, g, h} from 'bar.js';",
+            options: [{
+                ignoreDeclarationSort: true
+            }],
             errors: [{
                 message: "Member 'a' of the import declaration should be sorted alphabetically.",
                 type: "ImportSpecifier"


### PR DESCRIPTION
This allows users to enforce sorting import members, without having to enforce
sorting of import declarations.

fixes #11019 