### PR TITLE
Update: use `default` keyword in JSON schema (fixes #9929)

### DIFF
--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -454,6 +454,9 @@ class CLIEngine {
         if (this.options.rules && Object.keys(this.options.rules).length) {
             const loadedRules = this.linter.getRules();
 
+            // Ajv validator with default schema will mutate original object, so we must clone it recursively.
+            this.options.rules = lodash.cloneDeep(this.options.rules);
+
             Object.keys(this.options.rules).forEach(name => {
                 validator.validateRuleOptions(loadedRules.get(name), name, this.options.rules[name], "CLI");
             });

--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -10,6 +10,7 @@
 //------------------------------------------------------------------------------
 
 const fs = require("fs"),
+    lodash = require("lodash"),
     path = require("path"),
     ConfigOps = require("./config-ops"),
     validator = require("./config-validator"),
@@ -156,7 +157,7 @@ function loadLegacyConfigFile(filePath) {
 function loadJSConfigFile(filePath) {
     debug(`Loading JS config file: ${filePath}`);
     try {
-        return importFresh(filePath);
+        return lodash.cloneDeep(importFresh(filePath));
     } catch (e) {
         debug(`Error reading JavaScript file: ${filePath}`);
         e.message = `Cannot read config file: ${filePath}\nError: ${e.message}`;

--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -10,7 +10,6 @@
 //------------------------------------------------------------------------------
 
 const fs = require("fs"),
-    lodash = require("lodash"),
     path = require("path"),
     ConfigOps = require("./config-ops"),
     validator = require("./config-validator"),
@@ -157,7 +156,7 @@ function loadLegacyConfigFile(filePath) {
 function loadJSConfigFile(filePath) {
     debug(`Loading JS config file: ${filePath}`);
     try {
-        return lodash.cloneDeep(importFresh(filePath));
+        return importFresh(filePath);
     } catch (e) {
         debug(`Error reading JavaScript file: ${filePath}`);
         e.message = `Cannot read config file: ${filePath}\nError: ${e.message}`;

--- a/lib/rules/accessor-pairs.js
+++ b/lib/rules/accessor-pairs.js
@@ -85,10 +85,12 @@ module.exports = {
             type: "object",
             properties: {
                 getWithoutSet: {
-                    type: "boolean"
+                    type: "boolean",
+                    default: false
                 },
                 setWithoutGet: {
-                    type: "boolean"
+                    type: "boolean",
+                    default: true
                 }
             },
             additionalProperties: false

--- a/lib/rules/array-bracket-newline.js
+++ b/lib/rules/array-bracket-newline.js
@@ -34,11 +34,13 @@ module.exports = {
                         type: "object",
                         properties: {
                             multiline: {
-                                type: "boolean"
+                                type: "boolean",
+                                default: true
                             },
                             minItems: {
                                 type: ["integer", "null"],
-                                minimum: 0
+                                minimum: 0,
+                                default: null
                             }
                         },
                         additionalProperties: false

--- a/lib/rules/array-callback-return.js
+++ b/lib/rules/array-callback-return.js
@@ -155,7 +155,8 @@ module.exports = {
                 type: "object",
                 properties: {
                     allowImplicit: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     }
                 },
                 additionalProperties: false

--- a/lib/rules/array-element-newline.js
+++ b/lib/rules/array-element-newline.js
@@ -34,11 +34,13 @@ module.exports = {
                         type: "object",
                         properties: {
                             multiline: {
-                                type: "boolean"
+                                type: "boolean",
+                                default: false
                             },
                             minItems: {
                                 type: ["integer", "null"],
-                                minimum: 0
+                                minimum: 0,
+                                default: null
                             }
                         },
                         additionalProperties: false

--- a/lib/rules/arrow-body-style.js
+++ b/lib/rules/arrow-body-style.js
@@ -46,7 +46,7 @@ module.exports = {
                         {
                             type: "object",
                             properties: {
-                                requireReturnForObjectLiteral: { type: "boolean" }
+                                requireReturnForObjectLiteral: { type: "boolean", default: false }
                             },
                             additionalProperties: false
                         }

--- a/lib/rules/arrow-parens.js
+++ b/lib/rules/arrow-parens.js
@@ -35,7 +35,8 @@ module.exports = {
                 type: "object",
                 properties: {
                     requireForBlockBody: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     }
                 },
                 additionalProperties: false

--- a/lib/rules/arrow-spacing.js
+++ b/lib/rules/arrow-spacing.js
@@ -32,10 +32,12 @@ module.exports = {
                 type: "object",
                 properties: {
                     before: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: true
                     },
                     after: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: true
                     }
                 },
                 additionalProperties: false
@@ -54,11 +56,10 @@ module.exports = {
     create(context) {
 
         // merge rules with default
-        const rule = { before: true, after: true },
-            option = context.options[0] || {};
+        const rule = Object.assign({}, context.options[0]);
 
-        rule.before = option.before !== false;
-        rule.after = option.after !== false;
+        rule.before = rule.before !== false;
+        rule.after = rule.after !== false;
 
         const sourceCode = context.getSourceCode();
 

--- a/lib/rules/brace-style.js
+++ b/lib/rules/brace-style.js
@@ -30,7 +30,8 @@ module.exports = {
                 type: "object",
                 properties: {
                     allowSingleLine: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     }
                 },
                 additionalProperties: false

--- a/lib/rules/camelcase.js
+++ b/lib/rules/camelcase.js
@@ -25,7 +25,8 @@ module.exports = {
                 type: "object",
                 properties: {
                     ignoreDestructuring: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     },
                     properties: {
                         enum: ["always", "never"]
@@ -54,7 +55,7 @@ module.exports = {
 
         const options = context.options[0] || {};
         let properties = options.properties || "";
-        const ignoreDestructuring = options.ignoreDestructuring || false;
+        const ignoreDestructuring = options.ignoreDestructuring;
         const allow = options.allow || [];
 
         if (properties !== "always" && properties !== "never") {

--- a/lib/rules/capitalized-comments.js
+++ b/lib/rules/capitalized-comments.js
@@ -17,12 +17,7 @@ const astUtils = require("../util/ast-utils");
 
 const DEFAULT_IGNORE_PATTERN = astUtils.COMMENTS_IGNORE_PATTERN,
     WHITESPACE = /\s/g,
-    MAYBE_URL = /^\s*[^:/?#\s]+:\/\/[^?#]/, // TODO: Combine w/ max-len pattern?
-    DEFAULTS = {
-        ignorePattern: null,
-        ignoreInlineComments: false,
-        ignoreConsecutiveComments: false
-    };
+    MAYBE_URL = /^\s*[^:/?#\s]+:\/\/[^?#]/; // TODO: Combine w/ max-len pattern?
 
 /*
  * Base schema body for defining the basic capitalization rule, ignorePattern,
@@ -33,17 +28,27 @@ const SCHEMA_BODY = {
     type: "object",
     properties: {
         ignorePattern: {
-            type: "string"
+            type: "string",
+            default: ""
         },
         ignoreInlineComments: {
-            type: "boolean"
+            type: "boolean",
+            default: false
         },
         ignoreConsecutiveComments: {
-            type: "boolean"
+            type: "boolean",
+            default: false
         }
     },
     additionalProperties: false
 };
+const DEFAULTS = Object.keys(SCHEMA_BODY.properties).reduce(
+    (obj, current) => {
+        obj[current] = SCHEMA_BODY.properties[current].default;
+        return obj;
+    },
+    {}
+);
 
 /**
  * Get normalized options for either block or line comments from the given
@@ -59,11 +64,7 @@ const SCHEMA_BODY = {
  * @param {string} which Either "line" or "block".
  * @returns {Object} The normalized options.
  */
-function getNormalizedOptions(rawOptions, which) {
-    if (!rawOptions) {
-        return Object.assign({}, DEFAULTS);
-    }
-
+function getNormalizedOptions(rawOptions = {}, which) {
     return Object.assign({}, DEFAULTS, rawOptions[which] || rawOptions);
 }
 

--- a/lib/rules/class-methods-use-this.js
+++ b/lib/rules/class-methods-use-this.js
@@ -38,7 +38,7 @@ module.exports = {
         }
     },
     create(context) {
-        const config = context.options[0] ? Object.assign({}, context.options[0]) : {};
+        const config = Object.assign({}, context.options[0]);
         const exceptMethods = new Set(config.exceptMethods || []);
 
         const stack = [];

--- a/lib/rules/comma-spacing.js
+++ b/lib/rules/comma-spacing.js
@@ -28,10 +28,12 @@ module.exports = {
                 type: "object",
                 properties: {
                     before: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     },
                     after: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: true
                     }
                 },
                 additionalProperties: false
@@ -50,8 +52,8 @@ module.exports = {
         const tokensAndComments = sourceCode.tokensAndComments;
 
         const options = {
-            before: context.options[0] ? !!context.options[0].before : false,
-            after: context.options[0] ? !!context.options[0].after : true
+            before: context.options[0] ? context.options[0].before : false,
+            after: context.options[0] ? context.options[0].after : true
         };
 
         //--------------------------------------------------------------------------

--- a/lib/rules/complexity.js
+++ b/lib/rules/complexity.js
@@ -41,11 +41,13 @@ module.exports = {
                         properties: {
                             maximum: {
                                 type: "integer",
-                                minimum: 0
+                                minimum: 0,
+                                default: 20
                             },
                             max: {
                                 type: "integer",
-                                minimum: 0
+                                minimum: 0,
+                                default: 20
                             }
                         },
                         additionalProperties: false
@@ -63,13 +65,10 @@ module.exports = {
         const option = context.options[0];
         let THRESHOLD = 20;
 
-        if (typeof option === "object" && Object.prototype.hasOwnProperty.call(option, "maximum") && typeof option.maximum === "number") {
+        if (typeof option === "object") {
             THRESHOLD = option.maximum;
-        }
-        if (typeof option === "object" && Object.prototype.hasOwnProperty.call(option, "max") && typeof option.max === "number") {
             THRESHOLD = option.max;
-        }
-        if (typeof option === "number") {
+        } else if (typeof option === "number") {
             THRESHOLD = option;
         }
 

--- a/lib/rules/complexity.js
+++ b/lib/rules/complexity.js
@@ -66,8 +66,7 @@ module.exports = {
         let THRESHOLD = 20;
 
         if (typeof option === "object") {
-            THRESHOLD = option.maximum;
-            THRESHOLD = option.max;
+            THRESHOLD = option.maximum || option.max;
         } else if (typeof option === "number") {
             THRESHOLD = option;
         }

--- a/lib/rules/consistent-return.js
+++ b/lib/rules/consistent-return.js
@@ -66,7 +66,8 @@ module.exports = {
             type: "object",
             properties: {
                 treatUndefinedAsUnspecified: {
-                    type: "boolean"
+                    type: "boolean",
+                    default: false
                 }
             },
             additionalProperties: false

--- a/lib/rules/dot-notation.js
+++ b/lib/rules/dot-notation.js
@@ -33,10 +33,12 @@ module.exports = {
                 type: "object",
                 properties: {
                     allowKeywords: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: true
                     },
                     allowPattern: {
-                        type: "string"
+                        type: "string",
+                        default: ""
                     }
                 },
                 additionalProperties: false
@@ -53,7 +55,7 @@ module.exports = {
 
     create(context) {
         const options = context.options[0] || {};
-        const allowKeywords = options.allowKeywords === void 0 || !!options.allowKeywords;
+        const allowKeywords = options.allowKeywords === void 0 || options.allowKeywords;
         const sourceCode = context.getSourceCode();
 
         let allowPattern;

--- a/lib/rules/eqeqeq.js
+++ b/lib/rules/eqeqeq.js
@@ -38,7 +38,8 @@ module.exports = {
                             type: "object",
                             properties: {
                                 null: {
-                                    enum: ["always", "never", "ignore"]
+                                    enum: ["always", "never", "ignore"],
+                                    default: "always"
                                 }
                             },
                             additionalProperties: false

--- a/lib/rules/func-call-spacing.js
+++ b/lib/rules/func-call-spacing.js
@@ -50,7 +50,8 @@ module.exports = {
                             type: "object",
                             properties: {
                                 allowNewlines: {
-                                    type: "boolean"
+                                    type: "boolean",
+                                    default: false
                                 }
                             },
                             additionalProperties: false

--- a/lib/rules/func-style.js
+++ b/lib/rules/func-style.js
@@ -27,7 +27,8 @@ module.exports = {
                 type: "object",
                 properties: {
                     allowArrowFunctions: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     }
                 },
                 additionalProperties: false
@@ -43,7 +44,7 @@ module.exports = {
     create(context) {
 
         const style = context.options[0],
-            allowArrowFunctions = context.options[1] && context.options[1].allowArrowFunctions === true,
+            allowArrowFunctions = context.options[1] && context.options[1].allowArrowFunctions,
             enforceDeclarations = (style === "declaration"),
             stack = [];
 

--- a/lib/rules/getter-return.js
+++ b/lib/rules/getter-return.js
@@ -60,7 +60,8 @@ module.exports = {
                 type: "object",
                 properties: {
                     allowImplicit: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     }
                 },
                 additionalProperties: false

--- a/lib/rules/id-length.js
+++ b/lib/rules/id-length.js
@@ -26,10 +26,11 @@ module.exports = {
                 type: "object",
                 properties: {
                     min: {
-                        type: "number"
+                        type: "integer",
+                        default: 2
                     },
                     max: {
-                        type: "number"
+                        type: "integer"
                     },
                     exceptions: {
                         type: "array",

--- a/lib/rules/id-match.js
+++ b/lib/rules/id-match.js
@@ -28,13 +28,16 @@ module.exports = {
                 type: "object",
                 properties: {
                     properties: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     },
                     onlyDeclarations: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     },
                     ignoreDestructuring: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     }
                 }
             }

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -518,7 +518,8 @@ module.exports = {
                 properties: {
                     SwitchCase: {
                         type: "integer",
-                        minimum: 0
+                        minimum: 0,
+                        default: 0
                     },
                     VariableDeclarator: {
                         oneOf: [
@@ -582,7 +583,8 @@ module.exports = {
                     ObjectExpression: ELEMENT_LIST_SCHEMA,
                     ImportDeclaration: ELEMENT_LIST_SCHEMA,
                     flatTernaryExpressions: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     },
                     ignoredNodes: {
                         type: "array",
@@ -594,7 +596,8 @@ module.exports = {
                         }
                     },
                     ignoreComments: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     }
                 },
                 additionalProperties: false
@@ -647,7 +650,7 @@ module.exports = {
             }
 
             if (context.options[1]) {
-                lodash.merge(options, context.options[1]);
+                Object.assign(options, context.options[1]);
 
                 if (typeof options.VariableDeclarator === "number" || options.VariableDeclarator === "first") {
                     options.VariableDeclarator = {

--- a/lib/rules/init-declarations.js
+++ b/lib/rules/init-declarations.js
@@ -75,7 +75,8 @@ module.exports = {
                             type: "object",
                             properties: {
                                 ignoreForLoopInit: {
-                                    type: "boolean"
+                                    type: "boolean",
+                                    default: false
                                 }
                             },
                             additionalProperties: false

--- a/lib/rules/key-spacing.js
+++ b/lib/rules/key-spacing.js
@@ -153,16 +153,20 @@ module.exports = {
                                     type: "object",
                                     properties: {
                                         mode: {
-                                            enum: ["strict", "minimum"]
+                                            enum: ["strict", "minimum"],
+                                            default: "strict"
                                         },
                                         on: {
-                                            enum: ["colon", "value"]
+                                            enum: ["colon", "value"],
+                                            default: "colon"
                                         },
                                         beforeColon: {
-                                            type: "boolean"
+                                            type: "boolean",
+                                            default: false
                                         },
                                         afterColon: {
-                                            type: "boolean"
+                                            type: "boolean",
+                                            default: true
                                         }
                                     },
                                     additionalProperties: false
@@ -170,13 +174,16 @@ module.exports = {
                             ]
                         },
                         mode: {
-                            enum: ["strict", "minimum"]
+                            enum: ["strict", "minimum"],
+                            default: "strict"
                         },
                         beforeColon: {
-                            type: "boolean"
+                            type: "boolean",
+                            default: false
                         },
                         afterColon: {
-                            type: "boolean"
+                            type: "boolean",
+                            default: true
                         }
                     },
                     additionalProperties: false
@@ -188,13 +195,16 @@ module.exports = {
                             type: "object",
                             properties: {
                                 mode: {
-                                    enum: ["strict", "minimum"]
+                                    enum: ["strict", "minimum"],
+                                    default: "strict"
                                 },
                                 beforeColon: {
-                                    type: "boolean"
+                                    type: "boolean",
+                                    default: false
                                 },
                                 afterColon: {
-                                    type: "boolean"
+                                    type: "boolean",
+                                    default: true
                                 }
                             },
                             additionalProperties: false
@@ -211,16 +221,20 @@ module.exports = {
                                             type: "object",
                                             properties: {
                                                 mode: {
-                                                    enum: ["strict", "minimum"]
+                                                    enum: ["strict", "minimum"],
+                                                    default: "strict"
                                                 },
                                                 on: {
-                                                    enum: ["colon", "value"]
+                                                    enum: ["colon", "value"],
+                                                    default: "colon"
                                                 },
                                                 beforeColon: {
-                                                    type: "boolean"
+                                                    type: "boolean",
+                                                    default: false
                                                 },
                                                 afterColon: {
-                                                    type: "boolean"
+                                                    type: "boolean",
+                                                    default: true
                                                 }
                                             },
                                             additionalProperties: false
@@ -228,13 +242,16 @@ module.exports = {
                                     ]
                                 },
                                 mode: {
-                                    enum: ["strict", "minimum"]
+                                    enum: ["strict", "minimum"],
+                                    default: "strict"
                                 },
                                 beforeColon: {
-                                    type: "boolean"
+                                    type: "boolean",
+                                    default: false
                                 },
                                 afterColon: {
-                                    type: "boolean"
+                                    type: "boolean",
+                                    default: true
                                 }
                             },
                             additionalProperties: false
@@ -249,13 +266,16 @@ module.exports = {
                             type: "object",
                             properties: {
                                 mode: {
-                                    enum: ["strict", "minimum"]
+                                    enum: ["strict", "minimum"],
+                                    default: "strict"
                                 },
                                 beforeColon: {
-                                    type: "boolean"
+                                    type: "boolean",
+                                    default: false
                                 },
                                 afterColon: {
-                                    type: "boolean"
+                                    type: "boolean",
+                                    default: true
                                 }
                             },
                             additionalProperties: false
@@ -264,13 +284,16 @@ module.exports = {
                             type: "object",
                             properties: {
                                 mode: {
-                                    enum: ["strict", "minimum"]
+                                    enum: ["strict", "minimum"],
+                                    default: "strict"
                                 },
                                 beforeColon: {
-                                    type: "boolean"
+                                    type: "boolean",
+                                    default: false
                                 },
                                 afterColon: {
-                                    type: "boolean"
+                                    type: "boolean",
+                                    default: true
                                 }
                             },
                             additionalProperties: false
@@ -279,16 +302,20 @@ module.exports = {
                             type: "object",
                             properties: {
                                 mode: {
-                                    enum: ["strict", "minimum"]
+                                    enum: ["strict", "minimum"],
+                                    default: "strict"
                                 },
                                 on: {
-                                    enum: ["colon", "value"]
+                                    enum: ["colon", "value"],
+                                    default: "colon"
                                 },
                                 beforeColon: {
-                                    type: "boolean"
+                                    type: "boolean",
+                                    default: false
                                 },
                                 afterColon: {
-                                    type: "boolean"
+                                    type: "boolean",
+                                    default: true
                                 }
                             },
                             additionalProperties: false

--- a/lib/rules/keyword-spacing.js
+++ b/lib/rules/keyword-spacing.js
@@ -80,16 +80,16 @@ module.exports = {
             {
                 type: "object",
                 properties: {
-                    before: { type: "boolean" },
-                    after: { type: "boolean" },
+                    before: { type: "boolean", default: true },
+                    after: { type: "boolean", default: true },
                     overrides: {
                         type: "object",
                         properties: KEYS.reduce((retv, key) => {
                             retv[key] = {
                                 type: "object",
                                 properties: {
-                                    before: { type: "boolean" },
-                                    after: { type: "boolean" }
+                                    before: { type: "boolean", default: true },
+                                    after: { type: "boolean", default: true }
                                 },
                                 additionalProperties: false
                             };
@@ -222,9 +222,9 @@ module.exports = {
          *      Keys are keywords (there are for every keyword).
          *      Values are instances of `{"before": function, "after": function}`.
          */
-        function parseOptions(options) {
-            const before = !options || options.before !== false;
-            const after = !options || options.after !== false;
+        function parseOptions(options = {}) {
+            const before = options.before !== false;
+            const after = options.after !== false;
             const defaultValue = {
                 before: before ? expectSpaceBefore : unexpectSpaceBefore,
                 after: after ? expectSpaceAfter : unexpectSpaceAfter

--- a/lib/rules/line-comment-position.js
+++ b/lib/rules/line-comment-position.js
@@ -31,16 +31,19 @@ module.exports = {
                         type: "object",
                         properties: {
                             position: {
-                                enum: ["above", "beside"]
+                                enum: ["above", "beside"],
+                                default: "above"
                             },
                             ignorePattern: {
                                 type: "string"
                             },
                             applyDefaultPatterns: {
-                                type: "boolean"
+                                type: "boolean",
+                                default: true
                             },
                             applyDefaultIgnorePatterns: {
-                                type: "boolean"
+                                type: "boolean",
+                                default: true
                             }
                         },
                         additionalProperties: false
@@ -65,9 +68,9 @@ module.exports = {
             ignorePattern = options.ignorePattern;
 
             if (Object.prototype.hasOwnProperty.call(options, "applyDefaultIgnorePatterns")) {
-                applyDefaultIgnorePatterns = options.applyDefaultIgnorePatterns !== false;
+                applyDefaultIgnorePatterns = options.applyDefaultIgnorePatterns;
             } else {
-                applyDefaultIgnorePatterns = options.applyDefaultPatterns !== false;
+                applyDefaultIgnorePatterns = options.applyDefaultPatterns;
             }
         }
 

--- a/lib/rules/lines-around-comment.js
+++ b/lib/rules/lines-around-comment.js
@@ -68,22 +68,28 @@ module.exports = {
                 type: "object",
                 properties: {
                     beforeBlockComment: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: true
                     },
                     afterBlockComment: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     },
                     beforeLineComment: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     },
                     afterLineComment: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     },
                     allowBlockStart: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     },
                     allowBlockEnd: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     },
                     allowClassStart: {
                         type: "boolean"
@@ -117,19 +123,13 @@ module.exports = {
 
     create(context) {
 
-        const options = context.options[0] ? Object.assign({}, context.options[0]) : {};
+        const options = Object.assign({}, context.options[0]);
         const ignorePattern = options.ignorePattern;
         const defaultIgnoreRegExp = astUtils.COMMENTS_IGNORE_PATTERN;
         const customIgnoreRegExp = new RegExp(ignorePattern);
         const applyDefaultIgnorePatterns = options.applyDefaultIgnorePatterns !== false;
 
-
-        options.beforeLineComment = options.beforeLineComment || false;
-        options.afterLineComment = options.afterLineComment || false;
         options.beforeBlockComment = typeof options.beforeBlockComment !== "undefined" ? options.beforeBlockComment : true;
-        options.afterBlockComment = options.afterBlockComment || false;
-        options.allowBlockStart = options.allowBlockStart || false;
-        options.allowBlockEnd = options.allowBlockEnd || false;
 
         const sourceCode = context.getSourceCode();
 

--- a/lib/rules/lines-between-class-members.js
+++ b/lib/rules/lines-between-class-members.js
@@ -31,7 +31,8 @@ module.exports = {
                 type: "object",
                 properties: {
                     exceptAfterSingleLine: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     }
                 },
                 additionalProperties: false

--- a/lib/rules/max-depth.js
+++ b/lib/rules/max-depth.js
@@ -59,8 +59,7 @@ module.exports = {
         let maxDepth = 4;
 
         if (typeof option === "object") {
-            maxDepth = option.maximum;
-            maxDepth = option.max;
+            maxDepth = option.maximum || option.max;
         }
         if (typeof option === "number") {
             maxDepth = option;

--- a/lib/rules/max-depth.js
+++ b/lib/rules/max-depth.js
@@ -32,11 +32,13 @@ module.exports = {
                         properties: {
                             maximum: {
                                 type: "integer",
-                                minimum: 0
+                                minimum: 0,
+                                default: 4
                             },
                             max: {
                                 type: "integer",
-                                minimum: 0
+                                minimum: 0,
+                                default: 4
                             }
                         },
                         additionalProperties: false
@@ -56,10 +58,8 @@ module.exports = {
             option = context.options[0];
         let maxDepth = 4;
 
-        if (typeof option === "object" && Object.prototype.hasOwnProperty.call(option, "maximum") && typeof option.maximum === "number") {
+        if (typeof option === "object") {
             maxDepth = option.maximum;
-        }
-        if (typeof option === "object" && Object.prototype.hasOwnProperty.call(option, "max") && typeof option.max === "number") {
             maxDepth = option.max;
         }
         if (typeof option === "number") {

--- a/lib/rules/max-len.js
+++ b/lib/rules/max-len.js
@@ -14,7 +14,8 @@ const OPTIONS_SCHEMA = {
     properties: {
         code: {
             type: "integer",
-            minimum: 0
+            minimum: 0,
+            default: 80
         },
         comments: {
             type: "integer",
@@ -22,28 +23,35 @@ const OPTIONS_SCHEMA = {
         },
         tabWidth: {
             type: "integer",
-            minimum: 0
+            minimum: 0,
+            default: 4
         },
         ignorePattern: {
             type: "string"
         },
         ignoreComments: {
-            type: "boolean"
+            type: "boolean",
+            default: false
         },
         ignoreStrings: {
-            type: "boolean"
+            type: "boolean",
+            default: false
         },
         ignoreUrls: {
-            type: "boolean"
+            type: "boolean",
+            default: false
         },
         ignoreTemplateLiterals: {
-            type: "boolean"
+            type: "boolean",
+            default: false
         },
         ignoreRegExpLiterals: {
-            type: "boolean"
+            type: "boolean",
+            default: false
         },
         ignoreTrailingComments: {
-            type: "boolean"
+            type: "boolean",
+            default: false
         }
     },
     additionalProperties: false
@@ -117,8 +125,7 @@ module.exports = {
         }
 
         // The options object must be the last option specified…
-        const lastOption = context.options[context.options.length - 1];
-        const options = typeof lastOption === "object" ? Object.create(lastOption) : {};
+        const options = Object.assign({}, context.options[context.options.length - 1]);
 
         // …but max code length…
         if (typeof context.options[0] === "number") {

--- a/lib/rules/max-lines-per-function.js
+++ b/lib/rules/max-lines-per-function.js
@@ -19,16 +19,20 @@ const OPTIONS_SCHEMA = {
     properties: {
         max: {
             type: "integer",
-            minimum: 0
+            minimum: 0,
+            default: 50
         },
         skipComments: {
-            type: "boolean"
+            type: "boolean",
+            default: false
         },
         skipBlankLines: {
-            type: "boolean"
+            type: "boolean",
+            default: false
         },
         IIFEs: {
-            type: "boolean"
+            type: "boolean",
+            default: false
         }
     },
     additionalProperties: false
@@ -94,18 +98,10 @@ module.exports = {
         let IIFEs = false;
 
         if (typeof option === "object") {
-            if (typeof option.max === "number") {
-                maxLines = option.max;
-            }
-            if (typeof option.skipComments === "boolean") {
-                skipComments = option.skipComments;
-            }
-            if (typeof option.skipBlankLines === "boolean") {
-                skipBlankLines = option.skipBlankLines;
-            }
-            if (typeof option.IIFEs === "boolean") {
-                IIFEs = option.IIFEs;
-            }
+            maxLines = option.max;
+            skipComments = option.skipComments;
+            skipBlankLines = option.skipBlankLines;
+            IIFEs = option.IIFEs;
         } else if (typeof option === "number") {
             maxLines = option;
         }

--- a/lib/rules/max-lines.js
+++ b/lib/rules/max-lines.js
@@ -38,13 +38,16 @@ module.exports = {
                         properties: {
                             max: {
                                 type: "integer",
-                                minimum: 0
+                                minimum: 0,
+                                default: 300
                             },
                             skipComments: {
-                                type: "boolean"
+                                type: "boolean",
+                                default: false
                             },
                             skipBlankLines: {
-                                type: "boolean"
+                                type: "boolean",
+                                default: false
                             }
                         },
                         additionalProperties: false
@@ -58,11 +61,9 @@ module.exports = {
         const option = context.options[0];
         let max = 300;
 
-        if (typeof option === "object" && Object.prototype.hasOwnProperty.call(option, "max") && typeof option.max === "number") {
+        if (typeof option === "object") {
             max = option.max;
-        }
-
-        if (typeof option === "number") {
+        } else if (typeof option === "number") {
             max = option;
         }
 
@@ -83,7 +84,7 @@ module.exports = {
         /**
          * Returns the line numbers of a comment that don't have any code on the same line
          * @param {Node} comment The comment node to check
-         * @returns {int[]} The line numbers
+         * @returns {number[]} The line numbers
          */
         function getLinesWithoutCode(comment) {
             let start = comment.loc.start.line;

--- a/lib/rules/max-nested-callbacks.js
+++ b/lib/rules/max-nested-callbacks.js
@@ -57,8 +57,7 @@ module.exports = {
         let THRESHOLD = 10;
 
         if (typeof option === "object") {
-            THRESHOLD = option.maximum;
-            THRESHOLD = option.max;
+            THRESHOLD = option.maximum || option.max;
         } else if (typeof option === "number") {
             THRESHOLD = option;
         }

--- a/lib/rules/max-nested-callbacks.js
+++ b/lib/rules/max-nested-callbacks.js
@@ -32,11 +32,13 @@ module.exports = {
                         properties: {
                             maximum: {
                                 type: "integer",
-                                minimum: 0
+                                minimum: 0,
+                                default: 10
                             },
                             max: {
                                 type: "integer",
-                                minimum: 0
+                                minimum: 0,
+                                default: 10
                             }
                         },
                         additionalProperties: false
@@ -54,13 +56,10 @@ module.exports = {
         const option = context.options[0];
         let THRESHOLD = 10;
 
-        if (typeof option === "object" && Object.prototype.hasOwnProperty.call(option, "maximum") && typeof option.maximum === "number") {
+        if (typeof option === "object") {
             THRESHOLD = option.maximum;
-        }
-        if (typeof option === "object" && Object.prototype.hasOwnProperty.call(option, "max") && typeof option.max === "number") {
             THRESHOLD = option.max;
-        }
-        if (typeof option === "number") {
+        } else if (typeof option === "number") {
             THRESHOLD = option;
         }
 

--- a/lib/rules/max-params.js
+++ b/lib/rules/max-params.js
@@ -62,8 +62,7 @@ module.exports = {
         let numParams = 3;
 
         if (typeof option === "object") {
-            numParams = option.maximum;
-            numParams = option.max;
+            numParams = option.maximum || option.max;
         }
         if (typeof option === "number") {
             numParams = option;

--- a/lib/rules/max-params.js
+++ b/lib/rules/max-params.js
@@ -40,11 +40,13 @@ module.exports = {
                         properties: {
                             maximum: {
                                 type: "integer",
-                                minimum: 0
+                                minimum: 0,
+                                default: 3
                             },
                             max: {
                                 type: "integer",
-                                minimum: 0
+                                minimum: 0,
+                                default: 3
                             }
                         },
                         additionalProperties: false
@@ -59,10 +61,8 @@ module.exports = {
         const option = context.options[0];
         let numParams = 3;
 
-        if (typeof option === "object" && Object.prototype.hasOwnProperty.call(option, "maximum") && typeof option.maximum === "number") {
+        if (typeof option === "object") {
             numParams = option.maximum;
-        }
-        if (typeof option === "object" && Object.prototype.hasOwnProperty.call(option, "max") && typeof option.max === "number") {
             numParams = option.max;
         }
         if (typeof option === "number") {

--- a/lib/rules/max-statements-per-line.js
+++ b/lib/rules/max-statements-per-line.js
@@ -31,7 +31,8 @@ module.exports = {
                 properties: {
                     max: {
                         type: "integer",
-                        minimum: 1
+                        minimum: 1,
+                        default: 1
                     }
                 },
                 additionalProperties: false

--- a/lib/rules/max-statements.js
+++ b/lib/rules/max-statements.js
@@ -40,11 +40,13 @@ module.exports = {
                         properties: {
                             maximum: {
                                 type: "integer",
-                                minimum: 0
+                                minimum: 0,
+                                default: 10
                             },
                             max: {
                                 type: "integer",
-                                minimum: 0
+                                minimum: 0,
+                                default: 10
                             }
                         },
                         additionalProperties: false
@@ -75,13 +77,10 @@ module.exports = {
             topLevelFunctions = [];
         let maxStatements = 10;
 
-        if (typeof option === "object" && Object.prototype.hasOwnProperty.call(option, "maximum") && typeof option.maximum === "number") {
+        if (typeof option === "object") {
             maxStatements = option.maximum;
-        }
-        if (typeof option === "object" && Object.prototype.hasOwnProperty.call(option, "max") && typeof option.max === "number") {
             maxStatements = option.max;
-        }
-        if (typeof option === "number") {
+        } else if (typeof option === "number") {
             maxStatements = option;
         }
 

--- a/lib/rules/max-statements.js
+++ b/lib/rules/max-statements.js
@@ -78,8 +78,7 @@ module.exports = {
         let maxStatements = 10;
 
         if (typeof option === "object") {
-            maxStatements = option.maximum;
-            maxStatements = option.max;
+            maxStatements = option.maximum || option.max;
         } else if (typeof option === "number") {
             maxStatements = option;
         }

--- a/lib/rules/new-cap.js
+++ b/lib/rules/new-cap.js
@@ -88,10 +88,12 @@ module.exports = {
                 type: "object",
                 properties: {
                     newIsCap: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: true
                     },
                     capIsNew: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: true
                     },
                     newIsCapExceptions: {
                         type: "array",
@@ -112,7 +114,8 @@ module.exports = {
                         type: "string"
                     },
                     properties: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: true
                     }
                 },
                 additionalProperties: false
@@ -122,7 +125,7 @@ module.exports = {
 
     create(context) {
 
-        const config = context.options[0] ? Object.assign({}, context.options[0]) : {};
+        const config = Object.assign({}, context.options[0]);
 
         config.newIsCap = config.newIsCap !== false;
         config.capIsNew = config.capIsNew !== false;

--- a/lib/rules/newline-per-chained-call.js
+++ b/lib/rules/newline-per-chained-call.js
@@ -31,7 +31,8 @@ module.exports = {
                 ignoreChainWithDepth: {
                     type: "integer",
                     minimum: 1,
-                    maximum: 10
+                    maximum: 10,
+                    default: 2
                 }
             },
             additionalProperties: false

--- a/lib/rules/no-bitwise.js
+++ b/lib/rules/no-bitwise.js
@@ -43,7 +43,8 @@ module.exports = {
                         uniqueItems: true
                     },
                     int32Hint: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     }
                 },
                 additionalProperties: false

--- a/lib/rules/no-confusing-arrow.js
+++ b/lib/rules/no-confusing-arrow.js
@@ -41,7 +41,7 @@ module.exports = {
         schema: [{
             type: "object",
             properties: {
-                allowParens: { type: "boolean" }
+                allowParens: { type: "boolean", default: false }
             },
             additionalProperties: false
         }],

--- a/lib/rules/no-constant-condition.js
+++ b/lib/rules/no-constant-condition.js
@@ -25,7 +25,8 @@ module.exports = {
                 type: "object",
                 properties: {
                     checkLoops: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: true
                     }
                 },
                 additionalProperties: false

--- a/lib/rules/no-duplicate-imports.js
+++ b/lib/rules/no-duplicate-imports.js
@@ -114,7 +114,8 @@ module.exports = {
             type: "object",
             properties: {
                 includeExports: {
-                    type: "boolean"
+                    type: "boolean",
+                    default: false
                 }
             },
             additionalProperties: false

--- a/lib/rules/no-else-return.js
+++ b/lib/rules/no-else-return.js
@@ -31,7 +31,8 @@ module.exports = {
             type: "object",
             properties: {
                 allowElseIf: {
-                    type: "boolean"
+                    type: "boolean",
+                    default: true
                 }
             },
             additionalProperties: false

--- a/lib/rules/no-empty.js
+++ b/lib/rules/no-empty.js
@@ -30,7 +30,8 @@ module.exports = {
                 type: "object",
                 properties: {
                     allowEmptyCatch: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     }
                 },
                 additionalProperties: false

--- a/lib/rules/no-eval.js
+++ b/lib/rules/no-eval.js
@@ -89,7 +89,7 @@ module.exports = {
             {
                 type: "object",
                 properties: {
-                    allowIndirect: { type: "boolean" }
+                    allowIndirect: { type: "boolean", default: false }
                 },
                 additionalProperties: false
             }

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -44,11 +44,11 @@ module.exports = {
                         {
                             type: "object",
                             properties: {
-                                conditionalAssign: { type: "boolean" },
-                                nestedBinaryExpressions: { type: "boolean" },
-                                returnAssign: { type: "boolean" },
+                                conditionalAssign: { type: "boolean", default: true },
+                                nestedBinaryExpressions: { type: "boolean", default: true },
+                                returnAssign: { type: "boolean", default: true },
                                 ignoreJSX: { enum: ["none", "all", "single-line", "multi-line"] },
-                                enforceForArrowConditionals: { type: "boolean" }
+                                enforceForArrowConditionals: { type: "boolean", default: true }
                             },
                             additionalProperties: false
                         }

--- a/lib/rules/no-fallthrough.js
+++ b/lib/rules/no-fallthrough.js
@@ -69,7 +69,8 @@ module.exports = {
                 type: "object",
                 properties: {
                     commentPattern: {
-                        type: "string"
+                        type: "string",
+                        default: ""
                     }
                 },
                 additionalProperties: false

--- a/lib/rules/no-implicit-coercion.js
+++ b/lib/rules/no-implicit-coercion.js
@@ -21,9 +21,9 @@ const ALLOWABLE_OPERATORS = ["~", "!!", "+", "*"];
  */
 function parseOptions(options) {
     return {
-        boolean: "boolean" in options ? Boolean(options.boolean) : true,
-        number: "number" in options ? Boolean(options.number) : true,
-        string: "string" in options ? Boolean(options.string) : true,
+        boolean: "boolean" in options ? options.boolean : true,
+        number: "number" in options ? options.number : true,
+        string: "string" in options ? options.string : true,
         allow: options.allow || []
     };
 }
@@ -167,13 +167,16 @@ module.exports = {
             type: "object",
             properties: {
                 boolean: {
-                    type: "boolean"
+                    type: "boolean",
+                    default: true
                 },
                 number: {
-                    type: "boolean"
+                    type: "boolean",
+                    default: true
                 },
                 string: {
-                    type: "boolean"
+                    type: "boolean",
+                    default: true
                 },
                 allow: {
                     type: "array",

--- a/lib/rules/no-irregular-whitespace.js
+++ b/lib/rules/no-irregular-whitespace.js
@@ -41,16 +41,20 @@ module.exports = {
                 type: "object",
                 properties: {
                     skipComments: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     },
                     skipStrings: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: true
                     },
                     skipTemplates: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     },
                     skipRegExps: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     }
                 },
                 additionalProperties: false

--- a/lib/rules/no-labels.js
+++ b/lib/rules/no-labels.js
@@ -30,10 +30,12 @@ module.exports = {
                 type: "object",
                 properties: {
                     allowLoop: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     },
                     allowSwitch: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     }
                 },
                 additionalProperties: false
@@ -43,8 +45,8 @@ module.exports = {
 
     create(context) {
         const options = context.options[0];
-        const allowLoop = Boolean(options && options.allowLoop);
-        const allowSwitch = Boolean(options && options.allowSwitch);
+        const allowLoop = options && options.allowLoop;
+        const allowSwitch = options && options.allowSwitch;
         let scopeInfo = null;
 
         /**

--- a/lib/rules/no-magic-numbers.js
+++ b/lib/rules/no-magic-numbers.js
@@ -24,10 +24,12 @@ module.exports = {
             type: "object",
             properties: {
                 detectObjects: {
-                    type: "boolean"
+                    type: "boolean",
+                    default: false
                 },
                 enforceConst: {
-                    type: "boolean"
+                    type: "boolean",
+                    default: false
                 },
                 ignore: {
                     type: "array",
@@ -37,7 +39,8 @@ module.exports = {
                     uniqueItems: true
                 },
                 ignoreArrayIndexes: {
-                    type: "boolean"
+                    type: "boolean",
+                    default: false
                 }
             },
             additionalProperties: false

--- a/lib/rules/no-mixed-operators.js
+++ b/lib/rules/no-mixed-operators.js
@@ -42,10 +42,10 @@ const TARGET_NODE_TYPE = /^(?:Binary|Logical)Expression$/;
  * @param {Object|undefined} options - A options object to normalize.
  * @returns {Object} Normalized option object.
  */
-function normalizeOptions(options) {
-    const hasGroups = (options && options.groups && options.groups.length > 0);
+function normalizeOptions(options = {}) {
+    const hasGroups = options.groups && options.groups.length > 0;
     const groups = hasGroups ? options.groups : DEFAULT_GROUPS;
-    const allowSamePrecedence = (options && options.allowSamePrecedence) !== false;
+    const allowSamePrecedence = options.allowSamePrecedence !== false;
 
     return {
         groups,
@@ -95,7 +95,8 @@ module.exports = {
                         uniqueItems: true
                     },
                     allowSamePrecedence: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: true
                     }
                 },
                 additionalProperties: false

--- a/lib/rules/no-mixed-requires.js
+++ b/lib/rules/no-mixed-requires.js
@@ -30,10 +30,12 @@ module.exports = {
                         type: "object",
                         properties: {
                             grouping: {
-                                type: "boolean"
+                                type: "boolean",
+                                default: false
                             },
                             allowCall: {
-                                type: "boolean"
+                                type: "boolean",
+                                default: false
                             }
                         },
                         additionalProperties: false

--- a/lib/rules/no-multi-spaces.js
+++ b/lib/rules/no-multi-spaces.js
@@ -38,7 +38,8 @@ module.exports = {
                         additionalProperties: false
                     },
                     ignoreEOLComments: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     }
                 },
                 additionalProperties: false

--- a/lib/rules/no-param-reassign.js
+++ b/lib/rules/no-param-reassign.js
@@ -55,7 +55,7 @@ module.exports = {
     },
 
     create(context) {
-        const props = context.options[0] && Boolean(context.options[0].props);
+        const props = context.options[0] && context.options[0].props;
         const ignoredPropertyAssignmentsFor = context.options[0] && context.options[0].ignorePropertyModificationsFor || [];
 
         /**

--- a/lib/rules/no-plusplus.js
+++ b/lib/rules/no-plusplus.js
@@ -26,7 +26,8 @@ module.exports = {
                 type: "object",
                 properties: {
                     allowForLoopAfterthoughts: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     }
                 },
                 additionalProperties: false

--- a/lib/rules/no-redeclare.js
+++ b/lib/rules/no-redeclare.js
@@ -24,7 +24,7 @@ module.exports = {
             {
                 type: "object",
                 properties: {
-                    builtinGlobals: { type: "boolean" }
+                    builtinGlobals: { type: "boolean", default: false }
                 },
                 additionalProperties: false
             }
@@ -33,7 +33,7 @@ module.exports = {
 
     create(context) {
         const options = {
-            builtinGlobals: Boolean(context.options[0] && context.options[0].builtinGlobals)
+            builtinGlobals: context.options[0] && context.options[0].builtinGlobals
         };
 
         /**

--- a/lib/rules/no-self-assign.js
+++ b/lib/rules/no-self-assign.js
@@ -179,7 +179,8 @@ module.exports = {
                 type: "object",
                 properties: {
                     props: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: true
                     }
                 },
                 additionalProperties: false

--- a/lib/rules/no-shadow.js
+++ b/lib/rules/no-shadow.js
@@ -30,8 +30,8 @@ module.exports = {
             {
                 type: "object",
                 properties: {
-                    builtinGlobals: { type: "boolean" },
-                    hoist: { enum: ["all", "functions", "never"] },
+                    builtinGlobals: { type: "boolean", default: false },
+                    hoist: { enum: ["all", "functions", "never"], default: "functions" },
                     allow: {
                         type: "array",
                         items: {
@@ -47,7 +47,7 @@ module.exports = {
     create(context) {
 
         const options = {
-            builtinGlobals: Boolean(context.options[0] && context.options[0].builtinGlobals),
+            builtinGlobals: context.options[0] && context.options[0].builtinGlobals,
             hoist: (context.options[0] && context.options[0].hoist) || "functions",
             allow: (context.options[0] && context.options[0].allow) || []
         };

--- a/lib/rules/no-sync.js
+++ b/lib/rules/no-sync.js
@@ -27,7 +27,8 @@ module.exports = {
                 type: "object",
                 properties: {
                     allowAtRootLevel: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     }
                 },
                 additionalProperties: false

--- a/lib/rules/no-tabs.js
+++ b/lib/rules/no-tabs.js
@@ -30,7 +30,8 @@ module.exports = {
             type: "object",
             properties: {
                 allowIndentationTabs: {
-                    type: "boolean"
+                    type: "boolean",
+                    default: false
                 }
             },
             additionalProperties: false

--- a/lib/rules/no-trailing-spaces.js
+++ b/lib/rules/no-trailing-spaces.js
@@ -32,10 +32,12 @@ module.exports = {
                 type: "object",
                 properties: {
                     skipBlankLines: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     },
                     ignoreComments: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     }
                 },
                 additionalProperties: false
@@ -52,7 +54,7 @@ module.exports = {
 
         const options = context.options[0] || {},
             skipBlankLines = options.skipBlankLines || false,
-            ignoreComments = typeof options.ignoreComments === "boolean" && options.ignoreComments;
+            ignoreComments = options.ignoreComments || false;
 
         /**
          * Report the error message

--- a/lib/rules/no-undef.js
+++ b/lib/rules/no-undef.js
@@ -39,7 +39,8 @@ module.exports = {
                 type: "object",
                 properties: {
                     typeof: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     }
                 },
                 additionalProperties: false

--- a/lib/rules/no-underscore-dangle.js
+++ b/lib/rules/no-underscore-dangle.js
@@ -31,13 +31,16 @@ module.exports = {
                         }
                     },
                     allowAfterThis: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     },
                     allowAfterSuper: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     },
                     enforceInMethodNames: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     }
                 },
                 additionalProperties: false

--- a/lib/rules/no-unneeded-ternary.js
+++ b/lib/rules/no-unneeded-ternary.js
@@ -38,7 +38,8 @@ module.exports = {
                 type: "object",
                 properties: {
                     defaultAssignment: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: true
                     }
                 },
                 additionalProperties: false

--- a/lib/rules/no-unused-expressions.js
+++ b/lib/rules/no-unused-expressions.js
@@ -24,13 +24,16 @@ module.exports = {
                 type: "object",
                 properties: {
                     allowShortCircuit: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     },
                     allowTernary: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     },
                     allowTaggedTemplates: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     }
                 },
                 additionalProperties: false

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -37,22 +37,26 @@ module.exports = {
                         type: "object",
                         properties: {
                             vars: {
-                                enum: ["all", "local"]
+                                enum: ["all", "local"],
+                                default: "all"
                             },
                             varsIgnorePattern: {
                                 type: "string"
                             },
                             args: {
-                                enum: ["all", "after-used", "none"]
+                                enum: ["all", "after-used", "none"],
+                                default: "after-used"
                             },
                             ignoreRestSiblings: {
-                                type: "boolean"
+                                type: "boolean",
+                                default: false
                             },
                             argsIgnorePattern: {
                                 type: "string"
                             },
                             caughtErrors: {
-                                enum: ["all", "none"]
+                                enum: ["all", "none"],
+                                default: "none"
                             },
                             caughtErrorsIgnorePattern: {
                                 type: "string"

--- a/lib/rules/no-use-before-define.js
+++ b/lib/rules/no-use-before-define.js
@@ -154,9 +154,9 @@ module.exports = {
                     {
                         type: "object",
                         properties: {
-                            functions: { type: "boolean" },
-                            classes: { type: "boolean" },
-                            variables: { type: "boolean" }
+                            functions: { type: "boolean", default: true },
+                            classes: { type: "boolean", default: true },
+                            variables: { type: "boolean", default: true }
                         },
                         additionalProperties: false
                     }

--- a/lib/rules/no-useless-rename.js
+++ b/lib/rules/no-useless-rename.js
@@ -26,9 +26,9 @@ module.exports = {
             {
                 type: "object",
                 properties: {
-                    ignoreDestructuring: { type: "boolean" },
-                    ignoreImport: { type: "boolean" },
-                    ignoreExport: { type: "boolean" }
+                    ignoreDestructuring: { type: "boolean", default: false },
+                    ignoreImport: { type: "boolean", default: false },
+                    ignoreExport: { type: "boolean", default: false }
                 },
                 additionalProperties: false
             }

--- a/lib/rules/object-curly-newline.js
+++ b/lib/rules/object-curly-newline.js
@@ -26,14 +26,16 @@ const OPTION_VALUE = {
             type: "object",
             properties: {
                 multiline: {
-                    type: "boolean"
+                    type: "boolean",
+                    default: false
                 },
                 minProperties: {
                     type: "integer",
                     minimum: 0
                 },
                 consistent: {
-                    type: "boolean"
+                    type: "boolean",
+                    default: false
                 }
             },
             additionalProperties: false,
@@ -59,9 +61,9 @@ function normalizeOptionValue(value) {
         } else if (value === "never") {
             minProperties = Number.POSITIVE_INFINITY;
         } else {
-            multiline = Boolean(value.multiline);
+            multiline = value.multiline;
             minProperties = value.minProperties || Number.POSITIVE_INFINITY;
-            consistent = Boolean(value.consistent);
+            consistent = value.consistent;
         }
     } else {
         consistent = true;

--- a/lib/rules/object-property-newline.js
+++ b/lib/rules/object-property-newline.js
@@ -25,10 +25,12 @@ module.exports = {
                 type: "object",
                 properties: {
                     allowAllPropertiesOnSameLine: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     },
                     allowMultiplePropertiesPerLine: { // Deprecated
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     }
                 },
                 additionalProperties: false
@@ -40,7 +42,7 @@ module.exports = {
 
     create(context) {
         const allowSameLine = context.options[0] && (
-            (Boolean(context.options[0].allowAllPropertiesOnSameLine) || Boolean(context.options[0].allowMultiplePropertiesPerLine)) // Deprecated
+            (context.options[0].allowAllPropertiesOnSameLine || context.options[0].allowMultiplePropertiesPerLine /* Deprecated */)
         );
         const errorMessage = allowSameLine
             ? "Object properties must go on a new line if they aren't all on the same line."

--- a/lib/rules/object-shorthand.js
+++ b/lib/rules/object-shorthand.js
@@ -57,7 +57,8 @@ module.exports = {
                             type: "object",
                             properties: {
                                 avoidQuotes: {
-                                    type: "boolean"
+                                    type: "boolean",
+                                    default: false
                                 }
                             },
                             additionalProperties: false
@@ -76,13 +77,16 @@ module.exports = {
                             type: "object",
                             properties: {
                                 ignoreConstructors: {
-                                    type: "boolean"
+                                    type: "boolean",
+                                    default: false
                                 },
                                 avoidQuotes: {
-                                    type: "boolean"
+                                    type: "boolean",
+                                    default: false
                                 },
                                 avoidExplicitReturnArrows: {
-                                    type: "boolean"
+                                    type: "boolean",
+                                    default: false
                                 }
                             },
                             additionalProperties: false

--- a/lib/rules/one-var.js
+++ b/lib/rules/one-var.js
@@ -32,16 +32,20 @@ module.exports = {
                         type: "object",
                         properties: {
                             separateRequires: {
-                                type: "boolean"
+                                type: "boolean",
+                                default: false
                             },
                             var: {
-                                enum: ["always", "never", "consecutive"]
+                                enum: ["always", "never", "consecutive"],
+                                default: "always"
                             },
                             let: {
-                                enum: ["always", "never", "consecutive"]
+                                enum: ["always", "never", "consecutive"],
+                                default: "always"
                             },
                             const: {
-                                enum: ["always", "never", "consecutive"]
+                                enum: ["always", "never", "consecutive"],
+                                default: "always"
                             }
                         },
                         additionalProperties: false
@@ -76,42 +80,16 @@ module.exports = {
             options.let = { uninitialized: mode, initialized: mode };
             options.const = { uninitialized: mode, initialized: mode };
         } else if (typeof mode === "object") { // options configuration is an object
-            if (Object.prototype.hasOwnProperty.call(mode, "separateRequires")) {
-                options.separateRequires = !!mode.separateRequires;
-            }
-            if (Object.prototype.hasOwnProperty.call(mode, "var")) {
-                options.var = { uninitialized: mode.var, initialized: mode.var };
-            }
-            if (Object.prototype.hasOwnProperty.call(mode, "let")) {
-                options.let = { uninitialized: mode.let, initialized: mode.let };
-            }
-            if (Object.prototype.hasOwnProperty.call(mode, "const")) {
-                options.const = { uninitialized: mode.const, initialized: mode.const };
-            }
+            options.separateRequires = mode.separateRequires;
+            options.var = { uninitialized: mode.var, initialized: mode.var };
+            options.let = { uninitialized: mode.let, initialized: mode.let };
+            options.const = { uninitialized: mode.const, initialized: mode.const };
             if (Object.prototype.hasOwnProperty.call(mode, "uninitialized")) {
-                if (!options.var) {
-                    options.var = {};
-                }
-                if (!options.let) {
-                    options.let = {};
-                }
-                if (!options.const) {
-                    options.const = {};
-                }
                 options.var.uninitialized = mode.uninitialized;
                 options.let.uninitialized = mode.uninitialized;
                 options.const.uninitialized = mode.uninitialized;
             }
             if (Object.prototype.hasOwnProperty.call(mode, "initialized")) {
-                if (!options.var) {
-                    options.var = {};
-                }
-                if (!options.let) {
-                    options.let = {};
-                }
-                if (!options.const) {
-                    options.const = {};
-                }
                 options.var.initialized = mode.initialized;
                 options.let.initialized = mode.initialized;
                 options.const.initialized = mode.initialized;

--- a/lib/rules/prefer-arrow-callback.js
+++ b/lib/rules/prefer-arrow-callback.js
@@ -146,10 +146,12 @@ module.exports = {
                 type: "object",
                 properties: {
                     allowNamedFunctions: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     },
                     allowUnboundThis: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: true
                     }
                 },
                 additionalProperties: false

--- a/lib/rules/prefer-const.js
+++ b/lib/rules/prefer-const.js
@@ -345,8 +345,8 @@ module.exports = {
             {
                 type: "object",
                 properties: {
-                    destructuring: { enum: ["any", "all"] },
-                    ignoreReadBeforeAssign: { type: "boolean" }
+                    destructuring: { enum: ["any", "all"], default: "any" },
+                    ignoreReadBeforeAssign: { type: "boolean", default: false }
                 },
                 additionalProperties: false
             }

--- a/lib/rules/prefer-destructuring.js
+++ b/lib/rules/prefer-destructuring.js
@@ -34,10 +34,12 @@ module.exports = {
                                 type: "object",
                                 properties: {
                                     array: {
-                                        type: "boolean"
+                                        type: "boolean",
+                                        default: true
                                     },
                                     object: {
-                                        type: "boolean"
+                                        type: "boolean",
+                                        default: true
                                     }
                                 },
                                 additionalProperties: false
@@ -46,10 +48,12 @@ module.exports = {
                                 type: "object",
                                 properties: {
                                     array: {
-                                        type: "boolean"
+                                        type: "boolean",
+                                        default: true
                                     },
                                     object: {
-                                        type: "boolean"
+                                        type: "boolean",
+                                        default: true
                                     }
                                 },
                                 additionalProperties: false
@@ -61,10 +65,12 @@ module.exports = {
                         type: "object",
                         properties: {
                             array: {
-                                type: "boolean"
+                                type: "boolean",
+                                default: true
                             },
                             object: {
-                                type: "boolean"
+                                type: "boolean",
+                                default: true
                             }
                         },
                         additionalProperties: false
@@ -75,7 +81,8 @@ module.exports = {
                 type: "object",
                 properties: {
                     enforceForRenamedProperties: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     }
                 },
                 additionalProperties: false

--- a/lib/rules/prefer-promise-reject-errors.js
+++ b/lib/rules/prefer-promise-reject-errors.js
@@ -27,7 +27,7 @@ module.exports = {
             {
                 type: "object",
                 properties: {
-                    allowEmptyReject: { type: "boolean" }
+                    allowEmptyReject: { type: "boolean", default: false }
                 },
                 additionalProperties: false
             }

--- a/lib/rules/quote-props.js
+++ b/lib/rules/quote-props.js
@@ -32,7 +32,8 @@ module.exports = {
                     type: "array",
                     items: [
                         {
-                            enum: ["always", "as-needed", "consistent", "consistent-as-needed"]
+                            enum: ["always", "as-needed", "consistent", "consistent-as-needed"],
+                            default: "always"
                         }
                     ],
                     minItems: 0,
@@ -42,19 +43,23 @@ module.exports = {
                     type: "array",
                     items: [
                         {
-                            enum: ["always", "as-needed", "consistent", "consistent-as-needed"]
+                            enum: ["always", "as-needed", "consistent", "consistent-as-needed"],
+                            default: "always"
                         },
                         {
                             type: "object",
                             properties: {
                                 keywords: {
-                                    type: "boolean"
+                                    type: "boolean",
+                                    default: false
                                 },
                                 unnecessary: {
-                                    type: "boolean"
+                                    type: "boolean",
+                                    default: true
                                 },
                                 numbers: {
-                                    type: "boolean"
+                                    type: "boolean",
+                                    default: false
                                 }
                             },
                             additionalProperties: false

--- a/lib/rules/quotes.js
+++ b/lib/rules/quotes.js
@@ -100,10 +100,12 @@ module.exports = {
                         type: "object",
                         properties: {
                             avoidEscape: {
-                                type: "boolean"
+                                type: "boolean",
+                                default: false
                             },
                             allowTemplateLiterals: {
-                                type: "boolean"
+                                type: "boolean",
+                                default: false
                             }
                         },
                         additionalProperties: false

--- a/lib/rules/require-jsdoc.js
+++ b/lib/rules/require-jsdoc.js
@@ -44,13 +44,7 @@ module.exports = {
                             }
                         },
                         additionalProperties: false,
-                        default: {
-                            FunctionDeclaration: true,
-                            MethodDefinition: false,
-                            ClassDeclaration: false,
-                            ArrowFunctionExpression: false,
-                            FunctionExpression: false
-                        }
+                        default: {}
                     }
                 },
                 additionalProperties: false

--- a/lib/rules/require-jsdoc.js
+++ b/lib/rules/require-jsdoc.js
@@ -23,22 +23,34 @@ module.exports = {
                         type: "object",
                         properties: {
                             ClassDeclaration: {
-                                type: "boolean"
+                                type: "boolean",
+                                default: false
                             },
                             MethodDefinition: {
-                                type: "boolean"
+                                type: "boolean",
+                                default: false
                             },
                             FunctionDeclaration: {
-                                type: "boolean"
+                                type: "boolean",
+                                default: true
                             },
                             ArrowFunctionExpression: {
-                                type: "boolean"
+                                type: "boolean",
+                                default: false
                             },
                             FunctionExpression: {
-                                type: "boolean"
+                                type: "boolean",
+                                default: false
                             }
                         },
-                        additionalProperties: false
+                        additionalProperties: false,
+                        default: {
+                            FunctionDeclaration: true,
+                            MethodDefinition: false,
+                            ClassDeclaration: false,
+                            ArrowFunctionExpression: false,
+                            FunctionExpression: false
+                        }
                     }
                 },
                 additionalProperties: false
@@ -58,7 +70,7 @@ module.exports = {
             ArrowFunctionExpression: false,
             FunctionExpression: false
         };
-        const options = Object.assign(DEFAULT_OPTIONS, context.options[0] && context.options[0].require || {});
+        const options = Object.assign(DEFAULT_OPTIONS, context.options[0] && context.options[0].require);
 
         /**
          * Report the error message

--- a/lib/rules/semi-spacing.js
+++ b/lib/rules/semi-spacing.js
@@ -29,10 +29,12 @@ module.exports = {
                 type: "object",
                 properties: {
                     before: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     },
                     after: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: true
                     }
                 },
                 additionalProperties: false
@@ -48,12 +50,8 @@ module.exports = {
             requireSpaceAfter = true;
 
         if (typeof config === "object") {
-            if (Object.prototype.hasOwnProperty.call(config, "before")) {
-                requireSpaceBefore = config.before;
-            }
-            if (Object.prototype.hasOwnProperty.call(config, "after")) {
-                requireSpaceAfter = config.after;
-            }
+            requireSpaceBefore = config.before;
+            requireSpaceAfter = config.after;
         }
 
         /**

--- a/lib/rules/semi.js
+++ b/lib/rules/semi.js
@@ -40,7 +40,8 @@ module.exports = {
                             type: "object",
                             properties: {
                                 beforeStatementContinuationChars: {
-                                    enum: ["always", "any", "never"]
+                                    enum: ["always", "any", "never"],
+                                    default: "any"
                                 }
                             },
                             additionalProperties: false
@@ -58,7 +59,7 @@ module.exports = {
                         {
                             type: "object",
                             properties: {
-                                omitLastInOneLineBlock: { type: "boolean" }
+                                omitLastInOneLineBlock: { type: "boolean", default: false }
                             },
                             additionalProperties: false
                         }
@@ -75,8 +76,8 @@ module.exports = {
         const OPT_OUT_PATTERN = /^[-[(/+`]/; // One of [(/+-`
         const options = context.options[1];
         const never = context.options[0] === "never";
-        const exceptOneLine = Boolean(options && options.omitLastInOneLineBlock);
-        const beforeStatementContinuationChars = (options && options.beforeStatementContinuationChars) || "any";
+        const exceptOneLine = options && options.omitLastInOneLineBlock;
+        const beforeStatementContinuationChars = options && options.beforeStatementContinuationChars;
         const sourceCode = context.getSourceCode();
 
         //--------------------------------------------------------------------------

--- a/lib/rules/sort-imports.js
+++ b/lib/rules/sort-imports.js
@@ -25,7 +25,8 @@ module.exports = {
                 type: "object",
                 properties: {
                     ignoreCase: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     },
                     memberSyntaxSortOrder: {
                         type: "array",
@@ -37,10 +38,12 @@ module.exports = {
                         maxItems: 4
                     },
                     ignoreDeclarationSort: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     },
                     ignoreMemberSort: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     }
                 },
                 additionalProperties: false

--- a/lib/rules/sort-keys.js
+++ b/lib/rules/sort-keys.js
@@ -90,10 +90,12 @@ module.exports = {
                 type: "object",
                 properties: {
                     caseSensitive: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: true
                     },
                     natural: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     }
                 },
                 additionalProperties: false
@@ -106,8 +108,8 @@ module.exports = {
         // Parse options.
         const order = context.options[0] || "asc";
         const options = context.options[1];
-        const insensitive = (options && options.caseSensitive) === false;
-        const natual = Boolean(options && options.natural);
+        const insensitive = options && options.caseSensitive === false;
+        const natual = options && options.natural;
         const isValidOrder = isValidOrders[
             order + (insensitive ? "I" : "") + (natual ? "N" : "")
         ];

--- a/lib/rules/sort-vars.js
+++ b/lib/rules/sort-vars.js
@@ -25,7 +25,8 @@ module.exports = {
                 type: "object",
                 properties: {
                     ignoreCase: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     }
                 },
                 additionalProperties: false

--- a/lib/rules/space-before-function-paren.js
+++ b/lib/rules/space-before-function-paren.js
@@ -37,13 +37,16 @@ module.exports = {
                         type: "object",
                         properties: {
                             anonymous: {
-                                enum: ["always", "never", "ignore"]
+                                enum: ["always", "never", "ignore"],
+                                default: "always"
                             },
                             named: {
-                                enum: ["always", "never", "ignore"]
+                                enum: ["always", "never", "ignore"],
+                                default: "always"
                             },
                             asyncArrow: {
-                                enum: ["always", "never", "ignore"]
+                                enum: ["always", "never", "ignore"],
+                                default: "always"
                             }
                         },
                         additionalProperties: false

--- a/lib/rules/space-infix-ops.js
+++ b/lib/rules/space-infix-ops.js
@@ -26,7 +26,8 @@ module.exports = {
                 type: "object",
                 properties: {
                     int32Hint: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     }
                 },
                 additionalProperties: false

--- a/lib/rules/space-unary-ops.js
+++ b/lib/rules/space-unary-ops.js
@@ -32,10 +32,12 @@ module.exports = {
                 type: "object",
                 properties: {
                     words: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: true
                     },
                     nonwords: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     },
                     overrides: {
                         type: "object",
@@ -50,7 +52,7 @@ module.exports = {
     },
 
     create(context) {
-        const options = context.options && Array.isArray(context.options) && context.options[0] || { words: true, nonwords: false };
+        const options = context.options[0] || { words: true, nonwords: false };
 
         const sourceCode = context.getSourceCode();
 

--- a/lib/rules/spaced-comment.js
+++ b/lib/rules/spaced-comment.js
@@ -215,7 +215,8 @@ module.exports = {
                                 }
                             },
                             balanced: {
-                                type: "boolean"
+                                type: "boolean",
+                                default: false
                             }
                         },
                         additionalProperties: false

--- a/lib/rules/switch-colon-spacing.js
+++ b/lib/rules/switch-colon-spacing.js
@@ -30,8 +30,8 @@ module.exports = {
             {
                 type: "object",
                 properties: {
-                    before: { type: "boolean" },
-                    after: { type: "boolean" }
+                    before: { type: "boolean", default: false },
+                    after: { type: "boolean", default: true }
                 },
                 additionalProperties: false
             }

--- a/lib/rules/valid-jsdoc.js
+++ b/lib/rules/valid-jsdoc.js
@@ -42,22 +42,27 @@ module.exports = {
                         }
                     },
                     requireReturn: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: true
                     },
                     requireParamDescription: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: true
                     },
                     requireReturnDescription: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: true
                     },
                     matchDescription: {
                         type: "string"
                     },
                     requireReturnType: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: true
                     },
                     requireParamType: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: true
                     }
                 },
                 additionalProperties: false

--- a/lib/rules/valid-typeof.js
+++ b/lib/rules/valid-typeof.js
@@ -24,7 +24,8 @@ module.exports = {
                 type: "object",
                 properties: {
                     requireStringLiterals: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     }
                 },
                 additionalProperties: false

--- a/lib/rules/wrap-iife.js
+++ b/lib/rules/wrap-iife.js
@@ -34,7 +34,8 @@ module.exports = {
                 type: "object",
                 properties: {
                     functionPrototypeMethods: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     }
                 },
                 additionalProperties: false
@@ -47,7 +48,7 @@ module.exports = {
     create(context) {
 
         const style = context.options[0] || "outside";
-        const includeFunctionPrototypeMethods = (context.options[1] && context.options[1].functionPrototypeMethods) || false;
+        const includeFunctionPrototypeMethods = context.options[1] && context.options[1].functionPrototypeMethods;
 
         const sourceCode = context.getSourceCode();
 

--- a/lib/rules/yield-star-spacing.js
+++ b/lib/rules/yield-star-spacing.js
@@ -31,8 +31,8 @@ module.exports = {
                     {
                         type: "object",
                         properties: {
-                            before: { type: "boolean" },
-                            after: { type: "boolean" }
+                            before: { type: "boolean", default: false },
+                            after: { type: "boolean", default: true }
                         },
                         additionalProperties: false
                     }

--- a/lib/rules/yoda.js
+++ b/lib/rules/yoda.js
@@ -169,10 +169,12 @@ module.exports = {
                 type: "object",
                 properties: {
                     exceptRange: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     },
                     onlyEquality: {
-                        type: "boolean"
+                        type: "boolean",
+                        default: false
                     }
                 },
                 additionalProperties: false

--- a/lib/util/ajv.js
+++ b/lib/util/ajv.js
@@ -17,6 +17,7 @@ const Ajv = require("ajv"),
 
 const ajv = new Ajv({
     meta: false,
+    useDefaults: true,
     validateSchema: false,
     missingRefs: "ignore",
     verbose: true,


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain: use `default` keyword in JSON schema

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Fixes #9929 

**Is there anything you'd like reviewers to focus on?**

Not all rules can enable this feature because of the limitation of `Ajv`.

No tests have been changed because the tests shouldn't be changed.