### PR TITLE
Fix: support boundary spread elements in sort-keys

### DIFF
--- a/docs/rules/sort-keys.md
+++ b/docs/rules/sort-keys.md
@@ -53,7 +53,7 @@ let obj = {a: 1, ["c" + "d"]: 3, b: 2};
 let obj = {a: 1, [`${c}`]: 3, b: 2};
 let obj = {a: 1, [tag`c`]: 3, b: 2};
 
-// This rule ignores objects that have a non-boundary spread operator in them.
+// This rule does not report unsorted properties that are separated by a spread property.
 let obj = {b: 1, ...c, a: 2};
 ```
 

--- a/docs/rules/sort-keys.md
+++ b/docs/rules/sort-keys.md
@@ -53,7 +53,7 @@ let obj = {a: 1, ["c" + "d"]: 3, b: 2};
 let obj = {a: 1, [`${c}`]: 3, b: 2};
 let obj = {a: 1, [tag`c`]: 3, b: 2};
 
-// This rule ignores objects that have a spread operator in them.
+// This rule ignores objects that have a non-boundary spread operator in them.
 let obj = {b: 1, ...c, a: 2};
 ```
 

--- a/lib/rules/sort-keys.js
+++ b/lib/rules/sort-keys.js
@@ -127,8 +127,12 @@ module.exports = {
                 stack = stack.upper;
             },
 
