### PR TITLE
Update: support "bigint" in valid-typeof rule

### DIFF
--- a/docs/rules/valid-typeof.md
+++ b/docs/rules/valid-typeof.md
@@ -1,6 +1,6 @@
 # enforce comparing `typeof` expressions against valid strings (valid-typeof)
 
-For a vast majority of use cases, the result of the `typeof` operator is one of the following string literals: `"undefined"`, `"object"`, `"boolean"`, `"number"`, `"string"`, `"function"` and `"symbol"`. It is usually a typing mistake to compare the result of a `typeof` operator to other string literals.
+For a vast majority of use cases, the result of the `typeof` operator is one of the following string literals: `"undefined"`, `"object"`, `"boolean"`, `"number"`, `"string"`, `"function"`, `"symbol"`, and `"bigint"`. It is usually a typing mistake to compare the result of a `typeof` operator to other string literals.
 
 ## Rule Details
 

--- a/docs/rules/valid-typeof.md
+++ b/docs/rules/valid-typeof.md
@@ -57,3 +57,7 @@ typeof bar === typeof qux
 ## When Not To Use It
 
 You may want to turn this rule off if you will be using the `typeof` operator on host objects.
+
+## Further Reading
+
+* [MDN: `typeof` documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof)

--- a/lib/rules/valid-typeof.js
+++ b/lib/rules/valid-typeof.js
@@ -39,7 +39,7 @@ module.exports = {
 
     create(context) {
 
-        const VALID_TYPES = ["symbol", "undefined", "object", "boolean", "number", "string", "function"],
+        const VALID_TYPES = ["symbol", "undefined", "object", "boolean", "number", "string", "function", "bigint"],
             OPERATORS = ["==", "===", "!=", "!=="];
 
         const requireStringLiterals = context.options[0] && context.options[0].requireStringLiterals;

--- a/tests/lib/rules/valid-typeof.js
+++ b/tests/lib/rules/valid-typeof.js
@@ -26,6 +26,7 @@ ruleTester.run("valid-typeof", rule, {
         "typeof foo === 'undefined'",
         "typeof foo === 'boolean'",
         "typeof foo === 'number'",
+        "typeof foo === 'bigint'",
         "'string' === typeof foo",
         "'object' === typeof foo",
         "'function' === typeof foo",


### PR DESCRIPTION
[BigInt just moved to Stage 4](https://github.com/tc39/proposals/pull/217), so add support for it to the valid-typeof rule.

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What rule do you want to change?**
valid-typeof

**Does this change cause the rule to produce more or fewer warnings?**
fewer

**How will the change be implemented? (New option, new default behavior, etc.)?**
A new valid typeof value, 'bigint', is added.

**Please provide some example code that this change will affect:**

```js
if (typeof foo === 'bigint') {
  console.log('bigint');
}
```

**What does the rule currently do for this code?**
Reports an error.

**What will the rule do after it's changed?**
Accept bigint as a valid typeof value.

**What changes did you make? (Give an overview)**
Added a new typeof value to the rule, test, and docs.

**Is there anything you'd like reviewers to focus on?**
Nothing particular.