### PR TITLE
Update: Add enforceForClassMembers option to no-useless-computed-key

### DIFF
--- a/docs/rules/no-useless-computed-key.md
+++ b/docs/rules/no-useless-computed-key.md
@@ -1,4 +1,4 @@
-# Disallow unnecessary computed property keys (no-useless-computed-key)
+# Disallow unnecessary computed property keys in objects and classes (no-useless-computed-key)
 
 It's unnecessary to use computed properties with literals such as:
 
@@ -64,7 +64,7 @@ class Foo {
     [0]() {}
     ['a']() {}
     get ['b']() {}
-    set ['c']() {}
+    set ['c'](value) {}
 
     static ['a']() {}
 }

--- a/docs/rules/no-useless-computed-key.md
+++ b/docs/rules/no-useless-computed-key.md
@@ -1,4 +1,4 @@
-# Disallow unnecessary computed property keys on objects (no-useless-computed-key)
+# Disallow unnecessary computed property keys (no-useless-computed-key)
 
 It's unnecessary to use computed properties with literals such as:
 
@@ -15,8 +15,6 @@ var foo = {"a": "b"};
 ## Rule Details
 
 This rule disallows unnecessary usage of computed property keys.
-
-## Examples
 
 Examples of **incorrect** code for this rule:
 
@@ -41,6 +39,35 @@ var c = { 0: 0 };
 var a = { x() {} };
 var c = { a: 0 };
 var c = { '0+1,234': 0 };
