### PR TITLE
Build: gensite passes rulesMeta to formatter rendering

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -430,16 +430,17 @@ function getFormatterResults() {
     const stripAnsi = require("strip-ansi");
 
     const formatterFiles = fs.readdirSync("./lib/formatters/"),
+        rules = {
+            "no-else-return": "warn",
+            indent: ["warn", 4],
+            "space-unary-ops": "error",
+            semi: ["warn", "always"],
+            "consistent-return": "error"
+        },
         cli = new CLIEngine({
             useEslintrc: false,
             baseConfig: { extends: "eslint:recommended" },
-            rules: {
-                "no-else-return": 1,
-                indent: [1, 4],
-                "space-unary-ops": 2,
-                semi: [1, "always"],
-                "consistent-return": 2
-            }
+            rules
         }),
         codeString = [
             "function addOne(i) {",
@@ -450,15 +451,25 @@ function getFormatterResults() {
             "    }",
             "};"
         ].join("\n"),
-        rawMessages = cli.executeOnText(codeString, "fullOfProblems.js", true);
+        rawMessages = cli.executeOnText(codeString, "fullOfProblems.js", true),
+        rulesMap = cli.getRules(),
+        rulesMeta = Object.keys(rules).reduce((obj, ruleId) => {
+            obj[ruleId] = rulesMap.get(ruleId).meta;
+            return obj;
+        }, {});
 
     return formatterFiles.reduce((data, filename) => {
         const fileExt = path.extname(filename),
             name = path.basename(filename, fileExt);
 
         if (fileExt === ".js") {
+            const formattedOutput = cli.getFormatter(name)(
+                rawMessages.results,
+                { rulesMeta }
+            );
+
             data.formatterResults[name] = {
-                result: stripAnsi(cli.getFormatter(name)(rawMessages.results))
+                result: stripAnsi(formattedOutput)
             };
         }
         return data;

--- a/Makefile.js
+++ b/Makefile.js
@@ -453,10 +453,11 @@ function getFormatterResults() {
         ].join("\n"),
         rawMessages = cli.executeOnText(codeString, "fullOfProblems.js", true),
         rulesMap = cli.getRules(),
-        rulesMeta = Object.keys(rules).reduce((obj, ruleId) => {
-            obj[ruleId] = rulesMap.get(ruleId).meta;
-            return obj;
-        }, {});
+        rulesMeta = {};
+
+    Object.keys(rules).forEach(ruleId => {
+        rulesMeta[ruleId] = rulesMap.get(ruleId).meta;
+    });
 
     return formatterFiles.reduce((data, filename) => {
         const fileExt = path.extname(filename),


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Fixed an issue where gensite was not passing `{ rulesMeta }` to formatters when generating formatter output.

**Is there anything you'd like reviewers to focus on?**

Not really.