### PR TITLE
New: implement 'require-await-function-call' rule.

### DIFF
--- a/conf/eslint-recommended.js
+++ b/conf/eslint-recommended.js
@@ -245,6 +245,7 @@ module.exports = {
         radix: "off",
         "require-atomic-updates": "off",
         "require-await": "off",
+        "require-await-function-call": "off",
         "require-jsdoc": "off",
         "require-unicode-regexp": "off",
         "require-yield": "error",

--- a/docs/rules/require-await-function-call.md
+++ b/docs/rules/require-await-function-call.md
@@ -1,0 +1,76 @@
+# Require using `await` with calls to specified functions. (require-await-function-call)
+
+Some functions are asynchronous and we want to wait for their code to finish executing before continuing on. The modern `async` / `await` syntax can help us achieve this.
+
+## Rule Details
+
+This lint rule requires that specified functions be called with the `async` keyword. The benefits of this include:
+
+* Ensure code runs in the right (deterministic) order
+* Promote cleaner code by reducing unwieldy promise chain usage
+* Enforce a consistent way of calling/chaining asynchronous functions
+
+Code sample:
+
+```js
+// Lint rule configuration: ['error', { functions: ['asyncFunc1', 'asyncFunc2'] }]
+
+function doSomethingInvalid() {
+  // Invalid because specified functions are missing `await`.
+  return asyncFunc1().then(() => {
+    return asyncFunc2();
+  });
+}
+
+async function doSomethingValid() {
+  await asyncFunc1();
+  await asyncFunc2();
+}
+```
+
+Here's a code sample demonstrating how it can be especially useful to enforce using the `async` keyword with asynchronous test action / wait helpers to make tests more deterministic and potentially reduce flakiness.
+
+```js
+// Lint rule configuration: ['error', { functions: ['click'] }]
+
+test('clicking the button sends the action', function(assert) {
+  click('.my-button'); // Invalid usage.
+  assert.ok(this.myAction.calledOnce);
+});
+
+test('clicking the button sends the action', function(assert) {
+  click('.my-button').then(() => {
+    assert.ok(this.myAction.calledOnce);
+  }); // Invalid usage.
+});
+
+test('clicking the button sends the action', async function(assert) {
+  await click('.my-button'); // Valid usage.
+  assert.ok(this.myAction.calledOnce);
+});
+```
+
+## Options
+
+This rule accepts a single argument:
+
+* Set the required `functions` option to an array of the function names that must be called with `await`.
+
+## When Not To Use It
+
+You should avoid enabling this rule if:
+
+* Your JavaScript/browser environment does not support `async` functions (an ES8/ES2017 feature)
+* You have no asynchronous functions
+* You prefer to use promise chains instead of the `async` keyword
+
+## Related Rules
+
+* [no-await-in-loop](no-await-in-loop.md)
+* [no-return-await](no-return-await.md)
+* [require-atomic-updates](require-atomic-updates.md)
+* [require-await](require-await.md)
+
+## Resources
+
+* See the [documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function) for async functions

--- a/lib/rules/require-await-function-call.js
+++ b/lib/rules/require-await-function-call.js
@@ -1,0 +1,142 @@
+"use strict";
+
+//------------------------------------------------------------------------------
+// Helper functions.
+//------------------------------------------------------------------------------
+
+/**
+ * Checks if the given node is of the given type.
+ *
+ * @param {ASTNode} node - the node to check.
+ * @param {string} type - the type to look for.
+ * @returns {boolean} `true` if the node is of the given type.
+ */
+function isType(node, type) {
+    return node.type === type;
+}
+
+/**
+ * Checks if the given node is an Identifier.
+ *
+ * @param {ASTNode} node - the node to check.
+ * @returns {boolean} `true` if the node is an Identifier.
+ */
+function isIdentifier(node) {
+    return isType(node, "Identifier");
+}
+
+/**
+ * Checks if the given node is an AwaitExpression.
+ *
+ * @param {ASTNode} node - the node to check.
+ * @returns {boolean} `true` if the node is an AwaitExpression.
+ */
+function isAwaitExpression(node) {
+    return isType(node, "AwaitExpression");
+}
+
+/**
+ * Checks if the given node is a CallExpression.
+ *
+ * @param {ASTNode} node - the node to check.
+ * @returns {boolean} `true` if the node is a CallExpression.
+ */
+function isCallExpression(node) {
+    return isType(node, "CallExpression");
+}
+
+/**
+ * Checks if the given node is a MemberExpression.
+ *
+ * @param {ASTNode} node - the node to check.
+ * @returns {boolean} `true` if the node is a MemberExpression.
+ */
+function isMemberExpression(node) {
+    return isType(node, "MemberExpression");
+}
+
+/**
+ * Checks if the given node is part of a call with the `async` keyword.
+ *
+ * @param {ASTNode} node - the node to check.
+ * @returns {boolean} `true` if the node is part of a call with the `async` keyword.
+ */
+function isAsyncCall(node) {
+    if (!node.parent) {
+
+        // Can't be part of an AwaitExpression if it has no parent.
+        return false;
+    }
+
+    const parent = node.parent;
+
+    if (isAwaitExpression(parent)) {
+        return true;
+    }
+
+    if (isCallExpression(parent) || isMemberExpression(parent)) {
+
+        // Check to see if the AwaitExpression is still another level above.
+        return isAsyncCall(parent);
+    }
+
+    return false;
+}
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "require using `await` with calls to specified functions.",
+            category: "Possible Errors",
+            recommended: false,
+            url: "https://eslint.org/docs/rules/require-await-function-call"
+        },
+        fixable: null,
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    functions: {
+                        type: "array",
+                        items: {
+                            type: "string"
+                        },
+                        minItems: 1
+                    }
+                },
+                additionalProperties: false
+            }
+        ]
+    },
+    create(context) {
+        return {
+            CallExpression(node) {
+                const callee = node.callee;
+
+                if (
+                    !isIdentifier(callee) || !context.options[0].functions.includes(callee.name)
+                ) {
+
+                    // Not one of the specified async functions.
+                    return;
+                }
+
+                if (!isAsyncCall(node)) {
+
+                    // Missing `await`.
+                    context.report({
+                        node,
+                        message: "Use `await` with `{{ calleeName }}` function call.",
+                        data: {
+                            calleeName: callee.name
+                        }
+                    });
+                }
+            }
+        };
+    }
+};

