### PR TITLE
Fix: handle computed properties in camelcase (fixes #11084)

### DIFF
--- a/lib/rules/camelcase.js
+++ b/lib/rules/camelcase.js
@@ -100,14 +100,20 @@ module.exports = {
          * @private
          */
         function isInsideObjectPattern(node) {
-            let { parent } = node;
+            let current = node;
 
-            while (parent) {
-                if (parent.type === "ObjectPattern") {
+            while (current) {
+                const parent = current.parent;
+
+                if (parent && parent.type === "Property" && parent.computed && parent.key === current) {
+                    return false;
+                }
+
+                if (current.type === "ObjectPattern") {
                     return true;
                 }
 
-                parent = parent.parent;
+                current = parent;
             }
 
             return false;
@@ -169,11 +175,14 @@ module.exports = {
 
                     if (node.parent.parent && node.parent.parent.type === "ObjectPattern") {
                         if (node.parent.shorthand && node.parent.value.left && nameIsUnderscored) {
-
                             report(node);
                         }
 
                         const assignmentKeyEqualsValue = node.parent.key.name === node.parent.value.name;
+
+                        if (isUnderscored(name) && node.parent.computed) {
+                            report(node);
+                        }
 
                         // prevent checking righthand side of destructured object
                         if (node.parent.key === node && node.parent.value !== node) {

--- a/tests/lib/rules/camelcase.js
+++ b/tests/lib/rules/camelcase.js
@@ -107,6 +107,11 @@ ruleTester.run("camelcase", rule, {
             parserOptions: { ecmaVersion: 6 }
         },
         {
+            code: "var { [{category_id} = query]: categoryId } = query;",
+            options: [{ ignoreDestructuring: true }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
             code: "var { category_id: category } = query;",
             parserOptions: { ecmaVersion: 6 }
         },
@@ -341,6 +346,29 @@ ruleTester.run("camelcase", rule, {
                 {
                     messageId: "notCamelCase",
                     data: { name: "category_alias" },
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
+            code: "var { [category_id]: categoryId } = query;",
+            options: [{ ignoreDestructuring: true }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "notCamelCase",
+                    data: { name: "category_id" },
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
+            code: "var { [category_id]: categoryId } = query;",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "notCamelCase",
+                    data: { name: "category_id" },
                     type: "Identifier"
                 }
             ]


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**Tell us about your environment**

* **ESLint Version:** `5.9.0`
* **Node Version:** `11.0.0`
* **npm Version:** `6.4.1`

**What parser (default, Babel-ESLint, etc.) are you using?** default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

```js
camelcase: [2, {ignoreDestructuring: true}]
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
var { [category_id]: categoryId } = query;
```

**What did you expect to happen?**

Reported `camelcase` error for `category_id`.

**What actually happened? Please include the actual, raw output from ESLint.**

No errors reported

**What changes did you make? (Give an overview)**

`isInsideObjectPattern` now stops at computed properties (as the computed property can be a simple expression, and `node` cannot be part of an `ObjectPattern` anymore).

**Is there anything you'd like reviewers to focus on?**

I'd be happy to add more tests if you can think of more edge-cases.

