### PR TITLE
Fix: --rulesdir option didn't work (fixes #11888)

### DIFF
--- a/lib/cli-engine/cascading-config-array-factory.js
+++ b/lib/cli-engine/cascading-config-array-factory.js
@@ -313,6 +313,7 @@ class CascadingConfigArrayFactory {
 
         if (configArray.length > 0 && configArray.isRoot()) {
             debug("Stop traversing because of 'root:true'.");
+            configArray.unshift(...baseConfigArray);
             return this._cacheConfig(directoryPath, configArray);
         }
 

--- a/tests/lib/cli-engine/_utils.js
+++ b/tests/lib/cli-engine/_utils.js
@@ -314,6 +314,7 @@ function defineConfigArrayFactoryWithInMemoryFileSystem({
     // Override the default cwd.
     return {
         fs,
+        stubs,
         RelativeModuleResolver,
         ConfigArrayFactory: cwd === process.cwd
             ? ConfigArrayFactory
@@ -336,9 +337,9 @@ function defineCascadingConfigArrayFactoryWithInMemoryFileSystem({
     cwd = process.cwd,
     files = {}
 } = {}) {
-    const { fs, RelativeModuleResolver, ConfigArrayFactory } =
+    const { fs, stubs, RelativeModuleResolver, ConfigArrayFactory } =
            defineConfigArrayFactoryWithInMemoryFileSystem({ cwd, files });
-    const loadRules = proxyquire(LoadRulesPath, { fs });
+    const loadRules = proxyquire(LoadRulesPath, stubs);
     const { CascadingConfigArrayFactory } =
         proxyquire(CascadingConfigArrayFactoryPath, {
             "./config-array-factory": { ConfigArrayFactory },

--- a/tests/lib/cli-engine/cli-engine.js
+++ b/tests/lib/cli-engine/cli-engine.js
@@ -3421,6 +3421,38 @@ describe("CLIEngine", () => {
                 assert.fail("Expected to throw an error");
             });
         });
+
+        describe("with '--rulesdir' option", () => {
+            it("should use the configured rules which are defined by '--rulesdir' option.", () => {
+                const rootPath = getFixturePath("cli-engine/with-rulesdir");
+                const StubbedCLIEngine = defineCLIEngineWithInMemoryFileSystem({
+                    cwd: () => rootPath,
+                    files: {
+                        "internal-rules/test.js": `
+                            module.exports = context => ({
+                                ExpressionStatement(node) {
+                                    context.report({ node, message: "ok" })
+                                }
+                            })
+                        `,
+                        ".eslintrc.json": JSON.stringify({
+                            root: true,
+                            rules: { test: "error" }
+                        }),
+                        "test.js": "console.log('hello')"
+                    }
+                }).CLIEngine;
+
+                engine = new StubbedCLIEngine({
+                    rulePaths: ["internal-rules"]
+                });
+                const report = engine.executeOnFiles(["test.js"]);
+
+                assert.strictEqual(report.results.length, 1);
+                assert.strictEqual(report.results[0].messages.length, 1);
+                assert.strictEqual(report.results[0].messages[0].message, "ok");
+            });
+        });
     });
 
     describe("getConfigForFile", () => {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix: #11888

**What changes did you make? (Give an overview)**

This PR fixes a bug that `CLEngine` ignored `baseConfig` and `rulePaths` if a config file has `root:true`.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.
