### PR TITLE
Fix: fix the fixer of lone comma with comments (fixes #10632)

### DIFF
--- a/lib/rules/comma-style.js
+++ b/lib/rules/comma-style.js
@@ -85,7 +85,7 @@ module.exports = {
         function getReplacedText(styleType, text) {
             switch (styleType) {
                 case "between":
-                    return `,${text.replace("\n", "")}`;
+                    return `,${text.replace(/\r?\n/, "")}`;
 
                 case "first":
                     return `${text},`;
@@ -138,6 +138,11 @@ module.exports = {
             } else if (!astUtils.isTokenOnSameLine(commaToken, currentItemToken) &&
                     !astUtils.isTokenOnSameLine(previousItemToken, commaToken)) {
 
+                const comment = sourceCode.getCommentsAfter(commaToken)[0];
+                const styleType = comment && comment.type === "Block" && comment.loc.start.line === commaToken.loc.start.line
+                    ? style
+                    : "between";
+
                 // lone comma
                 context.report({
                     node: reportItem,
@@ -146,7 +151,7 @@ module.exports = {
                         column: commaToken.loc.start.column
                     },
                     messageId: "unexpectedLineBeforeAndAfterComma",
-                    fix: getFixerFunction("between", previousItemToken, commaToken, currentItemToken)
+                    fix: getFixerFunction(styleType, previousItemToken, commaToken, currentItemToken)
                 });
 
             } else if (style === "first" && !astUtils.isTokenOnSameLine(commaToken, currentItemToken)) {

--- a/tests/lib/rules/comma-style.js
+++ b/tests/lib/rules/comma-style.js
@@ -612,6 +612,13 @@ ruleTester.run("comma-style", rule, {
             code: "[\n[foo(3)],\n,\nbar\n];",
             output: "[\n[foo(3)],,\nbar\n];",
             errors: [{ messageId: "unexpectedLineBeforeAndAfterComma" }]
+        },
+        {
+
+            // https://github.com/eslint/eslint/issues/10632
+            code: "[foo//\n,/*block\ncomment*/];",
+            output: "[foo,//\n/*block\ncomment*/];",
+            errors: [{ messageId: "unexpectedLineBeforeAndAfterComma" }]
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix

**What changes did you make? (Give an overview)**

Fixes #10632 

**Is there anything you'd like reviewers to focus on?**

When I tried reproducing the issue, I found that if the source code uses CRLF as linebreak, this issue may not occur, because inside the function `getReplacedText`, the `between` branch only replaces LF with empty string. So in this PR, I fix it too.
