### PR TITLE
Fix: do not require backticks in type annotations

### DIFF
--- a/lib/rules/quotes.js
+++ b/lib/rules/quotes.js
@@ -222,6 +222,9 @@ module.exports = {
                 case "ExportAllDeclaration":
                     return parent.source === node;
 
+                case "TSLiteralType":
+                    return true;
+
                 // Others don't allow.
                 default:
                     return false;

--- a/tests/fixtures/parsers/type-annotations/type-declaration-with-literals.js
+++ b/tests/fixtures/parsers/type-annotations/type-declaration-with-literals.js
@@ -1,0 +1,262 @@
+/**
+ * Source code:
+ * type Foo = 'bar' | "baz"
+ */
+
+exports.parse = () => ({
+    "type": "Program",
+    "body": [
+        {
+            "type": "TSTypeAliasDeclaration",
+            "id": {
+                "type": "Identifier",
+                "name": "Foo",
+                "range": [
+                    5,
+                    8
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 5
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 8
+                    }
+                }
+            },
+            "typeAnnotation": {
+                "type": "TSUnionType",
+                "types": [
+                    {
+                        "type": "TSLiteralType",
+                        "literal": {
+                            "type": "Literal",
+                            "raw": "'bar'",
+                            "value": "bar",
+                            "range": [
+                                11,
+                                16
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 11
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 16
+                                }
+                            }
+                        },
+                        "range": [
+                            11,
+                            16
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 11
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 16
+                            }
+                        }
+                    },
+                    {
+                        "type": "TSLiteralType",
+                        "literal": {
+                            "type": "Literal",
+                            "raw": "\"baz\"",
+                            "value": "baz",
+                            "range": [
+                                19,
+                                24
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 19
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 24
+                                }
+                            }
+                        },
+                        "range": [
+                            19,
+                            24
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 19
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 24
+                            }
+                        }
+                    }
+                ],
+                "range": [
+                    11,
+                    24
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 11
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 24
+                    }
+                }
+            },
+            "range": [
+                0,
+                24
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 24
+                }
+            }
+        }
+    ],
+    "sourceType": "module",
+    "range": [
+        0,
+        24
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 1,
+            "column": 24
+        }
+    },
+    "tokens": [
+        {
+            "type": "Identifier",
+            "value": "type",
+            "range": [
+                0,
+                4
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 4
+                }
+            }
+        },
+        {
+            "type": "Identifier",
+            "value": "Foo",
+            "range": [
+                5,
+                8
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 5
+                },
+                "end": {
+                    "line": 1,
+                    "column": 8
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "range": [
+                9,
+                10
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 9
+                },
+                "end": {
+                    "line": 1,
+                    "column": 10
+                }
+            }
+        },
+        {
+            "type": "String",
+            "value": "'bar'",
+            "range": [
+                11,
+                16
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 11
+                },
+                "end": {
+                    "line": 1,
+                    "column": 16
+                }
+            }
+        },
+        {
+            "type": "Punctuator",
+            "value": "|",
+            "range": [
+                17,
+                18
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 17
+                },
+                "end": {
+                    "line": 1,
+                    "column": 18
+                }
+            }
+        },
+        {
+            "type": "String",
+            "value": "\"baz\"",
+            "range": [
+                19,
+                24
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 19
+                },
+                "end": {
+                    "line": 1,
+                    "column": 24
+                }
+            }
+        }
+    ],
+    "comments": []
+});

--- a/tests/lib/rules/quotes.js
+++ b/tests/lib/rules/quotes.js
@@ -10,7 +10,8 @@
 //------------------------------------------------------------------------------
 
 const rule = require("../../../lib/rules/quotes"),
-    RuleTester = require("../../../lib/testers/rule-tester");
+    RuleTester = require("../../../lib/testers/rule-tester"),
+    parser = require("../../fixtures/fixture-parser");
 
 const ruleTester = new RuleTester();
 
@@ -74,7 +75,10 @@ ruleTester.run("quotes", rule, {
         // `backtick` should not warn property/method names (not computed).
         { code: "var obj = {\"key0\": 0, 'key1': 1};", options: ["backtick"], parserOptions: { ecmaVersion: 6 } },
         { code: "class Foo { 'bar'(){} }", options: ["backtick"], parserOptions: { ecmaVersion: 6 } },
-        { code: "class Foo { static ''(){} }", options: ["backtick"], parserOptions: { ecmaVersion: 6 } }
+        { code: "class Foo { static ''(){} }", options: ["backtick"], parserOptions: { ecmaVersion: 6 } },
+
+        // `backtick` should not warn about literals in type annotations.
+        { code: "type Foo = 'bar' | \"bar\"", options: ["backtick"], parser: parser("type-annotations/type-declaration-with-literals"), parserOptions: { ecmaVersion: 6 } }
     ],
     invalid: [
         {


### PR DESCRIPTION
Neither Flow nor TypeScript permit backticks with string literals in
type definitions. This PR changes the `quotes` rule to stop triggering
on single-quoted or double-quoted string literals in types.

<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

I changed the `isAllowedAsNonBacktick` function so that if a literal's parent node type is `TSLiteralType`, the function always returns true.

I generated an example AST using [AST explorer](https://astexplorer.net/), created a new parser fixture and added a unit test.

**Is there anything you'd like reviewers to focus on?**

First PR, so all feedback welcome.