### PR TITLE
Update: Add allowAsiHazardAfter option to semi

### DIFF
--- a/lib/rules/semi.js
+++ b/lib/rules/semi.js
@@ -41,6 +41,9 @@ module.exports = {
                             properties: {
                                 beforeStatementContinuationChars: {
                                     enum: ["always", "any", "never"]
+                                },
+                                allowAsiHazardAfter: {
+                                    type: "boolean"
                                 }
                             },
                             additionalProperties: false
@@ -77,6 +80,7 @@ module.exports = {
         const never = context.options[0] === "never";
         const exceptOneLine = Boolean(options && options.omitLastInOneLineBlock);
         const beforeStatementContinuationChars = options && options.beforeStatementContinuationChars || "any";
+        const allowAsiHazardAfter = options && options.allowAsiHazardAfter || false;
         const sourceCode = context.getSourceCode();
 
         //--------------------------------------------------------------------------
@@ -176,6 +180,10 @@ module.exports = {
          * @returns {boolean} `true` if the node can connect the next line.
          */
         function maybeAsiHazardAfter(node) {
+            if (allowAsiHazardAfter) {
+                return false;
+            }
+
             const t = node.type;
 
             if (t === "DoWhileStatement" ||

--- a/tests/lib/rules/semi.js
+++ b/tests/lib/rules/semi.js
@@ -621,6 +621,19 @@ ruleTester.run("semi", rule, {
             options: ["never", { beforeStatementContinuationChars: "never" }],
             parserOptions: { ecmaVersion: 2015 },
             errors: ["Extra semicolon."]
+        },
+        {
+            code: `
+                const f = [1,2,3]
+                ;[4,5,6].forEach(doSomething)
+            `,
+            output: `
+                const f = [1,2,3]
+                [4,5,6].forEach(doSomething)
+            `,
+            options: ["never", { beforeStatementContinuationChars: "never", allowAsiHazardAfter: true }],
+            parserOptions: { ecmaVersion: 2015 },
+            errors: ["Extra semicolon."]
         }
     ]
 });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

> **What rule do you want to change?**
>
> [semi](https://eslint.org/docs/rules/semi#options)
>
> **Does this change cause the rule to produce more or fewer warnings?**
>
> More.
>
> **How will the change be implemented? (New option, new default behavior, etc.)?**
>
> New option that disables the exception for `{ "beforeStatementContinuationChars": "never" }` that currently allows semicolons before statement continuation characters. Currently "never" implements behavior that I'd describe as "never, if it doesn’t make ASI hazard", whereas I'd really like to use "never" in general.
>
> **Please provide some example code that this change will affect:**
>
> ```js
> /*eslint semi: ["error", "never", { "beforeStatementContinuationChars": "never"}] */
> 
> console.log(42)
> ;(function() {
>     // ...
> })()
> ```
>
> **What does the rule currently do for this code?**
>
> No errors detected.
>
> **What will the rule do after it's changed?**
> 
> Detect the error caused by the semicolon before the statement continuation characters.

Resolves #12228 