### PR TITLE
Chore: Fix wrong error object keys in test files

### DIFF
--- a/tests/lib/rules/callback-return.js
+++ b/tests/lib/rules/callback-return.js
@@ -159,7 +159,7 @@ ruleTester.run("callback-return", rule, {
                 messageId: "missingReturn",
                 line: 1,
                 column: 30,
-                nodeType: "CallExpression"
+                type: "CallExpression"
             }]
         },
         {
@@ -168,7 +168,7 @@ ruleTester.run("callback-return", rule, {
                 messageId: "missingReturn",
                 line: 1,
                 column: 63,
-                nodeType: "CallExpression"
+                type: "CallExpression"
             }]
         },
         {
@@ -177,7 +177,7 @@ ruleTester.run("callback-return", rule, {
                 messageId: "missingReturn",
                 line: 1,
                 column: 61,
-                nodeType: "CallExpression"
+                type: "CallExpression"
             }]
         },
         {
@@ -186,7 +186,7 @@ ruleTester.run("callback-return", rule, {
                 messageId: "missingReturn",
                 line: 1,
                 column: 35,
-                nodeType: "CallExpression"
+                type: "CallExpression"
             }]
         },
         {
@@ -196,7 +196,7 @@ ruleTester.run("callback-return", rule, {
                 messageId: "missingReturn",
                 line: 1,
                 column: 31,
-                nodeType: "CallExpression"
+                type: "CallExpression"
             }]
         },
         {
@@ -206,7 +206,7 @@ ruleTester.run("callback-return", rule, {
                 messageId: "missingReturn",
                 line: 1,
                 column: 31,
-                nodeType: "CallExpression"
+                type: "CallExpression"
             }]
         },
         {
@@ -215,7 +215,7 @@ ruleTester.run("callback-return", rule, {
                 messageId: "missingReturn",
                 line: 3,
                 column: 2,
-                nodeType: "CallExpression"
+                type: "CallExpression"
             }]
         },
         {
@@ -225,7 +225,7 @@ ruleTester.run("callback-return", rule, {
                 messageId: "missingReturn",
                 line: 1,
                 column: 43,
-                nodeType: "CallExpression"
+                type: "CallExpression"
             }]
         },
         {
@@ -234,7 +234,7 @@ ruleTester.run("callback-return", rule, {
                 messageId: "missingReturn",
                 line: 1,
                 column: 19,
-                nodeType: "CallExpression"
+                type: "CallExpression"
             }]
         },
         {
@@ -243,7 +243,7 @@ ruleTester.run("callback-return", rule, {
                 messageId: "missingReturn",
                 line: 1,
                 column: 19,
-                nodeType: "CallExpression"
+                type: "CallExpression"
             }]
         },
         {
@@ -252,7 +252,7 @@ ruleTester.run("callback-return", rule, {
                 messageId: "missingReturn",
                 line: 1,
                 column: 30,
-                nodeType: "CallExpression"
+                type: "CallExpression"
             }]
         },
         {
@@ -262,7 +262,7 @@ ruleTester.run("callback-return", rule, {
                 messageId: "missingReturn",
                 line: 1,
                 column: 20,
-                nodeType: "CallExpression"
+                type: "CallExpression"
             }]
         },
         {
@@ -271,7 +271,7 @@ ruleTester.run("callback-return", rule, {
                 messageId: "missingReturn",
                 line: 1,
                 column: 30,
-                nodeType: "CallExpression"
+                type: "CallExpression"
             }]
         },
         {
@@ -280,7 +280,7 @@ ruleTester.run("callback-return", rule, {
                 messageId: "missingReturn",
                 line: 3,
                 column: 1,
-                nodeType: "CallExpression"
+                type: "CallExpression"
 
             }]
         },
@@ -291,7 +291,7 @@ ruleTester.run("callback-return", rule, {
                 messageId: "missingReturn",
                 line: 1,
                 column: 32,
-                nodeType: "CallExpression"
+                type: "CallExpression"
             }]
         },
 
@@ -303,12 +303,12 @@ ruleTester.run("callback-return", rule, {
                 messageId: "missingReturn",
                 line: 1,
                 column: 30,
-                nodeType: "CallExpression"
+                type: "CallExpression"
             }, {
                 messageId: "missingReturn",
                 line: 1,
                 column: 50,
-                nodeType: "CallExpression"
+                type: "CallExpression"
             }]
         },
         {
@@ -318,7 +318,7 @@ ruleTester.run("callback-return", rule, {
                     messageId: "missingReturn",
                     line: 1,
                     column: 52,
-                    nodeType: "CallExpression"
+                    type: "CallExpression"
                 }
             ]
         },
