### PR TITLE
New: Add fixedCount for indicating eslint has fixed something/nothing

### DIFF
--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -141,12 +141,14 @@ function calculateStatsPerRun(results) {
     return results.reduce((stat, result) => {
         stat.errorCount += result.errorCount;
         stat.warningCount += result.warningCount;
+        stat.fixedCount += result.fixedCount;
         stat.fixableErrorCount += result.fixableErrorCount;
         stat.fixableWarningCount += result.fixableWarningCount;
         return stat;
     }, {
         errorCount: 0,
         warningCount: 0,
+        fixedCount: 0,
         fixableErrorCount: 0,
         fixableWarningCount: 0
     });
@@ -645,6 +647,7 @@ class CLIEngine {
             results,
             errorCount: stats.errorCount,
             warningCount: stats.warningCount,
+            fixedCount: stats.fixedCount,
             fixableErrorCount: stats.fixableErrorCount,
             fixableWarningCount: stats.fixableWarningCount,
             usedDeprecatedRules
@@ -707,6 +710,7 @@ class CLIEngine {
             results,
             errorCount: stats.errorCount,
             warningCount: stats.warningCount,
+            fixedCount: stats.fixedCount,
             fixableErrorCount: stats.fixableErrorCount,
             fixableWarningCount: stats.fixableWarningCount,
             usedDeprecatedRules

--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -208,6 +208,7 @@ function processText(text, configHelper, filename, fix, allowInlineConfig, repor
         messages: fixedResult.messages,
         errorCount: stats.errorCount,
         warningCount: stats.warningCount,
+        fixedCount: fixedResult.fixedCount,
         fixableErrorCount: stats.fixableErrorCount,
         fixableWarningCount: stats.fixableWarningCount
     };

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -1011,6 +1011,7 @@ module.exports = class Linter {
         let messages = [],
             fixedResult,
             fixed = false,
+            fixedCount = 0,
             passNumber = 0,
             currentText = text;
         const debugTextDescription = options && options.filename || `${text.slice(0, 10)}...`;
@@ -1033,6 +1034,8 @@ module.exports = class Linter {
 
             debug(`Generating fixed text for ${debugTextDescription} (pass ${passNumber})`);
             fixedResult = SourceCodeFixer.applyFixes(currentText, messages, shouldFix);
+
+            fixedCount += (messages.length - fixedResult.messages.length);
 
             /*
              * stop if there are any syntax errors.
@@ -1064,6 +1067,7 @@ module.exports = class Linter {
         // ensure the last result properly reflects if fixes were done
         fixedResult.fixed = fixed;
         fixedResult.output = currentText;
+        fixedResult.fixedCount = fixedCount;
 
         return fixedResult;
     }

--- a/tests/bin/eslint.js
+++ b/tests/bin/eslint.js
@@ -88,6 +88,7 @@ describe("bin/eslint.js", () => {
                     messages: [],
                     errorCount: 0,
                     warningCount: 0,
+                    fixedCount: 1,
                     fixableErrorCount: 0,
                     fixableWarningCount: 0,
                     output: "var foo = bar;\n"

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -291,6 +291,7 @@ describe("CLIEngine", () => {
                         messages: [],
                         errorCount: 0,
                         warningCount: 0,
+                        fixedCount: 1,
                         fixableErrorCount: 0,
                         fixableWarningCount: 0,
                         output: "var bar = foo;"
@@ -298,6 +299,7 @@ describe("CLIEngine", () => {
                 ],
                 errorCount: 0,
                 warningCount: 0,
+                fixedCount: 1,
                 fixableErrorCount: 0,
                 fixableWarningCount: 0,
                 usedDeprecatedRules: []
@@ -491,6 +493,7 @@ describe("CLIEngine", () => {
                         ],
                         errorCount: 1,
                         warningCount: 0,
+                        fixedCount: 0,
                         fixableErrorCount: 0,
                         fixableWarningCount: 0,
                         source: "var bar = foo"
@@ -498,6 +501,7 @@ describe("CLIEngine", () => {
                 ],
                 errorCount: 1,
                 warningCount: 0,
+                fixedCount: 0,
                 fixableErrorCount: 0,
                 fixableWarningCount: 0,
                 usedDeprecatedRules: []
@@ -533,6 +537,7 @@ describe("CLIEngine", () => {
                         ],
                         errorCount: 1,
                         warningCount: 0,
+                        fixedCount: 1,
                         fixableErrorCount: 0,
                         fixableWarningCount: 0,
                         output: "var bar = foothis is a syntax error."
@@ -540,6 +545,7 @@ describe("CLIEngine", () => {
                 ],
                 errorCount: 1,
                 warningCount: 0,
+                fixedCount: 1,
                 fixableErrorCount: 0,
                 fixableWarningCount: 0,
                 usedDeprecatedRules: []
@@ -575,6 +581,7 @@ describe("CLIEngine", () => {
                         ],
                         errorCount: 1,
                         warningCount: 0,
+                        fixedCount: 0,
                         fixableErrorCount: 0,
                         fixableWarningCount: 0,
                         source: "var bar ="
@@ -582,6 +589,7 @@ describe("CLIEngine", () => {
                 ],
                 errorCount: 1,
                 warningCount: 0,
+                fixedCount: 0,
                 fixableErrorCount: 0,
                 fixableWarningCount: 0,
                 usedDeprecatedRules: []
@@ -663,6 +671,7 @@ describe("CLIEngine", () => {
                         ],
                         errorCount: 1,
                         warningCount: 0,
+                        fixedCount: 0,
                         fixableErrorCount: 0,
                         fixableWarningCount: 0,
                         source: "var bar = foothis is a syntax error.\n return bar;"
@@ -670,6 +679,7 @@ describe("CLIEngine", () => {
                 ],
                 errorCount: 1,
                 warningCount: 0,
+                fixedCount: 0,
                 fixableErrorCount: 0,
                 fixableWarningCount: 0,
                 usedDeprecatedRules: []
@@ -1604,6 +1614,7 @@ describe("CLIEngine", () => {
                         messages: [],
                         errorCount: 0,
                         warningCount: 0,
+                        fixedCount: 2,
                         fixableErrorCount: 0,
                         fixableWarningCount: 0,
                         output: "true ? \"yes\" : \"no\";\n"
@@ -1613,6 +1624,7 @@ describe("CLIEngine", () => {
                         messages: [],
                         errorCount: 0,
                         warningCount: 0,
+                        fixedCount: 0,
                         fixableErrorCount: 0,
                         fixableWarningCount: 0
                     },
@@ -1631,6 +1643,7 @@ describe("CLIEngine", () => {
                         ],
                         errorCount: 1,
                         warningCount: 0,
+                        fixedCount: 3,
                         fixableErrorCount: 0,
                         fixableWarningCount: 0,
                         output: "var msg = \"hi\";\nif (msg == \"hi\") {\n\n}\n"
@@ -1651,6 +1664,7 @@ describe("CLIEngine", () => {
                         ],
                         errorCount: 1,
                         warningCount: 0,
+                        fixedCount: 1,
                         fixableErrorCount: 0,
                         fixableWarningCount: 0,
                         output: "var msg = \"hi\" + foo;\n"
@@ -1658,6 +1672,7 @@ describe("CLIEngine", () => {
                 ]);
                 assert.strictEqual(report.errorCount, 2);
                 assert.strictEqual(report.warningCount, 0);
+                assert.strictEqual(report.fixedCount, 6);
                 assert.strictEqual(report.fixableErrorCount, 0);
                 assert.strictEqual(report.fixableWarningCount, 0);
             });
@@ -3333,6 +3348,7 @@ describe("CLIEngine", () => {
                             ],
                             errorCount: 1,
                             warningCount: 0,
+                            fixedCount: 0,
                             fixableErrorCount: 0,
                             fixableWarningCount: 0,
                             source: "/* eslint-disable */"
@@ -3340,6 +3356,7 @@ describe("CLIEngine", () => {
                     ],
                     errorCount: 1,
                     warningCount: 0,
+                    fixedCount: 0,
                     fixableErrorCount: 0,
                     fixableWarningCount: 0,
                     usedDeprecatedRules: []

--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -4269,6 +4269,7 @@ describe("Linter", () => {
                 assert.strictEqual(fixResult.fixed, true);
                 assert.strictEqual(fixResult.messages.length, 0);
                 assert.strictEqual(fixResult.output, "FOO BAR BAZ");
+                assert.strictEqual(fixResult.fixedCount, 3);
             });
         });
     });
@@ -4283,6 +4284,7 @@ describe("Linter", () => {
 
             assert.strictEqual(messages.output, "var a;", "Fixes were applied correctly");
             assert.isTrue(messages.fixed);
+            assert.strictEqual(messages.fixedCount, 1);
         });
 
         it("does not require a third argument", () => {
@@ -4294,6 +4296,7 @@ describe("Linter", () => {
 
             assert.deepStrictEqual(fixResult, {
                 fixed: true,
+                fixedCount: 1,
                 messages: [],
                 output: "var a;"
             });
@@ -4307,6 +4310,7 @@ describe("Linter", () => {
             }, { fix: false });
 
             assert.strictEqual(fixResult.fixed, false);
+            assert.strictEqual(fixResult.fixedCount, 0);
         });
 
         it("stops fixing after 10 passes", () => {
@@ -4325,6 +4329,7 @@ describe("Linter", () => {
             assert.strictEqual(fixResult.fixed, true);
             assert.strictEqual(fixResult.output, `${" ".repeat(10)}a`);
             assert.strictEqual(fixResult.messages.length, 1);
+            assert.strictEqual(fixResult.fixedCount, 10);
         });
 
         it("should throw an error if fix is passed but meta has no `fixable` property", () => {


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

Currently, the stats output with `--fix` cannot tell us if the file is really fixed/saved/touched by eslint. For example, the first run has fixed and saved the files. If I do the second run after the first run, there is no way to know if the files have nothing to fix.

With `fixedCount`, the first run will return n. This means eslint has fixed n numbers of error/warning and save to disk. If I do the second run, it should return 0. This means eslint has nothing to fix.

**What changes did you make? (Give an overview)**

Add `fixedCount`

**Is there anything you'd like reviewers to focus on?**


