### PR TITLE
Upgrade: @babel/polyfill => core-js v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.4.3",
-    "@babel/polyfill": "^7.4.3",
     "@babel/preset-env": "^7.4.3",
     "acorn": "^6.1.1",
     "babel-loader": "^8.0.5",
@@ -93,6 +92,7 @@
     "chai": "^4.0.1",
     "cheerio": "^0.22.0",
     "common-tags": "^1.8.0",
+    "core-js": "^3.1.3",
     "coveralls": "^3.0.3",
     "dateformat": "^3.0.3",
     "ejs": "^2.6.1",
@@ -123,6 +123,7 @@
     "proxyquire": "^2.0.1",
     "puppeteer": "^1.14.0",
     "recast": "^0.17.6",
+    "regenerator-runtime": "^0.13.2",
     "shelljs": "^0.8.2",
     "sinon": "^3.3.0",
     "temp": "^0.9.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,8 +3,8 @@
 module.exports = {
     mode: "none",
     entry: {
-        eslint: ["@babel/polyfill", "./lib/linter/linter.js"],
-        espree: ["@babel/polyfill", "espree"]
+        eslint: ["core-js/stable", "regenerator-runtime/runtime", "./lib/linter/linter.js"],
+        espree: ["core-js/stable", "regenerator-runtime/runtime", "espree"]
     },
     output: {
         filename: "[name].js",


### PR DESCRIPTION
🚨 As of Babel 7.4.0, this package has been deprecated in favor of directly including core-js/stable (to polyfill ECMAScript features) and regenerator-runtime/runtime (needed to use transpiled generator functions):

<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**


[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**


**Is there anything you'd like reviewers to focus on?**

not really.