@@ -330,7 +330,7 @@ ruleTester.run("callback-return", rule, {
                     messageId: "missingReturn",
                     line: 1,
                     column: 18,
-                    nodeType: "CallExpression"
+                    type: "CallExpression"
                 }
             ]
         },
@@ -341,7 +341,7 @@ ruleTester.run("callback-return", rule, {
                     messageId: "missingReturn",
                     line: 1,
                     column: 42,
-                    nodeType: "CallExpression"
+                    type: "CallExpression"
                 }
             ]
         },
@@ -353,7 +353,7 @@ ruleTester.run("callback-return", rule, {
                     messageId: "missingReturn",
                     line: 1,
                     column: 42,
-                    nodeType: "CallExpression"
+                    type: "CallExpression"
                 }
             ]
         },
@@ -367,7 +367,7 @@ ruleTester.run("callback-return", rule, {
                     messageId: "missingReturn",
                     line: 1,
                     column: 33,
-                    nodeType: "CallExpression"
+                    type: "CallExpression"
                 }
             ]
         },
@@ -379,7 +379,7 @@ ruleTester.run("callback-return", rule, {
                     messageId: "missingReturn",
                     line: 1,
                     column: 47,
-                    nodeType: "CallExpression"
+                    type: "CallExpression"
                 }
             ]
         },
@@ -391,7 +391,7 @@ ruleTester.run("callback-return", rule, {
                     messageId: "missingReturn",
                     line: 1,
                     column: 51,
-                    nodeType: "CallExpression"
+                    type: "CallExpression"
                 }
             ]
         },
@@ -403,7 +403,7 @@ ruleTester.run("callback-return", rule, {
                     messageId: "missingReturn",
                     line: 1,
                     column: 30,
-                    nodeType: "CallExpression"
+                    type: "CallExpression"
                 }
             ]
         },
@@ -415,7 +415,7 @@ ruleTester.run("callback-return", rule, {
                     messageId: "missingReturn",
                     line: 1,
                     column: 30,
-                    nodeType: "CallExpression"
+                    type: "CallExpression"
                 }
             ]
         },
@@ -427,7 +427,7 @@ ruleTester.run("callback-return", rule, {
                     messageId: "missingReturn",
                     line: 1,
                     column: 30,
-                    nodeType: "CallExpression"
+                    type: "CallExpression"
                 }
             ]
         },
@@ -439,7 +439,7 @@ ruleTester.run("callback-return", rule, {
                     messageId: "missingReturn",
                     line: 1,
                     column: 41,
-                    nodeType: "CallExpression"
+                    type: "CallExpression"
                 }
             ]
         },
@@ -451,7 +451,7 @@ ruleTester.run("callback-return", rule, {
                     messageId: "missingReturn",
                     line: 2,
                     column: 1,
-                    nodeType: "CallExpression"
+                    type: "CallExpression"
                 }
             ]
         },
@@ -463,7 +463,7 @@ ruleTester.run("callback-return", rule, {
                     messageId: "missingReturn",
                     line: 1,
                     column: 30,
-                    nodeType: "CallExpression"
+                    type: "CallExpression"
                 }
             ]
         },
@@ -475,7 +475,7 @@ ruleTester.run("callback-return", rule, {
                     messageId: "missingReturn",
                     line: 1,
                     column: 30,
-                    nodeType: "CallExpression"
+                    type: "CallExpression"
                 }
             ]
         }

