### PR TITLE
Fix: enable getJSDocComment for ObjectExpression (fixes: 11898)

### DIFF
--- a/lib/source-code/source-code.js
+++ b/lib/source-code/source-code.js
@@ -355,6 +355,7 @@ class SourceCode extends TokenStore {
                 return findJSDocComment(parent.parent);
 
             case "ArrowFunctionExpression":
+            case "ObjectExpression":
             case "FunctionExpression":
                 if (parent.type !== "CallExpression" && parent.type !== "NewExpression") {
                     while (

--- a/tests/lib/source-code/source-code.js
+++ b/tests/lib/source-code/source-code.js
@@ -378,6 +378,35 @@ describe("SourceCode", () => {
 
         });
 
+        it("should get JSDoc comment for node when the node is an ObjectExpression", () => {
+
+            const code = [
+                "/** Desc*/",
+                "const A = {",
+                "};"
+            ].join("\n");
+
+            /**
+             * Check jsdoc presence
+             * @param {ASTNode} node not to check
+             * @returns {void}
+             * @private
+             */
+            function assertJSDoc(node) {
+                const sourceCode = linter.getSourceCode();
+                const jsdoc = sourceCode.getJSDocComment(node);
+
+                assert.strictEqual(jsdoc.type, "Block");
+                assert.strictEqual(jsdoc.value, "* Desc");
+            }
+
+            const spy = sinon.spy(assertJSDoc);
+
+            linter.defineRule("checker", () => ({ ObjectExpression: spy }));
+            linter.verify(code, { rules: { checker: "error" } });
+            assert.isFalse(spy.calledOnce, "Event handler should be called.");
+        });
+
         it("should get JSDoc comment for node when the node is a FunctionDeclaration but its parent is an export", () => {
 
             const code = [


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
`getJSDocComment` method used to not pick up the JSDocComment for object expression.
This PR add this feature.

**Is there anything you'd like reviewers to focus on?**
There is one line change in production, I don't think it will break other use cases but just in case😂.