+            SpreadElement() {
+                stack.prevName = null;
+            },
+
             Property(node) {
-                if (node.parent.type === "ObjectPattern" || node.parent.properties.some(n => n.type === "SpreadElement")) {
+                if (node.parent.type === "ObjectPattern") {
                     return;
                 }
 

--- a/tests/lib/rules/sort-keys.js
+++ b/tests/lib/rules/sort-keys.js
@@ -33,14 +33,14 @@ ruleTester.run("sort-keys", rule, {
         // ignore non-simple computed properties.
         { code: "var obj = {a:1, b:3, [a + b]: -1, c:2}", options: [], parserOptions: { ecmaVersion: 6 } },
 
-        // ignore non-boundary spread properties.
+        // ignore properties separated by spread properties
         { code: "var obj = {a:1, ...z, b:1}", options: [], parserOptions: { ecmaVersion: 2018 } },
         { code: "var obj = {b:1, ...z, a:1}", options: [], parserOptions: { ecmaVersion: 2018 } },
         { code: "var obj = {...a, b:1, ...c, d:1}", options: [], parserOptions: { ecmaVersion: 2018 } },
         { code: "var obj = {...a, b:1, ...d, ...c, e:2, z:5}", options: [], parserOptions: { ecmaVersion: 2018 } },
         { code: "var obj = {b:1, ...c, ...d, e:2}", options: [], parserOptions: { ecmaVersion: 2018 } },
 
-        // boundary spread properties
+        // not ignore properties not separated by spread properties
         { code: "var obj = {...z, a:1, b:1}", options: [], parserOptions: { ecmaVersion: 2018 } },
         { code: "var obj = {...z, ...c, a:1, b:1}", options: [], parserOptions: { ecmaVersion: 2018 } },
         { code: "var obj = {a:1, b:1, ...z}", options: [], parserOptions: { ecmaVersion: 2018 } },
@@ -160,7 +160,7 @@ ruleTester.run("sort-keys", rule, {
             errors: ["Expected object keys to be in ascending order. 'Z' should be before 'À'."]
         },
 
-        // not ignore boundary spread properties
+        // not ignore properties not separated by spread properties
         {
             code: "var obj = {...z, c:1, b:1}",
             options: [],

--- a/tests/lib/rules/sort-keys.js
+++ b/tests/lib/rules/sort-keys.js
@@ -33,9 +33,18 @@ ruleTester.run("sort-keys", rule, {
         // ignore non-simple computed properties.
         { code: "var obj = {a:1, b:3, [a + b]: -1, c:2}", options: [], parserOptions: { ecmaVersion: 6 } },
 
-        // ignore spread properties.
+        // ignore non-boundary spread properties.
         { code: "var obj = {a:1, ...z, b:1}", options: [], parserOptions: { ecmaVersion: 2018 } },
         { code: "var obj = {b:1, ...z, a:1}", options: [], parserOptions: { ecmaVersion: 2018 } },
+        { code: "var obj = {...a, b:1, ...c, d:1}", options: [], parserOptions: { ecmaVersion: 2018 } },
+        { code: "var obj = {...a, b:1, ...d, ...c, e:2, z:5}", options: [], parserOptions: { ecmaVersion: 2018 } },
+        { code: "var obj = {b:1, ...c, ...d, e:2}", options: [], parserOptions: { ecmaVersion: 2018 } },
+
+        // boundary spread properties
+        { code: "var obj = {...z, a:1, b:1}", options: [], parserOptions: { ecmaVersion: 2018 } },
+        { code: "var obj = {...z, ...c, a:1, b:1}", options: [], parserOptions: { ecmaVersion: 2018 } },
+        { code: "var obj = {a:1, b:1, ...z}", options: [], parserOptions: { ecmaVersion: 2018 } },
+        { code: "var obj = {...z, ...x, a:1, ...c, ...d, f:5, e:4}", options: ["desc"], parserOptions: { ecmaVersion: 2018 } },
 
         // ignore destructuring patterns.
         { code: "let {a, b} = {}", options: [], parserOptions: { ecmaVersion: 6 } },
@@ -149,6 +158,53 @@ ruleTester.run("sort-keys", rule, {
         {
             code: "var obj = {'#':1, À:3, 'Z':2, è:4}",
             errors: ["Expected object keys to be in ascending order. 'Z' should be before 'À'."]
+        },
+
+        // not ignore boundary spread properties
+        {
+            code: "var obj = {...z, c:1, b:1}",
+            options: [],
+            parserOptions: { ecmaVersion: 2018 },
+            errors: ["Expected object keys to be in ascending order. 'b' should be before 'c'."]
+        },
+        {
+            code: "var obj = {...z, ...c, d:4, b:1, ...y, ...f, e:2, a:1}",
+            options: [],
+            parserOptions: { ecmaVersion: 2018 },
+            errors: [
+                "Expected object keys to be in ascending order. 'b' should be before 'd'.",
+                "Expected object keys to be in ascending order. 'a' should be before 'e'."
+            ]
+        },
+        {
+            code: "var obj = {c:1, b:1, ...a}",
+            options: [],
+            parserOptions: { ecmaVersion: 2018 },
+            errors: ["Expected object keys to be in ascending order. 'b' should be before 'c'."]
+        },
+        {
+            code: "var obj = {...z, ...a, c:1, b:1}",
+            options: [],
+            parserOptions: { ecmaVersion: 2018 },
+            errors: ["Expected object keys to be in ascending order. 'b' should be before 'c'."]
+        },
+        {
+            code: "var obj = {...z, b:1, a:1, ...d, ...c}",
+            options: [],
+            parserOptions: { ecmaVersion: 2018 },
+            errors: ["Expected object keys to be in ascending order. 'a' should be before 'b'."]
+        },
+        {
+            code: "var obj = {...z, a:2, b:0, ...x, ...c}",
+            options: ["desc"],
+            parserOptions: { ecmaVersion: 2018 },
+            errors: ["Expected object keys to be in descending order. 'b' should be before 'a'."]
+        },
+        {
+            code: "var obj = {...z, a:2, b:0, ...x}",
+            options: ["desc"],
+            parserOptions: { ecmaVersion: 2018 },
+            errors: ["Expected object keys to be in descending order. 'b' should be before 'a'."]
         },
 
         // not ignore simple computed properties.


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
I added a check for boundary spread elements to fix #10760. The PR implements [the following suggeston](https://github.com/eslint/eslint/pull/10495#issuecomment-400037448).

**Is there anything you'd like reviewers to focus on?**
This is my very first PR in this particular project, so I might have missed something.
Please pay attention to the tests to make sure we cover all possible cases.


