### PR TITLE
Chore: remove dead code for loading rules

### DIFF
--- a/conf/eslint-all.js
+++ b/conf/eslint-all.js
@@ -9,16 +9,14 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const load = require("../lib/load-rules"),
-    Rules = require("../lib/rules");
-const rules = new Rules();
+const builtInRules = require("../lib/built-in-rules-index");
 
 //------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
 
-const enabledRules = Object.keys(load()).reduce((result, ruleId) => {
-    if (!rules.get(ruleId).meta.deprecated) {
+const enabledRules = Object.keys(builtInRules).reduce((result, ruleId) => {
+    if (!builtInRules[ruleId].meta.deprecated) {
         result[ruleId] = "error";
     }
     return result;

--- a/lib/config/config-rule.js
+++ b/lib/config/config-rule.js
@@ -10,7 +10,7 @@
 //------------------------------------------------------------------------------
 
 const Rules = require("../rules"),
-    loadRules = require("../load-rules");
+    builtInRules = require("../built-in-rules-index");
 
 const rules = new Rules();
 
@@ -299,9 +299,7 @@ function generateConfigsFromSchema(schema) {
  * @returns {rulesConfig} Hash of rule names and arrays of possible configurations
  */
 function createCoreRuleConfigs() {
-    const ruleList = loadRules();
-
-    return Object.keys(ruleList).reduce((accumulator, id) => {
+    return Object.keys(builtInRules).reduce((accumulator, id) => {
         const rule = rules.get(id);
         const schema = (typeof rule === "function") ? rule.schema : rule.meta.schema;
 

--- a/lib/load-rules.js
+++ b/lib/load-rules.js
@@ -20,15 +20,12 @@ const rulesDirCache = {};
 
 /**
  * Load all rule modules from specified directory.
- * @param {string} [relativeRulesDir] Path to rules directory, may be relative. Defaults to `lib/rules`.
+ * @param {string} relativeRulesDir Path to rules directory, may be relative.
  * @param {string} cwd Current working directory
  * @returns {Object} Loaded rule modules by rule ids (file names).
  */
 module.exports = function(relativeRulesDir, cwd) {
-
-    const rulesDir = relativeRulesDir
-        ? path.resolve(cwd, relativeRulesDir)
-        : path.join(__dirname, "rules");
+    const rulesDir = path.resolve(cwd, relativeRulesDir);
 
     // cache will help performance as IO operation are expensive
     if (rulesDirCache[rulesDir]) {

--- a/tests/lib/config/config-rule.js
+++ b/tests/lib/config/config-rule.js
@@ -11,7 +11,7 @@
 
 const assert = require("chai").assert,
     ConfigRule = require("../../../lib/config/config-rule"),
-    loadRules = require("../../../lib/load-rules"),
+    builtInRules = require("../../../lib/built-in-rules-index"),
     schema = require("../../fixtures/config-rule/schemas");
 
 //------------------------------------------------------------------------------
@@ -294,7 +294,7 @@ describe("ConfigRule", () => {
         const rulesConfig = ConfigRule.createCoreRuleConfigs();
 
         it("should create a rulesConfig containing all core rules", () => {
-            const coreRules = loadRules(),
+            const coreRules = builtInRules,
                 expectedRules = Object.keys(coreRules),
                 actualRules = Object.keys(rulesConfig);
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

The `lib/rules.js` file contains a code path that was previously needed to load core rules, but is no longer used as of aa56247746a0095996a41dd03bdbbf659f0f93b6.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
