### PR TITLE
Update: Disallow gremlin chars in no-irregular-whitespace

### DIFF
--- a/lib/rules/no-irregular-whitespace.js
+++ b/lib/rules/no-irregular-whitespace.js
@@ -16,8 +16,8 @@ const astUtils = require("./utils/ast-utils");
 // Constants
 //------------------------------------------------------------------------------
 
-const ALL_IRREGULARS = /[\f\v\u0085\ufeff\u00a0\u1680\u180e\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u200b\u202f\u205f\u3000\u2028\u2029]/u;
-const IRREGULAR_WHITESPACE = /[\f\v\u0085\ufeff\u00a0\u1680\u180e\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u200b\u202f\u205f\u3000]+/mgu;
+const ALL_IRREGULARS = /[\f\v\u0003\u0085\ufeff\ufffc\u00a0\u1680\u180e\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u200b\u200c\u200e\u201c\u201d\u202c\u202d\u202e\u202f\u205f\u3000\u2028\u2029]/u;
+const IRREGULAR_WHITESPACE = /[\f\v\u0003\u0085\ufeff\ufffc\u00a0\u1680\u180e\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u200b\u200c\u200e\u201c\u201d\u202c\u202d\u202e\u202f\u205f\u3000]+/mgu;
 const IRREGULAR_LINE_TERMINATORS = /[\u2028\u2029]/mgu;
 const LINE_BREAK = astUtils.createGlobalLinebreakMatcher();
 

--- a/tests/lib/rules/no-irregular-whitespace.js
+++ b/tests/lib/rules/no-irregular-whitespace.js
@@ -34,7 +34,6 @@ ruleTester.run("no-irregular-whitespace", rule, {
         "'\\u000B';",
         "'\\u000C';",
         "'\\u0085';",
-        "'\\u00A0';",
         "'\\u180E';",
         "'\\ufeff';",
         "'\\u2000';",
@@ -48,7 +47,6 @@ ruleTester.run("no-irregular-whitespace", rule, {
         "'\\u2008';",
         "'\\u2009';",
         "'\\u200A';",
-        "'\\u200B';",
         "'\\u2028';",
         "'\\u2029';",
         "'\\u202F';",
@@ -57,7 +55,6 @@ ruleTester.run("no-irregular-whitespace", rule, {
         "'\u000B';",
         "'\u000C';",
         "'\u0085';",
-        "'\u00A0';",
         "'\u180E';",
         "'\ufeff';",
         "'\u2000';",
@@ -71,7 +68,6 @@ ruleTester.run("no-irregular-whitespace", rule, {
         "'\u2008';",
         "'\u2009';",
         "'\u200A';",
-        "'\u200B';",
         "'\\\u2028';", // multiline string
         "'\\\u2029';", // multiline string
         "'\u202F';",


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What rule do you want to change?**

no-irregular-whitespace

**Does this change cause the rule to produce more or fewer warnings?**

more

**How will the change be implemented? (New option, new default behavior, etc.)?**

modify list of disallowed chars

**Please provide some example code that this change will affect:**

```js

\u0003\u00a0\u200b\u200c\u200e\u201c\u201d\u202c\u202d\u202e\ufffc

```

**What does the rule currently do for this code?**

no warning/error currently

**What will the rule do after it's changed?**

provide warning/error

**What changes did you make? (Give an overview)**

added to list of disallowed chars in lib/rules/no-irregular-whitespace.js

**Is there anything you'd like reviewers to focus on?**

Someone who is much more knowledgeable about Unicode should audit this list of chars. I grabbed the list directly from a [VSCode Extension](https://marketplace.visualstudio.com/items?itemName=nhoizey.gremlins), and commented about my experience with these chars on the related ticket #11800. However, I don't really know what these chars are or do except that I have seen some of them pop up in shared codebases and cause annoyance. Also listed on that ticket I reference a simple plugin I created which enacts this same change but as a new rule `no-gremlin-chars` - my team is using that plugin currently to keep these chars out of our codebases.