### PR TITLE
Fix: quotes autofix produces syntax error with octal escape sequences

### DIFF
--- a/lib/rules/quotes.js
+++ b/lib/rules/quotes.js
@@ -279,6 +279,12 @@ module.exports = {
                                 description: settings.description
                             },
                             fix(fixer) {
+                                if (quoteOption === "backtick" && astUtils.hasOctalEscapeSequence(rawVal)) {
+
+                                    // An octal escape sequence in a template literal would produce syntax error, even in non-strict mode.
+                                    return null;
+                                }
+
                                 return fixer.replaceText(node, settings.convert(node.raw));
                             }
                         });

--- a/tests/lib/rules/quotes.js
+++ b/tests/lib/rules/quotes.js
@@ -328,6 +328,96 @@ ruleTester.run("quotes", rule, {
             output: "\"\"``",
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Strings must use doublequote.", type: "TemplateLiteral", line: 1, column: 1 }]
+        },
+
+        // Strings containing octal escape sequences. Don't autofix to backticks.
+        {
+            code: "var foo = \"\\1\"",
+            output: "var foo = '\\1'",
+            options: ["single"],
+            errors: [
+                { message: "Strings must use singlequote.", type: "Literal" }
+            ]
+        },
+        {
+            code: "var foo = '\\1'",
+            output: "var foo = \"\\1\"",
+            options: ["double"],
+            errors: [
+                { message: "Strings must use doublequote.", type: "Literal" }
+            ]
+        },
+        {
+            code: "var notoctal = '\\0'",
+            output: "var notoctal = `\\0`",
+            options: ["backtick"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                { message: "Strings must use backtick.", type: "Literal" }
+            ]
+        },
+        {
+            code: "var foo = '\\1'",
+            output: null,
+            options: ["backtick"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                { message: "Strings must use backtick.", type: "Literal" }
+            ]
+        },
+        {
+            code: "var foo = \"\\1\"",
+            output: null,
+            options: ["backtick"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                { message: "Strings must use backtick.", type: "Literal" }
+            ]
+        },
+        {
+            code: "var foo = '\\01'",
+            output: null,
+            options: ["backtick"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                { message: "Strings must use backtick.", type: "Literal" }
+            ]
+        },
+        {
+            code: "var foo = '\\0\\1'",
+            output: null,
+            options: ["backtick"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                { message: "Strings must use backtick.", type: "Literal" }
+            ]
+        },
+        {
+            code: "var foo = '\\08'",
+            output: null,
+            options: ["backtick"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                { message: "Strings must use backtick.", type: "Literal" }
+            ]
+        },
+        {
+            code: "var foo = 'prefix \\33'",
+            output: null,
+            options: ["backtick"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                { message: "Strings must use backtick.", type: "Literal" }
+            ]
+        },
+        {
+            code: "var foo = 'prefix \\75 sufix'",
+            output: null,
+            options: ["backtick"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                { message: "Strings must use backtick.", type: "Literal" }
+            ]
         }
     ]
 });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
**Tell us about your environment**

* **ESLint Version:** 6.2.0
* **Node Version:** 10.16.0
* **npm Version:** 6.9.0

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
  parserOptions: {
    ecmaVersion: 2015,
  },
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
/*eslint quotes: ["error", "backtick"]*/

var foo = '\1';
```

**What did you expect to happen?**

Given how `prefer-template` works in similar situations, to report a warning but without the auto-fix.

**What actually happened? Please include the actual, raw output from ESLint.**

Fixed to:

```js
/*eslint quotes: ["error", "backtick"]*/

var foo = `\1`;
```

```
3:12  error  Parsing error: Octal literal in template string
```

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Prevent fix to a template literal if the source string contains an octal escape sequence.

An alternative would be to not report that string at all.

**Is there anything you'd like reviewers to focus on?**

