### PR TITLE
Docs: Document the exception in no-unsafe-negation

### DIFF
--- a/docs/rules/no-unsafe-negation.md
+++ b/docs/rules/no-unsafe-negation.md
@@ -39,10 +39,36 @@ if (!(key in object)) {
 if (!(obj instanceof Ctor)) {
     // obj is not an instance of Ctor
 }
+```
 
-if(("" + !key) in object) {
-    // make operator precedence and type conversion explicit
-    // in a rare situation when that is the intended meaning
+### Exception
+
+For rare situations when negating the left operand is intended, this rule allows an exception.
+If the whole negation is explicitly wrapped in parentheses, the rule will not report a problem.
+
+Examples of **correct** code for this rule:
+
+```js
+/*eslint no-unsafe-negation: "error"*/
+
+if ((!foo) in object) {
+    // allowed, because the negation is explicitly wrapped in parentheses
+    // it is equivalent to (foo ? "false" : "true") in object
+    // this is allowed as an exception for rare situations when that is the intended meaning
+}
+
+if(("" + !foo) in object) {
+    // you can also make the intention more explicit, with type conversion
+}
+```
+
+Examples of **incorrect** code for this rule:
+
+```js
+/*eslint no-unsafe-negation: "error"*/
+
+if (!(foo) in object) {
+    // this is not an allowed exception
 }
 ```
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Documentation update

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

`no-unsafe-negation` allows parenthesized negations, e.g.:

```js
/*eslint no-unsafe-negation: "error"*/

if ((!a) in b) {} // no errors
```

This PR documents that as an 'exception'.

**Is there anything you'd like reviewers to focus on?**

Technically, this might not be *'negating the left operand'*, which the rule disallows, so this wouldn't be an 'exception', but I think it should be documented either way.

