### PR TITLE
fix: Cannot read property 'range' of null error with indent

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -434,8 +434,8 @@ class OffsetStorage {
                     // (indentation for the first element's line)
                     this.getDesiredIndent(this._tokenInfo.getFirstTokenOfLine(firstToken)) +
 
-                        // (space between the start of the first element's line and the first element)
-                        this._indentType.repeat(firstToken.loc.start.column - this._tokenInfo.getFirstTokenOfLine(firstToken).loc.start.column)
+                    // (space between the start of the first element's line and the first element)
+                    this._indentType.repeat(firstToken.loc.start.column - this._tokenInfo.getFirstTokenOfLine(firstToken).loc.start.column)
                 );
             } else {
                 const offsetInfo = this._getOffsetDescriptor(token);
@@ -1075,7 +1075,9 @@ module.exports = {
                  * var foo = bar &&
                  *                   baz;
                  */
-
+                if (operator === null) {
+                    return;
+                }
                 const tokenAfterOperator = sourceCode.getTokenAfter(operator);
 
                 offsets.ignoreToken(operator);
@@ -1294,8 +1296,8 @@ module.exports = {
 
                 // Only indent the arguments if the NewExpression has parens (e.g. `new Foo(bar)` or `new Foo()`, but not `new Foo`
                 if (node.arguments.length > 0 ||
-                        astUtils.isClosingParenToken(sourceCode.getLastToken(node)) &&
-                        astUtils.isOpeningParenToken(sourceCode.getLastToken(node, 1))) {
+                    astUtils.isClosingParenToken(sourceCode.getLastToken(node)) &&
+                    astUtils.isOpeningParenToken(sourceCode.getLastToken(node, 1))) {
                     addFunctionCallIndent(node);
                 }
             },


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

- [ ] Documentation update
- [x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
- [ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
- [ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment**

* **ESLint Version:** 5.16.0
* **Node Version:** 10
* **npm Version:** 6

**What parser (default, Babel-ESLint, etc.) are you using?** 
`@typescript-eslint/parser`

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
const { specifiedRules: allGraphQLValidators } = require('graphql');
const { compose, map, prop, without } = require('ramda');
// We need to disable these validators because it's how Apollo works
// See https://github.com/apollographql/eslint-plugin-graphql#selecting-validation-rules
const allGraphQLValidatorNames = compose(
  without(['KnownDirectives', 'NoUnusedFragments', 'KnownFragmentNames']),
  map(prop('name')),
)(allGraphQLValidators);

module.exports = {
  parser: '@typescript-eslint/parser',
  extends: [
    'plugin:@typescript-eslint/recommended',
    'airbnb',
    'plugin:jest/recommended',
    'plugin:cypress/recommended',
    'prettier',
    'prettier/react',
    'prettier/@typescript-eslint',
  ],

  env: {
    browser: true,
    node: true,
    es6: true,
    jasmine: true,
    'jest/globals': true,
    'cypress/globals': true,
  },

  plugins: [
    'react',
    '@shinetools/eslint-plugin-shine',
    '@typescript-eslint',
    'graphql',
    'jest',
    'cypress',
  ],

  globals: {
    cancelAnimationFrame: true,
    requestAnimationFrame: true,
    fetch: false,
    element: true,
    by: true,
    device: true,
    waitFor: true,
  },

  rules: {
    'react/prop-types': 'off',
    'import/no-unresolved': 'error',
    indent: 2,
    'eslint/no-unused-vars': 0,
    '@typescript-eslint/no-unused-vars': [
      'error',
      { ignoreRestSiblings: true },
    ],
    '@typescript-eslint/indent': ['error', 2],
    '@typescript-eslint/explicit-function-return-type': [
      'error',
      {
        allowTypedFunctionExpressions: true,
      },
    ],
    'jest/no-disabled-tests': 2,
    'react/no-unused-state': 2,
    camelcase: 0,
    'react/jsx-filename-extension': [
      1,
      {
        extensions: ['.tsx'],
      },
    ],
    'global-require': 0,
    'jsx-a11y/accessible-emoji': 0,
    '@shinetools/shine/no-native-text-component': 2,
    '@shinetools/shine/no-several-button-styles': 2,
    'react/sort-comp': 0,
    'react/jsx-sort-props': [
      2,
      {
        callbacksLast: false,
        shorthandFirst: false,
        shorthandLast: false,
        ignoreCase: true,
        noSortAlphabetically: false,
        reservedFirst: false,
      },
    ],
    'react/jsx-sort-default-props': [
      2,
      {
        ignoreCase: true,
      },
    ],
    'react/sort-prop-types': 2,
    'import/prefer-default-export': 0,
    'import/named': 'error',
    'import/default': 'error',
    'no-underscore-dangle': 0,
    'import/no-extraneous-dependencies': [
      'error',
      {
        devDependencies: [
          'scripts/**',
          '__e2e__/**',
          'jest/**',
          '**/*.test.ts?',
          'jest.setup.js',
          'webpack/**',
        ],
      },
    ],
    'graphql/template-strings': [
      'error',
      {
        env: 'literal',
        validators: allGraphQLValidatorNames,
      },
    ],
    'graphql/no-deprecated-fields': [
      'error',
      {
        env: 'literal',
      },
    ],
    'graphql/capitalized-type-name': [
      'error',
      {
        env: 'literal',
      },
    ],
    'graphql/named-operations': [
      'error',
      {
        env: 'literal',
      },
    ],
  },

  settings: {
    'import/resolver': {
      // use <root>/tsconfig.json
      typescript: {},

      // use <root>/path/to/folder/tsconfig.json
      typescript: {
        directory: '.',
      },
    },
    react: {
      version: 'detect',
    },
  },
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**
Run `prettier-eslint --fix` on a file containing a TypeScript casting  using the `as` keyword:
```js
const a = 'hello' as string;
```

Very interestingly, manually running Prettier and then ESLint does *not* trigger the bug, I couldn't understand exactly why.

**What did you expect to happen?**
I expected ESLint to fix any errors I might have, after the file has been prettified.

**What actually happened? Please include the actual, raw output from ESLint.**
ESLint crashed with the following error:
```
prettier-eslint [ERROR]: eslint fix failed due to an eslint error
prettier-eslint-cli [ERROR]: There was an error formatting "index.tsx": 
    TypeError: Cannot read property 'range' of null
    Occurred while linting /index.tsx:1
        at SourceCode.getTokenAfter (/node_modules/eslint/lib/token-store/index.js:320:18)
        at Object.BinaryExpression, LogicalExpression [as listener] (/node_modules/eslint/lib/rules/indent.js:1081:55)
        at Program:exit.listenerCallQueue.filter.forEach.nodeInfo (/node_modules/eslint/lib/rules/indent.js:1554:55)
        at Array.forEach (<anonymous>)
        at Program:exit (/eslint/lib/rules/indent.js:1554:26)
        at listeners.(anonymous function).forEach.listener (/eslint/lib/util/safe-emitter.js:45:58)
        at Array.forEach (<anonymous>)
        at Object.emit (/eslint/lib/util/safe-emitter.js:45:38)
        at NodeEventGenerator.applySelector (/eslint/lib/util/node-event-generator.js:251:26)
        at NodeEventGenerator.applySelectors (/eslint/lib/util/node-event-generator.js:280:22)
failure formatting 1 file with prettier-eslint
error Command failed with exit code 1.
```
The issue has already been reported in different places, but it's hard to fully understand what causes the error. For example, https://github.com/babel/babel-eslint/issues/530#issuecomment-464512173

This apparently has already been fixed for some other rules (eg. https://github.com/eslint/eslint/pull/10938)

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
When parsing an expression containing `as`, it's identifed as a `BinaryExpression`, but the `operator` is `null`. If that's the case, shortcut the process as it will lead to errors.


**Is there anything you'd like reviewers to focus on?**


