### PR TITLE
Breaking: allow comments after no-fallthrough (fixes #10608)

### DIFF
--- a/docs/rules/no-fallthrough.md
+++ b/docs/rules/no-fallthrough.md
@@ -121,6 +121,16 @@ switch(foo) {
         doSomething();
         // falls through
 
+    // foo
+    default:
+        doSomething();
+}
+
+switch(foo) {
+    case 1:
+        doSomething();
+        // falls through
+
     case 2:
         doSomething();
 }

--- a/lib/rules/no-fallthrough.js
+++ b/lib/rules/no-fallthrough.js
@@ -25,9 +25,9 @@ const DEFAULT_FALLTHROUGH_COMMENT = /falls?\s?through/i;
  */
 function hasFallthroughComment(node, context, fallthroughCommentPattern) {
     const sourceCode = context.getSourceCode();
-    const comment = lodash.last(sourceCode.getCommentsBefore(node));
+    const comments = sourceCode.getCommentsBefore(node);
 
-    return Boolean(comment && fallthroughCommentPattern.test(comment.value));
+    return lodash.some(comments, comment => fallthroughCommentPattern.test(comment.value));
 }
 
 /**

--- a/tests/lib/rules/no-fallthrough.js
+++ b/tests/lib/rules/no-fallthrough.js
@@ -42,6 +42,7 @@ ruleTester.run("no-fallthrough", rule, {
         "switch(foo) { case 0: case 1: break; }",
         "switch(foo) { case 0:\n case 1: break; }",
         "switch(foo) { case 0: // comment\n case 1: break; }",
+        "switch(foo) { case 0: a();\n/* fall through */\n/* todo: fix readability */\ndefault: b() }",
         "function foo() { switch(foo) { case 0: case 1: return; } }",
         "function foo() { switch(foo) { case 0: {return;}\n case 1: {return;} } }",
         "switch(foo) { case 0: case 1: {break;} }",
@@ -158,7 +159,7 @@ ruleTester.run("no-fallthrough", rule, {
         {
             code: "switch(foo) { case 0: a();\n/* no break */\n/* todo: fix readability */\ndefault: b() }",
             options: [{
-                commentPattern: "no break"
+                commentPattern: "break omitted"
             }],
             errors: [
                 {


### PR DESCRIPTION
Allow comments between `// fall through` and next test case for the no-fallthrough test case.

**What is the purpose of this pull request? (put an "X" next to item)**

- [ ] Documentation update
- [ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
- [ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
- [X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

See https://github.com/eslint/eslint/issues/10608

**What changes did you make? (Give an overview)**

- Changed `no-fallthrough` behaviour to accept additional comments between the explicit `// fall through` comment and the following switch case
- Updated tests to reflect this
- Added example in docs to reflect this 

**Is there anything you'd like reviewers to focus on?**

This was explicitly [tested **against**](https://github.com/eslint/eslint/blob/617a2874ed085bca36ca289aac55e3b7f7ce937e/tests/lib/rules/no-fallthrough.js#L158-L171), but without any mention I could find as to why. I could put it behind an option, if needed.
