### PR TITLE
Docs: Fixes incorrect example

### DIFF
--- a/docs/rules/no-restricted-globals.md
+++ b/docs/rules/no-restricted-globals.md
@@ -13,7 +13,7 @@ This rule allows you to specify global variable names that you don't want to use
 
 ## Options
 
-This rule takes a list of strings.  The first string is the rule setting, such as "off", "warn", or "error".  The strings after the rule setting is a global to be restricted:
+This rule takes a list of strings.  The first string is the rule setting, such as "off", "warn", or "error".  The strings after the rule setting are the globals to be restricted:
 
 ```json
 {

--- a/docs/rules/no-restricted-globals.md
+++ b/docs/rules/no-restricted-globals.md
@@ -13,7 +13,7 @@ This rule allows you to specify global variable names that you don't want to use
 
 ## Options
 
-This rule takes a list of strings, where each string is a global to be restricted:
+This rule takes a list of strings.  The first string is the rule setting, such as "off", "warn", or "error".  The strings after the rule setting is a global to be restricted:
 
 ```json
 {
@@ -77,7 +77,7 @@ Examples of **incorrect** code for a sample `"event"` global variable name, alon
 
 ```js
 /*global event*/
-/* eslint no-restricted-globals: ["error", { name: "error", message: "Use local parameter instead." }] */
+/* eslint no-restricted-globals: ["error", { name: "event", message: "Use local parameter instead." }] */
 
 function onClick() {
     console.log(event);    // Unexpected global variable 'event'. Use local parameter instead.

--- a/docs/rules/no-restricted-globals.md
+++ b/docs/rules/no-restricted-globals.md
@@ -13,7 +13,7 @@ This rule allows you to specify global variable names that you don't want to use
 
 ## Options
 
-This rule takes a list of strings.  The first string is the rule setting, such as "off", "warn", or "error".  The strings after the rule setting are the globals to be restricted:
+This rule takes a list of strings.  The first string is the rule setting, such as "off", "warn", or "error".  Each string after the rule setting is a global to be restricted:
 
 ```json
 {


### PR DESCRIPTION
This commit also updates the documentation for the parameters to
include the fact that the first parameter is the rule setting and not a
global to be restricted.

<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
I've fixed an incorrect example in the documentation and clarified an incorrect sentence in the parameter explanation.

**Is there anything you'd like reviewers to focus on?**
no

