### PR TITLE
Fix: multiline-comment-style incorrect message

### DIFF
--- a/lib/rules/multiline-comment-style.js
+++ b/lib/rules/multiline-comment-style.js
@@ -25,6 +25,7 @@ module.exports = {
         schema: [{ enum: ["starred-block", "separate-lines", "bare-block"] }],
         messages: {
             expectedBlock: "Expected a block comment instead of consecutive line comments.",
+            expectedBareBlock: "Expected a block comment without padding stars.",
             startNewline: "Expected a linebreak after '/*'.",
             endNewline: "Expected a linebreak before '*/'.",
             missingStar: "Expected a '*' at the start of this line.",
@@ -250,7 +251,7 @@ module.exports = {
                                     start: block.loc.start,
                                     end: { line: block.loc.start.line, column: block.loc.start.column + 2 }
                                 },
-                                messageId: "expectedBlock",
+                                messageId: "expectedBareBlock",
                                 fix(fixer) {
                                     return fixer.replaceText(block, convertToBlock(block, commentLines.filter(line => line)));
                                 }

--- a/tests/lib/rules/multiline-comment-style.js
+++ b/tests/lib/rules/multiline-comment-style.js
@@ -481,7 +481,7 @@ ruleTester.run("multiline-comment-style", rule, {
                    bar */
             `,
             options: ["bare-block"],
-            errors: [{ messageId: "expectedBlock", line: 2 }]
+            errors: [{ messageId: "expectedBareBlock", line: 2 }]
         }
     ]
 });


### PR DESCRIPTION
**What did you do? Please include the actual source code causing the issue.**
```js
/* eslint multiline-comment-style: [2, 'bare-block'] */

// Expected a block comment instead of consecutive line comments. (multiline-comment-style)

/*
 * reqrewq
 * rewqrewq 
 */
```

**What actually happened? Please include the actual, raw output from ESLint.**

Error message is wrong because the code has no consecutive line comments.

This pr fix change the message when option `bare-block` is used and the code has a star-style comment. 

The error message is changed in the following way:
```diff
- Expected a block comment instead of consecutive line comments.
+ Expected a block comment without padding stars.
```

