### PR TITLE
Chore: fix test that fails when the CWD contains a space

### DIFF
--- a/tests/lib/config/config-file.js
+++ b/tests/lib/config/config-file.js
@@ -141,7 +141,7 @@ describe("ConfigFile", () => {
                     extends: "plugin:enable-nonexistent-parser/bar",
                     rules: { eqeqeq: 2 }
                 }, configContext, "/whatever");
-            }, /Failed to resolve parser 'nonexistent-parser' declared in '[-\w/.:\\]+'.\nReferenced from: \/whatever/u);
+            }, /Failed to resolve parser 'nonexistent-parser' declared in '.+'.\nReferenced from: \/whatever/u);
         });
 
         it("should fall back to default parser when a parser called 'espree' is not found", () => {


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates a test to avoid failing a regex match whenever the user's CWD contains a space.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
