### PR TITLE
Docs: Ensure `triage` label is added to new issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -2,7 +2,7 @@
 name: "\U0001F41E  Bug report"
 about: Report an issue with ESLint or rules bundled with ESLint
 title: ''
-labels: bug, triage, evaluating
+labels: bug, triage
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -2,7 +2,7 @@
 name: "\U0001F41E  Bug report"
 about: Report an issue with ESLint or rules bundled with ESLint
 title: ''
-labels: bug, evaluating
+labels: bug, triage, evaluating
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/CHANGE.md
+++ b/.github/ISSUE_TEMPLATE/CHANGE.md
@@ -2,7 +2,7 @@
 name: "\U0001F4DD Non-rule change request"
 about: Request a change that is not a bug fix, rule change, or new rule
 title: ''
-labels: core, enhancement, evaluating
+labels: enhancement, triage, core, evaluating
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/CHANGE.md
+++ b/.github/ISSUE_TEMPLATE/CHANGE.md
@@ -2,7 +2,7 @@
 name: "\U0001F4DD Non-rule change request"
 about: Request a change that is not a bug fix, rule change, or new rule
 title: ''
-labels: enhancement, triage, core, evaluating
+labels: enhancement, triage, core
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/NEW_RULE.md
+++ b/.github/ISSUE_TEMPLATE/NEW_RULE.md
@@ -2,7 +2,7 @@
 name: "\U0001F680 New rule proposal"
 about: Propose a new rule to be added to ESLint
 title: ''
-labels: rule, feature, evaluating
+labels: triage, rule, feature, evaluating
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/NEW_RULE.md
+++ b/.github/ISSUE_TEMPLATE/NEW_RULE.md
@@ -2,7 +2,7 @@
 name: "\U0001F680 New rule proposal"
 about: Propose a new rule to be added to ESLint
 title: ''
-labels: triage, rule, feature, evaluating
+labels: triage, rule, feature
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/RULE_CHANGE.md
+++ b/.github/ISSUE_TEMPLATE/RULE_CHANGE.md
@@ -2,7 +2,7 @@
 name: "\U0001F4DD Rule change request"
 about: Request a change to an existing rule
 title: ''
-labels: enhancement, triage, rule, evaluating
+labels: enhancement, triage, rule
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/RULE_CHANGE.md
+++ b/.github/ISSUE_TEMPLATE/RULE_CHANGE.md
@@ -2,7 +2,7 @@
 name: "\U0001F4DD Rule change request"
 about: Request a change to an existing rule
 title: ''
-labels: enhancement, evaluating, rule
+labels: enhancement, triage, rule, evaluating
 assignees: ''
 
 ---


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates the issue templates to ensure that the `triage` label is added to new issues. The bot had stopped adding the `triage` label to issues as an unintended side-effect of https://github.com/eslint/eslint/pull/11163.

(fixes https://github.com/eslint/eslint-github-bot/issues/99)

**Is there anything you'd like reviewers to focus on?**

Nothing in particular