### PR TITLE
Fix: no-new-wrappers reports only wrappers

### DIFF
--- a/lib/rules/no-new-wrappers.js
+++ b/lib/rules/no-new-wrappers.js
@@ -28,7 +28,7 @@ module.exports = {
         return {
 
             NewExpression(node) {
-                const wrapperObjects = ["String", "Number", "Boolean", "Math", "JSON"];
+                const wrapperObjects = ["String", "Number", "Boolean"];
 
                 if (wrapperObjects.indexOf(node.callee.name) > -1) {
                     context.report({ node, message: "Do not use {{fn}} as a constructor.", data: { fn: node.callee.name } });

--- a/tests/lib/rules/no-new-wrappers.js
+++ b/tests/lib/rules/no-new-wrappers.js
@@ -26,8 +26,6 @@ ruleTester.run("no-new-wrappers", rule, {
     invalid: [
         { code: "var a = new String('hello');", errors: [{ message: "Do not use String as a constructor.", type: "NewExpression" }] },
         { code: "var a = new Number(10);", errors: [{ message: "Do not use Number as a constructor.", type: "NewExpression" }] },
-        { code: "var a = new Boolean(false);", errors: [{ message: "Do not use Boolean as a constructor.", type: "NewExpression" }] },
-        { code: "var a = new Math();", errors: [{ message: "Do not use Math as a constructor.", type: "NewExpression" }] },
-        { code: "var a = new JSON({ myProp: 10 });", errors: [{ message: "Do not use JSON as a constructor.", type: "NewExpression" }] }
+        { code: "var a = new Boolean(false);", errors: [{ message: "Do not use Boolean as a constructor.", type: "NewExpression" }] }
     ]
 });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix

**Tell us about your environment**

* **ESLint Version:** 6.0.1
* **Node Version:** 12.2.0
* **npm Version:** 6.9.2

**What parser (default, Babel-ESLint, etc.) are you using?**

Default.

**Please show your full configuration:**
**What did you do? Please include the actual source code causing the issue.**

```js
new Math
new JSON
```

```
> eslint test.js --no-eslintrc --no-ignore --rule "no-new-wrappers:error"
```

**What did you expect to happen?**

No errors because those are not wrappers.

**What actually happened? Please include the actual, raw output from ESLint.**

```
~\dev\eslint\test.js
  1:1  error  Do not use Math as a constructor  no-new-wrappers
  2:1  error  Do not use JSON as a constructor  no-new-wrappers

✖ 2 problems (2 errors, 0 warnings)
```

**What changes did you make? (Give an overview)**

This PR makes `no-new-wrappers` reporting only wrappers.

I guess that `no-obj-calls` rule is a more proper place to report it.

**Is there anything you'd like reviewers to focus on?**

Is this direction correct?
