### PR TITLE
Docs: removed '>' prefix from from docs/working-with-rules

### DIFF
--- a/docs/developer-guide/working-with-rules.md
+++ b/docs/developer-guide/working-with-rules.md
@@ -412,21 +412,16 @@ Once you have an instance of `SourceCode`, you can use the methods on it to work
 * `getIndexFromLoc(loc)` - returns the index of a given location in the source code, where `loc` is an object with a 1-based `line` key and a 0-based `column` key.
 * `commentsExistBetween(nodeOrToken1, nodeOrToken2)` - returns `true` if comments exist between two nodes.
 
-> `skipOptions` is an object which has 3 properties; `skip`, `includeComments`, and `filter`. Default is `{skip: 0, includeComments: false, filter: null}`.
->
-> * `skip` is a positive integer, the number of skipping tokens. If `filter` option is given at the same time, it doesn't count filtered tokens as skipped.
-> * `includeComments` is a boolean value, the flag to include comment tokens into the result.
-> * `filter` is a function which gets a token as the first argument, if the function returns `false` then the result excludes the token.
->
-> `countOptions` is an object which has 3 properties; `count`, `includeComments`, and `filter`. Default is `{count: 0, includeComments: false, filter: null}`.
->
-> * `count` is a positive integer, the maximum number of returning tokens.
-> * `includeComments` is a boolean value, the flag to include comment tokens into the result.
-> * `filter` is a function which gets a token as the first argument, if the function returns `false` then the result excludes the token.
->
-> `rangeOptions` is an object which has 1 property: `includeComments`.
->
-> * `includeComments` is a boolean value, the flag to include comment tokens into the result.
+`skipOptions` is an object which has 3 properties; `skip`, `includeComments`, and `filter`. Default is `{skip: 0, includeComments: false, filter: null}`.
+* `skip` is a positive integer, the number of skipping tokens. If `filter` option is given at the same time, it doesn't count filtered tokens as skipped.
+* `includeComments` is a boolean value, the flag to include comment tokens into the result.
+* `filter` is a function which gets a token as the first argument, if the function returns `false` then the result excludes the token.
+`countOptions` is an object which has 3 properties; `count`, `includeComments`, and `filter`. Default is `{count: 0, includeComments: false, filter: null}`.
+* `count` is a positive integer, the maximum number of returning tokens.
+* `includeComments` is a boolean value, the flag to include comment tokens into the result.
+* `filter` is a function which gets a token as the first argument, if the function returns `false` then the result excludes the token.
+`rangeOptions` is an object which has 1 property: `includeComments`.
+* `includeComments` is a boolean value, the flag to include comment tokens into the result.
 
 There are also some properties you can access:
 

--- a/docs/developer-guide/working-with-rules.md
+++ b/docs/developer-guide/working-with-rules.md
@@ -413,14 +413,19 @@ Once you have an instance of `SourceCode`, you can use the methods on it to work
 * `commentsExistBetween(nodeOrToken1, nodeOrToken2)` - returns `true` if comments exist between two nodes.
 
 `skipOptions` is an object which has 3 properties; `skip`, `includeComments`, and `filter`. Default is `{skip: 0, includeComments: false, filter: null}`.
+
 * `skip` is a positive integer, the number of skipping tokens. If `filter` option is given at the same time, it doesn't count filtered tokens as skipped.
 * `includeComments` is a boolean value, the flag to include comment tokens into the result.
 * `filter` is a function which gets a token as the first argument, if the function returns `false` then the result excludes the token.
+
 `countOptions` is an object which has 3 properties; `count`, `includeComments`, and `filter`. Default is `{count: 0, includeComments: false, filter: null}`.
+
 * `count` is a positive integer, the maximum number of returning tokens.
 * `includeComments` is a boolean value, the flag to include comment tokens into the result.
 * `filter` is a function which gets a token as the first argument, if the function returns `false` then the result excludes the token.
+
 `rangeOptions` is an object which has 1 property: `includeComments`.
+
 * `includeComments` is a boolean value, the flag to include comment tokens into the result.
 
 There are also some properties you can access:


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Documentation update

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
 removed unnecessary `>` from docs


