### PR TITLE
Fix: patch hole in the no-lone-blocks rule

### DIFF
--- a/lib/rules/no-lone-blocks.js
+++ b/lib/rules/no-lone-blocks.js
@@ -79,7 +79,7 @@ module.exports = {
             }
         };
 
-        // ES6: report blocks without block-level bindings
+        // ES6: report blocks without block-level bindings, or that's only child of another block
         if (context.parserOptions.ecmaVersion >= 6) {
             ruleDef = {
                 BlockStatement(node) {
@@ -90,6 +90,11 @@ module.exports = {
                 "BlockStatement:exit"(node) {
                     if (loneBlocks.length > 0 && loneBlocks[loneBlocks.length - 1] === node) {
                         loneBlocks.pop();
+                        report(node);
+                    } else if (
+                        node.parent.type === "BlockStatement" &&
+                        node.parent.body.length === 1
+                    ) {
                         report(node);
                     }
                 }

--- a/tests/lib/rules/no-lone-blocks.js
+++ b/tests/lib/rules/no-lone-blocks.js
@@ -56,7 +56,8 @@ ruleTester.run("no-lone-blocks", rule, {
               baz;
             }
           }
-        `
+        `,
+        { code: "function foo() { { const x = 4 } const x = 3 }", parserOptions: { ecmaVersion: 6 } }
     ],
     invalid: [
         { code: "{}", errors: [{ message: "Block is redundant.", type: "BlockStatement" }] },
@@ -118,6 +119,39 @@ ruleTester.run("no-lone-blocks", rule, {
               }
             `,
             errors: [{ message: "Block is redundant.", type: "BlockStatement", line: 4 }]
+        },
+        {
+            code: `
+              function foo () {
+                {
+                  const x = 4;
+                }
+              }
+            `,
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    message: "Nested block is redundant.",
+                    type: "BlockStatement",
+                    line: 3
+                }
+            ]
+        },
+        {
+            code: `
+              function foo () {
+                {
+                  var x = 4;
+                }
+              }
+            `,
+            errors: [
+                {
+                    message: "Nested block is redundant.",
+                    type: "BlockStatement",
+                    line: 3
+                }
+            ]
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix

**Tell us about your environment**

* **ESLint Version:** 6.3.0
* **Node Version:** 11.12.0
* **npm Version:** 6.7.0

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
  parserOptions: {
    ecmaVersion: 2015,
  },
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**

There is a hole in the `ES6` logic for the `no-lone-blocks` rule. It is set to accept blocks with declarations, but if such a block appears as a lonely child of another block, it should be an error.

```javascript
// Not caught by the rule prior to this PR
function foo() {
  {
    const x = 4; 
  }
}
```

I've seen this more than once in the wild - I suspect it can (somewhat) easily happen when you extract a piece of logic into a function.

**What did you expect to happen?**

Such blocks should be flagged as errors by the rule.

**What actually happened? Please include the actual, raw output from ESLint.**

No error.

**What changes did you make? (Give an overview)**

Added extra condition and tests to cover this case.

**Is there anything you'd like reviewers to focus on?**

No.

**Is this a breaking change?**

No.

