### PR TITLE
Update: add fixer to require-await rule.

### DIFF
--- a/lib/rules/require-await.js
+++ b/lib/rules/require-await.js
@@ -40,6 +40,8 @@ module.exports = {
             url: "https://eslint.org/docs/rules/require-await"
         },
 
+        fixable: "code",
+
         schema: []
     },
 
@@ -76,6 +78,14 @@ module.exports = {
                         name: capitalizeFirstLetter(
                             astUtils.getFunctionNameWithKind(node)
                         )
+                    },
+                    fix(fixer) {
+                        const isAsyncKeywordOnParentNode = ["MethodDefinition", "Property"].includes(node.parent.type);
+                        const nodeWithAsyncKeyword = isAsyncKeywordOnParentNode ? node.parent : node;
+                        const text = sourceCode.getText(nodeWithAsyncKeyword);
+                        const textWithoutAsync = text.replace("async ", "");
+
+                        return fixer.replaceText(nodeWithAsyncKeyword, textWithoutAsync);
                     }
                 });
             }

--- a/tests/lib/rules/require-await.js
+++ b/tests/lib/rules/require-await.js
@@ -46,38 +46,47 @@ ruleTester.run("require-await", rule, {
     invalid: [
         {
             code: "async function foo() { doSomething() }",
+            output: "function foo() { doSomething() }",
             errors: ["Async function 'foo' has no 'await' expression."]
         },
         {
             code: "(async function() { doSomething() })",
+            output: "(function() { doSomething() })",
             errors: ["Async function has no 'await' expression."]
         },
         {
             code: "async () => { doSomething() }",
+            output: "() => { doSomething() }",
             errors: ["Async arrow function has no 'await' expression."]
         },
         {
             code: "async () => doSomething()",
+            output: "() => doSomething()",
             errors: ["Async arrow function has no 'await' expression."]
         },
         {
             code: "({ async foo() { doSomething() } })",
+            output: "({ foo() { doSomething() } })",
             errors: ["Async method 'foo' has no 'await' expression."]
         },
         {
             code: "class A { async foo() { doSomething() } }",
+            output: "class A { foo() { doSomething() } }",
             errors: ["Async method 'foo' has no 'await' expression."]
         },
         {
             code: "(class { async foo() { doSomething() } })",
+            output: "(class { foo() { doSomething() } })",
             errors: ["Async method 'foo' has no 'await' expression."]
         },
         {
             code: "async function foo() { async () => { await doSomething() } }",
+            output: "function foo() { async () => { await doSomething() } }",
             errors: ["Async function 'foo' has no 'await' expression."]
         },
         {
             code: "async function foo() { await async () => { doSomething() } }",
+            output: "async function foo() { await () => { doSomething() } }",
             errors: ["Async arrow function has no 'await' expression."]
         }
     ]


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Adds a fixer that removes unnecessary usages of the `async` function keyword.

**Is there anything you'd like reviewers to focus on?**

The fixer code including determining how and where to remove the `async` function keyword. 

**What rule do you want to change?**

`require-await`

**Does this change cause the rule to produce more or fewer warnings?**

No effect.

**How will the change be implemented? (New option, new default behavior, etc.)?**

The new fixer functionality will only be run if the user specifies to fix violations when running this rule.

**Please provide some example code that this change will affect:**

```js
async function foo() { doSomething() } // Before
function foo() { doSomething() } // After
```

**What does the rule currently do for this code?**

Detects the unnecessary `async` but is not capable of fixing it.

**What will the rule do after it's changed?**

In addition to detecting the issue, the rule can now automatically remove the unnecessary `async`.
