### PR TITLE
Fix: CLIEngine#getRules() contains plugin rules (fixes #11871)

### DIFF
--- a/lib/cli-engine/cascading-config-array-factory.js
+++ b/lib/cli-engine/cascading-config-array-factory.js
@@ -27,7 +27,7 @@ const os = require("os");
 const path = require("path");
 const { validateConfigArray } = require("../shared/config-validator");
 const { ConfigArrayFactory } = require("./config-array-factory");
-const { ConfigDependency } = require("./config-array");
+const { ConfigArray, ConfigDependency } = require("./config-array");
 const loadRules = require("./load-rules");
 const debug = require("debug")("eslint:cascading-config-array-factory");
 
@@ -225,11 +225,22 @@ class CascadingConfigArrayFactory {
 
     /**
      * Get the config array of a given file.
-     * @param {string} filePath The file path to a file.
+     * If `filePath` was not given, it returns the config which contains only
+     * `baseConfigData` and `cliConfigData`.
+     * @param {string} [filePath] The file path to a file.
      * @returns {ConfigArray} The config array of the file.
      */
     getConfigArrayForFile(filePath) {
-        const { cwd } = internalSlotsMap.get(this);
+        const {
+            baseConfigArray,
+            cliConfigArray,
+            cwd
+        } = internalSlotsMap.get(this);
+
+        if (!filePath) {
+            return new ConfigArray(...baseConfigArray, ...cliConfigArray);
+        }
+
         const directoryPath = path.dirname(path.resolve(cwd, filePath));
 
         debug(`Load config files for ${directoryPath}.`);

--- a/lib/cli-engine/cli-engine.js
+++ b/lib/cli-engine/cli-engine.js
@@ -573,7 +573,7 @@ class CLIEngine {
         const linter = new Linter();
 
         /** @type {ConfigArray[]} */
-        const lastConfigArrays = [];
+        const lastConfigArrays = [configArrayFactory.getConfigArrayForFile()];
 
         // Store private data.
         internalSlotsMap.set(this, {

--- a/tests/lib/cli-engine/cli-engine.js
+++ b/tests/lib/cli-engine/cli-engine.js
@@ -3796,8 +3796,13 @@ describe("CLIEngine", () => {
         it("should expose the list of rules", () => {
             const engine = new CLIEngine();
 
-            assert.isTrue(engine.getRules().has("no-eval"), "no-eval is present");
+            assert(engine.getRules().has("no-eval"), "no-eval is present");
+        });
 
+        it("should expose the list of plugin rules", () => {
+            const engine = new CLIEngine({ plugins: ["node"] });
+
+            assert(engine.getRules().has("node/no-deprecated-api"), "node/no-deprecated-api is present");
         });
     });
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix: #11871

**What changes did you make? (Give an overview)**

This PR fixes `CLIEngine` as the following code contains plugin rules.

```js
new CLIEngine({ plugins: ['foo'] }).getRules()
```

Previously, `CLIEngine#getRules()` contains core rules and the plugin rules that the last `CLIEngine#executeOn*()` methods call used.

This PR changes only the behavior that is before `CLIEngine#executeOn*()` methods called.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.



