### PR TITLE
Fix: no-var should not fix variables named 'let' (fixes #11830)

### DIFF
--- a/lib/rules/no-var.js
+++ b/lib/rules/no-var.js
@@ -174,6 +174,17 @@ function hasReferenceInTDZ(node) {
     };
 }
 
+/**
+ * Checks whether a given variable has name that is allowed for 'var' declarations,
+ * but disallowed for `let` declarations.
+ *
+ * @param {eslint-scope.Variable} variable The variable to check.
+ * @returns {boolean} `true` if the variable has a disallowed name.
+ */
+function hasNameDisallowedForLetDeclarations(variable) {
+    return variable.name === "let";
+}
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -223,6 +234,7 @@ module.exports = {
          * - A variable might be used before it is assigned within a loop.
          * - A variable might be used in TDZ.
          * - A variable is declared in statement position (e.g. a single-line `IfStatement`)
+         * - A variable has name that is disallowed for `let` declarations.
          *
          * ## A variable is declared on a SwitchCase node.
          *
@@ -271,7 +283,8 @@ module.exports = {
                 node.declarations.some(hasSelfReferenceInTDZ) ||
                 variables.some(isGlobal) ||
                 variables.some(isRedeclared) ||
-                variables.some(isUsedFromOutsideOf(scopeNode))
+                variables.some(isUsedFromOutsideOf(scopeNode)) ||
+                variables.some(hasNameDisallowedForLetDeclarations)
             ) {
                 return false;
             }

--- a/tests/lib/rules/no-var.js
+++ b/tests/lib/rules/no-var.js
@@ -307,6 +307,18 @@ ruleTester.run("no-var", rule, {
             parser: require.resolve("../../fixtures/parsers/typescript-parsers/declare-var"),
             parserOptions: { ecmaVersion: 6, sourceType: "module" },
             errors: ["Unexpected var, use let or const instead."]
+        },
+
+        // https://github.com/eslint/eslint/issues/11830
+        {
+            code: "function foo() { var let; }",
+            output: null,
+            errors: ["Unexpected var, use let or const instead."]
+        },
+        {
+            code: "function foo() { var { let } = {}; }",
+            output: null,
+            errors: ["Unexpected var, use let or const instead."]
         }
     ]
 });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix: [#11830](https://github.com/eslint/eslint/issues/11830)
<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This PR changes `no-var` auto fix behavior:

The rule will not fix declarations that contain a variable named `'let'`

**Is there anything you'd like reviewers to focus on?**


