### PR TITLE
Update: Make --init run js config files through linter (fixes #9947)

### DIFF
--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -280,6 +280,7 @@ function writeYAMLConfigFile(config, filePath) {
  * Writes a configuration file in JavaScript format.
  * @param {Object} config The configuration object to write.
  * @param {string} filePath The filename to write to.
+ * @throws {Error} If an error occurs linting the config file contents.
  * @returns {void}
  * @private
  */
@@ -300,10 +301,17 @@ function writeJSConfigFile(config, filePath) {
 
         contentToWrite = report.results[0].output || stringifiedContent;
     } catch (e) {
-        contentToWrite = stringifiedContent;
-    }
+        debug("Error linting JavaScript config file, writing unlinted version");
+        const errorMessage = e.message;
 
-    fs.writeFileSync(filePath, contentToWrite, "utf8");
+        contentToWrite = stringifiedContent;
+        e.message = "An error occurred while generating your JavaScript config file. ";
+        e.message += "A config file was still generated, but it may not follow your linting rules.";
+        e.message += `\nError: ${errorMessage}`;
+        throw e;
+    } finally {
+        fs.writeFileSync(filePath, contentToWrite, "utf8");
+    }
 }
 
 /**

--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -286,9 +286,24 @@ function writeYAMLConfigFile(config, filePath) {
 function writeJSConfigFile(config, filePath) {
     debug(`Writing JS config file: ${filePath}`);
 
-    const content = `module.exports = ${stringify(config, { cmp: sortByKey, space: 4 })};`;
+    let contentToWrite;
+    const stringifiedContent = `module.exports = ${stringify(config, { cmp: sortByKey, space: 4 })};`;
 
-    fs.writeFileSync(filePath, content, "utf8");
+    try {
+        const CLIEngine = require("../cli-engine");
+        const linter = new CLIEngine({
+            baseConfig: config,
+            fix: true,
+            useEslintrc: false
+        });
+        const report = linter.executeOnText(stringifiedContent);
+
+        contentToWrite = report.results[0].output || stringifiedContent;
+    } catch (e) {
+        contentToWrite = stringifiedContent;
+    }
+
+    fs.writeFileSync(filePath, contentToWrite, "utf8");
 }
 
 /**

--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -306,7 +306,7 @@ function writeJSConfigFile(config, filePath) {
 
         contentToWrite = stringifiedContent;
         e.message = "An error occurred while generating your JavaScript config file. ";
-        e.message += "A config file was still generated, but it may not follow your linting rules.";
+        e.message += "A config file was still generated, but the config file itself may not follow your linting rules.";
         e.message += `\nError: ${errorMessage}`;
         throw e;
     } finally {

--- a/tests/lib/config/config-file.js
+++ b/tests/lib/config/config-file.js
@@ -20,6 +20,7 @@ const Module = require("module"),
     espree = require("espree"),
     ConfigFile = require("../../../lib/config/config-file"),
     Linter = require("../../../lib/linter"),
+    CLIEngine = require("../../../lib/cli-engine"),
     Config = require("../../../lib/config");
 
 const userHome = os.homedir();
@@ -1282,6 +1283,29 @@ describe("ConfigFile", () => {
             });
 
             StubbedConfigFile.write(singleQuoteConfig, "test-config.js");
+        });
+
+        it("should still write a js config file even if linting fails", () => {
+            const fakeFS = leche.fake(fs);
+            const fakeCLIEngine = sandbox.mock().withExactArgs(sinon.match({
+                baseConfig: config,
+                fix: true,
+                useEslintrc: false
+            }));
+
+            fakeCLIEngine.prototype = leche.fake(CLIEngine.prototype);
+            sandbox.stub(fakeCLIEngine.prototype, "executeOnText").throws();
+
+            sandbox.mock(fakeFS).expects("writeFileSync").once();
+
+            const StubbedConfigFile = proxyquire("../../../lib/config/config-file", {
+                fs: fakeFS,
+                "../cli-engine": fakeCLIEngine
+            });
+
+            assert.throws(() => {
+                StubbedConfigFile.write(config, "test-config.js");
+            });
         });
 
         it("should throw error if file extension is not valid", () => {

--- a/tests/lib/config/config-file.js
+++ b/tests/lib/config/config-file.js
@@ -1262,6 +1262,28 @@ describe("ConfigFile", () => {
 
         });
 
+        it("should make sure js config files match linting rules", () => {
+            const fakeFS = leche.fake(fs);
+
+            const singleQuoteConfig = {
+                rules: {
+                    quotes: [2, "single"]
+                }
+            };
+
+            sandbox.mock(fakeFS).expects("writeFileSync").withExactArgs(
+                "test-config.js",
+                sinon.match(value => !value.includes("\"")),
+                "utf8"
+            );
+
+            const StubbedConfigFile = proxyquire("../../../lib/config/config-file", {
+                fs: fakeFS
+            });
+
+            StubbedConfigFile.write(singleQuoteConfig, "test-config.js");
+        });
+
         it("should throw error if file extension is not valid", () => {
             assert.throws(() => {
                 ConfigFile.write({}, getFixturePath("yaml/.eslintrc.class"));


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Update `--init` as described in #9947 
<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Updated the behavior of `--init` so generated JS config files follow linting rules. As described in #9947, this change makes `--init` run generated JS config files through the equivalent of `eslint --fix` to make sure they follow the selected linting rules.

**Is there anything you'd like reviewers to focus on?**
This is my first contribution to ESLint, so let me know if I need to change anything! The only weird part about the code change is the `require` on line 293 to get `CLIEngine`. This require cannot be at the top of the file because of a circular dependency between `config-file.js` and `cli-engine.js`.

