### PR TITLE
Fix: curly errors with lexical and function declarations (fixes #11908)

### DIFF
--- a/lib/rules/curly.js
+++ b/lib/rules/curly.js
@@ -118,6 +118,21 @@ module.exports = {
         }
 
         /**
+         * Determines if the given node is a lexical declaration, or a block statement containing
+         * only a single lexical declaration.
+         * @param {ASTNode} node The node to check
+         * @returns {boolean} True if the node is a single lexical declaration
+         * @private
+         */
+        function isSingleLexicalDeclaration(node) {
+            if (node.type === "BlockStatement") {
+                return node.body.length === 1 && isLexicalDeclaration(node.body[0]);
+            }
+
+            return isLexicalDeclaration(node);
+        }
+
+        /**
          * Checks if the given token is an `else` token or not.
          *
          * @param {Token} token - The token to check.
@@ -227,20 +242,26 @@ module.exports = {
          * @param {ASTNode} body The body node to check for blocks.
          * @param {string} name The name to report if there's a problem.
          * @param {{ condition: boolean }} opts Options to pass to the report functions
-         * @returns {Object} a prepared check object, with "actual", "expected", "check" properties.
+         * @returns {Object} a prepared check object, with "actual", "expected", "unchangeable", "check" properties.
          *   "actual" will be `true` or `false` whether the body is already a block statement.
-         *   "expected" will be `true` or `false` if the body should be a block statement or not, or
-         *   `null` if it doesn't matter, depending on the rule options. It can be modified to change
-         *   the final behavior of "check".
-         *   "check" will be a function reporting appropriate problems depending on the other
-         *   properties.
+         *   "expected" will be `true` or `false` if the body should be a block statement or not.
+         *   If both `true` and `false` can be valid by the rule options, "expected" will be set to "actual".
+         *   "unchangeable" will be `true` if the body, in its actual state (block or not a block), must not be
+         *   changed because it would produce a syntax error or change the semantics.
+         *   "check" will be a function reporting appropriate problems depending on the other properties.
          */
         function prepareCheck(node, body, name, opts) {
             const hasBlock = (body.type === "BlockStatement");
-            let expected = null;
+            let expected = hasBlock;
+            let unchangeable = false;
 
-            if (node.type === "IfStatement" && node.consequent === body && requiresBraceOfConsequent(node)) {
+            if (hasBlock && body.body.length >= 2) {
+                unchangeable = true;
+            } else if (isSingleLexicalDeclaration(body)) {
+                unchangeable = true;
+            } else if (node.type === "IfStatement" && node.consequent === body && requiresBraceOfConsequent(node)) {
                 expected = true;
+                unchangeable = true;
             } else if (multiOnly) {
                 if (hasBlock && body.body.length === 1) {
                     expected = false;
@@ -252,13 +273,8 @@ module.exports = {
             } else if (multiOrNest) {
                 if (hasBlock && body.body.length === 1 && isOneLiner(body.body[0])) {
                     const leadingComments = sourceCode.getCommentsBefore(body.body[0]);
-                    const isLexDef = isLexicalDeclaration(body.body[0]);
 
-                    if (isLexDef) {
-                        expected = true;
-                    } else {
-                        expected = leadingComments.length > 0;
-                    }
+                    expected = leadingComments.length > 0;
                 } else if (!isOneLiner(body)) {
                     expected = true;
                 }
@@ -269,8 +285,9 @@ module.exports = {
             return {
                 actual: hasBlock,
                 expected,
+                unchangeable,
                 check() {
-                    if (this.expected !== null && this.expected !== this.actual) {
+                    if (this.expected !== this.actual) {
                         if (this.expected) {
                             context.report({
                                 node,
@@ -349,16 +366,14 @@ module.exports = {
                  * all have braces.
                  * If all nodes shouldn't have braces, make sure they don't.
                  */
-                const expected = preparedChecks.some(preparedCheck => {
-                    if (preparedCheck.expected !== null) {
-                        return preparedCheck.expected;
-                    }
-                    return preparedCheck.actual;
-                });
+                const expected = preparedChecks.some(preparedCheck => preparedCheck.expected);
 
-                preparedChecks.forEach(preparedCheck => {
-                    preparedCheck.expected = expected;
-                });
+                preparedChecks
+                    .forEach(preparedCheck => {
+                        if (!preparedCheck.unchangeable) {
+                            preparedCheck.expected = expected;
+                        }
+                    });
             }
 
             return preparedChecks;

--- a/tests/lib/rules/curly.js
+++ b/tests/lib/rules/curly.js
@@ -231,6 +231,100 @@ ruleTester.run("curly", rule, {
             // https://github.com/feross/standard/issues/664
             code: "if (true) foo()\n;[1, 2, 3].bar()",
             options: ["multi-line"]
+        },
+
+        // https://github.com/eslint/eslint/issues/11908 (also in invalid)
+        {
+            code: "if (true) { const a = 1; }",
+            options: ["multi"],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "if (true) { let a; }",
+            options: ["multi"],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "if (true) { class a{} }",
+            options: ["multi"],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "if (true) { function a() {} }",
+            options: ["multi"]
+        },
+        "if (true) function a() {}",
+        {
+            code: "if (true) \n function a() {}",
+            options: ["multi-line"]
+        },
+        {
+            code: "if (true) function a() \n {}",
+            options: ["multi-line"]
+        },
+        {
+            code: "if (true) function a() \n {}",
+            options: ["multi-or-nest"]
+        },
+        {
+            code: "if (true) { let a; } else { foo; }",
+            options: ["multi", "consistent"],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "if (true) { function a() {} } else { foo; }",
+            options: ["multi", "consistent"]
+        },
+        {
+            code: "if (true) function a() {} else b;",
+            options: ["multi", "consistent"]
+        },
+        {
+            code: "if (true) function a() {} else { foo; bar; }",
+            options: ["multi", "consistent"]
+        },
+        {
+            code: "if (true) function a() {} else { let a }",
+            options: ["multi", "consistent"],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "if (true) function a() {} else { function b() {} }",
+            options: ["multi", "consistent"]
+        },
+        {
+            code: "if (true) function a() {} else { foo; }",
+            options: ["multi-line", "consistent"]
+        },
+        {
+            code: "if (true) { let a; } else { foo; }",
+            options: ["multi-or-nest", "consistent"],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "if (true) { function a() {} } else { foo; }",
+            options: ["multi-or-nest", "consistent"]
+        },
+        {
+            code: "if (true) function a() {} else { foo; bar; }",
+            options: ["multi-or-nest", "consistent"]
+        },
+        {
+            code: "if (true) function a() \n {} else { foo; bar; }",
+            options: ["multi-or-nest", "consistent"]
+        },
+        {
+            code: "if (true) function a() {} else { function b() \n {} }",
+            options: ["multi-or-nest", "consistent"]
+        },
+        {
+            code: "if (true) function a() {} else { let a }",
+            options: ["multi-or-nest", "consistent"],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "if (true) function a() {} else { function b() {} }",
+            options: ["multi-or-nest", "consistent"]
         }
     ],
     invalid: [
@@ -897,6 +991,100 @@ ruleTester.run("curly", rule, {
             output: "if (true)\n{foo()\n;}[1, 2, 3].bar()",
             options: ["multi-line"],
             errors: [{ messageId: "missingCurlyAfterCondition", data: { name: "if" }, type: "IfStatement" }]
+        },
+
+        // https://github.com/eslint/eslint/issues/11908 (also in valid)
+        {
+            code: "if (foo) { let a; } else b;",
+            output: "if (foo) { let a; } else {b;}",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "missingCurlyAfter", data: { name: "else" }, type: "IfStatement" }]
+        },
+        {
+            code: "if (foo) a; else { const b = 1; }",
+            output: "if (foo) {a;} else { const b = 1; }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "missingCurlyAfterCondition", data: { name: "if" }, type: "IfStatement" }]
+        },
+        {
+            code: "if (foo) function a() {} else b;",
+            output: "if (foo) function a() {} else {b;}",
+            errors: [{ messageId: "missingCurlyAfter", data: { name: "else" }, type: "IfStatement" }]
+        },
+        {
+            code: "if (foo) { let a; } else b;",
+            output: "if (foo) { let a; } else {b;}",
+            options: ["multi", "consistent"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "missingCurlyAfter", data: { name: "else" }, type: "IfStatement" }]
+        },
+        {
+            code: "if (foo) a; else { const b = 1; }",
+            output: "if (foo) {a;} else { const b = 1; }",
+            options: ["multi", "consistent"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "missingCurlyAfterCondition", data: { name: "if" }, type: "IfStatement" }]
+        },
+        {
+            code: "if (foo) a; else if (bar) { class b {} } else function c() {}",
+            output: "if (foo) {a;} else if (bar) { class b {} } else function c() {}",
+            options: ["multi", "consistent"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "missingCurlyAfterCondition", data: { name: "if" }, type: "IfStatement" }]
+        },
+        {
+            code: "if (foo) { a; } else function b() {}",
+            output: "if (foo)  a;  else function b() {}",
+            options: ["multi", "consistent"],
+            errors: [{ messageId: "unexpectedCurlyAfterCondition", data: { name: "if" }, type: "IfStatement" }]
+        },
+        {
+            code: "if (foo) { let a; } else b;",
+            output: "if (foo) { let a; } else {b;}",
+            options: ["multi-line", "consistent"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "missingCurlyAfter", data: { name: "else" }, type: "IfStatement" }]
+        },
+        {
+            code: "if (foo) a; else { const b = 1; }",
+            output: "if (foo) {a;} else { const b = 1; }",
+            options: ["multi-line", "consistent"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "missingCurlyAfterCondition", data: { name: "if" }, type: "IfStatement" }]
+        },
+        {
+            code: "if (foo) a; else if (bar) { class b {} } else function c() {}",
+            output: "if (foo) {a;} else if (bar) { class b {} } else function c() {}",
+            options: ["multi-line", "consistent"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "missingCurlyAfterCondition", data: { name: "if" }, type: "IfStatement" }]
+        },
+        {
+            code: "if (foo) { let a; } else b;",
+            output: "if (foo) { let a; } else {b;}",
+            options: ["multi-or-nest", "consistent"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "missingCurlyAfter", data: { name: "else" }, type: "IfStatement" }]
+        },
+        {
+            code: "if (foo) a; else { const b = 1; }",
+            output: "if (foo) {a;} else { const b = 1; }",
+            options: ["multi-or-nest", "consistent"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "missingCurlyAfterCondition", data: { name: "if" }, type: "IfStatement" }]
+        },
+        {
+            code: "if (foo) a; else if (bar) { class b {} } else function c() {}",
+            output: "if (foo) {a;} else if (bar) { class b {} } else function c() {}",
+            options: ["multi-or-nest", "consistent"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "missingCurlyAfterCondition", data: { name: "if" }, type: "IfStatement" }]
+        },
+        {
+            code: "if (foo) { a; } else function b() {}",
+            output: "if (foo)  a;  else function b() {}",
+            options: ["multi-or-nest", "consistent"],
+            errors: [{ messageId: "unexpectedCurlyAfterCondition", data: { name: "if" }, type: "IfStatement" }]
         }
     ]
 });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix #11908

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

1. Block statements with a single `const`, `let`, `class` or `function` declaration should not be reported.
2. Single statement `function` declarations (e.g. `if (true) function foo () {}`) should not be reported.
3. A small refactoring to avoid three-state boolean logic for `actual`, as it wasn't used as described in the comment (e.g. `consistent` code was overriding explicitly set `false`), and I guess it was a bit confusing.

**Is there anything you'd like reviewers to focus on?**

The refactoring.

Test cases with the `consistent` modifier.
