### PR TITLE
Fix: autofix of no-unneeded-ternary made syntax error (fixes #11579)

### DIFF
--- a/lib/rules/no-unneeded-ternary.js
+++ b/lib/rules/no-unneeded-ternary.js
@@ -17,6 +17,7 @@ const OPERATOR_INVERSES = {
 
     // Operators like < and >= are not true inverses, since both will return false with NaN.
 };
+const OR_PRECEDENCE = astUtils.getPrecedence({ type: "LogicalExpression", operator: "||" });
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -141,15 +142,16 @@ module.exports = {
                         loc: node.consequent.loc.start,
                         message: "Unnecessary use of conditional expression for default assignment.",
                         fix: fixer => {
-                            let nodeAlternate = astUtils.getParenthesisedText(sourceCode, node.alternate);
+                            const shouldParenthesizeAlternate = (
+                                astUtils.getPrecedence(node.alternate) < OR_PRECEDENCE &&
+                                !astUtils.isParenthesised(sourceCode, node.alternate)
+                            );
+                            const alternateText = shouldParenthesizeAlternate
+                                ? `(${sourceCode.getText(node.alternate)})`
+                                : astUtils.getParenthesisedText(sourceCode, node.alternate);
+                            const testText = astUtils.getParenthesisedText(sourceCode, node.test);
 
-                            if (node.alternate.type === "ConditionalExpression" || node.alternate.type === "YieldExpression") {
-                                const isAlternateParenthesised = astUtils.isParenthesised(sourceCode, node.alternate);
-
-                                nodeAlternate = isAlternateParenthesised ? nodeAlternate : `(${nodeAlternate})`;
-                            }
-
-                            return fixer.replaceText(node, `${astUtils.getParenthesisedText(sourceCode, node.test)} || ${nodeAlternate}`);
+                            return fixer.replaceText(node, `${testText} || ${alternateText}`);
                         }
                     });
                 }

--- a/tests/lib/rules/no-unneeded-ternary.js
+++ b/tests/lib/rules/no-unneeded-ternary.js
@@ -230,6 +230,90 @@ ruleTester.run("no-unneeded-ternary", rule, {
                 line: 1,
                 column: 24
             }]
+        },
+        {
+            code: "var a = b ? b : c => c;",
+            output: "var a = b || (c => c);",
+            options: [{ defaultAssignment: false }],
+            parserOptions: { ecmaVersion: 2015 },
+            errors: [{
+                message: "Unnecessary use of conditional expression for default assignment.",
+                type: "ConditionalExpression",
+                line: 1,
+                column: 13
+            }]
+        },
+        {
+            code: "var a = b ? b : c = 0;",
+            output: "var a = b || (c = 0);",
+            options: [{ defaultAssignment: false }],
+            parserOptions: { ecmaVersion: 2015 },
+            errors: [{
+                message: "Unnecessary use of conditional expression for default assignment.",
+                type: "ConditionalExpression",
+                line: 1,
+                column: 13
+            }]
+        },
+        {
+            code: "var a = b ? b : (c => c);",
+            output: "var a = b || (c => c);",
+            options: [{ defaultAssignment: false }],
+            parserOptions: { ecmaVersion: 2015 },
+            errors: [{
+                message: "Unnecessary use of conditional expression for default assignment.",
+                type: "ConditionalExpression",
+                line: 1,
+                column: 13
+            }]
+        },
+        {
+            code: "var a = b ? b : (c = 0);",
+            output: "var a = b || (c = 0);",
+            options: [{ defaultAssignment: false }],
+            parserOptions: { ecmaVersion: 2015 },
+            errors: [{
+                message: "Unnecessary use of conditional expression for default assignment.",
+                type: "ConditionalExpression",
+                line: 1,
+                column: 13
+            }]
+        },
+        {
+            code: "var a = b ? b : (c) => (c);",
+            output: "var a = b || ((c) => (c));",
+            options: [{ defaultAssignment: false }],
+            parserOptions: { ecmaVersion: 2015 },
+            errors: [{
+                message: "Unnecessary use of conditional expression for default assignment.",
+                type: "ConditionalExpression",
+                line: 1,
+                column: 13
+            }]
+        },
+        {
+            code: "var a = b ? b : c, d; // this is ((b ? b : c), (d))",
+            output: "var a = b || c, d; // this is ((b ? b : c), (d))",
+            options: [{ defaultAssignment: false }],
+            parserOptions: { ecmaVersion: 2015 },
+            errors: [{
+                message: "Unnecessary use of conditional expression for default assignment.",
+                type: "ConditionalExpression",
+                line: 1,
+                column: 13
+            }]
+        },
+        {
+            code: "var a = b ? b : (c, d);",
+            output: "var a = b || (c, d);",
+            options: [{ defaultAssignment: false }],
+            parserOptions: { ecmaVersion: 2015 },
+            errors: [{
+                message: "Unnecessary use of conditional expression for default assignment.",
+                type: "ConditionalExpression",
+                line: 1,
+                column: 13
+            }]
         }
     ]
 });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix

**What changes did you make? (Give an overview)**

This PR fixes #11579.
The new logic uses operator precedence instead of whitelist of node types in order to check the necessity of parenthesizing.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.