### PR TITLE
Update: Add for-in and for-of checks for props in no-param-reassign

### DIFF
--- a/docs/rules/no-param-reassign.md
+++ b/docs/rules/no-param-reassign.md
@@ -20,6 +20,14 @@ function foo(bar) {
 function foo(bar) {
     bar++;
 }
+
+function foo(bar) {
+    for (bar in baz) {}
+}
+
+function foo(bar) {
+    for (bar of baz) {}
+}
 ```
 
 Examples of **correct** code for this rule:
@@ -54,6 +62,14 @@ function foo(bar) {
 function foo(bar) {
     bar.aaa++;
 }
+
+function foo(bar) {
+    for (bar.aaa in baz) {}
+}
+
+function foo(bar) {
+    for (bar.aaa of baz) {}
+}
 ```
 
 Examples of **incorrect** code for the `{ "props": true }` option:
@@ -72,6 +88,14 @@ function foo(bar) {
 function foo(bar) {
     bar.aaa++;
 }
+
+function foo(bar) {
+    for (bar.aaa in baz) {}
+}
+
+function foo(bar) {
+    for (bar.aaa of baz) {}
+}
 ```
 
 Examples of **correct** code for the `{ "props": true }` option with `"ignorePropertyModificationsFor"` set:
@@ -89,6 +113,14 @@ function foo(bar) {
 
 function foo(bar) {
     bar.aaa++;
+}
+
+function foo(bar) {
+    for (bar.aaa in baz) {}
+}
+
+function foo(bar) {
+    for (bar.aaa of baz) {}
 }
 ```
 

--- a/lib/rules/no-param-reassign.js
+++ b/lib/rules/no-param-reassign.js
@@ -67,7 +67,8 @@ module.exports = {
             let node = reference.identifier;
             let parent = node.parent;
 
-            while (parent && !stopNodePattern.test(parent.type)) {
+            while (parent && (!stopNodePattern.test(parent.type) ||
+                    parent.type === "ForInStatement" || parent.type === "ForOfStatement")) {
                 switch (parent.type) {
 
                     // e.g. foo.a = 0;
@@ -84,6 +85,16 @@ module.exports = {
                             return true;
                         }
                         break;
+
+                    // e.g. for (foo.a in b) {}
+                    case "ForInStatement":
+                    case "ForOfStatement":
+                        if (parent.left === node) {
+                            return true;
+                        }
+
+                        // this is a stop node for parent.right and parent.body
+                        return false;
 
                     // EXCLUDES: e.g. cache.get(foo.a).b = 0;
                     case "CallExpression":

--- a/tests/lib/rules/no-param-reassign.js
+++ b/tests/lib/rules/no-param-reassign.js
@@ -21,7 +21,11 @@ ruleTester.run("no-param-reassign", rule, {
 
     valid: [
         "function foo(a) { var b = a; }",
+        "function foo(a) { for (b in a); }",
+        { code: "function foo(a) { for (b of a); }", parserOptions: { ecmaVersion: 6 } },
         "function foo(a) { a.prop = 'value'; }",
+        "function foo(a) { for (a.prop in obj); }",
+        { code: "function foo(a) { for (a.prop of arr); }", parserOptions: { ecmaVersion: 6 } },
         "function foo(a) { (function() { var a = 12; a++; })(); }",
         "function foo() { someGlobal = 13; }",
         { code: "function foo() { someGlobal = 13; }", globals: { someGlobal: false } },
@@ -37,6 +41,8 @@ ruleTester.run("no-param-reassign", rule, {
         { code: "function foo(a) { a.b = 0; }", options: [{ props: true, ignorePropertyModificationsFor: ["a"] }] },
         { code: "function foo(a) { ++a.b; }", options: [{ props: true, ignorePropertyModificationsFor: ["a"] }] },
         { code: "function foo(a) { delete a.b; }", options: [{ props: true, ignorePropertyModificationsFor: ["a"] }] },
+        { code: "function foo(a) { for (a.b in obj); }", options: [{ props: true, ignorePropertyModificationsFor: ["a"] }] },
+        { code: "function foo(a) { for (a.b of arr); }", options: [{ props: true, ignorePropertyModificationsFor: ["a"] }], parserOptions: { ecmaVersion: 6 } },
         { code: "function foo(a, z) { a.b = 0; x.y = 0; }", options: [{ props: true, ignorePropertyModificationsFor: ["a", "x"] }] },
         { code: "function foo(a) { a.b.c = 0;}", options: [{ props: true, ignorePropertyModificationsFor: ["a"] }] },
         {
@@ -53,6 +59,33 @@ ruleTester.run("no-param-reassign", rule, {
             code: "function foo(a) { ({...a.b} = obj); }",
             options: [{ props: false }],
             parserOptions: { ecmaVersion: 2018 }
+        },
+        {
+            code: "function foo(a) { for (obj[a.b] in obj); }",
+            options: [{ props: true }]
+        },
+        {
+            code: "function foo(a) { for (obj[a.b] of arr); }",
+            options: [{ props: true }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "function foo(a) { for (bar in a.b); }",
+            options: [{ props: true }]
+        },
+        {
+            code: "function foo(a) { for (bar of a.b); }",
+            options: [{ props: true }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "function foo(a) { for (bar in baz) a.b; }",
+            options: [{ props: true }]
+        },
+        {
+            code: "function foo(a) { for (bar of baz) a.b; }",
+            options: [{ props: true }],
+            parserOptions: { ecmaVersion: 6 }
         }
     ],
 
@@ -68,6 +101,8 @@ ruleTester.run("no-param-reassign", rule, {
         { code: "function foo([, {bar}]) { bar = 13; }", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Assignment to function parameter 'bar'." }] },
         { code: "function foo(bar) { ({bar} = {}); }", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Assignment to function parameter 'bar'." }] },
         { code: "function foo(bar) { ({x: [, bar = 0]} = {}); }", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Assignment to function parameter 'bar'." }] },
+        { code: "function foo(bar) { for (bar in baz); }", errors: [{ message: "Assignment to function parameter 'bar'." }] },
+        { code: "function foo(bar) { for (bar of baz); }", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Assignment to function parameter 'bar'." }] },
 
         {
             code: "function foo(bar) { bar.a = 0; }",
@@ -87,6 +122,17 @@ ruleTester.run("no-param-reassign", rule, {
         {
             code: "function foo(bar) { ++bar.a; }",
             options: [{ props: true }],
+            errors: [{ message: "Assignment to property of function parameter 'bar'." }]
+        },
+        {
+            code: "function foo(bar) { for (bar.a in {}); }",
+            options: [{ props: true }],
+            errors: [{ message: "Assignment to property of function parameter 'bar'." }]
+        },
+        {
+            code: "function foo(bar) { for (bar.a of []); }",
+            options: [{ props: true }],
+            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Assignment to property of function parameter 'bar'." }]
         },
         {
@@ -138,6 +184,18 @@ ruleTester.run("no-param-reassign", rule, {
             code: "function foo(a) { ({...a.b} = obj); }",
             options: [{ props: true }],
             parserOptions: { ecmaVersion: 2018 },
+            errors: [{ message: "Assignment to property of function parameter 'a'." }]
+        },
+        {
+            code: "function foo(a) { for ({bar: a.b} in {}); }",
+            options: [{ props: true }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Assignment to property of function parameter 'a'." }]
+        },
+        {
+            code: "function foo(a) { for ([a.b] of []); }",
+            options: [{ props: true }],
+            parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Assignment to property of function parameter 'a'." }]
         }
     ]


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Changes an existing rule

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**What rule do you want to change?**

no-param-reassign

**Does this change cause the rule to produce more or fewer warnings?**

more

**How will the change be implemented? (New option, new default behavior, etc.)?**

new default behavior

**Please provide some example code that this change will affect:**

```js
/* eslint no-param-reassign: ["error", { "props": true }] */

function foo(a) {

  for (a.prop in obj);

  for (a.prop of arr);

}
```

**What does the rule currently do for this code?**

No warnings

**What will the rule do after it's changed?**

2 warnings

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Added `ForInStatement.left` and `ForOfStatement.left` checks.

**Is there anything you'd like reviewers to focus on?**


