### PR TITLE
Fix: no-param-reassign schema (fixes #11837)

### DIFF
--- a/lib/rules/no-param-reassign.js
+++ b/lib/rules/no-param-reassign.js
@@ -23,33 +23,20 @@ module.exports = {
 
         schema: [
             {
-                oneOf: [
-                    {
-                        type: "object",
-                        properties: {
-                            props: {
-                                enum: [false]
-                            }
-                        },
-                        additionalProperties: false
+                type: "object",
+                properties: {
+                    props: {
+                        enum: [true, false]
                     },
-                    {
-                        type: "object",
-                        properties: {
-                            props: {
-                                enum: [true]
-                            },
-                            ignorePropertyModificationsFor: {
-                                type: "array",
-                                items: {
-                                    type: "string"
-                                },
-                                uniqueItems: true
-                            }
+                    ignorePropertyModificationsFor: {
+                        type: "array",
+                        items: {
+                            type: "string"
                         },
-                        additionalProperties: false
+                        uniqueItems: true
                     }
-                ]
+                },
+                additionalProperties: false
             }
         ]
     },

--- a/tests/lib/rules/no-param-reassign.js
+++ b/tests/lib/rules/no-param-reassign.js
@@ -50,8 +50,18 @@ ruleTester.run("no-param-reassign", rule, {
             parserOptions: { ecmaVersion: 2015 }
         },
         {
+            code: "function foo(a) { ([...a.b] = obj); }",
+            options: [{ props: false, ignorePropertyModificationsFor: [] }],
+            parserOptions: { ecmaVersion: 2015 }
+        },
+        {
             code: "function foo(a) { ({...a.b} = obj); }",
             options: [{ props: false }],
+            parserOptions: { ecmaVersion: 2018 }
+        },
+        {
+            code: "function foo(a) { ({...a.b} = obj); }",
+            options: [{ props: false, ignorePropertyModificationsFor: [] }],
             parserOptions: { ecmaVersion: 2018 }
         }
     ],


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Fixes #11837

- Changed the `no-param-reassign` schema to be more permissive so as to allow the `props` option property to be explicitly set to its default value (`false`).
- Added 2 test cases for this scenario.

**Is there anything you'd like reviewers to focus on?**
