### PR TITLE
Docs: `...` is not an operator

### DIFF
--- a/docs/rules/prefer-spread.md
+++ b/docs/rules/prefer-spread.md
@@ -1,4 +1,4 @@
-# Suggest using a spread argument instead of `.apply()`. (prefer-spread)
+# Suggest using spread syntax instead of `.apply()`. (prefer-spread)
 
 Before ES2015, one must use `Function.prototype.apply()` to call variadic functions.
 
@@ -7,7 +7,7 @@ var args = [1, 2, 3, 4];
 Math.max.apply(Math, args);
 ```
 
-In ES2015, one can use a spread argument to call variadic functions.
+In ES2015, one can use spread syntax to call variadic functions.
 
 ```js
 /*eslint-env es6*/
@@ -18,7 +18,7 @@ Math.max(...args);
 
 ## Rule Details
 
-This rule is aimed to flag usage of `Function.prototype.apply()` in situations where a spread argument could be used instead.
+This rule is aimed to flag usage of `Function.prototype.apply()` in situations where spread syntax could be used instead.
 
 ## Examples
 
@@ -37,7 +37,7 @@ Examples of **correct** code for this rule:
 ```js
 /*eslint prefer-spread: "error"*/
 
-// Using a spread argument
+// Using spread syntax
 foo(...args);
 obj.foo(...args);
 

--- a/docs/rules/prefer-spread.md
+++ b/docs/rules/prefer-spread.md
@@ -1,4 +1,4 @@
-# Suggest using the spread operator instead of `.apply()`. (prefer-spread)
+# Suggest using a spread argument instead of `.apply()`. (prefer-spread)
 
 Before ES2015, one must use `Function.prototype.apply()` to call variadic functions.
 
@@ -7,7 +7,7 @@ var args = [1, 2, 3, 4];
 Math.max.apply(Math, args);
 ```
 
-In ES2015, one can use the spread operator to call variadic functions.
+In ES2015, one can use a spread argument to call variadic functions.
 
 ```js
 /*eslint-env es6*/
@@ -18,7 +18,7 @@ Math.max(...args);
 
 ## Rule Details
 
-This rule is aimed to flag usage of `Function.prototype.apply()` in situations where the spread operator could be used instead.
+This rule is aimed to flag usage of `Function.prototype.apply()` in situations where a spread argument could be used instead.
 
 ## Examples
 
@@ -37,7 +37,7 @@ Examples of **correct** code for this rule:
 ```js
 /*eslint prefer-spread: "error"*/
 
-// Using the spread operator
+// Using a spread argument
 foo(...args);
 obj.foo(...args);
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

The `...` in function call syntax is not an operator. It's more of a punctuation supported in various places (function call, function definition, array/object definitions, destructuring syntax), but specific to those. It does not produce a value like actual operators do.

I'd appreciate it if we can avoid spreading (no pun intended) this misconception. 

**Is there anything you'd like reviewers to focus on?**

While "spread argument" isn't an official term either, there is none (https://www.ecma-international.org/ecma-262/9.0/index.html#sec-argument-lists), it's probably the closest reasonable term.

There might also be other pages that use this term which need to be updated.

Happy for alternative suggestions though, or to hear the reasons why this shouldn't be corrected.
