### PR TITLE
Chore: `leave` only takes one argument: `node`

### DIFF
--- a/lib/util/traverser.js
+++ b/lib/util/traverser.js
@@ -152,7 +152,7 @@ class Traverser {
         }
 
         if (!this._broken) {
-            this._leave(node, parent);
+            this._leave(node);
         }
 
         this._current = parent;


### PR DESCRIPTION

**What is the purpose of this pull request? (put an "X" next to item)**
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))


**What changes did you make? (Give an overview)**
removed an unused argument

**Is there anything you'd like reviewers to focus on?**
as far as I can tell by the two existing usages this is not used:

1. https://github.com/eslint/eslint/blob/5dad0b1d80c9cf380c49f46266c35d461d3cecad/lib/linter.js#L668
1. https://github.com/eslint/eslint/blob/5dad0b1d80c9cf380c49f46266c35d461d3cecad/lib/util/source-code.js#L402
