### PR TITLE
Fix: key-spacing shouldn't report object pattern properties

### DIFF
--- a/lib/rules/key-spacing.js
+++ b/lib/rules/key-spacing.js
@@ -643,6 +643,10 @@ module.exports = {
         // Obey beforeColon and afterColon in each property as configured
         return {
             Property(node) {
+                if (node.parent.type !== "ObjectExpression") {
+                    return;
+                }
+
                 verifySpacing(node, isSingleLine(node.parent) ? singleLineOptions : multiLineOptions);
             }
         };

--- a/tests/lib/rules/key-spacing.js
+++ b/tests/lib/rules/key-spacing.js
@@ -757,6 +757,22 @@ ruleTester.run("key-spacing", rule, {
             }
         }],
         parserOptions: { ecmaVersion: 6 }
+    },
+
+    // This rule does not check object pattern properties
+    {
+        code: "({ a : foo } = bar)",
+        options: [{ beforeColon: false }],
+        parserOptions: { ecmaVersion: 6 }
+    }, {
+        code: [
+            "({",
+            "    foo: a,",
+            "    bar:  b",
+            "} = baz)"
+        ].join("\n"),
+        options: [{ align: "value" }],
+        parserOptions: { ecmaVersion: 6 }
     }],
 
     invalid: [{


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment**

* **ESLint Version:** 6.1.0
* **Node Version:** 10.16.0
* **npm Version:** 6.9.0

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
  parserOptions: {
    ecmaVersion: 6,
  },
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
/*eslint key-spacing: ["error", { "beforeColon": false }]*/
({ a : foo } = bar)
```

```js
/*eslint key-spacing: ["error", { "align": "value" }]*/
({
    foo: a,
    bar:  b
} = baz)
```


**What did you expect to happen?**

No warnings. By the documentation for this rule it targets object literals, these are object patterns.
Also, there are no test cases with patterns.

**What actually happened? Please include the actual, raw output from ESLint.**

1 warning, for `beforeColon`.

No warnings for `align`.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Skip the check if the `Property` is not a property of an `ObjectExpression`.

**Is there anything you'd like reviewers to focus on?**

I guess this should be treated as a bug rather than as an undocumented behavior because it doesn't work well - some options report warnings, some not.