### PR TITLE
Fix: `overrides` handle relative paths as expected (fixes #11577)

### DIFF
--- a/lib/cli-engine/config-array/override-tester.js
+++ b/lib/cli-engine/config-array/override-tester.js
@@ -55,7 +55,17 @@ function toMatcher(patterns) {
     if (patterns.length === 0) {
         return null;
     }
-    return patterns.map(pattern => new Minimatch(pattern, minimatchOpts));
+    return patterns.map(pattern => {
+        if (/^\.[/\\]/u.test(pattern)) {
+            return new Minimatch(
+                pattern.slice(2),
+
+                // `./*.js` should not match with `subdir/foo.js`
+                { ...minimatchOpts, matchBase: false }
+            );
+        }
+        return new Minimatch(pattern, minimatchOpts);
+    });
 }
 
 /**

--- a/tests/lib/cli-engine/config-array/override-tester.js
+++ b/tests/lib/cli-engine/config-array/override-tester.js
@@ -191,10 +191,10 @@ describe("OverrideTester", () => {
         match("foo.js", ["*.js"], []);
         match("foo.js", ["**/*.js"], []);
         match("bar.js", ["*.js"], ["foo.js"]);
+        match("foo.js", ["./foo.js"], []);
+        match("foo.js", ["./*"], []);
+        match("foo.js", ["./**"], []);
 
-        noMatch("foo.js", ["./foo.js"], []);
-        noMatch("foo.js", ["./*"], []);
-        noMatch("foo.js", ["./**"], []);
         noMatch("foo.js", ["*"], ["foo.js"]);
         noMatch("foo.js", ["*.js"], ["foo.js"]);
         noMatch("foo.js", ["**/*.js"], ["foo.js"]);
@@ -208,11 +208,11 @@ describe("OverrideTester", () => {
         match("subdir/foo.js", ["subdir/foo.js"], []);
         match("subdir/foo.js", ["subdir/*"], []);
         match("subdir/second/foo.js", ["subdir/**"], []);
+        match("subdir/foo.js", ["./**"], []);
+        match("subdir/foo.js", ["./subdir/**"], []);
+        match("subdir/foo.js", ["./subdir/*"], []);
 
         noMatch("subdir/foo.js", ["./foo.js"], []);
-        noMatch("subdir/foo.js", ["./**"], []);
-        noMatch("subdir/foo.js", ["./subdir/**"], []);
-        noMatch("subdir/foo.js", ["./subdir/*"], []);
         noMatch("subdir/foo.js", ["*"], ["subdir/**"]);
         noMatch("subdir/very/deep/foo.js", ["*.js"], ["subdir/**"]);
         noMatch("subdir/second/foo.js", ["subdir/*"], []);


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix #11577

**What changes did you make? (Give an overview)**

This PR fixes `overrides[].files` and `overrides[].excludedFiles` to handle `./` as expected.

The change is below. Especially, we newly can specify `./*.js`-like patterns that match with the files in the root directory but not in subdirectories.

Pattern      | FilePath     | Before  | After   | Fixed
:------------|:-------------|:--------|:--------|:-----
`*.js`       | `foo.js`     | `true`  | `true`  |
`*.js`       | `dir/foo.js` | `true`  | `true`  |
`./*.js`     | `foo.js`     | `false` | `true`  | ✅
`./*.js`     | `dir/foo.js` | `false` | `false` |
`dir/*.js`   | `foo.js`     | `false` | `false` |
`dir/*.js`   | `dir/foo.js` | `true`  | `true`  |
`./dir/*.js` | `foo.js`     | `false` | `false` |
`./dir/*.js` | `dir/foo.js` | `false` | `true`  | ✅

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.
