### PR TITLE
Docs: updated no-proto rule (fixes #11743)

### DIFF
--- a/docs/rules/no-proto.md
+++ b/docs/rules/no-proto.md
@@ -1,10 +1,10 @@
 # Disallow Use of `__proto__` (no-proto)
 
-`__proto__` property has been deprecated as of ECMAScript 3.1 and shouldn't be used in the code. Use `getPrototypeOf` method instead.
+`__proto__` property has been deprecated as of ECMAScript 3.1 and shouldn't be used in the code. Use `Object.getPrototypeOf` and `Object.setPrototypeOf` instead.
 
 ## Rule Details
 
-When an object is created `__proto__` is set to the original prototype property of the object’s constructor function. `getPrototypeOf` is the preferred method of getting "the prototype".
+When an object is created with the `new` operator, `__proto__` is set to the original "prototype" property of the object's constructor function. `Object.getPrototypeOf` is the preferred method of getting the object's prototype. To change an object's prototype, use `Object.setPrototypeOf`.
 
 Examples of **incorrect** code for this rule:
 
@@ -14,6 +14,10 @@ Examples of **incorrect** code for this rule:
 var a = obj.__proto__;
 
 var a = obj["__proto__"];
+
+obj.__proto__ = b;
+
+obj["__proto__"] = b;
 ```
 
 Examples of **correct** code for this rule:
@@ -22,11 +26,16 @@ Examples of **correct** code for this rule:
 /*eslint no-proto: "error"*/
 
 var a = Object.getPrototypeOf(obj);
+
+Object.setPrototypeOf(obj, b);
+
+var c = { __proto__: a };
 ```
 
 ## When Not To Use It
 
-If you need to support legacy browsers, you might want to turn this rule off, since support for `getPrototypeOf` is not yet universal.
+You might want to turn this rule off if you need to support legacy browsers which implement the
+`__proto__` property but not `Object.getPrototypeOf` or `Object.setPrototypeOf`.
 
 ## Further Reading
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

#11743

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

* Added instructions to change an object's prototype with `Object.setPrototypeOf`.
* Disambiguated `getPrototypeOf` to `Object.getPrototypeOf`.
* Some new code examples.
* Revised "When Not To Use It" note, as `getPrototypeOf` is widely supported today.

**Is there anything you'd like reviewers to focus on?**
