### PR TITLE
Fix: no-restricted-imports to check re-export (fixes #9678)

### DIFF
--- a/docs/rules/no-restricted-imports.md
+++ b/docs/rules/no-restricted-imports.md
@@ -1,6 +1,6 @@
 # Disallow specific imports (no-restricted-imports)
 
-Imports are an ES6/ES2015 standard for making the functionality of other modules available in your current module. In CommonJS this is implemented through the require() call which makes this ESLint rule roughly equivalent to its CommonJS counterpart `no-restricted-modules`.
+Imports are an ES6/ES2015 standard for making the functionality of other modules available in your current module. In CommonJS this is implemented through the `require()` call which makes this ESLint rule roughly equivalent to its CommonJS counterpart `no-restricted-modules`.
 
 Why would you want to restrict imports?
 
@@ -88,6 +88,18 @@ import fs from 'fs';
 ```
 
 ```js
+/*eslint no-restricted-imports: ["error", "fs"]*/
+
+export { fs } from 'fs';
+```
+
+```js
+/*eslint no-restricted-imports: ["error", "fs"]*/
+
+export * from 'fs';
+```
+
+```js
 /*eslint no-restricted-imports: ["error", { "paths": ["cluster"] }]*/
 
 import cluster from 'cluster';
@@ -135,6 +147,7 @@ Examples of **correct** code for this rule:
 /*eslint no-restricted-imports: ["error", "fs"]*/
 
 import crypto from 'crypto';
+export { foo } from "bar";
 ```
 
 ```js
@@ -142,6 +155,7 @@ import crypto from 'crypto';
 
 import crypto from 'crypto';
 import eslint from 'eslint';
+export * from "path";
 ```
 
 ```js

--- a/lib/rules/no-restricted-imports.js
+++ b/lib/rules/no-restricted-imports.js
@@ -251,8 +251,8 @@ module.exports = {
                     set.add("*");
                 } else if (specifier.imported) {
                     set.add(specifier.imported.name);
-                } else if (specifier.exported) {
-                    set.add(specifier.exported.name);
+                } else if (specifier.local) {
+                    set.add(specifier.local.name);
                 }
                 return set;
             }, new Set()) : new Set();

--- a/lib/rules/no-restricted-imports.js
+++ b/lib/rules/no-restricted-imports.js
@@ -236,31 +236,47 @@ module.exports = {
             return restrictedPatterns.length > 0 && restrictedPatternsMatcher.ignores(importSource);
         }
 
-        return {
-            ImportDeclaration(node) {
-                const importSource = node.source.value.trim();
-                const importNames = node.specifiers.reduce((set, specifier) => {
-                    if (specifier.type === "ImportDefaultSpecifier") {
-                        set.add("default");
-                    } else if (specifier.type === "ImportNamespaceSpecifier") {
-                        set.add("*");
-                    } else {
-                        set.add(specifier.imported.name);
-                    }
-                    return set;
-                }, new Set());
+        /**
+         * Checks a node to see if any problems should be reported.
+         * @param {ASTNode} node The node to check.
+         * @returns {void}
+         * @private
+         */
+        function checkNode(node) {
+            const importSource = node.source.value.trim();
+            const importNames = node.specifiers ? node.specifiers.reduce((set, specifier) => {
+                if (specifier.type === "ImportDefaultSpecifier") {
+                    set.add("default");
+                } else if (specifier.type === "ImportNamespaceSpecifier") {
+                    set.add("*");
+                } else if (specifier.imported) {
+                    set.add(specifier.imported.name);
+                } else if (specifier.exported) {
+                    set.add(specifier.exported.name);
+                }
+                return set;
+            }, new Set()) : new Set();
 
-                if (isRestrictedForEverythingImported(importSource, importNames)) {
-                    reportPathForEverythingImported(importSource, node);
-                }
-
-                if (isRestrictedPath(importSource, importNames)) {
-                    reportPath(node);
-                }
-                if (isRestrictedPattern(importSource)) {
-                    reportPathForPatterns(node);
-                }
+            if (isRestrictedForEverythingImported(importSource, importNames)) {
+                reportPathForEverythingImported(importSource, node);
             }
+
+            if (isRestrictedPath(importSource, importNames)) {
+                reportPath(node);
+            }
+            if (isRestrictedPattern(importSource)) {
+                reportPathForPatterns(node);
+            }
+        }
+
+        return {
+            ImportDeclaration: checkNode,
+            ExportNamedDeclaration(node) {
+                if (node.source) {
+                    checkNode(node);
+                }
+            },
+            ExportAllDeclaration: checkNode
         };
     }
 };

--- a/tests/lib/rules/no-restricted-imports.js
+++ b/tests/lib/rules/no-restricted-imports.js
@@ -198,13 +198,19 @@ ruleTester.run("no-restricted-imports", rule, {
         options: ["fs"],
         errors: [{ message: "'fs' import is restricted from being used.", type: "ExportAllDeclaration" }]
     }, {
-        code: "export a from \"fs\";",
-        options: ["fs"],
-        errors: [{ message: "'fs' import is restricted from being used.", type: "ExportAllDeclaration" }]
-    }, {
         code: "export {a} from \"fs\";",
         options: ["fs"],
         errors: [{ message: "'fs' import is restricted from being used.", type: "ExportNamedDeclaration" }]
+    }, {
+        code: "export {foo as b} from \"fs\";",
+        options: [{
+            paths: [{
+                name: "fs",
+                importNames: ["foo"],
+                message: "Don't import 'foo'."
+            }]
+        }],
+        errors: [{ message: "'fs' import is restricted from being used. Don't import 'foo'.", type: "ExportNamedDeclaration" }]
     }, {
         code: "import withGitignores from \"foo\";",
         options: [{

--- a/tests/lib/rules/no-restricted-imports.js
+++ b/tests/lib/rules/no-restricted-imports.js
@@ -194,6 +194,18 @@ ruleTester.run("no-restricted-imports", rule, {
         options: [{ patterns: ["foo/*", "!foo/baz"] }],
         errors: [{ message: "'foo/bar' import is restricted from being used by a pattern.", type: "ImportDeclaration" }]
     }, {
+        code: "export * from \"fs\";",
+        options: ["fs"],
+        errors: [{ message: "'fs' import is restricted from being used.", type: "ExportAllDeclaration" }]
+    }, {
+        code: "export a from \"fs\";",
+        options: ["fs"],
+        errors: [{ message: "'fs' import is restricted from being used.", type: "ExportAllDeclaration" }]
+    }, {
+        code: "export {a} from \"fs\";",
+        options: ["fs"],
+        errors: [{ message: "'fs' import is restricted from being used.", type: "ExportNamedDeclaration" }]
+    }, {
         code: "import withGitignores from \"foo\";",
         options: [{
             name: "foo",


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Added checks to `no-restricted-imports` to check for re-export using `export * from 'foo'` and `export {f} from 'foo'` syntax forms.

**Is there anything you'd like reviewers to focus on?**

Did I miss anything?
