### PR TITLE
Fix: reset to the default color

### DIFF
--- a/lib/cli-engine/formatters/stylish.js
+++ b/lib/cli-engine/formatters/stylish.js
@@ -96,5 +96,6 @@ module.exports = function(results) {
         }
     }
 
-    return total > 0 ? output : "";
+    // Resets output color, for prevent change on top level
+    return total > 0 ? chalk.reset(output) : "";
 };

--- a/tests/lib/cli-engine/formatters/stylish.js
+++ b/tests/lib/cli-engine/formatters/stylish.js
@@ -19,6 +19,12 @@ const assert = require("chai").assert,
  * for Sinon to work.
  */
 const chalkStub = Object.create(chalk, {
+    reset: {
+        value(str) {
+            return chalk.reset(str);
+        },
+        writable: true
+    },
     yellow: {
         value(str) {
             return chalk.yellow(str);
@@ -47,6 +53,7 @@ describe("formatter:stylish", () => {
 
     beforeEach(() => {
         chalk.enabled = false;
+        sinon.spy(chalkStub, "reset");
         sinon.spy(chalkStub.yellow, "bold");
         sinon.spy(chalkStub.red, "bold");
     });
@@ -68,6 +75,7 @@ describe("formatter:stylish", () => {
             const result = formatter(code);
 
             assert.strictEqual(result, "");
+            assert.strictEqual(chalkStub.reset.callCount, 0);
             assert.strictEqual(chalkStub.yellow.bold.callCount, 0);
             assert.strictEqual(chalkStub.red.bold.callCount, 0);
         });
@@ -93,8 +101,10 @@ describe("formatter:stylish", () => {
             const result = formatter(code);
 
             assert.strictEqual(result, "\nfoo.js\n  5:10  error  Unexpected foo  foo\n\n\u2716 1 problem (1 error, 0 warnings)\n");
+            assert.strictEqual(chalkStub.reset.callCount, 1);
             assert.strictEqual(chalkStub.yellow.bold.callCount, 0);
             assert.strictEqual(chalkStub.red.bold.callCount, 1);
+
         });
 
         describe("when the error is fixable", () => {
@@ -106,6 +116,7 @@ describe("formatter:stylish", () => {
                 const result = formatter(code);
 
                 assert.strictEqual(result, "\nfoo.js\n  5:10  error  Unexpected foo  foo\n\n\u2716 1 problem (1 error, 0 warnings)\n  1 error and 0 warnings potentially fixable with the `--fix` option.\n");
+                assert.strictEqual(chalkStub.reset.callCount, 1);
                 assert.strictEqual(chalkStub.yellow.bold.callCount, 0);
                 assert.strictEqual(chalkStub.red.bold.callCount, 2);
             });
@@ -132,6 +143,7 @@ describe("formatter:stylish", () => {
             const result = formatter(code);
 
             assert.strictEqual(result, "\nfoo.js\n  5:10  warning  Unexpected foo  foo\n\n\u2716 1 problem (0 errors, 1 warning)\n");
+            assert.strictEqual(chalkStub.reset.callCount, 1);
             assert.strictEqual(chalkStub.yellow.bold.callCount, 1);
             assert.strictEqual(chalkStub.red.bold.callCount, 0);
         });
@@ -145,6 +157,7 @@ describe("formatter:stylish", () => {
                 const result = formatter(code);
 
                 assert.strictEqual(result, "\nfoo.js\n  5:10  warning  Unexpected foo  foo\n\n\u2716 1 problem (0 errors, 1 warning)\n  0 errors and 1 warning potentially fixable with the `--fix` option.\n");
+                assert.strictEqual(chalkStub.reset.callCount, 1);
                 assert.strictEqual(chalkStub.yellow.bold.callCount, 2);
                 assert.strictEqual(chalkStub.red.bold.callCount, 0);
             });
@@ -172,6 +185,7 @@ describe("formatter:stylish", () => {
             const result = formatter(code);
 
             assert.strictEqual(result, "\nfoo.js\n  5:10  warning  Unexpected .  foo\n\n\u2716 1 problem (0 errors, 1 warning)\n");
+            assert.strictEqual(chalkStub.reset.callCount, 1);
             assert.strictEqual(chalkStub.yellow.bold.callCount, 1);
             assert.strictEqual(chalkStub.red.bold.callCount, 0);
         });
@@ -195,6 +209,7 @@ describe("formatter:stylish", () => {
             const result = formatter(code);
 
             assert.strictEqual(result, "\nfoo.js\n  5:10  error  Unexpected foo  foo\n\n\u2716 1 problem (1 error, 0 warnings)\n");
+            assert.strictEqual(chalkStub.reset.callCount, 1);
             assert.strictEqual(chalkStub.yellow.bold.callCount, 0);
             assert.strictEqual(chalkStub.red.bold.callCount, 1);
         });
@@ -224,6 +239,7 @@ describe("formatter:stylish", () => {
             const result = formatter(code);
 
             assert.strictEqual(result, "\nfoo.js\n  5:10  error    Unexpected foo  foo\n  6:11  warning  Unexpected bar  bar\n\n\u2716 2 problems (1 error, 1 warning)\n");
+            assert.strictEqual(chalkStub.reset.callCount, 1);
             assert.strictEqual(chalkStub.yellow.bold.callCount, 0);
             assert.strictEqual(chalkStub.red.bold.callCount, 1);
         });
@@ -258,6 +274,7 @@ describe("formatter:stylish", () => {
             const result = formatter(code);
 
             assert.strictEqual(result, "\nfoo.js\n  5:10  error  Unexpected foo  foo\n\nbar.js\n  6:11  warning  Unexpected bar  bar\n\n\u2716 2 problems (1 error, 1 warning)\n");
+            assert.strictEqual(chalkStub.reset.callCount, 1);
             assert.strictEqual(chalkStub.yellow.bold.callCount, 0);
             assert.strictEqual(chalkStub.red.bold.callCount, 1);
         });
@@ -271,6 +288,7 @@ describe("formatter:stylish", () => {
             const result = formatter(code);
 
             assert.strictEqual(result, "\nfoo.js\n  5:10  error  Unexpected foo  foo\n\nbar.js\n  6:11  warning  Unexpected bar  bar\n\n\u2716 2 problems (2 errors, 0 warnings)\n");
+            assert.strictEqual(chalkStub.reset.callCount, 1);
             assert.strictEqual(chalkStub.yellow.bold.callCount, 0);
             assert.strictEqual(chalkStub.red.bold.callCount, 1);
         });
@@ -284,6 +302,7 @@ describe("formatter:stylish", () => {
             const result = formatter(code);
 
             assert.strictEqual(result, "\nfoo.js\n  5:10  error  Unexpected foo  foo\n\nbar.js\n  6:11  warning  Unexpected bar  bar\n\n\u2716 2 problems (0 errors, 2 warnings)\n");
+            assert.strictEqual(chalkStub.reset.callCount, 1);
             assert.strictEqual(chalkStub.yellow.bold.callCount, 0);
             assert.strictEqual(chalkStub.red.bold.callCount, 1);
         });
@@ -304,6 +323,7 @@ describe("formatter:stylish", () => {
             const result = formatter(code);
 
             assert.strictEqual(result, "\nfoo.js\n  0:0  error  Couldn't find foo.js\n\n\u2716 1 problem (1 error, 0 warnings)\n");
+            assert.strictEqual(chalkStub.reset.callCount, 1);
             assert.strictEqual(chalkStub.yellow.bold.callCount, 0);
             assert.strictEqual(chalkStub.red.bold.callCount, 1);
         });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

When we issue a warning on webpack, every warning is yellow and bold.
With `eslint-loader` and the` stylish` formatter the first line is different from the others.

https://github.com/webpack-contrib/eslint-loader/issues/292

**Is there anything you'd like reviewers to focus on?**

