### PR TITLE
Chore: lint all files in the repo at the same time

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -63,8 +63,6 @@ const NODE = "node ", // intentional extra space
     ESLINT = `${NODE} bin/eslint.js --report-unused-disable-directives `,
 
     // Files
-    MAKEFILE = "./Makefile.js",
-    JS_FILES = "\"lib/**/*.js\" \"conf/**/*.js\" \"bin/**/*.js\" \"tools/**/*.js\"",
     JSON_FILES = find("conf/").filter(fileType("json")),
     MARKDOWN_FILES_ARRAY = find("docs/").concat(ls(".")).filter(fileType("md")),
     TEST_FILES = getTestFilePatterns(),
@@ -502,14 +500,8 @@ target.lint = function() {
     let errors = 0,
         lastReturn;
 
-    echo("Validating Makefile.js");
-    lastReturn = exec(`${ESLINT} ${MAKEFILE}`);
-    if (lastReturn.code !== 0) {
-        errors++;
-    }
-
-    echo("Validating .eslintrc.js");
-    lastReturn = exec(`${ESLINT} .eslintrc.js`);
+    echo("Validating JavaScript files");
+    lastReturn = exec(`${ESLINT} .`);
     if (lastReturn.code !== 0) {
         errors++;
     }
@@ -519,18 +511,6 @@ target.lint = function() {
 
     echo("Validating Markdown Files");
     lastReturn = lintMarkdown(MARKDOWN_FILES_ARRAY);
-    if (lastReturn.code !== 0) {
-        errors++;
-    }
-
-    echo("Validating JavaScript files");
-    lastReturn = exec(`${ESLINT} ${JS_FILES}`);
-    if (lastReturn.code !== 0) {
-        errors++;
-    }
-
-    echo("Validating JavaScript test files");
-    lastReturn = exec(`${ESLINT} "tests/**/*.js"`);
     if (lastReturn.code !== 0) {
         errors++;
     }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -9,8 +9,10 @@ module.exports = function(config) {
         basePath: "",
 
 
-        // frameworks to use
-        // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+        /*
+         * frameworks to use
+         * available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+         */
         frameworks: ["mocha"],
 
 
@@ -26,8 +28,10 @@ module.exports = function(config) {
         ],
 
 
-        // preprocess matching files before serving them to the browser
-        // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+        /*
+         * preprocess matching files before serving them to the browser
+         * available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+         */
         preprocessors: {
             "tests/lib/linter.js": ["webpack"]
         },
@@ -40,9 +44,11 @@ module.exports = function(config) {
         },
 
 
-        // test results reporter to use
-        // possible values: "dots", "progress"
-        // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+        /*
+         * test results reporter to use
+         * possible values: "dots", "progress"
+         * available reporters: https://npmjs.org/browse/keyword/karma-reporter
+         */
         reporters: ["mocha"],
 
         mochaReporter: {
@@ -57,8 +63,10 @@ module.exports = function(config) {
         colors: true,
 
 
-        // level of logging
-        // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+        /*
+         * level of logging
+         * possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+         */
         logLevel: config.LOG_INFO,
 
 
@@ -66,22 +74,28 @@ module.exports = function(config) {
         autoWatch: false,
 
 
-        // start these browsers
-        // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+        /*
+         * start these browsers
+         * available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+         */
         browsers: ["HeadlessChrome"],
         customLaunchers: {
-          HeadlessChrome: {
-            base: 'ChromeHeadless',
-            flags: [ '--no-sandbox', ],
-             },
-            },
+            HeadlessChrome: {
+                base: "ChromeHeadless",
+                flags: ["--no-sandbox"]
+            }
+        },
 
-        // Continuous Integration mode
-        // if true, Karma captures browsers, runs the tests and exits
+        /*
+         * Continuous Integration mode
+         * if true, Karma captures browsers, runs the tests and exits
+         */
         singleRun: true,
 
-        // Concurrency level
-        // how many browser should be started simultaneous
+        /*
+         * Concurrency level
+         * how many browser should be started simultaneous
+         */
         concurrency: Infinity
     });
 };

--- a/packages/eslint-config-eslint/index.js
+++ b/packages/eslint-config-eslint/index.js
@@ -1,35 +1,9 @@
 /**
- * @fileoverview Converts YAML file into JSON.
- * @author Nicholas C. Zakas
+ * @fileoverview Index file to allow YAML file to be loaded
+ * @author Teddy Katz
  */
 "use strict";
 
-//------------------------------------------------------------------------------
-// Requirements
-//------------------------------------------------------------------------------
-
-var fs = require("fs"),
-    path = require("path"),
-    yaml = require("js-yaml");
-
-//------------------------------------------------------------------------------
-// Bootstrapping
-//------------------------------------------------------------------------------
-
-var filePath = path.resolve(__dirname, "./default.yml"),
-    config;
-
-try {
-    config = yaml.safeLoad(fs.readFileSync(filePath, "utf8")) || {};
-} catch (e) {
-    console.error(`Error reading YAML file: ${filePath}`);
-    e.message = `Cannot read config file: ${filePath}\nError: ${e.message}`;
-    throw e;
-}
-
-
-//------------------------------------------------------------------------------
-// Public Interface
-//------------------------------------------------------------------------------
-
-module.exports = config;
+module.exports = {
+    extends: ["./default.yml"]
+};

--- a/packages/eslint-config-eslint/package.json
+++ b/packages/eslint-config-eslint/package.json
@@ -19,9 +19,6 @@
   },
   "homepage": "https://eslint.org",
   "bugs": "https://github.com/eslint/eslint/issues/",
-  "dependencies": {
-    "js-yaml": "^3.12.1"
-  },
   "peerDependencies": {
     "eslint-plugin-node": "^6.0.1 || ^7.0.1 || ^8.0.0"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,5 @@
+"use strict";
+
 module.exports = {
     mode: "none",
     entry: ["@babel/polyfill", "./lib/linter.js"],


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Previously, `npm run lint` would invoke ESLint three separate times for different sets of files. There doesn't seem to have been a clear reason for this (it was added in 9b8c639d35d154a27b81470cd432a1ae0e707ef7 about 5 years ago), and some files in the repo were inadvertently being missed. This commit updates the lint task to simply invoke ESLint once on the entire repository. It also fixes some linting errors in files that were previously being skipped.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
