### PR TITLE
New: Added new force cli option ( refs #6882 )

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -225,7 +225,7 @@ const cli = {
                     log.error("ESLint found too many warnings (maximum: %s).", currentOptions.maxWarnings);
                 }
 
-                return (report.errorCount || tooManyWarnings) ? 1 : 0;
+                return !currentOptions.force && (report.errorCount || tooManyWarnings) ? 1 : 0;
             }
             return 2;
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -246,6 +246,11 @@ module.exports = optionator({
             option: "print-config",
             type: "path::String",
             description: "Print the configuration for the given file"
+        },
+        {
+            option: "force",
+            type: "Boolean",
+            description: "Forces 0 exit code for cli command even if errors occurred"
         }
     ]
 });

--- a/tests/bin/eslint.js
+++ b/tests/bin/eslint.js
@@ -364,7 +364,6 @@ describe("bin/eslint.js", () => {
         });
     });
 
-
     describe("emitting a warning for ecmaFeatures", () => {
         it("does not emit a warning when it does not find an ecmaFeatures option", () => {
             const child = runESLint(["Makefile.js"]);
@@ -385,6 +384,8 @@ describe("bin/eslint.js", () => {
             return Promise.all([exitCodePromise, outputPromise]);
         });
     });
+
+    describe("has exit code 0 if a linting error is reported while --force flag is set", () => assertExitCode(runESLint(["bin/eslint.js", "--force", "--env", "es6", "--no-eslintrc", "--rule", "semi: [2, never]"]), 0));
 
     afterEach(() => {
 


### PR DESCRIPTION
Option forces 0 exit code even if errors or warnings occurred. Useful for using in pre-commit hooks to remove fixable errors.

<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ X ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Added description of --force cli option, and condition which returns 0 exit code even if errors or warnings occurred in results.

**Is there anything you'd like reviewers to focus on?**

Nope
