### PR TITLE
Bug: nested plugins cannot be found when nested in a shared config (6.0.0)

### DIFF
--- a/lib/cli-engine/config-array-factory.js
+++ b/lib/cli-engine/config-array-factory.js
@@ -788,7 +788,7 @@ class ConfigArrayFactory {
     /**
      * Load a given plugin.
      * @param {string} name The plugin name to load.
-     * @param {string} importerPath The path to a config file that imports it.
+     * @param {string} importerPath The path to a config file that imports it. This is just a debug info.
      * @param {string} importerName The name of a config file that imports it. This is just a debug info.
      * @returns {DependentPlugin} The loaded plugin.
      * @private
@@ -799,7 +799,7 @@ class ConfigArrayFactory {
         const { additionalPluginPool, resolvePluginsRelativeTo } = internalSlotsMap.get(this);
         const request = naming.normalizePackageName(name, "eslint-plugin");
         const id = naming.getShorthandName(request, "eslint-plugin");
-        const relativeTo = importerPath || path.join(resolvePluginsRelativeTo, "__placeholder__.js");
+        const relativeTo = path.join(resolvePluginsRelativeTo, "__placeholder__.js");
 
         if (name.match(/\s+/u)) {
             const error = Object.assign(

--- a/lib/cli-engine/config-array-factory.js
+++ b/lib/cli-engine/config-array-factory.js
@@ -788,7 +788,7 @@ class ConfigArrayFactory {
     /**
      * Load a given plugin.
      * @param {string} name The plugin name to load.
-     * @param {string} importerPath The path to a config file that imports it. This is just a debug info.
+     * @param {string} importerPath The path to a config file that imports it.
      * @param {string} importerName The name of a config file that imports it. This is just a debug info.
      * @returns {DependentPlugin} The loaded plugin.
      * @private
@@ -799,7 +799,7 @@ class ConfigArrayFactory {
         const { additionalPluginPool, resolvePluginsRelativeTo } = internalSlotsMap.get(this);
         const request = naming.normalizePackageName(name, "eslint-plugin");
         const id = naming.getShorthandName(request, "eslint-plugin");
-        const relativeTo = path.join(resolvePluginsRelativeTo, "__placeholder__.js");
+        const relativeTo = importerPath || path.join(resolvePluginsRelativeTo, "__placeholder__.js");
 
         if (name.match(/\s+/u)) {
             const error = Object.assign(

--- a/tests/fixtures/config-hierarchy/nested-plugins-parser/.eslintrc.yml
+++ b/tests/fixtures/config-hierarchy/nested-plugins-parser/.eslintrc.yml
@@ -1,0 +1,2 @@
+extends:
+  - awesome

--- a/tests/fixtures/config-hierarchy/nested-plugins-parser/node_modules/eslint-config-awesome/index.js
+++ b/tests/fixtures/config-hierarchy/nested-plugins-parser/node_modules/eslint-config-awesome/index.js
@@ -1,0 +1,7 @@
+module.exports = {
+    parser: "awesome-parser",
+    plugins: ["awesome"],
+    rules: {
+        "awesome/is-awesome": [2]
+    }
+};

--- a/tests/fixtures/config-hierarchy/nested-plugins-parser/node_modules/eslint-config-awesome/node_modules/awesome-parser/package.json
+++ b/tests/fixtures/config-hierarchy/nested-plugins-parser/node_modules/eslint-config-awesome/node_modules/awesome-parser/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "awesome-parser",
+    "version": "1.0.0"
+}

--- a/tests/fixtures/config-hierarchy/nested-plugins-parser/node_modules/eslint-config-awesome/node_modules/eslint-plugin-awesome/package.json
+++ b/tests/fixtures/config-hierarchy/nested-plugins-parser/node_modules/eslint-config-awesome/node_modules/eslint-plugin-awesome/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "eslint-plugin-awesome",
+    "version": "1.0.0"
+}

--- a/tests/fixtures/config-hierarchy/nested-plugins-parser/node_modules/eslint-config-awesome/package.json
+++ b/tests/fixtures/config-hierarchy/nested-plugins-parser/node_modules/eslint-config-awesome/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "eslint-config-awesome",
+    "version": "1.0.0"
+}

--- a/tests/lib/cli-engine/cascading-config-array-factory.js
+++ b/tests/lib/cli-engine/cascading-config-array-factory.js
@@ -575,6 +575,24 @@ describe("CascadingConfigArrayFactory", () => {
             });
 
 
+            it("should resolve plugins/parsers nested within a shared package", () => {
+                const factory = new CascadingConfigArrayFactory({
+                    cwd: getFixturePath("nested-plugins-parser")
+                });
+                const file = getFixturePath("nested-plugins-parser", "foo.js");
+                const expected = {
+                    parser: getFixturePath("nested-plugins-parser", "node_modules", "eslint-config-awesome", "node_modules", "awesome-parser", "index.js"),
+                    plugins: ["awesome"],
+                    rules: {
+                        "awesome/is-awesome": [2]
+                    }
+                };
+                const actual = getConfig(factory, file);
+
+                assertConfigsEqual(actual, expected);
+            });
+
+
             it("should merge multiple different config file formats", () => {
                 const factory = new CascadingConfigArrayFactory();
                 const file = getFixturePath("fileexts/subdir/subsubdir/foo.js");

--- a/tests/lib/cli-engine/cascading-config-array-factory.js
+++ b/tests/lib/cli-engine/cascading-config-array-factory.js
@@ -148,7 +148,7 @@ describe("CascadingConfigArrayFactory", () => {
 
             // copy into clean area so as not to get "infected" by this project's .eslintrc files
             before(() => {
-                fixtureDir = `${os.tmpdir()}/eslint/fixtures`;
+                fixtureDir = `${fs.realpathSync(os.tmpdir())}/eslint/fixtures`;
                 sh.mkdir("-p", fixtureDir);
                 sh.cp("-r", "./tests/fixtures/config-hierarchy", fixtureDir);
                 sh.cp("-r", "./tests/fixtures/rules", fixtureDir);


### PR DESCRIPTION
TL;DR: if a shared config package has plugins that npm or yarn decides to install as descendents of it, those plugins cannot be found by the config factory.

This is a reproduction PR to highlight the issue—I haven't determined a fix yet, and would love pointers if you all have ideas!

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug report ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

**Tell us about your environment**

* **ESLint Version:** 6.0.0
* **Node Version:** 10.15.1
* **npm Version:** 6.9.0

**Please show your full configuration:**

[See the fixtures for real files](https://github.com/eslint/eslint/tree/84192fb4a5642cb4f22e854ee5330cc15e67801c/tests/fixtures/config-hierarchy/nested-plugins-parser)

<details>
<summary>Package Layout & Configuration</summary>

Package Tree:
```
<root>
  eslint-config-awesome
    awesome-parser
    eslint-plugin-awesome
```

`<root>/.eslintrc.yml`:
```yaml
extends:
  - awesome
```

`eslint-config-awesome/index.js`:
```js
module.exports = {
  parser: 'awesome-parser',
  plugins: ['awesome'],
  rules: {
    'awesome/is-awesome': [2]
  }
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**

`eslint any-file.js`

**What did you expect to happen?**

Eslint would make it to linting the desired file

**What actually happened? Please include the actual, raw output from ESLint.**

> Error: Failed to load plugin 'awesome' declared in '.eslintrc.yml » eslint-config-awesome': Cannot find module 'eslint-plugin-awesome'