### PR TITLE
Fix: Allow HTML formatter to handle no meta data

### DIFF
--- a/lib/formatters/html.js
+++ b/lib/formatters/html.js
@@ -119,6 +119,8 @@ module.exports = function(results, data) {
     let totalErrors,
         totalWarnings;
 
+    const metaData = data ? data.rulesMeta : {};
+
     totalErrors = 0;
     totalWarnings = 0;
 
@@ -132,6 +134,6 @@ module.exports = function(results, data) {
         date: new Date(),
         reportColor: renderColor(totalErrors, totalWarnings),
         reportSummary: renderSummary(totalErrors, totalWarnings),
-        results: renderResults(results, data.rulesMeta)
+        results: renderResults(results, metaData)
     });
 };

--- a/tests/lib/formatters/html.js
+++ b/tests/lib/formatters/html.js
@@ -115,6 +115,21 @@ describe("formatter:html", () => {
             checkHeaderRow($, $("tr")[0], { bgColor: "bg-2", group: "f-0", file: "foo.js", problems: "1 problem (1 error, 0 warnings)" });
             checkContentRow($, $("tr")[1], { group: "f-0", lineCol: "5:10", color: "clr-2", message: "Unexpected foo.", ruleId: "foo" });
         });
+
+        it("should not fail if metadata is not available", () => {
+            const result = formatter(code.results);
+
+            const $ = cheerio.load(result);
+
+            // Check overview
+            checkOverview($, { bgColor: "bg-2", problems: "1 problem (1 error, 0 warnings)" });
+
+            // Check rows
+            assert.strictEqual($("tr").length, 2, "Check that there are two (1 header, 1 content)");
+            assert.strictEqual($("tr[data-group|=\"f\"]").length, 1, "Check that is 1 header row (implying 1 content row)");
+            checkHeaderRow($, $("tr")[0], { bgColor: "bg-2", group: "f-0", file: "foo.js", problems: "1 problem (1 error, 0 warnings)" });
+            checkContentRow($, $("tr")[1], { group: "f-0", lineCol: "5:10", color: "clr-2", message: "Unexpected foo.", ruleId: "foo" });
+        });
     });
 
     describe("when passed a single warning message", () => {


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Added small check to allow HTML formatter to work without rules meta data. This is to fix a release issue introduced by #11551

**Is there anything you'd like reviewers to focus on?**
Nothing

