### PR TITLE
Fix: require-atomic-updates reports parameters (fixes #11723)

### DIFF
--- a/lib/rules/require-atomic-updates.js
+++ b/lib/rules/require-atomic-updates.js
@@ -30,6 +30,10 @@ function createReferenceMap(scope, outReferenceMap = new Map()) {
  * @returns {boolean} `true` if the variable is local to the given function, and is never referenced in a closure.
  */
 function isLocalVariableWithoutEscape(variable) {
+    if (!variable) {
+        return false; // A global variable which was not defined.
+    }
+
     const functionScope = variable.scope.variableScope;
 
     return variable.references.every(reference =>
@@ -47,39 +51,39 @@ class SegmentInfo {
      * @returns {void}
      */
     initialize(segment) {
-        const outdatedReadVariables = new Set();
-        const freshReadVariables = new Set();
+        const outdatedReadVariableNames = new Set();
+        const freshReadVariableNames = new Set();
 
         for (const prevSegment of segment.prevSegments) {
             const info = this.info.get(prevSegment);
 
             if (info) {
-                info.outdatedReadVariables.forEach(Set.prototype.add, outdatedReadVariables);
-                info.freshReadVariables.forEach(Set.prototype.add, freshReadVariables);
+                info.outdatedReadVariableNames.forEach(Set.prototype.add, outdatedReadVariableNames);
+                info.freshReadVariableNames.forEach(Set.prototype.add, freshReadVariableNames);
             }
         }
 
-        this.info.set(segment, { outdatedReadVariables, freshReadVariables });
+        this.info.set(segment, { outdatedReadVariableNames, freshReadVariableNames });
     }
 
     /**
      * Mark a given variable as read on given segments.
      * @param {PathSegment[]} segments The segments that it read the variable on.
-     * @param {escope.Variable} variable The variable to be read.
+     * @param {string} variableName The variable name to be read.
      * @returns {void}
      */
-    markAsRead(segments, variable) {
+    markAsRead(segments, variableName) {
         for (const segment of segments) {
             const info = this.info.get(segment);
 
             if (info) {
-                info.freshReadVariables.add(variable);
+                info.freshReadVariableNames.add(variableName);
             }
         }
     }
 
     /**
-     * Move `freshReadVariables` to `outdatedReadVariables`.
+     * Move `freshReadVariableNames` to `outdatedReadVariableNames`.
      * @param {PathSegment[]} segments The segments to process.
      * @returns {void}
      */
@@ -88,8 +92,8 @@ class SegmentInfo {
             const info = this.info.get(segment);
 
             if (info) {
-                info.freshReadVariables.forEach(Set.prototype.add, info.outdatedReadVariables);
-                info.freshReadVariables.clear();
+                info.freshReadVariableNames.forEach(Set.prototype.add, info.outdatedReadVariableNames);
+                info.freshReadVariableNames.clear();
             }
         }
     }
@@ -97,14 +101,14 @@ class SegmentInfo {
     /**
      * Check if a given variable is outdated on the current segments.
      * @param {PathSegment[]} segments The current segments.
-     * @param {escope.Variable} variable The variable to check.
+     * @param {string} variableName The variable name to check.
      * @returns {boolean} `true` if the variable is outdated on the segments.
      */
-    isOutdated(segments, variable) {
+    isOutdated(segments, variableName) {
         for (const segment of segments) {
             const info = this.info.get(segment);
 
-            if (info && info.outdatedReadVariables.has(variable)) {
+            if (info && info.outdatedReadVariableNames.has(variableName)) {
                 return true;
             }
         }
@@ -137,39 +141,9 @@ module.exports = {
 
     create(context) {
         const sourceCode = context.getSourceCode();
-        const globalScope = context.getScope();
-        const dummyVariables = new Map();
         const assignmentReferences = new Map();
         const segmentInfo = new SegmentInfo();
         let stack = null;
-
-        /**
-         * Get the variable of a given reference.
-         * If it's not defined, returns a dummy object.
-         * @param {escope.Reference} reference The reference to get.
-         * @returns {escope.Variable} The variable of the reference.
-         */
-        function getVariable(reference) {
-            if (reference.resolved) {
-                return reference.resolved;
-            }
-
-            // Get or create a dummy.
-            const name = reference.identifier.name;
-            let variable = dummyVariables.get(name);
-
-            if (!variable) {
-                variable = {
-                    name,
-                    scope: globalScope,
-                    references: []
-                };
-                dummyVariables.set(name, variable);
-            }
-            variable.references.push(reference);
-
-            return variable;
-        }
 
         /**
          * Get `reference.writeExpr` of a given reference.
@@ -231,12 +205,13 @@ module.exports = {
                 if (!reference) {
                     return;
                 }
-                const variable = getVariable(reference);
+                const name = reference.identifier.name;
+                const variable = reference.resolved;
                 const writeExpr = getWriteExpr(reference);
 
                 // Add a fresh read variable.
                 if (reference.isRead() && !(writeExpr && writeExpr.parent.operator === "=")) {
-                    segmentInfo.markAsRead(codePath.currentSegments, variable);
+                    segmentInfo.markAsRead(codePath.currentSegments, name);
                 }
 
                 /*
@@ -260,7 +235,7 @@ module.exports = {
 
             /*
              * Verify assignments.
-             * If the reference exists in `outdatedReadVariables` list, report it.
+             * If the reference exists in `outdatedReadVariableNames` list, report it.
              */
             ":expression:exit"(node) {
                 const { codePath, referenceMap } = stack;
@@ -282,9 +257,9 @@ module.exports = {
                     assignmentReferences.delete(node);
 
                     for (const reference of references) {
-                        const variable = getVariable(reference);
+                        const name = reference.identifier.name;
 
-                        if (segmentInfo.isOutdated(codePath.currentSegments, variable)) {
+                        if (segmentInfo.isOutdated(codePath.currentSegments, name)) {
                             context.report({
                                 node: node.parent,
                                 messageId: "nonAtomicUpdate",

--- a/lib/rules/require-atomic-updates.js
+++ b/lib/rules/require-atomic-updates.js
@@ -84,14 +84,11 @@ class SegmentInfo {
      * @returns {void}
      */
     makeOutdated(segments) {
-        const vars = new Set();
-
         for (const segment of segments) {
             const info = this.info.get(segment);
 
             if (info) {
                 info.freshReadVariables.forEach(Set.prototype.add, info.outdatedReadVariables);
-                info.freshReadVariables.forEach(Set.prototype.add, vars);
                 info.freshReadVariables.clear();
             }
         }

--- a/lib/rules/require-atomic-updates.js
+++ b/lib/rules/require-atomic-updates.js
@@ -25,6 +25,35 @@ function createReferenceMap(scope, outReferenceMap = new Map()) {
 }
 
 /**
+ * Get `reference.writeExpr` of a given reference.
+ * If it's the read reference of MemberExpression in LHS, returns RHS in order to address `a.b = await a`
+ * @param {escope.Reference} reference The reference to get.
+ * @returns {Expression|null} The `reference.writeExpr`.
+ */
+function getWriteExpr(reference) {
+    if (reference.writeExpr) {
+        return reference.writeExpr;
+    }
+    let node = reference.identifier;
+
+    while (node) {
+        const t = node.parent.type;
+
+        if (t === "AssignmentExpression" && node.parent.left === node) {
+            return node.parent.right;
+        }
+        if (t === "MemberExpression" && node.parent.object === node) {
+            node = node.parent;
+            continue;
+        }
+
+        break;
+    }
+
+    return null;
+}
+
+/**
  * Checks if an expression is a variable that can only be observed within the given function.
  * @param {escope.Variable} variable The variable to check
  * @returns {boolean} `true` if the variable is local to the given function, and is never referenced in a closure.
@@ -144,35 +173,6 @@ module.exports = {
         const assignmentReferences = new Map();
         const segmentInfo = new SegmentInfo();
         let stack = null;
-
-        /**
-         * Get `reference.writeExpr` of a given reference.
-         * If it's the read reference of MemberExpression in LHS, returns RHS in order to address `a.b = await a`
-         * @param {escope.Reference} reference The reference to get.
-         * @returns {Expression|null} The `reference.writeExpr`.
-         */
-        function getWriteExpr(reference) {
-            if (reference.writeExpr) {
-                return reference.writeExpr;
-            }
-            let node = reference.identifier;
-
-            while (node) {
-                const t = node.parent.type;
-
-                if (t === "AssignmentExpression" && node.parent.left === node) {
-                    return node.parent.right;
-                }
-                if (t === "MemberExpression" && node.parent.object === node) {
-                    node = node.parent;
-                    continue;
-                }
-
-                break;
-            }
-
-            return null;
-        }
 
         return {
             onCodePathStart(codePath) {

--- a/lib/rules/require-atomic-updates.js
+++ b/lib/rules/require-atomic-updates.js
@@ -55,12 +55,18 @@ function getWriteExpr(reference) {
 
 /**
  * Checks if an expression is a variable that can only be observed within the given function.
- * @param {escope.Variable} variable The variable to check
+ * @param {Variable|null} variable The variable to check
+ * @param {boolean} isMemberAccess If `true` then this is a member access.
  * @returns {boolean} `true` if the variable is local to the given function, and is never referenced in a closure.
  */
-function isLocalVariableWithoutEscape(variable) {
+function isLocalVariableWithoutEscape(variable, isMemberAccess) {
     if (!variable) {
         return false; // A global variable which was not defined.
+    }
+
+    // If the reference is a property access and the variable is a parameter, it handles the variable is not local.
+    if (isMemberAccess && variable.defs.some(d => d.type === "Parameter")) {
+        return false;
     }
 
     const functionScope = variable.scope.variableScope;
@@ -208,6 +214,7 @@ module.exports = {
                 const name = reference.identifier.name;
                 const variable = reference.resolved;
                 const writeExpr = getWriteExpr(reference);
+                const isMemberAccess = reference.identifier.parent.type === "MemberExpression";
 
                 // Add a fresh read variable.
                 if (reference.isRead() && !(writeExpr && writeExpr.parent.operator === "=")) {
@@ -220,7 +227,7 @@ module.exports = {
                  */
                 if (writeExpr &&
                     writeExpr.parent.right === writeExpr && // ← exclude variable declarations.
-                    !isLocalVariableWithoutEscape(variable)
+                    !isLocalVariableWithoutEscape(variable, isMemberAccess)
                 ) {
                     let refs = assignmentReferences.get(writeExpr);
 

--- a/tests/lib/rules/require-atomic-updates.js
+++ b/tests/lib/rules/require-atomic-updates.js
@@ -129,6 +129,27 @@ ruleTester.run("require-atomic-updates", rule, {
                     await doElse();
                 }
             }
+        `,
+
+        // https://github.com/eslint/eslint/issues/11723
+        `
+            async function f(foo) {
+                let bar = await get(foo.id);
+                bar.prop = foo.prop;
+            }
+        `,
+        `
+            async function f(foo) {
+                let bar = await get(foo.id);
+                foo = bar.prop;
+            }
+        `,
+        `
+            async function f() {
+                let foo = {}
+                let bar = await get(foo.id);
+                foo.prop = bar.prop;
+            }
         `
     ],
 
@@ -167,10 +188,6 @@ ruleTester.run("require-atomic-updates", rule, {
         },
         {
             code: "let foo; async function x() { foo += bar + await amount; }",
-            errors: [VARIABLE_ERROR]
-        },
-        {
-            code: "async function x() { let foo; bar(() => foo); foo += await amount; }",
             errors: [VARIABLE_ERROR]
         },
         {
@@ -228,6 +245,17 @@ ruleTester.run("require-atomic-updates", rule, {
         {
             code: "let foo = 0; async function x() { foo = (a ? b ? c ? d ? foo : e : f : g : h) + await bar; if (baz); }",
             errors: [VARIABLE_ERROR]
+        },
+
+        // https://github.com/eslint/eslint/issues/11723
+        {
+            code: `
+                async function f(foo) {
+                    let buz = await get(foo.id);
+                    foo.bar = buz.bar;
+                }
+            `,
+            errors: [STATIC_PROPERTY_ERROR]
         }
     ]
 });

--- a/tests/lib/rules/require-atomic-updates.js
+++ b/tests/lib/rules/require-atomic-updates.js
@@ -191,6 +191,10 @@ ruleTester.run("require-atomic-updates", rule, {
             errors: [VARIABLE_ERROR]
         },
         {
+            code: "async function x() { let foo; bar(() => foo); foo += await amount; }",
+            errors: [VARIABLE_ERROR]
+        },
+        {
             code: "let foo; function* x() { foo += yield baz }",
             errors: [VARIABLE_ERROR]
         },


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix: #11723 

But the resolution is different from the original report. The report was a false positive, but this is a false negative. (See also https://github.com/eslint/eslint/issues/11723#issuecomment-496038083)

**What changes did you make? (Give an overview)**

This PR changes `require-atomic-updates` behavior.

- Makes the member accesses of parameters were not local. Parameters are local variables, but if it updates the member of a parameter asynchronously, it causes a race condition. This is the false negative that #11723 reported.
- ~~Makes the closure handling relax because it causes a ton of false positive. We cannot know if the closure will be run sync or async. If the synchronous callbacks such as `Array#map` trigger `require-atomic-updates` errors, it will confuse people. Since the rule is in `eslint:recommended`, it's better if false negative is less.~~

a295496e844a50f30d299dc86af9c7700ef513f7 and 4e845fdc73805ca9a279dddba362695bd1216c01 are the change. This PR contains a few refactoring.

**Is there anything you'd like reviewers to focus on?**

Is this direction is right?

Especially, about the closure handling relaxing. Do you have another idea to reduce false positive?
