### PR TITLE
Update: Uniform messages for the rules in "complexity" section

### DIFF
--- a/lib/rules/complexity.js
+++ b/lib/rules/complexity.js
@@ -55,7 +55,7 @@ module.exports = {
         ],
 
         messages: {
-            complex: "{{name}} has a complexity of {{complexity}}."
+            complex: "{{name}} has a complexity of {{complexity}}. Maximum allowed is {{max}}."
         }
     },
 
@@ -102,7 +102,7 @@ module.exports = {
                 context.report({
                     node,
                     messageId: "complex",
-                    data: { name, complexity }
+                    data: { name, complexity, max: THRESHOLD }
                 });
             }
         }

--- a/lib/rules/max-classes-per-file.js
+++ b/lib/rules/max-classes-per-file.js
@@ -32,7 +32,7 @@ module.exports = {
         ],
 
         messages: {
-            maximumExceeded: "Number of classes per file must not exceed {{ max }}."
+            maximumExceeded: "File has too many classes ({{ classCount }}). Maximum allowed is {{ max }}."
         }
     },
     create(context) {
@@ -51,6 +51,7 @@ module.exports = {
                         node,
                         messageId: "maximumExceeded",
                         data: {
+                            classCount,
                             max: maxClasses
                         }
                     });

--- a/lib/rules/max-depth.js
+++ b/lib/rules/max-depth.js
@@ -45,7 +45,7 @@ module.exports = {
             }
         ],
         messages: {
-            tooDeeply: "Blocks are nested too deeply ({{depth}})."
+            tooDeeply: "Blocks are nested too deeply ({{depth}}). Maximum allowed is {{maxDepth}}."
         }
     },
 
@@ -97,7 +97,7 @@ module.exports = {
             const len = ++functionStack[functionStack.length - 1];
 
             if (len > maxDepth) {
-                context.report({ node, messageId: "tooDeeply", data: { depth: len } });
+                context.report({ node, messageId: "tooDeeply", data: { depth: len, maxDepth } });
             }
         }
 

--- a/lib/rules/max-len.js
+++ b/lib/rules/max-len.js
@@ -80,8 +80,8 @@ module.exports = {
             OPTIONS_SCHEMA
         ],
         messages: {
-            max: "Line {{lineNumber}} has a length of {{lineLength}}. Maximum allowed is {{maxLength}}.",
-            maxComment: "Line {{lineNumber}} has a comment length of {{lineLength}}. Maximum allowed is {{maxCommentLength}}."
+            max: "This line has a length of {{lineLength}}. Maximum allowed is {{maxLength}}.",
+            maxComment: "This line has a comment length of {{lineLength}}. Maximum allowed is {{maxCommentLength}}."
         }
     },
 
@@ -346,7 +346,6 @@ module.exports = {
                             loc: { line: lineNumber, column: 0 },
                             messageId: "maxComment",
                             data: {
-                                lineNumber: i + 1,
                                 lineLength,
                                 maxCommentLength
                             }
@@ -358,7 +357,6 @@ module.exports = {
                         loc: { line: lineNumber, column: 0 },
                         messageId: "max",
                         data: {
-                            lineNumber: i + 1,
                             lineLength,
                             maxLength
                         }

--- a/lib/rules/max-len.js
+++ b/lib/rules/max-len.js
@@ -80,8 +80,8 @@ module.exports = {
             OPTIONS_SCHEMA
         ],
         messages: {
-            max: "Line {{lineNumber}} exceeds the maximum line length of {{maxLength}}.",
-            maxComment: "Line {{lineNumber}} exceeds the maximum comment line length of {{maxCommentLength}}."
+            max: "Line {{lineNumber}} has a length of {{lineLength}}. Maximum allowed is {{maxLength}}.",
+            maxComment: "Line {{lineNumber}} has a comment length of {{lineLength}}. Maximum allowed is {{maxCommentLength}}."
         }
     },
 
@@ -347,6 +347,7 @@ module.exports = {
                             messageId: "maxComment",
                             data: {
                                 lineNumber: i + 1,
+                                lineLength,
                                 maxCommentLength
                             }
                         });
@@ -358,6 +359,7 @@ module.exports = {
                         messageId: "max",
                         data: {
                             lineNumber: i + 1,
+                            lineLength,
                             maxLength
                         }
                     });

--- a/lib/rules/max-lines-per-function.js
+++ b/lib/rules/max-lines-per-function.js
@@ -8,6 +8,8 @@
 // Requirements
 //------------------------------------------------------------------------------
 
+const lodash = require("lodash");
+
 const astUtils = require("../util/ast-utils");
 
 //------------------------------------------------------------------------------
@@ -192,7 +194,7 @@ module.exports = {
             }
 
             if (lineCount > maxLines) {
-                const name = astUtils.getFunctionNameWithKind(funcNode);
+                const name = lodash.upperFirst(astUtils.getFunctionNameWithKind(funcNode));
 
                 context.report({
                     node,

--- a/lib/rules/max-lines.js
+++ b/lib/rules/max-lines.js
@@ -53,7 +53,7 @@ module.exports = {
             }
         ],
         messages: {
-            exceed: "File must be at most {{max}} lines long. It's {{actual}} lines long."
+            exceed: "File has too many lines ({{actual}}). Maximum allowed is {{max}}."
         }
     },
 

--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -2685,7 +2685,7 @@ describe("Linter", () => {
 
             assert.strictEqual(messages.length, 1);
             assert.strictEqual(messages[0].ruleId, "max-len");
-            assert.strictEqual(messages[0].message, "Line 1 exceeds the maximum line length of 100.");
+            assert.strictEqual(messages[0].message, "Line 1 has a length of 122. Maximum allowed is 100.");
             assert.include(messages[0].nodeType, "Program");
         });
     });

