### PR TITLE
Docs: fix example for sort-imports ignoreDeclarationSort

### DIFF
--- a/docs/rules/sort-imports.md
+++ b/docs/rules/sort-imports.md
@@ -146,22 +146,22 @@ Examples of **incorrect** code for this rule with the default `{ "ignoreDeclarat
 
 ```js
 /*eslint sort-imports: ["error", { "ignoreDeclarationSort": false }]*/
-import 'foo.js'
-import 'bar.js'
+import b from 'foo.js'
+import a from 'bar.js'
 ```
 
 Examples of **correct** code for this rule with the `{ "ignoreDeclarationSort": true }` option:
 
 ```js
 /*eslint sort-imports: ["error", { "ignoreDeclarationSort": true }]*/
-import 'foo.js'
-import 'bar.js'
+import a from 'foo.js'
+import b from 'bar.js'
 ```
 
 ```js
 /*eslint sort-imports: ["error", { "ignoreDeclarationSort": true }]*/
-import 'bar.js'
-import 'foo.js'
+import b from 'foo.js'
+import a from 'bar.js'
 ```
 
 Default is `false`.


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Fixed the examples of the `ignoreDeclarationSort` option of the `sort-imports` rule. This was pointed out by @mysticatea after #11019 was merged.

**Is there anything you'd like reviewers to focus on?**

Nope