### PR TITLE
wip: Chore: switch to eslint-plugin-jsdoc (refs #11146)

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "eslint-config-eslint": "file:packages/eslint-config-eslint",
     "eslint-plugin-eslint-plugin": "^2.0.1",
     "eslint-plugin-internal-rules": "file:tools/internal-rules",
+    "eslint-plugin-jsdoc": "^6.0.2",
     "eslint-plugin-node": "^9.0.0",
     "eslint-release": "^1.2.0",
     "eslump": "^2.0.0",

--- a/packages/eslint-config-eslint/default.yml
+++ b/packages/eslint-config-eslint/default.yml
@@ -1,6 +1,9 @@
 extends:
     - "eslint:recommended"
     - "plugin:node/recommended"
+    - "plugin:jsdoc/recommended"
+plugins:
+    - "jsdoc"
 rules:
     array-bracket-spacing: "error"
     array-callback-return: "error"

--- a/packages/eslint-config-eslint/package.json
+++ b/packages/eslint-config-eslint/package.json
@@ -20,7 +20,8 @@
   "homepage": "https://eslint.org",
   "bugs": "https://github.com/eslint/eslint/issues/",
   "peerDependencies": {
-    "eslint-plugin-node": "^9.0.0"
+    "eslint-plugin-node": "^9.0.0",
+    "eslint-plugin-jsdoc": "^6.0.2"
   },
   "keywords": [
     "eslintconfig",


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
start to using `eslint-plugin-jsdoc`, since `valid-jsdoc` and `require-jsdoc` has been deprecated.

**Is there anything you'd like reviewers to focus on?**
just a wip, we might have to disable some rules in `jsdoc/recommended`, since there is a large number of linting errors to fix.

the original errors: https://ci.appveyor.com/project/nzakas/eslint/builds/20697383