### PR TITLE
Chore: fix invalid super() calls in tests

### DIFF
--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -3396,7 +3396,7 @@ describe("Linter", () => {
                 "var u = /^.$/u.test('𠮷');",
                 "var y = /hello/y.test('hello');",
                 "function restParam(a, ...rest) {}",
-                "function superInFunc() { super.foo(); }",
+                "class B { superInFunc() { super.foo(); } }",
                 "var template = `hello, ${a}`;",
                 "var unicode = '\\u{20BB7}';"
             ].join("\n");

--- a/tests/lib/rules/constructor-super.js
+++ b/tests/lib/rules/constructor-super.js
@@ -46,10 +46,6 @@ ruleTester.run("constructor-super", rule, {
         "class A extends B { constructor() { super(); class C extends D { constructor() { super(); } } } }",
         "class A extends B { constructor() { super(); class C { constructor() { } } } }",
 
-        // ignores out of constructors.
-        "class A { b() { super(); } }",
-        "function a() { super(); }",
-
         // multi code path.
         "class A extends B { constructor() { a ? super() : super(); } }",
         "class A extends B { constructor() { if (a) super(); else super(); } }",
@@ -78,9 +74,6 @@ ruleTester.run("constructor-super", rule, {
             "}"
         ].join("\n"),
 
-        // https://github.com/eslint/eslint/issues/5894
-        "class A { constructor() { return; super(); } }",
-
         // https://github.com/eslint/eslint/issues/8848
         `
             class A extends B {
@@ -98,12 +91,6 @@ ruleTester.run("constructor-super", rule, {
         `
     ],
     invalid: [
-
-        // non derived classes.
-        {
-            code: "class A { constructor() { super(); } }",
-            errors: [{ messageId: "unexpected", type: "CallExpression" }]
-        },
 
         // inherit from non constructors.
         {
@@ -135,11 +122,11 @@ ruleTester.run("constructor-super", rule, {
 
         // nested execution scope.
         {
-            code: "class A extends B { constructor() { function c() { super(); } } }",
+            code: "class A extends B { constructor() { class C extends D { constructor() { super(); } } } }",
             errors: [{ messageId: "missingAll", type: "MethodDefinition" }]
         },
         {
-            code: "class A extends B { constructor() { var c = function() { super(); } } }",
+            code: "class A extends B { constructor() { var c = class extends D { constructor() { super(); } } } }",
             errors: [{ messageId: "missingAll", type: "MethodDefinition" }]
         },
         {

--- a/tests/lib/rules/keyword-spacing.js
+++ b/tests/lib/rules/keyword-spacing.js
@@ -932,62 +932,62 @@ ruleTester.run("keyword-spacing", rule, {
         // super
         //----------------------------------------------------------------------
 
-        { code: "class A { a() { {} super[b](); } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A { a() { {}super[b](); } }", options: [NEITHER], parserOptions: { ecmaVersion: 6 } },
-        { code: "class A { a() { {} super[b](); } }", options: [override("super", BOTH)], parserOptions: { ecmaVersion: 6 } },
-        { code: "class A { a() { {}super[b](); } }", options: [override("super", NEITHER)], parserOptions: { ecmaVersion: 6 } },
+        { code: "class A extends B { a() { {} super[b](); } }", parserOptions: { ecmaVersion: 6 } },
+        { code: "class A extends B { a() { {}super[b](); } }", options: [NEITHER], parserOptions: { ecmaVersion: 6 } },
+        { code: "class A extends B { a() { {} super[b](); } }", options: [override("super", BOTH)], parserOptions: { ecmaVersion: 6 } },
+        { code: "class A extends B { a() { {}super[b](); } }", options: [override("super", NEITHER)], parserOptions: { ecmaVersion: 6 } },
 
         // not conflict with `array-bracket-spacing`
-        { code: "class A { a() { [super()]; } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A { a() { [ super() ]; } }", options: [NEITHER], parserOptions: { ecmaVersion: 6 } },
+        { code: "class A extends B { constructor() { [super()]; } }", parserOptions: { ecmaVersion: 6 } },
+        { code: "class A extends B { constructor() { [ super() ]; } }", options: [NEITHER], parserOptions: { ecmaVersion: 6 } },
 
         // not conflict with `arrow-spacing`
-        { code: "class A { a() { () =>super(); } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A { a() { () => super(); } }", options: [NEITHER], parserOptions: { ecmaVersion: 6 } },
+        { code: "class A extends B { constructor() { () =>super(); } }", parserOptions: { ecmaVersion: 6 } },
+        { code: "class A extends B { constructor() { () => super(); } }", options: [NEITHER], parserOptions: { ecmaVersion: 6 } },
 
         // not conflict with `block-spacing`
-        { code: "class A { a() {super()} }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A { a() { super() } }", options: [NEITHER], parserOptions: { ecmaVersion: 6 } },
+        { code: "class A extends B { constructor() {super()} }", parserOptions: { ecmaVersion: 6 } },
+        { code: "class A extends B { constructor() { super() } }", options: [NEITHER], parserOptions: { ecmaVersion: 6 } },
 
         // not conflict with `comma-spacing`
-        { code: "class A { a() { (0,super()) } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A { a() { (0, super()) } }", options: [NEITHER], parserOptions: { ecmaVersion: 6 } },
+        { code: "class A extends B { constructor() { (0,super()) } }", parserOptions: { ecmaVersion: 6 } },
+        { code: "class A extends B { constructor() { (0, super()) } }", options: [NEITHER], parserOptions: { ecmaVersion: 6 } },
 
         // not conflict with `computed-property-spacing`
-        { code: "class A { a() { ({[super()]: 0}) } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A { a() { ({[ super() ]: 0}) } }", options: [NEITHER], parserOptions: { ecmaVersion: 6 } },
+        { code: "class A extends B { constructor() { ({[super()]: 0}) } }", parserOptions: { ecmaVersion: 6 } },
+        { code: "class A extends B { constructor() { ({[ super() ]: 0}) } }", options: [NEITHER], parserOptions: { ecmaVersion: 6 } },
 
         // not conflict with `key-spacing`
-        { code: "class A { a() { ({a:super() }) } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A { a() { ({a: super() }) } }", options: [NEITHER], parserOptions: { ecmaVersion: 6 } },
+        { code: "class A extends B { constructor() { ({a:super() }) } }", parserOptions: { ecmaVersion: 6 } },
+        { code: "class A extends B { constructor() { ({a: super() }) } }", options: [NEITHER], parserOptions: { ecmaVersion: 6 } },
 
         // not conflict with `func-call-spacing`
-        { code: "class A { constructor() { super(); } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A { constructor() { super (); } }", options: [NEITHER], parserOptions: { ecmaVersion: 6 } },
+        { code: "class A extends B { constructor() { super(); } }", parserOptions: { ecmaVersion: 6 } },
+        { code: "class A extends B { constructor() { super (); } }", options: [NEITHER], parserOptions: { ecmaVersion: 6 } },
 
         // not conflict with `semi-spacing`
-        { code: "class A { a() { ;super(); } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A { a() { ; super() ; } }", options: [NEITHER], parserOptions: { ecmaVersion: 6 } },
+        { code: "class A extends B { constructor() { ;super(); } }", parserOptions: { ecmaVersion: 6 } },
+        { code: "class A extends B { constructor() { ; super() ; } }", options: [NEITHER], parserOptions: { ecmaVersion: 6 } },
 
         // not conflict with `space-in-parens`
-        { code: "class A { a() { (super()) } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A { a() { ( super() ) } }", options: [NEITHER], parserOptions: { ecmaVersion: 6 } },
+        { code: "class A extends B { constructor() { (super()) } }", parserOptions: { ecmaVersion: 6 } },
+        { code: "class A extends B { constructor() { ( super() ) } }", options: [NEITHER], parserOptions: { ecmaVersion: 6 } },
 
         // not conflict with `space-infix-ops`
-        { code: "class A { a() { b =super() } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A { a() { b = super() } }", options: [NEITHER], parserOptions: { ecmaVersion: 6 } },
+        { code: "class A extends B { constructor() { b =super() } }", parserOptions: { ecmaVersion: 6 } },
+        { code: "class A extends B { constructor() { b = super() } }", options: [NEITHER], parserOptions: { ecmaVersion: 6 } },
 
         // not conflict with `space-unary-ops`
-        { code: "class A { a() { !super() } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A { a() { ! super() } }", options: [NEITHER], parserOptions: { ecmaVersion: 6 } },
+        { code: "class A extends B { constructor() { !super() } }", parserOptions: { ecmaVersion: 6 } },
+        { code: "class A extends B { constructor() { ! super() } }", options: [NEITHER], parserOptions: { ecmaVersion: 6 } },
 
         // not conflict with `template-curly-spacing`
-        { code: "class A { a() { `${super()}` } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A { a() { `${ super() }` } }", options: [NEITHER], parserOptions: { ecmaVersion: 6 } },
+        { code: "class A extends B { constructor() { `${super()}` } }", parserOptions: { ecmaVersion: 6 } },
+        { code: "class A extends B { constructor() { `${ super() }` } }", options: [NEITHER], parserOptions: { ecmaVersion: 6 } },
 
         // not conflict with `jsx-curly-spacing`
-        { code: "class A { a() { <Foo onClick={super()} /> } }", parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
-        { code: "class A { a() { <Foo onClick={ super() } /> } }", options: [NEITHER], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
+        { code: "class A extends B { constructor() { <Foo onClick={super()} /> } }", parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
+        { code: "class A extends B { constructor() { <Foo onClick={ super() } /> } }", options: [NEITHER], parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } } },
 
         //----------------------------------------------------------------------
         // switch

--- a/tests/lib/rules/no-useless-constructor.js
+++ b/tests/lib/rules/no-useless-constructor.js
@@ -23,7 +23,6 @@ ruleTester.run("no-useless-constructor", rule, {
     valid: [
         "class A { }",
         "class A { constructor(){ doSomething(); } }",
-        "class A { constructor(){ super('foo'); } }",
         "class A extends B { constructor(){} }",
         "class A extends B { constructor(){ super('foo'); } }",
         "class A extends B { constructor(foo, bar){ super(foo, bar, 1); } }",

--- a/tests/lib/rules/prefer-arrow-callback.js
+++ b/tests/lib/rules/prefer-arrow-callback.js
@@ -38,8 +38,6 @@ ruleTester.run("prefer-arrow-callback", rule, {
         "foo(function bar() { bar; });",
         "foo(function bar() { arguments; });",
         "foo(function bar() { arguments; }.bind(this));",
-        "foo(function bar() { super.a; });",
-        "foo(function bar() { super.a; }.bind(this));",
         "foo(function bar() { new.target; });",
         "foo(function bar() { new.target; }.bind(this));",
         "foo(function bar() { this; }.bind(this, somethingElse));"


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Acorn now reports parsing errors for invalid uses of the `super` keyword, and some tests are failing on master as a result. This commit updates the affected tests as necessary (or removes them if they're no longer applicable).

**Is there anything you'd like reviewers to focus on?**

Nothing in particular