### PR TITLE
Docs: clarify motivation for no-prototype-builtins

### DIFF
--- a/docs/rules/no-prototype-builtins.md
+++ b/docs/rules/no-prototype-builtins.md
@@ -36,4 +36,4 @@ var barIsEnumerable = {}.propertyIsEnumerable.call(foo, "bar");
 
 ## When Not To Use It
 
-You may want to turn this rule off if your code never handles user input, and you will never use an object that shadows an `Object.prototype` method or which does not inherit from `Object.prototype`.
+You may want to turn this rule off if your code only touches objects with hardcoded keys, and you will never use an object that shadows an `Object.prototype` method or which does not inherit from `Object.prototype`.

--- a/docs/rules/no-prototype-builtins.md
+++ b/docs/rules/no-prototype-builtins.md
@@ -2,6 +2,10 @@
 
 In ECMAScript 5.1, `Object.create` was added, which enables the creation of objects with a specified `[[Prototype]]`. `Object.create(null)` is a common pattern used to create objects that will be used as a Map. This can lead to errors when it is assumed that objects will have properties from `Object.prototype`. This rule prevents calling some `Object.prototype` methods directly from an object.
 
+Additionally, objects can have properties that shadow the builtins on `Object.prototype`, potentially causing unintended behavior or denial-of-service security vulnerabilities. For example, it would be unsafe for a webserver to parse JSON input from a client and call `hasOwnProperty` directly on the resulting object, because a malicious client could send a JSON value like `{"hasOwnProperty": 1}` and cause the server to crash.
+
+To avoid subtle bugs like this, it's better to always call these methods from `Object.prototype`. For example, `foo.hasOwnProperty("bar")` should be replaced with `Object.prototype.hasOwnProperty.call(foo, "bar")`.
+
 ## Rule Details
 
 This rule disallows calling some `Object.prototype` methods directly on object instances.
@@ -32,4 +36,4 @@ var barIsEnumerable = {}.propertyIsEnumerable.call(foo, "bar");
 
 ## When Not To Use It
 
-You may want to turn this rule off if you will never use an object that shadows an `Object.prototype` method or which does not inherit from `Object.prototype`.
+You may want to turn this rule off if your code never handles user input, and you will never use an object that shadows an `Object.prototype` method or which does not inherit from `Object.prototype`.


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

The first section in the no-prototype-builtins docs mentions objects created with Object.create(null), but does not mention builtin shadowing (which is arguably a much more compelling reason to use the rule). This commit updates the description to clarify the risks of using prototype builtins on user input.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
