### PR TITLE
Update: space-in-parens linting messages and report behaviour

### DIFF
--- a/docs/rules/space-in-parens.md
+++ b/docs/rules/space-in-parens.md
@@ -12,7 +12,9 @@ var x = (1 + 2) * 3;
 
 ## Rule Details
 
-This rule will enforce consistency of spacing directly inside of parentheses, by disallowing or requiring one or more spaces to the right of `(` and to the left of `)`. In either case, `()` will still be allowed.
+This rule will enforce consistent spacing directly inside of parentheses, by disallowing or requiring one or more spaces to the right of `(` and to the left of `)`.
+
+As long as you do not explicitly disallow empty parentheses using the `"empty"` exception , `()` will be allowed.
 
 ## Options
 
@@ -87,7 +89,20 @@ var foo = ( 1 + 2 ) * 3;
 
 An object literal may be used as a third array item to specify exceptions, with the key `"exceptions"` and an array as the value. These exceptions work in the context of the first option. That is, if `"always"` is set to enforce spacing, then any "exception" will *disallow* spacing. Conversely, if `"never"` is set to disallow spacing, then any "exception" will *enforce* spacing.
 
+Note that this rule only enforces spacing within parentheses; it does not check spacing within curly or square brackets, but will enforce or disallow spacing of those brackets if and only if they are adjacent to an opening or closing parenthesis.
+
 The following exceptions are available: `["{}", "[]", "()", "empty"]`.
+
+### Empty Exception
+
+Empty parens exception and behavior:
+
+* `always` allows for both `()` and `( )`
+* `never` (default) requires `()`
+* `always` excepting `empty` requires `()`
+* `never` excepting `empty` requires `( )` (empty parens without a space is here forbidden)
+
+### Examples
 
 Examples of **incorrect** code for this rule with the `"never", { "exceptions": ["{}"] }` option:
 
@@ -168,6 +183,7 @@ Examples of **incorrect** code for this rule with the `"never", { "exceptions": 
 
 foo((1 + 2));
 foo((1 + 2), 1);
+foo(bar());
 ```
 
 Examples of **correct** code for this rule with the `"never", { "exceptions": ["()"] }]` option:
@@ -177,6 +193,7 @@ Examples of **correct** code for this rule with the `"never", { "exceptions": ["
 
 foo( (1 + 2) );
 foo( (1 + 2), 1);
+foo(bar() );
 ```
 
 Examples of **incorrect** code for this rule with the `"always", { "exceptions": ["()"] }]` option:

--- a/lib/rules/space-in-parens.js
+++ b/lib/rules/space-in-parens.js
@@ -40,23 +40,28 @@ module.exports = {
                 },
                 additionalProperties: false
             }
