### PR TITLE
Docs: no use eslint.linter in code example

### DIFF
--- a/docs/developer-guide/nodejs-api.md
+++ b/docs/developer-guide/nodejs-api.md
@@ -586,8 +586,9 @@ Once you have the configuration information, you can pass it into the `linter` o
 
 ```js
 const CLIEngine = require("eslint").CLIEngine,
-    linter = require("eslint").linter;
+    Linter = require("eslint").Linter;
 
+const linter = new Linter();
 const cli = new CLIEngine({
     envs: ["browser", "mocha"],
     useEslintrc: false,


### PR DESCRIPTION
`eslint.linter` exists for backwards compatibility, but we do not recommend using it because any mutations to it are shared among every module that uses `eslint`. Instead, please create your own instance of `eslint.Linter`.

<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update


<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**


**Is there anything you'd like reviewers to focus on?**

no.
