### PR TITLE
Update: remove invalid defaults from core rules (fixes #11415)

### DIFF
--- a/lib/rules/array-bracket-newline.js
+++ b/lib/rules/array-bracket-newline.js
@@ -34,13 +34,11 @@ module.exports = {
                         type: "object",
                         properties: {
                             multiline: {
-                                type: "boolean",
-                                default: true
+                                type: "boolean"
                             },
                             minItems: {
                                 type: ["integer", "null"],
-                                minimum: 0,
-                                default: null
+                                minimum: 0
                             }
                         },
                         additionalProperties: false

--- a/lib/rules/array-element-newline.js
+++ b/lib/rules/array-element-newline.js
@@ -34,13 +34,11 @@ module.exports = {
                         type: "object",
                         properties: {
                             multiline: {
-                                type: "boolean",
-                                default: false
+                                type: "boolean"
                             },
                             minItems: {
                                 type: ["integer", "null"],
-                                minimum: 0,
-                                default: null
+                                minimum: 0
                             }
                         },
                         additionalProperties: false

--- a/lib/rules/arrow-body-style.js
+++ b/lib/rules/arrow-body-style.js
@@ -46,7 +46,7 @@ module.exports = {
                         {
                             type: "object",
                             properties: {
-                                requireReturnForObjectLiteral: { type: "boolean", default: false }
+                                requireReturnForObjectLiteral: { type: "boolean" }
                             },
                             additionalProperties: false
                         }

--- a/lib/rules/capitalized-comments.js
+++ b/lib/rules/capitalized-comments.js
@@ -28,27 +28,22 @@ const SCHEMA_BODY = {
     type: "object",
     properties: {
         ignorePattern: {
-            type: "string",
-            default: ""
+            type: "string"
         },
         ignoreInlineComments: {
-            type: "boolean",
-            default: false
+            type: "boolean"
         },
         ignoreConsecutiveComments: {
-            type: "boolean",
-            default: false
+            type: "boolean"
         }
     },
     additionalProperties: false
 };
-const DEFAULTS = Object.keys(SCHEMA_BODY.properties).reduce(
-    (obj, current) => {
-        obj[current] = SCHEMA_BODY.properties[current].default;
-        return obj;
-    },
-    {}
-);
+const DEFAULTS = {
+    ignorePattern: "",
+    ignoreInlineComments: false,
+    ignoreConsecutiveComments: false
+};
 
 /**
  * Get normalized options for either block or line comments from the given

--- a/lib/rules/complexity.js
+++ b/lib/rules/complexity.js
@@ -41,13 +41,11 @@ module.exports = {
                         properties: {
                             maximum: {
                                 type: "integer",
-                                minimum: 0,
-                                default: 20
+                                minimum: 0
                             },
                             max: {
                                 type: "integer",
-                                minimum: 0,
-                                default: 20
+                                minimum: 0
                             }
                         },
                         additionalProperties: false
@@ -65,7 +63,10 @@ module.exports = {
         const option = context.options[0];
         let THRESHOLD = 20;
 
-        if (typeof option === "object") {
+        if (
+            typeof option === "object" &&
+            (Object.prototype.hasOwnProperty.call(option, "maximum") || Object.prototype.hasOwnProperty.call(option, "max"))
+        ) {
             THRESHOLD = option.maximum || option.max;
         } else if (typeof option === "number") {
             THRESHOLD = option;

--- a/lib/rules/eqeqeq.js
+++ b/lib/rules/eqeqeq.js
@@ -38,8 +38,7 @@ module.exports = {
                             type: "object",
                             properties: {
                                 null: {
-                                    enum: ["always", "never", "ignore"],
-                                    default: "always"
+                                    enum: ["always", "never", "ignore"]
                                 }
                             },
                             additionalProperties: false

--- a/lib/rules/func-call-spacing.js
+++ b/lib/rules/func-call-spacing.js
@@ -50,8 +50,7 @@ module.exports = {
                             type: "object",
                             properties: {
                                 allowNewlines: {
-                                    type: "boolean",
-                                    default: false
+                                    type: "boolean"
                                 }
                             },
                             additionalProperties: false

--- a/lib/rules/init-declarations.js
+++ b/lib/rules/init-declarations.js
@@ -75,8 +75,7 @@ module.exports = {
                             type: "object",
                             properties: {
                                 ignoreForLoopInit: {
-                                    type: "boolean",
-                                    default: false
+                                    type: "boolean"
                                 }
                             },
                             additionalProperties: false

--- a/lib/rules/key-spacing.js
+++ b/lib/rules/key-spacing.js
@@ -148,20 +148,16 @@ module.exports = {
                                     type: "object",
                                     properties: {
                                         mode: {
-                                            enum: ["strict", "minimum"],
-                                            default: "strict"
+                                            enum: ["strict", "minimum"]
                                         },
                                         on: {
-                                            enum: ["colon", "value"],
-                                            default: "colon"
+                                            enum: ["colon", "value"]
                                         },
                                         beforeColon: {
-                                            type: "boolean",
-                                            default: false
+                                            type: "boolean"
                                         },
                                         afterColon: {
-                                            type: "boolean",
-                                            default: true
+                                            type: "boolean"
                                         }
                                     },
                                     additionalProperties: false
@@ -169,16 +165,13 @@ module.exports = {
                             ]
                         },
                         mode: {
-                            enum: ["strict", "minimum"],
-                            default: "strict"
+                            enum: ["strict", "minimum"]
                         },
                         beforeColon: {
-                            type: "boolean",
-                            default: false
+                            type: "boolean"
                         },
                         afterColon: {
-                            type: "boolean",
-                            default: true
+                            type: "boolean"
                         }
                     },
                     additionalProperties: false
@@ -190,16 +183,13 @@ module.exports = {
                             type: "object",
                             properties: {
                                 mode: {
-                                    enum: ["strict", "minimum"],
-                                    default: "strict"
+                                    enum: ["strict", "minimum"]
                                 },
                                 beforeColon: {
-                                    type: "boolean",
-                                    default: false
+                                    type: "boolean"
                                 },
                                 afterColon: {
-                                    type: "boolean",
-                                    default: true
+                                    type: "boolean"
                                 }
                             },
                             additionalProperties: false
@@ -216,20 +206,16 @@ module.exports = {
                                             type: "object",
                                             properties: {
                                                 mode: {
-                                                    enum: ["strict", "minimum"],
-                                                    default: "strict"
+                                                    enum: ["strict", "minimum"]
                                                 },
                                                 on: {
-                                                    enum: ["colon", "value"],
-                                                    default: "colon"
+                                                    enum: ["colon", "value"]
                                                 },
                                                 beforeColon: {
-                                                    type: "boolean",
-                                                    default: false
+                                                    type: "boolean"
                                                 },
                                                 afterColon: {
-                                                    type: "boolean",
-                                                    default: true
+                                                    type: "boolean"
                                                 }
                                             },
                                             additionalProperties: false
@@ -237,16 +223,13 @@ module.exports = {
                                     ]
                                 },
                                 mode: {
-                                    enum: ["strict", "minimum"],
-                                    default: "strict"
+                                    enum: ["strict", "minimum"]
                                 },
                                 beforeColon: {
-                                    type: "boolean",
-                                    default: false
+                                    type: "boolean"
                                 },
                                 afterColon: {
-                                    type: "boolean",
-                                    default: true
+                                    type: "boolean"
                                 }
                             },
                             additionalProperties: false
@@ -261,16 +244,13 @@ module.exports = {
                             type: "object",
                             properties: {
                                 mode: {
-                                    enum: ["strict", "minimum"],
-                                    default: "strict"
+                                    enum: ["strict", "minimum"]
                                 },
                                 beforeColon: {
-                                    type: "boolean",
-                                    default: false
+                                    type: "boolean"
                                 },
                                 afterColon: {
-                                    type: "boolean",
-                                    default: true
+                                    type: "boolean"
                                 }
                             },
                             additionalProperties: false
@@ -279,16 +259,13 @@ module.exports = {
                             type: "object",
                             properties: {
                                 mode: {
-                                    enum: ["strict", "minimum"],
-                                    default: "strict"
+                                    enum: ["strict", "minimum"]
                                 },
                                 beforeColon: {
-                                    type: "boolean",
-                                    default: false
+                                    type: "boolean"
                                 },
                                 afterColon: {
-                                    type: "boolean",
-                                    default: true
+                                    type: "boolean"
                                 }
                             },
                             additionalProperties: false
@@ -297,20 +274,16 @@ module.exports = {
                             type: "object",
                             properties: {
                                 mode: {
-                                    enum: ["strict", "minimum"],
-                                    default: "strict"
+                                    enum: ["strict", "minimum"]
                                 },
                                 on: {
-                                    enum: ["colon", "value"],
-                                    default: "colon"
+                                    enum: ["colon", "value"]
                                 },
                                 beforeColon: {
-                                    type: "boolean",
-                                    default: false
+                                    type: "boolean"
                                 },
                                 afterColon: {
-                                    type: "boolean",
-                                    default: true
+                                    type: "boolean"
                                 }
                             },
                             additionalProperties: false

--- a/lib/rules/line-comment-position.js
+++ b/lib/rules/line-comment-position.js
@@ -38,12 +38,10 @@ module.exports = {
                                 type: "string"
                             },
                             applyDefaultPatterns: {
-                                type: "boolean",
-                                default: true
+                                type: "boolean"
                             },
                             applyDefaultIgnorePatterns: {
-                                type: "boolean",
-                                default: true
+                                type: "boolean"
                             }
                         },
                         additionalProperties: false
@@ -74,7 +72,7 @@ module.exports = {
             if (Object.prototype.hasOwnProperty.call(options, "applyDefaultIgnorePatterns")) {
                 applyDefaultIgnorePatterns = options.applyDefaultIgnorePatterns;
             } else {
-                applyDefaultIgnorePatterns = options.applyDefaultPatterns;
+                applyDefaultIgnorePatterns = options.applyDefaultPatterns !== false;
             }
         }
 

--- a/lib/rules/max-depth.js
+++ b/lib/rules/max-depth.js
@@ -32,13 +32,11 @@ module.exports = {
                         properties: {
                             maximum: {
                                 type: "integer",
-                                minimum: 0,
-                                default: 4
+                                minimum: 0
                             },
                             max: {
                                 type: "integer",
-                                minimum: 0,
-                                default: 4
+                                minimum: 0
                             }
                         },
                         additionalProperties: false
@@ -61,7 +59,10 @@ module.exports = {
             option = context.options[0];
         let maxDepth = 4;
 
-        if (typeof option === "object") {
+        if (
+            typeof option === "object" &&
+            (Object.prototype.hasOwnProperty.call(option, "maximum") || Object.prototype.hasOwnProperty.call(option, "max"))
+        ) {
             maxDepth = option.maximum || option.max;
         }
         if (typeof option === "number") {

--- a/lib/rules/max-lines.js
+++ b/lib/rules/max-lines.js
@@ -38,16 +38,13 @@ module.exports = {
                         properties: {
                             max: {
                                 type: "integer",
-                                minimum: 0,
-                                default: 300
+                                minimum: 0
                             },
                             skipComments: {
-                                type: "boolean",
-                                default: false
+                                type: "boolean"
                             },
                             skipBlankLines: {
-                                type: "boolean",
-                                default: false
+                                type: "boolean"
                             }
                         },
                         additionalProperties: false
@@ -64,7 +61,7 @@ module.exports = {
         const option = context.options[0];
         let max = 300;
 
-        if (typeof option === "object") {
+        if (typeof option === "object" && Object.prototype.hasOwnProperty.call(option, "max")) {
             max = option.max;
         } else if (typeof option === "number") {
             max = option;

--- a/lib/rules/max-nested-callbacks.js
+++ b/lib/rules/max-nested-callbacks.js
@@ -32,13 +32,11 @@ module.exports = {
                         properties: {
                             maximum: {
                                 type: "integer",
-                                minimum: 0,
-                                default: 10
+                                minimum: 0
                             },
                             max: {
                                 type: "integer",
-                                minimum: 0,
-                                default: 10
+                                minimum: 0
                             }
                         },
                         additionalProperties: false
@@ -59,7 +57,10 @@ module.exports = {
         const option = context.options[0];
         let THRESHOLD = 10;
 
-        if (typeof option === "object") {
+        if (
+            typeof option === "object" &&
+            (Object.prototype.hasOwnProperty.call(option, "maximum") || Object.prototype.hasOwnProperty.call(option, "max"))
+        ) {
             THRESHOLD = option.maximum || option.max;
         } else if (typeof option === "number") {
             THRESHOLD = option;

--- a/lib/rules/max-params.js
+++ b/lib/rules/max-params.js
@@ -40,13 +40,11 @@ module.exports = {
                         properties: {
                             maximum: {
                                 type: "integer",
-                                minimum: 0,
-                                default: 3
+                                minimum: 0
                             },
                             max: {
                                 type: "integer",
-                                minimum: 0,
-                                default: 3
+                                minimum: 0
                             }
                         },
                         additionalProperties: false
@@ -64,7 +62,10 @@ module.exports = {
         const option = context.options[0];
         let numParams = 3;
 
-        if (typeof option === "object") {
+        if (
+            typeof option === "object" &&
+            (Object.prototype.hasOwnProperty.call(option, "maximum") || Object.prototype.hasOwnProperty.call(option, "max"))
+        ) {
             numParams = option.maximum || option.max;
         }
         if (typeof option === "number") {

--- a/lib/rules/max-statements.js
+++ b/lib/rules/max-statements.js
@@ -40,13 +40,11 @@ module.exports = {
                         properties: {
                             maximum: {
                                 type: "integer",
-                                minimum: 0,
-                                default: 10
+                                minimum: 0
                             },
                             max: {
                                 type: "integer",
-                                minimum: 0,
-                                default: 10
+                                minimum: 0
                             }
                         },
                         additionalProperties: false
@@ -80,7 +78,10 @@ module.exports = {
             topLevelFunctions = [];
         let maxStatements = 10;
 
-        if (typeof option === "object") {
+        if (
+            typeof option === "object" &&
+            (Object.prototype.hasOwnProperty.call(option, "maximum") || Object.prototype.hasOwnProperty.call(option, "max"))
+        ) {
             maxStatements = option.maximum || option.max;
         } else if (typeof option === "number") {
             maxStatements = option;

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -44,11 +44,11 @@ module.exports = {
                         {
                             type: "object",
                             properties: {
-                                conditionalAssign: { type: "boolean", default: true },
-                                nestedBinaryExpressions: { type: "boolean", default: true },
-                                returnAssign: { type: "boolean", default: true },
+                                conditionalAssign: { type: "boolean" },
+                                nestedBinaryExpressions: { type: "boolean" },
+                                returnAssign: { type: "boolean" },
                                 ignoreJSX: { enum: ["none", "all", "single-line", "multi-line"] },
-                                enforceForArrowConditionals: { type: "boolean", default: true }
+                                enforceForArrowConditionals: { type: "boolean" }
                             },
                             additionalProperties: false
                         }

--- a/lib/rules/no-mixed-requires.js
+++ b/lib/rules/no-mixed-requires.js
@@ -30,12 +30,10 @@ module.exports = {
                         type: "object",
                         properties: {
                             grouping: {
-                                type: "boolean",
-                                default: false
+                                type: "boolean"
                             },
                             allowCall: {
-                                type: "boolean",
-                                default: false
+                                type: "boolean"
                             }
                         },
                         additionalProperties: false

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -37,26 +37,22 @@ module.exports = {
                         type: "object",
                         properties: {
                             vars: {
-                                enum: ["all", "local"],
-                                default: "all"
+                                enum: ["all", "local"]
                             },
                             varsIgnorePattern: {
                                 type: "string"
                             },
                             args: {
-                                enum: ["all", "after-used", "none"],
-                                default: "after-used"
+                                enum: ["all", "after-used", "none"]
                             },
                             ignoreRestSiblings: {
-                                type: "boolean",
-                                default: false
+                                type: "boolean"
                             },
                             argsIgnorePattern: {
                                 type: "string"
                             },
                             caughtErrors: {
-                                enum: ["all", "none"],
-                                default: "none"
+                                enum: ["all", "none"]
                             },
                             caughtErrorsIgnorePattern: {
                                 type: "string"

--- a/lib/rules/no-use-before-define.js
+++ b/lib/rules/no-use-before-define.js
@@ -154,9 +154,9 @@ module.exports = {
                     {
                         type: "object",
                         properties: {
-                            functions: { type: "boolean", default: true },
-                            classes: { type: "boolean", default: true },
-                            variables: { type: "boolean", default: true }
+                            functions: { type: "boolean" },
+                            classes: { type: "boolean" },
+                            variables: { type: "boolean" }
                         },
                         additionalProperties: false
                     }

--- a/lib/rules/object-curly-newline.js
+++ b/lib/rules/object-curly-newline.js
@@ -26,16 +26,14 @@ const OPTION_VALUE = {
             type: "object",
             properties: {
                 multiline: {
-                    type: "boolean",
-                    default: false
+                    type: "boolean"
                 },
                 minProperties: {
                     type: "integer",
                     minimum: 0
                 },
                 consistent: {
-                    type: "boolean",
-                    default: false
+                    type: "boolean"
                 }
             },
             additionalProperties: false,
@@ -61,9 +59,9 @@ function normalizeOptionValue(value) {
         } else if (value === "never") {
             minProperties = Number.POSITIVE_INFINITY;
         } else {
-            multiline = value.multiline;
+            multiline = Boolean(value.multiline);
             minProperties = value.minProperties || Number.POSITIVE_INFINITY;
-            consistent = value.consistent;
+            consistent = Boolean(value.consistent);
         }
     } else {
         consistent = true;

--- a/lib/rules/object-shorthand.js
+++ b/lib/rules/object-shorthand.js
@@ -57,8 +57,7 @@ module.exports = {
                             type: "object",
                             properties: {
                                 avoidQuotes: {
-                                    type: "boolean",
-                                    default: false
+                                    type: "boolean"
                                 }
                             },
                             additionalProperties: false
@@ -77,16 +76,13 @@ module.exports = {
                             type: "object",
                             properties: {
                                 ignoreConstructors: {
-                                    type: "boolean",
-                                    default: false
+                                    type: "boolean"
                                 },
                                 avoidQuotes: {
-                                    type: "boolean",
-                                    default: false
+                                    type: "boolean"
                                 },
                                 avoidExplicitReturnArrows: {
-                                    type: "boolean",
-                                    default: false
+                                    type: "boolean"
                                 }
                             },
                             additionalProperties: false

--- a/lib/rules/one-var.js
+++ b/lib/rules/one-var.js
@@ -36,16 +36,13 @@ module.exports = {
                                 default: false
                             },
                             var: {
-                                enum: ["always", "never", "consecutive"],
-                                default: "always"
+                                enum: ["always", "never", "consecutive"]
                             },
                             let: {
-                                enum: ["always", "never", "consecutive"],
-                                default: "always"
+                                enum: ["always", "never", "consecutive"]
                             },
                             const: {
-                                enum: ["always", "never", "consecutive"],
-                                default: "always"
+                                enum: ["always", "never", "consecutive"]
                             }
                         },
                         additionalProperties: false

--- a/lib/rules/prefer-destructuring.js
+++ b/lib/rules/prefer-destructuring.js
@@ -36,12 +36,10 @@ module.exports = {
                                 type: "object",
                                 properties: {
                                     array: {
-                                        type: "boolean",
-                                        default: true
+                                        type: "boolean"
                                     },
                                     object: {
-                                        type: "boolean",
-                                        default: true
+                                        type: "boolean"
                                     }
                                 },
                                 additionalProperties: false
@@ -50,12 +48,10 @@ module.exports = {
                                 type: "object",
                                 properties: {
                                     array: {
-                                        type: "boolean",
-                                        default: true
+                                        type: "boolean"
                                     },
                                     object: {
-                                        type: "boolean",
-                                        default: true
+                                        type: "boolean"
                                     }
                                 },
                                 additionalProperties: false
@@ -67,12 +63,10 @@ module.exports = {
                         type: "object",
                         properties: {
                             array: {
-                                type: "boolean",
-                                default: true
+                                type: "boolean"
                             },
                             object: {
-                                type: "boolean",
-                                default: true
+                                type: "boolean"
                             }
                         },
                         additionalProperties: false
@@ -83,8 +77,7 @@ module.exports = {
                 type: "object",
                 properties: {
                     enforceForRenamedProperties: {
-                        type: "boolean",
-                        default: false
+                        type: "boolean"
                     }
                 },
                 additionalProperties: false

--- a/lib/rules/quote-props.js
+++ b/lib/rules/quote-props.js
@@ -32,8 +32,7 @@ module.exports = {
                     type: "array",
                     items: [
                         {
-                            enum: ["always", "as-needed", "consistent", "consistent-as-needed"],
-                            default: "always"
+                            enum: ["always", "as-needed", "consistent", "consistent-as-needed"]
                         }
                     ],
                     minItems: 0,
@@ -43,23 +42,19 @@ module.exports = {
                     type: "array",
                     items: [
                         {
-                            enum: ["always", "as-needed", "consistent", "consistent-as-needed"],
-                            default: "always"
+                            enum: ["always", "as-needed", "consistent", "consistent-as-needed"]
                         },
                         {
                             type: "object",
                             properties: {
                                 keywords: {
-                                    type: "boolean",
-                                    default: false
+                                    type: "boolean"
                                 },
                                 unnecessary: {
-                                    type: "boolean",
-                                    default: true
+                                    type: "boolean"
                                 },
                                 numbers: {
-                                    type: "boolean",
-                                    default: false
+                                    type: "boolean"
                                 }
                             },
                             additionalProperties: false

--- a/lib/rules/quotes.js
+++ b/lib/rules/quotes.js
@@ -100,12 +100,10 @@ module.exports = {
                         type: "object",
                         properties: {
                             avoidEscape: {
-                                type: "boolean",
-                                default: false
+                                type: "boolean"
                             },
                             allowTemplateLiterals: {
-                                type: "boolean",
-                                default: false
+                                type: "boolean"
                             }
                         },
                         additionalProperties: false

--- a/lib/rules/semi.js
+++ b/lib/rules/semi.js
@@ -40,8 +40,7 @@ module.exports = {
                             type: "object",
                             properties: {
                                 beforeStatementContinuationChars: {
-                                    enum: ["always", "any", "never"],
-                                    default: "any"
+                                    enum: ["always", "any", "never"]
                                 }
                             },
                             additionalProperties: false
@@ -59,7 +58,7 @@ module.exports = {
                         {
                             type: "object",
                             properties: {
-                                omitLastInOneLineBlock: { type: "boolean", default: false }
+                                omitLastInOneLineBlock: { type: "boolean" }
                             },
                             additionalProperties: false
                         }
@@ -76,8 +75,8 @@ module.exports = {
         const OPT_OUT_PATTERN = /^[-[(/+`]/; // One of [(/+-`
         const options = context.options[1];
         const never = context.options[0] === "never";
-        const exceptOneLine = options && options.omitLastInOneLineBlock;
-        const beforeStatementContinuationChars = options && options.beforeStatementContinuationChars;
+        const exceptOneLine = Boolean(options && options.omitLastInOneLineBlock);
+        const beforeStatementContinuationChars = options && options.beforeStatementContinuationChars || "any";
         const sourceCode = context.getSourceCode();
 
         //--------------------------------------------------------------------------

--- a/lib/rules/space-before-function-paren.js
+++ b/lib/rules/space-before-function-paren.js
@@ -37,16 +37,13 @@ module.exports = {
                         type: "object",
                         properties: {
                             anonymous: {
-                                enum: ["always", "never", "ignore"],
-                                default: "always"
+                                enum: ["always", "never", "ignore"]
                             },
                             named: {
-                                enum: ["always", "never", "ignore"],
-                                default: "always"
+                                enum: ["always", "never", "ignore"]
                             },
                             asyncArrow: {
-                                enum: ["always", "never", "ignore"],
-                                default: "always"
+                                enum: ["always", "never", "ignore"]
                             }
                         },
                         additionalProperties: false

--- a/lib/rules/yield-star-spacing.js
+++ b/lib/rules/yield-star-spacing.js
@@ -31,8 +31,8 @@ module.exports = {
                     {
                         type: "object",
                         properties: {
-                            before: { type: "boolean", default: false },
-                            after: { type: "boolean", default: true }
+                            before: { type: "boolean" },
+                            after: { type: "boolean" }
                         },
                         additionalProperties: false
                     }

--- a/tests/lib/rules/complexity.js
+++ b/tests/lib/rules/complexity.js
@@ -106,6 +106,11 @@ ruleTester.run("complexity", rule, {
             code: createComplexity(21),
             errors: [makeError("Function 'test'", 21)]
         },
+        {
+            code: createComplexity(21),
+            options: [{}],
+            errors: [makeError("Function 'test'", 21)]
+        },
 
         // object property options
         { code: "function a(x) {}", options: [{ max: 0 }], errors: [makeError("Function 'a'", 1)] }

--- a/tests/lib/rules/line-comment-position.js
+++ b/tests/lib/rules/line-comment-position.js
@@ -80,6 +80,10 @@ ruleTester.run("line-comment-position", rule, {
         {
             code: "// above\n1 + 1; // ignored",
             options: [{ ignorePattern: "ignored" }]
+        },
+        {
+            code: "foo; // eslint-disable-line no-alert",
+            options: [{ position: "above" }]
         }
     ],
 

--- a/tests/lib/rules/max-depth.js
+++ b/tests/lib/rules/max-depth.js
@@ -38,6 +38,9 @@ ruleTester.run("max-depth", rule, {
         { code: "function foo() { if (true) { if (false) { if (true) { if (false) { if (true) { } } } } } }", errors: [{ messageId: "tooDeeply", data: { depth: 5 }, type: "IfStatement" }] },
 
         // object property options
-        { code: "function foo() { if (true) { if (false) { if (true) { } } } }", options: [{ max: 2 }], errors: [{ messageId: "tooDeeply", data: { depth: 3 }, type: "IfStatement" }] }
+        { code: "function foo() { if (true) { if (false) { if (true) { } } } }", options: [{ max: 2 }], errors: [{ messageId: "tooDeeply", data: { depth: 3 }, type: "IfStatement" }] },
+
+        { code: "function foo() { if (a) { if (b) { if (c) { if (d) { if (e) {} } } } } }", options: [{}], errors: [{ messageId: "tooDeeply", data: { depth: 5 } }] },
+        { code: "function foo() { if (true) {} }", options: [{ max: 0 }], errors: [{ messageId: "tooDeeply", data: { depth: 1 } }] }
     ]
 });

--- a/tests/lib/rules/max-lines.js
+++ b/tests/lib/rules/max-lines.js
@@ -148,6 +148,16 @@ ruleTester.run("max-lines", rule, {
             ].join("\n"),
             options: [{ max: 2, skipBlankLines: true }],
             errors: [{ messageId: "exceed", data: { max: 2, actual: 6 } }]
+        },
+        {
+            code: "AAAAAAAA\n".repeat(301).trim(),
+            options: [{}],
+            errors: [{ messageId: "exceed", data: { max: 300, actual: 301 } }]
+        },
+        {
+            code: "A",
+            options: [{ max: 0 }],
+            errors: [{ messageId: "exceed", data: { max: 0, actual: 1 } }]
         }
     ]
 });

--- a/tests/lib/rules/max-nested-callbacks.js
+++ b/tests/lib/rules/max-nested-callbacks.js
@@ -75,6 +75,16 @@ ruleTester.run("max-nested-callbacks", rule, {
             code: nestFunctions(11),
             errors: [{ messageId: "exceed", data: { num: 11, max: 10 }, type: "FunctionExpression" }]
         },
+        {
+            code: nestFunctions(11),
+            options: [{}],
+            errors: [{ messageId: "exceed", data: { num: 11, max: 10 }, type: "FunctionExpression" }]
+        },
+        {
+            code: "foo(function() {})",
+            options: [{ max: 0 }],
+            errors: [{ messageId: "exceed", data: { num: 1, max: 0 } }]
+        },
 
         // object property options
         {

--- a/tests/lib/rules/max-params.js
+++ b/tests/lib/rules/max-params.js
@@ -94,6 +94,22 @@ ruleTester.run("max-params", rule, {
                 type: "FunctionDeclaration"
             }]
         },
+        {
+            code: "function test(a, b, c, d) {}",
+            options: [{}],
+            errors: [{
+                messageId: "exceed",
+                data: { name: "Function 'test'", count: 4, max: 3 }
+            }]
+        },
+        {
+            code: "function test(a) {}",
+            options: [{ max: 0 }],
+            errors: [{
+                messageId: "exceed",
+                data: { name: "Function 'test'", count: 1, max: 0 }
+            }]
+        },
 
         // Error location should not cover the entire function; just the name.
         {

--- a/tests/lib/rules/max-statements.js
+++ b/tests/lib/rules/max-statements.js
@@ -133,6 +133,16 @@ ruleTester.run("max-statements", rule, {
             code: "var foo = { thing: function() { var bar = 1; var baz = 2; var baz2; } }",
             options: [{ max: 2 }],
             errors: [{ messageId: "exceed", data: { name: "Method 'thing'", count: "3", max: 2 } }]
+        },
+        {
+            code: "function foo() { 1; 2; 3; 4; 5; 6; 7; 8; 9; 10; 11; }",
+            options: [{}],
+            errors: [{ messageId: "exceed", data: { name: "Function 'foo'", count: 11, max: 10 } }]
+        },
+        {
+            code: "function foo() { 1; }",
+            options: [{ max: 0 }],
+            errors: [{ messageId: "exceed", data: { name: "Function 'foo'", count: 1, max: 0 } }]
         }
     ]
 });

--- a/tests/lib/rules/one-var.js
+++ b/tests/lib/rules/one-var.js
@@ -491,15 +491,11 @@ ruleTester.run("one-var", rule, {
         },
         {
             code: "var a; somethingElse(); var b;",
-            output: null,
-            options: [{ var: "never" }],
-            errors: null
+            options: [{ var: "never" }]
         },
         {
             code: "var foo = 1;\nlet bar = function() { var x; };\nvar baz = 2;",
-            output: null,
-            options: [{ var: "never" }],
-            errors: null
+            options: [{ var: "never" }]
         }
     ],
     invalid: [


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (https://github.com/eslint/eslint/issues/11415)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Ajv ignores the `default` property in JSON schemas when it appears inside `oneOf`, `anyOf`, or `not`. This commit removes ignored `default` properties and fixes a few bugs in rules that were incorrectly assuming the `default` properties would get processed.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
