### PR TITLE
Docs: add a case to func-names

### DIFF
--- a/docs/rules/func-names.md
+++ b/docs/rules/func-names.md
@@ -38,6 +38,10 @@ Examples of **incorrect** code for this rule with the default `"always"` option:
 
 Foo.prototype.bar = function() {};
 
+const cat = {
+  meow: function() {}
+}
+
 (function() {
     // ...
 }())
@@ -49,6 +53,10 @@ Examples of **correct** code for this rule with the default `"always"` option:
 /*eslint func-names: ["error", "always"]*/
 
 Foo.prototype.bar = function bar() {};
+
+const cat = {
+  meow() {}
+}
 
 (function bar() {
     // ...
@@ -77,6 +85,10 @@ Examples of **correct** code for this rule with the `"as-needed"` option:
 /*eslint func-names: ["error", "as-needed"]*/
 
 var bar = function() {};
+
+const cat = {
+  meow: function() {}
+}
 
 (function bar() {
     // ...


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

X [ ] Documentation update

**What changes did you make? (Give an overview)**
Add these cases to docs:

```js
// Both of the two functions has implied names by spec.
const cat = {
  meow: function() {}
}

const cat = {
  meow() {}
}
```
