### PR TITLE
Fix: use option.cwd to resolve shared config

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -82,7 +82,7 @@ class Config {
         this.configCache = new ConfigCache();
 
         this.baseConfig = options.baseConfig
-            ? ConfigOps.merge({}, ConfigFile.loadObject(options.baseConfig, this))
+            ? ConfigOps.merge({}, ConfigFile.loadObject(options.baseConfig, this, options.cwd))
             : { rules: {} };
         this.baseConfig.filePath = "";
         this.baseConfig.baseDirectory = this.options.cwd;

--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -349,11 +349,18 @@ function getBaseDir(configFilePath) {
  * Determines the lookup path, including node_modules, for package
  * references relative to a config file.
  * @param {string} configFilePath The config file referencing the file.
+ * @param {string} [cwd] The current working directory passed from options.
  * @returns {string} The lookup path for the file path.
  * @private
  */
-function getLookupPath(configFilePath) {
-    const basedir = getBaseDir(configFilePath);
+function getLookupPath(configFilePath, cwd) {
+    let basedir;
+
+    if (cwd) {
+        basedir = path.resolve(cwd);
+    } else {
+        basedir = getBaseDir(configFilePath);
+    }
 
     return path.join(basedir, "node_modules");
 }
@@ -392,11 +399,12 @@ function getEslintCoreConfigPath(name) {
  * @param {string} filePath The file path from which the configuration information
  *      was loaded.
  * @param {string} [relativeTo] The path to resolve relative to.
+ * @param {string} [cwd] The current working directory passed from options.
  * @returns {Object} A new configuration object with all of the "extends" fields
  *      loaded and merged.
  * @private
  */
-function applyExtends(config, configContext, filePath, relativeTo) {
+function applyExtends(config, configContext, filePath, relativeTo, cwd) {
     let configExtends = config.extends;
 
     // normalize into an array for easier handling
@@ -427,7 +435,7 @@ function applyExtends(config, configContext, filePath, relativeTo) {
             debug(`Loading ${extensionPath}`);
 
             // eslint-disable-next-line no-use-before-define
-            return ConfigOps.merge(load(extensionPath, configContext, relativeTo), previousValue);
+            return ConfigOps.merge(load(extensionPath, configContext, relativeTo, cwd), previousValue);
         } catch (e) {
 
             /*
@@ -448,6 +456,7 @@ function applyExtends(config, configContext, filePath, relativeTo) {
  * or package name.
  * @param {string} filePath The filepath to resolve.
  * @param {string} [relativeTo] The path to resolve relative to.
+ * @param {string} [cwd] The current working directory passed from options.
  * @returns {Object} An object containing 3 properties:
  * - 'filePath' (required) the resolved path that can be used directly to load the configuration.
  * - 'configName' the name of the configuration inside the plugin.
@@ -455,7 +464,7 @@ function applyExtends(config, configContext, filePath, relativeTo) {
  *     or the absolute path to a config file. This should uniquely identify a config.
  * @private
  */
-function resolve(filePath, relativeTo) {
+function resolve(filePath, relativeTo, cwd) {
     if (isFilePath(filePath)) {
         const fullPath = path.resolve(relativeTo || "", filePath);
 
@@ -481,7 +490,7 @@ function resolve(filePath, relativeTo) {
     debug(`Attempting to resolve ${normalizedPackageName}`);
 
     return {
-        filePath: resolver.resolve(normalizedPackageName, getLookupPath(relativeTo)),
+        filePath: resolver.resolve(normalizedPackageName, getLookupPath(relativeTo, cwd)),
         configFullName: filePath
     };
 
@@ -536,11 +545,12 @@ function loadFromDisk(resolvedPath, configContext) {
  * Loads a config object, applying extends if present.
  * @param {Object} configObject a config object to load
  * @param {Config} configContext Context for the config instance
+ * @param {string} cwd The current working directory passed from options
  * @returns {Object} the config object with extends applied if present, or the passed config if not
  * @private
  */
-function loadObject(configObject, configContext) {
-    return configObject.extends ? applyExtends(configObject, configContext, "") : configObject;
+function loadObject(configObject, configContext, cwd) {
+    return configObject.extends ? applyExtends(configObject, configContext, "", null, cwd) : configObject;
 }
 
 /**
@@ -549,11 +559,12 @@ function loadObject(configObject, configContext) {
  * @param {string} filePath the path to the config file
  * @param {Config} configContext Context for the config instance
  * @param {string} [relativeTo] The path to resolve relative to.
+ * @param {string} [cwd] The current working directory passed from options.
  * @returns {Object} the parsed config object (empty object if there was a parse error)
  * @private
  */
-function load(filePath, configContext, relativeTo) {
-    const resolvedPath = resolve(filePath, relativeTo);
+function load(filePath, configContext, relativeTo, cwd) {
+    const resolvedPath = resolve(filePath, relativeTo, cwd);
 
     const cachedConfig = configContext.configCache.getConfig(resolvedPath.configFullName);
 

--- a/tests/fixtures/config-file/cwd/node_modules/eslint-config-custom/index.js
+++ b/tests/fixtures/config-file/cwd/node_modules/eslint-config-custom/index.js
@@ -1,0 +1,5 @@
+module.exports = {
+	"rules": {
+        "eqeqeq": 2
+	}
+}

--- a/tests/fixtures/config-file/cwd/node_modules/eslint-config-custom/package.json
+++ b/tests/fixtures/config-file/cwd/node_modules/eslint-config-custom/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "eslint-config-custom",
+  "main": "index.js"
+}

--- a/tests/lib/config/config-file.js
+++ b/tests/lib/config/config-file.js
@@ -467,6 +467,26 @@ describe("ConfigFile", () => {
 
         });
 
+        it("should apply extension 'custom' when specified from cwd config", () => {
+            const cwd = getFixturePath("cwd");
+            const resolvedPath = path.resolve(cwd, "./node_modules/eslint-config-custom/index.js");
+
+            const config = ConfigFile.applyExtends({
+                extends: "custom"
+            }, configContext, "", null, cwd);
+
+            assert.deepStrictEqual(config, {
+                baseDirectory: path.dirname(resolvedPath),
+                filePath: resolvedPath,
+                extends: "custom",
+                parserOptions: {},
+                env: {},
+                globals: {},
+                rules: { eqeqeq: 2 }
+            });
+
+        });
+
     });
 
     describe("load()", () => {
@@ -1029,6 +1049,20 @@ describe("ConfigFile", () => {
             }
             assert.fail();
         });
+
+        it("should resolve when cwd is set", () => {
+            const cwd = getFixturePath("cwd");
+            const config = ConfigFile.load("custom", configContext, cwd);
+
+            assert.deepStrictEqual(config, {
+                baseDirectory: path.resolve(cwd, "node_modules/eslint-config-custom"),
+                filePath: path.resolve(cwd, "node_modules/eslint-config-custom/index.js"),
+                env: {},
+                globals: {},
+                parserOptions: {},
+                rules: { eqeqeq: 2 }
+            });
+        });
     });
 
     describe("resolve()", () => {
@@ -1192,6 +1226,12 @@ describe("ConfigFile", () => {
             const result = ConfigFile.getLookupPath(path.resolve("/tmp/foo"));
 
             assert.strictEqual(result, PROJECT_DEPS_PATH);
+        });
+
+        it("should return cwd path when cwd is set", () => {
+            const result = ConfigFile.getLookupPath(path.resolve("/tmp/foo"), "/tmp/foo");
+
+            assert.strictEqual(result, "/tmp/foo/node_modules");
         });
 
     });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Add additional fix to https://github.com/eslint/eslint/issues/7328

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Add `cwd` passed from CLIEngine to resolve shared config. 

When 7328 was closed,  the requested change is partial done: `baseConfig.extends` is resolved not to `__dirname` but `process.cwd()`, however it misses the part it can also be resolved to `cwd` passed from CLIEngine options.  This implementation adds resolve to `cwd` configured by user.

**Is there anything you'd like reviewers to focus on?**