--- a/tests/lib/rules/require-await-function-call.js
+++ b/tests/lib/rules/require-await-function-call.js
@@ -1,0 +1,88 @@
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../lib/rules/require-await-function-call");
+const RuleTester = require("../../../lib/testers/rule-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+    parserOptions: {
+        ecmaVersion: 8,
+        sourceType: "module"
+    }
+});
+
+const VALID_USAGES = [
+    {
+        code: "async function myFunction() { await asyncFunc(); }",
+        options: [{ functions: ["asyncFunc"] }]
+    },
+    {
+
+        // When the `AwaitExpression` isn't the direct parent of the `CallExpression`.
+        code: "async function myFunction() { await asyncFunc().then(() => {}); }",
+        options: [{ functions: ["asyncFunc"] }]
+    },
+    {
+
+        // Not one of the specified functions.
+        code: "otherFunc();",
+        options: [{ functions: ["asyncFunc"] }]
+    },
+    {
+
+        // Not one of the specified functions.
+        code: "async function myFunction() { await otherAsyncFunc(); }",
+        options: [{ functions: ["asyncFunc"] }]
+    }
+];
+
+const INVALID_USAGES = [
+    {
+
+        // Missing `await`.
+        code: "asyncFunc();",
+        options: [{ functions: ["asyncFunc"] }],
+        errors: [
+            {
+                message: "Use `await` with `asyncFunc` function call.",
+                type: "CallExpression"
+            }
+        ]
+    },
+    {
+
+        // Missing `await` and part of promise chain.
+        code: "asyncFunc().then(() => {});",
+        options: [{ functions: ["asyncFunc"] }],
+        errors: [
+            {
+                message: "Use `await` with `asyncFunc` function call.",
+                type: "CallExpression"
+            }
+        ]
+    },
+    {
+
+        // Missing `await` but inside another `await` function call.
+        code: "async function topLevelFunction() { await otherAsyncFunc(() => { asyncFunc(); }); }",
+        options: [{ functions: ["asyncFunc"] }],
+        errors: [
+            {
+                message: "Use `await` with `asyncFunc` function call.",
+                type: "CallExpression"
+            }
+        ]
+    }
+];
+
+ruleTester.run("require-await-function-call", rule, {
+    valid: VALID_USAGES,
+    invalid: INVALID_USAGES
+});

--- a/tools/rule-types.json
+++ b/tools/rule-types.json
@@ -234,6 +234,7 @@
     "radix": "suggestion",
     "require-atomic-updates": "problem",
     "require-await": "suggestion",
+    "require-await-function-call": "problem",
     "require-jsdoc": "suggestion",
     "require-unicode-regexp": "suggestion",
     "require-yield": "suggestion",


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[X] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Add new `require-await-function-call` rule.

**Is there anything you'd like reviewers to focus on?**

I added some generic helper functions that really belong in a util file. Should I move them?

**Please describe what the rule should do:**

This rule requires that specified functions be called with the `async` keyword.

**What category of rule is this? (place an "X" next to just one item)**

This rule could fit into each category. I'm not sure which is best.

[X] Enforces code style
[X] Warns about a potential error
[X] Suggests an alternate way of doing something
[ ] Other (please specify:)

**Provide 2-3 code examples that this rule will warn about:**

Please see the documentation file in this PR for code examples.

**Why should this rule be included in ESLint (instead of a plugin)?**

This rule relates to the ES8/ES2017 JavaScript `async`/`await` feature. It helps enforce usage of this modern JavaScript feature. It is not specific to any framework or library.