### PR TITLE
Update: Add never option for new-parens (refs #10034)

### DIFF
--- a/docs/rules/new-parens.md
+++ b/docs/rules/new-parens.md
@@ -1,4 +1,4 @@
-# require parentheses when invoking a constructor with no arguments (new-parens)
+# Require parentheses when invoking a constructor with no arguments (new-parens)
 
 JavaScript allows the omission of parentheses when invoking a function via the `new` keyword and the constructor has no arguments. However, some coders believe that omitting the parentheses is inconsistent with the rest of the language and thus makes code less clear.
 
@@ -8,9 +8,18 @@ var person = new Person;
 
 ## Rule Details
 
-This rule requires parentheses when invoking a constructor with no arguments using the `new` keyword in order to increase code clarity.
+This rule can enforce or disallow parentheses when invoking a constructor with no arguments using the `new` keyword.
 
-Examples of **incorrect** code for this rule:
+## Options
+
+This rule takes one option.
+
+- `"always"` enforces parenthesis after a new constructor with no arguments (default)
+- `"never"` enforces no parenthesis after a new constructor with no arguments
+
+### always
+
+Examples of **incorrect** code for this rule with the `"always"` option:
 
 ```js
 /*eslint new-parens: "error"*/
@@ -19,11 +28,32 @@ var person = new Person;
 var person = new (Person);
 ```
 
-Examples of **correct** code for this rule:
+Examples of **correct** code for this rule with the `"always"` option:
 
 ```js
 /*eslint new-parens: "error"*/
 
 var person = new Person();
 var person = new (Person)();
+```
+
+### never
+
+Examples of **incorrect** code for this rule with the `"never"` option:
+
+```js
+/*eslint new-parens: "error"*/
+
+var person = new Person();
+var person = new (Person)();
+```
+
+Examples of **correct** code for this rule with the `"never"` option:
+
+```js
+/*eslint new-parens: "error"*/
+
+var person = new Person;
+var person = (new Person);
+var person = new Person("Name");
 ```

--- a/docs/rules/new-parens.md
+++ b/docs/rules/new-parens.md
@@ -42,7 +42,7 @@ var person = new (Person)();
 Examples of **incorrect** code for this rule with the `"never"` option:
 
 ```js
-/*eslint new-parens: "error"*/
+/*eslint new-parens: ["error", "never"]*/
 
 var person = new Person();
 var person = new (Person)();
@@ -51,7 +51,7 @@ var person = new (Person)();
 Examples of **correct** code for this rule with the `"never"` option:
 
 ```js
-/*eslint new-parens: "error"*/
+/*eslint new-parens: ["error", "never"]*/
 
 var person = new Person;
 var person = (new Person);

--- a/lib/rules/new-parens.js
+++ b/lib/rules/new-parens.js
@@ -31,31 +31,63 @@ module.exports = {
         },
 
         fixable: "code",
-        schema: [],
+        schema: {
+            anyOf: [
+                {
+                    type: "array",
+                    items: [
+                        {
+                            enum: ["always", "never"]
+                        }
+                    ],
+                    minItems: 0,
+                    maxItems: 1
+                }
+            ]
+        },
         messages: {
-            missing: "Missing '()' invoking a constructor."
+            missing: "Missing '()' invoking a constructor.",
+            using: "'()' included invoking a constructor with no arguments."
         }
     },
 
     create(context) {
+        const options = context.options;
+        const always = options[0] !== "never"; // Default is never
+
         const sourceCode = context.getSourceCode();
 
         return {
             NewExpression(node) {
                 if (node.arguments.length !== 0) {
-                    return; // shortcut: if there are arguments, there have to be parens
+                    return; // if there are arguments, there have to be parens
                 }
 
                 const lastToken = sourceCode.getLastToken(node);
                 const hasLastParen = lastToken && astUtils.isClosingParenToken(lastToken);
                 const hasParens = hasLastParen && astUtils.isOpeningParenToken(sourceCode.getTokenBefore(lastToken));
 
-                if (!hasParens) {
-                    context.report({
-                        node,
-                        messageId: "missing",
-                        fix: fixer => fixer.insertTextAfter(node, "()")
-                    });
+                if (always) {
+                    if (!hasParens) {
+                        context.report({
+                            node,
+                            messageId: "missing",
+                            fix: fixer => fixer.insertTextAfter(node, "()")
+                        });
+                    }
+                } else {
+                    if (hasParens) {
+                        context.report({
+                            node,
+                            messageId: "using",
+                            fix: fixer => [
+                                fixer.remove(sourceCode.getTokenBefore(lastToken)),
+                                fixer.remove(lastToken),
+                                fixer.insertTextBefore(node, "("),
+                                fixer.insertTextAfter(node, ")")
+                            ]
+                        });
+                    }
                 }
             }
         };

--- a/lib/rules/new-parens.js
+++ b/lib/rules/new-parens.js
@@ -24,7 +24,7 @@ module.exports = {
         type: "layout",
 
         docs: {
-            description: "require parentheses when invoking a constructor with no arguments",
+            description: "enforce or disallow parentheses when invoking a constructor with no arguments",
             category: "Stylistic Issues",
             recommended: false,
             url: "https://eslint.org/docs/rules/new-parens"
@@ -47,13 +47,13 @@ module.exports = {
         },
         messages: {
             missing: "Missing '()' invoking a constructor.",
-            using: "'()' included invoking a constructor with no arguments."
+            unnecessary: "Unnecessary '()' invoking a constructor with no arguments."
         }
     },
 
     create(context) {
         const options = context.options;
-        const always = options[0] !== "never"; // Default is never
+        const always = options[0] !== "never"; // Default is always
 
         const sourceCode = context.getSourceCode();
 
@@ -79,7 +79,7 @@ module.exports = {
                     if (hasParens) {
                         context.report({
                             node,
-                            messageId: "using",
+                            messageId: "unnecessary",
                             fix: fixer => [
                                 fixer.remove(sourceCode.getTokenBefore(lastToken)),
                                 fixer.remove(lastToken),

--- a/tests/lib/rules/new-parens.js
+++ b/tests/lib/rules/new-parens.js
@@ -17,6 +17,7 @@ const parser = require("../../fixtures/fixture-parser"),
 // Tests
 //------------------------------------------------------------------------------
 const error = { messageId: "missing", type: "NewExpression" };
+const neverError = { messageId: "using", type: "NewExpression" };
 
 const ruleTester = new RuleTester();
 
@@ -29,7 +30,16 @@ ruleTester.run("new-parens", rule, {
         "var a = (new Date());",
         "var a = new foo.Bar();",
         "var a = (new Foo()).bar;",
-        { code: "new Storage<RootState>('state');", parser: parser("typescript-parsers/new-parens") }
+        { code: "new Storage<RootState>('state');", parser: parser("typescript-parsers/new-parens") },
+
+        // Never
+        { code: "var a = new Date;", options: ["never"] },
+        { code: "var a = new Date(function() {});", options: ["never"] },
+        { code: "var a = new (Date);", options: ["never"] },
+        { code: "var a = new ((Date));", options: ["never"] },
+        { code: "var a = (new Date);", options: ["never"] },
+        { code: "var a = new foo.Bar;", options: ["never"] },
+        { code: "var a = (new Foo).bar;", options: ["never"] }
     ],
     invalid: [
         {
@@ -73,6 +83,56 @@ ruleTester.run("new-parens", rule, {
             code: "var a = (new Foo).bar;",
             output: "var a = (new Foo()).bar;",
             errors: [error]
+        },
+
+        // Never
+        {
+            code: "var a = new Date();",
+            output: "var a = (new Date);",
+            options: ["never"],
+            errors: [neverError]
+        },
+        {
+            code: "var a = new Date()",
+            output: "var a = (new Date)",
+            options: ["never"],
+            errors: [neverError]
+        },
+        {
+            code: "var a = new (Date)();",
+            output: "var a = (new (Date));",
+            options: ["never"],
+            errors: [neverError]
+        },
+        {
+            code: "var a = new (Date)()",
+            output: "var a = (new (Date))",
+            options: ["never"],
+            errors: [neverError]
+        },
+        {
+            code: "var a = (new Date())",
+            output: "var a = ((new Date))",
+            options: ["never"],
+            errors: [neverError]
+        },
+        {
+            code: "var a = (new Date())()",
+            output: "var a = ((new Date))()",
+            options: ["never"],
+            errors: [neverError]
+        },
+        {
+            code: "var a = new foo.Bar();",
+            output: "var a = (new foo.Bar);",
+            options: ["never"],
+            errors: [neverError]
+        },
+        {
+            code: "var a = (new Foo()).bar;",
+            output: "var a = ((new Foo)).bar;",
+            options: ["never"],
+            errors: [neverError]
         }
     ]
 });

--- a/tests/lib/rules/new-parens.js
+++ b/tests/lib/rules/new-parens.js
@@ -23,6 +23,8 @@ const ruleTester = new RuleTester();
 
 ruleTester.run("new-parens", rule, {
     valid: [
+
+        // Default (Always)
         "var a = new Date();",
         "var a = new Date(function() {});",
         "var a = new (Date)();",
@@ -30,7 +32,15 @@ ruleTester.run("new-parens", rule, {
         "var a = (new Date());",
         "var a = new foo.Bar();",
         "var a = (new Foo()).bar;",
-        { code: "new Storage<RootState>('state');", parser: parser("typescript-parsers/new-parens") },
+        {
+            code: "new Storage<RootState>('state');",
+            parser: parser("typescript-parsers/new-parens")
+        },
+
+        // Explicit Always
+        { code: "var a = new Date();", options: ["always"] },
+        { code: "var a = new foo.Bar();", options: ["always"] },
+        { code: "var a = (new Foo()).bar;", options: ["always"] },
 
         // Never
         { code: "var a = new Date;", options: ["never"] },
@@ -39,9 +49,14 @@ ruleTester.run("new-parens", rule, {
         { code: "var a = new ((Date));", options: ["never"] },
         { code: "var a = (new Date);", options: ["never"] },
         { code: "var a = new foo.Bar;", options: ["never"] },
-        { code: "var a = (new Foo).bar;", options: ["never"] }
+        { code: "var a = (new Foo).bar;", options: ["never"] },
+        { code: "var a = new Person('Name')", options: ["never"] },
+        { code: "var a = new Person('Name', 12)", options: ["never"] },
+        { code: "var a = new ((Person))('Name');", options: ["never"] }
     ],
     invalid: [
+
+        // Default (Always)
         {
             code: "var a = new Date;",
             output: "var a = new Date();",
@@ -82,6 +97,26 @@ ruleTester.run("new-parens", rule, {
         {
             code: "var a = (new Foo).bar;",
             output: "var a = (new Foo()).bar;",
+            errors: [error]
+        },
+
+        // Explicit always
+        {
+            code: "var a = new Date;",
+            output: "var a = new Date();",
+            options: ["always"],
+            errors: [error]
+        },
+        {
+            code: "var a = new foo.Bar;",
+            output: "var a = new foo.Bar();",
+            options: ["always"],
+            errors: [error]
+        },
+        {
+            code: "var a = (new Foo).bar;",
+            output: "var a = (new Foo()).bar;",
+            options: ["always"],
             errors: [error]
         },
 

--- a/tests/lib/rules/new-parens.js
+++ b/tests/lib/rules/new-parens.js
@@ -17,7 +17,7 @@ const parser = require("../../fixtures/fixture-parser"),
 // Tests
 //------------------------------------------------------------------------------
 const error = { messageId: "missing", type: "NewExpression" };
-const neverError = { messageId: "using", type: "NewExpression" };
+const neverError = { messageId: "unnecessary", type: "NewExpression" };
 
 const ruleTester = new RuleTester();
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    Please ensure your pull request is ready:

    [X] Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    [X] Include tests for this change
    [X] Update documentation for this change (if appropriate)
-->

#10034 was closed automatically for a lack of interest, I'm not sure if this functionality is wanted.

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Added an argument to `new-parens` for always or never. The default with no arguments keeps the same functionality. Added tests for the never option and updated documentation.

**Is there anything you'd like reviewers to focus on?**

The fixer will always put parenthesis even when they're not required.

<!--
    From template:
-->

**What rule do you want to change?**

`new-parens`

**Does this change cause the rule to produce more or fewer warnings?**

No

**How will the change be implemented? (New option, new default behavior, etc.)?**

Adds an option for enforcing or disallowing parenthesis on constructors with no arguments using `new`. Default behavior stays the same. 

**Please provide some example code that this change will affect:**

Examples of **incorrect** code for this rule with the `"never"` option:

```js
/*eslint new-parens: ["error", "never"]*/

var person = new Person();
var person = new (Person)();
```

Examples of **correct** code for this rule with the `"never"` option:

```js
/*eslint new-parens: ["error", "never"]*/

var person = new Person;
var person = (new Person);
var person = new Person("Name");
```


**What does the rule currently do for this code?**

Errors because the arguments are invalid.

**What will the rule do after it's changed?**

The argument will no longer be invalid.
