### PR TITLE
Update: added ignoreTabsOnComments option to no-tabs rule (fixes #11562)

### DIFF
--- a/docs/rules/no-tabs.md
+++ b/docs/rules/no-tabs.md
@@ -37,6 +37,7 @@ var x = 1; // test
 This rule has an optional object option with the following properties:
 
 * `allowIndentationTabs` (default: false): If this is set to true, then the rule will not report tabs used for indentation.
+* `ignoreTabsOnComments` (default: false): If this is set to true, then the rule will not report tabs used for indentation in commented lines.
 
 #### allowIndentationTabs
 

--- a/lib/rules/no-tabs.js
+++ b/lib/rules/no-tabs.js
@@ -10,6 +10,7 @@
 //------------------------------------------------------------------------------
 
 const tabRegex = /\t+/gu;
+const isCommentRegex = /^[\s]*(\/\/)/u;
 const anyNonWhitespaceRegex = /\S/u;
 
 //------------------------------------------------------------------------------
@@ -32,6 +33,10 @@ module.exports = {
                 allowIndentationTabs: {
                     type: "boolean",
                     default: false
+                },
+                ignoreTabsOnComments: {
+                    type: "boolean",
+                    default: false
                 }
             },
             additionalProperties: false
@@ -41,6 +46,7 @@ module.exports = {
     create(context) {
         const sourceCode = context.getSourceCode();
         const allowIndentationTabs = context.options && context.options[0] && context.options[0].allowIndentationTabs;
+        const ignoreTabsOnComments = context.options && context.options[0] && context.options[0].ignoreTabsOnComments;
 
         return {
             Program(node) {
@@ -48,6 +54,9 @@ module.exports = {
                     let match;
 
                     while ((match = tabRegex.exec(line)) !== null) {
+                        if (ignoreTabsOnComments && isCommentRegex.test(line)) {
+                            continue;
+                        }
                         if (allowIndentationTabs && !anyNonWhitespaceRegex.test(line.slice(0, match.index))) {
                             continue;
                         }

--- a/lib/rules/no-tabs.js
+++ b/lib/rules/no-tabs.js
@@ -10,8 +10,9 @@
 //------------------------------------------------------------------------------
 
 const tabRegex = /\t+/gu;
-const isCommentRegex = /^[\s]*(\/\/)/u;
+const isCommentRegex = /^[ ]*(\/\/)/u;
 const anyNonWhitespaceRegex = /\S/u;
+const isCommentRegexAllowIndentationTabs = /^[\s]*(\/\/)/u;
 
 //------------------------------------------------------------------------------
 // Public Interface
@@ -54,11 +55,16 @@ module.exports = {
                     let match;
 
                     while ((match = tabRegex.exec(line)) !== null) {
-                        if (ignoreTabsOnComments && isCommentRegex.test(line)) {
-                            continue;
-                        }
                         if (allowIndentationTabs && !anyNonWhitespaceRegex.test(line.slice(0, match.index))) {
                             continue;
+                        }
+                        if (ignoreTabsOnComments) {
+                            if (allowIndentationTabs && isCommentRegexAllowIndentationTabs.test(line)) {
+                                break;
+                            }
+                            if (isCommentRegex.test(line)) {
+                                break;
+                            }
                         }
 
                         context.report({

--- a/tests/lib/rules/no-tabs.js
+++ b/tests/lib/rules/no-tabs.js
@@ -32,6 +32,34 @@ ruleTester.run("no-tabs", rule, {
         {
             code: "\t// comment",
             options: [{ allowIndentationTabs: true }]
+        },
+        {
+            code:
+            "function test(){\n" +
+            "//\tignore everything after a comment \n" +
+            "}",
+            options: [{ ignoreTabsOnComments: true }]
+        },
+        {
+            code:
+            "function test(){\n" +
+            "\t\t//\tindent comment with tabs \n" +
+            "}",
+            options: [{ ignoreTabsOnComments: true }]
+        },
+        {
+            code:
+            "function test(){\n" +
+            "\t //\t indent with tabs and spaces \n" +
+            "}",
+            options: [{ ignoreTabsOnComments: true }]
+        },
+        {
+            code:
+            "function test(){\n" +
+            " \t/// \t multiple slashes \n" +
+            "}",
+            options: [{ ignoreTabsOnComments: true }]
         }
     ],
     invalid: [

--- a/tests/lib/rules/no-tabs.js
+++ b/tests/lib/rules/no-tabs.js
@@ -43,23 +43,23 @@ ruleTester.run("no-tabs", rule, {
         {
             code:
             "function test(){\n" +
-            "\t\t//\tindent comment with tabs \n" +
+            "  //\tindent comment with tabs \n" +
             "}",
             options: [{ ignoreTabsOnComments: true }]
         },
         {
             code:
             "function test(){\n" +
-            "\t //\t indent with tabs and spaces \n" +
+            " /// \t multiple slashes \n" +
             "}",
             options: [{ ignoreTabsOnComments: true }]
         },
         {
             code:
             "function test(){\n" +
-            " \t/// \t multiple slashes \n" +
+            " \t/// \t multiple slashes and tabs \n" +
             "}",
-            options: [{ ignoreTabsOnComments: true }]
+            options: [{ ignoreTabsOnComments: true, allowIndentationTabs: true }]
         }
     ],
     invalid: [
@@ -69,6 +69,20 @@ ruleTester.run("no-tabs", rule, {
                 message: ERROR_MESSAGE,
                 line: 1,
                 column: 17
+            }]
+        },
+        {
+            code:
+            "\t //\t preceed comment with tabs \n",
+            errors: [{
+                message: ERROR_MESSAGE,
+                line: 1,
+                column: 1
+            },
+            {
+                message: ERROR_MESSAGE,
+                line: 1,
+                column: 5
             }]
         },
         {


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

[Issue](https://github.com/eslint/eslint/issues/11562)

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

- Added `ignoreTabsOnComments` option to no-tabs rule
- Added condition in no-tabs rule to identify _single-line comments_
- Added test cases for these scenarios
- Updated documentation for no-tabs rule


**Is there anything you'd like reviewers to focus on?**


