### PR TITLE
Add an option to auto-add "eslint-ignore" comments for all unfixable errors

### DIFF
--- a/lib/util/source-code-fixer.js
+++ b/lib/util/source-code-fixer.js
@@ -110,6 +110,13 @@ SourceCodeFixer.applyFixes = function(sourceText, messages, shouldFix) {
         if (Object.prototype.hasOwnProperty.call(problem, "fix")) {
             fixes.push(problem);
         } else {
+            let lbrPos = text.indexOf('\n');
+            let lineBreak = lbrPos > 0 && text[lbrPos - 1] === '\r' ? '\r\n' : '\n';
+            problem.fix = {
+              text: `/* eslint-disable ${problem.ruleId} */${lineBreak}`,
+              range: [0, 0],
+            };
+            fixes.push(problem);
             remainingMessages.push(problem);
         }
     });

--- a/lib/util/source-code-fixer.js
+++ b/lib/util/source-code-fixer.js
@@ -110,6 +110,7 @@ SourceCodeFixer.applyFixes = function(sourceText, messages, shouldFix) {
         if (Object.prototype.hasOwnProperty.call(problem, "fix")) {
             fixes.push(problem);
         } else {
+            // if (cliOptions.fixOrIgnore) {
             let lbrPos = text.indexOf('\n');
             let lineBreak = lbrPos > 0 && text[lbrPos - 1] === '\r' ? '\r\n' : '\n';
             problem.fix = {
@@ -117,7 +118,7 @@ SourceCodeFixer.applyFixes = function(sourceText, messages, shouldFix) {
               range: [0, 0],
             };
             fixes.push(problem);
-            remainingMessages.push(problem);
+            // } else { remainingMessages.push(problem); }
         }
     });
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[X] Add a CLI option
[X] Add something to the core
[X] Other, please explain:

When ESLint is being added (or its version/rules changed) to an already developed codebase, often numerous new errors might be introduced. In my case updating some versions and adding Prettier caused me to see 500-800 new errors from ESLint. Disabling new rules is not the best option if we want new code to be better. It's often a good solution to ignore new rules for old code, and keep them for new code. If ESLint would automatically add "eslint-ignore" comments to all unfixable error as a CLI option, it would make updating or introducing ESLint to existing codebases much much easier. 

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Modifying `source-code-fixer.js` so that it doesn't keep the problems (messages?) without `fix` object, but instead applies a default fix - which is adding an ignore comment. I'm using `/* eslint-ignore <ruleId> */` at the file beginning because adding `// eslint-ignore-line <ruleId>` doesn't always work for JSX (and multiline template strings probably too).

**Is there anything you'd like reviewers to focus on?**
Code in this PR isn't finished at the slightest. It's just the code I used to keep ESLint calm when adding Prettier to my existing codebase. Ideally I want to hide this functionality under a CLI option and add tests if possible, but I don't have any idea how ESLint codebase works and what place would be the best to add my logic into. If any reviewers would briefly guide me through a few points, I'd gladly improve my PR: 1) Is `source-code-fixer.js` a good place for this logic? 2) How do I pass a CLI option there? 3) Do I need any additional code anywhere as a consequence of adding a new CLI option? 4) What tests do I need to implement for this? 5) Is there a better way to determine CRLF/LF style? Mine is pretty dumb.

Thanks.