### PR TITLE
Fix: no-restricted-syntax - correct the schema

### DIFF
--- a/lib/rules/no-restricted-syntax.js
+++ b/lib/rules/no-restricted-syntax.js
@@ -21,7 +21,7 @@ module.exports = {
 
         schema: {
             type: "array",
-            items: [{
+            items: {
                 oneOf: [
                     {
                         type: "string"
@@ -36,7 +36,7 @@ module.exports = {
                         additionalProperties: false
                     }
                 ]
-            }],
+            },
             uniqueItems: true,
             minItems: 0
         }


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

**What did you do? Please include the actual source code causing the issue.**
configured the rule invalidly:
```js
{
  rules: {
    'no-restricted-syntax': ['error', 'FunctionExpression', 1, false, [], {}],
  }
}
```

**What did you expect to happen?**
eslint fails with a configuration validation errors

**What actually happened? Please include the actual, raw output from ESLint.**
the rule ran fine with no errors.

--------------

For reference, running the current schema through jsonschemavalidator.net:
![image](https://user-images.githubusercontent.com/7462525/62342334-50339880-b49b-11e9-96e2-31069be7bac0.png)

Running the new schema through jsonschemavalidator.net:
![image](https://user-images.githubusercontent.com/7462525/62342367-66415900-b49b-11e9-9bb3-ee3942cd313f.png)

Running a lint with the new schema:
```
Error: .eslintrc.js:
        Configuration for rule "no-restricted-syntax" is invalid:
        Value 1 should be string.
        Value 1 should be object.
        Value 1 should match exactly one schema in oneOf.
```