### PR TITLE
Update: single argument on newline with function-paren-newline multiline

### DIFF
--- a/lib/rules/function-paren-newline.js
+++ b/lib/rules/function-paren-newline.js
@@ -84,6 +84,9 @@ module.exports = {
          */
         function shouldHaveNewlines(elements, hasLeftNewline) {
             if (multilineOption) {
+                if (elements.length === 1) {
+                    return hasLeftNewline;
+                }
                 return elements.some((element, index) => index !== elements.length - 1 && element.loc.end.line !== elements[index + 1].loc.start.line);
             }
             if (consistentOption) {

--- a/tests/lib/rules/function-paren-newline.js
+++ b/tests/lib/rules/function-paren-newline.js
@@ -29,16 +29,25 @@ ruleTester.run("function-paren-newline", rule, {
 
         // multiline option (default)
         "function baz(foo, bar) {}",
+        "function baz(foo) {}",
         "(function(foo, bar) {});",
+        "(function(foo) {});",
         "(function baz(foo, bar) {});",
+        "(function baz(foo) {});",
         "(foo, bar) => {};",
         "foo => {};",
         "baz(foo, bar);",
+        "baz(foo);",
         "function baz() {}",
         `
             function baz(
                 foo,
                 bar
+            ) {}
+        `,
+        `
+            function baz(
+                foo
             ) {}
         `,
         `
@@ -48,9 +57,19 @@ ruleTester.run("function-paren-newline", rule, {
             ) {});
         `,
         `
+            (function(
+                foo
+            ) {});
+        `,
+        `
             (function baz(
                 foo,
                 bar
+            ) {});
+        `,
+        `
+            (function baz(
+                foo
             ) {});
         `,
         `
@@ -60,9 +79,19 @@ ruleTester.run("function-paren-newline", rule, {
             ) => {};
         `,
         `
+            (
+                foo
+            ) => {};
+        `,
+        `
             baz(
                 foo,
                 bar
+            );
+        `,
+        `
+            baz(
+                foo
             );
         `,
         `
@@ -70,6 +99,7 @@ ruleTester.run("function-paren-newline", rule, {
                 bar\`)
         `,
         "new Foo(bar, baz)",
+        "new Foo(bar)",
         "new Foo",
         "new (Foo)",
 
@@ -296,19 +326,6 @@ ruleTester.run("function-paren-newline", rule, {
         {
             code: `
                 function baz(
-                    foo =
-                    1
-                ) {}
-            `,
-            output: `
-                function baz(foo =
-                    1) {}
-            `,
-            errors: [LEFT_UNEXPECTED_ERROR, RIGHT_UNEXPECTED_ERROR]
-        },
-        {
-            code: `
-                function baz(
                 ) {}
             `,
             output: `
@@ -332,8 +349,11 @@ ruleTester.run("function-paren-newline", rule, {
                 function baz(/* not fixed due to comment */
                 foo) {}
             `,
-            output: null,
-            errors: [LEFT_UNEXPECTED_ERROR]
+            output: `
+                function baz(/* not fixed due to comment */
+                foo\n) {}
+            `,
+            errors: [RIGHT_MISSING_ERROR]
         },
         {
             code: `


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

- [ ] Documentation update
- [ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
- [ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
- [X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

**What rule do you want to change?**
`function-paren-newline` with `multiline` option.

**Does this change cause the rule to produce more or fewer warnings?**
Fewer.

**How will the change be implemented? (New option, new default behavior, etc.)?**
New default behavior.

**Please provide some example code that this change will affect:**

```js
function foo(
  param1
)

// or

foo(
  "some very long argument that I'd love to have on it's own line"
);
```

**What does the rule currently do for this code?**
This is a valid code.

**What will the rule do after it's changed?**
This code was invalid.

**Is there anything you'd like reviewers to focus on?**
There are some issues about this problem :: https://github.com/eslint/eslint/issues/9286 :: https://github.com/eslint/eslint/issues/9411

For `multiline` option this is obvious behavior when you can use single argument on their own line. But now for this you should use less strict `consistent` option.

```js
console.log(foo,
  bar,
  baz);
```
Airbnb JavaScript Style Guide [define this code as bad](https://github.com/airbnb/javascript#functions--signature-invocation-indentation). But their eslint config now use `consistent` option that miss many bad cases because `multiline` option disallow to use single argument on their own line. Until then they were forced to use [additional parens](https://github.com/airbnb/javascript/issues/1584) as workaround. 