### PR TITLE
Docs: Fixed a typo (fixes #11999)

### DIFF
--- a/docs/rules/no-duplicate-imports.md
+++ b/docs/rules/no-duplicate-imports.md
@@ -12,7 +12,7 @@ import { find } from 'module';
 
 ## Rule Details
 
-This rules requires that all imports from a single module exists in a single `import` statement.
+This rule requires that all imports from a single module exists in a single `import` statement.
 
 Example of **incorrect** code for this rule:
 


### PR DESCRIPTION
I adjusted a typo to match the description format of found in the Options section.

> _This rule_ takes one optional argument ...