### PR TITLE
Automatically remove `eslint-plugin-` from ruleId's in linter.js

### DIFF
--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -963,10 +963,12 @@ function getEnv(slots, envId) {
  * @returns {Rule|null} The rule.
  */
 function getRule(slots, ruleId) {
-    return (
+    const rule = (
         (slots.lastConfigArray && slots.lastConfigArray.pluginRules.get(ruleId)) ||
         slots.ruleMap.get(ruleId)
     );
+    
+    return !rule && ruleId.startsWith("eslint-plugin-") ? getRule(slots, ruleId.slice(14)) : rule;
 }
 
 /**


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[x] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
I made it so if a person defines a rule and forgets to remove "eslint-plugin-", it will still work.

If this PR is decided against, I request that a special error message be added so that people who make this mistake will have explicit instructions telling them how to fix their code.


