### PR TITLE
Update: Add enforceForSwitchCase option to use-isnan

### DIFF
--- a/docs/rules/use-isnan.md
+++ b/docs/rules/use-isnan.md
@@ -40,3 +40,50 @@ if (!isNaN(foo)) {
     // ...
 }
 ```
+
+## Options
+
+This rule has an object option, with one option:
+
+* `"enforceForSwitchCase"` when set to `true` disallows `case NaN` in `switch` statements. Default is `false`, meaning
+that this rule by default does not warn about `case NaN`.
+
+### enforceForSwitchCase
+
+The `switch` statement internally uses the `===` operator to match the expression's value to a case clause.
+Therefore, it can never match `case NaN`.
+
+Set `"enforceForSwitchCase"` to `true` if you want this rule to report `case NaN` in `switch` statements.
+
+Examples of **incorrect** code for this rule with `"enforceForSwitchCase"` option set to `true`:
+
+```js
+/*eslint use-isnan: ["error", {"enforceForSwitchCase": true}]*/
+
+switch (foo) {
+    case NaN:
+        bar();
+        break;
+    case 1:
+        baz();
+        break;
+    // ...
+}
+```
+
+Examples of **correct** code for this rule with `"enforceForSwitchCase"` option set to `true`:
+
+```js
+/*eslint use-isnan: ["error", {"enforceForSwitchCase": true}]*/
+
+if (Number.isNaN(foo)) {
+    bar();
+} else {
+    switch (foo) {
+        case 1:
+            baz();
+            break;
+        // ...
+    }
+}
+```

--- a/docs/rules/use-isnan.md
+++ b/docs/rules/use-isnan.md
@@ -45,15 +45,15 @@ if (!isNaN(foo)) {
 
 This rule has an object option, with one option:
 
-* `"enforceForSwitchCase"` when set to `true` disallows `case NaN` in `switch` statements. Default is `false`, meaning
-that this rule by default does not warn about `case NaN`.
+* `"enforceForSwitchCase"` when set to `true` disallows `case NaN` and `switch(NaN)` in `switch` statements. Default is `false`, meaning
+that this rule by default does not warn about `case NaN` or `switch(NaN)`.
 
 ### enforceForSwitchCase
 
-The `switch` statement internally uses the `===` operator to match the expression's value to a case clause.
-Therefore, it can never match `case NaN`.
+The `switch` statement internally uses the `===` comparison to match the expression's value to a case clause.
+Therefore, it can never match `case NaN`. Also, `switch(NaN)` can never match a case clause.
 
-Set `"enforceForSwitchCase"` to `true` if you want this rule to report `case NaN` in `switch` statements.
+Set `"enforceForSwitchCase"` to `true` if you want this rule to report `case NaN` and `switch(NaN)` in `switch` statements.
 
 Examples of **incorrect** code for this rule with `"enforceForSwitchCase"` option set to `true`:
 
@@ -65,6 +65,16 @@ switch (foo) {
         bar();
         break;
     case 1:
+        baz();
+        break;
+    // ...
+}
+
+switch (NaN) {
+    case a:
+        bar();
+        break;
+    case b:
         baz();
         break;
     // ...
@@ -86,4 +96,10 @@ if (Number.isNaN(foo)) {
         // ...
     }
 }
+
+if (Number.isNaN(a)) {
+    bar();
+} else if (Number.isNaN(b)) {
+    baz();
+} // ...
 ```

--- a/lib/rules/use-isnan.js
+++ b/lib/rules/use-isnan.js
@@ -6,6 +6,19 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Determines if the given node is a NaN `Identifier` node.
+ * @param {ASTNode|null} node The node to check.
+ * @returns {boolean} `true` if the node is 'NaN' identifier.
+ */
+function isNaNIdentifier(node) {
+    return Boolean(node) && node.type === "Identifier" && node.name === "NaN";
+}
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
@@ -35,6 +48,7 @@ module.exports = {
 
         messages: {
             comparisonWithNaN: "Use the isNaN function to compare with NaN.",
+            switchNaN: "'switch(NaN)' can never match a case clause. Use Number.isNaN instead of the switch.",
             caseNaN: "'case NaN' can never match. Use Number.isNaN before the switch."
         }
     },
