### PR TITLE
Fix: improve error message on --print-config (fixes #11874)

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -45,7 +45,7 @@ process.once("uncaughtException", err => {
         const pkg = require("../package.json");
 
         console.error("\nOops! Something went wrong! :(");
-        console.error(`\nESLint: ${pkg.version}.\n${template(err.messageData || {})}`);
+        console.error(`\nESLint: ${pkg.version}.\n\n${template(err.messageData || {})}`);
     } else {
 
         console.error(err.stack);

--- a/lib/cli-engine/cli-engine.js
+++ b/lib/cli-engine/cli-engine.js
@@ -904,6 +904,13 @@ class CLIEngine {
         const { configArrayFactory, options } = internalSlotsMap.get(this);
         const absolutePath = path.resolve(options.cwd, filePath);
 
+        if (directoryExists(absolutePath)) {
+            throw Object.assign(
+                new Error("'filePath' should not be a directory path."),
+                { messageTemplate: "print-config-with-directory-path" }
+            );
+        }
+
         return configArrayFactory
             .getConfigArrayForFile(absolutePath)
             .extractConfig(absolutePath)

--- a/messages/print-config-with-directory-path.txt
+++ b/messages/print-config-with-directory-path.txt
@@ -1,2 +1,2 @@
-'--print-config' CLI option requires a path to a source code file rather than a directory.
+The '--print-config' CLI option requires a path to a source code file rather than a directory.
 See also: https://eslint.org/docs/user-guide/command-line-interface#--print-config

--- a/messages/print-config-with-directory-path.txt
+++ b/messages/print-config-with-directory-path.txt
@@ -1,0 +1,2 @@
+'--print-config' CLI option requires a path to a source code file rather than a directory.
+See also: https://eslint.org/docs/user-guide/command-line-interface#--print-config

--- a/tests/lib/cli-engine/cli-engine.js
+++ b/tests/lib/cli-engine/cli-engine.js
@@ -3458,6 +3458,17 @@ describe("CLIEngine", () => {
             assert.deepStrictEqual(actualConfig, expectedConfig);
         });
 
+        it("should throw an error if a directory path was given.", () => {
+            const engine = new CLIEngine();
+
+            try {
+                engine.getConfigForFile(".");
+            } catch (error) {
+                assert.strictEqual(error.messageTemplate, "print-config-with-directory-path");
+                return;
+            }
+            assert.fail("should throw an error");
+        });
     });
 
     describe("isPathIgnored", () => {

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -1084,7 +1084,7 @@ describe("cli", () => {
 
     describe("when passing --print-config", () => {
         it("should print out the configuration", () => {
-            const filePath = getFixturePath("files");
+            const filePath = getFixturePath("xxxx");
 
             const exitCode = cli.execute(`--print-config ${filePath}`);
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix #11874

**What changes did you make? (Give an overview)**

This PR fixes the error message when people used `--print-config` with a directory path.

```
> eslint --print-config .     

Oops! Something went wrong! :(

ESLint: 6.0.0.

'--print-config' CLI option requires a path to a source code file rather than a directory.
See also: https://eslint.org/docs/user-guide/command-line-interface#--print-config
```

**Is there anything you'd like reviewers to focus on?**

Is this direction correct?
