### PR TITLE
Fix: creating of enabledGlobals object without prototype (fixes #11929)

### DIFF
--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -262,7 +262,7 @@ function createDisableDirectives(options) {
  */
 function getDirectiveComments(filename, ast, ruleMapper) {
     const configuredRules = {};
-    const enabledGlobals = {};
+    const enabledGlobals = Object.create(null);
     const exportedVariables = {};
     const problems = [];
     const disableDirectives = [];

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -1208,6 +1208,16 @@ describe("Linter", () => {
         });
     });
 
+    describe("when evaluating code containing a /*global */ block with specific variables", () => {
+        const code = "/* global toString hasOwnProperty valueOf: true */";
+
+        it("should not throw an error if comment block has global variables which are Object.prototype contains", () => {
+            const config = { rules: { checker: "error" } };
+
+            linter.verify(code, config);
+        });
+    });
+
     describe("when evaluating code containing /*eslint-env */ block", () => {
         it("variables should be available in global scope", () => {
             const code = `/*${ESLINT_ENV} node*/ function f() {} /*${ESLINT_ENV} browser, foo*/`;


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix

**issue:** #11929

**What changes did you make? (Give an overview)**

There was an issue when there were comments like `/*global toString:true*/`
Therefor `if (enabledGlobals[id])`

https://github.com/eslint/eslint/blob/8eaa9b259dc08dfb48269b1e4413d0d47698ed87/lib/linter/linter.js#L315

was `true` because of `Object.prototype.toString` 
