### PR TITLE
Update: add fixer for no-div-regex rule (fixes #11355)

### DIFF
--- a/docs/rules/no-div-regex.md
+++ b/docs/rules/no-div-regex.md
@@ -23,7 +23,7 @@ Examples of **correct** code for this rule:
 ```js
 /*eslint no-div-regex: "error"*/
 
-function bar() { return /\=foo/; }
+function bar() { return /[=]foo/; }
 ```
 
 ## Related Rules

--- a/lib/rules/no-div-regex.js
+++ b/lib/rules/no-div-regex.js
@@ -20,6 +20,8 @@ module.exports = {
             url: "https://eslint.org/docs/rules/no-div-regex"
         },
 
+        fixable: "code",
+
         schema: [],
 
         messages: {
@@ -36,7 +38,13 @@ module.exports = {
                 const token = sourceCode.getFirstToken(node);
 
                 if (token.type === "RegularExpression" && token.value[1] === "=") {
-                    context.report({ node, messageId: "unexpected" });
+                    context.report({
+                        node,
+                        messageId: "unexpected",
+                        fix(fixer) {
+                            return fixer.replaceTextRange([token.range[0] + 1, token.range[0] + 2], "[=]");
+                        }
+                    });
                 }
             }
         };

--- a/tests/lib/rules/no-div-regex.js
+++ b/tests/lib/rules/no-div-regex.js
@@ -24,6 +24,10 @@ ruleTester.run("no-div-regex", rule, {
         "var f = function() { return /\\=foo/; };"
     ],
     invalid: [
-        { code: "var f = function() { return /=foo/; };", errors: [{ messageId: "unexpected", type: "Literal" }] }
+        {
+            code: "var f = function() { return /=foo/; };",
+            output: "var f = function() { return /[=]foo/; };",
+            errors: [{ messageId: "unexpected", type: "Literal" }]
+        }
     ]
 });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[x] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
fixes: #11355
Adding fixer for no-div-regex-rule and use [=] instead of \\= as suggestion to avoid conflicting with no-useless-escape error.

**Is there anything you'd like reviewers to focus on?**
No.

