### PR TITLE
Docs edit arrow-parens as-needed explanation (fixes #11202)

### DIFF
--- a/docs/rules/arrow-parens.md
+++ b/docs/rules/arrow-parens.md
@@ -52,7 +52,7 @@ This rule has a string option and an object one.
 String options are:
 
 * `"always"` (default) requires parens around arguments in all cases.
-* `"as-needed"` allows omitting parens when there is only one argument.
+* `"as-needed"` enforces no braces where they can be omitted.
 
 Object properties for variants of the `"as-needed"` option:
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Corrected the explanation of the arrow-parens "as-needed" rule in the docs. 

**Is there anything you'd like reviewers to focus on?**
Make sure the wording is what we want. I took the wording from the [arrow-body-style](https://eslint.org/docs/rules/arrow-body-style#as-needed) as mentioned in the issue.

