### PR TITLE
New: function-call-argument-newline rule (fixes #10323)

### DIFF
--- a/docs/rules/function-call-argument-newline.md
+++ b/docs/rules/function-call-argument-newline.md
@@ -1,0 +1,202 @@
+# enforce line breaks between arguments of a function call (function-call-argument-newline)
+
+A number of style guides require or disallow line breaks between arguments of a function call.
+
+## Rule Details
+
+This rule enforces line breaks between arguments of a function call.
+
+## Options
+
+This rule has a string option:
+
+* `"always"` (default) requires line breaks between arguments
+* `"never"` disallows line breaks between arguments
+* `"consistent"` requires consistent usage of line breaks between arguments
+
+
+### always
+
+Examples of **incorrect** code for this rule with the default `"always"` option:
+
+```js
+/*eslint function-call-argument-newline: ["error", "always"]*/
+
+foo("one", "two", "three");
+
+bar("one", "two", {
+    one: 1,
+    two: 2
+});
+
+baz("one", "two", (x) => {
+    console.log(x);
+});
+```
+
+Examples of **correct** code for this rule with the default `"always"` option:
+
+```js
+/*eslint function-call-argument-newline: ["error", "always"]*/
+
+foo(
+    "one",
+    "two",
+    "three"
+);
+
+bar(
+    "one",
+    "two",
+    { one: 1, two: 2 }
+);
+// or
+bar(
+    "one",
+    "two",
+    {
+        one: 1,
+        two: 2
+    }
+);
+
+baz(
+    "one",
+    "two",
+    (x) => {
+        console.log(x);
+    }
+);
+```
+
+
+### never
+
+Examples of **incorrect** code for this rule with the default `"never"` option:
+
+```js
+/*eslint function-call-argument-newline: ["error", "never"]*/
+
+foo(
+    "one",
+    "two", "three"
+);
+
+bar(
+    "one",
+    "two", {
+        one: 1,
+        two: 2
+    }
+);
+
+baz(
+    "one",
+    "two", (x) => {
+        console.log(x);
+    }
+);
+```
+
+Examples of **correct** code for this rule with the `"never"` option:
+
+```js
+/*eslint function-call-argument-newline: ["error", "never"]*/
+
+foo("one", "two", "three");
+// or
+foo(
+    "one", "two", "three"
+);
+
+bar("one", "two", { one: 1, two: 2 });
+// or
+bar("one", "two", {
+    one: 1,
+    two: 2
+});
+
+baz("one", "two", (x) => {
+    console.log(x);
+});
+```
+
+### consistent
+
+Examples of **incorrect** code for this rule with the default `"consistent"` option:
+
+```js
+/*eslint function-call-argument-newline: ["error", "consistent"]*/
+
+foo("one", "two",
+    "three");
+//or
+foo("one",
+    "two", "three");
+
+bar("one", "two",
+    { one: 1, two: 2}
+);
+
+baz("one", "two",
+    (x) => { console.log(x); }
+);
+```
+
+Examples of **correct** code for this rule with the default `"consistent"` option:
+
+```js
+/*eslint function-call-argument-newline: ["error", "consistent"]*/
+
+foo("one", "two", "three");
+// or
+foo(
+    "one",
+    "two",
+    "three"
+);
+
+bar("one", "two", {
+    one: 1,
+    two: 2
+});
+// or
+bar(
+    "one",
+    "two",
+    { one: 1, two: 2 }
+);
+// or
+bar(
+    "one",
+    "two",
+    {
+        one: 1,
+        two: 2
+    }
+);
+
+baz("one", "two", (x) => {
+    console.log(x);
+});
+// or
+baz(
+    "one",
+    "two",
+    (x) => {
+        console.log(x);
+    }
+);
+```
+
+
+## When Not To Use It
+
+If you don't want to enforce line breaks between arguments, don't enable this rule.
+
+## Related Rules
+
+* [function-paren-newline](function-paren-newline.md)
+* [func-call-spacing](func-call-spacing.md)
+* [object-property-newline](object-property-newline.md)
+* [array-element-newline](array-element-newline.md)

--- a/lib/rules/function-call-argument-newline.js
+++ b/lib/rules/function-call-argument-newline.js
@@ -1,0 +1,120 @@
+/**
+ * @fileoverview Rule to enforce line breaks between arguments of a function call
+ * @author Alexey Gonchar <https://github.com/finico>
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+    meta: {
+        type: "layout",
+
+        docs: {
+            description: "enforce line breaks between arguments of a function call",
+            category: "Stylistic Issues",
+            recommended: false,
+            url: "https://eslint.org/docs/rules/function-call-argument-newline"
+        },
+
+        fixable: "whitespace",
+
+        schema: [
+            {
+                enum: ["always", "never", "consistent"]
+            }
+        ],
+
+        messages: {
+            unexpectedLineBreak: "There should be no line break here.",
+            missingLineBreak: "There should be a line break after this argument."
+        }
+    },
+
+    create(context) {
+        const sourceCode = context.getSourceCode();
+
+        const checkers = {
+            unexpected: {
+                messageId: "unexpectedLineBreak",
+                check: (prevToken, currentToken) => prevToken.loc.start.line !== currentToken.loc.start.line,
+                createFix: (token, tokenBefore) => fixer =>
+                    fixer.replaceTextRange([tokenBefore.range[1], token.range[0]], " ")
+            },
+            missing: {
+                messageId: "missingLineBreak",
+                check: (prevToken, currentToken) => prevToken.loc.start.line === currentToken.loc.start.line,
+                createFix: (token, tokenBefore) => fixer =>
+                    fixer.replaceTextRange([tokenBefore.range[1], token.range[0]], "\n")
+            }
+        };
+
+        /**
+         * Check all arguments for line breaks in the CallExpression
+         * @param {CallExpression} node node to evaluate
+         * @param {{ messageId: string, check: Function }} checker selected checker
+         * @returns {void}
+         * @private
+         */
+        function checkArguments(node, checker) {
+            for (let i = 1; i < node.arguments.length; i++) {
+                const prevArgToken = sourceCode.getFirstToken(node.arguments[i - 1]);
+                const currentArgToken = sourceCode.getFirstToken(node.arguments[i]);
+
+                if (checker.check(prevArgToken, currentArgToken)) {
+                    const tokenBefore = sourceCode.getTokenBefore(
+                        currentArgToken,
+                        { includeComments: true }
+                    );
+
+                    context.report({
+                        node,
+                        loc: {
+                            start: tokenBefore.loc.end,
+                            end: currentArgToken.loc.start
+                        },
+                        messageId: checker.messageId,
+                        fix: checker.createFix(currentArgToken, tokenBefore)
+                    });
+                }
+            }
+        }
+
+        /**
+         * Check if open space is present in a function name
+         * @param {CallExpression} node node to evaluate
+         * @returns {void}
+         * @private
+         */
+        function check(node) {
+            if (node.arguments.length < 2) {
+                return;
+            }
+
+            const option = context.options[0] || "always";
+
+            if (option === "never") {
+                checkArguments(node, checkers.unexpected);
+            } else if (option === "always") {
+                checkArguments(node, checkers.missing);
+            } else if (option === "consistent") {
+                const firstArgToken = sourceCode.getFirstToken(node.arguments[0]);
+                const secondArgToken = sourceCode.getFirstToken(node.arguments[1]);
+
+                if (firstArgToken.loc.start.line === secondArgToken.loc.start.line) {
+                    checkArguments(node, checkers.unexpected);
+                } else {
+                    checkArguments(node, checkers.missing);
+                }
+            }
+        }
+
+        return {
+            CallExpression: check,
+            NewExpression: check
+        };
+    }
+};

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -46,6 +46,7 @@ module.exports = new LazyLoadingRuleMap(Object.entries({
     "func-name-matching": () => require("./func-name-matching"),
     "func-names": () => require("./func-names"),
     "func-style": () => require("./func-style"),
+    "function-call-argument-newline": () => require("./function-call-argument-newline"),
     "function-paren-newline": () => require("./function-paren-newline"),
     "generator-star-spacing": () => require("./generator-star-spacing"),
     "getter-return": () => require("./getter-return"),

--- a/tests/lib/rules/function-call-argument-newline.js
+++ b/tests/lib/rules/function-call-argument-newline.js
@@ -1,0 +1,386 @@
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../lib/rules/function-call-argument-newline"),
+    { RuleTester } = require("../../../lib/rule-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("function-call-argument-newline", rule, {
+    valid: [
+
+        /* early return */
+        "fn()",
+        "fn(a)",
+        "new Foo()",
+        "new Foo(b)",
+
+        /* default ("always") */
+        "fn(a,\n\tb)",
+
+        /* "always" */
+        { code: "fn(a,\n\tb)", options: ["always"] },
+        { code: "fn(\n\ta,\n\tb\n)", options: ["always"] },
+        { code: "fn(\n\ta,\n\tb,\n\tc\n)", options: ["always"] },
+        {
+            code: "fn(\n\ta,\n\tb,\n\t[\n\t\t1,\n\t\t2\n\t]\n)",
+            options: ["always"]
+        },
+        {
+            code: "fn(\n\ta,\n\tb,\n\t{\n\t\ta: 1,\n\t\tb: 2\n\t}\n)",
+            options: ["always"]
+        },
+        {
+            code: "fn(\n\ta,\n\tb,\n\tfunction (x) {\n\t\tx()\n\t}\n)",
+            options: ["always"]
+        },
+        {
+            code: "fn(\n\ta,\n\tb,\n\tx => {\n\t\tx()\n\t}\n)",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 6 }
+        },
+
+        /* "never" */
+        { code: "fn(a, b)", options: ["never"] },
+        { code: "fn(\n\ta, b\n)", options: ["never"] },
+        { code: "fn(a, b, c)", options: ["never"] },
+        { code: "fn(a, b, [\n\t1,\n\t2\n])", options: ["never"] },
+        { code: "fn(a, b, {\n\ta: 1,\n\tb: 2\n})", options: ["never"] },
+        { code: "fn(a, b, function (x) {\n\tx()\n})", options: ["never"] },
+        {
+            code: "fn(a, b, x => {\n\tx()\n})",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 6 }
+        },
+
+        /* "consistent" */
+        { code: "fn(a, b, c)", options: ["consistent"] },
+        { code: "fn(a,\n\tb,\n\tc)", options: ["consistent"] }
+    ],
+    invalid: [
+
+        /* default ("always") */
+        {
+            code: "fn(a, b)",
+            output: "fn(a,\nb)",
+            errors: [
+                {
+                    messageId: "missingLineBreak",
+                    line: 1,
+                    column: 6,
+                    endLine: 1,
+                    endColumn: 7
+                }
+            ]
+        },
+
+        /* "always" */
+        {
+            code: "fn(a, b)",
+            output: "fn(a,\nb)",
+            options: ["always"],
+            errors: [
+                {
+                    messageId: "missingLineBreak",
+                    line: 1,
+                    column: 6,
+                    endLine: 1,
+                    endColumn: 7
+                }
+            ]
+        },
+        {
+            code: "fn(a, b, c)",
+            output: "fn(a,\nb,\nc)",
+            options: ["always"],
+            errors: [
+                {
+                    messageId: "missingLineBreak",
+                    line: 1,
+                    column: 6,
+                    endLine: 1,
+                    endColumn: 7
+                },
+                {
+                    messageId: "missingLineBreak",
+                    line: 1,
+                    column: 9,
+                    endLine: 1,
+                    endColumn: 10
+                }
+            ]
+        },
+        {
+            code: "fn(a, b, [\n\t1,\n\t2\n])",
+            output: "fn(a,\nb,\n[\n\t1,\n\t2\n])",
+            options: ["always"],
+            errors: [
+                {
+                    messageId: "missingLineBreak",
+                    line: 1,
+                    column: 6,
+                    endLine: 1,
+                    endColumn: 7
+                },
+                {
+                    messageId: "missingLineBreak",
+                    line: 1,
+                    column: 9,
+                    endLine: 1,
+                    endColumn: 10
+                }
+            ]
+        },
+        {
+            code: "fn(a, b, {\n\ta: 1,\n\tb: 2\n})",
+            output: "fn(a,\nb,\n{\n\ta: 1,\n\tb: 2\n})",
+            options: ["always"],
+            errors: [
+                {
+                    messageId: "missingLineBreak",
+                    line: 1,
+                    column: 6,
+                    endLine: 1,
+                    endColumn: 7
+                },
+                {
+                    messageId: "missingLineBreak",
+                    line: 1,
+                    column: 9,
+                    endLine: 1,
+                    endColumn: 10
+                }
+            ]
+        },
+        {
+            code: "fn(a, b, function (x) {\n\tx()\n})",
+            output: "fn(a,\nb,\nfunction (x) {\n\tx()\n})",
+            options: ["always"],
+            errors: [
+                {
+                    messageId: "missingLineBreak",
+                    line: 1,
+                    column: 6,
+                    endLine: 1,
+                    endColumn: 7
+                },
+                {
+                    messageId: "missingLineBreak",
+                    line: 1,
+                    column: 9,
+                    endLine: 1,
+                    endColumn: 10
+                }
+            ]
+        },
+        {
+            code: "fn(a, b, x => {\n\tx()\n})",
+            output: "fn(a,\nb,\nx => {\n\tx()\n})",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "missingLineBreak",
+                    line: 1,
+                    column: 6,
+                    endLine: 1,
+                    endColumn: 7
+                },
+                {
+                    messageId: "missingLineBreak",
+                    line: 1,
+                    column: 9,
+                    endLine: 1,
+                    endColumn: 10
+                }
+            ]
+        },
+
+        /* "never" */
+        {
+            code: "fn(a,\n\tb)",
+            output: "fn(a, b)",
+            options: ["never"],
+            errors: [
+                {
+                    messageId: "unexpectedLineBreak",
+                    line: 1,
+                    column: 6,
+                    endLine: 2,
+                    endColumn: 2
+                }
+            ]
+        },
+        {
+            code: "fn(a,\n\tb,\n\tc)",
+            output: "fn(a, b, c)",
+            options: ["never"],
+            errors: [
+                {
+                    messageId: "unexpectedLineBreak",
+                    line: 1,
+                    column: 6,
+                    endLine: 2,
+                    endColumn: 2
+                },
+                {
+                    messageId: "unexpectedLineBreak",
+                    line: 2,
+                    column: 4,
+                    endLine: 3,
+                    endColumn: 2
+                }
+            ]
+        },
+        {
+            code: "fn(a,\n\tb,\n\t[\n\t\t1,\n\t\t2\n])",
+            output: "fn(a, b, [\n\t\t1,\n\t\t2\n])",
+            options: ["never"],
+            errors: [
+                {
+                    messageId: "unexpectedLineBreak",
+                    line: 1,
+                    column: 6,
+                    endLine: 2,
+                    endColumn: 2
+                },
+                {
+                    messageId: "unexpectedLineBreak",
+                    line: 2,
+                    column: 4,
+                    endLine: 3,
+                    endColumn: 2
+                }
+            ]
+        },
+        {
+            code: "fn(a,\n\tb,\n\t{\n\t\ta: 1,\n\t\tb: 2\n})",
+            output: "fn(a, b, {\n\t\ta: 1,\n\t\tb: 2\n})",
+            options: ["never"],
+            errors: [
+                {
+                    messageId: "unexpectedLineBreak",
+                    line: 1,
+                    column: 6,
+                    endLine: 2,
+                    endColumn: 2
+                },
+                {
+                    messageId: "unexpectedLineBreak",
+                    line: 2,
+                    column: 4,
+                    endLine: 3,
+                    endColumn: 2
+                }
+            ]
+        },
+        {
+            code: "fn(a,\n\tb,\n\tfunction (x) {\n\t\tx()\n})",
+            output: "fn(a, b, function (x) {\n\t\tx()\n})",
+            options: ["never"],
+            errors: [
+                {
+                    messageId: "unexpectedLineBreak",
+                    line: 1,
+                    column: 6,
+                    endLine: 2,
+                    endColumn: 2
+                },
+                {
+                    messageId: "unexpectedLineBreak",
+                    line: 2,
+                    column: 4,
+                    endLine: 3,
+                    endColumn: 2
+                }
+            ]
+        },
+        {
+            code: "fn(a,\n\tb,\n\tx => {\n\t\tx()\n})",
+            output: "fn(a, b, x => {\n\t\tx()\n})",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "unexpectedLineBreak",
+                    line: 1,
+                    column: 6,
+                    endLine: 2,
+                    endColumn: 2
+                },
+                {
+                    messageId: "unexpectedLineBreak",
+                    line: 2,
+                    column: 4,
+                    endLine: 3,
+                    endColumn: 2
+                }
+            ]
+        },
+
+        /* "consistent" */
+        {
+            code: "fn(a, b,\n\tc)",
+            output: "fn(a, b, c)",
+            options: ["consistent"],
+            errors: [
+                {
+                    messageId: "unexpectedLineBreak",
+                    line: 1,
+                    column: 9,
+                    endLine: 2,
+                    endColumn: 2
+                }
+            ]
+        },
+        {
+            code: "fn(a,\n\tb, c)",
+            output: "fn(a,\n\tb,\nc)",
+            options: ["consistent"],
+            errors: [
+                {
+                    messageId: "missingLineBreak",
+                    line: 2,
+                    column: 4,
+                    endLine: 2,
+                    endColumn: 5
+                }
+            ]
+        },
+        {
+            code: "fn(a,\n\tb /* comment */, c)",
+            output: "fn(a,\n\tb /* comment */,\nc)",
+            options: ["consistent"],
+            errors: [
+                {
+                    messageId: "missingLineBreak",
+                    line: 2,
+                    column: 18,
+                    endLine: 2,
+                    endColumn: 19
+                }
+            ]
+        },
+        {
+            code: "fn(a,\n\tb, /* comment */ c)",
+            output: "fn(a,\n\tb, /* comment */\nc)",
+            options: ["consistent"],
+            errors: [
+                {
+                    messageId: "missingLineBreak",
+                    line: 2,
+                    column: 18,
+                    endLine: 2,
+                    endColumn: 19
+                }
+            ]
+        }
+    ]
+});

--- a/tools/rule-types.json
+++ b/tools/rule-types.json
@@ -33,6 +33,7 @@
     "func-name-matching": "suggestion",
     "func-names": "suggestion",
     "func-style": "suggestion",
+    "function-call-argument-newline": "layout",
     "function-paren-newline": "layout",
     "generator-star-spacing": "layout",
     "getter-return": "problem",


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[x] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**What category of rule is this? (place an "X" next to just one item)**

[x] Enforces code style
[ ] Warns about a potential error
[ ] Suggests an alternate way of doing something
[ ] Other (please specify:)

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
All information about this rule in #10323 

**Is there anything you'd like reviewers to focus on?**
I didn't add indentations in fixers. But I've checked other rules and they don't do it as well..