### PR TITLE
New: Add classname attribute to JUnit testcase (refs #11068)

### DIFF
--- a/lib/cli-engine/formatters/junit.js
+++ b/lib/cli-engine/formatters/junit.js
@@ -5,6 +5,7 @@
 "use strict";
 
 const xmlEscape = require("../xml-escape");
+const path = require("path");
 
 //------------------------------------------------------------------------------
 // Helper Functions
@@ -24,6 +25,16 @@ function getMessageType(message) {
 
 }
 
+/**
+ * Returns a full file path without extension
+ * @param {string} filePath input file path
+ * @returns {string} file path without extension
+ * @private
+ */
+function pathWithoutExt(filePath) {
+    return path.join(path.dirname(filePath), path.basename(filePath, path.extname(filePath)));
+}
+
 //------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
@@ -38,13 +49,14 @@ module.exports = function(results) {
     results.forEach(result => {
 
         const messages = result.messages;
+        const classname = pathWithoutExt(result.filePath);
 
         if (messages.length > 0) {
             output += `<testsuite package="org.eslint" time="0" tests="${messages.length}" errors="${messages.length}" name="${result.filePath}">\n`;
             messages.forEach(message => {
                 const type = message.fatal ? "error" : "failure";
 
-                output += `<testcase time="0" name="org.eslint.${message.ruleId || "unknown"}">`;
+                output += `<testcase time="0" name="org.eslint.${message.ruleId || "unknown"}" classname="${classname}">`;
                 output += `<${type} message="${xmlEscape(message.message || "")}">`;
                 output += "<![CDATA[";
                 output += `line ${message.line || 0}, col `;
@@ -58,7 +70,7 @@ module.exports = function(results) {
             output += "</testsuite>\n";
         } else {
             output += `<testsuite package="org.eslint" time="0" tests="1" errors="0" name="${result.filePath}">\n`;
-            output += `<testcase time="0" name="${result.filePath}" />\n`;
+            output += `<testcase time="0" name="${result.filePath}" classname="${classname}" />\n`;
             output += "</testsuite>\n";
         }
 

--- a/lib/cli-engine/formatters/junit.js
+++ b/lib/cli-engine/formatters/junit.js
@@ -32,7 +32,7 @@ function getMessageType(message) {
  * @private
  */
 function pathWithoutExt(filePath) {
-    return path.join(path.dirname(filePath), path.basename(filePath, path.extname(filePath)));
+    return path.join(path.posix.dirname(filePath), path.basename(filePath, path.extname(filePath)));
 }
 
 //------------------------------------------------------------------------------

--- a/lib/cli-engine/formatters/junit.js
+++ b/lib/cli-engine/formatters/junit.js
@@ -32,7 +32,7 @@ function getMessageType(message) {
  * @private
  */
 function pathWithoutExt(filePath) {
-    return path.join(path.posix.dirname(filePath), path.basename(filePath, path.extname(filePath)));
+    return path.posix.join(path.posix.dirname(filePath), path.basename(filePath, path.extname(filePath)));
 }
 
 //------------------------------------------------------------------------------

--- a/tests/lib/cli-engine/formatters/junit.js
+++ b/tests/lib/cli-engine/formatters/junit.js
@@ -31,7 +31,7 @@ describe("formatter:junit", () => {
 
     describe("when passed a single message", () => {
         const code = [{
-            filePath: "foo.js",
+            filePath: "/path/to/foo.js",
             messages: [{
                 message: "Unexpected foo.",
                 severity: 2,
@@ -44,14 +44,14 @@ describe("formatter:junit", () => {
         it("should return a single <testcase> with a message and the line and col number in the body (error)", () => {
             const result = formatter(code);
 
-            assert.strictEqual(result.replace(/\n/gu, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><failure message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Error - Unexpected foo. (foo)]]></failure></testcase></testsuite></testsuites>");
+            assert.strictEqual(result.replace(/\n/gu, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"/path/to/foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\" classname=\"/path/to/foo\"><failure message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Error - Unexpected foo. (foo)]]></failure></testcase></testsuite></testsuites>");
         });
 
         it("should return a single <testcase> with a message and the line and col number in the body (warning)", () => {
             code[0].messages[0].severity = 1;
             const result = formatter(code);
 
-            assert.strictEqual(result.replace(/\n/gu, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><failure message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Warning - Unexpected foo. (foo)]]></failure></testcase></testsuite></testsuites>");
+            assert.strictEqual(result.replace(/\n/gu, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"/path/to/foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\" classname=\"/path/to/foo\"><failure message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Warning - Unexpected foo. (foo)]]></failure></testcase></testsuite></testsuites>");
         });
     });
 
@@ -70,7 +70,7 @@ describe("formatter:junit", () => {
         it("should return a single <testcase> and an <error>", () => {
             const result = formatter(code);
 
-            assert.strictEqual(result.replace(/\n/gu, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><error message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Error - Unexpected foo. (foo)]]></error></testcase></testsuite></testsuites>");
+            assert.strictEqual(result.replace(/\n/gu, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\" classname=\"foo\"><error message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Error - Unexpected foo. (foo)]]></error></testcase></testsuite></testsuites>");
         });
     });
 
@@ -86,7 +86,7 @@ describe("formatter:junit", () => {
         it("should return a single <testcase> and an <error>", () => {
             const result = formatter(code);
 
-            assert.strictEqual(result.replace(/\n/gu, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.unknown\"><error message=\"Unexpected foo.\"><![CDATA[line 0, col 0, Error - Unexpected foo.]]></error></testcase></testsuite></testsuites>");
+            assert.strictEqual(result.replace(/\n/gu, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.unknown\" classname=\"foo\"><error message=\"Unexpected foo.\"><![CDATA[line 0, col 0, Error - Unexpected foo.]]></error></testcase></testsuite></testsuites>");
         });
     });
 
@@ -101,7 +101,7 @@ describe("formatter:junit", () => {
         it("should return a single <testcase> and an <error>", () => {
             const result = formatter(code);
 
-            assert.strictEqual(result.replace(/\n/gu, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.unknown\"><error message=\"\"><![CDATA[line 0, col 0, Error - ]]></error></testcase></testsuite></testsuites>");
+            assert.strictEqual(result.replace(/\n/gu, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.unknown\" classname=\"foo\"><error message=\"\"><![CDATA[line 0, col 0, Error - ]]></error></testcase></testsuite></testsuites>");
         });
     });
 
@@ -126,7 +126,7 @@ describe("formatter:junit", () => {
         it("should return a multiple <testcase>'s", () => {
             const result = formatter(code);
 
-            assert.strictEqual(result.replace(/\n/gu, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"2\" errors=\"2\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><failure message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Error - Unexpected foo. (foo)]]></failure></testcase><testcase time=\"0\" name=\"org.eslint.bar\"><failure message=\"Unexpected bar.\"><![CDATA[line 6, col 11, Warning - Unexpected bar. (bar)]]></failure></testcase></testsuite></testsuites>");
+            assert.strictEqual(result.replace(/\n/gu, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"2\" errors=\"2\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\" classname=\"foo\"><failure message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Error - Unexpected foo. (foo)]]></failure></testcase><testcase time=\"0\" name=\"org.eslint.bar\" classname=\"foo\"><failure message=\"Unexpected bar.\"><![CDATA[line 6, col 11, Warning - Unexpected bar. (bar)]]></failure></testcase></testsuite></testsuites>");
         });
     });
 
@@ -145,7 +145,7 @@ describe("formatter:junit", () => {
         it("should make them go away", () => {
             const result = formatter(code);
 
-            assert.strictEqual(result.replace(/\n/gu, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><failure message=\"Unexpected &lt;foo&gt;&lt;/foo&gt;&#8;&#9;&#10;&#12;&#13;&#29275;&#36924;.\"><![CDATA[line 5, col 10, Warning - Unexpected &lt;foo&gt;&lt;/foo&gt;&#8;&#9;&#10;&#12;&#13;&#29275;&#36924;. (foo)]]></failure></testcase></testsuite></testsuites>");
+            assert.strictEqual(result.replace(/\n/gu, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\" classname=\"foo\"><failure message=\"Unexpected &lt;foo&gt;&lt;/foo&gt;&#8;&#9;&#10;&#12;&#13;&#29275;&#36924;.\"><![CDATA[line 5, col 10, Warning - Unexpected &lt;foo&gt;&lt;/foo&gt;&#8;&#9;&#10;&#12;&#13;&#29275;&#36924;. (foo)]]></failure></testcase></testsuite></testsuites>");
         });
     });
 
@@ -173,7 +173,7 @@ describe("formatter:junit", () => {
         it("should return 2 <testsuite>'s", () => {
             const result = formatter(code);
 
-            assert.strictEqual(result.replace(/\n/gu, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><failure message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Warning - Unexpected foo. (foo)]]></failure></testcase></testsuite><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"bar.js\"><testcase time=\"0\" name=\"org.eslint.bar\"><failure message=\"Unexpected bar.\"><![CDATA[line 6, col 11, Error - Unexpected bar. (bar)]]></failure></testcase></testsuite></testsuites>");
+            assert.strictEqual(result.replace(/\n/gu, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\" classname=\"foo\"><failure message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Warning - Unexpected foo. (foo)]]></failure></testcase></testsuite><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"bar.js\"><testcase time=\"0\" name=\"org.eslint.bar\" classname=\"bar\"><failure message=\"Unexpected bar.\"><![CDATA[line 6, col 11, Error - Unexpected bar. (bar)]]></failure></testcase></testsuite></testsuites>");
         });
     });
 
@@ -195,7 +195,7 @@ describe("formatter:junit", () => {
         it("should return 2 <testsuite>", () => {
             const result = formatter(code);
 
-            assert.strictEqual(result.replace(/\n/gu, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><failure message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Warning - Unexpected foo. (foo)]]></failure></testcase></testsuite><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"0\" name=\"bar.js\"><testcase time=\"0\" name=\"bar.js\" /></testsuite></testsuites>");
+            assert.strictEqual(result.replace(/\n/gu, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\" classname=\"foo\"><failure message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Warning - Unexpected foo. (foo)]]></failure></testcase></testsuite><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"0\" name=\"bar.js\"><testcase time=\"0\" name=\"bar.js\" classname=\"bar\" /></testsuite></testsuites>");
         });
     });
 
@@ -208,7 +208,7 @@ describe("formatter:junit", () => {
         it("should print a passing <testcase>", () => {
             const result = formatter(code);
 
-            assert.strictEqual(result.replace(/\n/gu, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"0\" name=\"foo.js\"><testcase time=\"0\" name=\"foo.js\" /></testsuite></testsuites>");
+            assert.strictEqual(result.replace(/\n/gu, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"0\" name=\"foo.js\"><testcase time=\"0\" name=\"foo.js\" classname=\"foo\" /></testsuite></testsuites>");
         });
     });
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**
This PR is a follow up from the discussion in issue https://github.com/eslint/eslint/issues/11068. 
With this change we are adding `classname` attribute to the `<testcase>` item.

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain: Add new attribute to JUnit formatter

**What changes did you make? (Give an overview)**

The value of `classname` is defined as the file path without extension. 
Similar implementation to TSlint: https://github.com/palantir/tslint/pull/4327

example:
```xml
<?xml version="1.0" encoding="utf-8"?>
<testsuites>
  <testsuite package="org.eslint" time="0" tests="1" errors="1" name="/path/to/foo.js">
    <testcase time="0" name="org.eslint.foo" classname="/path/to/foo">
      <failure message="Unexpected foo.">
        <![CDATA[line 5, col 10, Error - Unexpected foo. (foo)]]>
      </failure>
    </testcase>
  </testsuite>
</testsuites>
```

**Is there anything you'd like reviewers to focus on?**

Does this schema also need to be updated? https://eslint.org/docs/user-guide/formatters/#junit
