### PR TITLE
Update: support single argument on newline with function-paren-newline

### DIFF
--- a/docs/rules/function-paren-newline.md
+++ b/docs/rules/function-paren-newline.md
@@ -14,6 +14,7 @@ This rule has a single option, which can either be a string or an object.
 * `"never"` disallows line breaks inside all function parentheses.
 * `"multiline"` (default) requires linebreaks inside function parentheses if any of the parameters/arguments have a line break between them. Otherwise, it disallows linebreaks.
 * `"consistent"` requires consistent usage of linebreaks for each pair of parentheses. It reports an error if one parenthesis in the pair has a linebreak inside it and the other parenthesis does not.
+* `"consistent-arguments"` requires consistent usage of linebreaks for each pair of parentheses and parameters/arguments. It allows linebreaks inside function parentheses if there is only one parameter/argument.
 * `{ "minItems": value }` requires linebreaks inside function parentheses if the number of parameters/arguments is at least `value`. Otherwise, it disallows linebreaks.
 
 Example configurations:
@@ -217,6 +218,56 @@ var foo = (
 foo(
   bar, baz
 );
+
+foo(
+  function() {
+    return baz;
+  }
+);
+```
+
+Examples of **incorrect** code for this rule with the `"consistent-arguments"` option:
+
+```js
+/* eslint function-paren-newline: ["error", "consistent-arguments"] */
+
+function foo(bar,
+  baz
+) {}
+
+var foo = function(bar,
+  baz
+) {};
+
+var foo = (
+  bar,
+  baz) => {};
+
+foo(
+  bar,
+  baz);
+
+foo(
+  bar, qux,
+  baz
+);
+```
+
+Examples of **correct** code for this rule with the consistent `"consistent-arguments"` option:
+
+```js
+/* eslint function-paren-newline: ["error", "consistent-arguments"] */
+
+function foo(
+  bar,
+  baz
+) {}
+
+var foo = function(bar, baz) {};
+
+var foo = (
+  bar
+) => {};
 
 foo(
   function() {

--- a/docs/rules/function-paren-newline.md
+++ b/docs/rules/function-paren-newline.md
@@ -13,8 +13,8 @@ This rule has a single option, which can either be a string or an object.
 * `"always"` requires line breaks inside all function parentheses.
 * `"never"` disallows line breaks inside all function parentheses.
 * `"multiline"` (default) requires linebreaks inside function parentheses if any of the parameters/arguments have a line break between them. Otherwise, it disallows linebreaks.
+* `"multiline-arguments"` works like `multiline` but allows linebreaks inside function parentheses if there is only one parameter/argument.
 * `"consistent"` requires consistent usage of linebreaks for each pair of parentheses. It reports an error if one parenthesis in the pair has a linebreak inside it and the other parenthesis does not.
-* `"consistent-arguments"` requires consistent usage of linebreaks for each pair of parentheses and parameters/arguments. It allows linebreaks inside function parentheses if there is only one parameter/argument.
 * `{ "minItems": value }` requires linebreaks inside function parentheses if the number of parameters/arguments is at least `value`. Otherwise, it disallows linebreaks.
 
 Example configurations:
@@ -226,10 +226,10 @@ foo(
 );
 ```
 
-Examples of **incorrect** code for this rule with the `"consistent-arguments"` option:
+Examples of **incorrect** code for this rule with the `"multiline-arguments"` option:
 
 ```js
-/* eslint function-paren-newline: ["error", "consistent-arguments"] */
+/* eslint function-paren-newline: ["error", "multiline-arguments"] */
 
 function foo(bar,
   baz
@@ -253,10 +253,10 @@ foo(
 );
 ```
 
-Examples of **correct** code for this rule with the consistent `"consistent-arguments"` option:
+Examples of **correct** code for this rule with the consistent `"multiline-arguments"` option:
 
 ```js
-/* eslint function-paren-newline: ["error", "consistent-arguments"] */
+/* eslint function-paren-newline: ["error", "multiline-arguments"] */
 
 function foo(
   bar,

--- a/lib/rules/function-paren-newline.js
+++ b/lib/rules/function-paren-newline.js
@@ -31,7 +31,7 @@ module.exports = {
             {
                 oneOf: [
                     {
-                        enum: ["always", "never", "consistent", "multiline", "consistent-arguments"]
+                        enum: ["always", "never", "consistent", "multiline", "multiline-arguments"]
                     },
                     {
                         type: "object",
@@ -60,7 +60,7 @@ module.exports = {
         const sourceCode = context.getSourceCode();
         const rawOption = context.options[0] || "multiline";
         const multilineOption = rawOption === "multiline";
-        const consistentArgumentsOption = rawOption === "consistent-arguments";
+        const multilineArgumentsOption = rawOption === "multiline-arguments";
         const consistentOption = rawOption === "consistent";
         let minItems;
 
@@ -85,10 +85,10 @@ module.exports = {
          * @returns {boolean} `true` if there should be newlines inside the function parens
          */
         function shouldHaveNewlines(elements, hasLeftNewline) {
-            if (consistentArgumentsOption && elements.length === 1) {
+            if (multilineArgumentsOption && elements.length === 1) {
                 return hasLeftNewline;
             }
-            if (multilineOption || consistentArgumentsOption) {
+            if (multilineOption || multilineArgumentsOption) {
                 return elements.some((element, index) => index !== elements.length - 1 && element.loc.end.line !== elements[index + 1].loc.start.line);
             }
             if (consistentOption) {
@@ -248,7 +248,7 @@ module.exports = {
             if (parens) {
                 validateParens(parens, astUtils.isFunction(node) ? node.params : node.arguments);
 
-                if (consistentArgumentsOption) {
+                if (multilineArgumentsOption) {
                     validateArguments(parens, astUtils.isFunction(node) ? node.params : node.arguments);
                 }
             }

--- a/lib/rules/function-paren-newline.js
+++ b/lib/rules/function-paren-newline.js
@@ -31,7 +31,7 @@ module.exports = {
             {
                 oneOf: [
                     {
-                        enum: ["always", "never", "consistent", "multiline"]
+                        enum: ["always", "never", "consistent", "multiline", "consistent-arguments"]
                     },
                     {
                         type: "object",
@@ -50,6 +50,7 @@ module.exports = {
         messages: {
             expectedBefore: "Expected newline before ')'.",
             expectedAfter: "Expected newline after '('.",
+            expectedBetween: "Expected newline between arguments/params.",
             unexpectedBefore: "Unexpected newline before '('.",
             unexpectedAfter: "Unexpected newline after ')'."
         }
@@ -59,6 +60,7 @@ module.exports = {
         const sourceCode = context.getSourceCode();
         const rawOption = context.options[0] || "multiline";
         const multilineOption = rawOption === "multiline";
+        const consistentArgumentsOption = rawOption === "consistent-arguments";
         const consistentOption = rawOption === "consistent";
         let minItems;
 
@@ -83,7 +85,10 @@ module.exports = {
          * @returns {boolean} `true` if there should be newlines inside the function parens
          */
         function shouldHaveNewlines(elements, hasLeftNewline) {
-            if (multilineOption) {
+            if (consistentArgumentsOption && elements.length === 1) {
+                return hasLeftNewline;
+            }
+            if (multilineOption || consistentArgumentsOption) {
                 return elements.some((element, index) => index !== elements.length - 1 && element.loc.end.line !== elements[index + 1].loc.start.line);
             }
             if (consistentOption) {
@@ -93,7 +98,7 @@ module.exports = {
         }
 
         /**
-         * Validates a list of arguments or parameters
+         * Validates parens
          * @param {Object} parens An object with keys `leftParen` for the left paren token, and `rightParen` for the right paren token
          * @param {ASTNode[]} elements The arguments or parameters in the list
          * @returns {void}
@@ -145,6 +150,33 @@ module.exports = {
                     messageId: "expectedBefore",
                     fix: fixer => fixer.insertTextBefore(rightParen, "\n")
                 });
+            }
+        }
+
+        /**
+         * Validates a list of arguments or parameters
+         * @param {Object} parens An object with keys `leftParen` for the left paren token, and `rightParen` for the right paren token
+         * @param {ASTNode[]} elements The arguments or parameters in the list
+         * @returns {void}
+         */
+        function validateArguments(parens, elements) {
+            const leftParen = parens.leftParen;
+            const tokenAfterLeftParen = sourceCode.getTokenAfter(leftParen);
+            const hasLeftNewline = !astUtils.isTokenOnSameLine(leftParen, tokenAfterLeftParen);
+            const needsNewlines = shouldHaveNewlines(elements, hasLeftNewline);
+
+            for (let i = 0; i <= elements.length - 2; i++) {
+                const currentElement = elements[i];
+                const nextElement = elements[i + 1];
+                const hasNewLine = currentElement.loc.end.line !== nextElement.loc.start.line;
+
+                if (!hasNewLine && needsNewlines) {
+                    context.report({
+                        node: currentElement,
+                        messageId: "expectedBetween",
+                        fix: fixer => fixer.insertTextBefore(nextElement, "\n")
+                    });
+                }
             }
         }
 
@@ -215,6 +247,10 @@ module.exports = {
 
             if (parens) {
                 validateParens(parens, astUtils.isFunction(node) ? node.params : node.arguments);
+
+                if (consistentArgumentsOption) {
+                    validateArguments(parens, astUtils.isFunction(node) ? node.params : node.arguments);
+                }
             }
         }
 

--- a/tests/lib/rules/function-paren-newline.js
+++ b/tests/lib/rules/function-paren-newline.js
@@ -88,50 +88,50 @@ ruleTester.run("function-paren-newline", rule, {
             options: ["multiline"]
         },
 
-        // consistent-arguments
+        // multiline-arguments
         {
             code: "function baz(foo, bar) {}",
-            options: ["consistent-arguments"]
+            options: ["multiline-arguments"]
         },
         {
             code: "function baz(foo) {}",
-            options: ["consistent-arguments"]
+            options: ["multiline-arguments"]
         },
         {
             code: "(function(foo, bar) {});",
-            options: ["consistent-arguments"]
+            options: ["multiline-arguments"]
         },
         {
             code: "(function(foo) {});",
-            options: ["consistent-arguments"]
+            options: ["multiline-arguments"]
         },
         {
             code: "(function baz(foo, bar) {});",
-            options: ["consistent-arguments"]
+            options: ["multiline-arguments"]
         },
         {
             code: "(function baz(foo) {});",
-            options: ["consistent-arguments"]
+            options: ["multiline-arguments"]
         },
         {
             code: "(foo, bar) => {};",
-            options: ["consistent-arguments"]
+            options: ["multiline-arguments"]
         },
         {
             code: "foo => {};",
-            options: ["consistent-arguments"]
+            options: ["multiline-arguments"]
         },
         {
             code: "baz(foo, bar);",
-            options: ["consistent-arguments"]
+            options: ["multiline-arguments"]
         },
         {
             code: "baz(foo);",
-            options: ["consistent-arguments"]
+            options: ["multiline-arguments"]
         },
         {
             code: "function baz() {}",
-            options: ["consistent-arguments"]
+            options: ["multiline-arguments"]
         },
         {
             code: `
@@ -140,7 +140,7 @@ ruleTester.run("function-paren-newline", rule, {
                     bar
                 ) {}
             `,
-            options: ["consistent-arguments"]
+            options: ["multiline-arguments"]
         },
         {
             code: `
@@ -148,7 +148,7 @@ ruleTester.run("function-paren-newline", rule, {
                     foo
                 ) {}
             `,
-            options: ["consistent-arguments"]
+            options: ["multiline-arguments"]
         },
         {
             code: `
@@ -157,7 +157,7 @@ ruleTester.run("function-paren-newline", rule, {
                     bar
                 ) {});
             `,
-            options: ["consistent-arguments"]
+            options: ["multiline-arguments"]
         },
         {
             code: `
@@ -165,7 +165,7 @@ ruleTester.run("function-paren-newline", rule, {
                     foo
                 ) {});
             `,
-            options: ["consistent-arguments"]
+            options: ["multiline-arguments"]
         },
         {
             code: `
@@ -174,7 +174,7 @@ ruleTester.run("function-paren-newline", rule, {
                     bar
                 ) {});
             `,
-            options: ["consistent-arguments"]
+            options: ["multiline-arguments"]
         },
         {
             code: `
@@ -182,7 +182,7 @@ ruleTester.run("function-paren-newline", rule, {
                     foo
                 ) {});
             `,
-            options: ["consistent-arguments"]
+            options: ["multiline-arguments"]
         },
         {
             code: `
@@ -191,7 +191,7 @@ ruleTester.run("function-paren-newline", rule, {
                     bar
                 ) => {};
             `,
-            options: ["consistent-arguments"]
+            options: ["multiline-arguments"]
         },
         {
             code: `
@@ -199,7 +199,7 @@ ruleTester.run("function-paren-newline", rule, {
                     foo
                 ) => {};
             `,
-            options: ["consistent-arguments"]
+            options: ["multiline-arguments"]
         },
         {
             code: `
@@ -208,7 +208,7 @@ ruleTester.run("function-paren-newline", rule, {
                     bar
                 );
             `,
-            options: ["consistent-arguments"]
+            options: ["multiline-arguments"]
         },
         {
             code: `
@@ -216,30 +216,30 @@ ruleTester.run("function-paren-newline", rule, {
                     foo
                 );
             `,
-            options: ["consistent-arguments"]
+            options: ["multiline-arguments"]
         },
         {
             code: `
                 baz(\`foo
                     bar\`)
             `,
-            options: ["consistent-arguments"]
+            options: ["multiline-arguments"]
         },
         {
             code: "new Foo(bar, baz)",
-            options: ["consistent-arguments"]
+            options: ["multiline-arguments"]
         },
         {
             code: "new Foo(bar)",
-            options: ["consistent-arguments"]
+            options: ["multiline-arguments"]
         },
         {
             code: "new Foo",
-            options: ["consistent-arguments"]
+            options: ["multiline-arguments"]
         },
         {
             code: "new (Foo)",
-            options: ["consistent-arguments"]
+            options: ["multiline-arguments"]
         },
 
         {
@@ -247,7 +247,7 @@ ruleTester.run("function-paren-newline", rule, {
                 (foo)
                 (bar)
             `,
-            options: ["consistent-arguments"]
+            options: ["multiline-arguments"]
         },
         {
             code: `
@@ -255,7 +255,7 @@ ruleTester.run("function-paren-newline", rule, {
                   return value;
                 })
             `,
-            options: ["consistent-arguments"]
+            options: ["multiline-arguments"]
         },
 
         // always option
@@ -515,7 +515,7 @@ ruleTester.run("function-paren-newline", rule, {
             errors: [RIGHT_UNEXPECTED_ERROR]
         },
 
-        // consistent-arguments
+        // multiline-arguments
         {
             code: `
                 function baz(foo,
@@ -527,7 +527,7 @@ ruleTester.run("function-paren-newline", rule, {
                     bar
                 ) {}
             `,
-            options: ["consistent-arguments"],
+            options: ["multiline-arguments"],
             errors: [LEFT_MISSING_ERROR]
         },
         {
@@ -541,7 +541,7 @@ ruleTester.run("function-paren-newline", rule, {
                     foo,
                     bar\n) {})
             `,
-            options: ["consistent-arguments"],
+            options: ["multiline-arguments"],
             errors: [RIGHT_MISSING_ERROR]
         },
         {
@@ -553,7 +553,7 @@ ruleTester.run("function-paren-newline", rule, {
                 (function baz(\nfoo,
                     bar\n) {})
             `,
-            options: ["consistent-arguments"],
+            options: ["multiline-arguments"],
             errors: [LEFT_MISSING_ERROR, RIGHT_MISSING_ERROR]
         },
         {
@@ -564,7 +564,7 @@ ruleTester.run("function-paren-newline", rule, {
             output: `
                 baz(foo, bar);
             `,
-            options: ["consistent-arguments"],
+            options: ["multiline-arguments"],
             errors: [LEFT_UNEXPECTED_ERROR]
         },
         {
@@ -575,7 +575,7 @@ ruleTester.run("function-paren-newline", rule, {
             output: `
                 (foo, bar) => {};
             `,
-            options: ["consistent-arguments"],
+            options: ["multiline-arguments"],
             errors: [RIGHT_UNEXPECTED_ERROR]
         },
         {
@@ -587,7 +587,7 @@ ruleTester.run("function-paren-newline", rule, {
             output: `
                 function baz(foo, bar) {}
             `,
-            options: ["consistent-arguments"],
+            options: ["multiline-arguments"],
             errors: [LEFT_UNEXPECTED_ERROR, RIGHT_UNEXPECTED_ERROR]
         },
         {
@@ -598,7 +598,7 @@ ruleTester.run("function-paren-newline", rule, {
             output: `
                 function baz() {}
             `,
-            options: ["consistent-arguments"],
+            options: ["multiline-arguments"],
             errors: [LEFT_UNEXPECTED_ERROR, RIGHT_UNEXPECTED_ERROR]
         },
         {
@@ -610,7 +610,7 @@ ruleTester.run("function-paren-newline", rule, {
                 new Foo(\nbar,
                     baz\n);
             `,
-            options: ["consistent-arguments"],
+            options: ["multiline-arguments"],
             errors: [LEFT_MISSING_ERROR, RIGHT_MISSING_ERROR]
         },
         {
@@ -622,7 +622,7 @@ ruleTester.run("function-paren-newline", rule, {
                 function baz(/* not fixed due to comment */
                 foo\n) {}
             `,
-            options: ["consistent-arguments"],
+            options: ["multiline-arguments"],
             errors: [RIGHT_MISSING_ERROR]
         },
         {
@@ -631,7 +631,7 @@ ruleTester.run("function-paren-newline", rule, {
                 /* not fixed due to comment */) {}
             `,
             output: null,
-            options: ["consistent-arguments"],
+            options: ["multiline-arguments"],
             errors: [RIGHT_UNEXPECTED_ERROR]
         },
         {
@@ -647,7 +647,7 @@ ruleTester.run("function-paren-newline", rule, {
                     foo, \nbar
                 ) {}
             `,
-            options: ["consistent-arguments"],
+            options: ["multiline-arguments"],
             errors: [EXPECTED_BETWEEN]
         },
         {
@@ -663,7 +663,7 @@ ruleTester.run("function-paren-newline", rule, {
                     bar
                 ) {}
             `,
-            options: ["consistent-arguments"],
+            options: ["multiline-arguments"],
             errors: [EXPECTED_BETWEEN]
         },
         {
@@ -675,7 +675,7 @@ ruleTester.run("function-paren-newline", rule, {
                 function baz(\nqwe, \nfoo,
                     bar\n) {}
             `,
-            options: ["consistent-arguments"],
+            options: ["multiline-arguments"],
             errors: [LEFT_MISSING_ERROR, EXPECTED_BETWEEN, RIGHT_MISSING_ERROR]
         },
         {
@@ -687,7 +687,7 @@ ruleTester.run("function-paren-newline", rule, {
                 baz(
                     foo\n);
             `,
-            options: ["consistent-arguments"],
+            options: ["multiline-arguments"],
             errors: [RIGHT_MISSING_ERROR]
         },
         {
@@ -698,7 +698,7 @@ ruleTester.run("function-paren-newline", rule, {
             output: `
                 baz(foo);
             `,
-            options: ["consistent-arguments"],
+            options: ["multiline-arguments"],
             errors: [RIGHT_UNEXPECTED_ERROR]
         },
 

--- a/tests/lib/rules/function-paren-newline.js
+++ b/tests/lib/rules/function-paren-newline.js
@@ -20,6 +20,7 @@ const LEFT_MISSING_ERROR = { messageId: "expectedAfter", type: "Punctuator" };
 const LEFT_UNEXPECTED_ERROR = { messageId: "unexpectedAfter", type: "Punctuator" };
 const RIGHT_MISSING_ERROR = { messageId: "expectedBefore", type: "Punctuator" };
 const RIGHT_UNEXPECTED_ERROR = { messageId: "unexpectedBefore", type: "Punctuator" };
+const EXPECTED_BETWEEN = { messageId: "expectedBetween", type: "Identifier" };
 
 const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
 
@@ -82,12 +83,182 @@ ruleTester.run("function-paren-newline", rule, {
               return value;
             })
         `,
-
-        // always option
         {
             code: "function baz(foo, bar) {}",
             options: ["multiline"]
         },
+
+        // consistent-arguments
+        {
+            code: "function baz(foo, bar) {}",
+            options: ["consistent-arguments"]
+        },
+        {
+            code: "function baz(foo) {}",
+            options: ["consistent-arguments"]
+        },
+        {
+            code: "(function(foo, bar) {});",
+            options: ["consistent-arguments"]
+        },
+        {
+            code: "(function(foo) {});",
+            options: ["consistent-arguments"]
+        },
+        {
+            code: "(function baz(foo, bar) {});",
+            options: ["consistent-arguments"]
+        },
+        {
+            code: "(function baz(foo) {});",
+            options: ["consistent-arguments"]
+        },
+        {
+            code: "(foo, bar) => {};",
+            options: ["consistent-arguments"]
+        },
+        {
+            code: "foo => {};",
+            options: ["consistent-arguments"]
+        },
+        {
+            code: "baz(foo, bar);",
+            options: ["consistent-arguments"]
+        },
+        {
+            code: "baz(foo);",
+            options: ["consistent-arguments"]
+        },
+        {
+            code: "function baz() {}",
+            options: ["consistent-arguments"]
+        },
+        {
+            code: `
+                function baz(
+                    foo,
+                    bar
+                ) {}
+            `,
+            options: ["consistent-arguments"]
+        },
+        {
+            code: `
+                function baz(
+                    foo
+                ) {}
+            `,
+            options: ["consistent-arguments"]
+        },
+        {
+            code: `
+                (function(
+                    foo,
+                    bar
+                ) {});
+            `,
+            options: ["consistent-arguments"]
+        },
+        {
+            code: `
+                (function(
+                    foo
+                ) {});
+            `,
+            options: ["consistent-arguments"]
+        },
+        {
+            code: `
+                (function baz(
+                    foo,
+                    bar
+                ) {});
+            `,
+            options: ["consistent-arguments"]
+        },
+        {
+            code: `
+                (function baz(
+                    foo
+                ) {});
+            `,
+            options: ["consistent-arguments"]
+        },
+        {
+            code: `
+                (
+                    foo,
+                    bar
+                ) => {};
+            `,
+            options: ["consistent-arguments"]
+        },
+        {
+            code: `
+                (
+                    foo
+                ) => {};
+            `,
+            options: ["consistent-arguments"]
+        },
+        {
+            code: `
+                baz(
+                    foo,
+                    bar
+                );
+            `,
+            options: ["consistent-arguments"]
+        },
+        {
+            code: `
+                baz(
+                    foo
+                );
+            `,
+            options: ["consistent-arguments"]
+        },
+        {
+            code: `
+                baz(\`foo
+                    bar\`)
+            `,
+            options: ["consistent-arguments"]
+        },
+        {
+            code: "new Foo(bar, baz)",
+            options: ["consistent-arguments"]
+        },
+        {
+            code: "new Foo(bar)",
+            options: ["consistent-arguments"]
+        },
+        {
+            code: "new Foo",
+            options: ["consistent-arguments"]
+        },
+        {
+            code: "new (Foo)",
+            options: ["consistent-arguments"]
+        },
+
+        {
+            code: `
+                (foo)
+                (bar)
+            `,
+            options: ["consistent-arguments"]
+        },
+        {
+            code: `
+                foo.map(value => {
+                  return value;
+                })
+            `,
+            options: ["consistent-arguments"]
+        },
+
+        // always option
         {
             code: `
                 function baz(
@@ -341,6 +512,193 @@ ruleTester.run("function-paren-newline", rule, {
                 /* not fixed due to comment */) {}
             `,
             output: null,
+            errors: [RIGHT_UNEXPECTED_ERROR]
+        },
+
+        // consistent-arguments
+        {
+            code: `
+                function baz(foo,
+                    bar
+                ) {}
+            `,
+            output: `
+                function baz(\nfoo,
+                    bar
+                ) {}
+            `,
+            options: ["consistent-arguments"],
+            errors: [LEFT_MISSING_ERROR]
+        },
+        {
+            code: `
+                (function(
+                    foo,
+                    bar) {})
+            `,
+            output: `
+                (function(
+                    foo,
+                    bar\n) {})
+            `,
+            options: ["consistent-arguments"],
+            errors: [RIGHT_MISSING_ERROR]
+        },
+        {
+            code: `
+                (function baz(foo,
+                    bar) {})
+            `,
+            output: `
+                (function baz(\nfoo,
+                    bar\n) {})
+            `,
+            options: ["consistent-arguments"],
+            errors: [LEFT_MISSING_ERROR, RIGHT_MISSING_ERROR]
+        },
+        {
+            code: `
+                baz(
+                    foo, bar);
+            `,
+            output: `
+                baz(foo, bar);
+            `,
+            options: ["consistent-arguments"],
+            errors: [LEFT_UNEXPECTED_ERROR]
+        },
+        {
+            code: `
+                (foo, bar
+                ) => {};
+            `,
+            output: `
+                (foo, bar) => {};
+            `,
+            options: ["consistent-arguments"],
+            errors: [RIGHT_UNEXPECTED_ERROR]
+        },
+        {
+            code: `
+                function baz(
+                    foo, bar
+                ) {}
+            `,
+            output: `
+                function baz(foo, bar) {}
+            `,
+            options: ["consistent-arguments"],
+            errors: [LEFT_UNEXPECTED_ERROR, RIGHT_UNEXPECTED_ERROR]
+        },
+        {
+            code: `
+                function baz(
+                ) {}
+            `,
+            output: `
+                function baz() {}
+            `,
+            options: ["consistent-arguments"],
+            errors: [LEFT_UNEXPECTED_ERROR, RIGHT_UNEXPECTED_ERROR]
+        },
+        {
+            code: `
+                new Foo(bar,
+                    baz);
+            `,
+            output: `
+                new Foo(\nbar,
+                    baz\n);
+            `,
+            options: ["consistent-arguments"],
+            errors: [LEFT_MISSING_ERROR, RIGHT_MISSING_ERROR]
+        },
+        {
+            code: `
+                function baz(/* not fixed due to comment */
+                foo) {}
+            `,
+            output: `
+                function baz(/* not fixed due to comment */
+                foo\n) {}
+            `,
+            options: ["consistent-arguments"],
+            errors: [RIGHT_MISSING_ERROR]
+        },
+        {
+            code: `
+                function baz(foo
+                /* not fixed due to comment */) {}
+            `,
+            output: null,
+            options: ["consistent-arguments"],
+            errors: [RIGHT_UNEXPECTED_ERROR]
+        },
+        {
+            code: `
+                function baz(
+                    qwe,
+                    foo, bar
+                ) {}
+            `,
+            output: `
+                function baz(
+                    qwe,
+                    foo, \nbar
+                ) {}
+            `,
+            options: ["consistent-arguments"],
+            errors: [EXPECTED_BETWEEN]
+        },
+        {
+            code: `
+                function baz(
+                    qwe, foo,
+                    bar
+                ) {}
+            `,
+            output: `
+                function baz(
+                    qwe, \nfoo,
+                    bar
+                ) {}
+            `,
+            options: ["consistent-arguments"],
+            errors: [EXPECTED_BETWEEN]
+        },
+        {
+            code: `
+                function baz(qwe, foo,
+                    bar) {}
+            `,
+            output: `
+                function baz(\nqwe, \nfoo,
+                    bar\n) {}
+            `,
+            options: ["consistent-arguments"],
+            errors: [LEFT_MISSING_ERROR, EXPECTED_BETWEEN, RIGHT_MISSING_ERROR]
+        },
+        {
+            code: `
+                baz(
+                    foo);
+            `,
+            output: `
+                baz(
+                    foo\n);
+            `,
+            options: ["consistent-arguments"],
+            errors: [RIGHT_MISSING_ERROR]
+        },
+        {
+            code: `
+                baz(foo
+                    );
+            `,
+            output: `
+                baz(foo);
+            `,
+            options: ["consistent-arguments"],
             errors: [RIGHT_UNEXPECTED_ERROR]
         },
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

- [ ] Documentation update
- [ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
- [ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
- [X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

**What rule do you want to change?**
`function-paren-newline`

**How will the change be implemented? (New option, new default behavior, etc.)?**
New option `consistent-arguments`.

**What changes did you make? (Give an overview)**

`"consistent-arguments"` requires consistent usage of linebreaks for each pair of parentheses and parameters/arguments. It allows linebreaks inside function parentheses if there is only one parameter/argument.

Examples of **incorrect** code for this rule with the `"consistent-arguments"` option:

```js
/* eslint function-paren-newline: ["error", "consistent-arguments"] */

function foo(bar,
  baz
) {}

var foo = function(bar,
  baz
) {};

var foo = (
  bar,
  baz) => {};

foo(
  bar,
  baz);

foo(
  bar, qux,
  baz
);
```

Examples of **correct** code for this rule with the consistent `"consistent-arguments"` option:

```js
/* eslint function-paren-newline: ["error", "consistent-arguments"] */

function foo(
  bar,
  baz
) {}

var foo = function(bar, baz) {};

var foo = (
  bar
) => {};

foo(
  function() {
    return baz;
  }
);
```

**Is there anything you'd like reviewers to focus on?**

There are some issues about this problem :: https://github.com/eslint/eslint/issues/9286 :: https://github.com/eslint/eslint/issues/9411

For `multiline` option this is obvious behavior when you can use single argument on their own line. But now for this you should use less strict `consistent` option.

```js
console.log(foo,
  bar,
  baz);
```
Airbnb JavaScript Style Guide [define this code as bad](https://github.com/airbnb/javascript#functions--signature-invocation-indentation). But their eslint config now use `consistent` option that miss many bad cases because `multiline` option disallow to use single argument on their own line. Until then they were forced to use [additional parens](https://github.com/airbnb/javascript/issues/1584) as workaround.