--- a/tests/lib/linter.js
+++ b/tests/lib/linter.js
@@ -2685,7 +2685,7 @@ describe("Linter", () => {
 
             assert.strictEqual(messages.length, 1);
             assert.strictEqual(messages[0].ruleId, "max-len");
-            assert.strictEqual(messages[0].message, "Line 1 has a length of 122. Maximum allowed is 100.");
+            assert.strictEqual(messages[0].message, "This line has a length of 122. Maximum allowed is 100.");
             assert.include(messages[0].nodeType, "Program");
         });
     });

--- a/tests/lib/rules/complexity.js
+++ b/tests/lib/rules/complexity.js
@@ -38,12 +38,13 @@ function createComplexity(complexity) {
  * Create an expected error object
  * @param   {string} name       The name of the symbol being tested
  * @param   {number} complexity The cyclomatic complexity value of the symbol
+ * @param   {number} max        The maximum cyclomatic complexity value of the symbol
  * @returns {Object}            The error object
  */
-function makeError(name, complexity) {
+function makeError(name, complexity, max) {
     return {
         messageId: "complex",
-        data: { name, complexity }
+        data: { name, complexity, max }
     };
 }
 
@@ -76,10 +77,10 @@ ruleTester.run("complexity", rule, {
         { code: "function b(x) {}", options: [{ max: 1 }] }
     ],
     invalid: [
-        { code: "function a(x) {}", options: [0], errors: [makeError("Function 'a'", 1)] },
-        { code: "var func = function () {}", options: [0], errors: [makeError("Function", 1)] },
-        { code: "var obj = { a(x) {} }", options: [0], parserOptions: { ecmaVersion: 6 }, errors: [makeError("Method 'a'", 1)] },
-        { code: "class Test { a(x) {} }", options: [0], parserOptions: { ecmaVersion: 6 }, errors: [makeError("Method 'a'", 1)] },
+        { code: "function a(x) {}", options: [0], errors: [makeError("Function 'a'", 1, 0)] },
+        { code: "var func = function () {}", options: [0], errors: [makeError("Function", 1, 0)] },
+        { code: "var obj = { a(x) {} }", options: [0], parserOptions: { ecmaVersion: 6 }, errors: [makeError("Method 'a'", 1, 0)] },
+        { code: "class Test { a(x) {} }", options: [0], parserOptions: { ecmaVersion: 6 }, errors: [makeError("Method 'a'", 1, 0)] },
         { code: "var a = (x) => {if (true) {return x;}}", options: [1], errors: 1, settings: { ecmascript: 6 } },
         { code: "function a(x) {if (true) {return x;}}", options: [1], errors: 1 },
         { code: "function a(x) {if (true) {return x;} else {return x+1;}}", options: [1], errors: 1 },
@@ -100,19 +101,19 @@ ruleTester.run("complexity", rule, {
         { code: "function a(x) {do {'foo';} while (true)}", options: [1], errors: 1 },
         { code: "function a(x) {(function() {while(true){'foo';}})(); (function() {while(true){'bar';}})();}", options: [1], errors: 2 },
         { code: "function a(x) {(function() {while(true){'foo';}})(); (function() {'bar';})();}", options: [1], errors: 1 },
-        { code: "var obj = { a(x) { return x ? 0 : 1; } };", options: [1], parserOptions: { ecmaVersion: 6 }, errors: [makeError("Method 'a'", 2)] },
-        { code: "var obj = { a: function b(x) { return x ? 0 : 1; } };", options: [1], errors: [makeError("Method 'b'", 2)] },
+        { code: "var obj = { a(x) { return x ? 0 : 1; } };", options: [1], parserOptions: { ecmaVersion: 6 }, errors: [makeError("Method 'a'", 2, 1)] },
+        { code: "var obj = { a: function b(x) { return x ? 0 : 1; } };", options: [1], errors: [makeError("Method 'b'", 2, 1)] },
         {
             code: createComplexity(21),
-            errors: [makeError("Function 'test'", 21)]
+            errors: [makeError("Function 'test'", 21, 20)]
         },
         {
             code: createComplexity(21),
             options: [{}],
-            errors: [makeError("Function 'test'", 21)]
+            errors: [makeError("Function 'test'", 21, 20)]
         },
 
         // object property options
-        { code: "function a(x) {}", options: [{ max: 0 }], errors: [makeError("Function 'a'", 1)] }
+        { code: "function a(x) {}", options: [{ max: 0 }], errors: [makeError("Function 'a'", 1, 0)] }
     ]
 });

--- a/tests/lib/rules/max-depth.js
+++ b/tests/lib/rules/max-depth.js
@@ -29,18 +29,18 @@ ruleTester.run("max-depth", rule, {
         { code: "function foo() { if (true) { if (false) { if (true) { } } } }", options: [{ max: 3 }] }
     ],
     invalid: [
-        { code: "function foo() { if (true) { if (false) { if (true) { } } } }", options: [2], errors: [{ messageId: "tooDeeply", data: { depth: 3 }, type: "IfStatement" }] },
-        { code: "var foo = () => { if (true) { if (false) { if (true) { } } } }", options: [2], parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "tooDeeply", data: { depth: 3 }, type: "IfStatement" }] },
-        { code: "function foo() { if (true) {} else { for(;;) {} } }", options: [1], errors: [{ messageId: "tooDeeply", data: { depth: 2 }, type: "ForStatement" }] },
-        { code: "function foo() { while (true) { if (true) {} } }", options: [1], errors: [{ messageId: "tooDeeply", data: { depth: 2 }, type: "IfStatement" }] },
-        { code: "function foo() { for (let x of foo) { if (true) {} } }", options: [1], parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "tooDeeply", data: { depth: 2 }, type: "IfStatement" }] },
-        { code: "function foo() { while (true) { if (true) { if (false) { } } } }", options: [1], errors: [{ messageId: "tooDeeply", data: { depth: 2 }, type: "IfStatement" }, { messageId: "tooDeeply", data: { depth: 3 }, type: "IfStatement" }] },
-        { code: "function foo() { if (true) { if (false) { if (true) { if (false) { if (true) { } } } } } }", errors: [{ messageId: "tooDeeply", data: { depth: 5 }, type: "IfStatement" }] },
+        { code: "function foo() { if (true) { if (false) { if (true) { } } } }", options: [2], errors: [{ messageId: "tooDeeply", data: { depth: 3, maxDepth: 2 }, type: "IfStatement" }] },
+        { code: "var foo = () => { if (true) { if (false) { if (true) { } } } }", options: [2], parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "tooDeeply", data: { depth: 3, maxDepth: 2 }, type: "IfStatement" }] },
+        { code: "function foo() { if (true) {} else { for(;;) {} } }", options: [1], errors: [{ messageId: "tooDeeply", data: { depth: 2, maxDepth: 1 }, type: "ForStatement" }] },
+        { code: "function foo() { while (true) { if (true) {} } }", options: [1], errors: [{ messageId: "tooDeeply", data: { depth: 2, maxDepth: 1 }, type: "IfStatement" }] },
+        { code: "function foo() { for (let x of foo) { if (true) {} } }", options: [1], parserOptions: { ecmaVersion: 6 }, errors: [{ messageId: "tooDeeply", data: { depth: 2, maxDepth: 1 }, type: "IfStatement" }] },
+        { code: "function foo() { while (true) { if (true) { if (false) { } } } }", options: [1], errors: [{ messageId: "tooDeeply", data: { depth: 2, maxDepth: 1 }, type: "IfStatement" }, { messageId: "tooDeeply", data: { depth: 3, maxDepth: 1 }, type: "IfStatement" }] },
+        { code: "function foo() { if (true) { if (false) { if (true) { if (false) { if (true) { } } } } } }", errors: [{ messageId: "tooDeeply", data: { depth: 5, maxDepth: 4 }, type: "IfStatement" }] },
 
         // object property options
