### PR TITLE
Fix: add parens for sequence expr in arrow-body-style (fixes #11917)

### DIFF
--- a/lib/rules/arrow-body-style.js
+++ b/lib/rules/arrow-body-style.js
@@ -175,10 +175,10 @@ module.exports = {
                             }
 
                             /*
-                             * If the first token of the reutrn value is `{`,
+                             * If the first token of the reutrn value is `{` or the return value is a sequence expression,
                              * enclose the return value by parentheses to avoid syntax error.
                              */
-                            if (astUtils.isOpeningBraceToken(firstValueToken)) {
+                            if (astUtils.isOpeningBraceToken(firstValueToken) || blockBody[0].argument.type === "SequenceExpression") {
                                 fixes.push(
                                     fixer.insertTextBefore(firstValueToken, "("),
                                     fixer.insertTextAfter(lastValueToken, ")")

--- a/tests/lib/rules/arrow-body-style.js
+++ b/tests/lib/rules/arrow-body-style.js
@@ -163,6 +163,18 @@ ruleTester.run("arrow-body-style", rule, {
             ]
         },
         {
+            code: "var foo = () => { return a, b }",
+            output: "var foo = () => (a, b)",
+            errors: [
+                {
+                    line: 1,
+                    column: 17,
+                    type: "ArrowFunctionExpression",
+                    messageId: "unexpectedSingleBlock"
+                }
+            ]
+        },
+        {
             code: "var foo = () => { return };",
             output: null, // not fixed
             options: ["as-needed", { requireReturnForObjectLiteral: true }],


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Add parens for `SequenceExpression`.

**Is there anything you'd like reviewers to focus on?**


