### PR TITLE
Fix: no-else-return autofix produces name collisions (fixes #11069)

### DIFF
--- a/tests/lib/rules/no-else-return.js
+++ b/tests/lib/rules/no-else-return.js
@@ -182,6 +182,342 @@ ruleTester.run("no-else-return", rule, {
             output: "function foo21() { var x = true; if (x) { return x; } if (x === false) { return false; } }",
             options: [{ allowElseIf: false }],
             errors: [{ messageId: "unexpected", type: "IfStatement" }]
+        },
+
+        // https://github.com/eslint/eslint/issues/11069
+        {
+            code: "function foo() { var a; if (bar) { return true; } else { var a; } }",
+            output: "function foo() { var a; if (bar) { return true; }  var a;  }",
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function foo() { if (bar) { var a; if (baz) { return true; } else { var a; } } }",
+            output: "function foo() { if (bar) { var a; if (baz) { return true; }  var a;  } }",
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function foo() { var a; if (bar) { return true; } else { var a; } }",
+            output: "function foo() { var a; if (bar) { return true; }  var a;  }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function foo() { if (bar) { var a; if (baz) { return true; } else { var a; } } }",
+            output: "function foo() { if (bar) { var a; if (baz) { return true; }  var a;  } }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function foo() { let a; if (bar) { return true; } else { let a; } }",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "class foo { bar() { let a; if (baz) { return true; } else { let a; } } }",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function foo() { if (bar) { let a; if (baz) { return true; } else { let a; } } }",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function foo() {let a; if (bar) { if (baz) { return true; } else { let a; } } }",
+            output: "function foo() {let a; if (bar) { if (baz) { return true; }  let a;  } }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function foo() { const a = 1; if (bar) { return true; } else { let a; } }",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function foo() { if (bar) { const a = 1; if (baz) { return true; } else { let a; } } }",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function foo() { let a; if (bar) { return true; } else { const a = 1 } }",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function foo() { if (bar) { let a; if (baz) { return true; } else { const a = 1; } } }",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function foo() { class a {}; if (bar) { return true; } else { const a = 1; } }",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function foo() { if (bar) { class a {}; if (baz) { return true; } else { const a = 1; } } }",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function foo() { const a = 1; if (bar) { return true; } else { class a {} } }",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function foo() { if (bar) { const a = 1; if (baz) { return true; } else { class a {} } } }",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function foo() { var a; if (bar) { return true; } else { let a; } }",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function foo() { if (bar) { var a; return true; } else { let a; } }",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function foo() { if (bar) { return true; } else { let a; }  while (baz) { var a; } }",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function foo(a) { if (bar) { return true; } else { let a; } }",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                { messageId: "unexpected", type: "BlockStatement" }
+            ]
+        },
+        {
+            code: "function foo(a = 1) { if (bar) { return true; } else { let a; } }",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function foo(a, b = a) { if (bar) { return true; } else { let a; }  if (bar) { return true; } else { let b; }}",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                { messageId: "unexpected", type: "BlockStatement" },
+                { messageId: "unexpected", type: "BlockStatement" }
+            ]
+        },
+        {
+            code: "function foo(...args) { if (bar) { return true; } else { let args; } }",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function foo() { try {} catch (a) { if (bar) { return true; } else { let a; } } }",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function foo() { try {} catch (a) { if (bar) { if (baz) { return true; } else { let a; } } } }",
+            output: "function foo() { try {} catch (a) { if (bar) { if (baz) { return true; }  let a;  } } }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function foo() { try {} catch ({bar, a = 1}) { if (baz) { return true; } else { let a; } } }",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function foo() { if (bar) { return true; } else { let arguments; } }",
+            output: "function foo() { if (bar) { return true; }  let arguments;  }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function foo() { if (bar) { return true; } else { let arguments; } return arguments[0]; }",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function foo() { if (bar) { return true; } else { let arguments; } if (baz) { return arguments[0]; } }",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function foo() { if (bar) { if (baz) { return true; } else { let arguments; } } }",
+            output: "function foo() { if (bar) { if (baz) { return true; }  let arguments;  } }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function foo() { if (bar) { return true; } else { let a; } a; }",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function foo() { if (bar) { return true; } else { let a; } if (baz) { a; } }",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function foo() { if (bar) { if (baz) { return true; } else { let a; } } a; }",
+            output: "function foo() { if (bar) { if (baz) { return true; }  let a;  } a; }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function foo() { if (bar) { if (baz) { return true; } else { let a; } a; } }",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function foo() { if (bar) { if (baz) { return true; } else { let a; } if (quux) { a; } } }",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function a() { if (foo) { return true; } else { let a; } a(); }",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function a() { if (a) { return true; } else { let a; } }",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function a() { if (foo) { return a; } else { let a; } }",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function foo() { if (bar) { return true; } else { let a; } function baz() { a; } }",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function foo() { if (bar) { if (baz) { return true; } else { let a; } (() => a) } }",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function foo() { if (bar) { return true; } else { let a; } var a; }",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function foo() { if (bar) { if (baz) { return true; } else { let a; } var a; } }",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function foo() { if (bar) { if (baz) { return true; } else { let a; } var { a } = {}; } }",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function foo() { if (bar) { if (baz) { return true; } else { let a; } if (quux) { var a; } } }",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function foo() { if (bar) { if (baz) { return true; } else { let a; } } if (quux) { var a; } }",
+            output: "function foo() { if (bar) { if (baz) { return true; }  let a;  } if (quux) { var a; } }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function foo() { if (quux) { var a; } if (bar) { if (baz) { return true; } else { let a; } } }",
+            output: "function foo() { if (quux) { var a; } if (bar) { if (baz) { return true; }  let a;  } }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function foo() { if (bar) { return true; } else { let a; } function a(){} }",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function foo() { if (baz) { if (bar) { return true; } else { let a; } function a(){} } }",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function foo() { if (bar) { if (baz) { return true; } else { let a; } } if (quux) { function a(){}  } }",
+            output: "function foo() { if (bar) { if (baz) { return true; }  let a;  } if (quux) { function a(){}  } }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function foo() { if (bar) { if (baz) { return true; } else { let a; } } function a(){} }",
+            output: "function foo() { if (bar) { if (baz) { return true; }  let a;  } function a(){} }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function foo() { let a; if (bar) { return true; } else { function a(){} } }",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function foo() { var a; if (bar) { return true; } else { function a(){} } }",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "function foo() { if (bar) { return true; } else function baz() {} };",
+            output: null,
+            errors: [{ messageId: "unexpected", type: "FunctionDeclaration" }]
+        },
+        {
+            code: "if (foo) { return true; } else { let a; }",
+            output: "if (foo) { return true; }  let a; ",
+            parserOptions: { ecmaVersion: 6 },
+            env: { node: true },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
+        },
+        {
+            code: "let a; if (foo) { return true; } else { let a; }",
+            output: null,
+            parserOptions: { ecmaVersion: 6 },
+            env: { node: true },
+            errors: [{ messageId: "unexpected", type: "BlockStatement" }]
         }
     ]
 });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix [#11069](https://github.com/eslint/eslint/issues/11069)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Disable `no-else-return` auto-fix in cases where it would cause name collisions.

This prevents syntax errors:

```js
function foo(){
    let bar = 0;
    if (cond) {
        return bar;
    } else {
        let bar = 1; // redeclaration, if the rule removes else and braces
        return bar;
    }
}
```

and reference changes:

```js
function bar() {
  return 0;
}

function foo(){
    if (cond) {
        return bar(); // reference to the variable below, if the rule removes else and braces
    } else {
        let bar = 1;
        return bar;
    }
}
```

**Is there anything you'd like reviewers to focus on?**