-        { code: "function foo() { if (true) { if (false) { if (true) { } } } }", options: [{ max: 2 }], errors: [{ messageId: "tooDeeply", data: { depth: 3 }, type: "IfStatement" }] },
+        { code: "function foo() { if (true) { if (false) { if (true) { } } } }", options: [{ max: 2 }], errors: [{ messageId: "tooDeeply", data: { depth: 3, maxDepth: 2 }, type: "IfStatement" }] },
 
-        { code: "function foo() { if (a) { if (b) { if (c) { if (d) { if (e) {} } } } } }", options: [{}], errors: [{ messageId: "tooDeeply", data: { depth: 5 } }] },
-        { code: "function foo() { if (true) {} }", options: [{ max: 0 }], errors: [{ messageId: "tooDeeply", data: { depth: 1 } }] }
+        { code: "function foo() { if (a) { if (b) { if (c) { if (d) { if (e) {} } } } } }", options: [{}], errors: [{ messageId: "tooDeeply", data: { depth: 5, maxDepth: 4 } }] },
+        { code: "function foo() { if (true) {} }", options: [{ max: 0 }], errors: [{ messageId: "tooDeeply", data: { depth: 1, maxDepth: 0 } }] }
     ]
 });

--- a/tests/lib/rules/max-len.js
+++ b/tests/lib/rules/max-len.js
@@ -198,7 +198,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "max",
-                    data: { lineNumber: 1, maxLength: 80 },
+                    data: { lineNumber: 1, lineLength: 86, maxLength: 80 },
                     type: "Program",
                     line: 1,
                     column: 1
@@ -211,7 +211,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "max",
-                    data: { lineNumber: 1, maxLength: 10 },
+                    data: { lineNumber: 1, lineLength: 24, maxLength: 10 },
                     type: "Program",
                     line: 1,
                     column: 1
@@ -224,7 +224,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "max",
-                    data: { lineNumber: 1, maxLength: 15 },
+                    data: { lineNumber: 1, lineLength: 22, maxLength: 15 },
                     type: "Program",
                     line: 1,
                     column: 1
