### PR TITLE
Chore: Add temporary test files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ versions.json
 .eslint-release-info.json
 .nyc_output
 /test-results.xml
+.temp-eslintcache
+/tests/fixtures/autofix-integration/temp.js


### PR DESCRIPTION
[X] Other, please explain:

These temporary files are being created during `npm test`, and could be accidentally committed:

* `.temp-eslintcache` created in `tests/bin/eslint.js` in `describe("cache files")`
* `tests/fixtures/autofix-integration/temp.js` created in `tests/bin/eslint.js` in `describe("automatically fixing files")`

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Added both to .gitignore

**Is there anything you'd like reviewers to focus on?**

Line endings, I got `LF will be replaced by CRLF` warning.


