### PR TITLE
Fix: ignore comma before closing paren (fixes #11295)

### DIFF
--- a/lib/rules/comma-spacing.js
+++ b/lib/rules/comma-spacing.js
@@ -118,6 +118,10 @@ module.exports = {
                 report(reportItem, "before", tokens.left);
             }
 
+            if (tokens.right && astUtils.isClosingParenToken(tokens.right)) {
+                return;
+            }
+
             if (tokens.right && !options.after && tokens.right.type === "Line") {
                 return;
             }

--- a/tests/lib/rules/comma-spacing.js
+++ b/tests/lib/rules/comma-spacing.js
@@ -62,6 +62,9 @@ ruleTester.run("comma-spacing", rule, {
         { code: "[`  ,  `]", parserOptions: { ecmaVersion: 6 } },
         { code: "`${[1, 2]}`", parserOptions: { ecmaVersion: 6 } },
         { code: "fn(a, b,)", parserOptions: { ecmaVersion: 2018 } }, // #11295
+        { code: "const fn = (a, b,) => {}", parserOptions: { ecmaVersion: 2018 } }, // #11295
+        { code: "const fn = function (a, b,) {}", parserOptions: { ecmaVersion: 2018 } }, // #11295
+        { code: "function fn(a, b,) {}", parserOptions: { ecmaVersion: 2018 } }, // #11295
         "foo(/,/, 'a')",
         "var x = ',,,,,';",
         "var code = 'var foo = 1, bar = 3;'",

--- a/tests/lib/rules/comma-spacing.js
+++ b/tests/lib/rules/comma-spacing.js
@@ -61,6 +61,7 @@ ruleTester.run("comma-spacing", rule, {
         "['  ,  ']",
         { code: "[`  ,  `]", parserOptions: { ecmaVersion: 6 } },
         { code: "`${[1, 2]}`", parserOptions: { ecmaVersion: 6 } },
+        { code: "fn(a, b,)", parserOptions: { ecmaVersion: 2018 } }, // #11295
         "foo(/,/, 'a')",
         "var x = ',,,,,';",
         "var code = 'var foo = 1, bar = 3;'",


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Fixes #11295 

**Is there anything you'd like reviewers to focus on?**
Maybe no.
