### PR TITLE
Fix: prefer-template autofix produces syntax error with octal escapes

### DIFF
--- a/lib/rules/prefer-template.js
+++ b/lib/rules/prefer-template.js
@@ -52,16 +52,7 @@ function isOctalEscapeSequence(node) {
         return false;
     }
 
-    const match = node.raw.match(/^([^\\]|\\[^0-7])*\\([0-7]{1,3})/u);
-
-    if (match) {
-
-        // \0 is actually not considered an octal
-        if (match[2] !== "0" || typeof match[3] !== "undefined") {
-            return true;
-        }
-    }
-    return false;
+    return astUtils.hasOctalEscapeSequence(node.raw);
 }
 
 /**

--- a/lib/rules/utils/ast-utils.js
+++ b/lib/rules/utils/ast-utils.js
@@ -38,6 +38,7 @@ const LINEBREAKS = new Set(["\r\n", "\r", "\n", "\u2028", "\u2029"]);
 const STATEMENT_LIST_PARENTS = new Set(["Program", "BlockStatement", "SwitchCase"]);
 
 const DECIMAL_INTEGER_PATTERN = /^(0|[1-9]\d*)$/u;
+const OCTAL_ESCAPE_PATTERN = /^(?:[^\\]|\\[^0-7]|\\0(?![0-9]))*\\(?:[1-7]|0[0-9])/u;
 
 /**
  * Checks reference if is non initializer and writable.
@@ -1373,5 +1374,20 @@ module.exports = {
             "/*".length +
             (match ? match.index + 1 : 0)
         );
+    },
+
+    /**
+     * Determines whether the given raw string contains an octal escape sequence.
+     *
+     * "\1", "\2" ... "\7"
+     * "\00", "\01" ... "\09"
+     *
+     * "\0", when not followed by a digit, is not an octal escape sequence.
+     *
+     * @param {string} rawString A string in its raw representation.
+     * @returns {boolean} `true` if the string contains at least one octal escape sequence.
+     */
+    hasOctalEscapeSequence(rawString) {
+        return OCTAL_ESCAPE_PATTERN.test(rawString);
     }
 };

--- a/tests/lib/rules/prefer-template.js
+++ b/tests/lib/rules/prefer-template.js
@@ -200,6 +200,16 @@ ruleTester.run("prefer-template", rule, {
             errors
         },
         {
+            code: "foo + '\\0\\1'",
+            output: null,
+            errors
+        },
+        {
+            code: "foo + '\\08'",
+            output: null,
+            errors
+        },
+        {
             code: "foo + '\\\\033'",
             output: "`${foo  }\\\\033`",
             errors

--- a/tests/lib/rules/utils/ast-utils.js
+++ b/tests/lib/rules/utils/ast-utils.js
@@ -1248,4 +1248,82 @@ describe("ast-utils", () => {
             assert.strictEqual(astUtils.equalTokens(ast.body[0], ast.body[1], sourceCode), false);
         });
     });
+
+    describe("hasOctalEscapeSequence", () => {
+
+        /* eslint-disable quote-props */
+        const expectedResults = {
+            "\\1": true,
+            "\\2": true,
+            "\\7": true,
+            "\\00": true,
+            "\\01": true,
+            "\\02": true,
+            "\\07": true,
+            "\\08": true,
+            "\\09": true,
+            "\\10": true,
+            "\\12": true,
+            " \\1": true,
+            "\\1 ": true,
+            "a\\1": true,
+            "\\1a": true,
+            "a\\1a": true,
+            " \\01": true,
+            "\\01 ": true,
+            "a\\01": true,
+            "\\01a": true,
+            "a\\01a": true,
+            "a\\08a": true,
+            "\\0\\1": true,
+            "\\0\\01": true,
+            "\\0\\08": true,
+            "\\n\\1": true,
+            "\\n\\01": true,
+            "\\n\\08": true,
+            "\\\\\\1": true,
+            "\\\\\\01": true,
+            "\\\\\\08": true,
+
+            "\\0": false,
+            "\\8": false,
+            "\\9": false,
+            " \\0": false,
+            "\\0 ": false,
+            "a\\0": false,
+            "\\0a": false,
+            "a\\8a": false,
+            "\\0\\8": false,
+            "\\8\\0": false,
+            "\\80": false,
+            "\\81": false,
+            "\\\\": false,
+            "\\\\0": false,
+            "\\\\01": false,
+            "\\\\08": false,
+            "\\\\1": false,
+            "\\\\12": false,
+            "\\\\\\0": false,
+            "\\\\\\8": false,
+            "\\0\\\\": false,
+            "0": false,
+            "1": false,
+            "8": false,
+            "01": false,
+            "08": false,
+            "80": false,
+            "12": false,
+            "\\a": false,
+            "\\n": false
+        };
+        /* eslint-enable quote-props */
+
+        Object.keys(expectedResults).forEach(key => {
+            it(`should return ${expectedResults[key]} for ${key}`, () => {
+                const ast = espree.parse(`"${key}"`);
+
+                assert.strictEqual(astUtils.hasOctalEscapeSequence(ast.body[0].expression.raw), expectedResults[key]);
+            });
+        });
+    });
 });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
**Tell us about your environment**

* **ESLint Version:** 6.1.0
* **Node Version:** 10.16.0
* **npm Version:** 6.9.0

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
  parserOptions: {
    ecmaVersion: 2015,
  },
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
/*eslint prefer-template: "error"*/

"\0 \1" + foo
```

```js
/*eslint prefer-template: "error"*/

"\08" + foo
```

**What did you expect to happen?**

Not a syntax error in autofix.

**What actually happened? Please include the actual, raw output from ESLint.**

```js
/*eslint prefer-template: "error"*/

`\0 \1${  foo}`
```

`Parsing error: Octal literal in template string`

```js
/*eslint prefer-template: "error"*/

`\08${  foo}`
```

`Parsing error: Octal literal in template string`
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Made a new regex in `astUtils`, which fixes two bugs:

* Octal escapes after a valid `\0` were missed (e.g. `"\0 \1"`). This bug was probably inherited from `no-octal-escape` (fixed there in #12079)
* Whether or not `"\08"` and `"\09"` are octal escapes (#12080) these two de facto produce parsing errors in template literals.

**Is there anything you'd like reviewers to focus on?**

* Regex and its performance.

I'll also fix the `quotes` rule in another PR when this gets merged.