### PR TITLE
Fix: Cache file error handling on read-only file system.

### DIFF
--- a/lib/cli-engine/cli-engine.js
+++ b/lib/cli-engine/cli-engine.js
@@ -734,7 +734,10 @@ class CLIEngine {
             try {
                 fs.unlinkSync(cacheFilePath);
             } catch (error) {
-                if (!error || error.code !== "ENOENT") {
+                const errorCode = error && error.code;
+
+                // Ignore errors when no such file exists or file system is read only (and cache file does not exist)
+                if (errorCode !== "ENOENT" && !(errorCode === "EROFS" && !fs.existsSync(cacheFilePath))) {
                     throw error;
                 }
             }


### PR DESCRIPTION
**What is the purpose of this pull request?**

[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

Fixes #11945.

**What changes did you make?**
Add additional exception for `EROFS` (when cache file does not exist) next to the already existing `ENOENT` exception upon trying to delete cache file.
