### PR TITLE
Docs: link to JSDoc EOL blogpost in valid-jsdoc and require-jsdoc

### DIFF
--- a/docs/rules/require-jsdoc.md
+++ b/docs/rules/require-jsdoc.md
@@ -1,6 +1,6 @@
 # require JSDoc comments (require-jsdoc)
 
-This rule was **deprecated** in ESLint v5.10.0.
+This rule was [**deprecated**](https://eslint.org/blog/2018/11/jsdoc-end-of-life) in ESLint v5.10.0.
 
 [JSDoc](http://usejsdoc.org) is a JavaScript API documentation generator. It uses specially-formatted comments inside of code to generate API documentation automatically. For example, this is what a JSDoc comment looks like for a function:
 

--- a/docs/rules/valid-jsdoc.md
+++ b/docs/rules/valid-jsdoc.md
@@ -1,6 +1,6 @@
 # enforce valid JSDoc comments (valid-jsdoc)
 
-This rule was **deprecated** in ESLint v5.10.0.
+This rule was [**deprecated**](https://eslint.org/blog/2018/11/jsdoc-end-of-life) in ESLint v5.10.0.
 
 [JSDoc](http://usejsdoc.org) generates application programming interface (API) documentation from specially-formatted comments in JavaScript code. For example, this is a JSDoc comment for a function:
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Linked in to the [end of life blog post](https://eslint.org/blog/2018/11/jsdoc-end-of-life) regarding the deprecation of JSDoc rules. It took a bit of searching to find the post when it could just be linked here.

**Is there anything you'd like reviewers to focus on?**
N/A