--- a/tests/lib/rules/no-extra-semi.js
+++ b/tests/lib/rules/no-extra-semi.js
@@ -47,68 +47,68 @@ ruleTester.run("no-extra-semi", rule, {
         {
             code: "var x = 5;;",
             output: "var x = 5;",
-            errors: [{ messgeId: "unexpected", type: "EmptyStatement" }]
+            errors: [{ messageId: "unexpected", type: "EmptyStatement" }]
         },
         {
             code: "function foo(){};",
             output: "function foo(){}",
-            errors: [{ messgeId: "unexpected", type: "EmptyStatement" }]
+            errors: [{ messageId: "unexpected", type: "EmptyStatement" }]
         },
         {
             code: "for(;;);;",
             output: "for(;;);",
-            errors: [{ messgeId: "unexpected", type: "EmptyStatement" }]
+            errors: [{ messageId: "unexpected", type: "EmptyStatement" }]
         },
         {
             code: "while(0);;",
             output: "while(0);",
-            errors: [{ messgeId: "unexpected", type: "EmptyStatement" }]
+            errors: [{ messageId: "unexpected", type: "EmptyStatement" }]
         },
         {
             code: "do;while(0);;",
             output: "do;while(0);",
-            errors: [{ messgeId: "unexpected", type: "EmptyStatement" }]
+            errors: [{ messageId: "unexpected", type: "EmptyStatement" }]
         },
         {
             code: "for(a in b);;",
             output: "for(a in b);",
-            errors: [{ messgeId: "unexpected", type: "EmptyStatement" }]
+            errors: [{ messageId: "unexpected", type: "EmptyStatement" }]
         },
         {
             code: "for(a of b);;",
             output: "for(a of b);",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ messgeId: "unexpected", type: "EmptyStatement" }]
+            errors: [{ messageId: "unexpected", type: "EmptyStatement" }]
         },
         {
             code: "if(true);;",
             output: "if(true);",
-            errors: [{ messgeId: "unexpected", type: "EmptyStatement" }]
+            errors: [{ messageId: "unexpected", type: "EmptyStatement" }]
         },
         {
             code: "if(true){} else;;",
             output: "if(true){} else;",
-            errors: [{ messgeId: "unexpected", type: "EmptyStatement" }]
+            errors: [{ messageId: "unexpected", type: "EmptyStatement" }]
         },
         {
             code: "if(true){;} else {;}",
             output: "if(true){} else {}",
-            errors: [{ messgeId: "unexpected", type: "EmptyStatement" }, { messgeId: "unexpected", type: "EmptyStatement" }]
+            errors: [{ messageId: "unexpected", type: "EmptyStatement" }, { messageId: "unexpected", type: "EmptyStatement" }]
         },
         {
             code: "foo:;;",
             output: "foo:;",
-            errors: [{ messgeId: "unexpected", type: "EmptyStatement" }]
+            errors: [{ messageId: "unexpected", type: "EmptyStatement" }]
         },
         {
             code: "with(foo);;",
             output: "with(foo);",
-            errors: [{ messgeId: "unexpected", type: "EmptyStatement" }]
+            errors: [{ messageId: "unexpected", type: "EmptyStatement" }]
         },
         {
             code: "with(foo){;}",
             output: "with(foo){}",
-            errors: [{ messgeId: "unexpected", type: "EmptyStatement" }]
+            errors: [{ messageId: "unexpected", type: "EmptyStatement" }]
         },
 
         // Class body.
@@ -116,47 +116,47 @@ ruleTester.run("no-extra-semi", rule, {
             code: "class A { ; }",
             output: "class A {  }",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ messgeId: "unexpected", type: "Punctuator", column: 11 }]
+            errors: [{ messageId: "unexpected", type: "Punctuator", column: 11 }]
         },
         {
             code: "class A { /*a*/; }",
             output: "class A { /*a*/ }",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ messgeId: "unexpected", type: "Punctuator", column: 16 }]
+            errors: [{ messageId: "unexpected", type: "Punctuator", column: 16 }]
         },
         {
             code: "class A { ; a() {} }",
             output: "class A {  a() {} }",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ messgeId: "unexpected", type: "Punctuator", column: 11 }]
+            errors: [{ messageId: "unexpected", type: "Punctuator", column: 11 }]
         },
         {
             code: "class A { a() {}; }",
             output: "class A { a() {} }",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ messgeId: "unexpected", type: "Punctuator", column: 17 }]
+            errors: [{ messageId: "unexpected", type: "Punctuator", column: 17 }]
         },
         {
             code: "class A { a() {}; b() {} }",
             output: "class A { a() {} b() {} }",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ messgeId: "unexpected", type: "Punctuator", column: 17 }]
+            errors: [{ messageId: "unexpected", type: "Punctuator", column: 17 }]
         },
         {
             code: "class A {; a() {}; b() {}; }",
             output: "class A { a() {} b() {} }",
             parserOptions: { ecmaVersion: 6 },
             errors: [
-                { messgeId: "unexpected", type: "Punctuator", column: 10 },
-                { messgeId: "unexpected", type: "Punctuator", column: 18 },
-                { messgeId: "unexpected", type: "Punctuator", column: 26 }
+                { messageId: "unexpected", type: "Punctuator", column: 10 },
+                { messageId: "unexpected", type: "Punctuator", column: 18 },
+                { messageId: "unexpected", type: "Punctuator", column: 26 }
             ]
         },
         {
             code: "class A { a() {}; get b() {} }",
             output: "class A { a() {} get b() {} }",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ messgeId: "unexpected", type: "Punctuator", column: 17 }]
