### PR TITLE
Update: deprecate valid-jsdoc and require-jsdoc

### DIFF
--- a/lib/rules/require-jsdoc.js
+++ b/lib/rules/require-jsdoc.js
@@ -43,7 +43,10 @@ module.exports = {
                 },
                 additionalProperties: false
             }
-        ]
+        ],
+
+        deprecated: true,
+        replacedBy: []
     },
 
     create(context) {

--- a/lib/rules/valid-jsdoc.js
+++ b/lib/rules/valid-jsdoc.js
@@ -64,7 +64,10 @@ module.exports = {
             }
         ],
 
-        fixable: "code"
+        fixable: "code",
+
+        deprecated: true,
+        replacedBy: []
     },
 
     create(context) {

--- a/lib/util/source-code.js
+++ b/lib/util/source-code.js
@@ -316,6 +316,7 @@ class SourceCode extends TokenStore {
      * @returns {Token|null} The Block comment token containing the JSDoc comment
      *      for the given node or null if not found.
      * @public
+     * @deprecated
      */
     getJSDocComment(node) {
 

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -733,6 +733,7 @@ describe("CLIEngine", () => {
         it("should warn when deprecated rules are found in a config", () => {
             engine = new CLIEngine({
                 cwd: originalDir,
+                useEslintrc: false,
                 configFile: "tests/fixtures/cli-engine/deprecated-rule-config/.eslintrc.yml"
             });
 
@@ -1530,7 +1531,11 @@ describe("CLIEngine", () => {
 
             assert.deepStrictEqual(
                 report.usedDeprecatedRules,
-                [{ ruleId: "indent-legacy", replacedBy: ["indent"] }]
+                [
+                    { ruleId: "indent-legacy", replacedBy: ["indent"] },
+                    { ruleId: "require-jsdoc", replacedBy: [] },
+                    { ruleId: "valid-jsdoc", replacedBy: [] }
+                ]
             );
         });
 
@@ -1538,7 +1543,7 @@ describe("CLIEngine", () => {
             engine = new CLIEngine({
                 cwd: originalDir,
                 configFile: ".eslintrc.js",
-                rules: { indent: 1 }
+                rules: { indent: 1, "valid-jsdoc": 0, "require-jsdoc": 0 }
             });
 
             const report = engine.executeOnFiles(["lib/cli*.js"]);
@@ -1549,7 +1554,8 @@ describe("CLIEngine", () => {
         it("should warn when deprecated rules are found in a config", () => {
             engine = new CLIEngine({
                 cwd: originalDir,
-                configFile: "tests/fixtures/cli-engine/deprecated-rule-config/.eslintrc.yml"
+                configFile: "tests/fixtures/cli-engine/deprecated-rule-config/.eslintrc.yml",
+                useEslintrc: false
             });
 
             const report = engine.executeOnFiles(["lib/cli*.js"]);


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Also see: https://eslint.org/blog/2018/11/jsdoc-end-of-life

This deprecates the `valid-jsdoc` and `require-jsdoc` rules. We are currently still using them to lint the ESLint codebase -- at some point we should probably switch to `eslint-plugin-jsdoc` to dogfood the process.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular