### PR TITLE
Update: Remove dependency on is-resolvable

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -15,8 +15,7 @@ const path = require("path"),
     ConfigFile = require("./config/config-file"),
     ConfigCache = require("./config/config-cache"),
     Plugins = require("./config/plugins"),
-    FileFinder = require("./util/file-finder"),
-    isResolvable = require("is-resolvable");
+    FileFinder = require("./util/file-finder");
 
 const debug = require("debug")("eslint:config");
 
@@ -39,6 +38,20 @@ const SUBCONFIG_SEP = ":";
  */
 function hasRules(options) {
     return options.rules && Object.keys(options.rules).length > 0;
+}
+
+/**
+ * Determines if a module is can be resolved.
+ * @param {string} moduleId The ID (name) of the module
+ * @returns {boolean} True if it is resolvable; False otherwise.
+ */
+function isResolvable(moduleId) {
+    try {
+        require.resolve(moduleId);
+        return true;
+    } catch (err) {
+        return false;
+    }
 }
 
 //------------------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "ignore": "^4.0.6",
     "imurmurhash": "^0.1.4",
     "inquirer": "^6.1.0",
-    "is-resolvable": "^1.1.0",
     "js-yaml": "^3.12.0",
     "json-stable-stringify-without-jsonify": "^1.0.1",
     "levn": "^0.3.0",


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

As `is-resolvable` is essentially a fancy if statement, and it is only used in one file, it seems unnecessary to include it as a dependency.

(I've become paranoid due to what recently happened to [event-stream](https://github.com/dominictarr/event-stream/issues/116) and other similar issues)

**What changes did you make? (Give an overview)**

Brought the code for `is-resolvable` into eslint, and slightly simplified it. Remove the dependency on `is-resolvable`.

**Is there anything you'd like reviewers to focus on?**


