### PR TITLE
Docs: Remove readonly/writable global logic from no-undef (fixes #11963)

### DIFF
--- a/docs/rules/no-undef.md
+++ b/docs/rules/no-undef.md
@@ -25,6 +25,12 @@ var foo = someFunction();
 var bar = a + 1;
 ```
 
+Note that this rule does not disallow assignments to read-only global variables.
+See [no-global-assign](no-global-assign.md) if you also want to disallow those assignments.
+
+This rule also does not disallow redeclarations of global variables.
+See [no-redeclare](no-redeclare.md) if you also want to disallow those redeclarations.
+
 ## Options
 
 * `typeof` set to true will warn for variables used inside typeof check (Default false).
@@ -98,3 +104,8 @@ If explicit declaration of global variables is not to your taste.
 ## Compatibility
 
 This rule provides compatibility with treatment of global variables in [JSHint](http://jshint.com/) and [JSLint](http://www.jslint.com).
+
+## Related Rules
+
+* [no-global-assign](no-global-assign.md)
+* [no-redeclare](no-redeclare.md)

--- a/docs/rules/no-undef.md
+++ b/docs/rules/no-undef.md
@@ -11,32 +11,19 @@ Examples of **incorrect** code for this rule:
 ```js
 /*eslint no-undef: "error"*/
 
-var a = someFunction();
-b = 10;
+var foo = someFunction();
+var bar = a + 1;
 ```
 
 Examples of **correct** code for this rule with `global` declaration:
 
 ```js
-/*global someFunction b:writable*/
+/*global someFunction, a*/
 /*eslint no-undef: "error"*/
 
-var a = someFunction();
-b = 10;
+var foo = someFunction();
+var bar = a + 1;
 ```
-
-The `b:writable` syntax in `/*global */` indicates that assignment to `b` is correct.
-
-Examples of **incorrect** code for this rule with `global` declaration:
-
-```js
-/*global b*/
-/*eslint no-undef: "error"*/
-
-b = 10;
-```
-
-By default, variables declared in `/*global */` are read-only, therefore assignment is incorrect.
 
 ## Options
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Documentation update #11963

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Removed an example that does not apply to this rule.

Removed `writable` flag as it's irrelevant for this rule.

Modified a 'write' example (`b = 10`) to 'read' example (`var bar = a + 1`).

**Is there anything you'd like reviewers to focus on?**

Should there be a 'correct' example like this:

```js
/*global b*/
/*eslint no-undef: "error"*/
b = 10;
```

It is indeed a correct code for this rule, but it isn't the right way to use eslint global variables in general.

