### PR TITLE
Update: make the rule 'no-sync' more exact

### DIFF
--- a/lib/rules/no-sync.js
+++ b/lib/rules/no-sync.js
@@ -36,9 +36,15 @@ module.exports = {
     },
 
     create(context) {
+
+        const assignmentExpressionSelector = "AssignmentExpression[right.type=MemberExpression][right.property.name=/.*Sync$/]";
+        const variableDeclarationSelector = "VariableDeclaration MemberExpression[property.name=/.*Sync$/]";
+        const callExpressionSelector = "CallExpression[callee.property.name=/.*Sync$/]";
+        const completeSelector = `:matches(${assignmentExpressionSelector},${variableDeclarationSelector}, ${callExpressionSelector}`;
+
         const selector = context.options[0] && context.options[0].allowAtRootLevel
-            ? ":function MemberExpression[property.name=/.*Sync$/]"
-            : "MemberExpression[property.name=/.*Sync$/]";
+            ? `:function ${completeSelector}`
+            : completeSelector;
 
         return {
             [selector](node) {

--- a/tests/lib/rules/no-sync.js
+++ b/tests/lib/rules/no-sync.js
@@ -22,16 +22,18 @@ ruleTester.run("no-sync", rule, {
     valid: [
         "var foo = fs.foo.foo();",
         { code: "var foo = fs.fooSync;", options: [{ allowAtRootLevel: true }] },
-        { code: "if (true) {fs.fooSync();}", options: [{ allowAtRootLevel: true }] }
+        { code: "foo = fs.fooSync;", options: [{ allowAtRootLevel: true }] },
+        { code: "if (true) {fs.fooSync();}", options: [{ allowAtRootLevel: true }] },
+        { code: "if (fs.fooSync) {}", options: [{ allowAtRootLevel: false }] }
     ],
     invalid: [
         { code: "var foo = fs.fooSync();", errors: [{ message: "Unexpected sync method: 'fooSync'.", type: "MemberExpression" }] },
         { code: "var foo = fs.fooSync();", options: [{ allowAtRootLevel: false }], errors: [{ message: "Unexpected sync method: 'fooSync'.", type: "MemberExpression" }] },
+        { code: "foo = fs.fooSync;", options: [{ allowAtRootLevel: false }], errors: [{ message: "Unexpected sync method: 'fooSync'.", type: "MemberExpression" }] },
         { code: "if (true) {fs.fooSync();}", errors: [{ message: "Unexpected sync method: 'fooSync'.", type: "MemberExpression" }] },
         { code: "var foo = fs.fooSync;", errors: [{ message: "Unexpected sync method: 'fooSync'.", type: "MemberExpression" }] },
         { code: "function someFunction() {fs.fooSync();}", errors: [{ message: "Unexpected sync method: 'fooSync'.", type: "MemberExpression" }] },
         { code: "function someFunction() {fs.fooSync();}", options: [{ allowAtRootLevel: true }], errors: [{ message: "Unexpected sync method: 'fooSync'.", type: "MemberExpression" }] },
         { code: "var a = function someFunction() {fs.fooSync();}", options: [{ allowAtRootLevel: true }], errors: [{ message: "Unexpected sync method: 'fooSync'.", type: "MemberExpression" }] }
-
     ]
 });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[] Documentation update
[] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Changed the rule's selector to make it more accurate.  The previous rule would report errors when dealing with attributes, but the correct one should be that only methods would report errors.

```
let options = {
     cacheUpdateSync: true
}
if (options.cacheUpdateSync) {
}
```
Like this, ‘cacheUpdateSync’ is an attribute and reports an error
```
Unexpected sync method: 'cacheUpdateSync'. (no-sync)
```

In fact, only methods should report errors.

The following way will report errors, because  the `obj.cacheUpdateSync`  is a method
```
obj.cacheUpdateSync();
```
```
let func = obj.cacheUpdateSync;
func()
```
```
func = obj.cacheUpdateSync;
func()
```
I considered all the cases, only direct invocation, initialization, assignment need to check.

**Is there anything you'd like reviewers to focus on?**

As above