@@ -43,22 +57,45 @@ module.exports = {
 
         const enforceForSwitchCase = context.options[0] && context.options[0].enforceForSwitchCase;
 
-        return {
-            BinaryExpression(node) {
-                if (/^(?:[<>]|[!=]=)=?$/u.test(node.operator) && (node.left.name === "NaN" || node.right.name === "NaN")) {
-                    context.report({ node, messageId: "comparisonWithNaN" });
-                }
-            },
-            SwitchCase(node) {
-                if (enforceForSwitchCase) {
-                    const test = node.test;
+        /**
+         * Checks the given `BinaryExpression` node.
+         * @param {ASTNode} node The node to check.
+         * @returns {void}
+         */
+        function checkBinaryExpression(node) {
+            if (
+                /^(?:[<>]|[!=]=)=?$/u.test(node.operator) &&
+                (isNaNIdentifier(node.left) || isNaNIdentifier(node.right))
+            ) {
+                context.report({ node, messageId: "comparisonWithNaN" });
+            }
+        }
 
-                    if (test && test.type === "Identifier" && test.name === "NaN") {
-                        context.report({ node, messageId: "caseNaN" });
-                    }
+        /**
+         * Checks the discriminant and all case clauses of the given `SwitchStatement` node.
+         * @param {ASTNode} node The node to check.
+         * @returns {void}
+         */
+        function checkSwitchStatement(node) {
+            if (isNaNIdentifier(node.discriminant)) {
+                context.report({ node, messageId: "switchNaN" });
+            }
+
+            for (const switchCase of node.cases) {
+                if (isNaNIdentifier(switchCase.test)) {
+                    context.report({ node: switchCase, messageId: "caseNaN" });
                 }
             }
+        }
+
+        const listeners = {
+            BinaryExpression: checkBinaryExpression
         };
 
+        if (enforceForSwitchCase) {
+            listeners.SwitchStatement = checkSwitchStatement;
+        }
+
+        return listeners;
     }
 };

--- a/lib/rules/use-isnan.js
+++ b/lib/rules/use-isnan.js
@@ -20,18 +20,42 @@ module.exports = {
             url: "https://eslint.org/docs/rules/use-isnan"
         },
 
-        schema: [],
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    enforceForSwitchCase: {
+                        type: "boolean",
+                        default: false
+                    }
+                },
+                additionalProperties: false
+            }
+        ],
+
         messages: {
-            useIsNaN: "Use the isNaN function to compare with NaN."
+            comparisonWithNaN: "Use the isNaN function to compare with NaN.",
+            caseNaN: "'case NaN' can never match. Use Number.isNaN before the switch."
         }
     },
 
     create(context) {
 
+        const enforceForSwitchCase = context.options[0] && context.options[0].enforceForSwitchCase;
+
         return {
             BinaryExpression(node) {
                 if (/^(?:[<>]|[!=]=)=?$/u.test(node.operator) && (node.left.name === "NaN" || node.right.name === "NaN")) {
-                    context.report({ node, messageId: "useIsNaN" });
+                    context.report({ node, messageId: "comparisonWithNaN" });
+                }
+            },
+            SwitchCase(node) {
+                if (enforceForSwitchCase) {
+                    const test = node.test;
+
+                    if (test && test.type === "Identifier" && test.name === "NaN") {
+                        context.report({ node, messageId: "caseNaN" });
+                    }
                 }
             }
         };

--- a/tests/lib/rules/use-isnan.js
+++ b/tests/lib/rules/use-isnan.js
@@ -18,7 +18,7 @@ const rule = require("../../../lib/rules/use-isnan"),
 
 const ruleTester = new RuleTester();
 
-const error = { messageId: "useIsNaN", type: "BinaryExpression" };
+const comparisonError = { messageId: "comparisonWithNaN", type: "BinaryExpression" };
 
 ruleTester.run("use-isnan", rule, {
     valid: [
@@ -35,72 +35,152 @@ ruleTester.run("use-isnan", rule, {
         "foo(2 * NaN)",
         "foo(NaN / 2)",
         "foo(2 / NaN)",
-        "var x; if (x = NaN) { }"
+        "var x; if (x = NaN) { }",
+
+        //------------------------------------------------------------------------------
+        // enforceForSwitchCase
+        //------------------------------------------------------------------------------
+
+        "switch(foo) { case NaN: break; }",
+        {
+            code: "switch(foo) { case NaN: break; }",
+            options: [{}]
+        },
+        {
+            code: "switch(foo) { case NaN: break; }",
+            options: [{ enforceForSwitchCase: false }]
+        },
+        {
+            code: "switch(foo) { case bar: break; case NaN: break; default: break; }",
+            options: [{ enforceForSwitchCase: false }]
+        },
+        {
+            code: "switch(foo) {}",
+            options: [{ enforceForSwitchCase: true }]
+        },
+        {
+            code: "switch(NaN) {}",
+            options: [{ enforceForSwitchCase: true }]
+        },
+        {
+            code: "switch(foo) { case Nan: break }",
+            options: [{ enforceForSwitchCase: true }]
+        },
+        {
+            code: "switch(foo) { case 'NaN': break }",
+            options: [{ enforceForSwitchCase: true }]
+        },
+        {
+            code: "switch(foo) { case foo(NaN): break }",
+            options: [{ enforceForSwitchCase: true }]
+        },
+        {
+            code: "switch(foo) { case bar: break; case 1: break; default: break; }",
+            options: [{ enforceForSwitchCase: true }]
+        }
     ],
     invalid: [
         {
             code: "123 == NaN;",
-            errors: [error]
+            errors: [comparisonError]
         },
         {
             code: "123 === NaN;",
-            errors: [error]
+            errors: [comparisonError]
         },
         {
             code: "NaN === \"abc\";",
-            errors: [error]
+            errors: [comparisonError]
         },
         {
             code: "NaN == \"abc\";",
-            errors: [error]
+            errors: [comparisonError]
         },
         {
             code: "123 != NaN;",
-            errors: [error]
+            errors: [comparisonError]
         },
         {
             code: "123 !== NaN;",
-            errors: [error]
+            errors: [comparisonError]
         },
         {
             code: "NaN !== \"abc\";",
-            errors: [error]
+            errors: [comparisonError]
         },
         {
             code: "NaN != \"abc\";",
-            errors: [error]
+            errors: [comparisonError]
         },
         {
             code: "NaN < \"abc\";",
-            errors: [error]
+            errors: [comparisonError]
         },
         {
             code: "\"abc\" < NaN;",
-            errors: [error]
+            errors: [comparisonError]
         },
         {
             code: "NaN > \"abc\";",
-            errors: [error]
+            errors: [comparisonError]
         },
         {
             code: "\"abc\" > NaN;",
-            errors: [error]
+            errors: [comparisonError]
         },
         {
             code: "NaN <= \"abc\";",
-            errors: [error]
+            errors: [comparisonError]
         },
         {
             code: "\"abc\" <= NaN;",
-            errors: [error]
+            errors: [comparisonError]
         },
         {
             code: "NaN >= \"abc\";",
-            errors: [error]
+            errors: [comparisonError]
         },
         {
             code: "\"abc\" >= NaN;",
-            errors: [error]
+            errors: [comparisonError]
+        },
+
+        //------------------------------------------------------------------------------
+        // enforceForSwitchCase
+        //------------------------------------------------------------------------------
+
+        {
+            code: "switch(foo) { case NaN: }",
+            options: [{ enforceForSwitchCase: true }],
+            errors: [{ messageId: "caseNaN", type: "SwitchCase", column: 15 }]
+        },
+        {
+            code: "switch(foo) { case NaN: break; }",
+            options: [{ enforceForSwitchCase: true }],
+            errors: [{ messageId: "caseNaN", type: "SwitchCase", column: 15 }]
+        },
+        {
+            code: "switch(foo) { case (NaN): break; }",
+            options: [{ enforceForSwitchCase: true }],
+            errors: [{ messageId: "caseNaN", type: "SwitchCase", column: 15 }]
+        },
+        {
+            code: "switch(foo) { case bar: break; case NaN: break; default: break; }",
+            options: [{ enforceForSwitchCase: true }],
+            errors: [{ messageId: "caseNaN", type: "SwitchCase", column: 32 }]
+        },
+        {
+            code: "switch(foo) { case bar: case NaN: default: break; }",
+            options: [{ enforceForSwitchCase: true }],
+            errors: [{ messageId: "caseNaN", type: "SwitchCase", column: 25 }]
+        },
+        {
+            code: "switch(foo) { case bar: break; case NaN: break; case baz: break; case NaN: break;}",
+            options: [{ enforceForSwitchCase: true }],
+            errors: [
+                { messageId: "caseNaN", type: "SwitchCase", column: 32 },
+                { messageId: "caseNaN", type: "SwitchCase", column: 66 }
+            ]
         }
     ]
 });

--- a/tests/lib/rules/use-isnan.js
+++ b/tests/lib/rules/use-isnan.js
@@ -41,13 +41,26 @@ ruleTester.run("use-isnan", rule, {
         // enforceForSwitchCase
         //------------------------------------------------------------------------------
 
+        "switch(NaN) { case foo: break; }",
         "switch(foo) { case NaN: break; }",
+        {
+            code: "switch(NaN) { case foo: break; }",
+            options: [{}]
+        },
         {
             code: "switch(foo) { case NaN: break; }",
             options: [{}]
         },
         {
+            code: "switch(NaN) { case foo: break; }",
+            options: [{ enforceForSwitchCase: false }]
+        },
+        {
             code: "switch(foo) { case NaN: break; }",
+            options: [{ enforceForSwitchCase: false }]
+        },
+        {
+            code: "switch(NaN) { case NaN: break; }",
             options: [{ enforceForSwitchCase: false }]
         },
         {
@@ -59,7 +72,27 @@ ruleTester.run("use-isnan", rule, {
             options: [{ enforceForSwitchCase: true }]
         },
         {
-            code: "switch(NaN) {}",
+            code: "switch(foo) { case bar: NaN; }",
+            options: [{ enforceForSwitchCase: true }]
+        },
+        {
+            code: "switch(foo) { default: NaN; }",
+            options: [{ enforceForSwitchCase: true }]
+        },
+        {
+            code: "switch(Nan) {}",
+            options: [{ enforceForSwitchCase: true }]
+        },
+        {
+            code: "switch('NaN') { default: break; }",
+            options: [{ enforceForSwitchCase: true }]
+        },
+        {
+            code: "switch(foo(NaN)) {}",
+            options: [{ enforceForSwitchCase: true }]
+        },
+        {
+            code: "switch(foo.NaN) {}",
             options: [{ enforceForSwitchCase: true }]
         },
         {
@@ -72,6 +105,10 @@ ruleTester.run("use-isnan", rule, {
         },
         {
             code: "switch(foo) { case foo(NaN): break }",
+            options: [{ enforceForSwitchCase: true }]
+        },
+        {
+            code: "switch(foo) { case foo.NaN: break }",
             options: [{ enforceForSwitchCase: true }]
         },
         {
@@ -150,6 +187,26 @@ ruleTester.run("use-isnan", rule, {
         //------------------------------------------------------------------------------
 
         {
+            code: "switch(NaN) {}",
+            options: [{ enforceForSwitchCase: true }],
+            errors: [{ messageId: "switchNaN", type: "SwitchStatement", column: 1 }]
+        },
+        {
+            code: "switch(NaN) { case foo: break; }",
+            options: [{ enforceForSwitchCase: true }],
+            errors: [{ messageId: "switchNaN", type: "SwitchStatement", column: 1 }]
+        },
+        {
+            code: "switch(NaN) { default: break; }",
+            options: [{ enforceForSwitchCase: true }],
+            errors: [{ messageId: "switchNaN", type: "SwitchStatement", column: 1 }]
+        },
+        {
+            code: "switch(NaN) { case foo: break; default: break; }",
+            options: [{ enforceForSwitchCase: true }],
+            errors: [{ messageId: "switchNaN", type: "SwitchStatement", column: 1 }]
+        },
+        {
             code: "switch(foo) { case NaN: }",
             options: [{ enforceForSwitchCase: true }],
             errors: [{ messageId: "caseNaN", type: "SwitchCase", column: 15 }]
@@ -175,11 +232,19 @@ ruleTester.run("use-isnan", rule, {
             errors: [{ messageId: "caseNaN", type: "SwitchCase", column: 25 }]
         },
         {
-            code: "switch(foo) { case bar: break; case NaN: break; case baz: break; case NaN: break;}",
+            code: "switch(foo) { case bar: break; case NaN: break; case baz: break; case NaN: break; }",
             options: [{ enforceForSwitchCase: true }],
             errors: [
                 { messageId: "caseNaN", type: "SwitchCase", column: 32 },
                 { messageId: "caseNaN", type: "SwitchCase", column: 66 }
+            ]
+        },
+        {
+            code: "switch(NaN) { case NaN: break; }",
+            options: [{ enforceForSwitchCase: true }],
+            errors: [
+                { messageId: "switchNaN", type: "SwitchStatement", column: 1 },
+                { messageId: "caseNaN", type: "SwitchCase", column: 15 }
             ]
         }
     ]


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Changes an existing rule

Refs #12207

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**What rule do you want to change?**

`use-isnan`

**Does this change cause the rule to produce more or fewer warnings?**

More if the option is set.

**How will the change be implemented? (New option, new default behavior, etc.)?**

New option, which might be removed in major version to be new default behavior.

**Please provide some example code that this change will affect:**

```js
/*eslint use-isnan: ["error", {"enforceForSwitchCase": true}]*/

switch (foo) {
    case NaN:
        bar();
        break;
    case 1:
        baz();
        break;
    // ...
}
```

**What does the rule currently do for this code?**

Nothing.

**What will the rule do after it's changed?**

Report warning.

`case NaN` is a possible error, basically the same as `foo === NaN` which the rule targets.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

New option.

**Is there anything you'd like reviewers to focus on?**

* The message in general. Also, there was an issue #375 should the rule recommend `Number.isNaN`.
* The `correct` example in docs, is there a 'better' way to solve it?
* Should the same option also report `switch (NaN)`?

I'll submit another PR for `.indexOf()` and `.lastIndexOf()`, that should be a separate option (and stay as an option) as it can cause false positives due to the limitations, so someone might want to turn these off.