### PR TITLE
Breaking: check unnamed default export in func-names (fixes #12194)

### DIFF
--- a/docs/rules/func-names.md
+++ b/docs/rules/func-names.md
@@ -16,8 +16,8 @@ This rule can enforce or disallow the use of named function expressions.
 
 This rule has a string option:
 
-* `"always"` (default) requires function expressions and default export functions to have a name
-* `"as-needed"` requires function expressions and default export functions to have a name, if the name cannot be assigned automatically in an ES6 environment
+* `"always"` (default) requires function expressions to have a name
+* `"as-needed"` requires function expressions to have a name, if the name cannot be assigned automatically in an ES6 environment
 * `"never"` disallows named function expressions, except in recursive functions, where a name is needed
 
 This rule has an object option:

--- a/docs/rules/func-names.md
+++ b/docs/rules/func-names.md
@@ -29,6 +29,8 @@ This rule has an object option:
 
 When a value for `generators` is not provided the behavior for generator functions falls back to the base option.
 
+Please note that `"always"` and `"as-needed"` require function expressions and function declarations in `export default` declarations to have a name.
+
 ### always
 
 Examples of **incorrect** code for this rule with the default `"always"` option:

--- a/docs/rules/func-names.md
+++ b/docs/rules/func-names.md
@@ -16,8 +16,8 @@ This rule can enforce or disallow the use of named function expressions.
 
 This rule has a string option:
 
-* `"always"` (default) requires function expressions to have a name
-* `"as-needed"` requires function expressions to have a name, if the name cannot be assigned automatically in an ES6 environment
+* `"always"` (default) requires function expressions and default export functions to have a name
+* `"as-needed"` requires function expressions and default export functions to have a name, if the name cannot be assigned automatically in an ES6 environment
 * `"never"` disallows named function expressions, except in recursive functions, where a name is needed
 
 This rule has an object option:

--- a/docs/rules/func-names.md
+++ b/docs/rules/func-names.md
@@ -45,6 +45,8 @@ const cat = {
 (function() {
     // ...
 }())
+
+export default function() {}
 ```
 
 Examples of **correct** code for this rule with the default `"always"` option:
@@ -61,6 +63,8 @@ const cat = {
 (function bar() {
     // ...
 }())
+
+export default function foo() {}
 ```
 
 ### as-needed
@@ -77,6 +81,8 @@ Foo.prototype.bar = function() {};
 (function() {
     // ...
 }())
+
+export default function() {}
 ```
 
 Examples of **correct** code for this rule with the `"as-needed"` option:
@@ -93,6 +99,8 @@ const cat = {
 (function bar() {
     // ...
 }())
+
+export default function foo() {}
 ```
 
 ### never

--- a/lib/rules/func-names.js
+++ b/lib/rules/func-names.js
@@ -119,7 +119,6 @@ module.exports = {
                 (parent.type === "VariableDeclarator" && parent.id.type === "Identifier" && parent.init === node) ||
                 (parent.type === "Property" && parent.value === node) ||
                 (parent.type === "AssignmentExpression" && parent.left.type === "Identifier" && parent.right === node) ||
-                (parent.type === "ExportDefaultDeclaration" && parent.declaration === node) ||
                 (parent.type === "AssignmentPattern" && parent.right === node);
         }
 
@@ -151,33 +150,41 @@ module.exports = {
             });
         }
 
