### PR TITLE
Fix: actual messageId and expected messageId are switched in rule tester

### DIFF
--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -549,8 +549,8 @@ class RuleTester {
                                 assert(false, `Invalid messageId '${error.messageId}'. Expected one of ${friendlyIDList}.`);
                             }
                             assert.strictEqual(
-                                error.messageId,
                                 message.messageId,
+                                error.messageId,
                                 `messageId '${message.messageId}' does not match expected messageId '${error.messageId}'.`
                             );
                             if (hasOwnProperty(error, "data")) {


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Other, please explain: Small fix in rule tester

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
**ESLint Version:** master
  
**What did you do? Please include the actual source code causing the issue.**

Add the following test example to `tests/lib/rules/dot-location.js`:

```js
{
      code: "obj\n.property",
      output: "obj.\nproperty",
      options: ["object"],
      errors: [{ messageId: "expectedDotBeforeProperty" }]
}
```

**What did you expect to happen?**

```
AssertionError [ERR_ASSERTION]: messageId 'expectedDotAfterObject' does not match expected messageId 'expectedDotBeforeProperty'.
+ expected - actual

-expectedDotAfterObject
+expectedDotBeforeProperty
```

**What actually happened? Please include the actual, raw output from ESLint.**

```
AssertionError [ERR_ASSERTION]: messageId 'expectedDotAfterObject' does not match expected messageId 'expectedDotBeforeProperty'.
+ expected - actual

-expectedDotBeforeProperty
+expectedDotAfterObject
```

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Switched args in rule tester.

**Is there anything you'd like reviewers to focus on?**


