### PR TITLE
Build: Add fetch team data during gensite (fixes eslint/eslint.github.io#515)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -56,8 +56,7 @@ module.exports = {
             files: ["tools/*"],
             rules: {
                 "node/no-unsupported-features/es-syntax": ["error", {
-                    "version": ">=7.6.0",
-                    "ignores": []
+                    version: ">=7.6.0"
                 }]
             }
         }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -52,6 +52,14 @@ module.exports = {
                     message: "`assert.doesNotThrow()` should be replaced with a comment next to the code."
                 }]
             }
+        }, {
+            files: ["tools/*"],
+            rules: {
+                "node/no-unsupported-features/es-syntax": ["error", {
+                    "version": ">=7.6.0",
+                    "ignores": []
+                }]
+            }
         }
     ]
 };

--- a/Makefile.js
+++ b/Makefile.js
@@ -251,16 +251,6 @@ function generateRuleIndexPage(basedir) {
 }
 
 /**
- * Generate a JSON file containing all team data from GitHub.
- * @returns {void}
- */
-function generateTeamData() {
-    const outputFile = "../eslint.github.io/_data/team.json";
-
-    exec(`node tools/fetch-team-data.js ${outputFile}`);
-}
-
-/**
  * Creates a git commit and tag in an adjacent `eslint.github.io` repository, without pushing it to
  * the remote. This assumes that the repository has already been modified somehow (e.g. by adding a blogpost).
  * @param {string} [tag] The string to tag the commit with
@@ -820,25 +810,21 @@ target.gensite = function(prereleaseVersion) {
     echo("> Generating the rule listing (Step 11)");
     generateRuleIndexPage(process.cwd());
 
-    // 12. Generate team page data
-    echo("> Generating the team data (Step 12)");
-    generateTeamData();
-
-    // 13. Delete temporary directory
-    echo("> Removing the temporary directory (Step 13)");
+    // 12. Delete temporary directory
+    echo("> Removing the temporary directory (Step 12)");
     rm("-rf", TEMP_DIR);
 
-    // 14. Update demos, but only for non-prereleases
+    // 13. Update demos, but only for non-prereleases
     if (!prereleaseVersion) {
-        echo("> Updating the demos (Step 14)");
+        echo("> Updating the demos (Step 13)");
         target.browserify();
         cp("-f", "build/eslint.js", `${SITE_DIR}js/app/eslint.js`);
     } else {
-        echo("> Skipped updating the demos (Step 14)");
+        echo("> Skipped updating the demos (Step 13)");
     }
 
-    // 15. Create Example Formatter Output Page
-    echo("> Creating the formatter examples (Step 15)");
+    // 14. Create Example Formatter Output Page
+    echo("> Creating the formatter examples (Step 14)");
     generateFormatterExamples(getFormatterResults(), prereleaseVersion);
 
     echo("Done generating eslint.org");

--- a/Makefile.js
+++ b/Makefile.js
@@ -251,6 +251,16 @@ function generateRuleIndexPage(basedir) {
 }
 
 /**
+ * Generate a JSON file containing all team data from GitHub.
+ * @returns {void}
+ */
+function generateTeamData() {
+    const outputFile = "../eslint.github.io/_data/team.json";
+
+    exec(`node tools/fetch-team-data.js ${outputFile}`);
+}
+
+/**
  * Creates a git commit and tag in an adjacent `eslint.github.io` repository, without pushing it to
  * the remote. This assumes that the repository has already been modified somehow (e.g. by adding a blogpost).
  * @param {string} [tag] The string to tag the commit with
@@ -810,21 +820,25 @@ target.gensite = function(prereleaseVersion) {
     echo("> Generating the rule listing (Step 11)");
     generateRuleIndexPage(process.cwd());
 
-    // 12. Delete temporary directory
-    echo("> Removing the temporary directory (Step 12)");
+    // 12. Generate team page data
+    echo("> Generating the team data (Step 12)");
+    generateTeamData();
+
+    // 13. Delete temporary directory
+    echo("> Removing the temporary directory (Step 13)");
     rm("-rf", TEMP_DIR);
 
-    // 13. Update demos, but only for non-prereleases
+    // 14. Update demos, but only for non-prereleases
     if (!prereleaseVersion) {
-        echo("> Updating the demos (Step 13)");
+        echo("> Updating the demos (Step 14)");
         target.browserify();
         cp("-f", "build/eslint.js", `${SITE_DIR}js/app/eslint.js`);
     } else {
-        echo("> Skipped updating the demos (Step 13)");
+        echo("> Skipped updating the demos (Step 14)");
     }
 
-    // 14. Create Example Formatter Output Page
-    echo("> Creating the formatter examples (Step 14)");
+    // 15. Create Example Formatter Output Page
+    echo("> Creating the formatter examples (Step 15)");
     generateFormatterExamples(getFormatterResults(), prereleaseVersion);
 
     echo("Done generating eslint.org");

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "text-table": "^0.2.0"
   },
   "devDependencies": {
+    "@octokit/rest": "^16.1.0",
     "babel-core": "^6.26.3",
     "babel-polyfill": "^6.26.0",
     "babel-preset-es2015": "^6.24.1",

--- a/tools/fetch-team-data.js
+++ b/tools/fetch-team-data.js
@@ -1,0 +1,87 @@
+/**
+ * @fileoverview Script to fetch team data from GitHub. Call using:
+ *     node fetch-team-data.js ../eslint.github.io/_data/team.json
+ * @author Nicholas C. Zakas
+ */
+
+/* eslint camelcase: [error, { properties: never }] */
+
+"use strict";
+
+//-----------------------------------------------------------------------------
+// Requirements
+//-----------------------------------------------------------------------------
+
+const fs = require("fs");
+const octokit = require("@octokit/rest")();
+
+//-----------------------------------------------------------------------------
+// Data
+//-----------------------------------------------------------------------------
+
+// filename to to output to is passed on the command line
+const [,, filename = "./team.json"] = process.argv;
+
+// retrieve token from environment
+const { ESLINT_GITHUB_TOKEN } = process.env;
+
+// exit early if no token is available
+if (!ESLINT_GITHUB_TOKEN) {
+    throw new Error("Missing ESLINT_GITHUB_TOKEN.");
+}
+
+// Github IDs for teams
+const ALUMNI_TEAM_ID = "3005888";
+const TSC_TEAM_ID = "2060414";
+const COMMITTERS_TEAM_ID = "1054435";
+
+// lookup table mapping Github team IDs to JSON keys
+const teamIds = {
+    [TSC_TEAM_ID]: "tsc",
+    [COMMITTERS_TEAM_ID]: "committers",
+    [ALUMNI_TEAM_ID]: "alumni"
+};
+
+// final data structure
+const team = {
+    tsc: [],
+    alumni: [],
+    committers: []
+};
+
+//-----------------------------------------------------------------------------
+// Requirements
+//-----------------------------------------------------------------------------
+
+(async() => {
+
+    octokit.authenticate({
+        type: "oauth",
+        token: ESLINT_GITHUB_TOKEN
+    });
+
+    for (const teamId of [TSC_TEAM_ID, ALUMNI_TEAM_ID, COMMITTERS_TEAM_ID]) {
+        const { data: result } = await octokit.teams.listMembers({
+            team_id: teamId,
+            per_page: 100
+        });
+
+        // this user only has login, need to fetch the full profile for useful data
+        for (const user of result) {
+            const { data: profile } = await octokit.users.getByUsername({ username: user.login });
+
+            team[teamIds[teamId]].push({
+                username: user.login,
+                name: profile.name,
+                website: profile.blog,
+                avatar_url: profile.avatar_url
+            });
+        }
+
+    }
+
+    // filter out TSC members from committers list
+    team.committers = team.committers.filter(user => !team.tsc.find(tscmember => tscmember.username === user.username));
+
+    fs.writeFileSync(filename, JSON.stringify(team, null, "    "), { encoding: "utf8" });
+})();


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

This adds a new step in the `gensite` build command that fetches ESLint team data from GitHub and stores it in a file that is used to create the `/team` page on the website.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

1. Added a new script in `tools` that fetches team data from the GitHub API.
2. Updated `Makefile.js` to call the script.
3. Updated `.eslintrc.js` to allow the new script to use `await`.

**Is there anything you'd like reviewers to focus on?**

The new script requires `ESLINT_GITHUB_TOKEN` to be defined in the environment. This is defined in the build environment, so I think that's okay, but please double-check.
