### PR TITLE
Fix: Allow escaped whitespace in paths for config initialization (fixes #11099)

### DIFF
--- a/lib/config/config-initializer.js
+++ b/lib/config/config-initializer.js
@@ -149,7 +149,7 @@ function configureRules(answers, config) {
     bar.tick(0); // Shows the progress bar
 
     // Get the SourceCode of all chosen files
-    const patterns = answers.patterns.split(/[\s]+/);
+    const patterns = answers.patterns.split(/(?<!\\)[\s]+/).map(s => s.replace(/\\/g,""));
 
     try {
         sourceCodes = getSourceCodeOfFiles(patterns, { baseConfig: newConfig, useEslintrc: false }, total => {


### PR DESCRIPTION
**What is the purpose of this pull request?**

[x] Bug fix

Reproduced and fixed issue #11099 with:

ESLint Version: v5.9.0
Node Version: v10.4.1

**What changes did you make?**

I changed the regex used in splitting the paths, to skip splitting on an escaped space. Then I remove any leftover `\` characters from the split-out patterns using a `.map(..)`.

**Is there anything you'd like reviewers to focus on?**

Because I'm using a regex negative lookbehind, it means this config tool could only run in Node with that recent JS feature present (ES2018), which (I think) was Node 10.0+. Not sure how that impacts eslint's Node support.

Also, I was going to modify the [tests for config-initializer here](https://github.com/eslint/eslint/blob/master/tests/lib/config/config-initializer.js#L335-L338), but decided not to, because it's not clear if there's any reasonable way to get an internal path in eslint with a space in it to be able to test against. :/