### PR TITLE
Fix: quote-props shouldn't report object pattern properties

### DIFF
--- a/lib/rules/quote-props.js
+++ b/lib/rules/quote-props.js
@@ -280,6 +280,10 @@ module.exports = {
 
         return {
             Property(node) {
+                if (node.parent.type !== "ObjectExpression") {
+                    return;
+                }
+
                 if (MODE === "always" || !MODE) {
                     checkOmittedQuotes(node);
                 }

--- a/tests/lib/rules/quote-props.js
+++ b/tests/lib/rules/quote-props.js
@@ -73,7 +73,13 @@ ruleTester.run("quote-props", rule, {
         { code: "({1: 1, x: 2})", options: ["consistent-as-needed", { numbers: true }] },
         { code: "({ ...x })", options: ["as-needed"], parserOptions: { ecmaVersion: 2018 } },
         { code: "({ ...x })", options: ["consistent"], parserOptions: { ecmaVersion: 2018 } },
-        { code: "({ ...x })", options: ["consistent-as-needed"], parserOptions: { ecmaVersion: 2018 } }
+        { code: "({ ...x })", options: ["consistent-as-needed"], parserOptions: { ecmaVersion: 2018 } },
+
+        // This rule does not check object pattern properties
+        { code: "({'a': foo, b: bar} = baz)", options: ["always"], parserOptions: { ecmaVersion: 2015 } },
+        { code: "({'a': foo, b: bar} = baz)", options: ["as-needed"], parserOptions: { ecmaVersion: 2015 } },
+        { code: "({'a': foo, b: bar} = baz)", options: ["consistent"], parserOptions: { ecmaVersion: 2015 } },
+        { code: "({'a': foo, b: bar} = baz)", options: ["consistent-as-needed"], parserOptions: { ecmaVersion: 2015 } }
     ],
     invalid: [{
         code: "({ a: 0 })",


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment**

* **ESLint Version:** 6.1.0
* **Node Version:** 10.16.0
* **npm Version:** 6.9.0

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
  parserOptions: {
    ecmaVersion: 6,
  },
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
/*eslint quote-props: ["error", "always"]*/
({'a': foo, b: bar} = baz)
```

```js
/*eslint quote-props: ["error", "as-needed"]*/
({'a': foo, b: bar} = baz)
```

```js
/*eslint quote-props: ["error", "consistent"]*/
({'a': foo, b: bar} = baz)
```

```js
/*eslint quote-props: ["error", "consistent-as-needed"]*/
({'a': foo, b: bar} = baz)
```


**What did you expect to happen?**

No warnings. By the documentation for this rule it targets object literals, these are object patterns.
Also, there are no test cases with patterns.

**What actually happened? Please include the actual, raw output from ESLint.**

2 warnings, for `always` and `as-needed`.

No warnings for `consistent` and `consistent-as-needed`.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Skip the check if the `Property` is not a property of an `ObjectExpression`.

**Is there anything you'd like reviewers to focus on?**

I guess this should be treated as a bug rather than as an undocumented behavior because it doesn't work well - some options report warnings, some not.



