### PR TITLE
Build: fix test failure on Node 11

### DIFF
--- a/tests/lib/util/npm-utils.js
+++ b/tests/lib/util/npm-utils.js
@@ -162,8 +162,7 @@ describe("npmUtils", () => {
         });
 
         it("should return false if package.json does not exist", () => {
-            mockFs({});
-            assert.strictEqual(npmUtils.checkPackageJson(), false);
+            assert.strictEqual(npmUtils.checkPackageJson("/"), false);
         });
     });
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This is a workaround for https://github.com/tschaub/mock-fs/issues/256, which has been causing the build to fail on master for the past few days. It seems like we might eventually need to find an alternative to mock-fs for future Node versions, but this workaround should make the build pass in the meantime.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular