### PR TITLE
Docs: mention 'prefer-spread' in docs of 'no-useless-call'

### DIFF
--- a/docs/rules/no-useless-call.md
+++ b/docs/rules/no-useless-call.md
@@ -37,6 +37,7 @@ obj.foo.call(otherObj, 1, 2, 3);
 obj.foo.apply(otherObj, [1, 2, 3]);
 
 // The argument list is variadic.
+// Those are warned by the `prefer-spread` rule.
 foo.apply(undefined, args);
 foo.apply(null, args);
 obj.foo.apply(obj, args);
@@ -66,3 +67,7 @@ a[++i].foo.call(a[i], 1, 2, 3);
 ## When Not To Use It
 
 If you don't want to be notified about unnecessary `.call()` and `.apply()`, you can safely disable this rule.
+
+## Related Rules
+
+* [prefer-spread](prefer-spread.md)


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

`prefer-spread` mentions `no-useless-call`, but not the other way around. This PR updates the docs of `no-useless-call` to mention `prefer-spread`.

**Is there anything you'd like reviewers to focus on?**


