### PR TITLE
Fix: Amend keyword-spacing to validate `default` keywords

### DIFF
--- a/lib/rules/keyword-spacing.js
+++ b/lib/rules/keyword-spacing.js
@@ -453,6 +453,10 @@ module.exports = {
             checkSpacingBefore(firstToken, PREV_TOKEN_M);
             checkSpacingAfter(firstToken, NEXT_TOKEN_M);
 
+            if (node.type === "ExportDefaultDeclaration") {
+                checkSpacingAround(sourceCode.getTokenAfter(firstToken));
+            }
+
             if (node.source) {
                 const fromToken = sourceCode.getTokenBefore(node.source);
 
@@ -554,7 +558,7 @@ module.exports = {
             // Statements - Declarations
             ClassDeclaration: checkSpacingForClass,
             ExportNamedDeclaration: checkSpacingForModuleDeclaration,
-            ExportDefaultDeclaration: checkSpacingAroundFirstToken,
+            ExportDefaultDeclaration: checkSpacingForModuleDeclaration,
             ExportAllDeclaration: checkSpacingForModuleDeclaration,
             FunctionDeclaration: checkSpacingForFunction,
             ImportDeclaration: checkSpacingForModuleDeclaration,

--- a/tests/lib/rules/keyword-spacing.js
+++ b/tests/lib/rules/keyword-spacing.js
@@ -2024,6 +2024,12 @@ ruleTester.run("keyword-spacing", rule, {
             errors: expectedBefore("export")
         },
         {
+            code: "export default{a}",
+            output: "export default {a}",
+            parserOptions: { sourceType: "module" },
+            errors: expectedAfter("default")
+        },
+        {
             code: "{}export* from \"a\"",
             output: "{} export * from \"a\"",
             parserOptions: { sourceType: "module" },


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->
**What changes did you make? (Give an overview)**
I updated the keyword-spacing rule definition to properly validate `default` keywords. At present, it mistakenly validates the `export` token rather than the accompanying `default`. I changed the handler to share `checkSpacingForModuleDeclaration` and amended that handler to include a special case for nodes with default export statements. This fixes: #11096 


