### PR TITLE
Docs: Fix inconsistent linking in migration guide

### DIFF
--- a/docs/user-guide/migrating-to-6.0.0.md
+++ b/docs/user-guide/migrating-to-6.0.0.md
@@ -131,7 +131,7 @@ Additionally, if you see new errors for `global` comments in your code, you shou
 
 **Related issue(s):** [eslint/eslint#11370](https://github.com/eslint/eslint/issues/11370), [eslint/eslint#11405](https://github.com/eslint/eslint/issues/11405)
 
-## <a name="comma-dangle-updates"></a> [The `comma-dangle` rule is now more strict by default](#comma-dangle-updates)
+## <a name="comma-dangle-updates"></a> The `comma-dangle` rule is now more strict by default
 
 Previously, the [`comma-dangle`](https://eslint.org/docs/rules/comma-dangle) rule would ignore trailing function arguments and parameters, unless explicitly configured to check for function commas. In ESLint v6, function commas are treated the same way as other types of trailing commas.
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This fixes some inconsistent formatting in the migration guide. Previously, the [`comma-dangle` header](https://eslint.org/docs/user-guide/migrating-to-6.0.0#comma-dangle-updates) was blue (and a link to itself) while all the other headers were not.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
