### PR TITLE
Build: compile deps to ES5 when generating browser file (fixes #11504)

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,12 +15,11 @@ module.exports = {
     module: {
         rules: [
             {
-                test: /\.js$/u,
+                test: /\.m?js$/u,
                 loader: "babel-loader",
                 options: {
                     presets: ["@babel/preset-env"]
-                },
-                exclude: /node_modules/u
+                }
             }
         ]
     },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,7 +19,8 @@ module.exports = {
                 loader: "babel-loader",
                 options: {
                     presets: ["@babel/preset-env"]
-                }
+                },
+                exclude: /node_modules\/lodash/u
             }
         ]
     },


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix (https://github.com/eslint/eslint/issues/11504)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates the webpack config to compile dependencies to ES5, to ensure that the final output file is runnable in ES5 browsers. It tests this behavior by running ESLint on the output file.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
