### PR TITLE
Fix: Curly rule incorrectly flagging lexical declarations (fixes #11663)

### DIFF
--- a/lib/rules/curly.js
+++ b/lib/rules/curly.js
@@ -104,6 +104,20 @@ module.exports = {
         }
 
         /**
+         * Determines if the given node is a lexical declaration (let, const, function, or class)
+         * @param {ASTNode} node The node to check
+         * @returns {boolean} True if the node is a lexical declaration
+         * @private
+         */
+        function isLexicalDeclaration(node) {
+            if (node.type === "VariableDeclaration") {
+                return node.kind === "const" || node.kind === "let";
+            }
+
+            return node.type === "FunctionDeclaration" || node.type === "ClassDeclaration";
+        }
+
+        /**
          * Checks if the given token is an `else` token or not.
          *
          * @param {Token} token - The token to check.
@@ -238,8 +252,13 @@ module.exports = {
             } else if (multiOrNest) {
                 if (hasBlock && body.body.length === 1 && isOneLiner(body.body[0])) {
                     const leadingComments = sourceCode.getCommentsBefore(body.body[0]);
+                    const isLexDef = isLexicalDeclaration(body.body[0]);
 
-                    expected = leadingComments.length > 0;
+                    if (isLexDef) {
+                        expected = true;
+                    } else {
+                        expected = leadingComments.length > 0;
+                    }
                 } else if (!isOneLiner(body)) {
                     expected = true;
                 }

--- a/tests/lib/rules/curly.js
+++ b/tests/lib/rules/curly.js
@@ -164,6 +164,26 @@ ruleTester.run("curly", rule, {
             options: ["multi-or-nest"],
             parserOptions: { ecmaVersion: 6 }
         },
+        {
+            code: "if (foo) { \n const bar = 'baz'; \n }",
+            options: ["multi-or-nest"],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "if (foo) { \n let bar = 'baz'; \n }",
+            options: ["multi-or-nest"],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "if (foo) { \n function bar() {} \n }",
+            options: ["multi-or-nest"],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "if (foo) { \n class bar {} \n }",
+            options: ["multi-or-nest"],
+            parserOptions: { ecmaVersion: 6 }
+        },
 
         // https://github.com/eslint/eslint/issues/3856
         {

--- a/tests/lib/rules/curly.js
+++ b/tests/lib/rules/curly.js
@@ -617,6 +617,18 @@ ruleTester.run("curly", rule, {
             ]
         },
         {
+            code: "if (foo) { \n var bar = 'baz'; \n }",
+            output: "if (foo)  \n var bar = 'baz'; \n ",
+            options: ["multi-or-nest"],
+            errors: [
+                {
+                    messageId: "unexpectedCurlyAfterCondition",
+                    data: { name: "if" },
+                    type: "IfStatement"
+                }
+            ]
+        },
+        {
             code: "while (true) { \n doSomething(); \n }",
             output: "while (true)  \n doSomething(); \n ",
             options: ["multi-or-nest"],


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Added a lexical declaration check to the `multi-or-nest` curly rule to prevent single line lexical declarations from being flagged as errors. See #11663 

**Is there anything you'd like reviewers to focus on?**
Nothing specific

