### PR TITLE
Docs: Add `npx` usage to Getting Started guide

### DIFF
--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -37,6 +37,12 @@ After that, you can run ESLint in your project's root directory like this:
 $ ./node_modules/.bin/eslint yourfile.js
 ```
 
+Note that you may also use `npx` to run `eslint`:
+
+```
+$ npx eslint
+```
+
 Any plugins or shareable configs that you use must also be installed locally to work with a locally-installed ESLint.
 
 ### Global Installation and Usage

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -43,7 +43,7 @@ Instead of navigating to `./node_modules/.bin/` you may also use `npx` to run `e
 $ npx eslint
 ```
 
-**Note:** If wasn't manually installed (via `npm`), `npx` will install `eslint` to a temporary directory and execute it.
+**Note:** If ESLint wasn't manually installed (via `npm`), `npx` will install `eslint` to a temporary directory and execute it.
 
 Any plugins or shareable configs that you use must also be installed locally to work with a locally-installed ESLint.
 

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -37,11 +37,13 @@ After that, you can run ESLint in your project's root directory like this:
 $ ./node_modules/.bin/eslint yourfile.js
 ```
 
-Note that you may also use `npx` to run `eslint`:
+Instead of navigating to `./node_modules/.bin/` you may also use `npx` to run `eslint`:
 
 ```
 $ npx eslint
 ```
+
+**Note:** If wasn't manually installed (via `npm`), `npx` will install `eslint` to a temporary directory and execute it.
 
 Any plugins or shareable configs that you use must also be installed locally to work with a locally-installed ESLint.
 


### PR DESCRIPTION
`npx` is a shorter alternative to navigating to the executable found in `node_modules/.bin`

<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
I've added a documentation regarding the usage of `eslint` with `npx`.

**Is there anything you'd like reviewers to focus on?**