@@ -237,14 +237,14 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "max",
-                    data: { lineNumber: 1, maxLength: 15 },
+                    data: { lineNumber: 1, lineLength: 22, maxLength: 15 },
                     type: "Program",
                     line: 1,
                     column: 1
                 },
                 {
                     messageId: "max",
-                    data: { lineNumber: 2, maxLength: 15 },
+                    data: { lineNumber: 2, lineLength: 22, maxLength: 15 },
                     type: "Program",
                     line: 2,
                     column: 1
@@ -257,7 +257,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "max",
-                    data: { lineNumber: 1, maxLength: 20 },
+                    data: { lineNumber: 1, lineLength: 56, maxLength: 20 },
                     type: "Program",
                     line: 1,
                     column: 1
@@ -272,7 +272,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "max",
-                    data: { lineNumber: 1, maxLength: 20 },
+                    data: { lineNumber: 1, lineLength: 54, maxLength: 20 },
                     type: "Program",
                     line: 1,
                     column: 1
@@ -285,7 +285,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "max",
-                    data: { lineNumber: 1, maxLength: 10 },
+                    data: { lineNumber: 1, lineLength: 30, maxLength: 10 },
                     type: "Program",
                     line: 1,
                     column: 1
@@ -298,7 +298,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "max",
-                    data: { lineNumber: 1, maxLength: 40 },
+                    data: { lineNumber: 1, lineLength: 62, maxLength: 40 },
                     type: "Program",
                     line: 1,
                     column: 1
@@ -311,7 +311,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "max",
-                    data: { lineNumber: 1, maxLength: 40 },
+                    data: { lineNumber: 1, lineLength: 57, maxLength: 40 },
                     type: "Program",
                     line: 1,
                     column: 1
@@ -323,7 +323,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "max",
-                    data: { lineNumber: 1, maxLength: 40 },
+                    data: { lineNumber: 1, lineLength: 53, maxLength: 40 },
                     type: "Program",
                     line: 1,
                     column: 1
@@ -335,7 +335,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "maxComment",
-                    data: { lineNumber: 1, maxCommentLength: 20 },
+                    data: { lineNumber: 1, lineLength: 49, maxCommentLength: 20 },
                     type: "Program",
                     line: 1,
                     column: 1
@@ -347,7 +347,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "maxComment",
-                    data: { lineNumber: 1, maxCommentLength: 80 },
+                    data: { lineNumber: 1, lineLength: 119, maxCommentLength: 80 },
                     type: "Program",
                     line: 1,
                     column: 1
@@ -359,7 +359,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "max",
-                    data: { lineNumber: 1, maxLength: 20 },
+                    data: { lineNumber: 1, lineLength: 49, maxLength: 20 },
                     type: "Program",
                     line: 1,
                     column: 1
@@ -371,7 +371,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "max",
-                    data: { lineNumber: 1, maxLength: 40 },
+                    data: { lineNumber: 1, lineLength: 73, maxLength: 40 },
                     type: "Program",
                     line: 1,
                     column: 1
@@ -388,7 +388,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "maxComment",
-                    data: { lineNumber: 2, maxCommentLength: 28 },
+                    data: { lineNumber: 2, lineLength: 29, maxCommentLength: 28 },
                     type: "Program",
                     line: 2,
                     column: 1
@@ -402,7 +402,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "maxComment",
-                    data: { lineNumber: 2, maxCommentLength: 32 },
+                    data: { lineNumber: 2, lineLength: 33, maxCommentLength: 32 },
                     type: "Program",
                     line: 2,
                     column: 1
@@ -417,14 +417,14 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "maxComment",
-                    data: { lineNumber: 2, maxCommentLength: 28 },
+                    data: { lineNumber: 2, lineLength: 29, maxCommentLength: 28 },
                     type: "Program",
                     line: 2,
                     column: 1
                 },
                 {
                     messageId: "maxComment",
-                    data: { lineNumber: 3, maxCommentLength: 28 },
+                    data: { lineNumber: 3, lineLength: 32, maxCommentLength: 28 },
                     type: "Program",
                     line: 3,
                     column: 1
@@ -439,14 +439,14 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "maxComment",
-                    data: { lineNumber: 2, maxCommentLength: 32 },
+                    data: { lineNumber: 2, lineLength: 33, maxCommentLength: 32 },
                     type: "Program",
                     line: 2,
                     column: 1
                 },
                 {
                     messageId: "maxComment",
-                    data: { lineNumber: 3, maxCommentLength: 32 },
+                    data: { lineNumber: 3, lineLength: 36, maxCommentLength: 32 },
                     type: "Program",
                     line: 3,
                     column: 1
@@ -461,14 +461,14 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "max",
-                    data: { lineNumber: 2, maxLength: 39 },
+                    data: { lineNumber: 2, lineLength: 40, maxLength: 39 },
                     type: "Program",
                     line: 2,
                     column: 1
                 },
                 {
                     messageId: "maxComment",
-                    data: { lineNumber: 3, maxCommentLength: 35 },
+                    data: { lineNumber: 3, lineLength: 36, maxCommentLength: 35 },
                     type: "Program",
                     line: 3,
                     column: 1
@@ -483,14 +483,14 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "maxComment",
-                    data: { lineNumber: 2, maxCommentLength: 32 },
+                    data: { lineNumber: 2, lineLength: 33, maxCommentLength: 32 },
                     type: "Program",
                     line: 2,
                     column: 1
                 },
                 {
                     messageId: "max",
-                    data: { lineNumber: 3, maxLength: 42 },
+                    data: { lineNumber: 3, lineLength: 43, maxLength: 42 },
                     type: "Program",
                     line: 3,
                     column: 1
@@ -506,7 +506,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "max",
-                    data: { lineNumber: 2, maxLength: 20 },
+                    data: { lineNumber: 2, lineLength: 51, maxLength: 20 },
                     type: "Program",
                     line: 2,
                     column: 1
@@ -521,7 +521,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "max",
-                    data: { lineNumber: 2, maxLength: 29 },
+                    data: { lineNumber: 2, lineLength: 39, maxLength: 29 },
                     type: "Program",
                     line: 2,
                     column: 1
@@ -534,7 +534,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "max",
-                    data: { lineNumber: 2, maxLength: 29 },
+                    data: { lineNumber: 2, lineLength: 45, maxLength: 29 },
                     type: "Program",
                     line: 2,
                     column: 1
@@ -547,7 +547,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "max",
-                    data: { lineNumber: 2, maxLength: 29 },
+                    data: { lineNumber: 2, lineLength: 57, maxLength: 29 },
                     type: "Program",
                     line: 2,
                     column: 1
@@ -560,7 +560,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "max",
-                    data: { lineNumber: 2, maxLength: 29 },
+                    data: { lineNumber: 2, lineLength: 39, maxLength: 29 },
                     type: "Program",
                     line: 2,
                     column: 1
@@ -574,7 +574,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "max",
-                    data: { lineNumber: 2, maxLength: 29 },
+                    data: { lineNumber: 2, lineLength: 39, maxLength: 29 },
                     type: "Program",
                     line: 2,
                     column: 1
@@ -588,14 +588,14 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "max",
-                    data: { lineNumber: 2, maxLength: 29 },
+                    data: { lineNumber: 2, lineLength: 37, maxLength: 29 },
                     type: "Program",
                     line: 2,
                     column: 1
                 },
                 {
                     messageId: "max",
-                    data: { lineNumber: 3, maxLength: 29 },
+                    data: { lineNumber: 3, lineLength: 44, maxLength: 29 },
                     type: "Program",
                     line: 3,
                     column: 1
@@ -609,7 +609,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "max",
-                    data: { lineNumber: 1, maxLength: 29 },
+                    data: { lineNumber: 1, lineLength: 58, maxLength: 29 },
                     type: "Program",
                     line: 1,
                     column: 1
@@ -624,7 +624,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "max",
-                    data: { lineNumber: 1, maxLength: 10 },
+                    data: { lineNumber: 1, lineLength: 12, maxLength: 10 },
                     type: "Program",
                     line: 1,
                     column: 1
@@ -638,7 +638,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "max",
-                    data: { lineNumber: 1, maxLength: 0 },
+                    data: { lineNumber: 1, lineLength: 1, maxLength: 0 },
                     type: "Program",
                     line: 1,
                     column: 1

--- a/tests/lib/rules/max-len.js
+++ b/tests/lib/rules/max-len.js
@@ -198,7 +198,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "max",
-                    data: { lineNumber: 1, lineLength: 86, maxLength: 80 },
+                    data: { lineLength: 86, maxLength: 80 },
                     type: "Program",
                     line: 1,
                     column: 1
@@ -211,7 +211,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "max",
-                    data: { lineNumber: 1, lineLength: 24, maxLength: 10 },
+                    data: { lineLength: 24, maxLength: 10 },
                     type: "Program",
                     line: 1,
                     column: 1
@@ -224,7 +224,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "max",
-                    data: { lineNumber: 1, lineLength: 22, maxLength: 15 },
+                    data: { lineLength: 22, maxLength: 15 },
                     type: "Program",
                     line: 1,
                     column: 1
@@ -237,14 +237,14 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "max",
-                    data: { lineNumber: 1, lineLength: 22, maxLength: 15 },
+                    data: { lineLength: 22, maxLength: 15 },
                     type: "Program",
                     line: 1,
                     column: 1
                 },
                 {
                     messageId: "max",
-                    data: { lineNumber: 2, lineLength: 22, maxLength: 15 },
+                    data: { lineLength: 22, maxLength: 15 },
                     type: "Program",
                     line: 2,
                     column: 1
@@ -257,7 +257,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "max",
-                    data: { lineNumber: 1, lineLength: 56, maxLength: 20 },
+                    data: { lineLength: 56, maxLength: 20 },
                     type: "Program",
                     line: 1,
                     column: 1
@@ -272,7 +272,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "max",
-                    data: { lineNumber: 1, lineLength: 54, maxLength: 20 },
+                    data: { lineLength: 54, maxLength: 20 },
                     type: "Program",
                     line: 1,
                     column: 1
@@ -285,7 +285,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "max",
-                    data: { lineNumber: 1, lineLength: 30, maxLength: 10 },
+                    data: { lineLength: 30, maxLength: 10 },
                     type: "Program",
                     line: 1,
                     column: 1
@@ -298,7 +298,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "max",
-                    data: { lineNumber: 1, lineLength: 62, maxLength: 40 },
+                    data: { lineLength: 62, maxLength: 40 },
                     type: "Program",
                     line: 1,
                     column: 1
@@ -311,7 +311,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "max",
-                    data: { lineNumber: 1, lineLength: 57, maxLength: 40 },
+                    data: { lineLength: 57, maxLength: 40 },
                     type: "Program",
                     line: 1,
                     column: 1
@@ -323,7 +323,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "max",
-                    data: { lineNumber: 1, lineLength: 53, maxLength: 40 },
+                    data: { lineLength: 53, maxLength: 40 },
                     type: "Program",
                     line: 1,
                     column: 1
@@ -335,7 +335,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "maxComment",
-                    data: { lineNumber: 1, lineLength: 49, maxCommentLength: 20 },
+                    data: { lineLength: 49, maxCommentLength: 20 },
                     type: "Program",
                     line: 1,
                     column: 1
@@ -347,7 +347,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "maxComment",
-                    data: { lineNumber: 1, lineLength: 119, maxCommentLength: 80 },
+                    data: { lineLength: 119, maxCommentLength: 80 },
                     type: "Program",
                     line: 1,
                     column: 1
@@ -359,7 +359,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "max",
-                    data: { lineNumber: 1, lineLength: 49, maxLength: 20 },
+                    data: { lineLength: 49, maxLength: 20 },
                     type: "Program",
                     line: 1,
                     column: 1
@@ -371,7 +371,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "max",
-                    data: { lineNumber: 1, lineLength: 73, maxLength: 40 },
+                    data: { lineLength: 73, maxLength: 40 },
                     type: "Program",
                     line: 1,
                     column: 1
@@ -388,7 +388,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "maxComment",
-                    data: { lineNumber: 2, lineLength: 29, maxCommentLength: 28 },
+                    data: { lineLength: 29, maxCommentLength: 28 },
                     type: "Program",
                     line: 2,
                     column: 1
@@ -402,7 +402,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "maxComment",
-                    data: { lineNumber: 2, lineLength: 33, maxCommentLength: 32 },
+                    data: { lineLength: 33, maxCommentLength: 32 },
                     type: "Program",
                     line: 2,
                     column: 1
@@ -417,14 +417,14 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "maxComment",
-                    data: { lineNumber: 2, lineLength: 29, maxCommentLength: 28 },
+                    data: { lineLength: 29, maxCommentLength: 28 },
                     type: "Program",
                     line: 2,
                     column: 1
                 },
                 {
                     messageId: "maxComment",
-                    data: { lineNumber: 3, lineLength: 32, maxCommentLength: 28 },
+                    data: { lineLength: 32, maxCommentLength: 28 },
                     type: "Program",
                     line: 3,
                     column: 1
@@ -439,14 +439,14 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "maxComment",
-                    data: { lineNumber: 2, lineLength: 33, maxCommentLength: 32 },
+                    data: { lineLength: 33, maxCommentLength: 32 },
                     type: "Program",
                     line: 2,
                     column: 1
                 },
                 {
                     messageId: "maxComment",
-                    data: { lineNumber: 3, lineLength: 36, maxCommentLength: 32 },
+                    data: { lineLength: 36, maxCommentLength: 32 },
                     type: "Program",
                     line: 3,
                     column: 1
@@ -461,14 +461,14 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "max",
-                    data: { lineNumber: 2, lineLength: 40, maxLength: 39 },
+                    data: { lineLength: 40, maxLength: 39 },
                     type: "Program",
                     line: 2,
                     column: 1
                 },
                 {
                     messageId: "maxComment",
-                    data: { lineNumber: 3, lineLength: 36, maxCommentLength: 35 },
+                    data: { lineLength: 36, maxCommentLength: 35 },
                     type: "Program",
                     line: 3,
                     column: 1
@@ -483,14 +483,14 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "maxComment",
-                    data: { lineNumber: 2, lineLength: 33, maxCommentLength: 32 },
+                    data: { lineLength: 33, maxCommentLength: 32 },
                     type: "Program",
                     line: 2,
                     column: 1
                 },
                 {
                     messageId: "max",
-                    data: { lineNumber: 3, lineLength: 43, maxLength: 42 },
+                    data: { lineLength: 43, maxLength: 42 },
                     type: "Program",
                     line: 3,
                     column: 1
@@ -506,7 +506,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "max",
-                    data: { lineNumber: 2, lineLength: 51, maxLength: 20 },
+                    data: { lineLength: 51, maxLength: 20 },
                     type: "Program",
                     line: 2,
                     column: 1
@@ -521,7 +521,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "max",
-                    data: { lineNumber: 2, lineLength: 39, maxLength: 29 },
+                    data: { lineLength: 39, maxLength: 29 },
                     type: "Program",
                     line: 2,
                     column: 1
@@ -534,7 +534,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "max",
-                    data: { lineNumber: 2, lineLength: 45, maxLength: 29 },
+                    data: { lineLength: 45, maxLength: 29 },
                     type: "Program",
                     line: 2,
                     column: 1
@@ -547,7 +547,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "max",
-                    data: { lineNumber: 2, lineLength: 57, maxLength: 29 },
+                    data: { lineLength: 57, maxLength: 29 },
                     type: "Program",
                     line: 2,
                     column: 1
@@ -560,7 +560,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "max",
-                    data: { lineNumber: 2, lineLength: 39, maxLength: 29 },
+                    data: { lineLength: 39, maxLength: 29 },
                     type: "Program",
                     line: 2,
                     column: 1
@@ -574,7 +574,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "max",
-                    data: { lineNumber: 2, lineLength: 39, maxLength: 29 },
+                    data: { lineLength: 39, maxLength: 29 },
                     type: "Program",
                     line: 2,
                     column: 1
@@ -588,14 +588,14 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "max",
-                    data: { lineNumber: 2, lineLength: 37, maxLength: 29 },
+                    data: { lineLength: 37, maxLength: 29 },
                     type: "Program",
                     line: 2,
                     column: 1
                 },
                 {
                     messageId: "max",
-                    data: { lineNumber: 3, lineLength: 44, maxLength: 29 },
+                    data: { lineLength: 44, maxLength: 29 },
                     type: "Program",
                     line: 3,
                     column: 1
@@ -609,7 +609,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "max",
-                    data: { lineNumber: 1, lineLength: 58, maxLength: 29 },
+                    data: { lineLength: 58, maxLength: 29 },
                     type: "Program",
                     line: 1,
                     column: 1
@@ -624,7 +624,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "max",
-                    data: { lineNumber: 1, lineLength: 12, maxLength: 10 },
+                    data: { lineLength: 12, maxLength: 10 },
                     type: "Program",
                     line: 1,
                     column: 1
@@ -638,7 +638,7 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     messageId: "max",
-                    data: { lineNumber: 1, lineLength: 1, maxLength: 0 },
+                    data: { lineLength: 1, maxLength: 0 },
                     type: "Program",
                     line: 1,
                     column: 1

--- a/tests/lib/rules/max-lines-per-function.js
+++ b/tests/lib/rules/max-lines-per-function.js
@@ -174,7 +174,7 @@ if ( x === y ) {
             code: "function name() {\n}",
             options: [1],
             errors: [
-                { messageId: "exceed", data: { name: "function 'name'", lineCount: 2, maxLines: 1 } }
+                { messageId: "exceed", data: { name: "Function 'name'", lineCount: 2, maxLines: 1 } }
             ]
         },
 
@@ -183,7 +183,7 @@ if ( x === y ) {
             code: "var func = function() {\n}",
             options: [1],
             errors: [
-                { messageId: "exceed", data: { name: "function", lineCount: 2, maxLines: 1 } }
+                { messageId: "exceed", data: { name: "Function", lineCount: 2, maxLines: 1 } }
             ]
         },
 
@@ -192,7 +192,7 @@ if ( x === y ) {
             code: "const bar = () => {\nconst x = 2 + 1;\nreturn x;\n}",
             options: [3],
             errors: [
-                { messageId: "exceed", data: { name: "arrow function", lineCount: 4, maxLines: 3 } }
+                { messageId: "exceed", data: { name: "Arrow function", lineCount: 4, maxLines: 3 } }
             ]
         },
 
@@ -201,7 +201,7 @@ if ( x === y ) {
             code: "const bar = () =>\n 2",
             options: [1],
             errors: [
-                { messageId: "exceed", data: { name: "arrow function", lineCount: 2, maxLines: 1 } }
+                { messageId: "exceed", data: { name: "Arrow function", lineCount: 2, maxLines: 1 } }
             ]
         },
 
@@ -210,7 +210,7 @@ if ( x === y ) {
             code: `() => {${"foo\n".repeat(60)}}`,
             options: [{}],
             errors: [
-                { messageId: "exceed", data: { name: "arrow function", lineCount: 61, maxLines: 50 } }
+                { messageId: "exceed", data: { name: "Arrow function", lineCount: 61, maxLines: 50 } }
             ]
         },
 
@@ -219,7 +219,7 @@ if ( x === y ) {
             code: "function name() {\nvar x = 5;\n\t\n \n\nvar x = 2;\n}",
             options: [{ max: 6, skipComments: false, skipBlankLines: false }],
             errors: [
-                { messageId: "exceed", data: { name: "function 'name'", lineCount: 7, maxLines: 6 } }
+                { messageId: "exceed", data: { name: "Function 'name'", lineCount: 7, maxLines: 6 } }
             ]
         },
 
@@ -228,7 +228,7 @@ if ( x === y ) {
             code: "function name() {\r\nvar x = 5;\r\n\t\r\n \r\n\r\nvar x = 2;\r\n}",
             options: [{ max: 6, skipComments: true, skipBlankLines: false }],
             errors: [
-                { messageId: "exceed", data: { name: "function 'name'", lineCount: 7, maxLines: 6 } }
+                { messageId: "exceed", data: { name: "Function 'name'", lineCount: 7, maxLines: 6 } }
             ]
         },
 
@@ -237,7 +237,7 @@ if ( x === y ) {
             code: "function name() {\nvar x = 5;\n\t\n \n\nvar x = 2;\n}",
             options: [{ max: 2, skipComments: true, skipBlankLines: true }],
             errors: [
-                { messageId: "exceed", data: { name: "function 'name'", lineCount: 4, maxLines: 2 } }
+                { messageId: "exceed", data: { name: "Function 'name'", lineCount: 4, maxLines: 2 } }
             ]
         },
 
@@ -246,7 +246,7 @@ if ( x === y ) {
             code: "function name() {\r\nvar x = 5;\r\n\t\r\n \r\n\r\nvar x = 2;\r\n}",
             options: [{ max: 2, skipComments: true, skipBlankLines: true }],
             errors: [
-                { messageId: "exceed", data: { name: "function 'name'", lineCount: 4, maxLines: 2 } }
+                { messageId: "exceed", data: { name: "Function 'name'", lineCount: 4, maxLines: 2 } }
             ]
         },
 
@@ -255,7 +255,7 @@ if ( x === y ) {
             code: "function name() { // end of line comment\nvar x = 5; /* mid line comment */\n\t// single line comment taking up whole line\n\t\n \n\nvar x = 2;\n}",
             options: [{ max: 6, skipComments: true, skipBlankLines: false }],
             errors: [
-                { messageId: "exceed", data: { name: "function 'name'", lineCount: 7, maxLines: 6 } }
+                { messageId: "exceed", data: { name: "Function 'name'", lineCount: 7, maxLines: 6 } }
             ]
         },
 
@@ -264,7 +264,7 @@ if ( x === y ) {
             code: "function name() { // end of line comment\nvar x = 5; /* mid line comment */\n\t// single line comment taking up whole line\n\t\n \n\nvar x = 2;\n}",
             options: [{ max: 1, skipComments: true, skipBlankLines: true }],
             errors: [
-                { messageId: "exceed", data: { name: "function 'name'", lineCount: 4, maxLines: 1 } }
+                { messageId: "exceed", data: { name: "Function 'name'", lineCount: 4, maxLines: 1 } }
             ]
         },
 
@@ -273,7 +273,7 @@ if ( x === y ) {
             code: "function name() { // end of line comment\nvar x = 5; /* mid line comment */\n\t// single line comment taking up whole line\n\t\n \n\nvar x = 2;\n}",
             options: [{ max: 1, skipComments: false, skipBlankLines: true }],
             errors: [
-                { messageId: "exceed", data: { name: "function 'name'", lineCount: 5, maxLines: 1 } }
+                { messageId: "exceed", data: { name: "Function 'name'", lineCount: 5, maxLines: 1 } }
             ]
         },
 
@@ -288,7 +288,7 @@ if ( x === y ) {
 }`,
             options: [{ max: 2, skipComments: true, skipBlankLines: false }],
             errors: [
-                { messageId: "exceed", data: { name: "function 'foo'", lineCount: 7, maxLines: 2 } }
+                { messageId: "exceed", data: { name: "Function 'foo'", lineCount: 7, maxLines: 2 } }
             ]
         },
 
@@ -303,7 +303,7 @@ function
 ()`,
             options: [{ max: 2, skipComments: true, skipBlankLines: false, IIFEs: true }],
             errors: [
-                { messageId: "exceed", data: { name: "function", lineCount: 4, maxLines: 2 } }
+                { messageId: "exceed", data: { name: "Function", lineCount: 4, maxLines: 2 } }
             ]
         },
 
