### PR TITLE
Fix: use async reading of stdin in bin/eslint.js

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -79,20 +79,19 @@ if (useStdIn) {
      *
      * Using the nodejs code example for reading from stdin.
      */
-    const input = [];
+    let contents = "",
+        chunk = "";
 
+    process.stdin.setEncoding("utf8");
     process.stdin.on("readable", () => {
-        let chunk;
 
         // Use a loop to make sure we read all available data.
         while ((chunk = process.stdin.read()) !== null) {
-            input.push(chunk);
+            contents += chunk;
         }
     });
 
     process.stdin.on("end", () => {
-        const contents = input.join("");
-
         process.exitCode = cli.execute(process.argv, contents, "utf8");
     });
 } else if (init) {

--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -60,13 +60,41 @@ process.once("uncaughtException", err => {
 if (useStdIn) {
 
     /*
-     * Note: `process.stdin.fd` is not used here due to https://github.com/nodejs/node/issues/7439.
-     * Accessing the `process.stdin` property seems to modify the behavior of file descriptor 0, resulting
-     * in an error when stdin is piped in asynchronously.
+     * Note: See
+     * - https://github.com/nodejs/node/blob/master/doc/api/process.md#processstdin
+     * - https://github.com/nodejs/node/blob/master/doc/api/process.md#a-note-on-process-io
+     * - https://lists.gnu.org/archive/html/bug-gnu-emacs/2016-01/msg00419.html
+     * - https://github.com/nodejs/node/issues/7439 (historical)
+     *
+     * On Windows using `fs.readFileSync(STDIN_FILE_DESCRIPTOR, "utf8")` seems
+     * to read 4096 bytes before blocking and never drains to read further data.
+     *
+     * The investigation on the Emacs thread indicates:
+     *
+     * > Emacs on MS-Windows uses pipes to communicate with subprocesses; a
+     * > pipe on Windows has a 4K buffer. So as soon as Emacs writes more than
+     * > 4096 bytes to the pipe, the pipe becomes full, and Emacs then waits for
+     * > the subprocess to read its end of the pipe, at which time Emacs will
+     * > write the rest of the stuff.
+     *
+     * Using the nodejs code example for reading from stdin.
      */
-    const STDIN_FILE_DESCRIPTOR = 0;
+    const input = [];
 
-    process.exitCode = cli.execute(process.argv, fs.readFileSync(STDIN_FILE_DESCRIPTOR, "utf8"));
+    process.stdin.on("readable", () => {
+        let chunk;
+
+        // Use a loop to make sure we read all available data.
+        while ((chunk = process.stdin.read()) !== null) {
+            input.push(chunk);
+        }
+    });
+
+    process.stdin.on("end", () => {
+        const contents = input.join("");
+
+        process.exitCode = cli.execute(process.argv, contents, "utf8");
+    });
 } else if (init) {
     const configInit = require("../lib/init/config-initializer");
 

--- a/tests/bin/eslint.js
+++ b/tests/bin/eslint.js
@@ -163,6 +163,15 @@ describe("bin/eslint.js", () => {
                 return assertExitCode(child, 0);
             });
         });
+
+        it("successfully handles more than 4k data via stdin", () => {
+            const child = runESLint(["--stdin", "--no-eslintrc"]);
+            const large = fs.createReadStream(`${__dirname}/../bench/large.js`, "utf8");
+
+            large.pipe(child.stdin);
+
+            return assertExitCode(child, 0);
+        });
     });
 
     describe("running on files", () => {


### PR DESCRIPTION
closes eslint/eslint#12212

<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

See https://github.com/eslint/eslint/issues/12212

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Applied nodejs recommendations for processing stdin as per https://github.com/nodejs/node/blob/master/doc/api/process.md#processstdin

**Is there anything you'd like reviewers to focus on?**

Compatibility with other operating systems.
I've only tested this on Windows.