### PR TITLE
Fix: OverrideTester basePath (fixes #12032)

### DIFF
--- a/lib/cli-engine/config-array/override-tester.js
+++ b/lib/cli-engine/config-array/override-tester.js
@@ -125,10 +125,10 @@ class OverrideTester {
      */
     static and(a, b) {
         if (!b) {
-            return a;
+            return a && new OverrideTester(a.patterns, a.basePath);
         }
         if (!a) {
-            return b;
+            return new OverrideTester(b.patterns, b.basePath);
         }
 
         assert.strictEqual(a.basePath, b.basePath);

--- a/tests/lib/cli-engine/cli-engine.js
+++ b/tests/lib/cli-engine/cli-engine.js
@@ -3592,6 +3592,36 @@ describe("CLIEngine", () => {
                 });
             });
         });
+
+        describe("with 'overrides[*].extends' setting on deep locations", () => {
+            const root = getFixturePath("cli-engine/deeply-overrides-i-extends");
+
+            it("should not throw.", () => {
+                CLIEngine = defineCLIEngineWithInMemoryFileSystem({
+                    cwd: () => root,
+                    files: {
+                        "node_modules/eslint-config-one/index.js": `module.exports = ${JSON.stringify({
+                            overrides: [{ files: ["*test*"], extends: "two" }]
+                        })}`,
+                        "node_modules/eslint-config-two/index.js": `module.exports = ${JSON.stringify({
+                            overrides: [{ files: ["*.js"], extends: "three" }]
+                        })}`,
+                        "node_modules/eslint-config-three/index.js": `module.exports = ${JSON.stringify({
+                            rules: { "no-console": "error" }
+                        })}`,
+                        "test.js": "console.log('hello')",
+                        ".eslintrc.yml": "extends: one"
+                    }
+                }).CLIEngine;
+                engine = new CLIEngine();
+
+                const { results } = engine.executeOnFiles(["test.js"]);
+                const messages = results[0].messages;
+
+                assert.strictEqual(messages.length, 1);
+                assert.strictEqual(messages[0].ruleId, "no-console");
+            });
+        });
     });
 
     describe("getConfigForFile", () => {

--- a/tests/lib/cli-engine/config-array/override-tester.js
+++ b/tests/lib/cli-engine/config-array/override-tester.js
@@ -58,16 +58,22 @@ describe("OverrideTester", () => {
             assert.strictEqual(OverrideTester.and(null, null), null);
         });
 
-        it("should return the first one if the second one was null.", () => {
-            const tester = OverrideTester.create("*.js");
+        it("should return a new tester with the the first one's properties if the second one was null.", () => {
+            const tester = OverrideTester.create("*.js", null, process.cwd());
+            const result = OverrideTester.and(tester, null);
 
-            assert.strictEqual(OverrideTester.and(tester, null), tester);
+            assert.notStrictEqual(result, tester);
+            assert.strictEqual(result.patterns, tester.patterns);
+            assert.strictEqual(result.basePath, tester.basePath);
         });
 
-        it("should return the second one if the first one was null.", () => {
-            const tester = OverrideTester.create("*.js");
+        it("should return a new tester with the the second one's properties if the first one was null.", () => {
+            const tester = OverrideTester.create("*.js", null, process.cwd());
+            const result = OverrideTester.and(null, tester);
 
-            assert.strictEqual(OverrideTester.and(null, tester), tester);
+            assert.notStrictEqual(result, tester);
+            assert.strictEqual(result.patterns, tester.patterns);
+            assert.strictEqual(result.basePath, tester.basePath);
         });
 
         it("should return another one what includes both patterns if both are testers.", () => {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix

**What changes did you make? (Give an overview)**

This PR fixes #12032.

The cause was the reuse of `OverrideTester` instances in spite of mutable.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.
