### PR TITLE
Update: Use 'readonly' and 'writable' for globals (fixes #11359)

### DIFF
--- a/docs/user-guide/configuring.md
+++ b/docs/user-guide/configuring.md
@@ -208,19 +208,19 @@ To specify globals using a comment inside of your JavaScript file, use the follo
 /* global var1, var2 */
 ```
 
-This defines two global variables, `var1` and `var2`. If you want to optionally specify that these global variables can be written to (rather than only being read), then you can set each with a `writeable` flag:
+This defines two global variables, `var1` and `var2`. If you want to optionally specify that these global variables can be written to (rather than only being read), then you can set each with a `"writable"` flag:
 
 ```js
-/* global var1:writeable, var2:writeable */
+/* global var1:writable, var2:writable */
 ```
 
-To configure global variables inside of a configuration file, set the `globals` configuration property to an object containing keys named for each of the global variables you want to use. For each global variable key, set the corresponding value equal to `"writeable"` to allow the variable to be overwritten or `"readable"` to disallow overwriting. For example:
+To configure global variables inside of a configuration file, set the `globals` configuration property to an object containing keys named for each of the global variables you want to use. For each global variable key, set the corresponding value equal to `"writable"` to allow the variable to be overwritten or `"readonly"` to disallow overwriting. For example:
 
 ```json
 {
     "globals": {
-        "var1": "writeable",
-        "var2": "readable"
+        "var1": "writable",
+        "var2": "readonly"
     }
 }
 ```
@@ -230,8 +230,8 @@ And in YAML:
 ```yaml
 ---
   globals:
-    var1: writeable
-    var2: readable
+    var1: writable
+    var2: readonly
 ```
 
 These examples allow `var1` to be overwritten in your code, but disallow it for `var2`.
@@ -249,7 +249,7 @@ Globals can be disabled with the string `"off"`. For example, in an environment 
 }
 ```
 
-For historical reasons, the boolean values `false` and `true` can also be used to configure globals, and are equivalent to `"readable"` and `"writeable"`, respectively. However, this usage of booleans is deprecated.
+For historical reasons, the boolean value `false` and the string value `"readable"` are equivalent to `"readonly"`. Similarly, the boolean value `true` and the string value `"writeable"` are equivalent to `"writable"`. However, the use of older values is deprecated.
 
 **Note:** Enable the [no-global-assign](../rules/no-global-assign.md) rule to disallow modifications to read-only global variables in your code.
 

--- a/lib/config/config-ops.js
+++ b/lib/config/config-ops.js
@@ -386,12 +386,14 @@ module.exports = {
             case true:
             case "true":
             case "writeable":
+            case "writable":
                 return "writeable";
 
             case null:
             case false:
             case "false":
             case "readable":
+            case "readonly":
                 return "readable";
 
             // Fallback to minimize compatibility impact

--- a/tests/lib/config/config-ops.js
+++ b/tests/lib/config/config-ops.js
@@ -908,7 +908,9 @@ describe("ConfigOps", () => {
             ["false", "readable"],
             [null, "readable"],
             ["writeable", "writeable"],
+            ["writable", "writeable"],
             ["readable", "readable"],
+            ["readonly", "readable"],
             ["writable", "writeable"],
             ["something else", "writeable"]
         ].forEach(([input, output]) => {


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Changes globals configuration to also accept "readonly" and "writable".

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

* Updated `config-ops#normalizeGlobalsConfig()` to also accept "readonly" and "writable" (the values returned from this function are unchanged).
* Updated the related tests.
* Updated documentation related to configuring globals.

**Is there anything you'd like reviewers to focus on?**

Did I miss anything?
