### PR TITLE
Docs: Reorder Node.js API sections

### DIFF
--- a/docs/developer-guide/nodejs-api.md
+++ b/docs/developer-guide/nodejs-api.md
@@ -721,6 +721,22 @@ const Linter = require("eslint").Linter;
 Linter.version; // => '4.5.0'
 ```
 
+## linter
+
+The `eslint.linter` object (deprecated) is an instance of the `Linter` class as defined [above](#linter). `eslint.linter` exists for backwards compatibility, but we do not recommend using it because any mutations to it are shared among every module that uses `eslint`. Instead, please create your own instance of `eslint.Linter`.
+
+```js
+var linter = require("eslint").linter;
+
+var messages = linter.verify("var foo;", {
+    rules: {
+        semi: 2
+    }
+}, { filename: "foo.js" });
+```
+
+Note: This API is deprecated as of 4.0.0.
+
 ## SourceCode
 
 The `SourceCode` type represents the parsed source code that ESLint executes on. It's used internally in ESLint and is also available so that already-parsed code can be used. You can create a new instance of `SourceCode` by passing in the text string representing the code and an abstract syntax tree (AST) in [ESTree](https://github.com/estree/estree) format (including location information, range information, comments, and tokens):
@@ -765,22 +781,6 @@ var codeLines = SourceCode.splitLines(code);
     ]
  */
 ```
-
-## linter
-
-The `eslint.linter` object (deprecated) is an instance of the `Linter` class as defined [above](#linter). `eslint.linter` exists for backwards compatibility, but we do not recommend using it because any mutations to it are shared among every module that uses `eslint`. Instead, please create your own instance of `eslint.Linter`.
-
-```js
-var linter = require("eslint").linter;
-
-var messages = linter.verify("var foo;", {
-    rules: {
-        semi: 2
-    }
-}, { filename: "foo.js" });
-```
-
-Note: This API is deprecated as of 4.0.0.
 
 ## RuleTester
 


### PR DESCRIPTION
CLIEngine is now first since it is closest to CLI capability, and SourceCode is moved down.

<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Reordered some sections in the Node.js API page within the Developer Guide. Specifically, I moved CLIEngine to the top and moved SourceCode below Linter/linter.

**Is there anything you'd like reviewers to focus on?**

Sadly, the diff is a little unwieldy. Sorry about that. I promise I changed none of the text within the sections.

Do the sections' intro text make sense in the new order? (e.g., no cross-references to a "previous" section that now occurs later)