### PR TITLE
Fix: wrong 'plugin-missing' error on Node.js 12 (fixes #11720)

### DIFF
--- a/lib/cli-engine/config-array-factory.js
+++ b/lib/cli-engine/config-array-factory.js
@@ -36,6 +36,7 @@
 const fs = require("fs");
 const path = require("path");
 const importFresh = require("import-fresh");
+const lodash = require("lodash");
 const stripComments = require("strip-json-comments");
 const { validateConfigSchema } = require("../config/config-validator");
 const { ConfigArray, ConfigDependency, OverrideTester } = require("./config-array");
@@ -57,6 +58,15 @@ const configFilenames = [
     ".eslintrc",
     "package.json"
 ];
+const currentRequireStack = (() => {
+    const requireStack = [];
+
+    for (let cursor = module; cursor; cursor = cursor.parent) {
+        requireStack.push(cursor.filename || cursor.id);
+    }
+
+    return Object.freeze(requireStack);
+})();
 
 // Define types for VSCode IntelliSense.
 /** @typedef {import("../util/types").ConfigData} ConfigData */
@@ -327,6 +337,46 @@ function normalizePlugin(plugin) {
     };
 }
 
+/**
+ * Check if a given error is a `MODULE_NOT_FOUND` error.
+ * @param {any} error The thrown value to check.
+ * @param {string} request The requested module ID or file path.
+ * @returns {boolean} `true` if the error is the `MODULE_NOT_FOUND` of the `request`.
+ */
+function isModuleNotFoundError(error, request) {
+    if (
+        typeof error !== "object" ||
+        error === null ||
+        error.code !== "MODULE_NOT_FOUND" ||
+        typeof error.message !== "string"
+    ) {
+        return false;
+    }
+
+    /*
+     * Before Node.js v12.0.0, it doesn't provide `error.requireStack`.
+     * Also, `Module.createRequire()` and `import-fresh` package don't provide
+     * the correct stack even after v12.0.0.
+     * In the case of either, check the error message.
+     */
+    if (!error.requireStack || error.requireStack.length < currentRequireStack.length) {
+
+        // Remove the part `loadJSConfigFile()` prepended and the `requireStack` part.
+        const message = error.message.startsWith("Cannot read config file:")
+            ? error.message.split("\n")[1]
+            : error.message.split("\n")[0];
+
+        return message.includes(request);
+    }
+
+    /*
+     * Since Node.js v12.0.0, the error message contains the `require` stack,
+     * so `error.message.includes(request)` doesn't work as expected.
+     * Check the `error.requireStack` is the expected `require` stack instead.
+     */
+    return lodash.isEqual(error.requireStack, currentRequireStack);
+}
+
 //------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
