### PR TITLE
Fix: handle optional catch bindings in no-useless-catch (fixes #11208)

### DIFF
--- a/lib/rules/no-useless-catch.js
+++ b/lib/rules/no-useless-catch.js
@@ -27,6 +27,7 @@ module.exports = {
         return {
             CatchClause(node) {
                 if (
+                    node.param &&
                     node.param.type === "Identifier" &&
                     node.body.body.length &&
                     node.body.body[0].type === "ThrowStatement" &&

--- a/tests/lib/rules/no-useless-catch.js
+++ b/tests/lib/rules/no-useless-catch.js
@@ -103,6 +103,16 @@ ruleTester.run("no-useless-catch", rule, {
                 }
             `,
             parserOptions: { ecmaVersion: 8 }
+        },
+        {
+            code: `
+                try {
+                    throw new Error('foo');
+                } catch {
+                    throw new Error('foo');
+                }
+            `,
+            parserOptions: { ecmaVersion: 2019 }
         }
 
     ],


### PR DESCRIPTION
When optional catch bindings are used, `node.param` is `null`.

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Added a missing check in no-useless-catch.

**Is there anything you'd like reviewers to focus on?**
No

