### PR TITLE
Fix: Manage severity of 1 with TAP reporter (fixes #11110)

### DIFF
--- a/lib/formatters/tap.js
+++ b/lib/formatters/tap.js
@@ -20,7 +20,6 @@ function getMessageType(message) {
         return "error";
     }
     return "warning";
-
 }
 
 /**
@@ -50,18 +49,22 @@ module.exports = function(results) {
         let diagnostics = {};
 
         if (messages.length > 0) {
-            testResult = "not ok";
-
             messages.forEach(message => {
+                const severity = getMessageType(message);
                 const diagnostic = {
                     message: message.message,
-                    severity: getMessageType(message),
+                    severity,
                     data: {
                         line: message.line || 0,
                         column: message.column || 0,
                         ruleId: message.ruleId || ""
                     }
                 };
+
+                // This ensures a warning message is not flagged as error
+                if (severity === "error") {
+                    testResult = "not ok";
+                }
 
                 /*
                  * If we have multiple messages place them under a messages key

--- a/tests/lib/formatters/tap.js
+++ b/tests/lib/formatters/tap.js
@@ -72,7 +72,7 @@ describe("formatter:tap", () => {
             }]
         }];
 
-        it("should return a an error string", () => {
+        it("should return an error string", () => {
             const result = formatter(code);
 
             assert.include(result, "not ok");
@@ -80,7 +80,70 @@ describe("formatter:tap", () => {
         });
     });
 
-    describe("when passed multiple messages", () => {
+    describe("when passed a message with a severity of 1", () => {
+        const code = [{
+            filePath: "foo.js",
+            messages: [{
+                message: "Unexpected foo.",
+                severity: 1,
+                line: 5,
+                column: 10,
+                ruleId: "foo"
+            }]
+        }];
+
+        it("should return a warning string", () => {
+            const result = formatter(code);
+
+            assert.include(result, "ok");
+            assert.notInclude(result, "not ok");
+            assert.include(result, "warning");
+        });
+    });
+
+    describe("when passed multiple messages with a severity of 1", () => {
+        const code = [{
+            filePath: "foo.js",
+            messages: [{
+                message: "Foo.",
+                severity: 1,
+                line: 5,
+                column: 10,
+                ruleId: "foo"
+            }, {
+                message: "Bar.",
+                severity: 1,
+                line: 6,
+                column: 11,
+                ruleId: "bar"
+            }, {
+                message: "Baz.",
+                severity: 1,
+                line: 7,
+                column: 12,
+                ruleId: "baz"
+            }]
+        }];
+
+        it("should return a string with multiple entries", () => {
+            const result = formatter(code);
+
+            assert.include(result, "ok");
+            assert.notInclude(result, "not ok");
+            assert.include(result, "messages");
+            assert.include(result, "Foo.");
+            assert.include(result, "line: 5");
+            assert.include(result, "column: 10");
+            assert.include(result, "Bar.");
+            assert.include(result, "line: 6");
+            assert.include(result, "column: 11");
+            assert.include(result, "Baz.");
+            assert.include(result, "line: 7");
+            assert.include(result, "column: 12");
+        });
+    });
+
+    describe("when passed multiple messages with different error severity", () => {
         const code = [{
             filePath: "foo.js",
             messages: [{
@@ -146,7 +209,8 @@ describe("formatter:tap", () => {
             const result = formatter(code);
 
             assert.include(result, "not ok 1");
-            assert.include(result, "not ok 2");
+            assert.include(result, "ok 2");
+            assert.notInclude(result, "not ok 2");
         });
     });
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
As reported in #11110, result with severity of 1 (ie. warning) were reported as errors (not ok)
This will allow:
- a result with one or many messages and all of them are of severity of 1 to be `ok`
- a result with many message with both severity of 1 and 2 to be still `not ok`

**Is there anything you'd like reviewers to focus on?**
Nothing!

