### PR TITLE
Breaking: Test with an unknown error property should fail in RuleTester

### DIFF
--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -135,6 +135,16 @@ const errorObjectParameters = new Set([
 ]);
 const friendlyErrorObjectParameterList = `[${[...errorObjectParameters].map(key => `'${key}'`).join(", ")}]`;
 
+/*
+ * All allowed property names in suggestion objects.
+ */
+const suggestionObjectParameters = new Set([
+    "desc",
+    "messageId",
+    "output"
+]);
+const friendlySuggestionObjectParameterList = `[${[...suggestionObjectParameters].map(key => `'${key}'`).join(", ")}]`;
+
 const hasOwnProperty = Function.call.bind(Object.hasOwnProperty);
 
 /**
@@ -678,6 +688,17 @@ class RuleTester {
                                 assert.strictEqual(message.suggestions.length, error.suggestions.length, `Error should have ${error.suggestions.length} suggestions. Instead found ${message.suggestions.length} suggestions`);
 
                                 error.suggestions.forEach((expectedSuggestion, index) => {
+                                    assert.ok(
+                                        typeof expectedSuggestion === "object" && expectedSuggestion !== null,
+                                        "Test suggestion in 'suggestions' array must be an object."
+                                    );
+                                    Object.keys(expectedSuggestion).forEach(propertyName => {
+                                        assert.ok(
+                                            suggestionObjectParameters.has(propertyName),
+                                            `Invalid suggestion property name '${propertyName}'. Expected one of ${friendlySuggestionObjectParameterList}.`
+                                        );
+                                    });
+
                                     const actualSuggestion = message.suggestions[index];
 
                                     /**

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -119,6 +119,22 @@ const RuleTesterParameters = [
     "output"
 ];
 
+/*
+ * All allowed property names in error objects.
+ */
+const errorObjectParameters = new Set([
+    "message",
+    "messageId",
+    "data",
+    "type",
+    "line",
+    "column",
+    "endLine",
+    "endColumn",
+    "suggestions"
+]);
+const friendlyErrorObjectParameterList = `[${[...errorObjectParameters].map(key => `'${key}'`).join(", ")}]`;
+
 const hasOwnProperty = Function.call.bind(Object.hasOwnProperty);
 
 /**
@@ -573,13 +589,21 @@ class RuleTester {
 
                         // Just an error message.
                         assertMessageMatches(message.message, error);
-                    } else if (typeof error === "object") {
+                    } else if (typeof error === "object" && error !== null) {
 
                         /*
                          * Error object.
                          * This may have a message, messageId, data, node type, line, and/or
                          * column.
                          */
+
+                        Object.keys(error).forEach(propertyName => {
+                            assert.ok(
+                                errorObjectParameters.has(propertyName),
+                                `Invalid error property name '${propertyName}'. Expected one of ${friendlyErrorObjectParameterList}.`
+                            );
+                        });
+
                         if (hasOwnProperty(error, "message")) {
                             assert.ok(!hasOwnProperty(error, "messageId"), "Error should not specify both 'message' and a 'messageId'.");
                             assert.ok(!hasOwnProperty(error, "data"), "Error should not specify both 'data' and 'message'.");

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -182,6 +182,21 @@ describe("RuleTester", () => {
         }, /Error should be a string, object, or RegExp/u);
     });
 
+    it("should throw an error when any of the errors is not a supported type", () => {
+        assert.throws(() => {
+            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+
+                // Only the invalid test matters here
+                valid: [
+                    "bar = baz;"
+                ],
+                invalid: [
+                    { code: "var foo = bar; var baz = quux", errors: [{ type: "VariableDeclaration" }, null] }
+                ]
+            });
+        }, /Error should be a string, object, or RegExp/u);
+    });
+
     it("should throw an error when the error is a string and it does not match error message", () => {
         assert.throws(() => {
             ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
@@ -230,6 +245,38 @@ describe("RuleTester", () => {
                 { code: "var foo = bar;", errors: [/^Bad var/u] }
             ]
         });
+    });
+
+    it("should throw an error when the error is an object with an unknown property name", () => {
+        assert.throws(() => {
+            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+                valid: [
+                    "bar = baz;"
+                ],
+                invalid: [
+                    { code: "var foo = bar;", errors: [{ Message: "Bad var." }] }
+                ]
+            });
+        }, /Invalid error property name 'Message'/u);
+    });
+
+    it("should throw an error when any of the errors is an object with an unknown property name", () => {
+        assert.throws(() => {
+            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+                valid: [
+                    "bar = baz;"
+                ],
+                invalid: [
+                    {
+                        code: "var foo = bar; var baz = quux",
+                        errors: [
+                            { message: "Bad var.", type: "VariableDeclaration" },
+                            { message: "Bad var.", typo: "VariableDeclaration" }
+                        ]
+                    }
+                ]
+            });
+        }, /Invalid error property name 'typo'/u);
     });
 
     it("should not throw an error when the error is a regex in an object and it matches error message", () => {

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -1163,6 +1163,76 @@ describe("RuleTester", () => {
                 });
             }, "Expected the applied suggestion fix to match the test suggestion output");
         });
