### PR TITLE
Docs: Fix incorrect example comments for unicode-bom rule (fixes #11937)

### DIFF
--- a/docs/rules/unicode-bom.md
+++ b/docs/rules/unicode-bom.md
@@ -43,7 +43,7 @@ var abc;
 Example of **correct** code for this rule with the default `"never"` option:
 
 ```js
-/*eslint unicode-bom: "error"*/
+/*eslint unicode-bom: ["error", "never"]*/
 
 var abc;
 ```
@@ -51,7 +51,7 @@ var abc;
 Example of **incorrect** code for this rule with the `"never"` option:
 
 ```js
-/*eslint unicode-bom: "error"*/
+/*eslint unicode-bom: ["error", "never"]*/
 
 U+FEFF
 var abc;

--- a/docs/rules/unicode-bom.md
+++ b/docs/rules/unicode-bom.md
@@ -24,7 +24,7 @@ This rule has a string option:
 Example of **correct** code for this rule with the `"always"` option:
 
 ```js
-/*eslint unicode-bom: "error"*/
+/*eslint unicode-bom: ["error", "always"]*/
 
 U+FEFF
 var abc;
@@ -33,7 +33,7 @@ var abc;
 Example of **incorrect** code for this rule with the `"always"` option:
 
 ```js
-/*eslint unicode-bom: "error"*/
+/*eslint unicode-bom: ["error", "always"]*/
 
 var abc;
 ```
@@ -43,7 +43,7 @@ var abc;
 Example of **correct** code for this rule with the default `"never"` option:
 
 ```js
-/*eslint unicode-bom: ["error", "never"]*/
+/*eslint unicode-bom: "error"*/
 
 var abc;
 ```
@@ -51,7 +51,7 @@ var abc;
 Example of **incorrect** code for this rule with the `"never"` option:
 
 ```js
-/*eslint unicode-bom: ["error", "never"]*/
+/*eslint unicode-bom: "error"*/
 
 U+FEFF
 var abc;


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Fixed incorrect code comments in code examples for "unicode-bom" rule

**Is there anything you'd like reviewers to focus on?**
Comments in example code blocks (assuming wrong default)