### PR TITLE
Chore: fix exports in comma-dangle tests

### DIFF
--- a/tests/lib/rules/comma-dangle.js
+++ b/tests/lib/rules/comma-dangle.js
@@ -182,7 +182,7 @@ ruleTester.run("comma-dangle", rule, {
             parserOptions: { sourceType: "module" }
         },
         {
-            code: "export {foo} from 'foo';",
+            code: "var foo = 'foo'; export {foo} from 'foo';",
             options: ["never"],
             parserOptions: { sourceType: "module" }
         },
@@ -197,12 +197,12 @@ ruleTester.run("comma-dangle", rule, {
             parserOptions: { sourceType: "module" }
         },
         {
-            code: "export {foo} from 'foo';",
+            code: "var foo = 'foo'; export {foo} from 'foo';",
             options: ["always-multiline"],
             parserOptions: { sourceType: "module" }
         },
         {
-            code: "export {foo} from 'foo';",
+            code: "var foo = 'foo'; export {foo} from 'foo';",
             options: ["only-multiline"],
             parserOptions: { sourceType: "module" }
         },
@@ -994,7 +994,7 @@ ruleTester.run("comma-dangle", rule, {
             errors: [{ messageId: "missing", type: "ImportSpecifier" }]
         },
         {
-            code: "export {foo} from 'foo';",
+            code: "var foo = 'foo'; export {foo} from 'foo';",
             output: "export {foo,} from 'foo';",
             options: ["always"],
             parserOptions: { sourceType: "module" },
@@ -1030,14 +1030,14 @@ ruleTester.run("comma-dangle", rule, {
         },
         {
             code: "export {foo,} from 'foo';",
-            output: "export {foo} from 'foo';",
+            output: "var foo = 'foo'; export {foo} from 'foo';",
             options: ["never"],
             parserOptions: { sourceType: "module" },
             errors: [{ messageId: "unexpected", type: "ExportSpecifier" }]
         },
         {
             code: "export {foo,} from 'foo';",
-            output: "export {foo} from 'foo';",
+            output: "var foo = 'foo'; export {foo} from 'foo';",
             options: ["only-multiline"],
             parserOptions: { sourceType: "module" },
             errors: [{ messageId: "unexpected", type: "ExportSpecifier" }]
@@ -1051,7 +1051,7 @@ ruleTester.run("comma-dangle", rule, {
         },
         {
             code: "export {foo,} from 'foo';",
-            output: "export {foo} from 'foo';",
+            output: "var foo = 'foo'; export {foo} from 'foo';",
             options: ["always-multiline"],
             parserOptions: { sourceType: "module" },
             errors: [{ messageId: "unexpected", type: "ExportSpecifier" }]


### PR DESCRIPTION
codes like `export {foo}` could pass using earlier acorn, but acorn@6.0.7 fixes it.

<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
the master is failing as the new release of acorn, the pr fixed it.

**Is there anything you'd like reviewers to focus on?**
no