+
+        it("should fail when specified suggestion isn't an object", () => {
+            assert.throws(() => {
+                ruleTester.run("suggestions-basic", require("../../fixtures/testers/rule-tester/suggestions").basic, {
+                    valid: [],
+                    invalid: [{
+                        code: "var foo;",
+                        errors: [{
+                            suggestions: [null]
+                        }]
+                    }]
+                });
+            }, "Test suggestion in 'suggestions' array must be an object.");
+
+            assert.throws(() => {
+                ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
+                    valid: [],
+                    invalid: [{
+                        code: "var foo;",
+                        errors: [{
+                            suggestions: [
+                                {
+                                    messageId: "renameFoo",
+                                    output: "var bar;"
+                                },
+                                "Rename identifier 'foo' to 'baz'"
+                            ]
+                        }]
+                    }]
+                });
+            }, "Test suggestion in 'suggestions' array must be an object.");
+        });
+
+        it("should fail when the suggestion is an object with an unknown property name", () => {
+            assert.throws(() => {
+                ruleTester.run("suggestions-basic", require("../../fixtures/testers/rule-tester/suggestions").basic, {
+                    valid: [
+                        "var boo;"
+                    ],
+                    invalid: [{
+                        code: "var foo;",
+                        errors: [{
+                            suggestions: [{
+                                message: "Rename identifier 'foo' to 'bar'"
+                            }]
+                        }]
+                    }]
+                });
+            }, /Invalid suggestion property name 'message'/u);
+        });
+
+        it("should fail when any of the suggestions is an object with an unknown property name", () => {
+            assert.throws(() => {
+                ruleTester.run("suggestions-messageIds", require("../../fixtures/testers/rule-tester/suggestions").withMessageIds, {
+                    valid: [],
+                    invalid: [{
+                        code: "var foo;",
+                        errors: [{
+                            suggestions: [{
+                                messageId: "renameFoo",
+                                output: "var bar;"
+                            }, {
+                                messageId: "renameFoo",
+                                outpt: "var baz;"
+                            }]
+                        }]
+                    }]
+                });
+            }, /Invalid suggestion property name 'outpt'/u);
+        });
     });
 
     describe("naming test cases", () => {

--- a/tests/lib/rules/multiline-comment-style.js
+++ b/tests/lib/rules/multiline-comment-style.js
@@ -1289,7 +1289,7 @@ ${"                   "}
                 // bar${" "}
             `,
             options: ["separate-lines"],
-            errors: [{ messageid: "expectedlines", line: 2 }]
+            errors: [{ messageId: "expectedLines", line: 2 }]
         },
         {
             code: `
@@ -1303,7 +1303,7 @@ ${"                   "}
                 // bar${" "}
             `,
             options: ["separate-lines"],
-            errors: [{ messageid: "expectedlines", line: 2 }]
+            errors: [{ messageId: "expectedLines", line: 2 }]
         },
         {
             code: `


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Add something to the core

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Additional check in the `RuleTester` - an `invalid` test will fail if any of its error objects contains a key that isn't expected.

Since none of the error params is mandatory, test case might be silently useless or missing to check an important detail (e.g. node type or location) just because of a small typo.

**Is there anything you'd like reviewers to focus on?**

This might be a breaking change at the moment, but at least it found 90 tests with typos such as `messsage`, `messgeId`, `messagesId`, or using `nodeType` instead of `type`.

If accepted, I'll add test cases for this change, of course.