+            errors: [{ messageId: "unexpected", type: "Punctuator", column: 17 }]
         }
     ]
 });

--- a/tests/lib/rules/no-inline-comments.js
+++ b/tests/lib/rules/no-inline-comments.js
@@ -17,11 +17,11 @@ const rule = require("../../../lib/rules/no-inline-comments"),
 
 const ruleTester = new RuleTester(),
     lineError = {
-        messsage: "Unexpected comment inline with code.",
+        message: "Unexpected comment inline with code.",
         type: "Line"
     },
     blockError = {
-        messsage: "Unexpected comment inline with code.",
+        message: "Unexpected comment inline with code.",
         type: "Block"
     };
 

--- a/tests/lib/rules/space-infix-ops.js
+++ b/tests/lib/rules/space-infix-ops.js
@@ -312,12 +312,12 @@ ruleTester.run("space-infix-ops", rule, {
                 message: "Operator '=' must be spaced.",
                 line: 1,
                 column: 7,
-                nodeType: "AssignmentPattern"
+                type: "AssignmentPattern"
             }, {
                 message: "Operator '=' must be spaced.",
                 line: 1,
                 column: 10,
-                nodeType: "VariableDeclarator"
+                type: "VariableDeclarator"
             }]
         },
         {
@@ -328,7 +328,7 @@ ruleTester.run("space-infix-ops", rule, {
                 message: "Operator '=' must be spaced.",
                 line: 1,
                 column: 15,
-                nodeType: "AssignmentPattern"
+                type: "AssignmentPattern"
             }]
         },
         {
@@ -339,7 +339,7 @@ ruleTester.run("space-infix-ops", rule, {
                 message: "Operator '**' must be spaced.",
                 line: 1,
                 column: 2,
-                nodeType: "BinaryExpression"
+                type: "BinaryExpression"
             }]
         },
         {
@@ -349,7 +349,7 @@ ruleTester.run("space-infix-ops", rule, {
                 message: "Operator 'in' must be spaced.",
                 line: 1,
                 column: 6,
-                nodeType: "BinaryExpression"
+                type: "BinaryExpression"
             }]
         },
         {
@@ -359,7 +359,7 @@ ruleTester.run("space-infix-ops", rule, {
                 message: "Operator 'instanceof' must be spaced.",
                 line: 1,
                 column: 6,
-                nodeType: "BinaryExpression"
+                type: "BinaryExpression"
             }]
         },
 
@@ -385,7 +385,7 @@ ruleTester.run("space-infix-ops", rule, {
                 message: "Operator '=' must be spaced.",
                 line: 1,
                 column: 23,
-                nodeType: "AssignmentPattern"
+                type: "AssignmentPattern"
             }]
         }
     ]

--- a/tests/lib/rules/spaced-comment.js
+++ b/tests/lib/rules/spaced-comment.js
@@ -313,7 +313,7 @@ ruleTester.run("spaced-comment", rule, {
             output: "// An invalid comment NOT starting with space\nvar a = 1;",
             options: ["always"],
             errors: [{
-                messsage: "Expected space or tab after '//' in comment.",
+                message: "Expected space or tab after '//' in comment.",
                 type: "Line"
             }]
         },

--- a/tests/lib/rules/switch-colon-spacing.js
+++ b/tests/lib/rules/switch-colon-spacing.js
@@ -18,10 +18,10 @@ const rule = require("../../../lib/rules/switch-colon-spacing"),
 
 const ruleTester = new RuleTester();
 
-const expectedBeforeError = { messagesId: "expectedBefore" };
-const expectedAfterError = { messagesId: "expectedAfter" };
-const unexpectedBeforeError = { messagesId: "unexpectedBefore" };
-const unexpectedAfterError = { messagesId: "unexpectedAfter" };
+const expectedBeforeError = { messageId: "expectedBefore" };
+const expectedAfterError = { messageId: "expectedAfter" };
+const unexpectedBeforeError = { messageId: "unexpectedBefore" };
+const unexpectedAfterError = { messageId: "unexpectedAfter" };
 
 ruleTester.run("switch-colon-spacing", rule, {
     valid: [


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Fixed test cases that had `nodeType` instead of `type` and various typos like `messgeId` in 6 files.

**Is there anything you'd like reviewers to focus on?**

`no-extra-parens` tests are fixed in #12142. Other test files are OK in regard to this.


