### PR TITLE
New: no-uneeded-conditionals to flag identical ternary and boolean tests (fixes #12097) (wip)

### DIFF
--- a/conf/eslint-recommended.js
+++ b/conf/eslint-recommended.js
@@ -37,6 +37,7 @@ module.exports = {
         "no-fallthrough": "error",
         "no-func-assign": "error",
         "no-global-assign": "error",
+        "no-identical-ternary-expressions": "error",
         "no-inner-declarations": "error",
         "no-invalid-regexp": "error",
         "no-irregular-whitespace": "error",

--- a/docs/rules/no-identical-ternary-expressions.md
+++ b/docs/rules/no-identical-ternary-expressions.md
@@ -1,0 +1,92 @@
+# Disallow identical expressions and duplicate tests conditions in ternary operators (no-identical-ternary-expressions)
+
+Identical left and right hand expressions inside a ternary operator are a logical type of programming error, since the consequent and alternate (the if and else blocks) are in fact executing the exact same code. Chances are the developer meant to do something else.
+
+Identical test conditions inside chained ternary operators are also a logical error since this will result in unreachable code.
+
+## Rule Details
+
+This rule disallows left and right hand expressions within ternary operators that are logically identical. It also catches duplicate test conditions.
+
+It will ignore grouping parentheses and strip out whitespace when comparing left and right hand expressions that are not string literals.
+
+It does not apply to if/else blocks.
+
+Examples of **incorrect** code for this rule:
+
+```js
+/*eslint no-identical-ternary-expressions: "error"*/
+
+function getFee(isMember) {
+  return (isMember ? "$2.00" : "$2.00");
+}
+
+x === 2
+  ? getFee(bar)
+  : getFee(bar);
+
+var foo = bar > baz ? value1 : value1;
+
+var a = foo ? (((2+5)*7)*2) : ( ( (2+5)* 7)*2 );
+// the left and right hand expressions are identical once stripped of whitespace
+
+var a = foo ? (bar === getFee((baz))) : ((((bar === getFee(baz)))));
+// the left and right hand expressions are identical, grouping parentheses are ignored
+
+return condition1 ? value1 : condition1 ? value2 : value3
+// the first and second tests are identical (condition1 used twice, value2 is unreachable code)
+
+return condition1 ? value1 : condition2 ? value2 : condition1 ? value3 : value4
+// the first and third tests are identical (condition1 used twice, value3 is unreachable code)
+```
+
+Examples of **correct** code for this rule:
+
+```js
+/*eslint no-identical-ternary-expressions: "error"*/
+
+function getFee(isMember) {
+  return (isMember ? "$2.00" : "$5.00");
+}
+
+x === 2
+  ? getFee(bar)
+  : getFee(baz);
+
+var foo = bar > baz ? value1 : value2;
+
+var a = foo ? (((2+5)*7)*2) : ( ( (5+5)* 7)*2 );
+
+var a = foo ? (bar === getFee((bar))) : ((((bar === getFee(baz)))));
+
+return condition1 ? value1 : condition2 ? value2 : value3
+
+return condition1 ? value1 : condition2 ? value2 : condition3 ? value3 : value4
+```
+
+## Style Note
+
+This rule compares the consequent and alternate of individual ternary operators, it will not check for identical values within a chained ternary operator.
+
+This is because this rule is only concerned with logical errors, not with enforcing a consistent style. See the related rules for enforcing a specific ternary style.
+
+```js
+// this code returns value1 when either condition1 or condition3 is met. It's probably an error, but not something this rule would catch
+function foo() {
+    return condition1 ? value1
+         : condition2 ? value2
+         : condition3 ? value1 : value3
+}
+
+// No error even though the above code could be shortened to something like this:
+function foo() {
+    return (condition1 || condition3) ? value1 : condition2 ? value2 : value3
+}
+```
+
+## Related Rules
+
+* [multiline-ternary](multiline-ternary.md)
+* [no-nested-ternary](no-nested-ternary.md)
+* [no-ternary](no-ternary.md)
+* [no-unneeded-ternary](no-unneeded-ternary.md)

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -127,6 +127,7 @@ module.exports = new LazyLoadingRuleMap(Object.entries({
     "no-floating-decimal": () => require("./no-floating-decimal"),
     "no-func-assign": () => require("./no-func-assign"),
     "no-global-assign": () => require("./no-global-assign"),
+    "no-identical-ternary-expressions": () => require("./no-identical-ternary-expressions"),
     "no-implicit-coercion": () => require("./no-implicit-coercion"),
     "no-implicit-globals": () => require("./no-implicit-globals"),
     "no-implied-eval": () => require("./no-implied-eval"),

--- a/lib/rules/no-identical-ternary-expressions.js
+++ b/lib/rules/no-identical-ternary-expressions.js
@@ -1,0 +1,102 @@
+/**
+ * @fileoverview Rule to flag ternary operators that have identical left and right expressions
+ * @author Che Fisher
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+    meta: {
+        type: "problem",
+
+        docs: {
+            description: "disallow ternary operators with identical left and right hand expressions",
+            category: "Possible Errors",
+            recommended: true,
+            url: "https://eslint.org/docs/rules/no-identical-ternary-expressions"
+        },
+
+        schema: [],
+
+        messages: {
+            expressions: "Identical left and right hand expressions '{{expression}}'.",
+            conditions: "Identical test conditions encountered '{{condition}}'."
+        }
+    },
+
+    create(context) {
+        const sourceCode = context.getSourceCode();
+        const conditions = [];
+
+        /**
+         * Checks if the consequent and alternate expressions are identical, stripping out all whitespace first for non literals
+         *
+         * @param  {string} first a string representation of an expression
+         * @param  {string} second a string representation of an expression
+         * @param  {boolean} literal true if node type is a string literal
+         * @returns {boolean} True if the expressions are logically identical
+         * @private
+         */
+        function identicalExpressions(first, second, literal) {
+            if (literal) {
+                return first === second;
+            }
+            return first.replace(/\s/gu, "") === second.replace(/\s/gu, "");
+        }
+
+        /**
+         * Checks if there are identical test conditions used within a chained ternary operator
+         *
+         * @param  {ASTNode} node the current node being checked
+         * @returns {boolean} True if there are duplicate/identical test conditions
+         * @private
+         */
+        function identicalConditions(node) {
+            const testCondition = sourceCode.getText(node.test);
+
+            conditions.push(testCondition);
+            if (node.parent.type === "ConditionalExpression") {
+                return conditions.some((value, i) => conditions.indexOf(value) !== i);
+            }
+            return false;
+        }
+
+        /**
+         * Determins if a given node has identical left and right hand expressions or duplicate test conditions
+         * @param  {ASTNode} node the node to check
+         * @returns {void}
+         * @private
+         */
+        function checkTernary(node) {
+            const leftExpression = sourceCode.getText(node.consequent);
+            const rightExpression = sourceCode.getText(node.alternate);
+            const literal = node.consequent.type === "Literal" || node.alternate.type === "Literal";
+
+            if (identicalExpressions(leftExpression, rightExpression, literal)) {
+                context.report({
+                    node,
+                    loc: node.alternate.loc.start,
+                    messageId: "expressions",
+                    data: { expression: leftExpression }
+                });
+            }
+
+            if (identicalConditions(node)) {
+                context.report({
+                    node,
+                    loc: node.test.loc.start,
+                    messageId: "conditions",
+                    data: { condition: sourceCode.getText(node.test) }
+                });
+            }
+        }
+
+        return {
+            ConditionalExpression: checkTernary
+        };
+    }
+};

--- a/tests/lib/rules/no-identical-ternary-expressions.js
+++ b/tests/lib/rules/no-identical-ternary-expressions.js
@@ -1,0 +1,207 @@
+/**
+ * @fileoverview Tests for no-identical-ternary-expressions rule
+ * @author Che Fisher
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../lib/rules/no-identical-ternary-expressions"),
+    { RuleTester } = require("../../../lib/rule-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-identical-ternary-expressions", rule, {
+
+    valid: [
+        "x === 1 ? 'true' : true;",
+        "var a = x === 1 ? 'false' : false;",
+        "foo() ? null : undefined;",
+        "foo() ? true : foo();",
+        "var a = x === 1 ? foo(x) : foo(y);",
+        "var a = foo ? foo : bar;",
+        "var value = 'a';var set = true;var result = value || (set ? 'unset' : 'cannot set')",
+        "x === 1 ? value1 : x === 2 ? value2 : x === 3 ? value1 : value2",
+        "condition1 ? value1 : condition2 ? value2 : condition3 ? value1 : value3",
+        "matched = options.selector ? options.selector.match(filePath) : options.selector.test(filePath)",
+        "openingElseCurly.range[0] ? ' ' : ''",
+        "foo ? 1 : '1'"
+    ],
+    invalid: [
+
+        // primitives
+        {
+            code: "foo() ? '$2.00' : '$2.00';",
+            errors: [{
+                messageId: "expressions",
+                data: { expression: "'$2.00'" },
+                line: 1,
+                column: 19
+            }]
+        },
+        {
+            code: "foo() ? null : null",
+            errors: [{
+                messageId: "expressions",
+                data: { expression: "null" },
+                line: 1,
+                column: 16
+            }]
+        },
+        {
+            code: "foo() ? undefined : undefined",
+            errors: [{
+                messageId: "expressions",
+                data: { expression: "undefined" },
+                line: 1,
+                column: 21
+            }]
+        },
+        {
+            code: "var a = x === 2 ? true : true;",
+            errors: [{
+                messageId: "expressions",
+                data: { expression: "true" },
+                line: 1,
+                column: 26
+            }]
+        },
+        {
+            code: "var a = foo() ? false : false;",
+            errors: [{
+                messageId: "expressions",
+                data: { expression: "false" },
+                line: 1,
+                column: 25
+            }]
+        },
+
+        // comparisons
+        {
+            code: "var a = x instanceof foo ? x === y : x === y;",
+            errors: [{
+                messageId: "expressions",
+                data: { expression: "x === y" },
+                line: 1,
+                column: 38
+            }]
+        },
+
+        // function calls
+        {
+            code: "x === 2 ? foo() : foo();",
+            errors: [{
+                messageId: "expressions",
+                data: { expression: "foo()" },
+                line: 1,
+                column: 19
+            }]
+        },
+        {
+            code: `
+                value === x
+                ? foo(bar)
+                : foo(bar)`,
+            errors: [{
+                messageId: "expressions",
+                data: { expression: "foo(bar)" },
+                line: 4,
+                column: 19
+            }]
+        },
+
+        // conditions
+        {
+            code: "condition1 ? value1 : condition1 ? value2 : value3;",
+            errors: [{
+                messageId: "conditions",
+                data: { condition: "condition1" },
+                line: 1,
+                column: 23
+            }]
+        },
+        {
+            code: "condition1 ? value1 : condition2 ? value2 : condition1 ? value3 : value4;",
+            errors: [{
+                messageId: "conditions",
+                data: { condition: "condition1" },
+                line: 1,
+                column: 45
+            }]
+        },
+
+        // other
+        {
+            code: "var a = ((foo)) ? ((bar)) : (((((bar)))));",
+            errors: [{
+                messageId: "expressions",
+                data: { expression: "bar" },
+                line: 1,
+                column: 34
+            }]
+        },
+        {
+            code: "var a = foo ? (bar === getFee(baz)) : ((((bar === getFee(baz)))));",
+            errors: [{
+                messageId: "expressions",
+                data: { expression: "bar === getFee(baz)" },
+                line: 1,
+                column: 43
+            }]
+        },
+        {
+            code: "var a = ((foo)) ? (((2+5)*7)*2) : ( ( (2+5)* 7)*2 );",
+            errors: [{
+                messageId: "expressions",
+                data: { expression: "((2+5)*7)*2" },
+                line: 1,
+                column: 37
+            }]
+        },
+        {
+            code: "var result = value ? value : canSet ? value : value",
+            errors: [{
+                messageId: "expressions",
+                data: { expression: "value" },
+                line: 1,
+                column: 47
+            }]
+        },
+        {
+            code: "foo ? bar : (qux ? baz : baz)",
+            errors: [{
+                messageId: "expressions",
+                data: { expression: "baz" },
+                line: 1,
+                column: 26
+            }]
+        },
+        {
+            code: "function* fn() { foo ? yield bar : yield bar }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                messageId: "expressions",
+                data: { expression: "yield bar" },
+                line: 1,
+                column: 36
+            }]
+        },
+        {
+            code: "var a = b ? c => c : c => c;",
+            parserOptions: { ecmaVersion: 2015 },
+            errors: [{
+                messageId: "expressions",
+                data: { expression: "c => c" },
+                line: 1,
+                column: 22
+            }]
+        }
+    ]
+});

--- a/tools/rule-types.json
+++ b/tools/rule-types.json
@@ -96,6 +96,7 @@
     "no-dupe-keys": "problem",
     "no-duplicate-case": "problem",
     "no-duplicate-imports": "problem",
+    "no-identical-ternary-expressions": "problem",
     "no-else-return": "suggestion",
     "no-empty": "suggestion",
     "no-empty-character-class": "problem",


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**
- [x] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))

- the rule would detect identical left and right hand statements within a ternary operator
- the rule would also detect duplicate test conditions within chained ternary operators, which results in unreachable code
- the rule would detect duplicate left and right hand statements separated by boolean operators (`['||', '&&', '==', '===', '!=', '!==', '=>', '<=', '>', '<']`) inside if blocks
- the rule would detect instances where the left and right hand statements of a conditional are the inversion of each other
- the rule would detect boolean comparisons that use NaN as part of the condition since it's probably doing the opposite of what is expected 
- the rule would not detect instances of repeated conditions which could be a style choice

**What category of rule is this? (place an "X" next to just one item)**
- [x] Warns about a potential (very likely) error (problem)

**Provide 2-3 code examples that this rule will warn about:**

<!-- Put your code examples here -->
```js
function getFee(isMember) {
  return (isMember ? "$2.00" : "$2.00")
  // "Error: Identical left and right hand expressions"
}

thing === otherThing
  ? getFee(isMember)
  : getFee(isMember)
// "Error: identical left and right hand expressions"

var foo = bar > baz ? value1 : value1
// "Error: identical left and right hand expressions"

return condition1 ? value1 : condition1 ? value2 : value3
// "Error: identical test conditions encountered"
// the first and second tests are identical (condition1 used twice, value2 is unreachable
// code)

return condition1 ? value1 : condition2 ? value2 : condition1 ? value3 : value4
// "Error: identical test conditions encountered"
// the first and third tests are identical (condition1 used twice, value3 is unreachable
// code)

// example of what is quite possibly a style choice, rule would not flag this
function example(…) {
    return condition1 ? value1
         : condition2 ? value2
         : condition3 ? value1
}
// No error here, even though the above code could be shortened to something 
// like this:
function example(…) {
    return (condition1 || condition3) ? value1
         : condition2 ? value2
}
// Rule will not try and enforce a specific ternary style

// excepting the case of NaN, there is no type of variable in JavaScript that is
// not equal to itself
// conditions that always evaluate to true (except NaN) and are unnecessary
if (x == x) {}
if (x === x) {}
if (x >= x) {}
if (x <= x) {}
// "Error: no unneeded conditionals"

// conditions which always evaluate to false (except NaN) and are unnecessary
if (x != x) {}
if (x !== x) {}
if (x > x) {}
if (x < x) {}
// "Error: no unneeded conditionals"

// conditions which always evaluate to true/false depending on variable type
// and are unnecessary
if (x && x) {}
if (!x && !x) {}
if (x || x) {}
if (!x || !x) {}
// "Error: no unneeded conditionals"

// conditions which always evaluate to true/false due to testing the inversion
// of the variable and are unnecessary
if (x || !x) {}
if (x && !x) {}
if (x == !x) {}
if (x === !x) {}
if (foo(x) || foo(!x)) {}
if (foo(x) || !foo(x)) {}
// we don't need to know the returned type, I would argue that assuming this is
// an error makes sense even if the condition is a function call
// "Error: no unneeded conditionals"

// testing for NaN is bad practice, since it's the only global property/variable type
// not equal to itself
if (NaN === NaN) // false
if (NaN == NaN) // false
if (NaN !== NaN) // true
if (NaN != NaN) // true
// "Error: no unneeded conditionals, use isNaN(variable) when checking if something is NaN"

// slightly more realistic example of why we should not let people use NaN
// anywhere inside a conditional
let x = 'string'
if (x === NaN) {} // false, as expected
x = x / 5 // x becomes NaN
if (x === NaN) {} // false, unexpected, since x is now NaN
```

**Why should this rule be included in ESLint (instead of a plugin)?** 
It finds statements that are logical errors - I cannot think of a case where such conditions would be necessary.

**What changes did you make? (Give an overview)**
- [x] added logic to detect identical left and right hand ternary operators
- [x] added tests for identical left and right hand ternary operators
- [x] added logic to detect identical ternary conditions
- [x] added tests for identical ternary conditions
- [ ] added logic to detect identical left and right hand boolean expressions
- [ ] added tests for identical left and right hand boolean expressions
- [ ] added logic to detect unneeded boolean expressions
- [ ] added tests for unneeded boolean expressions
- [ ] added logic to detect when NaN is used inside conditionals
- [ ] added tests for when NaN is used inside conditionals
- [ ] added docs with examples for said rule

**Is there anything you'd like reviewers to focus on?**
- if tests seem complete (hard to tell)
- if this should be a recommended core rule or not
- if we can think of conditionals using the `typeof` and `instanceof` checks that this rule could catch

There are other examples I can think of (i.e. mathematical equations) which might be out of scope but are technically unneeded. Here are some examples which are worth considering, perhaps we want to catch some but not all of them:

```
if (1 + 2 === 1 + 1 + 1)
// would argue that this is too complex to check for, would require eslint actually doing the
math and solving it as part of the linting
if (5)
// always true, probably worth flagging
if (5 || !6)
// slightly more complex case, always true, probably worth flagging
if (!6 || false)
// slightly more complex case, always false, probably worth flagging
if (!!x === true)
// boolean conversion with double not operator, would leave that one alone, technically this is always going to be true if x is truthy  ("string", 1, []) and always going to be false if value is falsy (null, "", undefined, 0)
```

This rule has the potential to balloon out and become quite complex to implement, I would like to get some feedback about where/what are healthy limits to the unneeded conditionals part :thinking: 