### PR TITLE
New: prefer-async-await rule (fixes #9649)

### DIFF
--- a/docs/rules/prefer-async-await.md
+++ b/docs/rules/prefer-async-await.md
@@ -1,0 +1,128 @@
+# Require using the `async`/`await` syntax instead of the Promise methods (prefer-async-await)
+
+With the addition of the `async`/`await` syntax in ECMAScript 2017, one can write asynchronous code
+in a synchronous-like manner.
+
+This rule restricts the use of the Promise methods in favor of the `async`/`await` syntax,
+which is easier to write and to read afterwards.
+
+## Rule Details
+
+This rule flags all `.then()`, `.catch()` and `.finally()` method calls, assuming they are made on a promise object.
+
+Examples of **incorrect** code for this rule:
+
+```js
+/*eslint prefer-async-await: "error"*/
+
+function show(id) {
+  getBook()
+      .then(book => {
+          getAuthor(book.authorId)
+              .then((author) => {
+                  display(book, author)
+              })
+      })
+}
+
+function show(id) {
+  let book;
+  getBook()
+      .then(b => {
+          book = b;
+          return getAuthor(book.authorId);
+      })
+      .then((author) => {
+          display(book, author);
+      })
+}
+```
+
+Examples of **correct** code for this rule:
+
+```js
+/*eslint prefer-async-await: "error"*/
+
+async function show(id) {
+  const book = await getBook();
+  const author = await getAuthor(book.authorId);
+  display(book, author);
+}
+```
+
+## Options
+
+This rule has an object option with two options:
+
+* `"atTopLevel": false` allows promise method calls at the top level
+* `"inGetOrSet": false` allows promise method calls in getters and setters
+
+### atTopLevel
+
+The `await` expression cannot be used at the top level, yet. An alternative is to
+wrap the expression in an async IIFE.
+
+If you want to allow Promise method calls at the top level, set this option to `false`.
+
+Examples of **incorrect** code for this rule with `"atTopLevel"` option set to `true` (default):
+
+```js
+/*eslint prefer-async-await: ["error", {"atTopLevel": true}]*/
+
+getSomething().then(x => doSomething(x));
+```
+
+Examples of **correct** code for this rule with `"atTopLevel"` option set to `true` (default):
+
+```js
+/*eslint prefer-async-await: ["error", {"atTopLevel": true}]*/
+
+(async () => {
+    const x = await getSomething();
+    doSomething(x);
+})();
+```
+
+Examples of **correct** code for this rule with `"atTopLevel"` option set to `false`:
+
+```js
+/*eslint prefer-async-await: ["error", {"atTopLevel": false}]*/
+
+getSomething().then(x => doSomething(x));
+```
+
+### inGetOrSet
+
+If you consume promises in getters or setters, switching to the `async`/`await` syntax would require
+certain refactoring, since the getters and setters cannot be async.
+
+If you want to allow Promise method calls in getters and setters, set this option to `false`.
+
+Examples of **incorrect** code for this rule with `"inGetOrSet"` option set to `true` (default):
+
+```js
+/*eslint prefer-async-await: ["error", {"inGetOrSet": true}]*/
+
+class foo {
+    set bar(x) {
+        doSomething(x).then(y => this.y = y);
+    }
+}
+```
+
+Examples of **correct** code for this rule with `"inGetOrSet"` option set to `false`:
+
+```js
+/*eslint prefer-async-await: ["error", {"inGetOrSet": false}]*/
+
+class foo {
+    set bar(x) {
+        doSomething(x).then(y => this.y = y);
+    }
+}
+```
+
+## Further Reading
+
+* [Making asynchronous programming easier with async and await](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Asynchronous/Async_await)
+

--- a/docs/rules/prefer-async-await.md
+++ b/docs/rules/prefer-async-await.md
@@ -1,10 +1,15 @@
-# Require using the `async`/`await` syntax instead of the Promise methods (prefer-async-await)
+# Require using the `async`/`await` syntax instead of the Promise prototype methods (prefer-async-await)
 
 With the addition of the `async`/`await` syntax in ECMAScript 2017, one can write asynchronous code
 in a synchronous-like manner.
 
-This rule restricts the use of the Promise methods in favor of the `async`/`await` syntax,
+This rule restricts the use of the Promise prototype methods in favor of the `async`/`await` syntax,
 which is easier to write and to read afterwards.
+
+Namely, restricted methods are: `.then()`, `.catch()` and `.finally()`.
+
+Static methods, such as `Promise.all()`, are **not** restricted.
+You should still use `Promise.all()` for parallel execution.
 
 ## Rule Details
 
@@ -16,25 +21,25 @@ Examples of **incorrect** code for this rule:
 /*eslint prefer-async-await: "error"*/
 
 function show(id) {
-  getBook()
-      .then(book => {
-          getAuthor(book.authorId)
-              .then((author) => {
-                  display(book, author)
-              })
-      })
+    return getBook()
+        .then(book => {
+            return getAuthor(book.authorId)
+                .then((author) => {
+                    display(book, author);
+                });
+        });
 }
 
 function show(id) {
-  let book;
-  getBook()
-      .then(b => {
-          book = b;
-          return getAuthor(book.authorId);
-      })
-      .then((author) => {
-          display(book, author);
-      })
+    let book;
+    return getBook()
+        .then(b => {
+            book = b;
+            return getAuthor(book.authorId);
+        })
+        .then((author) => {
+            display(book, author);
+        });
 }
 ```
 
@@ -44,25 +49,71 @@ Examples of **correct** code for this rule:
 /*eslint prefer-async-await: "error"*/
 
 async function show(id) {
-  const book = await getBook();
-  const author = await getAuthor(book.authorId);
-  display(book, author);
+    const book = await getBook();
+    const author = await getAuthor(book.authorId);
+    display(book, author);
+}
+```
+
+### Promise.all()
+
+`Promise.all()` can be used along with the `async`/`await` syntax.
+
+Example of **incorrect** code for this rule:
+
+```js
+/*eslint prefer-async-await: "error"*/
+
+function foo() {
+    return Promise.all([
+        asyncFunc1(),
+        asyncFunc2(),
+    ]).then(([result1, result2]) => {
+        doSomething(result1, result2);
+    });
+}
+```
+
+Example of **correct** code for this rule:
+
+```js
+/*eslint prefer-async-await: "error"*/
+
+async function foo() {
+    const [result1, result2] = await Promise.all([
+        asyncFunc1(),
+        asyncFunc2(),
+    ]);
+    doSomething(result1, result2);
+}
+```
+
+Note that the following code is **not equivalent** to the previous two examples.
+In this example, the function calls are executed **sequentially**:
+
+```js
+async function foo() {
+    const result1 = await asyncFunc1();
+    const result2 = await asyncFunc2();
+    doSomething(result1, result2);
 }
 ```
 
 ## Options
 
-This rule has an object option with two options:
+This rule has an object option with four options:
 
-* `"atTopLevel": false` allows promise method calls at the top level
-* `"inGetOrSet": false` allows promise method calls in getters and setters
+* `"atTopLevel": false` allows Promise prototype method calls at the top level
+* `"inGetOrSet": false` allows Promise prototype method calls in getters and setters
+* `"inAwaitExpressions": false` allows Promise prototype method calls in await expressions
+* `"inYieldExpressions": false` allows Promise prototype method calls in yield expressions
 
 ### atTopLevel
 
 The `await` expression cannot be used at the top level, yet. An alternative is to
 wrap the expression in an async IIFE.
 
-If you want to allow Promise method calls at the top level, set this option to `false`.
+If you want to allow Promise prototype method calls at the top level, set this option to `false`.
 
 Examples of **incorrect** code for this rule with `"atTopLevel"` option set to `true` (default):
 
@@ -96,7 +147,7 @@ getSomething().then(x => doSomething(x));
 If you consume promises in getters or setters, switching to the `async`/`await` syntax would require
 certain refactoring, since the getters and setters cannot be async.
 
-If you want to allow Promise method calls in getters and setters, set this option to `false`.
+If you want to allow Promise prototype method calls in getters and setters, set this option to `false`.
 
 Examples of **incorrect** code for this rule with `"inGetOrSet"` option set to `true` (default):
 
@@ -119,6 +170,60 @@ class foo {
     set bar(x) {
         doSomething(x).then(y => this.y = y);
     }
+}
+```
+
+### inAwaitExpressions
+
+If you want to allow Promise prototype method calls in `await` expressions, set this option to `false`.
+
+Examples of **incorrect** code for this rule with `"inAwaitExpressions"` option set to `true` (default):
+
+```js
+/*eslint prefer-async-await: ["error", {"inAwaitExpressions": true}]*/
+
+async function foo() {
+    const x = await getSomething().catch(err => {});
+    if (x) {
+        doSomething();
+    }
+}
+```
+
+Examples of **correct** code for this rule with `"inAwaitExpressions"` option set to `false`:
+
+```js
+/*eslint prefer-async-await: ["error", {"inAwaitExpressions": false}]*/
+
+async function foo() {
+    const x = await getSomething().catch(err => {});
+    if (x) {
+        doSomething();
+    }
+}
+```
+
+### inYieldExpressions
+
+If you want to allow Promise prototype method calls in `yield` expressions, set this option to `false`.
+
+Examples of **incorrect** code for this rule with `"inYieldExpressions"` option set to `true` (default):
+
+```js
+/*eslint prefer-async-await: ["error", {"inYieldExpressions": true}]*/
+
+function *foo() {
+    yield getSomething().catch(err => {});
+}
+```
+
+Examples of **correct** code for this rule with `"inYieldExpressions"` option set to `false`:
+
+```js
+/*eslint prefer-async-await: ["error", {"inYieldExpressions": false}]*/
+
+function *foo() {
+    yield getSomething().catch(err => {});
 }
 ```
 

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -233,6 +233,7 @@ module.exports = new LazyLoadingRuleMap(Object.entries({
     "padded-blocks": () => require("./padded-blocks"),
     "padding-line-between-statements": () => require("./padding-line-between-statements"),
     "prefer-arrow-callback": () => require("./prefer-arrow-callback"),
+    "prefer-async-await": () => require("./prefer-async-await"),
     "prefer-const": () => require("./prefer-const"),
     "prefer-destructuring": () => require("./prefer-destructuring"),
     "prefer-named-capture-group": () => require("./prefer-named-capture-group"),

--- a/lib/rules/prefer-async-await.js
+++ b/lib/rules/prefer-async-await.js
@@ -123,7 +123,7 @@ module.exports = {
                     const methodName = callee.property.name;
 
                     if (isPromiseMethodName(methodName) && isInForbiddenContext(node)) {
-                        report(node, methodName);
+                        report(node);
                     }
                 }
             }

--- a/lib/rules/prefer-async-await.js
+++ b/lib/rules/prefer-async-await.js
@@ -1,0 +1,132 @@
+/**
+ * @fileoverview Rule to require using `async`/`await` syntax instead of Promise methods
+ * @author Milos Djermanovic
+ */
+"use strict";
+
+const astUtils = require("./utils/ast-utils");
+
+const PROMISE_METHOD_NAMES = new Set(["then", "catch", "finally"]);
+const ACCESSOR_KINDS = new Set(["get", "set"]);
+const ACCESSOR_TYPES = new Set(["Property", "MethodDefinition"]);
+
+/**
+ * Checks whether the given name matches with any of the standard Promise method names
+ * (names from Promise.prototype)
+ *
+ * @param {string} name Name to check.
+ * @returns {boolean} True if the given name is a Promise method name.
+ */
+function isPromiseMethodName(name) {
+    return PROMISE_METHOD_NAMES.has(name);
+}
+
+/**
+ * Checks whether the given node is used as an accesssor value
+ *
+ * @param {Node} node Node to check.
+ * @returns {boolean} True if the node is used as an accessor value.
+ */
+function isAccessorValue(node) {
+    const parent = node.parent;
+
+    return parent && ACCESSOR_TYPES.has(parent.type) && parent.value === node &&
+        ACCESSOR_KINDS.has(parent.kind);
+
+}
+
+module.exports = {
+    meta: {
+        type: "suggestion",
+
+        docs: {
+            description: "require using `async`/`await` syntax instead of Promise methods",
+            category: "Best Practices",
+            recommended: false,
+            url: "https://eslint.org/docs/rules/prefer-async-await"
+        },
+
+        fixable: null,
+        schema: [{
+            type: "object",
+            properties: {
+                atTopLevel: {
+                    type: "boolean",
+                    default: true
+                },
+                inGetOrSet: {
+                    type: "boolean",
+                    default: true
+                }
+            },
+            additionalProperties: false
+        }],
+
+        messages: {
+            promiseMethodCall: "Use async/await syntax instead of .{{name}}() method."
+        }
+    },
+
+    create(context) {
+
+        const shouldReportTopLevel = !(context.options[0] && context.options[0].atTopLevel === false);
+        const shouldReportGetOrSet = !(context.options[0] && context.options[0].inGetOrSet === false);
+
+        /**
+         * Checks whether the given node is in a context where promise method calls are forbidden,
+         * depending on the configuration.
+         * @param {Node} node Node to check.
+         * @returns {boolean} True if the given node is in a forbidden context.
+         */
+        function isInForbiddenContext(node) {
+
+            if (shouldReportTopLevel && shouldReportGetOrSet) {
+
+                // forbidden everywhere
+                return true;
+            }
+
+            const upperFunction = astUtils.getUpperFunction(node);
+
+            if (upperFunction) {
+                if (shouldReportGetOrSet) {
+                    return true;
+                }
+
+                return !isAccessorValue(upperFunction);
+            }
+
+            // top level
+            return shouldReportTopLevel;
+        }
+
+        /**
+         * Reports the given node.
+         *
+         * @param {Node} node CallExpression node
+         * @returns {void}
+         */
+        function report(node) {
+            context.report({
+                node,
+                data: node.callee.property,
+                messageId: "promiseMethodCall"
+            });
+        }
+
+        return {
+            CallExpression(node) {
+                const { callee } = node;
+
+                if (callee && callee.type === "MemberExpression" && !callee.computed &&
+                    callee.property.type === "Identifier") {
+                    const methodName = callee.property.name;
+
+                    if (isPromiseMethodName(methodName) && isInForbiddenContext(node)) {
+                        report(node, methodName);
+                    }
+                }
+            }
+        };
+    }
+};

--- a/lib/rules/prefer-async-await.js
+++ b/lib/rules/prefer-async-await.js
@@ -9,11 +9,10 @@ const astUtils = require("./utils/ast-utils");
 const PROMISE_METHOD_NAMES = new Set(["then", "catch", "finally"]);
 const ACCESSOR_KINDS = new Set(["get", "set"]);
 const ACCESSOR_TYPES = new Set(["Property", "MethodDefinition"]);
+const EXPRESSION_STOP_NODES = /(?:Statement|Declaration|Function(?:Expression)?|Program)$/u;
 
 /**
- * Checks whether the given name matches with any of the standard Promise method names
- * (names from Promise.prototype)
- *
+ * Checks whether the given name matches with any of the standard Promise.prototype method names.
  * @param {string} name Name to check.
  * @returns {boolean} True if the given name is a Promise method name.
  */
@@ -22,8 +21,7 @@ function isPromiseMethodName(name) {
 }
 
 /**
- * Checks whether the given node is used as an accesssor value
- *
+ * Checks whether the given node is used as an accesssor value.
  * @param {Node} node Node to check.
  * @returns {boolean} True if the node is used as an accessor value.
  */
@@ -32,7 +30,30 @@ function isAccessorValue(node) {
 
     return parent && ACCESSOR_TYPES.has(parent.type) && parent.value === node &&
         ACCESSOR_KINDS.has(parent.kind);
+}
 
+/**
+ * Checks whether the given node is in any of the given expression types.
+ * @param {Node} node Node to check.
+ * @param {Set} types Set containing expression types.
+ * @returns {boolean} True if the node is in one of the given expression types.
+ */
+function isInExpressionType(node, types) {
+
+    if (!types.size) {
+        return false;
+    }
+
+    let ancestor = node.parent;
+
+    while (ancestor && !EXPRESSION_STOP_NODES.test(ancestor.type)) {
+        if (types.has(ancestor.type)) {
+            return true;
+        }
+        ancestor = ancestor.parent;
+    }
+
+    return false;
 }
 
 module.exports = {
@@ -40,7 +61,7 @@ module.exports = {
         type: "suggestion",
 
         docs: {
-            description: "require using `async`/`await` syntax instead of Promise methods",
+            description: "require using `async`/`await` syntax instead of Promise prototype methods",
             category: "Best Practices",
             recommended: false,
             url: "https://eslint.org/docs/rules/prefer-async-await"
@@ -57,6 +78,14 @@ module.exports = {
                 inGetOrSet: {
                     type: "boolean",
                     default: true
+                },
+                inAwaitExpressions: {
+                    type: "boolean",
+                    default: true
+                },
+                inYieldExpressions: {
+                    type: "boolean",
+                    default: true
                 }
             },
             additionalProperties: false
@@ -71,6 +100,15 @@ module.exports = {
 
         const shouldReportTopLevel = !(context.options[0] && context.options[0].atTopLevel === false);
         const shouldReportGetOrSet = !(context.options[0] && context.options[0].inGetOrSet === false);
+        const allowedExpressionTypes = new Set();
+
+        if (context.options[0] && context.options[0].inAwaitExpressions === false) {
+            allowedExpressionTypes.add("AwaitExpression");
+        }
+
+        if (context.options[0] && context.options[0].inYieldExpressions === false) {
+            allowedExpressionTypes.add("YieldExpression");
+        }
 
         /**
          * Checks whether the given node is in a context where promise method calls are forbidden,
@@ -79,6 +117,10 @@ module.exports = {
          * @returns {boolean} True if the given node is in a forbidden context.
          */
         function isInForbiddenContext(node) {
+
+            if (isInExpressionType(node, allowedExpressionTypes)) {
+                return false;
+            }
 
             if (shouldReportTopLevel && shouldReportGetOrSet) {
 

--- a/tests/lib/rules/prefer-async-await.js
+++ b/tests/lib/rules/prefer-async-await.js
@@ -54,12 +54,57 @@ ruleTester.run("prefer-async-await", rule, {
         {
             code: "class foo { get a() { bar.then(); } set a(b) { baz.then(); } }",
             options: [{ inGetOrSet: false }],
-            parserOptions: { ecmaVersion: 6 }
+            parserOptions: { ecmaVersion: 2015 }
         },
         {
             code: "class foo { get a() { bar.then(); } set b(c) { baz.then(); } }",
             options: [{ inGetOrSet: false }],
-            parserOptions: { ecmaVersion: 6 }
+            parserOptions: { ecmaVersion: 2015 }
+        },
+        {
+            code: "async function foo() { await bar.then(); }",
+            options: [{ inAwaitExpressions: false }],
+            parserOptions: { ecmaVersion: 2017 }
+        },
+        {
+            code: "async function foo() { await bar.catch(); }",
+            options: [{ inAwaitExpressions: false }],
+            parserOptions: { ecmaVersion: 2017 }
+        },
+        {
+            code: "async function foo() { await bar.baz.then(); }",
+            options: [{ inAwaitExpressions: false }],
+            parserOptions: { ecmaVersion: 2017 }
+        },
+        {
+            code: "async function foo() { await bar().then().baz().catch().finally(); }",
+            options: [{ inAwaitExpressions: false }],
+            parserOptions: { ecmaVersion: 2017 }
+        },
+        {
+            code: "function *foo() { yield bar.then(); }",
+            options: [{ inYieldExpressions: false }],
+            parserOptions: { ecmaVersion: 2015 }
+        },
+        {
+            code: "function *foo() { yield bar.catch(); }",
+            options: [{ inYieldExpressions: false }],
+            parserOptions: { ecmaVersion: 2015 }
+        },
+        {
+            code: "function *foo() { yield bar.baz.then(); }",
+            options: [{ inYieldExpressions: false }],
+            parserOptions: { ecmaVersion: 2015 }
+        },
+        {
+            code: "function *foo() { yield bar().then().baz().catch().finally(); }",
+            options: [{ inYieldExpressions: false }],
+            parserOptions: { ecmaVersion: 2015 }
+        },
+        {
+            code: "function *foo() { yield 1 + bar.then() + 2; }",
+            options: [{ inYieldExpressions: false }],
+            parserOptions: { ecmaVersion: 2015 }
         }
     ],
     invalid: [
@@ -154,7 +199,7 @@ ruleTester.run("prefer-async-await", rule, {
         {
             code: "function foo() { bar.then(); }",
             options: [{ atTopLevel: false, inGetOrSet: false }],
-            parserOptions: { ecmaVersion: 6 },
+            parserOptions: { ecmaVersion: 2015 },
             errors: [{
                 messageId: "promiseMethodCall",
                 type: "CallExpression"
@@ -163,7 +208,7 @@ ruleTester.run("prefer-async-await", rule, {
         {
             code: "const foo = function() { bar.then(); }",
             options: [{ atTopLevel: false, inGetOrSet: false }],
-            parserOptions: { ecmaVersion: 6 },
+            parserOptions: { ecmaVersion: 2015 },
             errors: [{
                 messageId: "promiseMethodCall",
                 type: "CallExpression"
@@ -172,7 +217,7 @@ ruleTester.run("prefer-async-await", rule, {
         {
             code: "const foo = () => { bar.then(); }",
             options: [{ atTopLevel: false, inGetOrSet: false }],
-            parserOptions: { ecmaVersion: 6 },
+            parserOptions: { ecmaVersion: 2015 },
             errors: [{
                 messageId: "promiseMethodCall",
                 type: "CallExpression"
@@ -181,7 +226,7 @@ ruleTester.run("prefer-async-await", rule, {
         {
             code: "const foo = { a() { bar.then(); } }",
             options: [{ atTopLevel: false, inGetOrSet: false }],
-            parserOptions: { ecmaVersion: 6 },
+            parserOptions: { ecmaVersion: 2015 },
             errors: [{
                 messageId: "promiseMethodCall",
                 type: "CallExpression"
@@ -190,7 +235,7 @@ ruleTester.run("prefer-async-await", rule, {
         {
             code: "class foo { a() { bar.then(); } }",
             options: [{ atTopLevel: false, inGetOrSet: false }],
-            parserOptions: { ecmaVersion: 6 },
+            parserOptions: { ecmaVersion: 2015 },
             errors: [{
                 messageId: "promiseMethodCall",
                 type: "CallExpression"
@@ -242,7 +287,7 @@ ruleTester.run("prefer-async-await", rule, {
         },
         {
             code: "class foo { get a() { bar.then(); } set a(b) { baz.then(); } }",
-            parserOptions: { ecmaVersion: 6 },
+            parserOptions: { ecmaVersion: 2015 },
             errors: [
                 {
                     messageId: "promiseMethodCall",
@@ -285,12 +330,98 @@ ruleTester.run("prefer-async-await", rule, {
         {
             code: "class foo { get a() { bar.then(); } set a(b) { baz.then(); } }",
             options: [{ inGetOrSet: true }],
-            parserOptions: { ecmaVersion: 6 },
+            parserOptions: { ecmaVersion: 2015 },
             errors: [
                 {
                     messageId: "promiseMethodCall",
                     type: "CallExpression"
                 },
+                {
+                    messageId: "promiseMethodCall",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "async function foo() { await bar.then(); }",
+            parserOptions: { ecmaVersion: 2017 },
+            errors: [
+                {
+                    messageId: "promiseMethodCall",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "async function foo() { await bar.then(); }",
+            options: [{ inAwaitExpressions: true }],
+            parserOptions: { ecmaVersion: 2017 },
+            errors: [
+                {
+                    messageId: "promiseMethodCall",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "async function foo() { await (() => bar.then()) }",
+            options: [{ inAwaitExpressions: false }],
+            parserOptions: { ecmaVersion: 2017 },
+            errors: [
+                {
+                    messageId: "promiseMethodCall",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "async function foo() { await bar.then(); }",
+            options: [{ inAwaitExpressions: true, inYieldExpressions: false }],
+            parserOptions: { ecmaVersion: 2017 },
+            errors: [
+                {
+                    messageId: "promiseMethodCall",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "function *foo() { yield bar.then(); }",
+            parserOptions: { ecmaVersion: 2015 },
+            errors: [
+                {
+                    messageId: "promiseMethodCall",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "function *foo() { yield bar.then(); }",
+            options: [{ inYieldExpressions: true }],
+            parserOptions: { ecmaVersion: 2015 },
+            errors: [
+                {
+                    messageId: "promiseMethodCall",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "function *foo() { yield (() => bar.then()) }",
+            options: [{ inYieldExpressions: false }],
+            parserOptions: { ecmaVersion: 2015 },
+            errors: [
+                {
+                    messageId: "promiseMethodCall",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "function *foo() { yield bar.then(); }",
+            options: [{ inAwaitExpressions: false, inYieldExpressions: true }],
+            parserOptions: { ecmaVersion: 2015 },
+            errors: [
                 {
                     messageId: "promiseMethodCall",
                     type: "CallExpression"

--- a/tests/lib/rules/prefer-async-await.js
+++ b/tests/lib/rules/prefer-async-await.js
@@ -1,0 +1,301 @@
+/**
+ * @fileoverview Tests for prefer-async-await rule.
+ * @author Milos Djermanovic
+ */
+
+"use strict";
+
+const rule = require("../../../lib/rules/prefer-async-await");
+const { RuleTester } = require("../../../lib/rule-tester");
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("prefer-async-await", rule, {
+    valid: [
+        "function foo() { then; }",
+        "function foo() { then(); }",
+        "function foo() { bar.then; }",
+        "function foo() { bar.catch; }",
+        "function foo() { bar.finally; }",
+        "function foo() { then.then; }",
+        "function foo() { then.catch.finally; }",
+        "function foo() { then().bar; }",
+        "function foo() { then().then; }",
+        "function foo() { then().catch; }",
+        "function foo() { bar().then; }",
+        "function foo() { bar().catch; }",
+        "function foo() { bar().then.catch; }",
+        "function foo() { bar.then.baz; }",
+        "function foo() { bar.then.then; }",
+        "function foo() { then.bar(); }",
+        "function foo() { bar.then.baz(); }",
+        "function foo() { bar(then); }",
+        "function foo() { bar.baz(then); }",
+        "function then() {}",
+        "function foo() { bar[then](); }",
+
+        // options
+        {
+            code: "foo.then()",
+            options: [{ atTopLevel: false }]
+        },
+        {
+            code: "if (true) { foo.then() }",
+            options: [{ atTopLevel: false }]
+        },
+        {
+            code: "var foo = { get a() { bar.then(); }, set a(b) { baz.then(); } }",
+            options: [{ inGetOrSet: false }]
+        },
+        {
+            code: "var foo = { get a() { bar.then(); }, set b(c) { baz.then(); } }",
+            options: [{ inGetOrSet: false }]
+        },
+        {
+            code: "class foo { get a() { bar.then(); } set a(b) { baz.then(); } }",
+            options: [{ inGetOrSet: false }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "class foo { get a() { bar.then(); } set b(c) { baz.then(); } }",
+            options: [{ inGetOrSet: false }],
+            parserOptions: { ecmaVersion: 6 }
+        }
+    ],
+    invalid: [
+        {
+            code: "function foo() { bar.then(); }",
+            errors: [{
+                message: "Use async/await syntax instead of .then() method.",
+                type: "CallExpression"
+            }]
+        },
+        {
+            code: "function foo() { bar.catch(); }",
+            errors: [{
+                message: "Use async/await syntax instead of .catch() method.",
+                type: "CallExpression"
+            }]
+        },
+        {
+            code: "function foo() { bar.finally(); }",
+            errors: [{
+                message: "Use async/await syntax instead of .finally() method.",
+                type: "CallExpression"
+            }]
+        },
+        {
+            code: "function foo() { bar.then().then().catch().then().catch().finally(); }",
+            errors: [
+                {
+                    message: "Use async/await syntax instead of .finally() method.",
+                    type: "CallExpression"
+                },
+                {
+                    message: "Use async/await syntax instead of .catch() method.",
+                    type: "CallExpression"
+                },
+                {
+                    message: "Use async/await syntax instead of .then() method.",
+                    type: "CallExpression"
+                },
+                {
+                    message: "Use async/await syntax instead of .catch() method.",
+                    type: "CallExpression"
+                },
+                {
+                    message: "Use async/await syntax instead of .then() method.",
+                    type: "CallExpression"
+                },
+
+                {
+                    message: "Use async/await syntax instead of .then() method.",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "function foo() { bar().then(); }",
+            errors: [{
+                messageId: "promiseMethodCall",
+                type: "CallExpression"
+            }]
+        },
+        {
+            code: "function foo() { bar.then().baz; }",
+            errors: [{
+                messageId: "promiseMethodCall",
+                type: "CallExpression"
+            }]
+        },
+        {
+            code: "function foo() { bar.baz.then(); }",
+            errors: [{
+                messageId: "promiseMethodCall",
+                type: "CallExpression"
+            }]
+        },
+        {
+            code: "function foo() { then.then(); }",
+            errors: [{
+                messageId: "promiseMethodCall",
+                type: "CallExpression"
+            }]
+        },
+        {
+            code: "function foo() { bar.then.then(); }",
+            errors: [{
+                messageId: "promiseMethodCall",
+                type: "CallExpression"
+            }]
+        },
+
+        // options
+        {
+            code: "function foo() { bar.then(); }",
+            options: [{ atTopLevel: false, inGetOrSet: false }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "promiseMethodCall",
+                type: "CallExpression"
+            }]
+        },
+        {
+            code: "const foo = function() { bar.then(); }",
+            options: [{ atTopLevel: false, inGetOrSet: false }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "promiseMethodCall",
+                type: "CallExpression"
+            }]
+        },
+        {
+            code: "const foo = () => { bar.then(); }",
+            options: [{ atTopLevel: false, inGetOrSet: false }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "promiseMethodCall",
+                type: "CallExpression"
+            }]
+        },
+        {
+            code: "const foo = { a() { bar.then(); } }",
+            options: [{ atTopLevel: false, inGetOrSet: false }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "promiseMethodCall",
+                type: "CallExpression"
+            }]
+        },
+        {
+            code: "class foo { a() { bar.then(); } }",
+            options: [{ atTopLevel: false, inGetOrSet: false }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "promiseMethodCall",
+                type: "CallExpression"
+            }]
+        },
+        {
+            code: "foo.then()",
+            errors: [{
+                messageId: "promiseMethodCall",
+                type: "CallExpression"
+            }]
+        },
+        {
+            code: "foo.then()",
+            options: [{ atTopLevel: true }],
+            errors: [{
+                messageId: "promiseMethodCall",
+                type: "CallExpression"
+            }]
+        },
+        {
+            code: "foo.then()",
+            options: [{ atTopLevel: true, inGetOrSet: false }],
+            errors: [{
+                messageId: "promiseMethodCall",
+                type: "CallExpression"
+            }]
+        },
+        {
+            code: "if (true) { foo.then() }",
+            options: [{ atTopLevel: true }],
+            errors: [{
+                messageId: "promiseMethodCall",
+                type: "CallExpression"
+            }]
+        },
+        {
+            code: "var foo = { get a() { bar.then(); }, set a(b) { baz.then(); } }",
+            errors: [
+                {
+                    messageId: "promiseMethodCall",
+                    type: "CallExpression"
+                },
+                {
+                    messageId: "promiseMethodCall",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "class foo { get a() { bar.then(); } set a(b) { baz.then(); } }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "promiseMethodCall",
+                    type: "CallExpression"
+                },
+                {
+                    messageId: "promiseMethodCall",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "var foo = { get a() { bar.then(); }, set a(b) { baz.then(); } }",
+            options: [{ inGetOrSet: true }],
+            errors: [
+                {
+                    messageId: "promiseMethodCall",
+                    type: "CallExpression"
+                },
+                {
+                    messageId: "promiseMethodCall",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "var foo = { get a() { bar.then(); }, set a(b) { baz.then(); } }",
+            options: [{ atTopLevel: false, inGetOrSet: true }],
+            errors: [
+                {
+                    messageId: "promiseMethodCall",
+                    type: "CallExpression"
+                },
+                {
+                    messageId: "promiseMethodCall",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "class foo { get a() { bar.then(); } set a(b) { baz.then(); } }",
+            options: [{ inGetOrSet: true }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "promiseMethodCall",
+                    type: "CallExpression"
+                },
+                {
+                    messageId: "promiseMethodCall",
+                    type: "CallExpression"
+                }
+            ]
+        }
+    ]
+});

--- a/tools/rule-types.json
+++ b/tools/rule-types.json
@@ -220,6 +220,7 @@
     "padded-blocks": "layout",
     "padding-line-between-statements": "layout",
     "prefer-arrow-callback": "suggestion",
+    "prefer-async-await": "suggestion",
     "prefer-const": "suggestion",
     "prefer-destructuring": "suggestion",
     "prefer-named-capture-group": "suggestion",


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] New rule #9649

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

* Checks only method calls, like `foo.then()`
* Reports `.then()`, `.catch()` and `.finally()`
* Has ~~two~~ four options, to allow at top level, in getters/setters, await and yield expr.
* The main example is designed to show advantages of `async`/`await`


**Is there anything you'd like reviewers to focus on?**


