### PR TITLE
Fix: no-self-assign false positive with rest and spread in array

### DIFF
--- a/lib/rules/no-self-assign.js
+++ b/lib/rules/no-self-assign.js
@@ -94,9 +94,19 @@ function eachSelfAssignment(left, right, props, report) {
         const end = Math.min(left.elements.length, right.elements.length);
 
         for (let i = 0; i < end; ++i) {
+            const leftElement = left.elements[i];
             const rightElement = right.elements[i];
 
-            eachSelfAssignment(left.elements[i], rightElement, props, report);
+            // Avoid cases such as [...a] = [...a, 1]
+            if (
+                leftElement &&
+                leftElement.type === "RestElement" &&
+                i < right.elements.length - 1
+            ) {
+                break;
+            }
+
+            eachSelfAssignment(leftElement, rightElement, props, report);
 
             // After a spread element, those indices are unknown.
             if (rightElement && rightElement.type === "SpreadElement") {

--- a/tests/lib/rules/no-self-assign.js
+++ b/tests/lib/rules/no-self-assign.js
@@ -32,6 +32,8 @@ ruleTester.run("no-self-assign", rule, {
         { code: "[a, b] = [b, a]", parserOptions: { ecmaVersion: 6 } },
         { code: "[a,, b] = [, b, a]", parserOptions: { ecmaVersion: 6 } },
         { code: "[x, a] = [...x, a]", parserOptions: { ecmaVersion: 6 } },
+        { code: "[...a] = [...a, 1]", parserOptions: { ecmaVersion: 6 } },
+        { code: "[a, ...b] = [0, ...b, 1]", parserOptions: { ecmaVersion: 6 } },
         { code: "[a, b] = {a, b}", parserOptions: { ecmaVersion: 6 } },
         { code: "({a} = a)", parserOptions: { ecmaVersion: 6 } },
         { code: "({a = 1} = {a})", parserOptions: { ecmaVersion: 6 } },


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
**Tell us about your environment**

* **ESLint Version:** 6.1.0
* **Node Version:** 10.16.0
* **npm Version:** 6.9.0

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
  parserOptions: {
    ecmaVersion: 2015,
  },
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
/*eslint no-self-assign: "error"*/

let a = [];

[...a] = [...a, 1]

console.log(a); // [ 1 ]
```

**What did you expect to happen?**

No errors as this is not a self assign.

**What actually happened? Please include the actual, raw output from ESLint.**

`'a' is assigned to itself  no-self-assign` error
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Skip comparing a rest element if it isn't vs the last element.

**Is there anything you'd like reviewers to focus on?**
