### PR TITLE
Fix: improve diagnostics for shareable-config-missing errors

### DIFF
--- a/lib/cli-engine/config-array-factory.js
+++ b/lib/cli-engine/config-array-factory.js
@@ -224,15 +224,16 @@ function loadPackageJSONConfigFile(filePath) {
 /**
  * Creates an error to notify about a missing config to extend from.
  * @param {string} configName The name of the missing config.
+ * @param {string} importerName The name of the config that imported the missing config
  * @returns {Error} The error object to throw
  * @private
  */
-function configMissingError(configName) {
+function configMissingError(configName, importerName) {
     return Object.assign(
         new Error(`Failed to load config "${configName}" to extend from.`),
         {
             messageTemplate: "extend-config-missing",
-            messageData: { configName }
+            messageData: { configName, importerName }
         }
     );
 }
@@ -637,7 +638,7 @@ class ConfigArrayFactory {
             return this._loadConfigData(eslintAllPath, name);
         }
 
-        throw configMissingError(extendName);
+        throw configMissingError(extendName, importerName);
     }
 
     /**
@@ -670,7 +671,7 @@ class ConfigArrayFactory {
             );
         }
 
-        throw plugin.error || configMissingError(extendName);
+        throw plugin.error || configMissingError(extendName, importerPath);
     }
 
     /**
@@ -704,7 +705,7 @@ class ConfigArrayFactory {
         } catch (error) {
             /* istanbul ignore else */
             if (error && error.code === "MODULE_NOT_FOUND") {
-                throw configMissingError(extendName);
+                throw configMissingError(extendName, importerPath);
             }
             throw error;
         }

--- a/messages/extend-config-missing.txt
+++ b/messages/extend-config-missing.txt
@@ -1,3 +1,5 @@
 ESLint couldn't find the config "<%- configName %>" to extend from. Please check that the name of the config is correct.
 
+The config "<%- configName %>" was referenced from the config file in "<%- importerName %>".
+
 If you still have problems, please stop by https://gitter.im/eslint/eslint to chat with the team.

--- a/tests/lib/cli-engine/cli-engine.js
+++ b/tests/lib/cli-engine/cli-engine.js
@@ -3338,7 +3338,8 @@ describe("CLIEngine", () => {
                 } catch (err) {
                     assert.strictEqual(err.messageTemplate, "extend-config-missing");
                     assert.deepStrictEqual(err.messageData, {
-                        configName: "nonexistent-config"
+                        configName: "nonexistent-config",
+                        importerName: getFixturePath("module-not-found", "extends-js", ".eslintrc.yml")
                     });
                     return;
                 }


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix

**Tell us about your environment**

* **ESLint Version:** master
* **Node Version:** 12.4.0
* **npm Version:** 6.9.0

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
  extends: 'nonexistent-config'
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**

(Any source code)

**What did you expect to happen?**

I expected to get an error message saying that `nonexistent-config` doesn't exist, with a useful indicator for which config was trying to load `nonexistent-config`.

**What actually happened? Please include the actual, raw output from ESLint.**

I got the following error message:

ESLint couldn't find the config "nonexistent-config" to extend from. Please check that the name of the config is correct.

This error message makes it difficult to debug the problem if I'm not sure who is trying to load a given missing config.

**What changes did you make? (Give an overview)**

This updates the missing-shareable-config error message to include more useful diagnostic information about the problem, by mentioning which config tried to load the nonexistent config.

**Is there anything you'd like reviewers to focus on?**

I'm labelling this as a "bug" because the fix wouldn't have any semver impact (even if reverted), but feel free to comment if you disagree with this categorization.