### PR TITLE
Docs: Update no-confusing-arrow with the new default option

### DIFF
--- a/docs/rules/no-confusing-arrow.md
+++ b/docs/rules/no-confusing-arrow.md
@@ -1,6 +1,6 @@
 # Disallow arrow functions where they could be confused with comparisons (no-confusing-arrow)
 
-Arrow functions (`=>`) are similar in syntax to some comparison operators (`>`, `<`, `<=`, and `>=`). This rule warns against using the arrow function syntax in places where it could be confused with a comparison operator. Even if the arguments of the arrow function are wrapped with parens, this rule still warns about it unless `allowParens` is set to `true`.
+Arrow functions (`=>`) are similar in syntax to some comparison operators (`>`, `<`, `<=`, and `>=`). This rule warns against using the arrow function syntax in places where it could be confused with a comparison operator.
 
 Here's an example where the usage of `=>` could be confusing:
 
@@ -22,8 +22,6 @@ Examples of **incorrect** code for this rule:
 /*eslint-env es6*/
 
 var x = a => 1 ? 2 : 3;
-var x = (a) => 1 ? 2 : 3;
-var x = (a) => (1 ? 2 : 3);
 ```
 
 Examples of **correct** code for this rule:
@@ -32,6 +30,8 @@ Examples of **correct** code for this rule:
 /*eslint no-confusing-arrow: "error"*/
 /*eslint-env es6*/
 
+var x = (a) => 1 ? 2 : 3;
+var x = (a) => (1 ? 2 : 3);
 var x = a => { return 1 ? 2 : 3; };
 var x = (a) => { return 1 ? 2 : 3; };
 ```
@@ -43,7 +43,7 @@ This rule accepts a single options argument with the following defaults:
 ```json
 {
     "rules": {
-        "no-confusing-arrow": ["error", {"allowParens": false}]
+        "no-confusing-arrow": ["error", {"allowParens": true}]
     }
 }
 ```
@@ -53,10 +53,10 @@ This rule accepts a single options argument with the following defaults:
 1. `true` relaxes the rule and accepts parenthesis as a valid "confusion-preventing" syntax.
 2. `false` warns even if the expression is wrapped in parenthesis
 
-Examples of **correct** code for this rule with the `{"allowParens": true}` option:
+Examples of **incorrect** code for this rule with the `{"allowParens": false}` option:
 
 ```js
-/*eslint no-confusing-arrow: ["error", {"allowParens": true}]*/
+/*eslint no-confusing-arrow: ["error", {"allowParens": false}]*/
 /*eslint-env es6*/
 var x = a => (1 ? 2 : 3);
 var x = (a) => (1 ? 2 : 3);

--- a/docs/rules/no-confusing-arrow.md
+++ b/docs/rules/no-confusing-arrow.md
@@ -22,6 +22,7 @@ Examples of **incorrect** code for this rule:
 /*eslint-env es6*/
 
 var x = a => 1 ? 2 : 3;
+var x = (a) => 1 ? 2 : 3;
 ```
 
 Examples of **correct** code for this rule:
@@ -30,7 +31,7 @@ Examples of **correct** code for this rule:
 /*eslint no-confusing-arrow: "error"*/
 /*eslint-env es6*/
 
-var x = (a) => 1 ? 2 : 3;
+var x = a => (1 ? 2 : 3);
 var x = (a) => (1 ? 2 : 3);
 var x = a => { return 1 ? 2 : 3; };
 var x = (a) => { return 1 ? 2 : 3; };


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
- Removed redundant sentence from the summary as the default for allowParens is now true.
- Updated examples according to the new default.

**Is there anything you'd like reviewers to focus on?**
N/A