@@ -321,7 +321,7 @@ if ( x === y ) {
 }`,
             options: [{ max: 9, skipComments: true, skipBlankLines: false }],
             errors: [
-                { messageId: "exceed", data: { name: "function 'parent'", lineCount: 10, maxLines: 9 } }
+                { messageId: "exceed", data: { name: "Function 'parent'", lineCount: 10, maxLines: 9 } }
             ]
         },
 
@@ -339,8 +339,8 @@ if ( x === y ) {
 }`,
             options: [{ max: 2, skipComments: true, skipBlankLines: false }],
             errors: [
-                { messageId: "exceed", data: { name: "function 'parent'", lineCount: 10, maxLines: 2 } },
-                { messageId: "exceed", data: { name: "function 'nested'", lineCount: 4, maxLines: 2 } }
+                { messageId: "exceed", data: { name: "Function 'parent'", lineCount: 10, maxLines: 2 } },
+                { messageId: "exceed", data: { name: "Function 'nested'", lineCount: 4, maxLines: 2 } }
             ]
         },
 
@@ -355,7 +355,7 @@ if ( x === y ) {
 }`,
             options: [{ max: 2, skipComments: true, skipBlankLines: false }],
             errors: [
-                { messageId: "exceed", data: { name: "method 'method'", lineCount: 5, maxLines: 2 } }
+                { messageId: "exceed", data: { name: "Method 'method'", lineCount: 5, maxLines: 2 } }
             ]
         },
 
@@ -370,7 +370,7 @@ if ( x === y ) {
 }`,
             options: [{ max: 2, skipComments: true, skipBlankLines: false }],
             errors: [
-                { messageId: "exceed", data: { name: "static method 'foo'", lineCount: 5, maxLines: 2 } }
+                { messageId: "exceed", data: { name: "Static method 'foo'", lineCount: 5, maxLines: 2 } }
             ]
         },
 