+```
+
+## Options
+
+This rule has an object option:
+
+* `enforceForClassMembers` set to `true` additionally applies this rule to class members (Default `false`).
+
+### enforceForClassMembers
+
+By default, this rule does not check class declarations and class expressions,
+as the default value for `enforceForClassMembers` is `false`.
+
+When `enforceForClassMembers` is set to `true`, the rule will also disallow unnecessary computed
+keys inside of class methods, getters and setters.
+
+Examples of **incorrect** code for `{ "enforceForClassMembers": true }`:
+
+```js
+/*eslint no-useless-computed-key: ["error", { "enforceForClassMembers": true }]*/
+
+class Foo {
+    [0]() {}
+    ['a']() {}
+    get ['b']() {}
+    set ['c']() {}
+
+    static ['a']() {}
+}
 ```
 
 ## When Not To Use It

--- a/lib/rules/no-useless-computed-key.js
+++ b/lib/rules/no-useless-computed-key.js
@@ -8,6 +8,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
+const lodash = require("lodash");
 const astUtils = require("./utils/ast-utils");
 
 //------------------------------------------------------------------------------
@@ -27,51 +28,71 @@ module.exports = {
             url: "https://eslint.org/docs/rules/no-useless-computed-key"
         },
 
-        schema: [],
+        schema: [{
+            type: "object",
+            properties: {
+                checkMethods: {
+                    type: "boolean",
+                    default: false
+                }
+            },
+            additionalProperties: false
+        }],
         fixable: "code"
     },
     create(context) {
         const sourceCode = context.getSourceCode();
+        const checkMethods = context.options[0] && context.options[0].checkMethods;
+
+        /**
+         * Reports a given node if it violated this rule.
+         *
+         * @param {ASTNode} node - The node to check.
+         * @returns {void}
+         */
+        function check(node) {
+            if (!node.computed) {
+                return;
+            }
+
+            const allowedKeys = node.type === "MethodDefinition" ? ["constructor"] : ["__proto__"];
+            const key = node.key,
+                nodeType = typeof key.value;
+
+            if (key.type === "Literal" && (nodeType === "string" || nodeType === "number") && !allowedKeys.includes(key.value)) {
+                context.report({
+                    node,
+                    message: MESSAGE_UNNECESSARY_COMPUTED,
+                    data: { property: sourceCode.getText(key) },
+                    fix(fixer) {
+                        const leftSquareBracket = sourceCode.getFirstToken(node, astUtils.isOpeningBracketToken);
+                        const rightSquareBracket = sourceCode.getFirstTokenBetween(node.key, node.value, astUtils.isClosingBracketToken);
+                        const tokensBetween = sourceCode.getTokensBetween(leftSquareBracket, rightSquareBracket, 1);
+
+                        if (tokensBetween.slice(0, -1).some((token, index) =>
+                            sourceCode.getText().slice(token.range[1], tokensBetween[index + 1].range[0]).trim())) {
+
+                            // If there are comments between the brackets and the property name, don't do a fix.
+                            return null;
+                        }
+
+                        const tokenBeforeLeftBracket = sourceCode.getTokenBefore(leftSquareBracket);
+
+                        // Insert a space before the key to avoid changing identifiers, e.g. ({ get[2]() {} }) to ({ get2() {} })
+                        const needsSpaceBeforeKey = tokenBeforeLeftBracket.range[1] === leftSquareBracket.range[0] &&
+                            !astUtils.canTokensBeAdjacent(tokenBeforeLeftBracket, sourceCode.getFirstToken(key));
+
+                        const replacementKey = (needsSpaceBeforeKey ? " " : "") + key.raw;
+
+                        return fixer.replaceTextRange([leftSquareBracket.range[0], rightSquareBracket.range[1]], replacementKey);
+                    }
+                });
+            }
+        }
 
         return {
-            Property(node) {
-                if (!node.computed) {
-                    return;
-                }
-
-                const key = node.key,
-                    nodeType = typeof key.value;
-
-                if (key.type === "Literal" && (nodeType === "string" || nodeType === "number") && key.value !== "__proto__") {
-                    context.report({
-                        node,
-                        message: MESSAGE_UNNECESSARY_COMPUTED,
-                        data: { property: sourceCode.getText(key) },
-                        fix(fixer) {
-                            const leftSquareBracket = sourceCode.getFirstToken(node, astUtils.isOpeningBracketToken);
-                            const rightSquareBracket = sourceCode.getFirstTokenBetween(node.key, node.value, astUtils.isClosingBracketToken);
-                            const tokensBetween = sourceCode.getTokensBetween(leftSquareBracket, rightSquareBracket, 1);
-
-                            if (tokensBetween.slice(0, -1).some((token, index) =>
-                                sourceCode.getText().slice(token.range[1], tokensBetween[index + 1].range[0]).trim())) {
-
-                                // If there are comments between the brackets and the property name, don't do a fix.
-                                return null;
-                            }
-
-                            const tokenBeforeLeftBracket = sourceCode.getTokenBefore(leftSquareBracket);
-
-                            // Insert a space before the key to avoid changing identifiers, e.g. ({ get[2]() {} }) to ({ get2() {} })
-                            const needsSpaceBeforeKey = tokenBeforeLeftBracket.range[1] === leftSquareBracket.range[0] &&
-                                !astUtils.canTokensBeAdjacent(tokenBeforeLeftBracket, sourceCode.getFirstToken(key));
-
-                            const replacementKey = (needsSpaceBeforeKey ? " " : "") + key.raw;
-
-                            return fixer.replaceTextRange([leftSquareBracket.range[0], rightSquareBracket.range[1]], replacementKey);
-                        }
-                    });
-                }
-            }
+            Property: check,
+            MethodDefinition: checkMethods ? check : lodash.noop
         };
     }
 };

--- a/lib/rules/no-useless-computed-key.js
+++ b/lib/rules/no-useless-computed-key.js
@@ -31,7 +31,7 @@ module.exports = {
         schema: [{
             type: "object",
             properties: {
-                checkMethods: {
+                enforceForClassMembers: {
                     type: "boolean",
                     default: false
                 }
@@ -42,7 +42,7 @@ module.exports = {
     },
     create(context) {
         const sourceCode = context.getSourceCode();
-        const checkMethods = context.options[0] && context.options[0].checkMethods;
+        const enforceForClassMembers = context.options[0] && context.options[0].enforceForClassMembers;
 
         /**
          * Reports a given node if it violated this rule.
@@ -99,7 +99,7 @@ module.exports = {
 
         return {
             Property: check,
-            MethodDefinition: checkMethods ? check : lodash.noop
+            MethodDefinition: enforceForClassMembers ? check : lodash.noop
         };
     }
 };

--- a/lib/rules/no-useless-computed-key.js
+++ b/lib/rules/no-useless-computed-key.js
@@ -22,7 +22,7 @@ module.exports = {
         type: "suggestion",
 
         docs: {
-            description: "disallow unnecessary computed property keys in object literals",
+            description: "disallow unnecessary computed property keys in objects and classes",
             category: "ECMAScript 6",
             recommended: false,
             url: "https://eslint.org/docs/rules/no-useless-computed-key"

--- a/lib/rules/no-useless-computed-key.js
+++ b/lib/rules/no-useless-computed-key.js
@@ -58,18 +58,15 @@ module.exports = {
             const key = node.key,
                 nodeType = typeof key.value;
 
-            const allowedKeys = [];
+            let allowedKey;
 
             if (node.type === "MethodDefinition") {
-                allowedKeys.push("constructor");
-                if (node.static) {
-                    allowedKeys.push("prototype");
-                }
+                allowedKey = node.static ? "prototype" : "constructor";
             } else {
-                allowedKeys.push("__proto__");
+                allowedKey = "__proto__";
             }
 
-            if (key.type === "Literal" && (nodeType === "string" || nodeType === "number") && !allowedKeys.includes(key.value)) {
+            if (key.type === "Literal" && (nodeType === "string" || nodeType === "number") && key.value !== allowedKey) {
                 context.report({
                     node,
                     message: MESSAGE_UNNECESSARY_COMPUTED,

--- a/lib/rules/no-useless-computed-key.js
+++ b/lib/rules/no-useless-computed-key.js
@@ -46,8 +46,7 @@ module.exports = {
 
         /**
          * Reports a given node if it violated this rule.
-         *
-         * @param {ASTNode} node - The node to check.
+         * @param {ASTNode} node The node to check.
          * @returns {void}
          */
         function check(node) {

--- a/lib/rules/no-useless-computed-key.js
+++ b/lib/rules/no-useless-computed-key.js
@@ -55,9 +55,19 @@ module.exports = {
                 return;
             }
 
-            const allowedKeys = node.type === "MethodDefinition" ? ["constructor"] : ["__proto__"];
             const key = node.key,
                 nodeType = typeof key.value;
+
+            const allowedKeys = [];
+
+            if (node.type === "MethodDefinition") {
+                allowedKeys.push("constructor");
+                if (node.static) {
+                    allowedKeys.push("prototype");
+                }
+            } else {
+                allowedKeys.push("__proto__");
+            }
 
             if (key.type === "Literal" && (nodeType === "string" || nodeType === "number") && !allowedKeys.includes(key.value)) {
                 context.report({

--- a/tests/lib/rules/no-useless-computed-key.js
+++ b/tests/lib/rules/no-useless-computed-key.js
@@ -23,7 +23,10 @@ ruleTester.run("no-useless-computed-key", rule, {
         "({ 'a': 0, b(){} })",
         "({ [x]: 0 });",
         "({ a: 0, [b](){} })",
-        "({ ['__proto__']: [] })"
+        "({ ['__proto__']: [] })",
+        "class Foo { 'a'() {} }",
+        "class Foo { [x]() {} }",
+        "class Foo { ['constructor']() {} }"
     ],
     invalid: [
         {
@@ -167,6 +170,157 @@ ruleTester.run("no-useless-computed-key", rule, {
             output: "({ async*2() {} })",
             errors: [{
                 message: "Unnecessarily computed property [2] found.", type: "Property"
+            }]
+        }, {
+            code: "class Foo { ['0']() {} }",
+            output: "class Foo { '0'() {} }",
+            options: [{ checkMethods: true }],
+            errors: [{
+                message: "Unnecessarily computed property ['0'] found.", type: "MethodDefinition"
+            }]
+        }, {
+            code: "class Foo { ['0+1,234']() {} }",
+            output: "class Foo { '0+1,234'() {} }",
+            options: [{ checkMethods: true }],
+            errors: [{
+                message: "Unnecessarily computed property ['0+1,234'] found.", type: "MethodDefinition"
+            }]
+        }, {
+            code: "class Foo { ['x']() {} }",
+            output: "class Foo { 'x'() {} }",
+            options: [{ checkMethods: true }],
+            errors: [{
+                message: "Unnecessarily computed property ['x'] found.", type: "MethodDefinition"
+            }]
+        }, {
+            code: "class Foo { [/* this comment prevents a fix */ 'x']() {} }",
+            output: null,
+            options: [{ checkMethods: true }],
+            errors: [{
+                message: "Unnecessarily computed property ['x'] found.", type: "MethodDefinition"
+            }]
+        }, {
+            code: "class Foo { ['x' /* this comment also prevents a fix */]() {} }",
+            output: null,
+            options: [{ checkMethods: true }],
+            errors: [{
+                message: "Unnecessarily computed property ['x'] found.", type: "MethodDefinition"
+            }]
+        }, {
+            code: "class Foo { [('x')]() {} }",
+            output: "class Foo { 'x'() {} }",
+            options: [{ checkMethods: true }],
+            errors: [{
+                message: "Unnecessarily computed property ['x'] found.", type: "MethodDefinition"
+            }]
+        }, {
+            code: "class Foo { *['x']() {} }",
+            output: "class Foo { *'x'() {} }",
+            options: [{ checkMethods: true }],
+            errors: [{
+                message: "Unnecessarily computed property ['x'] found.", type: "MethodDefinition"
+            }]
+        }, {
+            code: "class Foo { async ['x']() {} }",
+            output: "class Foo { async 'x'() {} }",
+            options: [{ checkMethods: true }],
+            parserOptions: { ecmaVersion: 8 },
+            errors: [{
+                message: "Unnecessarily computed property ['x'] found.", type: "MethodDefinition"
+            }]
+        }, {
+            code: "class Foo { get[.2]() {} }",
+            output: "class Foo { get.2() {} }",
+            options: [{ checkMethods: true }],
+            errors: [{
+                message: "Unnecessarily computed property [.2] found.", type: "MethodDefinition"
+            }]
+        }, {
+            code: "class Foo { set[.2](value) {} }",
+            output: "class Foo { set.2(value) {} }",
+            options: [{ checkMethods: true }],
+            errors: [{
+                message: "Unnecessarily computed property [.2] found.", type: "MethodDefinition"
+            }]
+        }, {
+            code: "class Foo { async[.2]() {} }",
+            output: "class Foo { async.2() {} }",
+            options: [{ checkMethods: true }],
+            parserOptions: { ecmaVersion: 8 },
+            errors: [{
+                message: "Unnecessarily computed property [.2] found.", type: "MethodDefinition"
+            }]
+        }, {
+            code: "class Foo { [2]() {} }",
+            output: "class Foo { 2() {} }",
+            options: [{ checkMethods: true }],
+            errors: [{
+                message: "Unnecessarily computed property [2] found.", type: "MethodDefinition"
+            }]
+        }, {
+            code: "class Foo { get [2]() {} }",
+            output: "class Foo { get 2() {} }",
+            options: [{ checkMethods: true }],
+            errors: [{
+                message: "Unnecessarily computed property [2] found.", type: "MethodDefinition"
+            }]
+        }, {
+            code: "class Foo { set [2](value) {} }",
+            output: "class Foo { set 2(value) {} }",
+            options: [{ checkMethods: true }],
+            errors: [{
+                message: "Unnecessarily computed property [2] found.", type: "MethodDefinition"
+            }]
+        }, {
+            code: "class Foo { async [2]() {} }",
+            output: "class Foo { async 2() {} }",
+            options: [{ checkMethods: true }],
+            parserOptions: { ecmaVersion: 8 },
+            errors: [{
+                message: "Unnecessarily computed property [2] found.", type: "MethodDefinition"
+            }]
+        }, {
+            code: "class Foo { get[2]() {} }",
+            output: "class Foo { get 2() {} }",
+            options: [{ checkMethods: true }],
+            errors: [{
+                message: "Unnecessarily computed property [2] found.", type: "MethodDefinition"
+            }]
+        }, {
+            code: "class Foo { set[2](value) {} }",
+            output: "class Foo { set 2(value) {} }",
+            options: [{ checkMethods: true }],
+            errors: [{
+                message: "Unnecessarily computed property [2] found.", type: "MethodDefinition"
+            }]
+        }, {
+            code: "class Foo { async[2]() {} }",
+            output: "class Foo { async 2() {} }",
+            options: [{ checkMethods: true }],
+            parserOptions: { ecmaVersion: 8 },
+            errors: [{
+                message: "Unnecessarily computed property [2] found.", type: "MethodDefinition"
+            }]
+        }, {
+            code: "class Foo { get['foo']() {} }",
+            output: "class Foo { get'foo'() {} }",
+            options: [{ checkMethods: true }],
+            errors: [{
+                message: "Unnecessarily computed property ['foo'] found.", type: "MethodDefinition"
+            }]
+        }, {
+            code: "class Foo { *[2]() {} }",
+            output: "class Foo { *2() {} }",
+            options: [{ checkMethods: true }],
+            errors: [{
+                message: "Unnecessarily computed property [2] found.", type: "MethodDefinition"
+            }]
+        }, {
+            code: "class Foo { async*[2]() {} }",
+            output: "class Foo { async*2() {} }",
+            options: [{ checkMethods: true }],
+            errors: [{
+                message: "Unnecessarily computed property [2] found.", type: "MethodDefinition"
             }]
         }
     ]

--- a/tests/lib/rules/no-useless-computed-key.js
+++ b/tests/lib/rules/no-useless-computed-key.js
@@ -27,7 +27,6 @@ ruleTester.run("no-useless-computed-key", rule, {
         "class Foo { 'a'() {} }",
         "class Foo { [x]() {} }",
         "class Foo { ['constructor']() {} }",
-        "class Foo { static ['constructor']() {} }",
         "class Foo { static ['prototype']() {} }"
     ],
     invalid: [
@@ -323,6 +322,13 @@ ruleTester.run("no-useless-computed-key", rule, {
             options: [{ checkMethods: true }],
             errors: [{
                 message: "Unnecessarily computed property [2] found.", type: "MethodDefinition"
+            }]
+        }, {
+            code: "class Foo { static ['constructor']() {} }",
+            output: "class Foo { static 'constructor'() {} }",
+            options: [{ checkMethods: true }],
+            errors: [{
+                message: "Unnecessarily computed property ['constructor'] found.", type: "MethodDefinition"
             }]
         }, {
             code: "class Foo { ['prototype']() {} }",

--- a/tests/lib/rules/no-useless-computed-key.js
+++ b/tests/lib/rules/no-useless-computed-key.js
@@ -26,7 +26,9 @@ ruleTester.run("no-useless-computed-key", rule, {
         "({ ['__proto__']: [] })",
         "class Foo { 'a'() {} }",
         "class Foo { [x]() {} }",
-        "class Foo { ['constructor']() {} }"
+        "class Foo { ['constructor']() {} }",
+        "class Foo { static ['constructor']() {} }",
+        "class Foo { static ['prototype']() {} }"
     ],
     invalid: [
         {
@@ -321,6 +323,13 @@ ruleTester.run("no-useless-computed-key", rule, {
             options: [{ checkMethods: true }],
             errors: [{
                 message: "Unnecessarily computed property [2] found.", type: "MethodDefinition"
+            }]
+        }, {
+            code: "class Foo { ['prototype']() {} }",
+            output: "class Foo { 'prototype'() {} }",
+            options: [{ checkMethods: true }],
+            errors: [{
+                message: "Unnecessarily computed property ['prototype'] found.", type: "MethodDefinition"
             }]
         }
     ]

--- a/tests/lib/rules/no-useless-computed-key.js
+++ b/tests/lib/rules/no-useless-computed-key.js
@@ -24,10 +24,10 @@ ruleTester.run("no-useless-computed-key", rule, {
         "({ [x]: 0 });",
         "({ a: 0, [b](){} })",
         "({ ['__proto__']: [] })",
-        "class Foo { 'a'() {} }",
-        "class Foo { [x]() {} }",
-        "class Foo { ['constructor']() {} }",
-        "class Foo { static ['prototype']() {} }"
+        { code: "class Foo { 'a'() {} }", options: [{ enforceForClassMembers: true }] },
+        { code: "class Foo { [x]() {} }", options: [{ enforceForClassMembers: true }] },
+        { code: "class Foo { ['constructor']() {} }", options: [{ enforceForClassMembers: true }] },
+        { code: "class Foo { static ['prototype']() {} }", options: [{ enforceForClassMembers: true }] }
     ],
     invalid: [
         {

--- a/tests/lib/rules/no-useless-computed-key.js
+++ b/tests/lib/rules/no-useless-computed-key.js
@@ -24,6 +24,7 @@ ruleTester.run("no-useless-computed-key", rule, {
         "({ [x]: 0 });",
         "({ a: 0, [b](){} })",
         "({ ['__proto__']: [] })",
+        { code: "class Foo { a() {} }", options: [{ enforceForClassMembers: true }] },
         { code: "class Foo { 'a'() {} }", options: [{ enforceForClassMembers: true }] },
         { code: "class Foo { [x]() {} }", options: [{ enforceForClassMembers: true }] },
         { code: "class Foo { ['constructor']() {} }", options: [{ enforceForClassMembers: true }] },

--- a/tests/lib/rules/no-useless-computed-key.js
+++ b/tests/lib/rules/no-useless-computed-key.js
@@ -175,56 +175,56 @@ ruleTester.run("no-useless-computed-key", rule, {
         }, {
             code: "class Foo { ['0']() {} }",
             output: "class Foo { '0'() {} }",
-            options: [{ checkMethods: true }],
+            options: [{ enforceForClassMembers: true }],
             errors: [{
                 message: "Unnecessarily computed property ['0'] found.", type: "MethodDefinition"
             }]
         }, {
             code: "class Foo { ['0+1,234']() {} }",
             output: "class Foo { '0+1,234'() {} }",
-            options: [{ checkMethods: true }],
+            options: [{ enforceForClassMembers: true }],
             errors: [{
                 message: "Unnecessarily computed property ['0+1,234'] found.", type: "MethodDefinition"
             }]
         }, {
             code: "class Foo { ['x']() {} }",
             output: "class Foo { 'x'() {} }",
-            options: [{ checkMethods: true }],
+            options: [{ enforceForClassMembers: true }],
             errors: [{
                 message: "Unnecessarily computed property ['x'] found.", type: "MethodDefinition"
             }]
         }, {
             code: "class Foo { [/* this comment prevents a fix */ 'x']() {} }",
             output: null,
-            options: [{ checkMethods: true }],
+            options: [{ enforceForClassMembers: true }],
             errors: [{
                 message: "Unnecessarily computed property ['x'] found.", type: "MethodDefinition"
             }]
         }, {
             code: "class Foo { ['x' /* this comment also prevents a fix */]() {} }",
             output: null,
-            options: [{ checkMethods: true }],
+            options: [{ enforceForClassMembers: true }],
             errors: [{
                 message: "Unnecessarily computed property ['x'] found.", type: "MethodDefinition"
             }]
         }, {
             code: "class Foo { [('x')]() {} }",
             output: "class Foo { 'x'() {} }",
-            options: [{ checkMethods: true }],
+            options: [{ enforceForClassMembers: true }],
             errors: [{
                 message: "Unnecessarily computed property ['x'] found.", type: "MethodDefinition"
             }]
         }, {
             code: "class Foo { *['x']() {} }",
             output: "class Foo { *'x'() {} }",
-            options: [{ checkMethods: true }],
+            options: [{ enforceForClassMembers: true }],
             errors: [{
                 message: "Unnecessarily computed property ['x'] found.", type: "MethodDefinition"
             }]
         }, {
             code: "class Foo { async ['x']() {} }",
             output: "class Foo { async 'x'() {} }",
-            options: [{ checkMethods: true }],
+            options: [{ enforceForClassMembers: true }],
             parserOptions: { ecmaVersion: 8 },
             errors: [{
                 message: "Unnecessarily computed property ['x'] found.", type: "MethodDefinition"
@@ -232,21 +232,21 @@ ruleTester.run("no-useless-computed-key", rule, {
         }, {
             code: "class Foo { get[.2]() {} }",
             output: "class Foo { get.2() {} }",
-            options: [{ checkMethods: true }],
+            options: [{ enforceForClassMembers: true }],
             errors: [{
                 message: "Unnecessarily computed property [.2] found.", type: "MethodDefinition"
             }]
         }, {
             code: "class Foo { set[.2](value) {} }",
             output: "class Foo { set.2(value) {} }",
-            options: [{ checkMethods: true }],
+            options: [{ enforceForClassMembers: true }],
             errors: [{
                 message: "Unnecessarily computed property [.2] found.", type: "MethodDefinition"
             }]
         }, {
             code: "class Foo { async[.2]() {} }",
             output: "class Foo { async.2() {} }",
-            options: [{ checkMethods: true }],
+            options: [{ enforceForClassMembers: true }],
             parserOptions: { ecmaVersion: 8 },
             errors: [{
                 message: "Unnecessarily computed property [.2] found.", type: "MethodDefinition"
@@ -254,28 +254,28 @@ ruleTester.run("no-useless-computed-key", rule, {
         }, {
             code: "class Foo { [2]() {} }",
             output: "class Foo { 2() {} }",
-            options: [{ checkMethods: true }],
+            options: [{ enforceForClassMembers: true }],
             errors: [{
                 message: "Unnecessarily computed property [2] found.", type: "MethodDefinition"
             }]
         }, {
             code: "class Foo { get [2]() {} }",
             output: "class Foo { get 2() {} }",
-            options: [{ checkMethods: true }],
+            options: [{ enforceForClassMembers: true }],
             errors: [{
                 message: "Unnecessarily computed property [2] found.", type: "MethodDefinition"
             }]
         }, {
             code: "class Foo { set [2](value) {} }",
             output: "class Foo { set 2(value) {} }",
-            options: [{ checkMethods: true }],
+            options: [{ enforceForClassMembers: true }],
             errors: [{
                 message: "Unnecessarily computed property [2] found.", type: "MethodDefinition"
             }]
         }, {
             code: "class Foo { async [2]() {} }",
             output: "class Foo { async 2() {} }",
-            options: [{ checkMethods: true }],
+            options: [{ enforceForClassMembers: true }],
             parserOptions: { ecmaVersion: 8 },
             errors: [{
                 message: "Unnecessarily computed property [2] found.", type: "MethodDefinition"
@@ -283,21 +283,21 @@ ruleTester.run("no-useless-computed-key", rule, {
         }, {
             code: "class Foo { get[2]() {} }",
             output: "class Foo { get 2() {} }",
-            options: [{ checkMethods: true }],
+            options: [{ enforceForClassMembers: true }],
             errors: [{
                 message: "Unnecessarily computed property [2] found.", type: "MethodDefinition"
             }]
         }, {
             code: "class Foo { set[2](value) {} }",
             output: "class Foo { set 2(value) {} }",
-            options: [{ checkMethods: true }],
+            options: [{ enforceForClassMembers: true }],
             errors: [{
                 message: "Unnecessarily computed property [2] found.", type: "MethodDefinition"
             }]
         }, {
             code: "class Foo { async[2]() {} }",
             output: "class Foo { async 2() {} }",
-            options: [{ checkMethods: true }],
+            options: [{ enforceForClassMembers: true }],
             parserOptions: { ecmaVersion: 8 },
             errors: [{
                 message: "Unnecessarily computed property [2] found.", type: "MethodDefinition"
@@ -305,35 +305,35 @@ ruleTester.run("no-useless-computed-key", rule, {
         }, {
             code: "class Foo { get['foo']() {} }",
             output: "class Foo { get'foo'() {} }",
-            options: [{ checkMethods: true }],
+            options: [{ enforceForClassMembers: true }],
             errors: [{
                 message: "Unnecessarily computed property ['foo'] found.", type: "MethodDefinition"
             }]
         }, {
             code: "class Foo { *[2]() {} }",
             output: "class Foo { *2() {} }",
-            options: [{ checkMethods: true }],
+            options: [{ enforceForClassMembers: true }],
             errors: [{
                 message: "Unnecessarily computed property [2] found.", type: "MethodDefinition"
             }]
         }, {
             code: "class Foo { async*[2]() {} }",
             output: "class Foo { async*2() {} }",
-            options: [{ checkMethods: true }],
+            options: [{ enforceForClassMembers: true }],
             errors: [{
                 message: "Unnecessarily computed property [2] found.", type: "MethodDefinition"
             }]
         }, {
             code: "class Foo { static ['constructor']() {} }",
             output: "class Foo { static 'constructor'() {} }",
-            options: [{ checkMethods: true }],
+            options: [{ enforceForClassMembers: true }],
             errors: [{
                 message: "Unnecessarily computed property ['constructor'] found.", type: "MethodDefinition"
             }]
         }, {
             code: "class Foo { ['prototype']() {} }",
             output: "class Foo { 'prototype'() {} }",
-            options: [{ checkMethods: true }],
+            options: [{ enforceForClassMembers: true }],
             errors: [{
                 message: "Unnecessarily computed property ['prototype'] found.", type: "MethodDefinition"
             }]

--- a/tests/lib/rules/no-useless-computed-key.js
+++ b/tests/lib/rules/no-useless-computed-key.js
@@ -28,10 +28,16 @@ ruleTester.run("no-useless-computed-key", rule, {
         { code: "class Foo { [x]() {} }", options: [{ enforceForClassMembers: true }] },
         { code: "class Foo { ['constructor']() {} }", options: [{ enforceForClassMembers: true }] },
         { code: "class Foo { static ['prototype']() {} }", options: [{ enforceForClassMembers: true }] },
+        { code: "(class { 'a'() {} })", options: [{ enforceForClassMembers: true }] },
+        { code: "(class { [x]() {} })", options: [{ enforceForClassMembers: true }] },
+        { code: "(class { ['constructor']() {} })", options: [{ enforceForClassMembers: true }] },
+        { code: "(class { static ['prototype']() {} })", options: [{ enforceForClassMembers: true }] },
         "class Foo { ['x']() {} }",
+        "(class { ['x']() {} })",
         "class Foo { static ['constructor']() {} }",
         "class Foo { ['prototype']() {} }",
         { code: "class Foo { ['x']() {} }", options: [{ enforceForClassMembers: false }] },
+        { code: "(class { ['x']() {} })", options: [{ enforceForClassMembers: false }] },
         { code: "class Foo { static ['constructor']() {} }", options: [{ enforceForClassMembers: false }] },
         { code: "class Foo { ['prototype']() {} }", options: [{ enforceForClassMembers: false }] }
     ],
@@ -339,6 +345,27 @@ ruleTester.run("no-useless-computed-key", rule, {
         }, {
             code: "class Foo { ['prototype']() {} }",
             output: "class Foo { 'prototype'() {} }",
+            options: [{ enforceForClassMembers: true }],
+            errors: [{
+                message: "Unnecessarily computed property ['prototype'] found.", type: "MethodDefinition"
+            }]
+        }, {
+            code: "(class { ['x']() {} })",
+            output: "(class { 'x'() {} })",
+            options: [{ enforceForClassMembers: true }],
+            errors: [{
+                message: "Unnecessarily computed property ['x'] found.", type: "MethodDefinition"
+            }]
+        }, {
+            code: "(class { static ['constructor']() {} })",
+            output: "(class { static 'constructor'() {} })",
+            options: [{ enforceForClassMembers: true }],
+            errors: [{
+                message: "Unnecessarily computed property ['constructor'] found.", type: "MethodDefinition"
+            }]
+        }, {
+            code: "(class { ['prototype']() {} })",
+            output: "(class { 'prototype'() {} })",
             options: [{ enforceForClassMembers: true }],
             errors: [{
                 message: "Unnecessarily computed property ['prototype'] found.", type: "MethodDefinition"

--- a/tests/lib/rules/no-useless-computed-key.js
+++ b/tests/lib/rules/no-useless-computed-key.js
@@ -27,7 +27,13 @@ ruleTester.run("no-useless-computed-key", rule, {
         { code: "class Foo { 'a'() {} }", options: [{ enforceForClassMembers: true }] },
         { code: "class Foo { [x]() {} }", options: [{ enforceForClassMembers: true }] },
         { code: "class Foo { ['constructor']() {} }", options: [{ enforceForClassMembers: true }] },
-        { code: "class Foo { static ['prototype']() {} }", options: [{ enforceForClassMembers: true }] }
+        { code: "class Foo { static ['prototype']() {} }", options: [{ enforceForClassMembers: true }] },
+        "class Foo { ['x']() {} }",
+        "class Foo { static ['constructor']() {} }",
+        "class Foo { ['prototype']() {} }",
+        { code: "class Foo { ['x']() {} }", options: [{ enforceForClassMembers: false }] },
+        { code: "class Foo { static ['constructor']() {} }", options: [{ enforceForClassMembers: false }] },
+        { code: "class Foo { ['prototype']() {} }", options: [{ enforceForClassMembers: false }] }
     ],
     invalid: [
         {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Fixes #12041.

**What changes did you make? (Give an overview)**

- Added a new `enforceForClassMembers` option to the schema
- Extracted `Property` visitor to a `check` function
- Added a `MethodDefinition` visitor that is `check` if option is enabled and noop function if it's not (would it be better to check node type in `check` function?)
- Changed visitor code to allow `['constructor']` method name (like `__proto__` in object, it has different behavior) 

**Is there anything you'd like reviewers to focus on?**

~~I'm not sure about `checkMethods` option name. What is the rule on `check` in option names? Is `methods` clear enough considering that it also handles accessors (even though they share same node kind it might be not so obvious to users). Would it require a new option once class fields would be standardized (if no, it could be `classMembers`)?~~
