### PR TITLE
Fix: func-name-matching crash on descriptor-like arguments

### DIFF
--- a/lib/rules/func-name-matching.js
+++ b/lib/rules/func-name-matching.js
@@ -118,6 +118,7 @@ module.exports = {
                 return false;
             }
             return node.type === "CallExpression" &&
+                node.callee.type === "MemberExpression" &&
                 node.callee.object.name === objName &&
                 node.callee.property.name === funcName;
         }

--- a/tests/lib/rules/func-name-matching.js
+++ b/tests/lib/rules/func-name-matching.js
@@ -255,6 +255,10 @@ ruleTester.run("func-name-matching", rule, {
             code: "Reflect.defineProperty(foo, 'bar', { value() {} })",
             options: ["never", { considerPropertyDescriptor: true }],
             parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "foo({ value: function value() {} })",
+            options: ["always", { considerPropertyDescriptor: true }]
         }
     ],
     invalid: [
@@ -445,6 +449,13 @@ ruleTester.run("func-name-matching", rule, {
             options: ["never", { considerPropertyDescriptor: true }],
             errors: [
                 { messageId: "notMatchProperty", data: { funcName: "bar", name: "bar" } }
+            ]
+        },
+        {
+            code: "foo({ value: function bar() {} })",
+            options: ["always", { considerPropertyDescriptor: true }],
+            errors: [
+                { messageId: "matchProperty", data: { funcName: "bar", name: "value" } }
             ]
         }
     ]


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
**Tell us about your environment**

* **ESLint Version:** 6.1.0
* **Node Version:** 10.16.0
* **npm Version:** 6.9.0

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
  parserOptions: {
    ecmaVersion: 2015,
  },
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
/*eslint func-name-matching: ["error", { "considerPropertyDescriptor": true }]*/

foo({ value: function bar() {} })
```

**What did you expect to happen?**

Not to crash.

**What actually happened? Please include the actual, raw output from ESLint.**

`TypeError: Cannot read property 'name' of undefined`
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Fixed the bug.

**Is there anything you'd like reviewers to focus on?**

There is still a number of places where the rule can crash or produce false positives on a designed example, as the code doesn't check parent types, correct index of the child in parent's arguments, existence and types of other arguments from which it reads etc.

An example like this can easily occur in a real code, so it might make sense to fix just this at the moment.

For the rest, I believe it would be better to make helpers in `astUtils` as there are at least 3 other rules that also work with descriptors and have a very similar code (and some small bugs as well).