### PR TITLE
New: add prefer-async-await rule

### DIFF
--- a/docs/rules/prefer-async-await.md
+++ b/docs/rules/prefer-async-await.md
@@ -1,0 +1,50 @@
+# Prefer `async`/`await` over `.then()` (prefer-async-await)
+
+With the addition of `async`/`await` in ES2017, one can write asynchronous code
+in a synchronous-like manner.
+
+## Rule Details
+
+This rule flags `then` calls so they can be converted to use `async`/`await`.
+
+Examples of **incorrect** code for this rule:
+
+```js
+/*eslint prefer-async-await: "error"*/
+
+getData()
+  .then((data) => console.log(data))
+  .catch((error) => console.error(error))
+  .finally(() => cleanUp())
+
+dataPromise.then(function(data) { }).then(x).catch()
+```
+
+Examples of **correct** code for this rule:
+
+```js
+/*eslint prefer-async-await: "error"*/
+async function useData() {
+  try {
+    let data = await getData();
+    console.log(data)
+  } catch (error) {
+    console.error(error)
+  }
+  cleanUp();
+    
+  console.log(await getData())
+}
+```
+
+## When Not To Use It
+
+This rule should not be enabled in environments that don't support ES2017 or which aren't transpiled to ES2015 code.
+Also, this rule shouldn't be used in case async/await syntax is not preferred.
+
+## Further Reading
+
+To learn more about `async`/`await`, check out the links below:
+
+- [`async function` (MDN)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function)
+- [`await` (MDN)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await)

--- a/docs/rules/prefer-async-await.md
+++ b/docs/rules/prefer-async-await.md
@@ -32,7 +32,7 @@ async function useData() {
     console.error(error)
   }
   cleanUp();
