### PR TITLE
Update: auto-fix global strict mode (fixes #12034)

### DIFF
--- a/docs/rules/strict.md
+++ b/docs/rules/strict.md
@@ -49,7 +49,7 @@ This rule disallows strict mode directives, no matter which option is specified,
 
 This rule disallows strict mode directives, no matter which option is specified, in functions with non-simple parameter lists (for example, parameter lists with default parameter values) because that is a syntax error in **ECMAScript 2016** and later. See the examples of the [function](#function) option.
 
-The `--fix` option on the command line does not insert new `"use strict"` statements, but only removes unneeded statements.
+The `--fix` option on the command line inserts new `'use strict'` statements with the `"global"` option, but otherwise only removes unneeded statements.
 
 ## Options
 

--- a/lib/rules/strict.js
+++ b/lib/rules/strict.js
@@ -255,7 +255,7 @@ module.exports = {
                         context.report({
                             node,
                             messageId: "global",
-                            fix: fixer => fixer.insertTextBefore(node, "'use strict'; ")
+                            fix: fixer => fixer.insertTextBefore(node, "'use strict';\n")
                         });
                     }
                     reportAllExceptFirst(getUseStrictDirectives(node.body), "multiple", true);

--- a/lib/rules/strict.js
+++ b/lib/rules/strict.js
@@ -252,12 +252,10 @@ module.exports = {
 
                 if (mode === "global") {
                     if (node.body.length > 0 && useStrictDirectives.length === 0) {
-
-                        // We should only get here if the node is not strict.
                         context.report({
                             node,
                             messageId: "global",
-                            fix: fixer => fixer.insertTextBefore(context.getSourceCode().getFirstToken(node), "'use strict'; ")
+                            fix: fixer => fixer.insertTextBefore(node, "'use strict'; ")
                         });
                     }
                     reportAllExceptFirst(getUseStrictDirectives(node.body), "multiple", true);

--- a/lib/rules/strict.js
+++ b/lib/rules/strict.js
@@ -223,14 +223,21 @@ module.exports = {
                 useStrictDirectives = isBlock
                     ? getUseStrictDirectives(node.body.body) : [];
 
+            const isGlobal = mode === "global";
+
             if (mode === "function") {
                 enterFunctionInFunctionMode(node, useStrictDirectives);
             } else if (useStrictDirectives.length > 0) {
                 if (isSimpleParameterList(node.params)) {
-                    reportAll(useStrictDirectives, mode, shouldFix(mode));
+                    reportAll(useStrictDirectives, mode, shouldFix(mode) || isGlobal);
                 } else {
-                    context.report({ node: useStrictDirectives[0], messageId: "nonSimpleParameterList" });
-                    reportAllExceptFirst(useStrictDirectives, "multiple", true);
+                    context.report({
+                        node: useStrictDirectives[0],
+                        messageId: "nonSimpleParameterList",
+                        fix: getFixFunction(useStrictDirectives[0])
+                    });
+
+                    reportAllExceptFirst(useStrictDirectives, "multiple", shouldFix(mode) || isGlobal);
                 }
             }
         }
@@ -245,9 +252,15 @@ module.exports = {
 
                 if (mode === "global") {
                     if (node.body.length > 0 && useStrictDirectives.length === 0) {
-                        context.report({ node, messageId: "global" });
+
+                        // We should only get here if the node is not strict.
+                        context.report({
+                            node,
+                            messageId: "global",
+                            fix: fixer => fixer.insertTextBefore(context.getSourceCode().getFirstToken(node), "'use strict'; ")
+                        });
                     }
-                    reportAllExceptFirst(useStrictDirectives, "multiple", true);
+                    reportAllExceptFirst(getUseStrictDirectives(node.body), "multiple", true);
                 } else {
                     reportAll(useStrictDirectives, mode, shouldFix(mode));
                 }

--- a/tests/lib/cli-engine/cli-engine.js
+++ b/tests/lib/cli-engine/cli-engine.js
@@ -137,7 +137,7 @@ describe("CLIEngine", () => {
             assert.strictEqual(report.results.length, 1);
             assert.strictEqual(report.errorCount, 5);
             assert.strictEqual(report.warningCount, 0);
-            assert.strictEqual(report.fixableErrorCount, 3);
+            assert.strictEqual(report.fixableErrorCount, 4);
             assert.strictEqual(report.fixableWarningCount, 0);
             assert.strictEqual(report.results[0].messages.length, 5);
             assert.strictEqual(report.results[0].messages[0].ruleId, "strict");
@@ -145,7 +145,7 @@ describe("CLIEngine", () => {
             assert.strictEqual(report.results[0].messages[2].ruleId, "no-unused-vars");
             assert.strictEqual(report.results[0].messages[3].ruleId, "quotes");
             assert.strictEqual(report.results[0].messages[4].ruleId, "eol-last");
-            assert.strictEqual(report.results[0].fixableErrorCount, 3);
+            assert.strictEqual(report.results[0].fixableErrorCount, 4);
             assert.strictEqual(report.results[0].fixableWarningCount, 0);
         });
 
@@ -167,7 +167,7 @@ describe("CLIEngine", () => {
             assert.strictEqual(report.errorCount, 0);
             assert.strictEqual(report.warningCount, 5);
             assert.strictEqual(report.fixableErrorCount, 0);
-            assert.strictEqual(report.fixableWarningCount, 3);
+            assert.strictEqual(report.fixableWarningCount, 4);
             assert.strictEqual(report.results[0].messages.length, 5);
             assert.strictEqual(report.results[0].messages[0].ruleId, "strict");
             assert.strictEqual(report.results[0].messages[1].ruleId, "no-var");
@@ -175,7 +175,7 @@ describe("CLIEngine", () => {
             assert.strictEqual(report.results[0].messages[3].ruleId, "quotes");
             assert.strictEqual(report.results[0].messages[4].ruleId, "eol-last");
             assert.strictEqual(report.results[0].fixableErrorCount, 0);
-            assert.strictEqual(report.results[0].fixableWarningCount, 3);
+            assert.strictEqual(report.results[0].fixableWarningCount, 4);
         });
 
         it("should report one message when using specific config file", () => {
@@ -3714,7 +3714,7 @@ describe("CLIEngine", () => {
 
             assert.lengthOf(errorResults[0].messages, 5);
             assert.strictEqual(errorResults[0].errorCount, 5);
-            assert.strictEqual(errorResults[0].fixableErrorCount, 3);
+            assert.strictEqual(errorResults[0].fixableErrorCount, 4);
             assert.strictEqual(errorResults[0].fixableWarningCount, 0);
             assert.strictEqual(errorResults[0].messages[0].ruleId, "strict");
             assert.strictEqual(errorResults[0].messages[0].severity, 2);

--- a/tests/lib/rules/strict.js
+++ b/tests/lib/rules/strict.js
@@ -157,14 +157,14 @@ ruleTester.run("strict", rule, {
         // "global" mode
         {
             code: "foo();",
-            output: "'use strict'; foo();",
+            output: "'use strict';\nfoo();",
             options: ["global"],
             errors: [
                 { messageId: "global", type: "Program" }
             ]
         }, {
             code: "function foo() { 'use strict'; return; }",
-            output: "'use strict'; function foo() {  return; }",
+            output: "'use strict';\nfunction foo() {  return; }",
             options: ["global"],
             errors: [
                 { messageId: "global", type: "Program" },
@@ -172,7 +172,7 @@ ruleTester.run("strict", rule, {
             ]
         }, {
             code: "var foo = function() { 'use strict'; return; }",
-            output: "'use strict'; var foo = function() {  return; }",
+            output: "'use strict';\nvar foo = function() {  return; }",
             options: ["global"],
             errors: [
                 { messageId: "global", type: "Program" },
@@ -180,7 +180,7 @@ ruleTester.run("strict", rule, {
             ]
         }, {
             code: "var foo = () => { 'use strict'; return () => 1; }",
-            output: "'use strict'; var foo = () => {  return () => 1; }",
+            output: "'use strict';\nvar foo = () => {  return () => 1; }",
             options: ["global"],
             parserOptions: { ecmaVersion: 6 },
             errors: [
@@ -418,7 +418,7 @@ ruleTester.run("strict", rule, {
         },
         {
             code: "function foo() { 'use strict'; return; }",
-            output: "'use strict'; function foo() {  return; }",
+            output: "'use strict';\nfunction foo() {  return; }",
             options: ["safe"],
             parserOptions: { ecmaFeatures: { globalReturn: true } },
             errors: [
@@ -463,7 +463,7 @@ ruleTester.run("strict", rule, {
         },
         {
             code: "function foo() { 'use strict'; return; }",
-            output: "'use strict'; function foo() {  return; }",
+            output: "'use strict';\nfunction foo() {  return; }",
             parserOptions: { ecmaFeatures: { globalReturn: true } },
             errors: [
                 { messageId: "global", type: "Program" },
@@ -506,7 +506,7 @@ ruleTester.run("strict", rule, {
         },
         {
             code: "function foo(a = 0) { 'use strict' }",
-            output: "'use strict'; function foo(a = 0) {  }",
+            output: "'use strict';\nfunction foo(a = 0) {  }",
             options: [],
             parserOptions: { ecmaVersion: 6, ecmaFeatures: { globalReturn: true } },
             errors: [
@@ -530,7 +530,7 @@ ruleTester.run("strict", rule, {
         },
         {
             code: "function foo(a = 0) { 'use strict' }",
-            output: "'use strict'; function foo(a = 0) {  }",
+            output: "'use strict';\nfunction foo(a = 0) {  }",
             options: ["global"],
             parserOptions: { ecmaVersion: 6 },
             errors: [

--- a/tests/lib/rules/strict.js
+++ b/tests/lib/rules/strict.js
@@ -98,7 +98,7 @@ ruleTester.run("strict", rule, {
                 { messageId: "never", type: "ExpressionStatement" }
             ]
         }, {
-            code: "function foo() { 'use strict'; return; }",
+            code: "function foo() { 'use strict'; return }",
             output: null,
             options: ["never"],
             errors: [
@@ -157,14 +157,14 @@ ruleTester.run("strict", rule, {
         // "global" mode
         {
             code: "foo();",
-            output: null,
+            output: "'use strict'; foo();",
             options: ["global"],
             errors: [
                 { messageId: "global", type: "Program" }
             ]
         }, {
             code: "function foo() { 'use strict'; return; }",
-            output: null,
+            output: "'use strict'; function foo() {  return; }",
             options: ["global"],
             errors: [
                 { messageId: "global", type: "Program" },
@@ -172,7 +172,7 @@ ruleTester.run("strict", rule, {
             ]
         }, {
             code: "var foo = function() { 'use strict'; return; }",
-            output: null,
+            output: "'use strict'; var foo = function() {  return; }",
             options: ["global"],
             errors: [
                 { messageId: "global", type: "Program" },
@@ -180,7 +180,7 @@ ruleTester.run("strict", rule, {
             ]
         }, {
             code: "var foo = () => { 'use strict'; return () => 1; }",
-            output: null,
+            output: "'use strict'; var foo = () => {  return () => 1; }",
             options: ["global"],
             parserOptions: { ecmaVersion: 6 },
             errors: [
@@ -189,14 +189,14 @@ ruleTester.run("strict", rule, {
             ]
         }, {
             code: "'use strict'; function foo() { 'use strict'; return; }",
-            output: null,
+            output: "'use strict'; function foo() {  return; }",
             options: ["global"],
             errors: [
                 { messageId: "global", type: "ExpressionStatement" }
             ]
         }, {
             code: "'use strict'; var foo = function() { 'use strict'; return; };",
-            output: null,
+            output: "'use strict'; var foo = function() {  return; };",
             options: ["global"],
             errors: [
                 { messageId: "global", type: "ExpressionStatement" }
@@ -418,7 +418,7 @@ ruleTester.run("strict", rule, {
         },
         {
             code: "function foo() { 'use strict'; return; }",
-            output: null,
+            output: "'use strict'; function foo() {  return; }",
             options: ["safe"],
             parserOptions: { ecmaFeatures: { globalReturn: true } },
             errors: [
@@ -463,7 +463,7 @@ ruleTester.run("strict", rule, {
         },
         {
             code: "function foo() { 'use strict'; return; }",
-            output: null,
+            output: "'use strict'; function foo() {  return; }",
             parserOptions: { ecmaFeatures: { globalReturn: true } },
             errors: [
                 { messageId: "global", type: "Program" },
@@ -506,7 +506,7 @@ ruleTester.run("strict", rule, {
         },
         {
             code: "function foo(a = 0) { 'use strict' }",
-            output: null,
+            output: "'use strict'; function foo(a = 0) {  }",
             options: [],
             parserOptions: { ecmaVersion: 6, ecmaFeatures: { globalReturn: true } },
             errors: [
@@ -516,21 +516,21 @@ ruleTester.run("strict", rule, {
         },
         {
             code: "'use strict'; function foo(a = 0) { 'use strict' }",
-            output: null,
+            output: "'use strict'; function foo(a = 0) {  }",
             options: [],
             parserOptions: { ecmaVersion: 6, ecmaFeatures: { globalReturn: true } },
             errors: [{ messageId: "nonSimpleParameterList" }]
         },
         {
             code: "function foo(a = 0) { 'use strict' }",
-            output: null,
+            output: "function foo(a = 0) {  }",
             options: ["never"],
             parserOptions: { ecmaVersion: 6 },
             errors: [{ messageId: "nonSimpleParameterList" }]
         },
         {
             code: "function foo(a = 0) { 'use strict' }",
-            output: null,
+            output: "'use strict'; function foo(a = 0) {  }",
             options: ["global"],
             parserOptions: { ecmaVersion: 6 },
             errors: [
@@ -540,7 +540,7 @@ ruleTester.run("strict", rule, {
         },
         {
             code: "'use strict'; function foo(a = 0) { 'use strict' }",
-            output: null,
+            output: "'use strict'; function foo(a = 0) {  }",
             options: ["global"],
             parserOptions: { ecmaVersion: 6 },
             errors: [{ messageId: "nonSimpleParameterList" }]


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[X] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)** Previously ESLint was able to report errors when the strict rule had the "global" option, but it wasn't able to fix the error. This commit adds an automatic fix that adds `'use strict'; ` to the beginning of each file that doesn't already have a strict mode declaration.


**Is there anything you'd like reviewers to focus on?** This is my second contribution to ESLint and I'm probably doing at least *something* wrong, so I'd appreciate any input or suggestions on how to
improve this code. My main concerns right now:

- This uses single-quotes, which seems like an unnecessary opinion.
- This adds a ~~single space~~ newline, which also seems ~~like an unnecessary opinion~~ fine?
- This passes tests but there could be edge-cases I haven't considered.

<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

Thanks for your help!