### PR TITLE
Fix: ignore return statements in dead code (fixes #11647)

### DIFF
--- a/lib/rules/no-useless-return.js
+++ b/lib/rules/no-useless-return.js
@@ -255,7 +255,14 @@ module.exports = {
                 if (node.argument) {
                     markReturnStatementsOnCurrentSegmentsAsUsed();
                 }
-                if (node.argument || astUtils.isInLoop(node) || isInFinally(node)) {
+                if (
+                    node.argument ||
+                    astUtils.isInLoop(node) ||
+                    isInFinally(node) ||
+
+                    // Ignore `return` statements in unreachable places (https://github.com/eslint/eslint/issues/11647).
+                    !scopeInfo.codePath.currentSegments.some(s => s.reachable)
+                ) {
                     return;
                 }
 

--- a/tests/lib/rules/no-useless-return.js
+++ b/tests/lib/rules/no-useless-return.js
@@ -165,6 +165,17 @@ ruleTester.run("no-useless-return", rule, {
             throw new Error('foo');
             while (false);
           } catch (err) {}
+        `,
+
+        // https://github.com/eslint/eslint/issues/11647
+        `
+          function foo(arg) {
+            throw new Error("Debugging...");
+            if (!arg) {
+              return;
+            }
+            console.log(arg);
+          }
         `
     ],
 
@@ -418,11 +429,7 @@ ruleTester.run("no-useless-return", rule, {
         },
         {
             code: "function foo() { return; return; }",
-            output: "function foo() {  return; }", // Other case is fixed in the second pass.
-            errors: [
-                { message: "Unnecessary return statement.", type: "ReturnStatement" },
-                { message: "Unnecessary return statement.", type: "ReturnStatement" }
-            ]
+            output: "function foo() {  return; }"
         }
     ].map(invalidCase => Object.assign({ errors: [{ message: "Unnecessary return statement.", type: "ReturnStatement" }] }, invalidCase))
 });

--- a/tests/lib/rules/no-useless-return.js
+++ b/tests/lib/rules/no-useless-return.js
@@ -429,7 +429,12 @@ ruleTester.run("no-useless-return", rule, {
         },
         {
             code: "function foo() { return; return; }",
-            output: "function foo() {  return; }"
+            output: "function foo() {  return; }",
+            errors: [{
+                message: "Unnecessary return statement.",
+                type: "ReturnStatement",
+                column: 18
+            }]
         }
     ].map(invalidCase => Object.assign({ errors: [{ message: "Unnecessary return statement.", type: "ReturnStatement" }] }, invalidCase))
 });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix #11647

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This PR fixes `no-useless-return` rule to ignore `return` statements in unreachable code.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.
