### PR TITLE
New: add rule default-param-last (fixes #11361)

### DIFF
--- a/docs/rules/default-param-last.md
+++ b/docs/rules/default-param-last.md
@@ -1,0 +1,25 @@
+# enforce default parameters to be last (default-param-last)
+
+Putting default parameter at last allowes function calls to omit optional tail arguments.
+
+## Rule Details
+
+This rule enforces default parameters to be the last of paramters.
+
+Examples of **incorrect** code for this rule:
+
+```js
+/* eslint default-param-last: ["error"] */
+
+function f(a = 0, b) {}
+
+function f(a, b = 0, c) {}
+```
+
+Examples of **correct** code for this rule:
+
+```js
+/* eslint default-param-last: ["error"] */
+
+function f(a, b = 0) {}
+```

--- a/docs/rules/default-param-last.md
+++ b/docs/rules/default-param-last.md
@@ -1,10 +1,10 @@
 # enforce default parameters to be last (default-param-last)
 
-Putting default parameter at last allowes function calls to omit optional tail arguments.
+Putting default parameter at last allows function calls to omit optional tail arguments.
 
 ## Rule Details
 
-This rule enforces default parameters to be the last of paramters.
+This rule enforces default parameters to be the last of parameters.
 
 Examples of **incorrect** code for this rule:
 

--- a/docs/rules/default-param-last.md
+++ b/docs/rules/default-param-last.md
@@ -2,6 +2,16 @@
 
 Putting default parameter at last allows function calls to omit optional tail arguments.
 
+```js
+// Correct: optional argument can be omitted
+function createUser(id, isAdmin = false) {}
+createUser("tabby")
+
+// Incorrect: optional argument can **not** be omitted
+function createUser(isAdmin = false, id) {}
+createUser(undefined, "tabby")
+```
+
 ## Rule Details
 
 This rule enforces default parameters to be the last of parameters.

--- a/lib/rules/default-param-last.js
+++ b/lib/rules/default-param-last.js
@@ -19,7 +19,7 @@ module.exports = {
         schema: [],
 
         messages: {
-            shouldBeLast: "Default parameters should be the last of parameters."
+            shouldBeLast: "Default parameters should be last."
         }
     },
 

--- a/lib/rules/default-param-last.js
+++ b/lib/rules/default-param-last.js
@@ -1,0 +1,61 @@
+/**
+ * @fileoverview enforce default parameters to be last
+ * @author Chiawen Chen
+ */
+
+"use strict";
+
+module.exports = {
+    meta: {
+        type: "suggestion",
+
+        docs: {
+            description: "enforce default parameters to be last",
+            category: "Best Practices",
+            recommended: false,
+            url: "https://eslint.org/docs/rules/default-param-last"
+        },
+
+        schema: [],
+
+        messages: {
+            shouldBeLast: "Default parameters should be the last of parameters."
+        }
+    },
+
+    create(context) {
+
+        /**
+         * @param {ASTNode} node function node
+         * @returns {void}
+         */
+        function handleFunction(node) {
+            let hasSeenPlainParam = false;
+
+            for (let i = node.params.length - 1; i >= 0; i -= 1) {
+                const param = node.params[i];
+
+                if (
+                    param.type !== "AssignmentPattern" &&
+                    param.type !== "RestElement"
+                ) {
+                    hasSeenPlainParam = true;
+                    continue;
+                }
+
+                if (hasSeenPlainParam && param.type === "AssignmentPattern") {
+                    context.report({
+                        node: param,
+                        messageId: "shouldBeLast"
+                    });
+                }
+            }
+        }
+
+        return {
+            FunctionDeclaration: handleFunction,
+            FunctionExpression: handleFunction,
+            ArrowFunctionExpression: handleFunction
+        };
+    }
+};

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -37,6 +37,7 @@ module.exports = new LazyLoadingRuleMap(Object.entries({
     "constructor-super": () => require("./constructor-super"),
     curly: () => require("./curly"),
     "default-case": () => require("./default-case"),
+    "default-param-last": () => require("./default-param-last"),
     "dot-location": () => require("./dot-location"),
     "dot-notation": () => require("./dot-notation"),
     "eol-last": () => require("./eol-last"),

--- a/tests/lib/rules/default-param-last.js
+++ b/tests/lib/rules/default-param-last.js
@@ -85,6 +85,22 @@ ruleTester.run("default-param-last", rule, {
         {
             code: "const f = (a = 5, { b }) => {}",
             errors: [cannedError]
+        },
+        {
+            code: "const f = ({ a } = {}, b) => {}",
+            errors: [cannedError]
+        },
+        {
+            code: "const f = ({ a, b } = { a: 1, b: 2 }, c) => {}",
+            errors: [cannedError]
+        },
+        {
+            code: "const f = ([a] = [], b) => {}",
+            errors: [cannedError]
+        },
+        {
+            code: "const f = ([a, b] = [1, 2], c) => {}",
+            errors: [cannedError]
         }
     ]
 });

--- a/tests/lib/rules/default-param-last.js
+++ b/tests/lib/rules/default-param-last.js
@@ -1,0 +1,76 @@
+/**
+ * @fileoverview Test file for default-param-last
+ * @author Chiawen Chen
+ */
+"use strict";
+
+const rule = require("../../../lib/rules/default-param-last");
+const { RuleTester } = require("../../../lib/rule-tester");
+
+const SHOULD_BE_LAST = "shouldBeLast";
+
+const ruleTester = new RuleTester({
+    parserOptions: { ecmaVersion: 8 }
+});
+
+const cannedError = {
+    messageId: SHOULD_BE_LAST,
+    type: "AssignmentPattern"
+};
+
+ruleTester.run("default-param-last", rule, {
+    valid: [
+        "function f(a) {}",
+        "function f(a = 5) {}",
+        "function f(a, b = 5) {}",
+        "function f(a, b = 5, c = 5) {}",
+        "function f(a, b = 5, ...c) {}"
+    ],
+    invalid: [
+        {
+            code: "function f(a = 5, b) {}",
+            errors: [
+                {
+                    messageId: SHOULD_BE_LAST,
+                    column: 12,
+                    columnEnd: 15
+                }
+            ]
+        },
+        {
+            code: "function f(a = 5, b = 6, c) {}",
+            errors: [
+                {
+                    messageId: SHOULD_BE_LAST,
+                    column: 12,
+                    endColumn: 17
+                },
+                {
+                    messageId: SHOULD_BE_LAST,
+                    column: 19,
+                    endColumn: 24
+                }
+            ]
+        },
+        {
+            code: "function f (a = 5, b, c = 6, d) {}",
+            errors: [cannedError, cannedError]
+        },
+        {
+            code: "function f(a = 5, b, c = 5) {}",
+            errors: [cannedError]
+        },
+        {
+            code: "const f = (a = 5, b, ...c) => {}",
+            errors: [cannedError]
+        },
+        {
+            code: "const f = function f (a, b = 5, c) {}",
+            errors: [cannedError]
+        },
+        {
+            code: "const f = (a = 5, { b }) => {}",
+            errors: [cannedError]
+        }
+    ]
+});

--- a/tests/lib/rules/default-param-last.js
+++ b/tests/lib/rules/default-param-last.js
@@ -66,7 +66,13 @@ ruleTester.run("default-param-last", rule, {
         },
         {
             code: "function f(a = 5, b, c = 5) {}",
-            errors: [cannedError]
+            errors: [
+                {
+                    messageId: SHOULD_BE_LAST,
+                    column: 12,
+                    endColumn: 17
+                }
+            ]
         },
         {
             code: "const f = (a = 5, b, ...c) => {}",

--- a/tests/lib/rules/default-param-last.js
+++ b/tests/lib/rules/default-param-last.js
@@ -33,7 +33,7 @@ ruleTester.run("default-param-last", rule, {
                 {
                     messageId: SHOULD_BE_LAST,
                     column: 12,
-                    columnEnd: 15
+                    endColumn: 17
                 }
             ]
         },

--- a/tests/lib/rules/default-param-last.js
+++ b/tests/lib/rules/default-param-last.js
@@ -20,11 +20,19 @@ const cannedError = {
 
 ruleTester.run("default-param-last", rule, {
     valid: [
+        "function f() {}",
         "function f(a) {}",
         "function f(a = 5) {}",
+        "function f(a, b) {}",
         "function f(a, b = 5) {}",
         "function f(a, b = 5, c = 5) {}",
-        "function f(a, b = 5, ...c) {}"
+        "function f(a, b = 5, ...c) {}",
+        "const f = () => {}",
+        "const f = (a) => {}",
+        "const f = (a = 5) => {}",
+        "const f = function f() {}",
+        "const f = function f(a) {}",
+        "const f = function f(a = 5) {}"
     ],
     invalid: [
         {

--- a/tools/rule-types.json
+++ b/tools/rule-types.json
@@ -24,6 +24,7 @@
     "constructor-super": "problem",
     "curly": "suggestion",
     "default-case": "suggestion",
+    "default-param-last": "suggestion",
     "dot-location": "layout",
     "dot-notation": "suggestion",
     "eol-last": "layout",


### PR DESCRIPTION
closes #11361.

**What is the purpose of this pull request? (put an "X" next to item)**

X [ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))

**Please describe what the rule should do:**
Enforce default params to be last. Only es6 default params are dealt with.

**What category of rule is this? (place an "X" next to just one item)**

[ ] Enforces code style
[ ] Warns about a potential error
X [ ] Suggests an alternate way of doing something
[ ] Other (please specify:)

**Provide 2-3 code examples that this rule will warn about:**

```js
function f(a = 5, b) {}
function f(a, b = 5, c) {}
```

**Why should this rule be included in ESLint (instead of a plugin)?**
See the accepted proposal #11361.

**What changes did you make? (Give an overview)**
Add a new rule.

**Is there anything you'd like reviewers to focus on?**
Yes.
