### PR TITLE
Fix: exclude `\u000d` so new line won't convert to text (fixes #12027)

### DIFF
--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -130,7 +130,7 @@ function freezeDeeply(x) {
  */
 function sanitize(text) {
     return text.replace(
-        /[\u0000-\u001f]/gu, // eslint-disable-line no-control-regex
+        /[\u0000-\u0009|\u000b-\u001a]/gu, // eslint-disable-line no-control-regex
         c => `\\u${c.codePointAt(0).toString(16).padStart(4, "0")}`
     );
 }

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -325,8 +325,7 @@ describe("RuleTester", () => {
                 ],
                 invalid: [
                     {
-                        code: `var foo = bar;
-var qux = boop;`,
+                        code: "var foo = bar; var qux = boop;",
                         output: null,
                         errors: 2
                     }

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -324,7 +324,12 @@ describe("RuleTester", () => {
                     "bar = baz;"
                 ],
                 invalid: [
-                    { code: "var foo = bar; var qux = boop;", output: null, errors: 2 }
+                    {
+                        code: `var foo = bar;
+var qux = boop;`,
+                        output: null,
+                        errors: 2
+                    }
                 ]
             });
         }, /Expected no autofixes to be suggested/u);
@@ -1071,5 +1076,53 @@ describe("RuleTester", () => {
                 }
             );
         }, /A fatal parsing error occurred in autofix/u);
+    });
+
+    describe("sanitize test cases", () => {
+        let originalRuleTesterIt;
+        let spyRuleTesterIt;
+
+        before(() => {
+            originalRuleTesterIt = RuleTester.it;
+            spyRuleTesterIt = sinon.spy();
+            RuleTester.it = spyRuleTesterIt;
+        });
+        after(() => {
+            RuleTester.it = originalRuleTesterIt;
+        });
+        beforeEach(() => {
+            spyRuleTesterIt.resetHistory();
+            ruleTester = new RuleTester();
+        });
+        it("should present newline when using back-tick as new line", () => {
+            const code = `
+            var foo = bar;`;
+
+            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+                valid: [],
+                invalid: [
+                    {
+                        code,
+                        errors: [/^Bad var/u]
+                    }
+                ]
+            });
+            sinon.assert.calledWith(spyRuleTesterIt, code);
+        });
+        it("should present \\u0000 as a string", () => {
+            const code = "\u0000";
+
+            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+                valid: [],
+                invalid: [
+                    {
+                        code,
+                        errors: [/^Bad var/u]
+                    }
+                ]
+            });
+            sinon.assert.calledWith(spyRuleTesterIt, "\\u0000");
+        });
+
     });
 });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

https://github.com/eslint/eslint/issues/12027

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make?**
I remove an unnecessary `\u000d` so that a new line will show properly.  


**Is there anything you'd like reviewers to focus on?**


