### PR TITLE
New: Add switch-final-break rule

### DIFF
--- a/docs/rules/switch-final-break.md
+++ b/docs/rules/switch-final-break.md
@@ -1,0 +1,32 @@
+# Checks whether the final clause of a switch statement ends in unnecessary `break;`. (switch-final-break)
+
+Examples of **correct** code:
+
+```js
+switch (x) {
+  case 0: {
+    foo();
+  }
+}
+```
+
+Examples of **incorrect** code:
+
+```js
+switch (x) {
+  case 0: {
+    foo();
+    break;
+  }
+}
+```
+
+## Options
+
+Can get `never` (the default) or `always` (always ends with `break;`):
+
+```json
+{
+  "switch-final-break": ["error", "always"]
+}
+```

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -266,6 +266,7 @@ module.exports = new LazyLoadingRuleMap(Object.entries({
     "spaced-comment": () => require("./spaced-comment"),
     strict: () => require("./strict"),
     "switch-colon-spacing": () => require("./switch-colon-spacing"),
+    "switch-final-break": () => require("./switch-final-break"),
     "symbol-description": () => require("./symbol-description"),
     "template-curly-spacing": () => require("./template-curly-spacing"),
     "template-tag-spacing": () => require("./template-tag-spacing"),

--- a/lib/rules/switch-final-break.js
+++ b/lib/rules/switch-final-break.js
@@ -1,0 +1,142 @@
+/**
+ * @fileoverview disallow an unnecessary `break` at the final clause of a switch statement.
+ * @author Eran Shabi <https://github.com/eranshabi>
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+    meta: {
+        docs: {
+            description:
+                "disallow an unnecessary `break` at the final clause of a switch statement.",
+            category: "Best Practices",
+            recommended: false,
+            url: "https://eslint.org/docs/rules/switch-final-break"
+        },
+        fixable: "code",
+        messages: {
+            switchFinalBreakNever:
+                "Final clause in 'switch' statement should not end with 'break;'.",
+            switchFinalBreakAlways:
+                "Final clause in 'switch' statement should end with 'break;'."
+        },
+        schema: [
+            {
+                enum: ["never", "always"]
+            }
+        ],
+        type: "suggestion"
+    },
+    create(context) {
+        const requireBreak = context.options[0] ? context.options[0] : "never";
+
+        /**
+         * Returns the last statement of a given switch clause
+         * @param {ASTNode} node switch clause node
+         * @returns {ASTNode} - the final statement of the switch clause
+         */
+        function getLastStatement(node) {
+            if (
+                node.consequent.length === 1 &&
+                node.consequent[0].type === "BlockStatement"
+            ) {
+
+                // block statement
+                const block = node.consequent[0];
+
+                return block.body[block.body.length - 1];
+            }
+            return node.consequent[node.consequent.length - 1];
+        }
+
+        return {
+            SwitchStatement(node) {
+                if (node.cases.length !== 0) {
+                    const lastCase = node.cases[node.cases.length - 1];
+                    const lastStatement = getLastStatement(lastCase);
+
+                    if (requireBreak === "always") {
+                        if (
+                            !lastStatement ||
+                            lastStatement.type !== "BreakStatement"
+                        ) {
+                            context.report({
+                                node: lastCase,
+                                messageId: "switchFinalBreakAlways",
+                                fix: fixer => {
+                                    if (!lastStatement) {
+                                        return fixer.insertTextAfter(lastCase, " break;");
+                                    }
+                                    const lastStatementText = context.getSourceCode().getLines()[
+                                        lastStatement.loc.start.line - 1
+                                    ];
+                                    const indentation = lastStatementText.slice(
+                                        0,
+                                        lastStatementText.search(/\S+/u)
+                                    );
+
+                                    return fixer.insertTextAfter(
+                                        lastStatement,
+                                        `\n${indentation}break;`
+                                    );
+                                }
+                            });
+                        }
+
+                        return;
+                    }
+
+                    if (
+                        !lastStatement ||
+                        lastStatement.type !== "BreakStatement"
+                    ) {
+                        return;
+                    }
+
+                    if (lastStatement.label !== null) {
+                        const parent = node.parent;
+
+                        if (
+                            parent &&
+                            (!(parent.type === "LabeledStatement") ||
+                                parent.label === lastStatement.label)) {
+
+                            // break jumps somewhere else, don't complain
+                            return;
+                        }
+                    }
+
+                    context.report({
+                        node: lastStatement,
+                        messageId: "switchFinalBreakNever",
+                        fix: fixer => {
+                            const sourceText = context.getSourceCode().getText();
+                            const reversedSourceText = sourceText
+                                .split("")
+                                .reverse()
+                                .join("");
+                            const lastStatementReversedIndex =
+                                reversedSourceText.length - lastStatement.range[0];
+                            const substringToTrimMatch = reversedSourceText
+                                .slice(lastStatementReversedIndex)
+                                .match(/\s*\n?/gu);
+                            const trimLength = substringToTrimMatch
+                                ? substringToTrimMatch[0].length
+                                : 0;
+
+                            return fixer.removeRange([
+                                lastStatement.range[0] - trimLength,
+                                lastStatement.range[1]
+                            ]);
+                        }
+                    });
+                }
+            }
+        };
+    }
+};

--- a/tests/lib/rules/switch-final-break.js
+++ b/tests/lib/rules/switch-final-break.js
@@ -1,0 +1,321 @@
+/**
+ * @fileoverview Tests for switch-final-break rule.
+ * @author Eran Shabi <https://github.com/eranshabi>
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const { RuleTester } = require("../../../lib/rule-tester");
+const rule = require("../../../lib/rules/switch-final-break");
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("switch-final-break", rule, {
+    valid: [
+
+        // default option
+        `switch (x) {
+    case 0:
+        foo();
+}
+`,
+        `
+    switch (x) {}
+    `,
+        `
+switch (x) {
+    case 0: {
+        foo();
+    }
+}
+`,
+        `switch (x) {
+    default:
+        foo();
+}
+`,
+        `switch (x) {
+    default: {
+        foo();
+    }
+}
+`,
+        `
+switch (x) {
+    case 0:
+}
+`,
+        `outer: while (true) {
+    switch (x) {
+        case 0:
+            x++;
+            break;
+        default:
+            break outer;
+    }
+}`,
+
+        // always option
+        {
+            code: `switch (x) {
+  case 0:
+    foo();
+    break;
+  }`,
+            options: ["always"]
+        },
+        {
+            code: `switch (x) {
+  case 0: {
+      foo();
+      break;
+    }
+  }`,
+            options: ["always"]
+        },
+        {
+            code: `switch (x) {
+  default:
+    foo();
+    break;
+  }`,
+            options: ["always"]
+        }
+    ],
+    invalid: [
+        {
+            code: `switch (x) {
+    case 0:
+        foo();
+        break;
+}
+      `,
+            output: `switch (x) {
+    case 0:
+        foo();
+}
+      `,
+            errors: [
+                {
+                    messageId: "switchFinalBreakNever",
+                    line: 4,
+                    column: 9
+                }
+            ]
+        },
+        {
+            code: `
+switch (x) {
+    case 0: {
+        foo();
+        break;
+    }
+}
+      `,
+            output: `
+switch (x) {
+    case 0: {
+        foo();
+    }
+}
+      `,
+            errors: [
+                {
+                    messageId: "switchFinalBreakNever",
+                    line: 5,
+                    column: 9
+                }
+            ]
+        },
+        {
+            code: `switch (x) {
+    case 0: {
+        foo();break;
+    }
+}`,
+            output: `switch (x) {
+    case 0: {
+        foo();
+    }
+}`,
+            errors: [
+                {
+                    messageId: "switchFinalBreakNever",
+                    line: 3,
+                    column: 15
+                }
+            ]
+        },
+        {
+            code: `switch (x) {
+    case 0: {
+        foo();  break;
+    }
+}`,
+            output: `switch (x) {
+    case 0: {
+        foo();
+    }
+}`,
+            errors: [
+                {
+                    messageId: "switchFinalBreakNever",
+                    line: 3,
+                    column: 17
+                }
+            ]
+        },
+        {
+            code: `
+switch (x) {
+    default:
+        foo();
+        break;
+}
+      `,
+            output: `
+switch (x) {
+    default:
+        foo();
+}
+      `,
+            errors: [
+                {
+                    messageId: "switchFinalBreakNever",
+                    line: 5,
+                    column: 9
+                }
+            ]
+        },
+
+        {
+            code: `
+outer2: while (true) {
+    inner: switch (x) {
+        case 0:
+            ++x;
+            break;
+        default:
+            break inner;
+    }
+}      `,
+            output: `
+outer2: while (true) {
+    inner: switch (x) {
+        case 0:
+            ++x;
+            break;
+        default:
+    }
+}      `,
+            errors: [
+                {
+                    messageId: "switchFinalBreakNever",
+                    line: 8,
+                    column: 13
+                }
+            ]
+        },
+
+        // always option
+        {
+            code: `switch (x) {
+  case 0:
+    foo();
+  }`,
+            output: `switch (x) {
+  case 0:
+    foo();
+    break;
+  }`,
+            options: ["always"],
+            errors: [
+                {
+                    messageId: "switchFinalBreakAlways",
+                    line: 2,
+                    column: 3
+                }
+            ]
+        },
+        {
+            code: `switch (x) {
+  case 0: {
+      foo();
+    }
+  }`,
+            output: `switch (x) {
+  case 0: {
+      foo();
+      break;
+    }
+  }`,
+            options: ["always"],
+            errors: [
+                {
+                    messageId: "switchFinalBreakAlways",
+                    line: 2,
+                    column: 3
+                }
+            ]
+        },
+        {
+            code: `switch (x) {
+  default:
+    foo();
+  }`,
+            output: `switch (x) {
+  default:
+    foo();
+    break;
+  }`,
+            options: ["always"],
+            errors: [
+                {
+                    messageId: "switchFinalBreakAlways",
+                    line: 2,
+                    column: 3
+                }
+            ]
+        },
+        {
+            code: `switch (x) {
+  default: {
+      foo();
+    }
+  }`,
+            output: `switch (x) {
+  default: {
+      foo();
+      break;
+    }
+  }`,
+            options: ["always"],
+            errors: [
+                {
+                    messageId: "switchFinalBreakAlways",
+                    line: 2,
+                    column: 3
+                }
+            ]
+        },
+        {
+            code: `switch (x) {
+  case 0:
+  }`,
+            output: `switch (x) {
+  case 0: break;
+  }`,
+            options: ["always"],
+            errors: [
+                {
+                    messageId: "switchFinalBreakAlways",
+                    line: 2,
+                    column: 3
+                }
+            ]
+        }
+    ]
+});

--- a/tools/rule-types.json
+++ b/tools/rule-types.json
@@ -253,6 +253,7 @@
     "spaced-comment": "suggestion",
     "strict": "suggestion",
     "switch-colon-spacing": "layout",
+    "switch-final-break": "suggestion",
     "symbol-description": "suggestion",
     "template-curly-spacing": "layout",
     "template-tag-spacing": "layout",


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[x] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
**Please describe what the rule should do:**
Disallow (or enforce) an unnecessary break statement in the last case of a switch-case

**What category of rule is this? (place an "X" next to just one item)**

[x] Enforces code style
[ ] Warns about a potential error
[ ] Suggests an alternate way of doing something
[ ] Other (please specify:)

**Provide 2-3 code examples that this rule will warn about:**
Examples of **correct** code:
```js
switch (x) {
  case 0: {
    foo(); //good - no unnecessary break statement
  }
}
```

Examples of **incorrect** code:

```js
switch (x) {
  case 0: {
    foo();
    break;  //unnecessary break statement
  }
}
```
Alternatively the user can use the `always` option to enforce a break statement at the end of all final cases.

**Why should this rule be included in ESLint (instead of a plugin)?**
It's a common use case that appears in lot of code bases. Now they will have to ability to have a more unified code style, whatever they choose to never have an unnecessary `break` or always have it using the option.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Added the `switch-final-break` rule + tests + documentation.

**Is there anything you'd like reviewers to focus on?**
no 🙂 

