### PR TITLE
Update: Add --no-warn-ignored CLI option to suppress ignored file warnings (fixes #9977)

### DIFF
--- a/conf/default-cli-options.js
+++ b/conf/default-cli-options.js
@@ -15,6 +15,7 @@ module.exports = {
     extensions: [".js"],
     ignore: true,
     ignorePath: null,
+    warnIgnored: true,
     cache: false,
 
     /*

--- a/docs/user-guide/command-line-interface.md
+++ b/docs/user-guide/command-line-interface.md
@@ -52,6 +52,7 @@ Ignoring files:
   --ignore-path path::String     Specify path of ignore file
   --no-ignore                    Disable use of ignore files and patterns
   --ignore-pattern [String]      Pattern of files to ignore (in addition to those in .eslintignore)
+  --no-warn-ignored              Disable the warnings produced by ignored files being in list of files to be linted
 
 Using stdin:
   --stdin                        Lint code provided on <STDIN> - default: false

--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -57,6 +57,7 @@ const validFixTypes = new Set(["problem", "suggestion", "layout"]);
  * @property {boolean} ignore False disables use of .eslintignore.
  * @property {string} ignorePath The ignore file to use instead of .eslintignore.
  * @property {string} ignorePattern A glob pattern of files to ignore.
+ * @property {boolean} warnIgnored default true. adds warning reports for files requested to be linted but were ignored.
  * @property {boolean} useEslintrc False disables looking for .eslintrc
  * @property {string} parser The name of the parser to use.
  * @property {Object} parserOptions An object of parserOption settings to use.
@@ -263,15 +264,15 @@ function createIgnoreResult(filePath, baseDir) {
     const isInBowerComponents = baseDir && path.relative(baseDir, filePath).startsWith("bower_components");
 
     if (isHidden) {
-        message = "File ignored by default.  Use a negated ignore pattern (like \"--ignore-pattern '!<relative/path/to/filename>'\") to override.";
+        message = "File ignored by default.  Use a negated ignore pattern (like \"--ignore-pattern '!<relative/path/to/filename>'\") to override " +
+            "or --no-warn-ignored to suppress this warning.";
     } else if (isInNodeModules) {
-        message = "File ignored by default. Use \"--ignore-pattern '!node_modules/*'\" to override.";
+        message = "File ignored by default. Use \"--ignore-pattern '!node_modules/*'\" to override or --no-warn-ignored to suppress this warning.";
     } else if (isInBowerComponents) {
-        message = "File ignored by default. Use \"--ignore-pattern '!bower_components/*'\" to override.";
+        message = "File ignored by default. Use \"--ignore-pattern '!bower_components/*'\" to override or --no-warn-ignored to suppress this warning.";
     } else {
-        message = "File ignored because of a matching ignore pattern. Use \"--no-ignore\" to override.";
+        message = "File ignored because of a matching ignore pattern. Use \"--no-ignore\" to override or --no-warn-ignored to suppress this warning.";
     }
-
     return {
         filePath: path.resolve(filePath),
         messages: [
@@ -587,7 +588,17 @@ class CLIEngine {
         const allUsedRules = new Set();
         const results = fileList.map(fileInfo => {
             if (fileInfo.ignored) {
-                return createIgnoreResult(fileInfo.filename, options.cwd);
+                if (options.warnIgnored) {
+                    return createIgnoreResult(fileInfo.filename, options.cwd);
+                }
+                return {
+                    filePath: path.resolve(fileInfo.filename),
+                    messages: [],
+                    errorCount: 0,
+                    warningCount: 0,
+                    fixableErrorCount: 0,
+                    fixableWarningCount: 0
+                };
             }
 
             if (options.cache) {

--- a/lib/options.js
+++ b/lib/options.js
@@ -125,6 +125,12 @@ module.exports = optionator({
             }]
         },
         {
+            option: "warn-ignored",
+            type: "Boolean",
+            default: "true",
+            description: "Disable the warnings produced by ignored files being in list of files to be linted"
+        },
+        {
             heading: "Using stdin"
         },
         {


### PR DESCRIPTION
As referenced from multiple prior issues (#9977, #5623, #905, #8353), using eslint in a monorepo style repository where it is only run on changed files is difficult with its default configuration because of warnings generated on ignored files.

This PR adds a '--no-warn-ignored' command line flag similar to the inverse of the (warnIgnored) third parameter to the executeOnText function of the cli-engine which sets a new "warnIgnored" boolean option on the CLIEngineOptions to false.  The default of this option is true as it maintains the current behavior of emitting a warning if a file is linted but ignored for by default or by configuration. 

However if "warnIgnored" is passed as false in your eslint options or --no-warn-ignored is passed as a CLI option, files that were ignored by default or by custom configuration will no longer generate warnings (they will silently succeed) if listed explicitly in the list of files to lint (or matched by glob pattern).

lib/options.js has been updated with the new option so that help menus should show it appropriately and docs/user-guide/command-line-interface.md has the new option documented as well.

Test cases are included with this PR that cover all changes to existing warning messages (which now mention the new cli option).