-        return {
-            "FunctionExpression:exit"(node) {
+        /**
+         * The listener for function nodes.
+         * @param {ASTNode} node function node
+         * @returns {void}
+         */
+        function handleFunction(node) {
 
-                // Skip recursive functions.
-                const nameVar = context.getDeclaredVariables(node)[0];
+            // Skip recursive functions.
+            const nameVar = context.getDeclaredVariables(node)[0];
 
-                if (isFunctionName(nameVar) && nameVar.references.length > 0) {
-                    return;
+            if (isFunctionName(nameVar) && nameVar.references.length > 0) {
+                return;
+            }
+
+            const hasName = Boolean(node.id && node.id.name);
+            const config = getConfigForNode(node);
+
+            if (config === "never") {
+                if (hasName && node.type !== "FunctionDeclaration") {
+                    reportUnexpectedNamedFunction(node);
                 }
-
-                const hasName = Boolean(node.id && node.id.name);
-                const config = getConfigForNode(node);
-
-                if (config === "never") {
-                    if (hasName) {
-                        reportUnexpectedNamedFunction(node);
-                    }
-                } else if (config === "as-needed") {
-                    if (!hasName && !hasInferredName(node)) {
-                        reportUnexpectedUnnamedFunction(node);
-                    }
-                } else {
-                    if (!hasName && !isObjectOrClassMethod(node)) {
-                        reportUnexpectedUnnamedFunction(node);
-                    }
+            } else if (config === "as-needed") {
+                if (!hasName && !hasInferredName(node)) {
+                    reportUnexpectedUnnamedFunction(node);
+                }
+            } else {
+                if (!hasName && !isObjectOrClassMethod(node)) {
+                    reportUnexpectedUnnamedFunction(node);
                 }
             }
+        }
+
+        return {
+            "FunctionExpression:exit": handleFunction,
+            "ExportDefaultDeclaration > FunctionDeclaration": handleFunction
         };
     }
 };

--- a/tests/lib/rules/func-names.js
+++ b/tests/lib/rules/func-names.js
@@ -65,14 +65,6 @@ ruleTester.run("func-names", rule, {
             options: ["as-needed"]
         },
         {
-            code: "export default (function(){});",
-            options: ["as-needed"],
-            parserOptions: {
-                ecmaVersion: 6,
-                sourceType: "module"
-            }
-        },
-        {
             code: "({foo = function(){}} = {});",
             options: ["as-needed"],
             parserOptions: { ecmaVersion: 6 }
@@ -125,6 +117,28 @@ ruleTester.run("func-names", rule, {
             code: "({ foo() {} });",
             options: ["never"],
             parserOptions: { ecmaVersion: 6 }
+        },
+
+        // export default
+        {
+            code: "export default function foo() {}",
+            options: ["always"],
+            parserOptions: { sourceType: "module", ecmaVersion: 6 }
+        },
+        {
+            code: "export default function foo() {}",
+            options: ["as-needed"],
+            parserOptions: { sourceType: "module", ecmaVersion: 6 }
+        },
+        {
+            code: "export default function foo() {}",
+            options: ["never"],
+            parserOptions: { sourceType: "module", ecmaVersion: 6 }
+        },
+        {
+            code: "export default function() {}",
+            options: ["never"],
+            parserOptions: { sourceType: "module", ecmaVersion: 6 }
         },
 
         // generators
@@ -412,6 +426,41 @@ ruleTester.run("func-names", rule, {
                 line: 1,
                 column: 3,
                 endColumn: 20
+            }]
+        },
+
+        // export default
+        {
+            code: "export default function() {}",
+            options: ["always"],
+            parserOptions: { sourceType: "module", ecmaVersion: 6 },
+            errors: [{
+                messageId: "unnamed",
+                type: "FunctionDeclaration",
+                column: 16,
+                endColumn: 24
+            }]
+        },
+        {
+            code: "export default function() {}",
+            options: ["as-needed"],
+            parserOptions: { sourceType: "module", ecmaVersion: 6 },
+            errors: [{
+                messageId: "unnamed",
+                type: "FunctionDeclaration",
+                column: 16,
+                endColumn: 24
+            }]
+        },
+        {
+            code: "export default (function(){});",
+            options: ["as-needed"],
+            parserOptions: { sourceType: "module", ecmaVersion: 6 },
+            errors: [{
+                messageId: "unnamed",
+                type: "FunctionExpression",
+                column: 17,
+                endColumn: 25
             }]
         },
 


### PR DESCRIPTION
fixes #12194

**What is the purpose of this pull request? (put an "X" next to item)**
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

**What changes did you make? (Give an overview)**
Start report code like `export default function() {}` when `always` or `as-needed`.

**Is there anything you'd like reviewers to focus on?**
Yes.