### PR TITLE
Docs: (Grammar) "the setup" -> "to set up".

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If you want to include ESLint as part of your project's build system, we recomme
 $ npm install eslint --save-dev
 ```
 
-You should then setup a configuration file:
+You should then set up a configuration file:
 
 ```
 $ ./node_modules/.bin/eslint --init
@@ -60,7 +60,7 @@ If you want to make ESLint available to tools that run across all of your projec
 $ npm install -g eslint
 ```
 
-You should then setup a configuration file:
+You should then set up a configuration file:
 
 ```
 $ eslint --init


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

- [x] Documentation update
- [ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
- [ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
- [ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [x] Other, please explain: **Fixed a typo.**

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
I fixed the typo `to setup`.
`setup` is a noun. The correct verb is `to set up`

Source: 
- http://www.future-perfect.co.uk/grammar-tip/is-it-setup-set-up-or-set-up/
- https://grammarist.com/spelling/set-up-vs-setup/


**Is there anything you'd like reviewers to focus on?**
No