-    
+
   console.log(await getData())
 }
 ```

--- a/docs/rules/prefer-async-await.md
+++ b/docs/rules/prefer-async-await.md
@@ -44,7 +44,5 @@ Also, this rule shouldn't be used in case async/await syntax is not preferred.
 
 ## Further Reading
 
-To learn more about `async`/`await`, check out the links below:
-
 - [`async function` (MDN)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function)
 - [`await` (MDN)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await)

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -233,6 +233,7 @@ module.exports = new LazyLoadingRuleMap(Object.entries({
     "padded-blocks": () => require("./padded-blocks"),
     "padding-line-between-statements": () => require("./padding-line-between-statements"),
     "prefer-arrow-callback": () => require("./prefer-arrow-callback"),
+    "prefer-async-await": () => require("./prefer-async-await"),
     "prefer-const": () => require("./prefer-const"),
     "prefer-destructuring": () => require("./prefer-destructuring"),
     "prefer-named-capture-group": () => require("./prefer-named-capture-group"),

--- a/lib/rules/prefer-async-await.js
+++ b/lib/rules/prefer-async-await.js
@@ -1,0 +1,50 @@
+/**
+ * @fileoverview Prefer async/await over .then()
+ * @author Elad Shahar
+ * @author Alexander Lichter
+ */
+
+'use strict'
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Determine if a node is accessing a `then` property
+ * @private
+ * @param {ASTNode} node - node to test
+ * @returns {boolean} True if `node` is a `then` property access
+ */
+function isThenPropertyAccess(node) {
+  return node.property.type === 'Identifier' && node.property.name === 'then'
+}
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'require usage of async/await over .then()',
+      category: 'Best Practices',
+      recommended: false,
+      url: 'https://eslint.org/docs/rules/prefer-async-await'
+    },
+    schema: [],
+    messages: {
+      unexpected: 'Prefer using async/await over .then().'
+    }
+  },
+
+  create(context) {
+    return {
+      MemberExpression(node) {
+        if (isThenPropertyAccess(node)) {
+          context.report({ node: node.property, messageId: 'unexpected' })
+        }
+      }
+    }
+  }
+}

--- a/lib/rules/prefer-async-await.js
+++ b/lib/rules/prefer-async-await.js
@@ -20,6 +20,16 @@ function isThenPropertyAccess(node) {
     return node.property.type === "Identifier" && node.property.name === "then";
 }
 
+/**
+ * Determine if a node's callee has the type MemberExpression
+ * @private
+ * @param {ASTNode} node - node to test
+ * @returns {boolean} True if the `node`'s callee has the type MemberExpression
+ */
+function isCalleeMemberExpression(node) {
+    return node.callee.type === "MemberExpression";
+}
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -41,9 +51,14 @@ module.exports = {
 
     create(context) {
         return {
-            MemberExpression(node) {
-                if (isThenPropertyAccess(node)) {
-                    context.report({ node: node.property, messageId: "preferAsyncAwait" });
+            CallExpression(node) {
+                if (!isCalleeMemberExpression(node)) {
+                    return;
+                }
+                const memberExpression = node.callee;
+
+                if (isThenPropertyAccess(memberExpression)) {
+                    context.report({ node: memberExpression.property, messageId: "preferAsyncAwait" });
                 }
             }
         };

--- a/lib/rules/prefer-async-await.js
+++ b/lib/rules/prefer-async-await.js
@@ -4,7 +4,7 @@
  * @author Alexander Lichter
  */
 
-'use strict'
+"use strict";
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -17,7 +17,7 @@
  * @returns {boolean} True if `node` is a `then` property access
  */
 function isThenPropertyAccess(node) {
-  return node.property.type === 'Identifier' && node.property.name === 'then'
+    return node.property.type === "Identifier" && node.property.name === "then";
 }
 
 //------------------------------------------------------------------------------
@@ -25,26 +25,27 @@ function isThenPropertyAccess(node) {
 //------------------------------------------------------------------------------
 
 module.exports = {
-  meta: {
-    docs: {
-      description: 'require usage of async/await over .then()',
-      category: 'Best Practices',
-      recommended: false,
-      url: 'https://eslint.org/docs/rules/prefer-async-await'
-    },
-    schema: [],
-    messages: {
-      unexpected: 'Prefer using async/await over .then().'
-    }
-  },
-
-  create(context) {
-    return {
-      MemberExpression(node) {
-        if (isThenPropertyAccess(node)) {
-          context.report({ node: node.property, messageId: 'unexpected' })
+    meta: {
+        type: "suggestion",
+        docs: {
+            description: "require usage of async/await over .then()",
+            category: "Best Practices",
+            recommended: false,
+            url: "https://eslint.org/docs/rules/prefer-async-await"
+        },
+        schema: [],
+        messages: {
+            unexpected: "Prefer using async/await over .then()."
         }
-      }
+    },
+
+    create(context) {
+        return {
+            MemberExpression(node) {
+                if (isThenPropertyAccess(node)) {
+                    context.report({ node: node.property, messageId: "unexpected" });
+                }
+            }
+        };
     }
-  }
-}
+};

--- a/lib/rules/prefer-async-await.js
+++ b/lib/rules/prefer-async-await.js
@@ -35,7 +35,7 @@ module.exports = {
         },
         schema: [],
         messages: {
-            unexpected: "Prefer using async/await over .then()."
+            preferAsyncAwait: "Prefer using async/await over .then()."
         }
     },
 
@@ -43,7 +43,7 @@ module.exports = {
         return {
             MemberExpression(node) {
                 if (isThenPropertyAccess(node)) {
-                    context.report({ node: node.property, messageId: "unexpected" });
+                    context.report({ node: node.property, messageId: "preferAsyncAwait" });
                 }
             }
         };

--- a/tests/lib/rules/prefer-async-await.js
+++ b/tests/lib/rules/prefer-async-await.js
@@ -1,0 +1,40 @@
+/**
+ * @fileoverview Tests for prefer-async-await rule.
+ * @author Elad Shahar
+ * @author Alexander Lichter
+ */
+
+"use strict";
+
+const rule = require("../../../lib/rules/prefer-async-await");
+const RuleTester = require("../../../lib/testers/rule-tester");
+
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2017 } });
+
+ruleTester.run("prefer-async-await", rule, {
+  valid: [
+    "async function a() { await getData(); }",
+    "async function hi() { await thing() }",
+    "async function hi() { await thing().catch() }",
+    "a = async () => (await something())"
+  ],
+  invalid: [
+    { code: "getData().then(() => {});", errors: [{ messageId: "unexpected" }] },
+    {
+      code: "function foo() { hey.then(x => {}) }",
+      errors: [{ messageId: "unexpected" }]
+    },
+    {
+      code: "function foo() { hey.then(function() { }).then() }",
+      errors: [{ messageId: "unexpected" }, { messageId: "unexpected" }]
+    },
+    {
+      code: "function foo() { hey.then(function() { }).then(x).catch() }",
+      errors: [{ messageId: "unexpected" }, { messageId: "unexpected" }]
+    },
+    {
+      code: "async function a() { hey.then(function() { }).then(function() { }) }",
+      errors: [{ messageId: "unexpected" }, { messageId: "unexpected" }]
+    }
+  ]
+});

--- a/tests/lib/rules/prefer-async-await.js
+++ b/tests/lib/rules/prefer-async-await.js
@@ -16,7 +16,8 @@ ruleTester.run("prefer-async-await", rule, {
         "async function a() { await getData(); }",
         "async function hi() { await thing() }",
         "async function hi() { await thing().catch() }",
-        "a = async () => (await something())"
+        "a = async () => (await something())",
+        "doSomething(foo.then)"
     ],
     invalid: [
         { code: "getData().then(() => {});", errors: [{ messageId: "preferAsyncAwait" }] },

--- a/tests/lib/rules/prefer-async-await.js
+++ b/tests/lib/rules/prefer-async-await.js
@@ -19,22 +19,22 @@ ruleTester.run("prefer-async-await", rule, {
         "a = async () => (await something())"
     ],
     invalid: [
-        { code: "getData().then(() => {});", errors: [{ messageId: "unexpected" }] },
+        { code: "getData().then(() => {});", errors: [{ messageId: "preferAsyncAwait" }] },
         {
             code: "function foo() { hey.then(x => {}) }",
-            errors: [{ messageId: "unexpected" }]
+            errors: [{ messageId: "preferAsyncAwait" }]
         },
         {
             code: "function foo() { hey.then(function() { }).then() }",
-            errors: [{ messageId: "unexpected" }, { messageId: "unexpected" }]
+            errors: [{ messageId: "preferAsyncAwait" }, { messageId: "preferAsyncAwait" }]
         },
         {
             code: "function foo() { hey.then(function() { }).then(x).catch() }",
-            errors: [{ messageId: "unexpected" }, { messageId: "unexpected" }]
+            errors: [{ messageId: "preferAsyncAwait" }, { messageId: "preferAsyncAwait" }]
         },
         {
             code: "async function a() { hey.then(function() { }).then(function() { }) }",
-            errors: [{ messageId: "unexpected" }, { messageId: "unexpected" }]
+            errors: [{ messageId: "preferAsyncAwait" }, { messageId: "preferAsyncAwait" }]
         }
     ]
 });

--- a/tests/lib/rules/prefer-async-await.js
+++ b/tests/lib/rules/prefer-async-await.js
@@ -7,34 +7,34 @@
 "use strict";
 
 const rule = require("../../../lib/rules/prefer-async-await");
-const RuleTester = require("../../../lib/testers/rule-tester");
+const { RuleTester } = require("../../../lib/rule-tester");
 
 const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2017 } });
 
 ruleTester.run("prefer-async-await", rule, {
-  valid: [
-    "async function a() { await getData(); }",
-    "async function hi() { await thing() }",
-    "async function hi() { await thing().catch() }",
-    "a = async () => (await something())"
-  ],
-  invalid: [
-    { code: "getData().then(() => {});", errors: [{ messageId: "unexpected" }] },
-    {
-      code: "function foo() { hey.then(x => {}) }",
-      errors: [{ messageId: "unexpected" }]
-    },
-    {
-      code: "function foo() { hey.then(function() { }).then() }",
-      errors: [{ messageId: "unexpected" }, { messageId: "unexpected" }]
-    },
-    {
-      code: "function foo() { hey.then(function() { }).then(x).catch() }",
-      errors: [{ messageId: "unexpected" }, { messageId: "unexpected" }]
-    },
-    {
-      code: "async function a() { hey.then(function() { }).then(function() { }) }",
-      errors: [{ messageId: "unexpected" }, { messageId: "unexpected" }]
-    }
-  ]
+    valid: [
+        "async function a() { await getData(); }",
+        "async function hi() { await thing() }",
+        "async function hi() { await thing().catch() }",
+        "a = async () => (await something())"
+    ],
+    invalid: [
+        { code: "getData().then(() => {});", errors: [{ messageId: "unexpected" }] },
+        {
+            code: "function foo() { hey.then(x => {}) }",
+            errors: [{ messageId: "unexpected" }]
+        },
+        {
+            code: "function foo() { hey.then(function() { }).then() }",
+            errors: [{ messageId: "unexpected" }, { messageId: "unexpected" }]
+        },
+        {
+            code: "function foo() { hey.then(function() { }).then(x).catch() }",
+            errors: [{ messageId: "unexpected" }, { messageId: "unexpected" }]
+        },
+        {
+            code: "async function a() { hey.then(function() { }).then(function() { }) }",
+            errors: [{ messageId: "unexpected" }, { messageId: "unexpected" }]
+        }
+    ]
 });

--- a/tools/rule-types.json
+++ b/tools/rule-types.json
@@ -220,6 +220,7 @@
     "padded-blocks": "layout",
     "padding-line-between-statements": "layout",
     "prefer-arrow-callback": "suggestion",
+    "prefer-async-await": "suggestion",
     "prefer-const": "suggestion",
     "prefer-destructuring": "suggestion",
     "prefer-named-capture-group": "suggestion",


### PR DESCRIPTION
Hey all! My first PR to eslint. Thanks so far for this amazing piece of work :raised_hands: 	


Taking over PR #11033. All changes mentioned by @not-an-aardvark are added.

Fixes #9649

**What is the purpose of this pull request? (put an "X" next to item)**

[x] New rule

**Please describe what the rule should do:**

The rule should suggest to replace promise-based (`then`) solutions with async/await


**What category of rule is this? (place an "X" next to just one item)**

[x] Enforces code style
[x] Suggests an alternate way of doing something

**Why should this rule be included in ESLint (instead of a plugin)?**

Preferring async/await over promises is a major step for writing modern JavaScript (in a ES2017+ or transpiled environment). Thus, the rule should be part of the core.

**What changes did you make? (Give an overview)**

I've adopted the content from #11033 and applied change requests from there.


**Is there anything you'd like reviewers to focus on?**

Potential edge cases, suggestions for further coverage


