### PR TITLE
Fix: max-len properly ignore trailing comments (fixes #11838)

### DIFF
--- a/lib/rules/max-len.js
+++ b/lib/rules/max-len.js
@@ -315,6 +315,13 @@ module.exports = {
                         textToMeasure = line;
                     } else if (ignoreTrailingComments && isTrailingComment(line, lineNumber, comment)) {
                         textToMeasure = stripTrailingComment(line, comment);
+
+                        // ignore multiple trailing comments in the same line
+                        let lastIndex = commentsIndex;
+
+                        while (isTrailingComment(textToMeasure, lineNumber, comments[--lastIndex])) {
+                            textToMeasure = stripTrailingComment(textToMeasure, comments[lastIndex]);
+                        }
                     } else {
                         textToMeasure = line;
                     }

--- a/tests/lib/rules/max-len.js
+++ b/tests/lib/rules/max-len.js
@@ -51,6 +51,9 @@ ruleTester.run("max-len", rule, {
         }, {
             code: "// really long comment on its own line sitting here",
             options: [40, 4, { ignoreComments: true }]
+        }, {
+            code: "var foo = module.exports = {}; /* inline some other comments */ //more",
+            options: [40, 4, { ignoreComments: true }]
         },
         "var /*inline-comment*/ i = 1;",
         {
@@ -86,6 +89,9 @@ ruleTester.run("max-len", rule, {
             options: [{ code: 30, tabWidth: 4, comments: 20, ignoreTrailingComments: true }]
         }, {
             code: "var foo = module.exports = {}; // really long trailing comment",
+            options: [40, 4, { ignoreTrailingComments: true }]
+        }, {
+            code: "var foo = module.exports = {}; /* inline some other comments */ //more",
             options: [40, 4, { ignoreTrailingComments: true }]
         }, {
             code: "var foo = module.exports = {}; // really long trailing comment",


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Fixes: #11838

`stripTrailingComment` recursively to ignore trailing comments properly in the same line.

**Is there anything you'd like reviewers to focus on?**


