### PR TITLE
Docs: Fix link to rule `no-useless-rename`

### DIFF
--- a/docs/rules/object-shorthand.md
+++ b/docs/rules/object-shorthand.md
@@ -84,7 +84,7 @@ var foo = {
 
 See Also:
 
-- [`no-useless-rename`](https://eslint.org/docs/rules/object-shorthand) which disallows renaming import, export, and destructured assignments to the same name.
+- [`no-useless-rename`](https://eslint.org/docs/rules/no-useless-rename) which disallows renaming import, export, and destructured assignments to the same name.
 
 ## Options
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Documentation update

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Fixed link to rule: no-useless-rename that erroneously linked to the same currently viewed rule: object-shorthand

**Is there anything you'd like reviewers to focus on?**
Trivial fix.