@@ -385,7 +385,7 @@ if ( x === y ) {
 }`,
             options: [{ max: 2, skipComments: true, skipBlankLines: false }],
             errors: [
-                { messageId: "exceed", data: { name: "getter 'foo'", lineCount: 5, maxLines: 2 } }
+                { messageId: "exceed", data: { name: "Getter 'foo'", lineCount: 5, maxLines: 2 } }
             ]
         },
 
@@ -400,7 +400,7 @@ if ( x === y ) {
 }`,
             options: [{ max: 2, skipComments: true, skipBlankLines: false }],
             errors: [
-                { messageId: "exceed", data: { name: "setter 'foo'", lineCount: 5, maxLines: 2 } }
+                { messageId: "exceed", data: { name: "Setter 'foo'", lineCount: 5, maxLines: 2 } }
             ]
         },
 
@@ -418,7 +418,7 @@ if ( x === y ) {
 }`,
             options: [{ max: 2, skipComments: true, skipBlankLines: false }],
             errors: [
-                { messageId: "exceed", data: { name: "static method", lineCount: 8, maxLines: 2 } }
+                { messageId: "exceed", data: { name: "Static method", lineCount: 8, maxLines: 2 } }
             ]
         },
 
@@ -433,7 +433,7 @@ if ( x === y ) {
 }());`,
             options: [{ max: 2, skipComments: true, skipBlankLines: false, IIFEs: true }],
             errors: [
-                { messageId: "exceed", data: { name: "function", lineCount: 7, maxLines: 2 } }
+                { messageId: "exceed", data: { name: "Function", lineCount: 7, maxLines: 2 } }
             ]
         }
     ]


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

