### PR TITLE
Fix: Check literal type explicitly in dot-notation

### DIFF
--- a/lib/rules/dot-notation.js
+++ b/lib/rules/dot-notation.js
@@ -9,13 +9,16 @@
 //------------------------------------------------------------------------------
 
 const astUtils = require("./utils/ast-utils");
+const keywords = require("./utils/keywords");
 
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
 const validIdentifier = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/u;
-const keywords = require("./utils/keywords");
+
+// `null` literal must be handled separately.
+const literalTypesToCheck = new Set(["string", "boolean"]);
 
 module.exports = {
     meta: {
@@ -115,7 +118,8 @@ module.exports = {
             MemberExpression(node) {
                 if (
                     node.computed &&
-                    node.property.type === "Literal"
+                    node.property.type === "Literal" &&
+                    (literalTypesToCheck.has(typeof node.property.value) || astUtils.isNullLiteral(node.property))
                 ) {
                     checkComputedProperty(node, node.property.value);
                 }

--- a/tests/lib/rules/dot-notation.js
+++ b/tests/lib/rules/dot-notation.js
@@ -57,7 +57,8 @@ ruleTester.run("dot-notation", rule, {
         "a.null;",
         "a[undefined];",
         "a[void 0];",
-        "a[b()];"
+        "a[b()];",
+        { code: "a[/(?<zero>0)/];", parserOptions: { ecmaVersion: 2018 } }
     ],
     invalid: [
         {
@@ -81,6 +82,16 @@ ruleTester.run("dot-notation", rule, {
             code: "a[null];",
             output: "a.null;",
             errors: [{ messageId: "useDot", data: { key: "null" } }]
+        },
+        {
+            code: "a[true];",
+            output: "a.true;",
+            errors: [{ messageId: "useDot", data: { key: "true" } }]
+        },
+        {
+            code: "a[false];",
+            output: "a.false;",
+            errors: [{ messageId: "useDot", data: { key: "false" } }]
         },
         {
             code: "a['b'];",


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

This is a small fix that prevents `dot-notation` from converting `bigint` and some regex literals to `null` in Node 8.

[Demo link](https://eslint.org/demo#eyJ0ZXh0IjoiLyplc2xpbnQgZG90LW5vdGF0aW9uOmVycm9yKi9cblxuYVsvKD88emVybz4wKS9dO1xuXG5cbiIsIm9wdGlvbnMiOnsicGFyc2VyT3B0aW9ucyI6eyJlY21hVmVyc2lvbiI6OSwic291cmNlVHlwZSI6InNjcmlwdCIsImVjbWFGZWF0dXJlcyI6e319LCJydWxlcyI6e30sImVudiI6e319fQ==) - the error is observable if you open this link in Firefox (which also doesn't support the syntax, like Node 8).

**Tell us about your environment**

* **ESLint Version:** 6.1.0
* **Node Version:** 8.16.0
* **npm Version:** 6.4.1

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
  parserOptions: {
    ecmaVersion: 2018,
  },
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
/*eslint dot-notation:error*/

a[/(?<zero>0)/];
```

**What did you expect to happen?**

No warnings.

**What actually happened? Please include the actual, raw output from ESLint.**

Warning and the fix:

```js
/*eslint dot-notation:error*/

a.null;
```

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Fixed `dot-notation` to explicitly check only `"string"`, `"boolean"` and `null` literals.

**Is there anything you'd like reviewers to focus on?**

The test in `valid` fails in Node 8 before the fix. Tests in `invalid` are for regression only.
