### PR TITLE
New: add option `first` for VariableDeclarator in indent (fixes #8976)

### DIFF
--- a/docs/rules/indent.md
+++ b/docs/rules/indent.md
@@ -69,7 +69,7 @@ if (a) {
 This rule has an object option:
 
 * `"SwitchCase"` (default: 0) enforces indentation level for `case` clauses in `switch` statements
-* `"VariableDeclarator"` (default: 1) enforces indentation level for `var` declarators; can also take an object to define separate rules for `var`, `let` and `const` declarations.
+* `"VariableDeclarator"` (default: 1) enforces indentation level for `var` declarators; can also take an object to define separate rules for `var`, `let` and `const` declarations. It can also be `"first"`, indicating all the declarators should be aligned with the first declarator.
 * `"outerIIFEBody"` (default: 1) enforces indentation level for file-level IIFEs.
 * `"MemberExpression"` (default: 1) enforces indentation level for multi-line property chains. This can also be set to `"off"` to disable checking for MemberExpression indentation.
 * `"FunctionDeclaration"` takes an object to define rules for function declarations.
@@ -211,6 +211,40 @@ let a,
 const a = 1,
     b = 2,
     c = 3;
+```
+
+Examples of **incorrect** code for this rule with the `2, { "VariableDeclarator": "first" }` options:
+
+```js
+/*eslint indent: ["error", 2, { "VariableDeclarator": "first" }]*/
+/*eslint-env es6*/
+
+var a,
+  b,
+  c;
+let a,
+  b,
+  c;
+const a = 1,
+  b = 2,
+  c = 3;
+```
+
+Examples of **correct** code for this rule with the `2, { "VariableDeclarator": "first" }` options:
+
+```js
+/*eslint indent: ["error", 2, { "VariableDeclarator": "first" }]*/
+/*eslint-env es6*/
+
+var a,
+    b,
+    c;
+let a,
+    b,
+    c;
+const a = 1,
+      b = 2,
+      c = 3;
 ```
 
 Examples of **correct** code for this rule with the `2, { "VariableDeclarator": { "var": 2, "let": 2, "const": 3 } }` options:

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -522,25 +522,13 @@ module.exports = {
                     },
                     VariableDeclarator: {
                         oneOf: [
-                            {
-                                type: "integer",
-                                minimum: 0
-                            },
+                            ELEMENT_LIST_SCHEMA,
                             {
                                 type: "object",
                                 properties: {
-                                    var: {
-                                        type: "integer",
-                                        minimum: 0
-                                    },
-                                    let: {
-                                        type: "integer",
-                                        minimum: 0
-                                    },
-                                    const: {
-                                        type: "integer",
-                                        minimum: 0
-                                    }
+                                    var: ELEMENT_LIST_SCHEMA,
+                                    let: ELEMENT_LIST_SCHEMA,
+                                    const: ELEMENT_LIST_SCHEMA
                                 },
                                 additionalProperties: false
                             }
@@ -661,7 +649,7 @@ module.exports = {
             if (context.options[1]) {
                 lodash.merge(options, context.options[1]);
 
-                if (typeof options.VariableDeclarator === "number") {
+                if (typeof options.VariableDeclarator === "number" || options.VariableDeclarator === "first") {
                     options.VariableDeclarator = {
                         var: options.VariableDeclarator,
                         let: options.VariableDeclarator,
@@ -1384,6 +1372,15 @@ module.exports = {
 
                 if (astUtils.isSemicolonToken(lastToken)) {
                     offsets.ignoreToken(lastToken);
+                }
+
+                if (options.VariableDeclarator[node.kind] === "first") {
+                    addElementListIndent(
+                        node.declarations,
+                        sourceCode.getFirstToken(node),
+                        sourceCode.getLastToken(node),
+                        "first"
+                    );
                 }
             },
 

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -616,6 +616,24 @@ ruleTester.run("indent", rule, {
         },
         {
             code: unIndent`
+                let foo = 'foo',
+                    bar = bar;
+                const a = 'a',
+                      b = 'b';
+            `,
+            options: [2, { VariableDeclarator: "first" }]
+        },
+        {
+            code: unIndent`
+                let foo = 'foo',
+                    bar = bar  // <-- no semicolon here
+                const a = 'a',
+                      b = 'b'  // <-- no semicolon here
+            `,
+            options: [2, { VariableDeclarator: "first" }]
+        },
+        {
+            code: unIndent`
                 var foo = 1,
                     bar = 2,
                     baz = 3
@@ -631,6 +649,20 @@ ruleTester.run("indent", rule, {
                     ;
             `,
             options: [2, { VariableDeclarator: { var: 2 } }]
+        },
+        {
+            code: unIndent`
+                var foo = 'foo',
+                    bar = bar;
+            `,
+            options: [2, { VariableDeclarator: { var: "first" } }]
+        },
+        {
+            code: unIndent`
+                var foo = 'foo',
+                    bar = 'bar'  // <-- no semicolon here
+            `,
+            options: [2, { VariableDeclarator: { var: "first" } }]
         },
         {
             code: unIndent`
@@ -5929,6 +5961,39 @@ ruleTester.run("indent", rule, {
                     rotate;
             `,
             options: [2, { VariableDeclarator: 2 }],
+            errors: expectedErrors([
+                [2, 4, 2, "Identifier"]
+            ])
+        },
+        {
+            code: unIndent`
+                let foo = 'foo',
+                  bar = bar;
+                const a = 'a',
+                  b = 'b';
+            `,
+            output: unIndent`
+                let foo = 'foo',
+                    bar = bar;
+                const a = 'a',
+                      b = 'b';
+            `,
+            options: [2, { VariableDeclarator: "first" }],
+            errors: expectedErrors([
+                [2, 4, 2, "Identifier"],
+                [4, 6, 2, "Identifier"]
+            ])
+        },
+        {
+            code: unIndent`
+                var foo = 'foo',
+                  bar = bar;
+            `,
+            output: unIndent`
+                var foo = 'foo',
+                    bar = bar;
+            `,
+            options: [2, { VariableDeclarator: { var: "first" } }],
             errors: expectedErrors([
                 [2, 4, 2, "Identifier"]
             ])


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Changes an existing rule 

**What changes did you make? (Give an overview)**

Fixes #8976 

**Is there anything you'd like reviewers to focus on?**

I have used a guard for checking whether the option is `first` or not. If the option isn't `first`, it won't execute the `addElementListIndent` function to make sure not breaking the current rule logic and not doing unnecessary execution of the `addElementListIndent` function.

