### PR TITLE
Fix: fails the test case if autofix made syntax error (fixes #11615)

### DIFF
--- a/tests/lib/rules/complexity.js
+++ b/tests/lib/rules/complexity.js
@@ -81,7 +81,7 @@ ruleTester.run("complexity", rule, {
         { code: "var func = function () {}", options: [0], errors: [makeError("Function", 1, 0)] },
         { code: "var obj = { a(x) {} }", options: [0], parserOptions: { ecmaVersion: 6 }, errors: [makeError("Method 'a'", 1, 0)] },
         { code: "class Test { a(x) {} }", options: [0], parserOptions: { ecmaVersion: 6 }, errors: [makeError("Method 'a'", 1, 0)] },
-        { code: "var a = (x) => {if (true) {return x;}}", options: [1], errors: 1, settings: { ecmascript: 6 } },
+        { code: "var a = (x) => {if (true) {return x;}}", options: [1], parserOptions: { ecmaVersion: 6 }, errors: 1 },
         { code: "function a(x) {if (true) {return x;}}", options: [1], errors: 1 },
         { code: "function a(x) {if (true) {return x;} else {return x+1;}}", options: [1], errors: 1 },
         { code: "function a(x) {if (true) {return x;} else if (false) {return x+1;} else {return 4;}}", options: [2], errors: 1 },

--- a/tests/lib/rules/quotes.js
+++ b/tests/lib/rules/quotes.js
@@ -160,30 +160,35 @@ ruleTester.run("quotes", rule, {
             code: "var foo = 'bar';",
             output: "var foo = `bar`;",
             options: ["backtick"],
+            parserOptions: { ecmaVersion: 2015 },
             errors: [{ message: "Strings must use backtick.", type: "Literal" }]
         },
         {
             code: "var foo = 'b${x}a$r';",
             output: "var foo = `b\\${x}a$r`;",
             options: ["backtick"],
+            parserOptions: { ecmaVersion: 2015 },
             errors: [{ message: "Strings must use backtick.", type: "Literal" }]
         },
         {
             code: "var foo = \"bar\";",
             output: "var foo = `bar`;",
             options: ["backtick"],
+            parserOptions: { ecmaVersion: 2015 },
             errors: [{ message: "Strings must use backtick.", type: "Literal" }]
         },
         {
             code: "var foo = \"bar\";",
             output: "var foo = `bar`;",
             options: ["backtick", { avoidEscape: true }],
+            parserOptions: { ecmaVersion: 2015 },
             errors: [{ message: "Strings must use backtick.", type: "Literal" }]
         },
         {
             code: "var foo = 'bar';",
             output: "var foo = `bar`;",
             options: ["backtick", { avoidEscape: true }],
+            parserOptions: { ecmaVersion: 2015 },
             errors: [{ message: "Strings must use backtick.", type: "Literal" }]
         },
 
@@ -255,7 +260,7 @@ ruleTester.run("quotes", rule, {
             code: "<div blah={'blah'} />",
             output: "<div blah={`blah`} />",
             options: ["backtick"],
-            parserOptions: { ecmaFeatures: { jsx: true } },
+            parserOptions: { ecmaFeatures: { jsx: true }, ecmaVersion: 2015 },
             errors: [
                 { message: "Strings must use backtick.", type: "Literal" }
             ]


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix #11615

**What changes did you make? (Give an overview)**

This PR fixes `RuleTester` to fail the test case if autofix made syntax errors.

Additionally,

- fixes some test cases that autofix made syntax errors.
- fixes the side-effect that overrides `RuleTester.describe` and `RuleTester.it` permanently in `tests/lib/rule-tester/rule-tester.js`. This side-effect had confused `tests/lib/rules/*.js` as using the stub functions to test rules.

I have noticed that `errors` property with a number allows syntax errors. Some of our tests depend on the behavior in order to use syntax error in rule's tests (E.g. [tests/lib/rules/spaced-comment.js#L577-L589](https://github.com/eslint/eslint/blob/cb1922bdc07e58de0e55c13fd992dd8faf3292a4/tests/lib/rules/spaced-comment.js#L577-L589)). I'm not sure if it's intentional, but I left it as is.

I wonder if we should deprecate the `errors` property with a number. It causes false negatives such as [tests/lib/rules/complexity.js#L84](https://github.com/eslint/eslint/blob/cb1922bdc07e58de0e55c13fd992dd8faf3292a4/tests/lib/rules/complexity.js#L84).

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.