- [x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))

**What rule do you want to change?**

It is proposed to unify the content of messages from the category "[complexity](https://eslint.org/docs/rules/complexity)". And make them more informative.


**Does this change cause the rule to produce more or fewer warnings?**

no changed


**How will the change be implemented? (New option, new default behavior, etc.)?**

- Changing the message template in `exports.meta.messages`
- Changing `data` in a `context.report` method call


**Please provide some example code that this change will affect:**

```js
function test(a) {
  // Comment qwerty qwerty qwerty qwerty
  if (a) {
    if (a) {
      console.log('qwerty');
    }
    a(function() {
      onsole.log('qwerty qwerty');
    })
    a++;a++;a++
    if (a) a(); else a();
  }
}
 
test(a);test(a);

class a {
  
}

class b {
  
}
```

*rules config*
```json
  "rules": {
    "complexity": ["warn", 1],
    "max-depth": ["warn", 1],
    "max-len": ["warn", { "code": 30, "comments": 36 }],
    "max-lines": ["warn", 7],
    "max-lines-per-function": ["warn", 5],
    "max-nested-callbacks": ["warn", 0],
    "max-params": ["warn", 0],
    "max-statements": ["warn", 2],
    "max-statements-per-line": ["warn", { "max": 1 }],
    "max-classes-per-file": ["warn", 1]
  }
```


**What does the rule currently do for this code?**

![изображение](https://user-images.githubusercontent.com/3082812/57559438-7a892480-738a-11e9-947c-f6e1d7991fa4.png)

**What will the rule do after it's changed?**

![изображение](https://user-images.githubusercontent.com/3082812/57559425-60e7dd00-738a-11e9-816e-6658ae822c83.png)

**What changes did you make? (Give an overview)**

*complexity*, *max-depth*
- Added maximum allowed rule value

*max-len*, *max-classes-per-file*
- Added actually rule value 

*max-lines*, *max-lines-per-function*
- Uniforming a rule message

**Is there anything you'd like reviewers to focus on?**

Also I want to change the messages for the rules: *max-classes-per-file*, *max-statements-per-line*, and possibly other similar rules that use numeric metrics. Are there any other such rules?


