### PR TITLE
Chore: add eslint as a devDependeny

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "lint-staged": {
     "*.js": [
-      "node ./bin/eslint.js --fix",
+      "eslint --fix",
       "git add"
     ],
     "*.md": "markdownlint"

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "coveralls": "^3.0.3",
     "dateformat": "^3.0.3",
     "ejs": "^2.6.1",
+    "eslint": "file:.",
     "eslint-config-eslint": "file:packages/eslint-config-eslint",
     "eslint-plugin-eslint-plugin": "^2.0.1",
     "eslint-plugin-internal-rules": "file:tools/internal-rules",


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Other, please explain: add `eslint` to devDependencies

**What changes did you make? (Give an overview)**

This PR adds `eslint` to `devDepndencies`.

```diff
+     "eslint": "file:.",
```

From this, npm makes a symbolic link `./node_modules/eslint` ⇔ `./` so editors such as VSCode can use it to lint our codebase.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.
