### PR TITLE
Fix: allow package name in parser in RuleTester (fixes #11728)

### DIFF
--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -47,6 +47,7 @@ const
     lodash = require("lodash"),
     { getRuleOptionsSchema, validate } = require("../config/config-validator"),
     { Linter } = require("../linter"),
+    ModuleResolver = require("../util/relative-module-resolver"),
     SourceCodeFixer = require("../util/source-code-fixer"),
     interpolate = require("../util/interpolate");
 
@@ -366,8 +367,12 @@ class RuleTester {
             }));
 
             if (typeof config.parser === "string") {
-                assert(path.isAbsolute(config.parser), "Parsers provided as strings to RuleTester must be absolute paths");
-                linter.defineParser(config.parser, require(config.parser));
+                const parserPath = ModuleResolver.resolve(
+                    config.parser,
+                    path.join(process.cwd(), "__placeholder__.js")
+                );
+
+                linter.defineParser(config.parser, require(parserPath));
             }
 
             if (schema) {

--- a/tests/lib/testers/rule-tester.js
+++ b/tests/lib/testers/rule-tester.js
@@ -609,7 +609,27 @@ describe("RuleTester", () => {
         }, /options must be an array/u);
     });
 
-    it("should pass-through the parser to the rule", () => {
+    it("should pass-through the parser to the rule (package)", () => {
+        const spy = sinon.spy(ruleTester.linter, "verify");
+
+        ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+            valid: [
+                {
+                    code: "Eval(foo)"
+                }
+            ],
+            invalid: [
+                {
+                    code: "eval(foo)",
+                    parser: "esprima",
+                    errors: [{}]
+                }
+            ]
+        });
+        assert.strictEqual(spy.args[1][1].parser, "esprima");
+    });
+
+    it("should pass-through the parser to the rule (absolute path)", () => {
         const spy = sinon.spy(ruleTester.linter, "verify");
 
         ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
@@ -627,6 +647,25 @@ describe("RuleTester", () => {
             ]
         });
         assert.strictEqual(spy.args[1][1].parser, require.resolve("esprima"));
+    });
+
+    it("should fail the parser was not found.", () => {
+        assert.throws(() => {
+            ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+                valid: [
+                    {
+                        code: "Eval(foo)"
+                    }
+                ],
+                invalid: [
+                    {
+                        code: "eval(foo)",
+                        parser: "xxxx-invalid-parser",
+                        errors: [{}]
+                    }
+                ]
+            });
+        }, /Cannot find module 'xxxx-invalid-parser'/u);
     });
 
     it("should prevent invalid options schemas", () => {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix: #11728

**What changes did you make? (Give an overview)**

This PR fixes `RuleTester` to accept a package name with the `parser` option. That was valid on ESLint 5.

As same as `Linter`, rules receive an absolute path as `context.parserPath`.

**Is there anything you'd like reviewers to focus on?**

In this PR, `RuleTester` loads the parser relative to CWD. Is this valid?