### PR TITLE
Fix: Empty glob pattern incorrectly expands to "/**"

### DIFF
--- a/lib/util/glob-utils.js
+++ b/lib/util/glob-utils.js
@@ -166,7 +166,9 @@ function resolveFileGlobPatterns(patterns, options) {
 
     const processPathExtensions = processPath(options);
 
-    return patterns.map(processPathExtensions);
+    return patterns
+        .filter(pattern => pattern.length > 0)
+        .map(processPathExtensions);
 }
 
 const dotfilesPattern = /(?:(?:^\.)|(?:[/\\]\.))[^/\\.].*/u;

--- a/lib/util/glob-utils.js
+++ b/lib/util/glob-utils.js
@@ -70,6 +70,10 @@ function processPath(options) {
      * @private
      */
     return function(pathname) {
+        if (pathname === "") {
+            return "";
+        }
+
         let newPath = pathname;
         const resolvedPath = path.resolve(cwd, pathname);
 
@@ -166,9 +170,7 @@ function resolveFileGlobPatterns(patterns, options) {
 
     const processPathExtensions = processPath(options);
 
-    return patterns
-        .filter(pattern => pattern.length > 0)
-        .map(processPathExtensions);
+    return patterns.map(processPathExtensions);
 }
 
 const dotfilesPattern = /(?:(?:^\.)|(?:[/\\]\.))[^/\\.].*/u;
@@ -203,6 +205,13 @@ function listFilesToProcess(globPatterns, providedOptions) {
 
     debug("Creating list of files to process.");
     const resolvedPathsByGlobPattern = resolvedGlobPatterns.map(pattern => {
+        if (pattern === "") {
+            return [{
+                filename: "",
+                behavior: SILENTLY_IGNORE
+            }];
+        }
+
         const file = path.resolve(cwd, pattern);
 
         if (options.globInputPaths === false || (fs.existsSync(file) && fs.statSync(file).isFile())) {
@@ -242,7 +251,7 @@ function listFilesToProcess(globPatterns, providedOptions) {
     });
 
     const allPathDescriptors = resolvedPathsByGlobPattern.reduce((pathsForAllGlobs, pathsForCurrentGlob, index) => {
-        if (pathsForCurrentGlob.every(pathDescriptor => pathDescriptor.behavior === SILENTLY_IGNORE)) {
+        if (pathsForCurrentGlob.every(pathDescriptor => pathDescriptor.behavior === SILENTLY_IGNORE && pathDescriptor.filename !== "")) {
             throw new (pathsForCurrentGlob.length ? AllFilesIgnoredError : NoFilesFoundError)(globPatterns[index]);
         }
 

--- a/tests/lib/util/glob-utils.js
+++ b/tests/lib/util/glob-utils.js
@@ -69,16 +69,6 @@ describe("globUtils", () => {
             assert.deepStrictEqual(result, ["one-js-file"]);
         });
 
-        it("should not convert empty path string to a glob pattern", () => {
-            const patterns = [""];
-            const opts = {
-                cwd: getFixturePath("glob-util")
-            };
-            const result = globUtils.resolveFileGlobPatterns(patterns, opts);
-
-            assert.deepStrictEqual(result, []);
-        });
-
         it("should convert an absolute directory name with no provided extensions into a posix glob pattern", () => {
             const patterns = [getFixturePath("glob-util", "one-js-file")];
             const opts = {
@@ -337,6 +327,13 @@ describe("globUtils", () => {
             assert.throws(() => {
                 globUtils.listFilesToProcess(patterns);
             }, `No files matching '${patterns[0]}' were found.`);
+        });
+
+        it("should ignore empty patterns", () => {
+            const patterns = [""];
+            const result = globUtils.listFilesToProcess(patterns);
+
+            assert.deepStrictEqual(result, []);
         });
 
         it("should return an ignored file, if ignore option is turned off", () => {

--- a/tests/lib/util/glob-utils.js
+++ b/tests/lib/util/glob-utils.js
@@ -69,6 +69,16 @@ describe("globUtils", () => {
             assert.deepStrictEqual(result, ["one-js-file"]);
         });
 
+        it("should not convert empty path string to a glob pattern", () => {
+            const patterns = [""];
+            const opts = {
+                cwd: getFixturePath("glob-util")
+            };
+            const result = globUtils.resolveFileGlobPatterns(patterns, opts);
+
+            assert.deepStrictEqual(result, []);
+        });
+
         it("should convert an absolute directory name with no provided extensions into a posix glob pattern", () => {
             const patterns = [getFixturePath("glob-util", "one-js-file")];
             const opts = {


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment**

* **ESLint Version:** 5.15.0
* **Node Version:** 10.15.2
* **npm Version:** 6.4.1

**What parser (default, Babel-ESLint, etc.) are you using?**

Any; this bug occurs before ESLint parses anything.

**Please show your full configuration:**

This works without a configuration (e.g. `npx eslint ""` in any folder)

**What did you do? Please include the actual source code causing the issue.**

I passed an empty string to ESLint on the command line.

**What did you expect to happen?**

The empty string would be ignored.

**What actually happened? Please include the actual, raw output from ESLint.**

The empty string got expanded to `/**` and ESLint tried to lint my whole filesystem.

[See a live example on `repl.it`](https://repl.it/@bdchauvette/ESLint-Empty-glob-pattern) ([download as zip](https://repl.it/@bdchauvette/ESLint-Empty-glob-pattern.zip))

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

In `lib/util/glob-utils.js`, empty strings are now filtered out before mapping over the glob patterns.


[See a live example on `repl.it`](https://repl.it/@bdchauvette/ESLint-Empty-glob-pattern-fix) ([download as zip](https://repl.it/@bdchauvette/ESLint-Empty-glob-pattern-fix.zip))

**Is there anything you'd like reviewers to focus on?**

Nope, thanks for all the hard work on ESLint! :bowing_man: 
