### PR TITLE
Docs: Replace global true and false with writable and readonly in rules

### DIFF
--- a/docs/rules/no-global-assign.md
+++ b/docs/rules/no-global-assign.md
@@ -37,7 +37,7 @@ top = 1
 
 ```js
 /*eslint no-global-assign: "error"*/
-/*globals a:false*/
+/*global a:readonly*/
 
 a = 1
 ```
@@ -61,7 +61,7 @@ onload = function() {}
 
 ```js
 /*eslint no-global-assign: "error"*/
-/*globals a:true*/
+/*global a:writable*/
 
 a = 1
 ```

--- a/docs/rules/no-native-reassign.md
+++ b/docs/rules/no-native-reassign.md
@@ -39,7 +39,7 @@ top = 1
 
 ```js
 /*eslint no-native-reassign: "error"*/
-/*globals a:false*/
+/*global a:readonly*/
 
 a = 1
 ```
@@ -63,7 +63,7 @@ onload = function() {}
 
 ```js
 /*eslint no-native-reassign: "error"*/
-/*globals a:true*/
+/*global a:writable*/
 
 a = 1
 ```

--- a/docs/rules/no-undef.md
+++ b/docs/rules/no-undef.md
@@ -18,14 +18,14 @@ b = 10;
 Examples of **correct** code for this rule with `global` declaration:
 
 ```js
-/*global someFunction b:true*/
+/*global someFunction b:writable*/
 /*eslint no-undef: "error"*/
 
 var a = someFunction();
 b = 10;
 ```
 
-The `b:true` syntax in `/*global */` indicates that assignment to `b` is correct.
+The `b:writable` syntax in `/*global */` indicates that assignment to `b` is correct.
 
 Examples of **incorrect** code for this rule with `global` declaration:
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Documentation update

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Replace in rule docs: 

`/*global a:false*/` with  `/*global a:readonly*/`
`/*global a:true*/` with  `/*global a:writable*/`

as these are now the preferable option names and more expressive than their aliases.

Also replaced `globals` with `global` to be consistent with the configuring doc and other rules (except `capitalized-comments` where there are both).

**Is there anything you'd like reviewers to focus on?**


