### PR TITLE
New: Fix for "no-useless-constructor" (fixes #11693)

### DIFF
--- a/lib/rules/no-useless-constructor.js
+++ b/lib/rules/no-useless-constructor.js
@@ -151,6 +151,8 @@ module.exports = {
             url: "https://eslint.org/docs/rules/no-useless-constructor"
         },
 
+        fixable: "code",
+
         schema: []
     },
 
@@ -173,7 +175,10 @@ module.exports = {
             if (superClass ? isRedundantSuperCall(body, ctorParams) : (body.length === 0)) {
                 context.report({
                     node,
-                    message: "Useless constructor."
+                    message: "Useless constructor.",
+                    fix(fixer) {
+                        return fixer.remove(node);
+                    }
                 });
             }
         }

--- a/tests/lib/rules/no-useless-constructor.js
+++ b/tests/lib/rules/no-useless-constructor.js
@@ -41,38 +41,47 @@ ruleTester.run("no-useless-constructor", rule, {
     invalid: [
         {
             code: "class A { constructor(){} }",
+            output: "class A {  }",
             errors: [error]
         },
         {
             code: "class A { 'constructor'(){} }",
+            output: "class A {  }",
             errors: [error]
         },
         {
             code: "class A extends B { constructor() { super(); } }",
+            output: "class A extends B {  }",
             errors: [error]
         },
         {
             code: "class A extends B { constructor(foo){ super(foo); } }",
+            output: "class A extends B {  }",
             errors: [error]
         },
         {
             code: "class A extends B { constructor(foo, bar){ super(foo, bar); } }",
+            output: "class A extends B {  }",
             errors: [error]
         },
         {
             code: "class A extends B { constructor(...args){ super(...args); } }",
+            output: "class A extends B {  }",
             errors: [error]
         },
         {
             code: "class A extends B.C { constructor() { super(...arguments); } }",
+            output: "class A extends B.C {  }",
             errors: [error]
         },
         {
             code: "class A extends B { constructor(a, b, ...c) { super(...arguments); } }",
+            output: "class A extends B {  }",
             errors: [error]
         },
         {
             code: "class A extends B { constructor(a, b, ...c) { super(a, b, ...c); } }",
+            output: "class A extends B {  }",
             errors: [error]
         }
     ]


### PR DESCRIPTION
Adding a fixer for the "no-useless-constructor" which removes the (by definition) useless node.

<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[X] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

I added a fixer for the "no-useless-constructor" which removes the (by definition) useless node.

**Is there anything you'd like reviewers to focus on?**

The whitespace in the tests is a bit funky, not sure if there's a more elegant way to detect the double space and tidy up? Or if that's another rule's job?
