### PR TITLE
Docs: fix example in object-curly-newline docs

### DIFF
--- a/docs/rules/object-curly-newline.md
+++ b/docs/rules/object-curly-newline.md
@@ -347,9 +347,7 @@ let {i, j
 } = obj;
 let {
     k, l} = obj;
-let {m,
-    n} = obj;
-let {o = function() {
+let {m = function() {
     dosomething();
 }} = obj;
 ```
@@ -385,13 +383,15 @@ let {i, j} = obj;
 let {
     k, l
 } = obj;
+let {m,
+    n} = obj;
 let {
-    m,
-    n
+    o,
+    p
 } = obj;
-let {o = function() {dosomething();}} = obj;
+let {q = function() {dosomething();}} = obj;
 let {
-    p = function() {
+    r = function() {
         dosomething();
     }
 } = obj;

--- a/docs/rules/object-curly-newline.md
+++ b/docs/rules/object-curly-newline.md
@@ -333,21 +333,19 @@ let c = {foo: 1, bar: 2
 };
 let d = {
     foo: 1, bar: 2};
-let e = {foo: 1,
-    bar: 2};
-let f = {foo: function() {
+let e = {foo: function() {
     dosomething();
 }};
 
-let {g
+let {f
 } = obj;
 let {
-    h} = obj;
-let {i, j
+    g} = obj;
+let {h, i
 } = obj;
 let {
-    k, l} = obj;
-let {m = function() {
+    j, k} = obj;
+let {l = function() {
     dosomething();
 }} = obj;
 ```


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update
**What changes did you make? (Give an overview)**
Move an example from invalid to valid.
```js
o = {a,
  b}
// This should pass `{consistent: true}`, but the docs say otherwise.
```
**Is there anything you'd like reviewers to focus on?**
No.