### PR TITLE
Chore: eslint-config-eslint require node >= 8

### DIFF
--- a/packages/eslint-config-eslint/package.json
+++ b/packages/eslint-config-eslint/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://eslint.org",
   "bugs": "https://github.com/eslint/eslint/issues/",
   "peerDependencies": {
-    "eslint-plugin-node": "^6.0.1 || ^7.0.1 || ^8.0.0"
+    "eslint-plugin-node": "^9.0.0"
   },
   "keywords": [
     "eslintconfig",
@@ -29,6 +29,6 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=0.10"
+    "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
   }
 }


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**


**Is there anything you'd like reviewers to focus on?**
I presume there is no much need to target the EOL node versions. and it seems too wordy to add something like `"eslint-plugin-node": "^6.0.1 || ^7.0.1 || ^8.0.0 || ^9.0.0..."` :)

