### PR TITLE
Docs: Fix incorrect example for max-depth rule (#11991)

### DIFF
--- a/docs/rules/max-depth.md
+++ b/docs/rules/max-depth.md
@@ -20,18 +20,17 @@ Examples of **incorrect** code for this rule with the default `{ "max": 4 }` opt
 
 ```js
 /*eslint max-depth: ["error", 4]*/
-/*eslint-env es6*/
 
 function foo() {
     for (;;) { // Nested 1 deep
-        let val = () => (param) => { // Nested 2 deep
+        while (true) { // Nested 2 deep
             if (true) { // Nested 3 deep
                 if (true) { // Nested 4 deep
                     if (true) { // Nested 5 deep
                     }
                 }
             }
-        };
+        }
     }
 }
 ```
@@ -40,16 +39,15 @@ Examples of **correct** code for this rule with the default `{ "max": 4 }` optio
 
 ```js
 /*eslint max-depth: ["error", 4]*/
-/*eslint-env es6*/
 
 function foo() {
     for (;;) { // Nested 1 deep
-        let val = () => (param) => { // Nested 2 deep
-           if (true) { // Nested 3 deep
+        while (true) { // Nested 2 deep
+            if (true) { // Nested 3 deep
                 if (true) { // Nested 4 deep
                 }
             }
-        };
+        }
     }
 }
 ```


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Documentation update

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Modified examples to reflect the current implementation: replaced an arrow function with a while loop because a function expression doesn't increase the depth count.

**Is there anything you'd like reviewers to focus on?**


