### PR TITLE
Update: Allow regex in no-param-reassign ignore option array

### DIFF
--- a/docs/rules/no-param-reassign.md
+++ b/docs/rules/no-param-reassign.md
@@ -34,7 +34,7 @@ function foo(bar) {
 
 ## Options
 
-This rule takes one option, an object, with a boolean property `"props"` and an array `"ignorePropertyModificationsFor"`. `"props"` is `false` by default. If `"props"` is set to `true`, this rule warns against the modification of parameter properties unless they're included in `"ignorePropertyModificationsFor"`, which is an empty array by default.
+This rule takes one option, an object, with a boolean property `"props"`, and  arrays `"ignorePropertyModificationsFor"` and `"ignorePropertyModificationsForRegex"`. `"props"` is `false` by default. If `"props"` is set to `true`, this rule warns against the modification of parameter properties unless they're included in `"ignorePropertyModificationsFor"` or `"ignorePropertyModificationsForRegex"`, which is an empty array by default.
 
 ### props
 
@@ -89,6 +89,24 @@ function foo(bar) {
 
 function foo(bar) {
     bar.aaa++;
+}
+```
+
+Examples of **correct** code for the `{ "props": true }` option with `"ignorePropertyModificationsForRegex"` set:
+
+```js
+/*eslint no-param-reassign: ["error", { "props": true, "ignorePropertyModificationsForRegex": ["^bar"] }]*/
+
+function foo(bar) {
+    barVar.prop = "value";
+}
+
+function foo(bar) {
+    delete barrito.aaa;
+}
+
+function foo(bar) {
+    bar_.aaa++;
 }
 ```
 

--- a/lib/rules/no-param-reassign.js
+++ b/lib/rules/no-param-reassign.js
@@ -45,6 +45,13 @@ module.exports = {
                                     type: "string"
                                 },
                                 uniqueItems: true
+                            },
+                            ignorePropertyModificationsForRegex: {
+                                type: "array",
+                                items: {
+                                    type: "string"
+                                },
+                                uniqueItems: true
                             }
                         },
                         additionalProperties: false
@@ -57,6 +64,7 @@ module.exports = {
     create(context) {
         const props = context.options[0] && context.options[0].props;
         const ignoredPropertyAssignmentsFor = context.options[0] && context.options[0].ignorePropertyModificationsFor || [];
+        const ignoredPropertyAssignmentsForRegex = context.options[0] && context.options[0].ignorePropertyModificationsForRegex || [];
 
         /**
          * Checks whether or not the reference modifies properties of its variable.
@@ -126,6 +134,19 @@ module.exports = {
         }
 
         /**
+         * Tests that an identifier name matches any of the ignored property assignments.
+         * First we test strings in ignoredPropertyAssignmentsFor.
+         * Then we instantiate and test RegExp objects from ignoredPropertyAssignmentsForRegex strings.
+         * @param {string} identifierName - A string that describes the name of an identifier to
+         * ignore property assignments for.
+         * @returns {boolean} Whether the string matches an ignored property assignment regular expression or not.
+         */
+        function isIgnoredPropertyAssignment(identifierName) {
+            return ignoredPropertyAssignmentsFor.includes(identifierName) ||
+                ignoredPropertyAssignmentsForRegex.some(ignored => new RegExp(ignored, "u").test(identifierName));
+        }
+
+        /**
          * Reports a reference if is non initializer and writable.
          * @param {Reference} reference - A reference to check.
          * @param {int} index - The index of the reference in the references.
@@ -146,7 +167,7 @@ module.exports = {
             ) {
                 if (reference.isWrite()) {
                     context.report({ node: identifier, message: "Assignment to function parameter '{{name}}'.", data: { name: identifier.name } });
-                } else if (props && isModifyingProp(reference) && ignoredPropertyAssignmentsFor.indexOf(identifier.name) === -1) {
+                } else if (props && isModifyingProp(reference) && !isIgnoredPropertyAssignment(identifier.name)) {
                     context.report({ node: identifier, message: "Assignment to property of function parameter '{{name}}'.", data: { name: identifier.name } });
                 }
             }

--- a/tests/lib/rules/no-param-reassign.js
+++ b/tests/lib/rules/no-param-reassign.js
@@ -39,6 +39,11 @@ ruleTester.run("no-param-reassign", rule, {
         { code: "function foo(a) { delete a.b; }", options: [{ props: true, ignorePropertyModificationsFor: ["a"] }] },
         { code: "function foo(a, z) { a.b = 0; x.y = 0; }", options: [{ props: true, ignorePropertyModificationsFor: ["a", "x"] }] },
         { code: "function foo(a) { a.b.c = 0;}", options: [{ props: true, ignorePropertyModificationsFor: ["a"] }] },
+        { code: "function foo(aFoo) { aFoo.b = 0; }", options: [{ props: true, ignorePropertyModificationsForRegex: ["^a.*$"] }] },
+        { code: "function foo(aFoo) { ++aFoo.b; }", options: [{ props: true, ignorePropertyModificationsForRegex: ["^a.*$"] }] },
+        { code: "function foo(aFoo) { delete aFoo.b; }", options: [{ props: true, ignorePropertyModificationsForRegex: ["^a.*$"] }] },
+        { code: "function foo(a, z) { aFoo.b = 0; x.y = 0; }", options: [{ props: true, ignorePropertyModificationsForRegex: ["^a.*$", "^x.*$"] }] },
+        { code: "function foo(aFoo) { aFoo.b.c = 0;}", options: [{ props: true, ignorePropertyModificationsForRegex: ["^a.*$"] }] },
         {
             code: "function foo(a) { ({ [a]: variable } = value) }",
             options: [{ props: true }],
@@ -103,6 +108,18 @@ ruleTester.run("no-param-reassign", rule, {
         {
             code: "function foo(bar) { [bar.a] = []; }",
             options: [{ props: true, ignorePropertyModificationsFor: ["a"] }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Assignment to property of function parameter 'bar'." }]
+        },
+        {
+            code: "function foo(bar) { [bar.a] = []; }",
+            options: [{ props: true, ignorePropertyModificationsForRegex: ["^a.*$"] }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Assignment to property of function parameter 'bar'." }]
+        },
+        {
+            code: "function foo(bar) { [bar.a] = []; }",
+            options: [{ props: true, ignorePropertyModificationsForRegex: ["^B.*$"] }],
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Assignment to property of function parameter 'bar'." }]
         },


### PR DESCRIPTION
Clickbait title. Not actually regex. Just a string that looks like a regex.

<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What rule do you want to change?**

`no-param-reassign`: https://eslint.org/docs/rules/no-param-reassign

**Does this change cause the rule to produce more or fewer warnings?**

No difference.

**How will the change be implemented? (New option, new default behavior, etc.)?**

Change how an existing option is used.

**Please provide some example code that this change will affect:**

```
function foo(fooBar) {
  fooBar.aaa++;
}
```

**What does the rule currently do for this code?**

> Disallow Reassignment of Function Parameters, using strings

**What will the rule do after it's changed?**

> Disallow Reassignment of Function Parameters, using strings and regex-like strings

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

https://eslint.org/docs/rules/no-param-reassign

I didn't really like matching string literals for the `ignorePropertyModificationsFor` configuration array for `no-param-reassign`. If you want to avoid adding disable comments for this rule, you have to agree on a set of property names. These will have to be generic names that could be more descriptive and useful from a glance, or the array will continuously have more useful property names added to it and it will continue to grow.

Now we can agree on a naming pattern, rather than an explicit name. i.e. `/^mutable.*$/`. Now instead of just `element`, I can have `mutableSettingsButton`.

**Understanding the code:** 

* Parse all `ignorePropertyModificationsFor` array string items into RegExp objects.
  * If this item is a string surrounded in forward slashes (`/`), it will be parsed into `/$1/$2`, which will be used to instantiate a RegExp object with `new RegExp($1, $2)`.
  * If this item is not surrounded in forward slashes, it will be parsed using `new RegExp('^$1$')` so it is backwards compatible.

* Adds tests for valid and invalid regex cases.

* Adds to a documentation example to demonstrate using a regex string item.


**Is there anything you'd like reviewers to focus on?**

Personally, I couldn't decide the best way to approach this as my first eslint contribution. I personally would rather have separate and explicit rule configuration properties for regular expressions and string literals, but this seemed simpler than finding out what to call that configuration property. 😅I hope it's OK! Thanks a bunch for your time and efforts reviewing this ❤️  