-        ]
+        ],
+
+        messages: {
+            missingOpeningSpace: "There must be a space after this paren.",
+            missingClosingSpace: "There must be a space before this paren.",
+            rejectedOpeningSpace: "There should be no space after this paren.",
+            rejectedClosingSpace: "There should be no space before this paren."
+        }
     },
 
     create(context) {
-
-        const MISSING_SPACE_MESSAGE = "There must be a space inside this paren.",
-            REJECTED_SPACE_MESSAGE = "There should be no spaces inside this paren.",
-            ALWAYS = context.options[0] === "always",
+        const ALWAYS = context.options[0] === "always",
             exceptionsArrayOptions = (context.options[1] && context.options[1].exceptions) || [],
             options = {};
+
         let exceptions;
 
         if (exceptionsArrayOptions.length) {
-            options.braceException = exceptionsArrayOptions.indexOf("{}") !== -1;
-            options.bracketException = exceptionsArrayOptions.indexOf("[]") !== -1;
-            options.parenException = exceptionsArrayOptions.indexOf("()") !== -1;
-            options.empty = exceptionsArrayOptions.indexOf("empty") !== -1;
+            options.braceException = exceptionsArrayOptions.includes("{}");
+            options.bracketException = exceptionsArrayOptions.includes("[]");
+            options.parenException = exceptionsArrayOptions.includes("()");
+            options.empty = exceptionsArrayOptions.includes("empty");
         }
 
         /**
@@ -105,7 +110,7 @@ module.exports = {
          * @returns {boolean} True if the token is one of the exceptions for the opener paren
          */
         function isOpenerException(token) {
-            return token.type === "Punctuator" && exceptions.openers.indexOf(token.value) >= 0;
+            return exceptions.openers.includes(token.value);
         }
 
         /**
@@ -114,102 +119,95 @@ module.exports = {
          * @returns {boolean} True if the token is one of the exceptions for the closer paren
          */
         function isCloserException(token) {
-            return token.type === "Punctuator" && exceptions.closers.indexOf(token.value) >= 0;
+            return exceptions.closers.includes(token.value);
         }
 
         /**
-         * Determines if an opener paren should have a missing space after it
-         * @param {Object} left The paren token
-         * @param {Object} right The token after it
-         * @returns {boolean} True if the paren should have a space
+         * Determines if an opening paren is immediately followed by a required space
+         * @param {Object} openingParenToken The paren token
+         * @param {Object} tokenAfterOpeningParen The token after it
+         * @returns {boolean} True if the opening paren is missing a required space
          */
-        function shouldOpenerHaveSpace(left, right) {
-            if (sourceCode.isSpaceBetweenTokens(left, right)) {
+        function openerMissingSpace(openingParenToken, tokenAfterOpeningParen) {
+            if (sourceCode.isSpaceBetweenTokens(openingParenToken, tokenAfterOpeningParen)) {
+                return false;
+            }
+
+            if (!options.empty && astUtils.isClosingParenToken(tokenAfterOpeningParen)) {
                 return false;
             }
 
             if (ALWAYS) {
-                if (astUtils.isClosingParenToken(right)) {
-                    return false;
-                }
-                return !isOpenerException(right);
+                return !isOpenerException(tokenAfterOpeningParen);
             }
-            return isOpenerException(right);
-
+            return isOpenerException(tokenAfterOpeningParen);
         }
 
         /**
-         * Determines if an closer paren should have a missing space after it
-         * @param {Object} left The token before the paren
-         * @param {Object} right The paren token
-         * @returns {boolean} True if the paren should have a space
+         * Determines if an opening paren is immediately followed by a disallowed space
+         * @param {Object} openingParenToken The paren token
+         * @param {Object} tokenAfterOpeningParen The token after it
+         * @returns {boolean} True if the opening paren has a disallowed space
          */
-        function shouldCloserHaveSpace(left, right) {
-            if (astUtils.isOpeningParenToken(left)) {
+        function openerRejectsSpace(openingParenToken, tokenAfterOpeningParen) {
+            if (!astUtils.isTokenOnSameLine(openingParenToken, tokenAfterOpeningParen)) {
                 return false;
             }
 
-            if (sourceCode.isSpaceBetweenTokens(left, right)) {
+            if (tokenAfterOpeningParen.type === "Line") {
+                return false;
+            }
+
+            if (!sourceCode.isSpaceBetweenTokens(openingParenToken, tokenAfterOpeningParen)) {
                 return false;
             }
 
             if (ALWAYS) {
-                return !isCloserException(left);
+                return isOpenerException(tokenAfterOpeningParen);
             }
-            return isCloserException(left);
-
+            return !isOpenerException(tokenAfterOpeningParen);
         }
 
         /**
-         * Determines if an opener paren should not have an existing space after it
-         * @param {Object} left The paren token
-         * @param {Object} right The token after it
-         * @returns {boolean} True if the paren should reject the space
+         * Determines if a closing paren is immediately preceeded by a required space
+         * @param {Object} tokenBeforeClosingParen The token before the paren
+         * @param {Object} closingParenToken The paren token
+         * @returns {boolean} True if the closing paren is missing a required space
          */
-        function shouldOpenerRejectSpace(left, right) {
-            if (right.type === "Line") {
+        function closerMissingSpace(tokenBeforeClosingParen, closingParenToken) {
+            if (sourceCode.isSpaceBetweenTokens(tokenBeforeClosingParen, closingParenToken)) {
                 return false;
             }
 
-            if (!astUtils.isTokenOnSameLine(left, right)) {
-                return false;
-            }
-
-            if (!sourceCode.isSpaceBetweenTokens(left, right)) {
+            if (!options.empty && astUtils.isOpeningParenToken(tokenBeforeClosingParen)) {
                 return false;
             }
 
             if (ALWAYS) {
-                return isOpenerException(right);
+                return !isCloserException(tokenBeforeClosingParen);
             }
-            return !isOpenerException(right);
-
+            return isCloserException(tokenBeforeClosingParen);
         }
 
         /**
-         * Determines if an closer paren should not have an existing space after it
-         * @param {Object} left The token before the paren
-         * @param {Object} right The paren token
-         * @returns {boolean} True if the paren should reject the space
+         * Determines if a closer paren is immediately preceeded by a disallowed space
+         * @param {Object} tokenBeforeClosingParen The token before the paren
+         * @param {Object} closingParenToken The paren token
+         * @returns {boolean} True if the closing paren has a disallowed space
          */
-        function shouldCloserRejectSpace(left, right) {
-            if (astUtils.isOpeningParenToken(left)) {
+        function closerRejectsSpace(tokenBeforeClosingParen, closingParenToken) {
+            if (!astUtils.isTokenOnSameLine(tokenBeforeClosingParen, closingParenToken)) {
                 return false;
             }
 
-            if (!astUtils.isTokenOnSameLine(left, right)) {
-                return false;
-            }
-
-            if (!sourceCode.isSpaceBetweenTokens(left, right)) {
+            if (!sourceCode.isSpaceBetweenTokens(tokenBeforeClosingParen, closingParenToken)) {
                 return false;
             }
 
             if (ALWAYS) {
-                return isCloserException(left);
+                return isCloserException(tokenBeforeClosingParen);
             }
-            return !isCloserException(left);
-
+            return !isCloserException(tokenBeforeClosingParen);
         }
 
         //--------------------------------------------------------------------------
@@ -225,44 +223,53 @@ module.exports = {
                     const prevToken = tokens[i - 1];
                     const nextToken = tokens[i + 1];
 
+                    // if token is not an opening or closing paren token, do nothing
                     if (!astUtils.isOpeningParenToken(token) && !astUtils.isClosingParenToken(token)) {
                         return;
                     }
 
-                    if (token.value === "(" && shouldOpenerHaveSpace(token, nextToken)) {
+                    // if token is an opening paren and is not followed by a required space
+                    if (token.value === "(" && openerMissingSpace(token, nextToken)) {
                         context.report({
                             node,
                             loc: token.loc.start,
-                            message: MISSING_SPACE_MESSAGE,
+                            messageId: "missingOpeningSpace",
                             fix(fixer) {
                                 return fixer.insertTextAfter(token, " ");
                             }
                         });
-                    } else if (token.value === "(" && shouldOpenerRejectSpace(token, nextToken)) {
+                    }
+
+                    // if token is an opening paren and is followed by a disallowed space
+                    if (token.value === "(" && openerRejectsSpace(token, nextToken)) {
                         context.report({
                             node,
                             loc: token.loc.start,
-                            message: REJECTED_SPACE_MESSAGE,
+                            messageId: "rejectedOpeningSpace",
                             fix(fixer) {
                                 return fixer.removeRange([token.range[1], nextToken.range[0]]);
                             }
                         });
-                    } else if (token.value === ")" && shouldCloserHaveSpace(prevToken, token)) {
+                    }
 
-                        // context.report(node, token.loc.start, MISSING_SPACE_MESSAGE);
+                    // if token is a closing paren and is not preceded by a required space
+                    if (token.value === ")" && closerMissingSpace(prevToken, token)) {
                         context.report({
                             node,
                             loc: token.loc.start,
-                            message: MISSING_SPACE_MESSAGE,
+                            messageId: "missingClosingSpace",
                             fix(fixer) {
                                 return fixer.insertTextBefore(token, " ");
                             }
                         });
-                    } else if (token.value === ")" && shouldCloserRejectSpace(prevToken, token)) {
+                    }
+
+                    // if token is a closing paren and is preceded by a disallowed space
+                    if (token.value === ")" && closerRejectsSpace(prevToken, token)) {
                         context.report({
                             node,
                             loc: token.loc.start,
-                            message: REJECTED_SPACE_MESSAGE,
+                            messageId: "rejectedClosingSpace",
                             fix(fixer) {
                                 return fixer.removeRange([prevToken.range[1], token.range[0]]);
                             }
@@ -271,6 +278,5 @@ module.exports = {
                 });
             }
         };
-
     }
 };

--- a/tests/lib/rules/space-in-parens.js
+++ b/tests/lib/rules/space-in-parens.js
@@ -11,9 +11,6 @@
 const rule = require("../../../lib/rules/space-in-parens"),
     { RuleTester } = require("../../../lib/rule-tester");
 
-const MISSING_SPACE_ERROR = "There must be a space inside this paren.",
-    REJECTED_SPACE_ERROR = "There should be no spaces inside this paren.";
-
 //------------------------------------------------------------------------------
 // Tests
 //------------------------------------------------------------------------------
@@ -23,6 +20,7 @@ const ruleTester = new RuleTester();
 ruleTester.run("space-in-parens", rule, {
 
     valid: [
+        { code: "foo()", options: ["never"] },
         { code: "foo()", options: ["always"] },
         { code: "foo( bar )", options: ["always"] },
         { code: "foo\n(\nbar\n)\n", options: ["always"] },
@@ -38,7 +36,6 @@ ruleTester.run("space-in-parens", rule, {
         { code: "var foo = `(bar)`;", options: ["always"], parserOptions: { ecmaVersion: 6 } },
         { code: "var foo = `(bar ${baz})`;", options: ["always"], parserOptions: { ecmaVersion: 6 } },
         { code: "var foo = `(bar ${( 1 + 2 )})`;", options: ["always"], parserOptions: { ecmaVersion: 6 } },
-        { code: "bar()", options: ["never"] },
         { code: "bar(baz)", options: ["never"] },
         { code: "var x = (4 + 5) * 6", options: ["never"] },
         { code: "foo\n(\nbar\n)\n", options: ["never"] },
@@ -64,6 +61,7 @@ ruleTester.run("space-in-parens", rule, {
         // exceptions
         { code: "foo({ bar: 'baz' })", options: ["always", { exceptions: ["{}"] }] },
         { code: "foo( { bar: 'baz' } )", options: ["always", { exceptions: ["[]", "()"] }] },
+        { code: "( (foo(bar() ) ) );", options: ["never", { exceptions: ["()"] }] },
         { code: "foo( 1, { bar: 'baz' })", options: ["always", { exceptions: ["{}"] }] },
         { code: "foo({ bar: 'baz' }, 1 )", options: ["always", { exceptions: ["{}"] }] },
         { code: "foo({\nbar: 'baz',\nbaz: 'bar'\n})", options: ["always", { exceptions: ["{}"] }] },
@@ -95,16 +93,18 @@ ruleTester.run("space-in-parens", rule, {
         { code: "foo( (1 + 2) / 1)", options: ["never", { exceptions: ["()"] }] },
         { code: "foo( (\n1 + 2\n) )", options: ["never", { exceptions: ["()"] }] },
 
-        { code: "foo()", options: ["always", { exceptions: ["empty"] }] },
-        { code: "foo( )", options: ["always", { exceptions: ["{}"] }] },
-        { code: "foo(\n1 + 2\n)", options: ["always", { exceptions: ["empty"] }] },
         { code: "foo()", options: ["never", { exceptions: ["{}"] }] },
         { code: "foo( )", options: ["never", { exceptions: ["empty"] }] },
+        { code: "foo()", options: ["always", { exceptions: ["empty"] }] },
+        { code: "foo( )", options: ["always", { exceptions: ["[]"] }] },
+        { code: "foo(( x, {bar:'baz'} ))", options: ["always", { exceptions: ["empty", "()"] }] },
+        { code: "foo( [1, 2], 1 )", options: ["always", { exceptions: ["empty", "()"] }] },
+        { code: "foo(\n1 + 2\n)", options: ["always", { exceptions: ["empty"] }] },
         { code: "foo( \n1 + 2\n )", options: ["never", { exceptions: ["empty"] }] },
 
         { code: "foo({ bar: 'baz' }, [ 1, 2 ])", options: ["always", { exceptions: ["{}", "[]"] }] },
         { code: "foo({\nbar: 'baz'\n}, [\n1,\n2\n])", options: ["always", { exceptions: ["{}", "[]"] }] },
-        { code: "foo(); bar({bar:'baz'}); baz([1,2])", options: ["always", { exceptions: ["{}", "[]", "()"] }] },
+        { code: "foo(); bar({bar:'baz'}); baz([1,2])", options: ["always", { exceptions: ["{}", "[]", "()", "empty"] }] },
         { code: "foo( { bar: 'baz' }, [ 1, 2 ] )", options: ["never", { exceptions: ["{}", "[]"] }] },
         { code: "foo( {\nbar: 'baz'\n}, [\n1,\n2\n] )", options: ["never", { exceptions: ["{}", "[]"] }] },
         { code: "foo( ); bar( {bar:'baz'} ); baz( [1,2] )", options: ["never", { exceptions: ["{}", "[]", "empty"] }] },
@@ -115,71 +115,90 @@ ruleTester.run("space-in-parens", rule, {
     ],
 
     invalid: [
-        {
-            code: "foo( )",
-            output: "foo()",
-            options: ["never"],
-            errors: [{ message: REJECTED_SPACE_ERROR, line: 1, column: 4 }]
-        },
-        {
-            code: "foo( bar)",
-            output: "foo( bar )",
-            options: ["always"],
-            errors: [{ message: MISSING_SPACE_ERROR, line: 1, column: 9 }]
-        },
-        {
-            code: "foo(bar)",
-            output: "foo( bar )",
-            options: ["always"],
-            errors: [
-                { message: MISSING_SPACE_ERROR, line: 1, column: 4 },
-                { message: MISSING_SPACE_ERROR, line: 1, column: 8 }
-            ]
-        },
-        {
-            code: "var x = ( 1 + 2) * 3",
-            output: "var x = ( 1 + 2 ) * 3",
-            options: ["always"],
-            errors: [{ message: MISSING_SPACE_ERROR, line: 1, column: 16 }]
-        },
-        {
-            code: "var x = (1 + 2 ) * 3",
-            output: "var x = ( 1 + 2 ) * 3",
-            options: ["always"],
-            errors: [{ message: MISSING_SPACE_ERROR, line: 1, column: 9 }]
-        },
-        {
-            code: "foo\n(bar\n)\n",
-            output: "foo\n( bar\n)\n",
-            options: ["always"],
-            errors: [{ message: MISSING_SPACE_ERROR, line: 2, column: 1 }]
-        },
+
+        // methods and functions
         {
             code: "bar(baz )",
             output: "bar(baz)",
             options: ["never"],
-            errors: [REJECTED_SPACE_ERROR]
+            errors: [{ messageId: "rejectedClosingSpace" }]
         },
         {
             code: "bar( baz )",
             output: "bar(baz)",
             options: ["never"],
             errors: [
-                { message: REJECTED_SPACE_ERROR, line: 1, column: 4 },
-                { message: REJECTED_SPACE_ERROR, line: 1, column: 10 }
+                { messageId: "rejectedOpeningSpace", line: 1, column: 4 },
+                { messageId: "rejectedClosingSpace", line: 1, column: 10 }
             ]
+        },
+        {
+            code: "foo( )",
+            output: "foo()",
+            options: ["never"],
+            errors: [
+                { messageId: "rejectedOpeningSpace", line: 1, column: 4 },
+                { messageId: "rejectedClosingSpace", line: 1, column: 6 }
+            ]
+        },
+        {
+            code: "foo(bar() )",
+            output: "foo(bar())",
+            options: ["never"],
+            errors: [{ messageId: "rejectedClosingSpace" }]
+        },
+        {
+            code: "foo\n(\nbar )",
+            output: "foo\n(\nbar)",
+            options: ["never"],
+            errors: [{ messageId: "rejectedClosingSpace", line: 3, column: 5 }]
+        },
+        {
+            code: "foo\n(bar\n)\n",
+            output: "foo\n( bar\n)\n",
+            options: ["always"],
+            errors: [{ messageId: "missingOpeningSpace", line: 2, column: 1 }]
+        },
+        {
+            code: "foo( bar)",
+            output: "foo( bar )",
+            options: ["always"],
+            errors: [{ messageId: "missingClosingSpace", line: 1, column: 9 }]
+        },
+        {
+            code: "foo(bar)",
+            output: "foo( bar )",
+            options: ["always"],
+            errors: [
+                { messageId: "missingOpeningSpace", line: 1, column: 4 },
+                { messageId: "missingClosingSpace", line: 1, column: 8 }
+            ]
+        },
+
+        // variable declaration and formulas
+        {
+            code: "var x = ( 1 + 2) * 3",
+            output: "var x = ( 1 + 2 ) * 3",
+            options: ["always"],
+            errors: [{ messageId: "missingClosingSpace", line: 1, column: 16 }]
+        },
+        {
+            code: "var x = (1 + 2 ) * 3",
+            output: "var x = ( 1 + 2 ) * 3",
+            options: ["always"],
+            errors: [{ messageId: "missingOpeningSpace", line: 1, column: 9 }]
         },
         {
             code: "var x = ( 4 + 5) * 6",
             output: "var x = (4 + 5) * 6",
             options: ["never"],
-            errors: [REJECTED_SPACE_ERROR]
+            errors: [{ messageId: "rejectedOpeningSpace" }]
         },
         {
             code: "var x = (4 + 5 ) * 6",
             output: "var x = (4 + 5) * 6",
             options: ["never"],
-            errors: [REJECTED_SPACE_ERROR]
+            errors: [{ messageId: "rejectedClosingSpace" }]
         },
 
         // comments
@@ -187,247 +206,345 @@ ruleTester.run("space-in-parens", rule, {
             code: "foo(/* bar */)",
             output: "foo( /* bar */ )",
             options: ["always"],
-            errors: [MISSING_SPACE_ERROR, MISSING_SPACE_ERROR]
+            errors: [
+                { messageId: "missingOpeningSpace" },
+                { messageId: "missingClosingSpace" }
+            ]
         },
         {
             code: "foo(/* bar */baz )",
             output: "foo( /* bar */baz )",
             options: ["always"],
-            errors: [MISSING_SPACE_ERROR]
+            errors: [{ messageId: "missingOpeningSpace" }]
         },
         {
             code: "foo(/* bar */ baz )",
             output: "foo( /* bar */ baz )",
             options: ["always"],
-            errors: [MISSING_SPACE_ERROR]
+            errors: [{ messageId: "missingOpeningSpace" }]
         },
         {
             code: "foo( baz/* bar */)",
             output: "foo( baz/* bar */ )",
             options: ["always"],
-            errors: [MISSING_SPACE_ERROR]
+            errors: [{ messageId: "missingClosingSpace" }]
         },
         {
             code: "foo( baz /* bar */)",
             output: "foo( baz /* bar */ )",
             options: ["always"],
-            errors: [MISSING_SPACE_ERROR]
+            errors: [{ messageId: "missingClosingSpace" }]
         },
         {
             code: "foo( /* bar */ )",
             output: "foo(/* bar */)",
             options: ["never"],
-            errors: [REJECTED_SPACE_ERROR, REJECTED_SPACE_ERROR]
+            errors: [
+                { messageId: "rejectedOpeningSpace" },
+                { messageId: "rejectedClosingSpace" }
+            ]
         },
         {
             code: "foo( /* bar */ baz)",
             output: "foo(/* bar */ baz)",
             options: ["never"],
-            errors: [{ message: REJECTED_SPACE_ERROR, line: 1, column: 4 }]
+            errors: [{ messageId: "rejectedOpeningSpace", line: 1, column: 4 }]
         },
 
         // exceptions
         {
-            code: "foo({ bar: 'baz' })",
-            output: "foo( { bar: 'baz' } )",
-            options: ["always", { exceptions: ["[]"] }],
-            errors: [MISSING_SPACE_ERROR, MISSING_SPACE_ERROR]
-        },
-        {
-            code: "foo( { bar: 'baz' } )",
-            output: "foo({ bar: 'baz' })",
-            options: ["always", { exceptions: ["{}"] }],
-            errors: [REJECTED_SPACE_ERROR, REJECTED_SPACE_ERROR]
-        },
-        {
-            code: "foo({ bar: 'baz' })",
-            output: "foo( { bar: 'baz' } )",
-            options: ["never", { exceptions: ["{}"] }],
-            errors: [MISSING_SPACE_ERROR, MISSING_SPACE_ERROR]
-        },
-        {
-            code: "foo( { bar: 'baz' } )",
-            output: "foo({ bar: 'baz' })",
-            options: ["never", { exceptions: ["[]"] }],
-            errors: [REJECTED_SPACE_ERROR, REJECTED_SPACE_ERROR]
-        },
-        {
-            code: "foo( { bar: 'baz' })",
-            output: "foo({ bar: 'baz' })",
-            options: ["always", { exceptions: ["{}"] }],
-            errors: [REJECTED_SPACE_ERROR]
-        },
-        {
-            code: "foo( { bar: 'baz' })",
-            output: "foo( { bar: 'baz' } )",
-            options: ["never", { exceptions: ["{}"] }],
-            errors: [MISSING_SPACE_ERROR]
-        },
-        {
-            code: "foo({ bar: 'baz' } )",
-            output: "foo({ bar: 'baz' })",
-            options: ["always", { exceptions: ["{}"] }],
-            errors: [REJECTED_SPACE_ERROR]
-        },
-        {
-            code: "foo({ bar: 'baz' } )",
-            output: "foo( { bar: 'baz' } )",
-            options: ["never", { exceptions: ["{}"] }],
-            errors: [MISSING_SPACE_ERROR]
-        },
-        {
-            code: "foo([ 1, 2 ])",
-            output: "foo( [ 1, 2 ] )",
-            options: ["always", { exceptions: ["empty"] }],
-            errors: [MISSING_SPACE_ERROR, MISSING_SPACE_ERROR]
-        },
-        {
-            code: "foo( [ 1, 2 ] )",
-            output: "foo([ 1, 2 ])",
-            options: ["always", { exceptions: ["[]"] }],
-            errors: [REJECTED_SPACE_ERROR, REJECTED_SPACE_ERROR]
-        },
-        {
-            code: "foo([ 1, 2 ])",
-            output: "foo( [ 1, 2 ] )",
-            options: ["never", { exceptions: ["[]"] }],
-            errors: [MISSING_SPACE_ERROR, MISSING_SPACE_ERROR]
-        },
-        {
-            code: "foo( [ 1, 2 ] )",
-            output: "foo([ 1, 2 ])",
-            options: ["never", { exceptions: ["()"] }],
-            errors: [REJECTED_SPACE_ERROR, REJECTED_SPACE_ERROR]
-        },
-        {
-            code: "foo([ 1, 2 ] )",
-            output: "foo([ 1, 2 ])",
-            options: ["always", { exceptions: ["[]"] }],
-            errors: [REJECTED_SPACE_ERROR]
-        },
-        {
-            code: "foo([ 1, 2 ] )",
-            output: "foo( [ 1, 2 ] )",
-            options: ["never", { exceptions: ["[]"] }],
-            errors: [MISSING_SPACE_ERROR]
-        },
-        {
-            code: "foo( [ 1, 2 ])",
-            output: "foo([ 1, 2 ])",
-            options: ["always", { exceptions: ["[]"] }],
-            errors: [REJECTED_SPACE_ERROR]
-        },
-        {
-            code: "foo( [ 1, 2 ])",
-            output: "foo( [ 1, 2 ] )",
-            options: ["never", { exceptions: ["[]"] }],
-            errors: [MISSING_SPACE_ERROR]
-        },
-        {
-            code: "(( 1 + 2 ))",
-            output: "( ( 1 + 2 ) )",
-            options: ["always", { exceptions: ["[]"] }],
-            errors: [MISSING_SPACE_ERROR, MISSING_SPACE_ERROR]
-        },
-        {
-            code: "( ( 1 + 2 ) )",
-            output: "(( 1 + 2 ))",
-            options: ["always", { exceptions: ["()"] }],
+            code: "foo()",
+            output: "foo( )",
+            options: ["never", { exceptions: ["empty"] }],
             errors: [
-                { message: REJECTED_SPACE_ERROR, line: 1, column: 1 },
-                { message: REJECTED_SPACE_ERROR, line: 1, column: 13 }
+                { messageId: "missingOpeningSpace", line: 1, column: 4 },
+                { messageId: "missingClosingSpace", line: 1, column: 5 }
             ]
         },
         {
-            code: "( ( 1 + 2 ) )",
-            output: "((1 + 2))",
-            options: ["never"],
+            code: "foo( )",
+            output: "foo()",
+            options: ["always", { exceptions: ["()", "empty"] }],
             errors: [
-                { message: REJECTED_SPACE_ERROR, line: 1, column: 1 },
-                { message: REJECTED_SPACE_ERROR, line: 1, column: 3 },
-                { message: REJECTED_SPACE_ERROR, line: 1, column: 11 },
-                { message: REJECTED_SPACE_ERROR, line: 1, column: 13 }
+                { messageId: "rejectedOpeningSpace", line: 1, column: 4 },
+                { messageId: "rejectedClosingSpace", line: 1, column: 6 }
             ]
-        },
-        {
-            code: "( ( 1 + 2 ) )",
-            output: "((1 + 2))",
-            options: ["never", { exceptions: ["[]"] }],
-            errors: [REJECTED_SPACE_ERROR, REJECTED_SPACE_ERROR, REJECTED_SPACE_ERROR, REJECTED_SPACE_ERROR]
-        },
-        {
-            code: "( ( 1 + 2 ))",
-            output: "(( 1 + 2 ))",
-            options: ["always", { exceptions: ["()"] }],
-            errors: [{ message: REJECTED_SPACE_ERROR, line: 1, column: 1 }]
-        },
-        {
-            code: "( (1 + 2))",
-            output: "( (1 + 2) )",
-            options: ["never", { exceptions: ["()"] }],
-            errors: [MISSING_SPACE_ERROR]
-        },
-        {
-            code: "(( 1 + 2 ) )",
-            output: "(( 1 + 2 ))",
-            options: ["always", { exceptions: ["()"] }],
-            errors: [REJECTED_SPACE_ERROR]
-        },
-        {
-            code: "((1 + 2) )",
-            output: "( (1 + 2) )",
-            options: ["never", { exceptions: ["()"] }],
-            errors: [MISSING_SPACE_ERROR]
-        },
-        {
-            code: "var result = ( 1 / ( 1 + 2 ) ) + 3",
-            output: "var result = ( 1 / ( 1 + 2 )) + 3",
-            options: ["always", { exceptions: ["()"] }],
-            errors: [REJECTED_SPACE_ERROR]
-        },
-        {
-            code: "var result = (1 / (1 + 2)) + 3",
-            output: "var result = (1 / (1 + 2) ) + 3",
-            options: ["never", { exceptions: ["()"] }],
-            errors: [MISSING_SPACE_ERROR]
-        },
-        {
-            code: "var result = ( 1 / ( 1 + 2)) + 3",
-            output: "var result = ( 1 / ( 1 + 2 )) + 3",
-            options: ["always", { exceptions: ["()"] }],
-            errors: [MISSING_SPACE_ERROR]
         },
         {
             code: "foo( )",
             output: "foo()",
             options: ["always", { exceptions: ["empty"] }],
-            errors: [{ message: REJECTED_SPACE_ERROR, line: 1, column: 4 }]
+            errors: [
+                { messageId: "rejectedOpeningSpace", line: 1, column: 4 },
+                { messageId: "rejectedClosingSpace", line: 1, column: 6 }
+            ]
         },
         {
-            code: "foo()",
-            output: "foo( )",
+            code: "foo( bar() )",
+            output: "foo( bar())",
+            options: ["always", { exceptions: ["()", "empty"] }],
+            errors: [
+                { messageId: "rejectedClosingSpace", line: 1, column: 12 }
+            ]
+        },
+        {
+            code: "foo(bar())",
+            output: "foo(bar() )",
+            options: ["never", { exceptions: ["()"] }],
+            errors: [
+                { messageId: "missingClosingSpace", line: 1, column: 10 }
+            ]
+        },
+        {
+            code: "foo( bar() )",
+            output: "foo(bar( ))",
             options: ["never", { exceptions: ["empty"] }],
-            errors: [{ message: MISSING_SPACE_ERROR, line: 1, column: 4 }]
+            errors: [
+                { messageId: "rejectedOpeningSpace", line: 1, column: 4 },
+                { messageId: "missingOpeningSpace", line: 1, column: 9 },
+                { messageId: "missingClosingSpace", line: 1, column: 10 },
+                { messageId: "rejectedClosingSpace", line: 1, column: 12 }
+            ]
         },
         {
-            code: "foo\n(\nbar )\n",
-            output: "foo\n(\nbar)\n",
+            code: "foo([1,2], bar() )",
+            output: "foo( [1,2], bar())",
+            options: ["never", { exceptions: ["[]"] }],
+            errors: [
+                { messageId: "missingOpeningSpace", line: 1, column: 4 },
+                { messageId: "rejectedClosingSpace", line: 1, column: 18 }
+            ]
+        },
+        {
+            code: "foo({ bar: 'baz' })",
+            output: "foo( { bar: 'baz' } )",
+            options: ["always", { exceptions: ["[]"] }],
+            errors: [
+                { messageId: "missingOpeningSpace" },
+                { messageId: "missingClosingSpace" }
+            ]
+        },
+        {
+            code: "foo( { bar: 'baz' } )",
+            output: "foo({ bar: 'baz' })",
+            options: ["always", { exceptions: ["{}"] }],
+            errors: [
+                { messageId: "rejectedOpeningSpace" },
+                { messageId: "rejectedClosingSpace" }
+            ]
+        },
+        {
+            code: "foo({ bar: 'baz' })",
+            output: "foo( { bar: 'baz' } )",
+            options: ["never", { exceptions: ["{}"] }],
+            errors: [
+                { messageId: "missingOpeningSpace" },
+                { messageId: "missingClosingSpace" }
+            ]
+        },
+        {
+            code: "foo( { bar: 'baz' } )",
+            output: "foo({ bar: 'baz' })",
+            options: ["never", { exceptions: ["[]"] }],
+            errors: [
+                { messageId: "rejectedOpeningSpace" },
+                { messageId: "rejectedClosingSpace" }
+            ]
+        },
+        {
+            code: "foo( { bar: 'baz' })",
+            output: "foo({ bar: 'baz' })",
+            options: ["always", { exceptions: ["{}"] }],
+            errors: [{ messageId: "rejectedOpeningSpace" }]
+        },
+        {
+            code: "foo( { bar: 'baz' })",
+            output: "foo( { bar: 'baz' } )",
+            options: ["never", { exceptions: ["{}"] }],
+            errors: [{ messageId: "missingClosingSpace" }]
+        },
+        {
+            code: "foo({ bar: 'baz' } )",
+            output: "foo({ bar: 'baz' })",
+            options: ["always", { exceptions: ["{}"] }],
+            errors: [{ messageId: "rejectedClosingSpace" }]
+        },
+        {
+            code: "foo({ bar: 'baz' } )",
+            output: "foo( { bar: 'baz' } )",
+            options: ["never", { exceptions: ["{}"] }],
+            errors: [{ messageId: "missingOpeningSpace" }]
+        },
+        {
+            code: "foo([ 1, 2 ])",
+            output: "foo( [ 1, 2 ] )",
+            options: ["always", { exceptions: ["empty"] }],
+            errors: [
+                { messageId: "missingOpeningSpace" },
+                { messageId: "missingClosingSpace" }
+            ]
+        },
+        {
+            code: "foo( [ 1, 2 ] )",
+            output: "foo([ 1, 2 ])",
+            options: ["always", { exceptions: ["[]"] }],
+            errors: [
+                { messageId: "rejectedOpeningSpace" },
+                { messageId: "rejectedClosingSpace" }
+            ]
+        },
+        {
+            code: "foo([ 1, 2 ])",
+            output: "foo( [ 1, 2 ] )",
+            options: ["never", { exceptions: ["[]"] }],
+            errors: [
+                { messageId: "missingOpeningSpace" },
+                { messageId: "missingClosingSpace" }
+            ]
+        },
+        {
+            code: "foo( [ 1, 2 ] )",
+            output: "foo([ 1, 2 ])",
+            options: ["never", { exceptions: ["()"] }],
+            errors: [
+                { messageId: "rejectedOpeningSpace" },
+                { messageId: "rejectedClosingSpace" }
+            ]
+        },
+        {
+            code: "foo([ 1, 2 ] )",
+            output: "foo([ 1, 2 ])",
+            options: ["always", { exceptions: ["[]"] }],
+            errors: [{ messageId: "rejectedClosingSpace" }]
+        },
+        {
+            code: "foo([ 1, 2 ] )",
+            output: "foo( [ 1, 2 ] )",
+            options: ["never", { exceptions: ["[]"] }],
+            errors: [{ messageId: "missingOpeningSpace" }]
+        },
+        {
+            code: "foo( [ 1, 2 ])",
+            output: "foo([ 1, 2 ])",
+            options: ["always", { exceptions: ["[]"] }],
+            errors: [{ messageId: "rejectedOpeningSpace" }]
+        },
+        {
+            code: "foo( [ 1, 2 ])",
+            output: "foo( [ 1, 2 ] )",
+            options: ["never", { exceptions: ["[]"] }],
+            errors: [{ messageId: "missingClosingSpace" }]
+        },
+        {
+            code: "(( 1 + 2 ))",
+            output: "( ( 1 + 2 ) )",
+            options: ["always", { exceptions: ["[]"] }],
+            errors: [
+                { messageId: "missingOpeningSpace" },
+                { messageId: "missingClosingSpace" }
+            ]
+        },
+        {
+            code: "( ( 1 + 2 ) )",
+            output: "(( 1 + 2 ))",
+            options: ["always", { exceptions: ["()"] }],
+            errors: [
+                { messageId: "rejectedOpeningSpace", line: 1, column: 1 },
+                { messageId: "rejectedClosingSpace", line: 1, column: 13 }
+            ]
+        },
+        {
+            code: "( ( 1 + 2 ) )",
+            output: "((1 + 2))",
             options: ["never"],
-            errors: [{ message: REJECTED_SPACE_ERROR, line: 3, column: 5 }]
+            errors: [
+                { messageId: "rejectedOpeningSpace", line: 1, column: 1 },
+                { messageId: "rejectedOpeningSpace", line: 1, column: 3 },
+                { messageId: "rejectedClosingSpace", line: 1, column: 11 },
+                { messageId: "rejectedClosingSpace", line: 1, column: 13 }
+            ]
         },
         {
-            code: "var foo = `(bar ${(1 + 2 )})`;",
+            code: "( ( 1 + 2 ) )",
+            output: "((1 + 2))",
+            options: ["never", { exceptions: ["[]"] }],
+            errors: [
+                { messageId: "rejectedOpeningSpace" },
+                { messageId: "rejectedOpeningSpace" },
+                { messageId: "rejectedClosingSpace" },
+                { messageId: "rejectedClosingSpace" }
+            ]
+        },
+        {
+            code: "((1 + 2))",
+            output: "(( 1 + 2 ))",
+            options: ["always", { exceptions: ["()"] }],
+            errors: [
+                { messageId: "missingOpeningSpace", line: 1, column: 2 },
+                { messageId: "missingClosingSpace", line: 1, column: 8 }
+            ]
+        },
+        {
+            code: "((1 + 2))",
+            output: "( (1 + 2) )",
+            options: ["never", { exceptions: ["()"] }],
+            errors: [
+                { messageId: "missingOpeningSpace", line: 1, column: 1 },
+                { messageId: "missingClosingSpace", line: 1, column: 9 }
+            ]
+        },
+        {
+            code: "((1 + 2) )",
+            output: "( (1 + 2) )",
+            options: ["never", { exceptions: ["()"] }],
+            errors: [
+                { messageId: "missingOpeningSpace", line: 1, column: 1 }
+            ]
+        },
+        {
+            code: "var result = ( 1 / ( 1 + 2 ) ) + 3",
+            output: "var result = ( 1 / ( 1 + 2 )) + 3",
+            options: ["always", { exceptions: ["()"] }],
+            errors: [
+                { messageId: "rejectedClosingSpace", line: 1, column: 30 }
+            ]
+        },
+        {
+            code: "var result = (1 / (1 + 2)) + 3",
+            output: "var result = (1 / (1 + 2) ) + 3",
+            options: ["never", { exceptions: ["()"] }],
+            errors: [
+                { messageId: "missingClosingSpace", line: 1, column: 26 }
+            ]
+        },
+        {
+            code: "var result = (1 / ( 1 + 2) ) + 3",
+            output: "var result = ( 1 / ( 1 + 2 )) + 3",
+            options: ["always", { exceptions: ["()"] }],
+            errors: [
+                { messageId: "missingOpeningSpace", line: 1, column: 14 },
+                { messageId: "missingClosingSpace", line: 1, column: 26 },
+                { messageId: "rejectedClosingSpace", line: 1, column: 28 }
+            ]
+        },
+
+        // ES6
+        {
+            code: "var foo = `(bar ${( 1 + 2 )})`;",
             output: "var foo = `(bar ${(1 + 2)})`;",
             options: ["never"],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: REJECTED_SPACE_ERROR, line: 1, column: 26 }]
+            errors: [
+                { messageId: "rejectedOpeningSpace", line: 1, column: 19 },
+                { messageId: "rejectedClosingSpace", line: 1, column: 27 }
+            ]
         },
         {
             code: "var foo = `(bar ${(1 + 2 )})`;",
             output: "var foo = `(bar ${( 1 + 2 )})`;",
             options: ["always"],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: MISSING_SPACE_ERROR, line: 1, column: 19 }]
+            errors: [{ messageId: "missingOpeningSpace", line: 1, column: 19 }]
         }
     ]
 });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

- [x] Documentation update
- [x] Changes an existing rule ([template]https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
- [x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

The current space-in-parens description is a little unclear. Technically empty parens can trigger an error if specified in the exceptions options. This PR updates that line in the docs and adds a paragraph that attempts to explain what exactly this rule does. [Current rule description](https://eslint.org/docs/rules/space-in-parens#rule-details).

The linting error messages are now more specific and inform whether the paren token is either rejecting an extra space or missing a required space. Previously the output did not specify if the space was required or missing (so it could be either).

The previous context/report behavior would sometimes report only the first error encountered within a node due to the token checks being nested inside `else if` blocks. This is a non-breaking change: it simply means all errors will be reported within a node instead of only one - it does not introduce a new error type. The fallout of this change is that there is now at least one interesting case: using the default settings `foo( )` technically contains two errors: that single space is both a rejected opening and closing space, so two errors will be reported despite the fact that removing the one space fixes both errors.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->


