### PR TITLE
Fix: no-octal should report NonOctalDecimalIntegerLiteral (fixes #11794)

### DIFF
--- a/lib/rules/no-octal.js
+++ b/lib/rules/no-octal.js
@@ -28,7 +28,7 @@ module.exports = {
         return {
 
             Literal(node) {
-                if (typeof node.value === "number" && /^0[0-7]/u.test(node.raw)) {
+                if (typeof node.value === "number" && /^0[0-9]/u.test(node.raw)) {
                     context.report({ node, message: "Octal literals should not be used." });
                 }
             }

--- a/tests/lib/rules/no-octal.js
+++ b/tests/lib/rules/no-octal.js
@@ -30,6 +30,14 @@ ruleTester.run("no-octal", rule, {
     invalid: [
         { code: "var a = 01234;", errors: [{ message: "Octal literals should not be used.", type: "Literal" }] },
         { code: "a = 1 + 01234;", errors: [{ message: "Octal literals should not be used.", type: "Literal" }] },
-        { code: "00", errors: [{ message: "Octal literals should not be used.", type: "Literal" }] }
+        { code: "00", errors: [{ message: "Octal literals should not be used.", type: "Literal" }] },
+        { code: "08", errors: [{ message: "Octal literals should not be used.", type: "Literal" }] },
+        { code: "09.1", errors: [{ message: "Octal literals should not be used.", type: "Literal" }] },
+        { code: "09e1", errors: [{ message: "Octal literals should not be used.", type: "Literal" }] },
+        { code: "09.1e1", errors: [{ message: "Octal literals should not be used.", type: "Literal" }] },
+        { code: "018", errors: [{ message: "Octal literals should not be used.", type: "Literal" }] },
+        { code: "019.1", errors: [{ message: "Octal literals should not be used.", type: "Literal" }] },
+        { code: "019e1", errors: [{ message: "Octal literals should not be used.", type: "Literal" }] },
+        { code: "019.1e1", errors: [{ message: "Octal literals should not be used.", type: "Literal" }] }
     ]
 });


### PR DESCRIPTION
Examples: 08, 018, 08.1

<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix:  [#11794](https://github.com/eslint/eslint/issues/11794)

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Reference: [ECMAScript Additional Syntax Numeric Literals](https://www.ecma-international.org/ecma-262/9.0/index.html#sec-additional-syntax-numeric-literals)

no-octal rule used to report all LegacyOctalIntegerLiteral literals (00, 01, 071...) and only some NonOctalDecimalIntegerLiteral literals (018...).

The rule didn't report NonOctalDecimalIntegerLiteral literals that start with 08 or 09.

With this fix, the rule will report all LegacyOctalIntegerLiteral and all NonOctalDecimalIntegerLiteral literals as well as all DecimalLiteral literals that contain them (e.g. 08.1, 08e1...).

**Is there anything you'd like reviewers to focus on?**


