### PR TITLE
Update: handle undefined as ambiguous in consistent-return

### DIFF
--- a/lib/rules/consistent-return.js
+++ b/lib/rules/consistent-return.js
@@ -68,6 +68,10 @@ module.exports = {
                 treatUndefinedAsUnspecified: {
                     type: "boolean",
                     default: false
+                },
+                treatExplicitUndefinedAsAmbiguous: {
+                    type: "boolean",
+                    default: false
                 }
             },
             additionalProperties: false
@@ -83,6 +87,7 @@ module.exports = {
     create(context) {
         const options = context.options[0] || {};
         const treatUndefinedAsUnspecified = options.treatUndefinedAsUnspecified === true;
+        const skipExplicitUndefined = options.treatExplicitUndefinedAsAmbiguous === true;
         let funcInfo = null;
 
         /**
@@ -165,8 +170,15 @@ module.exports = {
                 const argument = node.argument;
                 let hasReturnValue = Boolean(argument);
 
-                if (treatUndefinedAsUnspecified && hasReturnValue) {
-                    hasReturnValue = !isIdentifier(argument, "undefined") && argument.operator !== "void";
+                if (hasReturnValue) {
+                    const isExplicitUndefined = isIdentifier(argument, "undefined");
+
+                    if (skipExplicitUndefined && isExplicitUndefined) {
+                        return;
+                    }
+                    if (treatUndefinedAsUnspecified) {
+                        hasReturnValue = !isExplicitUndefined && argument.operator !== "void";
+                    }
                 }
 
                 if (!funcInfo.hasReturn) {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

- [ ] Documentation update
- [ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
- [ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
- [x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

**What rule do you want to change?**

`consistent-return`

**Does this change cause the rule to produce more or fewer warnings?**

Fewer, in a configurable way.

**How will the change be implemented? (New option, new default behavior, etc.)?**

New option.

**Please provide some example code that this change will affect:**

```js
// allow when treatUndefinedAsUnspecified && treatExplicitUndefinedAsAmbiguous
window.addEventListener('beforeunload', (e) => {
  if (shouldPreventUnload()) {
    return false;
  }
  return undefined;
});

// still allow the void pattern with both flags set
node.addEventListener('nextStep', () => {
  if (isLastStep()) {
    return void onDone();
  }

  setState({
    currentStep: this.state.currentStep + 1,
  });
});
```

**What does the rule currently do for this code?**

Without `treatUndefinedAsUnspecified`, marks the second function as inconsistent. With `treatUndefinedAsUnspecified`, marks the first function as inconsistent.

**What will the rule do after it's changed?**

If both `treatUndefinedAsUnspecified` and `treatExplicitUndefinedAsAmbiguous` are set, it would mark neither as inconsistent.

**What changes did you make? (Give an overview)**

- Add a new flag `treatExplicitUndefinedAsAmbiguous` to treat `return undefined;` as an ambiguous statement that shouldn't impact the function's return consistency.

**Is there anything you'd like reviewers to focus on?**

Another option might be to introduce a new flag `treatVoidAsUnspecified` that would only interact with `return void` constructs, as that's what the pair of flags becomes.