### PR TITLE
Chore: fix CLIEngine tests when os.tmpdir is a symlink

### DIFF
--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -40,7 +40,7 @@ describe("CLIEngine", () => {
         },
         examplePreprocessorName = "eslint-plugin-processor",
         originalDir = process.cwd(),
-        fixtureDir = path.resolve(os.tmpdir(), "eslint/fixtures");
+        fixtureDir = path.resolve(fs.realpathSync(os.tmpdir()), "eslint/fixtures");
 
     /** @type {import("../../lib/cli-engine")["CLIEngine"]} */
     let CLIEngine;


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This fixes a test failure on macOS. Previously, some `CLIEngine` tests were failing because some parts of the CLIEngine tests call realpath() and others didn't.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
