### PR TITLE
Docs: fix a misleading example in one-var

### DIFF
--- a/docs/rules/one-var.md
+++ b/docs/rules/one-var.md
@@ -324,7 +324,9 @@ Examples of **correct** code for this rule with the `{ separateRequires: true }`
 
 var foo = require("foo");
 var bar = "bar";
+```
 
+```js
 var foo = require("foo"),
     bar = require("bar");
 ```


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
splitting the code to 2 blocks for less confusion.

**Is there anything you'd like reviewers to focus on?**

should we do the same thing to other code blocks?
