### PR TITLE
Update: in quote-props rule allow consistent-as-needed with numbers option (fixes #8093)

### DIFF
--- a/docs/rules/quote-props.md
+++ b/docs/rules/quote-props.md
@@ -50,7 +50,7 @@ Object option:
 * `"keywords": true` requires quotes around language keywords used as object property names (only applies when using `as-needed` or `consistent-as-needed`)
 * `"unnecessary": true` (default) disallows quotes around object literal property names that are not strictly required (only applies when using `as-needed`)
 * `"unnecessary": false` allows quotes around object literal property names that are not strictly required (only applies when using `as-needed`)
-* `"numbers": true` requires quotes around numbers used as object property names (only applies when using `as-needed`)
+* `"numbers": true` requires quotes around numbers used as object property names (only applies when using `as-needed` or `consistent-as-needed`)
 
 ### always
 
@@ -256,7 +256,39 @@ Examples of additional **incorrect** code for this rule with the `"as-needed", {
 
 var x = {
     100: 1
-}
+};
+```
+
+Examples of additional **correct** code for this rule with the `"as-needed", { "numbers": true }` options:
+
+```js
+/*eslint quote-props: ["error", "as-needed", { "numbers": true }]*/
+
+var x = {
+    '100': 1
+};
+```
+
+Examples of additional **incorrect** code for this rule with the `"consistent-as-needed", { "numbers": true }` options:
+
+```js
+/*eslint quote-props: ["error", "consistent-as-needed", { "numbers": true }]*/
+
+var x = {
+    '100': 1,
+    name: 'thecotne'
+};
+```
+
+Examples of additional **correct** code for this rule with the `"consistent-as-needed", { "numbers": true }` options:
+
+```js
+/*eslint quote-props: ["error", "consistent-as-needed", { "numbers": true }]*/
+
+var x = {
+    '100': 1,
+    'name': 'thecotne'
+};
 ```
 
 ## When Not To Use It

--- a/lib/rules/quote-props.js
+++ b/lib/rules/quote-props.js
@@ -238,7 +238,12 @@ module.exports = {
                             return;
                         }
 
-                        necessaryQuotes = necessaryQuotes || !areQuotesRedundant(key.value, tokens) || KEYWORDS && isKeyword(tokens[0].value);
+                        necessaryQuotes = (
+                            necessaryQuotes ||
+                            !areQuotesRedundant(key.value, tokens) ||
+                            KEYWORDS && isKeyword(tokens[0].value) ||
+                            NUMBERS && tokens[0].type === "Numeric"
+                        );
                     }
                 } else if (KEYWORDS && checkQuotesRedundancy && key.type === "Identifier" && isKeyword(key.name)) {
                     unquotedProps.push(property);

--- a/tests/lib/rules/quote-props.js
+++ b/tests/lib/rules/quote-props.js
@@ -70,7 +70,7 @@ ruleTester.run("quote-props", rule, {
         { code: "({'unnecessary': 1, 'if': 0})", options: ["as-needed", { keywords: true, unnecessary: false }] },
         { code: "({'1': 1})", options: ["as-needed", { numbers: true }] },
         { code: "({1: 1, x: 2})", options: ["consistent", { numbers: true }] },
-        { code: "({1: 1, x: 2})", options: ["consistent-as-needed", { numbers: true }] },
+        { code: "({'1': 1, 'x': 2})", options: ["consistent-as-needed", { numbers: true }] },
         { code: "({ ...x })", options: ["as-needed"], parserOptions: { ecmaVersion: 2018 } },
         { code: "({ ...x })", options: ["consistent"], parserOptions: { ecmaVersion: 2018 } },
         { code: "({ ...x })", options: ["consistent-as-needed"], parserOptions: { ecmaVersion: 2018 } }


### PR DESCRIPTION
fixes #8093

<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

It is explained here #8093

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

 - Updated tests in `tests/lib/rules/quote-props.js` according to issue description (#8093)
 - Updated rules in `lib/rules/quote-props.js` to fix tests
 - Updated docs in `docs/rules/quote-props.md` to explain new behavior

**Is there anything you'd like reviewers to focus on?**

No
