### PR TITLE
New: Add option 'allowSingleLineArrow' to brace-style (fixes #11217)

### DIFF
--- a/docs/rules/brace-style.md
+++ b/docs/rules/brace-style.md
@@ -53,6 +53,7 @@ This rule has a string option:
 This rule has an object option for an exception:
 
 * `"allowSingleLine": true` (default `false`) allows the opening and closing braces for a block to be on the *same* line
+* `"allowSingleLineArrow": true` (default `false`) allows the opening and closing braces for arrow functions to be on the *same* line
 
 ### 1tbs
 
@@ -129,6 +130,16 @@ if (foo) { bar(); }
 if (foo) { bar(); } else { baz(); }
 
 try { somethingRisky(); } catch(e) { handleError(); }
+```
+
+Examples of **correct** code for this rule with the `"1tbs", { "allowSingleLineArrow": true }` options:
+
+```js
+/*eslint brace-style: ["error", "1tbs", { "allowSingleLineArrow": true }]*/
+
+let foo = () => { bar(); };
+
+baz(() => { foo(); };
 ```
 
 ### stroustrup
@@ -209,6 +220,16 @@ else { baz(); }
 
 try { somethingRisky(); }
 catch(e) { handleError(); }
+```
+
+Examples of **correct** code for this rule with the `"stroustrup", { "allowSingleLineArrow": true }` options:
+
+```js
+/*eslint brace-style: ["error", "stroustrup", { "allowSingleLineArrow": true }]*/
+
+let foo = () => { bar(); };
+
+baz(() => { foo(); };
 ```
 
 ### allman
@@ -293,6 +314,16 @@ else { baz(); }
 
 try { somethingRisky(); }
 catch(e) { handleError(); }
+```
+
+Examples of **correct** code for this rule with the `"allman", { "allowSingleLineArrow": true }` options:
+
+```js
+/*eslint brace-style: ["error", "allman", { "allowSingleLineArrow": true }]*/
+
+let foo = () => { bar(); };
+
+baz(() => { foo(); };
 ```
 
 ## When Not To Use It

--- a/lib/rules/brace-style.js
+++ b/lib/rules/brace-style.js
@@ -31,6 +31,9 @@ module.exports = {
                 properties: {
                     allowSingleLine: {
                         type: "boolean"
+                    },
+                    allowSingleLineArrow: {
+                        type: "boolean"
                     }
                 },
                 additionalProperties: false
@@ -151,6 +154,12 @@ module.exports = {
 
         return {
             BlockStatement(node) {
+
+                // If the allowSingleLineArrow option is true, skip all single line arrow functions.
+                if (params.allowSingleLineArrow && node.parent.type === "ArrowFunctionExpression" && astUtils.isTokenOnSameLine(sourceCode.getFirstToken(node), sourceCode.getLastToken(node))) {
+                    return;
+                }
+
                 if (!astUtils.STATEMENT_LIST_PARENTS.has(node.parent.type)) {
                     validateCurlyPair(sourceCode.getFirstToken(node), sourceCode.getLastToken(node));
                 }

--- a/tests/lib/rules/brace-style.js
+++ b/tests/lib/rules/brace-style.js
@@ -82,6 +82,9 @@ ruleTester.run("brace-style", rule, {
         { code: "if (foo) {}\nelse {}", options: ["allman", { allowSingleLine: true }] },
         { code: "try {  bar(); }\ncatch (e) { baz();  }", options: ["allman", { allowSingleLine: true }] },
         { code: "var foo = () => { return; }", options: ["allman", { allowSingleLine: true }], parserOptions: { ecmaVersion: 6 } },
+        { code: "var foo = () => { return; }", options: ["allman", { allowSingleLineArrow: true }], parserOptions: { ecmaVersion: 6 } },
+        { code: "var foo = () => { return; }", options: ["1tbs", { allowSingleLineArrow: true }], parserOptions: { ecmaVersion: 6 } },
+        { code: "var foo = () => { return; }", options: ["stroustrup", { allowSingleLineArrow: true }], parserOptions: { ecmaVersion: 6 } },
         {
             code: "if (tag === 1) fontstack.name = pbf.readString(); \nelse if (tag === 2) fontstack.range = pbf.readString(); \nelse if (tag === 3) {\n var glyph = pbf.readMessage(readGlyph, {});\n fontstack.glyphs[glyph.id] = glyph; \n}",
             options: ["1tbs"]


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Fixes #11217 

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

I added an option called `allowSingleLineArrow` to the `brace-style` rule. If this option is set to `true`, single line arrow functions are skipped when checking brace style.

I also added some tests for this option.

Finally, I updated the docs to include the `allowSingleLineArrow` option and added some examples of correct code. 
