### PR TITLE
Docs: Improve examples and clarify default option

### DIFF
--- a/docs/rules/operator-linebreak.md
+++ b/docs/rules/operator-linebreak.md
@@ -38,7 +38,7 @@ The default configuration is `"after", { "overrides": { "?": "before", ":": "bef
 
 ### after
 
-Examples of **incorrect** code for this rule with the default `"after"` option:
+Examples of **incorrect** code for this rule with the `"after"` option:
 
 ```js
 /*eslint operator-linebreak: ["error", "after"]*/
@@ -62,7 +62,7 @@ answer = everything
   : foo;
 ```
 
-Examples of **correct** code for this rule with the default `"after"` option:
+Examples of **correct** code for this rule with the `"after"` option:
 
 ```js
 /*eslint operator-linebreak: ["error", "after"]*/
@@ -175,14 +175,24 @@ answer = everything ? 42 : foo;
 
 ### overrides
 
-Examples of additional **correct** code for this rule with the `{ "overrides": { "+=": "before" } }` option:
+Examples of additional **incorrect** code for this rule with the default `{ "overrides": { "?": "before", ":": "before" } }` option:
 
 ```js
-/*eslint operator-linebreak: ["error", "after", { "overrides": { "+=": "before" } }]*/
+/*eslint operator-linebreak: ["error", "after", { "overrides": { "?": "before", ":": "before" } }]*/
 
-var thing = 'thing';
-thing
-  += 's';
+answer = everything ?
+  42 :
+  foo;
+```
+
+Examples of additional **correct** code for this rule with the default `{ "overrides": { "?": "before", ":": "before" } }` option:
+
+```js
+/*eslint operator-linebreak: ["error", "after", { "overrides": { "?": "before", ":": "before" } }]*/
+
+answer = everything
+  ? 42
+  : foo;
 ```
 
 Examples of additional **correct** code for this rule with the `{ "overrides": { "?": "ignore", ":": "ignore" } }` option:

--- a/docs/rules/operator-linebreak.md
+++ b/docs/rules/operator-linebreak.md
@@ -175,24 +175,24 @@ answer = everything ? 42 : foo;
 
 ### overrides
 
-Examples of additional **incorrect** code for this rule with the default `{ "overrides": { "?": "before", ":": "before" } }` option:
+Examples of additional **incorrect** code for this rule with the `{ "overrides": { "+=": "before" } }` option:
 
 ```js
-/*eslint operator-linebreak: ["error", "after", { "overrides": { "?": "before", ":": "before" } }]*/
+/*eslint operator-linebreak: ["error", "after", { "overrides": { "+=": "before" } }]*/
 
-answer = everything ?
-  42 :
-  foo;
+var thing = 'thing';
+thing +=
+  's';
 ```
 
-Examples of additional **correct** code for this rule with the default `{ "overrides": { "?": "before", ":": "before" } }` option:
+Examples of additional **correct** code for this rule with the `{ "overrides": { "+=": "before" } }` option:
 
 ```js
-/*eslint operator-linebreak: ["error", "after", { "overrides": { "?": "before", ":": "before" } }]*/
+/*eslint operator-linebreak: ["error", "after", { "overrides": { "+=": "before" } }]*/
 
-answer = everything
-  ? 42
-  : foo;
+var thing = 'thing';
+thing
+  += 's';
 ```
 
 Examples of additional **correct** code for this rule with the `{ "overrides": { "?": "ignore", ":": "ignore" } }` option:
@@ -209,6 +209,52 @@ answer = everything
   42
   :
   foo;
+```
+
+Examples of **incorrect** code for this rule with the default `"after", { "overrides": { "?": "before", ":": "before" } }` option:
+
+```js
+/*eslint operator-linebreak: ["error", "after", { "overrides": { "?": "before", ":": "before" } }]*/
+
+foo = 1
++
+2;
+
+foo = 1
+    + 2;
+
+foo
+    = 5;
+
+if (someCondition
+    || otherCondition) {
+}
+
+answer = everything ?
+  42 :
+  foo;
+```
+
+Examples of **correct** code for this rule with the default `"after", { "overrides": { "?": "before", ":": "before" } }` option:
+
+```js
+/*eslint operator-linebreak: ["error", "after", { "overrides": { "?": "before", ":": "before" } }]*/
+
+foo = 1 + 2;
+
+foo = 1 +
+      2;
+
+foo =
+    5;
+
+if (someCondition ||
+    otherCondition) {
+}
+
+answer = everything
+  ? 42
+  : foo;
 ```
 
 ## When Not To Use It


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
- The "default" option is now set to `overrides` instead of `after` because the ternary examples in `after` may be misleading.
- Changed the example in `overrides` to reflect the default behavior. The old one `+=` is removed as it serves no purpose after the change.
- A new incorrect example is added to `overrides` to clarify whether the overridden style can still be used.

**Is there anything you'd like reviewers to focus on?**
No.

