### PR TITLE
New: add allowSingleLineBlocks opt. to padded-blocks rule (fixes #7145)

### DIFF
--- a/docs/rules/padded-blocks.md
+++ b/docs/rules/padded-blocks.md
@@ -20,7 +20,10 @@ This rule enforces consistent empty line padding within blocks.
 
 ## Options
 
-This rule has one option, which can be a string option or an object option.
+This rule has two options, the first one can be a string option or an object option.
+The second one is an object option, it can allow exceptions.
+
+### First option
 
 String option:
 
@@ -32,6 +35,10 @@ Object option:
 * `"blocks"` require or disallow padding within block statements
 * `"classes"` require or disallow padding within classes
 * `"switches"` require or disallow padding within `switch` statements
+
+### Second option
+
+* `"allowSingleLineBlocks": true` allows single-line blocks
 
 ### always
 
@@ -338,6 +345,42 @@ Examples of **correct** code for this rule with the `{ "switches": "never" }` op
 switch (a) {
     case 0: foo();
 }
+
+if (a) {
+
+    b();
+
+}
+```
+
+### always + allowSingleLineBlocks
+
+Examples of **incorrect** code for this rule with the `"always", {"allowSingleLineBlocks": true}` options:
+
+```js
+/*eslint padded-blocks: ["error", "always", { allowSingleLineBlocks: true }]*/
+
+if (a) {
+    b();
+}
+
+if (a) {
+
+    b();
+}
+
+if (a) {
+    b();
+
+}
+```
+
+Examples of **correct** code for this rule with the `"always", {"allowSingleLineBlocks": true}` options:
+
+```js
+/*eslint padded-blocks: ["error", "always", { allowSingleLineBlocks: true }]*/
+
+if (a) { b(); }
 
 if (a) {
 

--- a/tests/lib/rules/padded-blocks.js
+++ b/tests/lib/rules/padded-blocks.js
@@ -54,6 +54,8 @@ ruleTester.run("padded-blocks", rule, {
         { code: "{\na();}", options: ["never"] },
         { code: "{a();\n}", options: ["never"] },
         { code: "{a();}", options: ["never"] },
+        { code: "{a();}", options: ["always", { allowSingleLineBlocks: true }] },
+        { code: "{\n\na();\n\n}", options: ["always", { allowSingleLineBlocks: true }] },
         { code: "{//comment\na();}", options: ["never"] },
         { code: "{\n//comment\na()\n}", options: ["never"] },
         { code: "{a();//comment\n}", options: ["never"] },


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What rule do you want to change?**
padded-blocks

**Does this change cause the rule to produce more or fewer warnings?**
Less

**How will the change be implemented? (New option, new default behavior, etc.)?**
New option: `allowSingleLineBlocks` property in a new object parameter
It will allow to use single line blocks (as described in #7145)

**Please provide some example code that this change will affect:**
from
```js
if (cond) {

  doSomething();

}

let myObj = {
  myFunc (test) {

    return !test;

  }
}
```
to
```js
if (cond) { doSomething(); }

let myObj = {
  myFunc (test) { return !test; }
}
```

**What does the rule currently do for this code?**
Warning / Error: "Block must be padded by blank lines."

**What will the rule do after it's changed?**
Emits no warning if using `{allowSingleLineBlocks: true}` option (as second parameter)

**What changes did you make? (Give an overview)**
- implemented the change in the rule sourcecode

**Is there anything you'd like reviewers to focus on?**
- [x] write test cases
- [x] update docs
 
