### PR TITLE
Chore: export checkBinary in space-infix-ops

### DIFF
--- a/lib/rules/space-infix-ops.js
+++ b/lib/rules/space-infix-ops.js
@@ -4,6 +4,98 @@
  */
 "use strict";
 
+/**
+ * Returns the first token which violates the rule
+ * @param {SourceCode} sourceCode The source code object to get the operator
+ * @param {ASTNode} left - The left node of the main node
+ * @param {ASTNode} right - The right node of the main node
+ * @param {string} op - The operator of the main node
+ * @returns {Object} The violator token or null
+ * @private
+ */
+function getFirstNonSpacedToken({ sourceCode, left, right, op }) {
+    const operator = sourceCode.getFirstTokenBetween(left, right, token => token.value === op);
+    const prev = sourceCode.getTokenBefore(operator);
+    const next = sourceCode.getTokenAfter(operator);
+
+    if (!sourceCode.isSpaceBetweenTokens(prev, operator) || !sourceCode.isSpaceBetweenTokens(operator, next)) {
+        return operator;
+    }
+
+    return null;
+}
+
+/**
+ * Reports an AST node as a rule violation
+ * @param {SourceCode} sourceCode - The source code object to get the tokens
+ * @param {ASTNode} mainNode - The node to report
+ * @param {Object} culpritToken - The token which has a problem
+ * @returns {MessageDescriptor} descriptor A descriptor for the report from a rule.
+ * @private
+ */
+function getDescriptor({ sourceCode, mainNode, culpritToken }) {
+    return {
+        node: mainNode,
+        loc: culpritToken.loc.start,
+        message: "Operator '{{operator}}' must be spaced.",
+        data: {
+            operator: culpritToken.value
+        },
+        fix(fixer) {
+            const previousToken = sourceCode.getTokenBefore(culpritToken);
+            const afterToken = sourceCode.getTokenAfter(culpritToken);
+            let fixString = "";
+
+            if (culpritToken.range[0] - previousToken.range[1] === 0) {
+                fixString = " ";
+            }
+
+            fixString += culpritToken.value;
+
+            if (afterToken.range[0] - culpritToken.range[1] === 0) {
+                fixString += " ";
+            }
+
+            return fixer.replaceText(culpritToken, fixString);
+        }
+    };
+}
+
+/**
+ * Check if the node is binary then report
+ * @param {SourceCode} sourceCode - sourceCode object of the file
+ * @param {ASTNode} node node to evaluate
+ * @param {boolean} int32Hint is int32Hint or not
+ * @returns {MessageDescriptor | null} descriptor A descriptor for the report from a rule.
+ * @public
+ */
+function checkBinary({ sourceCode, node, int32Hint }) {
+    const leftNode = (node.left.typeAnnotation) ? node.left.typeAnnotation : node.left;
+    const rightNode = node.right;
+
+    // search for = in AssignmentPattern nodes
+    const operator = node.operator || "=";
+
+    const nonSpacedNode = getFirstNonSpacedToken({
+        sourceCode,
+        left: leftNode,
+        right: rightNode,
+        op: operator
+    });
+
+    if (
+        nonSpacedNode &&
+        !(int32Hint && sourceCode.getText(node).endsWith("|0"))
+    ) {
+        return getDescriptor({
+            sourceCode,
+            mainNode: node,
+            culpritToken: nonSpacedNode
+        });
+    }
+    return null;
+}
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -40,96 +132,39 @@ module.exports = {
         const sourceCode = context.getSourceCode();
 
         /**
-         * Returns the first token which violates the rule
-         * @param {ASTNode} left - The left node of the main node
-         * @param {ASTNode} right - The right node of the main node
-         * @param {string} op - The operator of the main node
-         * @returns {Object} The violator token or null
-         * @private
-         */
-        function getFirstNonSpacedToken(left, right, op) {
-            const operator = sourceCode.getFirstTokenBetween(left, right, token => token.value === op);
-            const prev = sourceCode.getTokenBefore(operator);
-            const next = sourceCode.getTokenAfter(operator);
-
-            if (!sourceCode.isSpaceBetweenTokens(prev, operator) || !sourceCode.isSpaceBetweenTokens(operator, next)) {
-                return operator;
-            }
-
-            return null;
-        }
-
-        /**
-         * Reports an AST node as a rule violation
-         * @param {ASTNode} mainNode - The node to report
-         * @param {Object} culpritToken - The token which has a problem
-         * @returns {void}
-         * @private
-         */
-        function report(mainNode, culpritToken) {
-            context.report({
-                node: mainNode,
-                loc: culpritToken.loc.start,
-                message: "Operator '{{operator}}' must be spaced.",
-                data: {
-                    operator: culpritToken.value
-                },
-                fix(fixer) {
-                    const previousToken = sourceCode.getTokenBefore(culpritToken);
-                    const afterToken = sourceCode.getTokenAfter(culpritToken);
-                    let fixString = "";
-
-                    if (culpritToken.range[0] - previousToken.range[1] === 0) {
-                        fixString = " ";
-                    }
-
-                    fixString += culpritToken.value;
-
-                    if (afterToken.range[0] - culpritToken.range[1] === 0) {
-                        fixString += " ";
-                    }
-
-                    return fixer.replaceText(culpritToken, fixString);
-                }
-            });
-        }
-
-        /**
-         * Check if the node is binary then report
-         * @param {ASTNode} node node to evaluate
-         * @returns {void}
-         * @private
-         */
-        function checkBinary(node) {
-            const leftNode = (node.left.typeAnnotation) ? node.left.typeAnnotation : node.left;
-            const rightNode = node.right;
-
-            // search for = in AssignmentPattern nodes
-            const operator = node.operator || "=";
-
-            const nonSpacedNode = getFirstNonSpacedToken(leftNode, rightNode, operator);
-
-            if (nonSpacedNode) {
-                if (!(int32Hint && sourceCode.getText(node).endsWith("|0"))) {
-                    report(node, nonSpacedNode);
-                }
-            }
-        }
-
-        /**
          * Check if the node is conditional
          * @param {ASTNode} node node to evaluate
          * @returns {void}
          * @private
          */
         function checkConditional(node) {
-            const nonSpacedConsequesntNode = getFirstNonSpacedToken(node.test, node.consequent, "?");
-            const nonSpacedAlternateNode = getFirstNonSpacedToken(node.consequent, node.alternate, ":");
+            const nonSpacedConsequesntNode = getFirstNonSpacedToken({
+                sourceCode,
+                left: node.test,
+                right: node.consequent,
+                op: "?"
+            });
+            const nonSpacedAlternateNode = getFirstNonSpacedToken({
+                sourceCode,
+                left: node.consequent,
+                right: node.alternate,
+                op: ":"
+            });
 
             if (nonSpacedConsequesntNode) {
-                report(node, nonSpacedConsequesntNode);
+                context.report(getDescriptor({
+                    context,
+                    sourceCode,
+                    mainNode: node,
+                    culpritToken: nonSpacedConsequesntNode
+                }));
             } else if (nonSpacedAlternateNode) {
-                report(node, nonSpacedAlternateNode);
+                context.report(getDescriptor({
+                    context,
+                    sourceCode,
+                    mainNode: node,
+                    culpritToken: nonSpacedAlternateNode
+                }));
             }
         }
 
@@ -144,22 +179,49 @@ module.exports = {
             const rightNode = node.init;
 
             if (rightNode) {
-                const nonSpacedNode = getFirstNonSpacedToken(leftNode, rightNode, "=");
+                const nonSpacedNode = getFirstNonSpacedToken({
+                    sourceCode,
+                    left: leftNode,
+                    right: rightNode,
+                    op: "="
+                });
 
                 if (nonSpacedNode) {
-                    report(node, nonSpacedNode);
+                    context.report(getDescriptor({
+                        context,
+                        sourceCode,
+                        mainNode: node,
+                        culpritToken: nonSpacedNode
+                    }));
                 }
             }
         }
 
+        /**
+         * Check if the node is binary then report
+         * @param {ASTNode} node node to evaluate
+         * @param {boolean} int32Hint is int32Hint or not
+         * @returns {void}
+         * @private
+         */
+        function checkBinaryImpl(node) {
+            const descriptor = checkBinary({ sourceCode, node, int32Hint });
+
+            if (descriptor !== null) {
+                context.report(descriptor);
+            }
+        }
+
         return {
-            AssignmentExpression: checkBinary,
-            AssignmentPattern: checkBinary,
-            BinaryExpression: checkBinary,
-            LogicalExpression: checkBinary,
+            AssignmentExpression: checkBinaryImpl,
+            AssignmentPattern: checkBinaryImpl,
+            BinaryExpression: checkBinaryImpl,
+            LogicalExpression: checkBinaryImpl,
             ConditionalExpression: checkConditional,
             VariableDeclarator: checkVar
         };
 
     }
 };
+
+module.exports.checkBinary = checkBinary;


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What rule do you want to change?**
`space-infix-ops`

**Does this change cause the rule to produce more or fewer warnings?**
No, it's just a refactoring

**How will the change be implemented? (New option, new default behavior, etc.)?**
N/A

**Please provide some example code that this change will affect:**
N/A

**What does the rule currently do for this code?**
N/A

**What will the rule do after it's changed?**
N/A

**What changes did you make? (Give an overview)**
Export the `checkBinary` function by moving `getFirstNonSpacedToken`, `report` and `checkBinary` outside the closure.

The benefit (only one):
1. (Major) TSLint is migrated to eslint now, and there are quite a few eslint rules need to be tweaked very little to be a tslint equivalent rule. For example, it will be natural to check the `type A=number` to have space around "=" in typescript in this rule. And this rule probably should be in `typescript-eslint` instead of in `eslint`. However, due to the reason of the closure, a new rule need to copy and paste large amount of codes which is not a good sign. see https://github.com/typescript-eslint/typescript-eslint/issues/664
2. (Minor) Instead of creating three functions for every file, one function is created only! Which should increase the runtime performance and decrease the memory usage by very little.😂

**Is there anything you'd like reviewers to focus on?**
The refactoring, thanks.

