### PR TITLE
Breaking: Let `no-new-object` pass with arguments (fixes #11810)

### DIFF
--- a/docs/rules/no-new-object.md
+++ b/docs/rules/no-new-object.md
@@ -40,6 +40,29 @@ var myObject = new CustomObject();
 var myObject = {};
 ```
 
+## Options
+
+This rule has a single `allowWithArguments` option.
+
+### allowWithArguments
+
+One can coerce primitives into objects by passing `new Object()` an argument.
+This option allows for this usage.
+
+Examples of **incorrect** code for the `{ "allowWithArguments": true }` option:
+
+```js
+/*eslint no-new-object: [2, { "allowWithArguments": true }]*/
+var myObject = new Object();
+```
+
+Examples of **correct** code for the `{ "allowWithArguments": true }` option:
+
+```js
+/*eslint no-new-object: [2, { "allowWithArguments": true }]*/
+var myObject = new Object(BigInt('1'));
+```
+
 ## When Not To Use It
 
 If you wish to allow the use of the `Object` constructor, you can safely turn this rule off.

--- a/lib/rules/no-new-object.js
+++ b/lib/rules/no-new-object.js
@@ -20,15 +20,28 @@ module.exports = {
             url: "https://eslint.org/docs/rules/no-new-object"
         },
 
-        schema: []
+        schema: [
+            {
+                additionalProperties: false,
+                properties: {
+                    allowWithArguments: {
+                        type: "boolean"
+                    }
+                },
+                type: "object"
+            }
+        ]
     },
 
     create(context) {
+        const { allowWithArguments } = context.options[0] || {};
 
         return {
 
             NewExpression(node) {
-                if (node.callee.name === "Object") {
+                if (node.callee.name === "Object" && (
+                    !allowWithArguments || !node.arguments.length
+                )) {
                     context.report({ node, message: "The object literal notation {} is preferrable." });
                 }
             }

--- a/tests/lib/rules/no-new-object.js
+++ b/tests/lib/rules/no-new-object.js
@@ -20,9 +20,16 @@ const ruleTester = new RuleTester();
 
 ruleTester.run("no-new-object", rule, {
     valid: [
-        "var foo = new foo.Object()"
+        "var foo = new foo.Object()",
+        {
+            code: "var foo = new Object(BigInt('1n'))",
+            options: [
+                { allowWithArguments: true }
+            ]
+        }
     ],
     invalid: [
-        { code: "var foo = new Object()", errors: [{ message: "The object literal notation {} is preferrable.", type: "NewExpression" }] }
+        { code: "var foo = new Object()", errors: [{ message: "The object literal notation {} is preferrable.", type: "NewExpression" }] },
+        { code: "var foo = new Object(BigInt('1n'))", errors: [{ message: "The object literal notation {} is preferrable.", type: "NewExpression" }] }
     ]
 });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Fixes #11810

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Loosen default requirement to allow arguments to `new Object` in the `no-new-object` rule.

**Is there anything you'd like reviewers to focus on?**

No.