### PR TITLE
Fix: getErrorResults function to not mutate passed parameter

### DIFF
--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -521,13 +521,14 @@ class CLIEngine {
 
             if (filteredMessages.length > 0) {
                 filtered.push(
-                    Object.assign(result, {
+                    {
+                        ...result,
                         messages: filteredMessages,
                         errorCount: filteredMessages.length,
                         warningCount: 0,
                         fixableErrorCount: result.fixableErrorCount,
                         fixableWarningCount: 0
-                    })
+                    }
                 );
             }
         });

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -3113,6 +3113,20 @@ describe("CLIEngine", () => {
             assert.strictEqual(errorResults[0].messages[4].severity, 2);
         });
 
+        it("should not mutate passed report.results parameter", () => {
+            process.chdir(originalDir);
+            const engine = new CLIEngine({
+                rules: { quotes: [1, "double"] }
+            });
+
+            const report = engine.executeOnText("var foo = 'bar';");
+            const reportResultsLength = report.results[0].messages.length;
+
+            CLIEngine.getErrorResults(report.results);
+
+            assert.lengthOf(report.results[0].messages, reportResultsLength);
+        });
+
         it("should report a warningCount of 0 when looking for errors only", () => {
 
             process.chdir(originalDir);


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment**

* **ESLint Version:** 5.9.0
* **Node Version:** 10.9.0
* **npm Version:** 6.2.0

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Changed the `getErrorResults` to not mutate passed parameter

**Is there anything you'd like reviewers to focus on?**
`getErrorResults` function

See issue #11589