### PR TITLE
Docs: no-console#When-Not-To-Use provides incorrect rule snippet

### DIFF
--- a/docs/rules/no-console.md
+++ b/docs/rules/no-console.md
@@ -78,10 +78,11 @@ However, you might not want to manually add `eslint-disable-next-line` or `eslin
 ```json
 {
     "rules": {
+        "no-console": "off",
         "no-restricted-syntax": [
             "error",
             {
-                "selector": "CallExpression[callee.object.name='console'][callee.property.name=/^(log|warn|error|info|trace)$/]",
+                "selector": "CallExpression[callee.object.name='console'][callee.property.name!=/^(log|warn|error|info|trace)$/]",
                 "message": "Unexpected property on console object was called"
             }
         ]


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

- [x] Documentation update
- [ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
- [ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
- [ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

The snippet provided in [no-console#When Not To Use It](https://eslint.org/docs/rules/no-console#when-not-to-use-it) aims to achieve "only receiving errors for console calls" but the selector results in a warning for `console.log()` instead of `console.foobar()`. 
<img width="1019" alt="screen shot 2018-11-17 at 12 17 05 pm" src="https://user-images.githubusercontent.com/12410942/48657361-a32f0200-ea6a-11e8-872d-c0a0d9fcff3b.png">

To fix it, the 'unexpected property' should be  selected with `!=` instead of `=`. Also, turning off "no-console" is still required to achieve "only receiving errors for console calls with unexpected property"

After change:
`console.log()` is ok
`console.logs()` is warned
<img width="1023" alt="default" src="https://user-images.githubusercontent.com/12410942/48656812-ef774380-ea64-11e8-8d31-d7c6876bfd72.png">


**Is there anything you'd like reviewers to focus on?**