@@ -437,8 +487,8 @@ class ConfigArrayFactory {
             } catch (error) {
                 if (
                     error.code !== "ENOENT" &&
-                    error.code !== "MODULE_NOT_FOUND" &&
-                    error.code !== "ESLINT_CONFIG_FIELD_NOT_FOUND"
+                    error.code !== "ESLINT_CONFIG_FIELD_NOT_FOUND" &&
+                    !isModuleNotFoundError(error, filePath)
                 ) {
                     throw error;
                 }
@@ -703,7 +753,7 @@ class ConfigArrayFactory {
             return this._loadConfigData(filePath, `${importerName} » ${request}`);
         } catch (error) {
             /* istanbul ignore next */
-            if (!error || error.code !== "MODULE_NOT_FOUND") {
+            if (!isModuleNotFoundError(error, request)) {
                 throw error;
             }
         }
@@ -848,7 +898,7 @@ class ConfigArrayFactory {
         } catch (error) {
             debug("Failed to load plugin '%s' declared in '%s'.", name, importerName);
 
-            if (error && error.code === "MODULE_NOT_FOUND" && error.message.includes(request)) {
+            if (isModuleNotFoundError(error, request)) {
                 error.messageTemplate = "plugin-missing";
                 error.messageData = {
                     pluginName: request,

--- a/lib/cli-engine/config-array-factory.js
+++ b/lib/cli-engine/config-array-factory.js
@@ -36,7 +36,6 @@
 const fs = require("fs");
 const path = require("path");
 const importFresh = require("import-fresh");
-const lodash = require("lodash");
 const stripComments = require("strip-json-comments");
 const { validateConfigSchema } = require("../config/config-validator");
 const { ConfigArray, ConfigDependency, OverrideTester } = require("./config-array");
@@ -58,15 +57,6 @@ const configFilenames = [
     ".eslintrc",
     "package.json"
 ];
-const currentRequireStack = (() => {
-    const requireStack = [];
-
-    for (let cursor = module; cursor; cursor = cursor.parent) {
-        requireStack.push(cursor.filename || cursor.id);
-    }
-
-    return Object.freeze(requireStack);
-})();
 
 // Define types for VSCode IntelliSense.
 /** @typedef {import("../util/types").ConfigData} ConfigData */
@@ -337,46 +327,6 @@ function normalizePlugin(plugin) {
     };
 }
 
-/**
- * Check if a given error is a `MODULE_NOT_FOUND` error.
- * @param {any} error The thrown value to check.
- * @param {string} request The requested module ID or file path.
- * @returns {boolean} `true` if the error is the `MODULE_NOT_FOUND` of the `request`.
- */
-function isModuleNotFoundError(error, request) {
-    if (
-        typeof error !== "object" ||
-        error === null ||
-        error.code !== "MODULE_NOT_FOUND" ||
-        typeof error.message !== "string"
-    ) {
-        return false;
-    }
-
-    /*
-     * Before Node.js v12.0.0, it doesn't provide `error.requireStack`.
-     * Also, `Module.createRequire()` and `import-fresh` package don't provide
-     * the correct stack even after v12.0.0.
-     * In the case of either, check the error message.
-     */
-    if (!error.requireStack || error.requireStack.length < currentRequireStack.length) {
-
-        // Remove the part `loadJSConfigFile()` prepended and the `requireStack` part.
-        const message = error.message.startsWith("Cannot read config file:")
-            ? error.message.split("\n")[1]
-            : error.message.split("\n")[0];
-
-        return message.includes(request);
-    }
-
-    /*
-     * Since Node.js v12.0.0, the error message contains the `require` stack,
-     * so `error.message.includes(request)` doesn't work as expected.
-     * Check the `error.requireStack` is the expected `require` stack instead.
-     */
-    return lodash.isEqual(error.requireStack, currentRequireStack);
-}
-
 //------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
@@ -477,28 +427,22 @@ class ConfigArrayFactory {
     _loadConfigDataInDirectory(directoryPath, name) {
         for (const filename of configFilenames) {
             const filePath = path.join(directoryPath, filename);
-            const originalDebugEnabled = debug.enabled;
-            let configData;
 
-            // Make silent temporary because of too verbose.
-            debug.enabled = false;
-            try {
-                configData = loadConfigFile(filePath);
-            } catch (error) {
-                if (
-                    error.code !== "ENOENT" &&
-                    error.code !== "ESLINT_CONFIG_FIELD_NOT_FOUND" &&
-                    !isModuleNotFoundError(error, filePath)
-                ) {
-                    throw error;
+            if (fs.existsSync(filePath)) {
+                let configData;
+
+                try {
+                    configData = loadConfigFile(filePath);
+                } catch (error) {
+                    if (!error || error.code !== "ESLINT_CONFIG_FIELD_NOT_FOUND") {
+                        throw error;
+                    }
                 }
-            } finally {
-                debug.enabled = originalDebugEnabled;
-            }
 
-            if (configData) {
-                debug(`Config file found: ${filePath}`);
-                return this._normalizeConfigData(configData, filePath, name);
+                if (configData) {
+                    debug(`Config file found: ${filePath}`);
+                    return this._normalizeConfigData(configData, filePath, name);
+                }
             }
         }
 
@@ -745,20 +689,16 @@ class ConfigArrayFactory {
             );
         }
 
+        let filePath;
+
         try {
-            const filePath = ModuleResolver.resolve(request, relativeTo);
-
-            writeDebugLogForLoading(request, relativeTo, filePath);
-
-            return this._loadConfigData(filePath, `${importerName} » ${request}`);
+            filePath = ModuleResolver.resolve(request, relativeTo);
         } catch (error) {
-            /* istanbul ignore next */
-            if (!isModuleNotFoundError(error, request)) {
-                throw error;
-            }
+            throw configMissingError(extendName);
         }
 
-        throw configMissingError(extendName);
+        writeDebugLogForLoading(request, relativeTo, filePath);
+        return this._loadConfigData(filePath, `${importerName} » ${request}`);
     }
 
     /**
@@ -847,6 +787,7 @@ class ConfigArrayFactory {
         const { additionalPluginPool, resolvePluginsRelativeTo } = internalSlotsMap.get(this);
         const request = naming.normalizePackageName(name, "eslint-plugin");
         const id = naming.getShorthandName(request, "eslint-plugin");
+        const relativeTo = path.join(resolvePluginsRelativeTo, "__placeholder__.js");
 
         if (name.match(/\s+/u)) {
             const error = Object.assign(
@@ -880,41 +821,44 @@ class ConfigArrayFactory {
             });
         }
 
+        let filePath;
+        let error;
+
         try {
-
-            // Resolve the plugin file
-            const relativeTo = path.join(resolvePluginsRelativeTo, "__placeholder__.js");
-            const filePath = ModuleResolver.resolve(request, relativeTo);
-
-            writeDebugLogForLoading(request, relativeTo, filePath);
-
-            return new ConfigDependency({
-                definition: normalizePlugin(require(filePath)),
-                filePath,
-                id,
-                importerName,
-                importerPath
-            });
-        } catch (error) {
-            debug("Failed to load plugin '%s' declared in '%s'.", name, importerName);
-
-            if (isModuleNotFoundError(error, request)) {
-                error.messageTemplate = "plugin-missing";
-                error.messageData = {
-                    pluginName: request,
-                    resolvePluginsRelativeTo,
-                    importerName
-                };
-            }
-            error.message = `Failed to load plugin '${name}' declared in '${importerName}': ${error.message}`;
-
-            return new ConfigDependency({
-                error,
-                id,
-                importerName,
-                importerPath
-            });
+            filePath = ModuleResolver.resolve(request, relativeTo);
+        } catch (resolveError) {
+            error = resolveError;
+            error.messageTemplate = "plugin-missing";
+            error.messageData = {
+                pluginName: request,
+                resolvePluginsRelativeTo,
+                importerName
+            };
         }
+
+        if (filePath) {
+            try {
+                writeDebugLogForLoading(request, relativeTo, filePath);
+                return new ConfigDependency({
+                    definition: normalizePlugin(require(filePath)),
+                    filePath,
+                    id,
+                    importerName,
+                    importerPath
+                });
+            } catch (loadError) {
+                error = loadError;
+            }
+        }
+
+        debug("Failed to load plugin '%s' declared in '%s'.", name, importerName);
+        error.message = `Failed to load plugin '${name}' declared in '${importerName}': ${error.message}`;
+        return new ConfigDependency({
+            error,
+            id,
+            importerName,
+            importerPath
+        });
     }
 
     /**

--- a/lib/cli-engine/config-array-factory.js
+++ b/lib/cli-engine/config-array-factory.js
@@ -694,7 +694,11 @@ class ConfigArrayFactory {
         try {
             filePath = ModuleResolver.resolve(request, relativeTo);
         } catch (error) {
-            throw configMissingError(extendName);
+            /* istanbul ignore else */
+            if (error && error.code === "MODULE_NOT_FOUND") {
+                throw configMissingError(extendName);
+            }
+            throw error;
         }
 
         writeDebugLogForLoading(request, relativeTo, filePath);
@@ -828,12 +832,15 @@ class ConfigArrayFactory {
             filePath = ModuleResolver.resolve(request, relativeTo);
         } catch (resolveError) {
             error = resolveError;
-            error.messageTemplate = "plugin-missing";
-            error.messageData = {
-                pluginName: request,
-                resolvePluginsRelativeTo,
-                importerName
-            };
+            /* istanbul ignore else */
+            if (error && error.code === "MODULE_NOT_FOUND") {
+                error.messageTemplate = "plugin-missing";
+                error.messageData = {
+                    pluginName: request,
+                    resolvePluginsRelativeTo,
+                    importerName
+                };
+            }
         }
 
         if (filePath) {

--- a/lib/util/relative-module-resolver.js
+++ b/lib/util/relative-module-resolver.js
@@ -42,8 +42,14 @@ module.exports = {
         try {
             return createRequire(relativeToPath).resolve(moduleName);
         } catch (error) {
-            if (error && error.code === "MODULE_NOT_FOUND" && error.message.includes(moduleName)) {
-                error.message += ` relative to '${relativeToPath}'`;
+            if (
+                typeof error === "object" &&
+                error !== null &&
+                error.code === "MODULE_NOT_FOUND" &&
+                !error.requireStack &&
+                error.message.includes(moduleName)
+            ) {
+                error.message += `\nRequire stack:\n- ${relativeToPath}`;
             }
             throw error;
         }

--- a/tests/fixtures/module-not-found/.eslintrc.yml
+++ b/tests/fixtures/module-not-found/.eslintrc.yml
@@ -1,0 +1,1 @@
+root: true

--- a/tests/fixtures/module-not-found/extends-js/.eslintrc.yml
+++ b/tests/fixtures/module-not-found/extends-js/.eslintrc.yml
@@ -1,0 +1,1 @@
+extends: nonexistent-config

--- a/tests/fixtures/module-not-found/extends-plugin/.eslintrc.yml
+++ b/tests/fixtures/module-not-found/extends-plugin/.eslintrc.yml
@@ -1,0 +1,1 @@
+extends: plugin:nonexistent-plugin/foo

--- a/tests/fixtures/module-not-found/node_modules/eslint-config-throw.js
+++ b/tests/fixtures/module-not-found/node_modules/eslint-config-throw.js
@@ -1,0 +1,1 @@
+require("eslint/lib/util/glob-utils")

--- a/tests/fixtures/module-not-found/node_modules/eslint-plugin-throw.js
+++ b/tests/fixtures/module-not-found/node_modules/eslint-plugin-throw.js
@@ -1,0 +1,1 @@
+require("eslint/lib/util/glob-utils")

--- a/tests/fixtures/module-not-found/plugins/.eslintrc.yml
+++ b/tests/fixtures/module-not-found/plugins/.eslintrc.yml
@@ -1,0 +1,1 @@
+plugins: [nonexistent-plugin]

--- a/tests/fixtures/module-not-found/throw-in-config-itself/.eslintrc.js
+++ b/tests/fixtures/module-not-found/throw-in-config-itself/.eslintrc.js
@@ -1,0 +1,1 @@
+require("eslint/lib/util/glob-utils")

--- a/tests/fixtures/module-not-found/throw-in-extends-js/.eslintrc.yml
+++ b/tests/fixtures/module-not-found/throw-in-extends-js/.eslintrc.yml
@@ -1,0 +1,1 @@
+extends: throw

--- a/tests/fixtures/module-not-found/throw-in-extends-plugin/.eslintrc.yml
+++ b/tests/fixtures/module-not-found/throw-in-extends-plugin/.eslintrc.yml
@@ -1,0 +1,1 @@
+extends: plugin:throw/foo

--- a/tests/fixtures/module-not-found/throw-in-plugins/.eslintrc.yml
+++ b/tests/fixtures/module-not-found/throw-in-plugins/.eslintrc.yml
@@ -1,0 +1,1 @@
+plugins: [throw]

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -3031,6 +3031,103 @@ describe("CLIEngine", () => {
                 assert.deepStrictEqual(results[0].output, "fixed;");
             });
         });
+
+        describe("MODULE_NOT_FOUND error handling", () => {
+            const cwd = getFixturePath("module-not-found");
+
+            beforeEach(() => {
+                engine = new CLIEngine({ cwd });
+            });
+
+            it("should throw an error with a message template when 'extends' property has a non-existence JavaScript config.", () => {
+                try {
+                    engine.executeOnText("test", "extends-js/test.js");
+                } catch (err) {
+                    assert.strictEqual(err.messageTemplate, "extend-config-missing");
+                    assert.deepStrictEqual(err.messageData, {
+                        configName: "nonexistent-config"
+                    });
+                    return;
+                }
+                assert.fail("Expected to throw an error");
+            });
+
+            it("should throw an error with a message template when 'extends' property has a non-existence plugin config.", () => {
+                try {
+                    engine.executeOnText("test", "extends-plugin/test.js");
+                } catch (err) {
+                    assert.strictEqual(err.code, "MODULE_NOT_FOUND");
+                    assert.strictEqual(err.messageTemplate, "plugin-missing");
+                    assert.deepStrictEqual(err.messageData, {
+                        importerName: `extends-plugin${path.sep}.eslintrc.yml`,
+                        pluginName: "eslint-plugin-nonexistent-plugin",
+                        resolvePluginsRelativeTo: cwd
+                    });
+                    return;
+                }
+                assert.fail("Expected to throw an error");
+            });
+
+            it("should throw an error with a message template when 'plugins' property has a non-existence plugin.", () => {
+                try {
+                    engine.executeOnText("test", "plugins/test.js");
+                } catch (err) {
+                    assert.strictEqual(err.code, "MODULE_NOT_FOUND");
+                    assert.strictEqual(err.messageTemplate, "plugin-missing");
+                    assert.deepStrictEqual(err.messageData, {
+                        importerName: `plugins${path.sep}.eslintrc.yml`,
+                        pluginName: "eslint-plugin-nonexistent-plugin",
+                        resolvePluginsRelativeTo: cwd
+                    });
+                    return;
+                }
+                assert.fail("Expected to throw an error");
+            });
+
+            it("should throw an error with no message template when a JavaScript config threw a 'MODULE_NOT_FOUND' error.", () => {
+                try {
+                    engine.executeOnText("test", "throw-in-config-itself/test.js");
+                } catch (err) {
+                    assert.strictEqual(err.code, "MODULE_NOT_FOUND");
+                    assert.strictEqual(err.messageTemplate, void 0);
+                    return;
+                }
+                assert.fail("Expected to throw an error");
+            });
+
+            it("should throw an error with no message template when 'extends' property has a JavaScript config that throws a 'MODULE_NOT_FOUND' error.", () => {
+                try {
+                    engine.executeOnText("test", "throw-in-extends-js/test.js");
+                } catch (err) {
+                    assert.strictEqual(err.code, "MODULE_NOT_FOUND");
+                    assert.strictEqual(err.messageTemplate, void 0);
+                    return;
+                }
+                assert.fail("Expected to throw an error");
+            });
+
+            it("should throw an error with no message template when 'extends' property has a plugin config that throws a 'MODULE_NOT_FOUND' error.", () => {
+                try {
+                    engine.executeOnText("test", "throw-in-extends-plugin/test.js");
+                } catch (err) {
+                    assert.strictEqual(err.code, "MODULE_NOT_FOUND");
+                    assert.strictEqual(err.messageTemplate, void 0);
+                    return;
+                }
+                assert.fail("Expected to throw an error");
+            });
+
+            it("should throw an error with no message template when 'plugins' property has a plugin config that throws a 'MODULE_NOT_FOUND' error.", () => {
+                try {
+                    engine.executeOnText("test", "throw-in-plugins/test.js");
+                } catch (err) {
+                    assert.strictEqual(err.code, "MODULE_NOT_FOUND");
+                    assert.strictEqual(err.messageTemplate, void 0);
+                    return;
+                }
+                assert.fail("Expected to throw an error");
+            });
+        });
     });
 
     describe("getConfigForFile", () => {


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix: #11720 (wrong `plugin-missing` errors on Node.js 12)

**What changes did you make? (Give an overview)**

This PR fixes wrong `plugin-missing` errors on Node.js 12.

The config array factory distinguishes by the following way if a `MODULE_NOT_FOUND` error was plugin's or came from inside of the `plugin`.

```js
error.code === "MODULE_NOT_FOUND" && error.message.includes(request)
```

Because the `error.message` was `"Cannot find module '${request}'"` until Node.js 12.

Since Node.js 12, the `error.message` contains the `require` stack. For example:

```
Cannot find module 'eslint/lib/util/glob-util'
Require stack:
- C:\Users\t-nagashima.AD\dev\sandbox\node_modules\eslint-plugin-import\lib\rules\no-unused-modules.js
- C:\Users\t-nagashima.AD\dev\sandbox\node_modules\eslint-plugin-import\lib\index.js
- C:\Users\t-nagashima.AD\dev\sandbox\node_modules\eslint\lib\cli-engine\config-array-factory.js
- C:\Users\t-nagashima.AD\dev\sandbox\node_modules\eslint\lib\cli-engine\cascading-config-array-factory.js
- C:\Users\t-nagashima.AD\dev\sandbox\node_modules\eslint\lib\cli-engine.js
- C:\Users\t-nagashima.AD\dev\sandbox\node_modules\eslint\lib\cli.js
- C:\Users\t-nagashima.AD\dev\sandbox\node_modules\eslint\bin\eslint.js
```

Then, `error.message.includes(request)` (that `request` is `eslint-plugin-import` in that case) was `true` as unexpected.

Now, ~~the config array factory checks `error.requireStack` if it existed.~~ the `try` blocks of resolving and loading are separated.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.
