### PR TITLE
Docs: Add JSHint W047 compat to no-floating-decimal

### DIFF
--- a/docs/rules/no-floating-decimal.md
+++ b/docs/rules/no-floating-decimal.md
@@ -40,4 +40,4 @@ If you aren't concerned about misinterpreting floating decimal point values, the
 
 ## Compatibility
 
-* **JSHint**: W008
+* **JSHint**: W008, W047


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

* [x] Documentation update

**What changes did you make? (Give an overview)**

This ESLint rule handles both leading and trailing decimal points.
In order to ease discovery of this ESLint rule, mention the latter
warning as well, as users might only find those in their code.

https://github.com/jshint/jshint/blob/7993101/src/style.js#L100-L116
