### PR TITLE
Docs: fix example of ImportDeclaration in indent-rule docs

### DIFF
--- a/docs/rules/indent.md
+++ b/docs/rules/indent.md
@@ -575,7 +575,7 @@ import {
 } from 'qux';
 ```
 
-Examples of **incorrect** code for this rule with the `4, { ImportDeclaration: "first" }` option:
+Examples of **incorrect** code for this rule with the `4, { "ImportDeclaration": "first" }` option:
 
 ```js
 /*eslint indent: ["error", 4, { ImportDeclaration: "first" }]*/
@@ -586,7 +586,7 @@ import { foo,
 } from 'qux';
 ```
 
-Examples of **correct** code for this rule with the `4, { ImportDeclaration: "first" }` option:
+Examples of **correct** code for this rule with the `4, { "ImportDeclaration": "first" }` option:
 
 ```js
 /*eslint indent: ["error", 4, { ImportDeclaration: "first" }]*/

--- a/docs/rules/indent.md
+++ b/docs/rules/indent.md
@@ -561,7 +561,7 @@ var foo = { bar: 1,
 Examples of **correct** code for this rule with the `4, { "ImportDeclaration": 1 }` option (the default):
 
 ```js
-/*eslint indent: ["error", 4, { ImportDeclaration: 1 }]*/
+/*eslint indent: ["error", 4, { "ImportDeclaration": 1 }]*/
 
 import { foo,
     bar,
@@ -578,7 +578,7 @@ import {
 Examples of **incorrect** code for this rule with the `4, { "ImportDeclaration": "first" }` option:
 
 ```js
-/*eslint indent: ["error", 4, { ImportDeclaration: "first" }]*/
+/*eslint indent: ["error", 4, { "ImportDeclaration": "first" }]*/
 
 import { foo,
     bar,
@@ -589,7 +589,7 @@ import { foo,
 Examples of **correct** code for this rule with the `4, { "ImportDeclaration": "first" }` option:
 
 ```js
-/*eslint indent: ["error", 4, { ImportDeclaration: "first" }]*/
+/*eslint indent: ["error", 4, { "ImportDeclaration": "first" }]*/
 
 import { foo,
          bar,


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update
<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
`ex. 4, { ImportDeclaration: 1 } vs. 4, { "ImportDeclaration": 1 }`


**Is there anything you'd like reviewers to focus on?**


