### PR TITLE
Fix: Allow line comment exception in object-curly-spacing (fixes #11902)

### DIFF
--- a/lib/rules/object-curly-spacing.js
+++ b/lib/rules/object-curly-spacing.js
@@ -167,7 +167,7 @@ module.exports = {
                 if (options.spaced && !firstSpaced) {
                     reportRequiredBeginningSpace(node, first);
                 }
-                if (!options.spaced && firstSpaced) {
+                if (!options.spaced && firstSpaced && second.type !== "Line") {
                     reportNoBeginningSpace(node, first);
                 }
             }

--- a/tests/lib/rules/object-curly-spacing.js
+++ b/tests/lib/rules/object-curly-spacing.js
@@ -26,6 +26,8 @@ ruleTester.run("object-curly-spacing", rule, {
         { code: "var obj = { foo: bar, baz: qux };", options: ["always"] },
         { code: "var obj = { foo: { bar: quxx }, baz: qux };", options: ["always"] },
         { code: "var obj = {\nfoo: bar,\nbaz: qux\n};", options: ["always"] },
+        { code: "var obj = { /**/foo:bar/**/ };", options: ["always"] },
+        { code: "var obj = { //\nfoo:bar };", options: ["always"] },
 
         // always - destructuring
         { code: "var { x } = y", options: ["always"], parserOptions: { ecmaVersion: 6 } },
@@ -33,6 +35,8 @@ ruleTester.run("object-curly-spacing", rule, {
         { code: "var { x,y } = y", options: ["always"], parserOptions: { ecmaVersion: 6 } },
         { code: "var {\nx,y } = y", options: ["always"], parserOptions: { ecmaVersion: 6 } },
         { code: "var {\nx,y\n} = z", options: ["always"], parserOptions: { ecmaVersion: 6 } },
+        { code: "var { /**/x/**/ } = y", options: ["always"], parserOptions: { ecmaVersion: 6 } },
+        { code: "var { //\nx } = y", options: ["always"], parserOptions: { ecmaVersion: 6 } },
         { code: "var { x = 10, y } = y", options: ["always"], parserOptions: { ecmaVersion: 6 } },
         { code: "var { x: { z }, y } = y", options: ["always"], parserOptions: { ecmaVersion: 6 } },
         { code: "var {\ny,\n} = x", options: ["always"], parserOptions: { ecmaVersion: 6 } },
@@ -44,6 +48,8 @@ ruleTester.run("object-curly-spacing", rule, {
         { code: "import * as door from 'room'", options: ["always"], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
         { code: "import { door } from 'room'", options: ["always"], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
         { code: "import {\ndoor } from 'room'", options: ["always"], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
+        { code: "import { /**/door/**/ } from 'room'", options: ["always"], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
+        { code: "import { //\ndoor } from 'room'", options: ["always"], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
         { code: "export { door } from 'room'", options: ["always"], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
         { code: "import { house, mouse } from 'caravan'", options: ["always"], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
         { code: "import house, { mouse } from 'caravan'", options: ["always"], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
@@ -55,6 +61,10 @@ ruleTester.run("object-curly-spacing", rule, {
         { code: "import {\nx,\n} from 'foo';", options: ["always"], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
         { code: "export { x, } from 'foo';", options: ["always"], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
         { code: "export {\nx,\n} from 'foo';", options: ["always"], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
+        { code: "export { /**/x/**/ } from 'foo';", options: ["always"], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
+        { code: "export { //\nx } from 'foo';", options: ["always"], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
+        { code: "var x = 1;\nexport { /**/x/**/ };", options: ["always"], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
+        { code: "var x = 1;\nexport { //\nx };", options: ["always"], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
 
         // always - empty object
         { code: "var foo = {};", options: ["always"] },
@@ -86,6 +96,8 @@ ruleTester.run("object-curly-spacing", rule, {
         { code: "var obj = {\nfoo: bar,\nbaz: qux\n};", options: ["never"] },
         { code: "var obj = {foo: bar, baz: qux /* */};", options: ["never"] },
         { code: "var obj = {/* */ foo: bar, baz: qux};", options: ["never"] },
+        { code: "var obj = {//\n foo: bar};", options: ["never"] },
+        { code: "var obj = { // line comment exception\n foo: bar};", options: ["never"] },
 
         // never - destructuring
         { code: "var {x} = y", options: ["never"], parserOptions: { ecmaVersion: 6 } },
@@ -101,6 +113,8 @@ ruleTester.run("object-curly-spacing", rule, {
         { code: "var {y:x} = x", options: ["never"], parserOptions: { ecmaVersion: 6 } },
         { code: "var {/* */ y} = x", options: ["never"], parserOptions: { ecmaVersion: 6 } },
         { code: "var {y /* */} = x", options: ["never"], parserOptions: { ecmaVersion: 6 } },
+        { code: "var {//\n y} = x", options: ["never"], parserOptions: { ecmaVersion: 6 } },
+        { code: "var { // line comment exception\n y} = x", options: ["never"], parserOptions: { ecmaVersion: 6 } },
 
         // never - import / export
         { code: "import door from 'room'", options: ["never"], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
@@ -111,6 +125,12 @@ ruleTester.run("object-curly-spacing", rule, {
         { code: "export {/* */ door} from 'room'", options: ["never"], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
         { code: "import {door /* */} from 'room'", options: ["never"], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
         { code: "export {door /* */} from 'room'", options: ["never"], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
+        { code: "import {//\n door} from 'room'", options: ["never"], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
+        { code: "export {//\n door} from 'room'", options: ["never"], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
+        { code: "var door = foo;\nexport {//\n door}", options: ["never"], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
+        { code: "import { // line comment exception\n door} from 'room'", options: ["never"], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
+        { code: "export { // line comment exception\n door} from 'room'", options: ["never"], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
+        { code: "var door = foo; export { // line comment exception\n door}", options: ["never"], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
         { code: "import {\ndoor} from 'room'", options: ["never"], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
         { code: "export {\ndoor\n} from 'room'", options: ["never"], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
         { code: "import {house,mouse} from 'caravan'", options: ["never"], parserOptions: { ecmaVersion: 6, sourceType: "module" } },
@@ -272,6 +292,20 @@ ruleTester.run("object-curly-spacing", rule, {
             ]
         },
         {
+            code: "import x, {//\n bar } from 'foo';",
+            output: "import x, { //\n bar } from 'foo';",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [
+                {
+                    message: "A space is required after '{'.",
+                    type: "ImportDeclaration",
+                    line: 1,
+                    column: 11
+                }
+            ]
+        },
+        {
             code: "import x, { bar, baz} from 'foo';",
             output: "import x, { bar, baz } from 'foo';",
             options: ["always"],
@@ -405,6 +439,40 @@ ruleTester.run("object-curly-spacing", rule, {
                     type: "ExportNamedDeclaration",
                     line: 2,
                     column: 12
+                }
+            ]
+        },
+        {
+            code: "var bar = 0;\nexport {/* */ bar /* */};",
+            output: "var bar = 0;\nexport { /* */ bar /* */ };",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [
+                {
+                    message: "A space is required after '{'.",
+                    type: "ExportNamedDeclaration",
+                    line: 2,
+                    column: 8
+                },
+                {
+                    message: "A space is required before '}'.",
+                    type: "ExportNamedDeclaration",
+                    line: 2,
+                    column: 24
+                }
+            ]
+        },
+        {
+            code: "var bar = 0;\nexport {//\n bar };",
+            output: "var bar = 0;\nexport { //\n bar };",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [
+                {
+                    message: "A space is required after '{'.",
+                    type: "ExportNamedDeclaration",
+                    line: 2,
+                    column: 8
                 }
             ]
         },
@@ -620,6 +688,19 @@ ruleTester.run("object-curly-spacing", rule, {
             ]
         },
         {
+            code: "var obj = {//\n foo: bar };",
+            output: "var obj = { //\n foo: bar };",
+            options: ["always"],
+            errors: [
+                {
+                    message: "A space is required after '{'.",
+                    type: "ObjectExpression",
+                    line: 1,
+                    column: 11
+                }
+            ]
+        },
+        {
             code: "var obj = { foo: bar, baz: qux};",
             output: "var obj = { foo: bar, baz: qux };",
             options: ["always"],
@@ -712,6 +793,19 @@ ruleTester.run("object-curly-spacing", rule, {
                     message: "There should be no space after '{'.",
                     type: "ObjectExpression",
                     line: 1,
+                    column: 11
+                }
+            ]
+        },
+        {
+            code: "var obj = { // line comment exception\n foo: bar };",
+            output: "var obj = { // line comment exception\n foo: bar};",
+            options: ["never"],
+            errors: [
+                {
+                    message: "There should be no space before '}'.",
+                    type: "ObjectExpression",
+                    line: 2,
                     column: 11
                 }
             ]
@@ -821,6 +915,20 @@ ruleTester.run("object-curly-spacing", rule, {
         {
             code: "var {/* */x, y } = y",
             output: "var { /* */x, y } = y",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    message: "A space is required after '{'.",
+                    type: "ObjectPattern",
+                    line: 1,
+                    column: 5
+                }
+            ]
+        },
+        {
+            code: "var {//\n x } = y",
+            output: "var { //\n x } = y",
             options: ["always"],
             parserOptions: { ecmaVersion: 6 },
             errors: [


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix #11902
[X] Changes an existing rule

This PR allows one particular exception in `object-curly-spacing` default behavior, and nothing more:

* When the option is `never`, spaces will be allowed between `{` and a line comment `//`.

All other combinations of options and comments are unchanged.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**What rule do you want to change?**

`object-curly-spacing`

**Does this change cause the rule to produce more or fewer warnings?**

fewer

**How will the change be implemented? (New option, new default behavior, etc.)?**

new default behavior

**Please provide some example code that this change will affect:**

```js
/*eslint object-curly-spacing: ["error", "never"]*/

var foo = { // line comment
  bar: baz
}

var { // line comment
  foo 
} = bar;

import { // line comment
  bar
} from 'foo'

export { // line comment
  bar
}

export { // line comment
  foo
} from 'bar'
```

**What does the rule currently do for this code?**

5 errors.

**What will the rule do after it's changed?**

No errors.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Don't report disallowed spaces between `{` and `//...` tokens when the option is `never.`

**Is there anything you'd like reviewers to focus on?**

There are no details in the documentation on how the rule works with comments inside `{}`, so this technically isn't a bug.

However, it seems that all other spacing rules that account for comments do allow this particular exception. Namely, `space-in-parens`, `block-spacing` and `comma-spacing`.