### PR TITLE
Fix: no-regex-spaces false positives and invalid autofix (fixes #12226)

### DIFF
--- a/lib/rules/no-regex-spaces.js
+++ b/lib/rules/no-regex-spaces.js
@@ -17,6 +17,7 @@ const regexpp = require("regexpp");
 //------------------------------------------------------------------------------
 
 const regExpParser = new regexpp.RegExpParser();
+const DOUBLE_SPACE = / {2}/u;
 
 /**
  * Check if node is a string
@@ -62,59 +63,49 @@ module.exports = {
          */
         function checkRegex(nodeToReport, pattern, rawPattern, rawPatternStartRange, flags) {
 
-            // Skip if there are no consecutive spaces in the source code
-            if (!/ {2}/u.test(rawPattern)) {
+            // Skip if there are no consecutive spaces in the source code, to avoid reporting e.g., RegExp(' \ ').
+            if (!DOUBLE_SPACE.test(rawPattern)) {
                 return;
             }
 
-            let ast;
+            const characterClassNodes = [];
+            let regExpAST;
 
             try {
-                ast = regExpParser.parsePattern(pattern, 0, pattern.length, flags.includes("u"));
+                regExpAST = regExpParser.parsePattern(pattern, 0, pattern.length, flags.includes("u"));
             } catch (e) {
 
                 // Ignore regular expressions with syntax errors
                 return;
             }
 
-            const spaces = [];
-
-            regexpp.visitRegExpAST(ast, {
-                onCharacterEnter(character) {
-                    if (
-                        character.parent.type === "Alternative" &&
-                        (character.raw === " " || character.raw === "\\ ")
-                    ) {
-                        spaces.push(character);
-                    }
+            regexpp.visitRegExpAST(regExpAST, {
+                onCharacterClassEnter(ccNode) {
+                    characterClassNodes.push(ccNode);
                 }
             });
 
-            for (let i = 0; i < spaces.length - 1; i++) {
-                let j = i;
+            const spacesPattern = /( {2,})(?: [+*{?]|[^+*{?]|$)/gu;
+            let match;
 
-                while (
-                    j < spaces.length - 1 &&
-                    spaces[j].end === spaces[j + 1].start &&
-                    spaces[j + 1].raw === " "
+            while ((match = spacesPattern.exec(pattern))) {
+                const { 1: { length }, index } = match;
+
+                // Report only consecutive spaces that are not in character classes.
+                if (
+                    characterClassNodes.every(({ start, end }) => index < start || end <= index)
                 ) {
-                    j++;
-                }
-
-                if (j > i) {
-                    const count = j - i + 1;
-
                     context.report({
                         node: nodeToReport,
-                        message: "Spaces are hard to count. Use {{{count}}}.",
-                        data: { count },
+                        message: "Spaces are hard to count. Use {{{length}}}.",
+                        data: { length },
                         fix(fixer) {
                             if (pattern !== rawPattern) {
                                 return null;
                             }
                             return fixer.replaceTextRange(
-                                [rawPatternStartRange + spaces[i + 1].start, rawPatternStartRange + spaces[j].end],
-                                `{${count}}`
+                                [rawPatternStartRange + index, rawPatternStartRange + index + length],
+                                ` {${length}}`
                             );
                         }
                     });

--- a/lib/rules/no-regex-spaces.js
+++ b/lib/rules/no-regex-spaces.js
@@ -123,11 +123,6 @@ module.exports = {
                     return;
                 }
             }
-
-            /*
-             * TODO: (platinumazure) Fix message to use rule message
-             * substitution when api.report is fixed in lib/eslint.js.
-             */
         }
 
         /**

--- a/lib/rules/no-regex-spaces.js
+++ b/lib/rules/no-regex-spaces.js
@@ -5,7 +5,28 @@
 
 "use strict";
 
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
 const astUtils = require("./utils/ast-utils");
+const regexpp = require("regexpp");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+const regExpParser = new regexpp.RegExpParser();
+
+/**
+ * Check if node is a string
+ * @param {ASTNode} node node to evaluate
+ * @returns {boolean} True if its a string
+ * @private
+ */
+function isString(node) {
+    return node && node.type === "Literal" && typeof node.value === "string";
+}
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -27,41 +48,86 @@ module.exports = {
     },
 
     create(context) {
-        const sourceCode = context.getSourceCode();
 
         /**
-         * Validate regular expressions
-         * @param {ASTNode} node node to validate
-         * @param {string} value regular expression to validate
-         * @param {number} valueStart The start location of the regex/string literal. It will always be the case that
-         * `sourceCode.getText().slice(valueStart, valueStart + value.length) === value`
+         * Validate regular expression
+         *
+         * @param {ASTNode} nodeToReport Node to report.
+         * @param {string} pattern Regular expression pattern to validate.
+         * @param {string} rawPattern Raw representation of the pattern in the source code.
+         * @param {number} rawPatternStartRange Start range of the pattern in the source code.
+         * @param {string} flags Regular expression flags.
          * @returns {void}
          * @private
          */
-        function checkRegex(node, value, valueStart) {
-            const multipleSpacesRegex = /( {2,})( [+*{?]|[^+*{?]|$)/u,
-                regexResults = multipleSpacesRegex.exec(value);
+        function checkRegex(nodeToReport, pattern, rawPattern, rawPatternStartRange, flags) {
 
-            if (regexResults !== null) {
-                const count = regexResults[1].length;
-
-                context.report({
-                    node,
-                    message: "Spaces are hard to count. Use {{{count}}}.",
-                    data: { count },
-                    fix(fixer) {
-                        return fixer.replaceTextRange(
-                            [valueStart + regexResults.index, valueStart + regexResults.index + count],
-                            ` {${count}}`
-                        );
-                    }
-                });
-
-                /*
-                 * TODO: (platinumazure) Fix message to use rule message
-                 * substitution when api.report is fixed in lib/eslint.js.
-                 */
+            // Skip if there are no consecutive spaces in the source code
+            if (!/ {2}/u.test(rawPattern)) {
+                return;
             }
+
+            let ast;
+
+            try {
+                ast = regExpParser.parsePattern(pattern, 0, pattern.length, flags.includes("u"));
+            } catch (e) {
+
+                // Ignore regular expressions with syntax errors
+                return;
+            }
+
+            const spaces = [];
+
+            regexpp.visitRegExpAST(ast, {
+                onCharacterEnter(character) {
+                    if (
+                        character.parent.type === "Alternative" &&
+                        (character.raw === " " || character.raw === "\\ ")
+                    ) {
+                        spaces.push(character);
+                    }
+                }
+            });
+
+            for (let i = 0; i < spaces.length - 1; i++) {
+                let j = i;
+
+                while (
+                    j < spaces.length - 1 &&
+                    spaces[j].end === spaces[j + 1].start &&
+                    spaces[j + 1].raw === " "
+                ) {
+                    j++;
+                }
+
+                if (j > i) {
+                    const count = j - i + 1;
+
+                    context.report({
+                        node: nodeToReport,
+                        message: "Spaces are hard to count. Use {{{count}}}.",
+                        data: { count },
+                        fix(fixer) {
+                            if (pattern !== rawPattern) {
+                                return null;
+                            }
+                            return fixer.replaceTextRange(
+                                [rawPatternStartRange + spaces[i + 1].start, rawPatternStartRange + spaces[j].end],
+                                `{${count}}`
+                            );
+                        }
+                    });
+
+                    // Report only the first occurence of consecutive spaces
+                    return;
+                }
+            }
+
+            /*
+             * TODO: (platinumazure) Fix message to use rule message
+             * substitution when api.report is fixed in lib/eslint.js.
+             */
         }
 
         /**
@@ -71,23 +137,20 @@ module.exports = {
          * @private
          */
         function checkLiteral(node) {
-            const token = sourceCode.getFirstToken(node),
-                nodeType = token.type,
-                nodeValue = token.value;
+            if (node.regex) {
+                const pattern = node.regex.pattern;
+                const rawPattern = node.raw.slice(1, node.raw.lastIndexOf("/"));
+                const rawPatternStartRange = node.range[0] + 1;
+                const flags = node.regex.flags;
 
-            if (nodeType === "RegularExpression") {
-                checkRegex(node, nodeValue, token.range[0]);
+                checkRegex(
+                    node,
+                    pattern,
+                    rawPattern,
+                    rawPatternStartRange,
+                    flags
+                );
             }
-        }
-
-        /**
-         * Check if node is a string
-         * @param {ASTNode} node node to evaluate
-         * @returns {boolean} True if its a string
-         * @private
-         */
-        function isString(node) {
-            return node && node.type === "Literal" && typeof node.value === "string";
         }
 
         /**
@@ -100,9 +163,22 @@ module.exports = {
             const scope = context.getScope();
             const regExpVar = astUtils.getVariableByName(scope, "RegExp");
             const shadowed = regExpVar && regExpVar.defs.length > 0;
+            const patternNode = node.arguments[0];
+            const flagsNode = node.arguments[1];
 
-            if (node.callee.type === "Identifier" && node.callee.name === "RegExp" && isString(node.arguments[0]) && !shadowed) {
-                checkRegex(node, node.arguments[0].value, node.arguments[0].range[0] + 1);
+            if (node.callee.type === "Identifier" && node.callee.name === "RegExp" && isString(patternNode) && !shadowed) {
+                const pattern = patternNode.value;
+                const rawPattern = patternNode.raw.slice(1, -1);
+                const rawPatternStartRange = patternNode.range[0] + 1;
+                const flags = isString(flagsNode) ? flagsNode.value : "";
+
+                checkRegex(
+                    node,
+                    pattern,
+                    rawPattern,
+                    rawPatternStartRange,
+                    flags
+                );
             }
         }
 
@@ -111,6 +187,5 @@ module.exports = {
             CallExpression: checkFunction,
             NewExpression: checkFunction
         };
-
     }
 };

--- a/tests/lib/rules/no-regex-spaces.js
+++ b/tests/lib/rules/no-regex-spaces.js
@@ -16,18 +16,56 @@ const ruleTester = new RuleTester();
 
 ruleTester.run("no-regex-spaces", rule, {
     valid: [
-        "var foo = /bar {3}baz/;",
-        "var foo = RegExp('bar {3}baz')",
+        "var foo = /foo/;",
+        "var foo = RegExp('foo')",
+        "var foo = / /;",
+        "var foo = RegExp(' ')",
+        "var foo = /bar {3}baz/g;",
+        "var foo = RegExp('bar {3}baz', 'g')",
         "var foo = new RegExp('bar {3}baz')",
         "var foo = /bar\t\t\tbaz/;",
         "var foo = RegExp('bar\t\t\tbaz');",
         "var foo = new RegExp('bar\t\t\tbaz');",
         "var RegExp = function() {}; var foo = new RegExp('bar   baz');",
         "var RegExp = function() {}; var foo = RegExp('bar   baz');",
-        "var foo = /  +/;"
+        "var foo = /  +/;",
+
+        // don't report if there are no consecutive spaces in the source code
+        "var foo = /bar \\ baz/;",
+        "var foo = /bar\\ \\ baz/;",
+        "var foo = /bar \\u0020 baz/;",
+        "var foo = /bar\\u0020\\u0020baz/;",
+        "var foo = new RegExp('bar \\ baz')",
+        "var foo = new RegExp('bar\\ \\ baz')",
+        "var foo = new RegExp('bar \\\\ baz')",
+        "var foo = new RegExp('bar \\u0020 baz')",
+        "var foo = new RegExp('bar\\u0020\\u0020baz')",
+        "var foo = new RegExp('bar \\\\u0020 baz')",
+
+        // don't report spaces in character classes
+        "var foo = /[  ]/;",
+        "var foo = /[   ]/;",
+        "var foo = / [  ] /;",
+        "var foo = new RegExp('[  ]');",
+        "var foo = new RegExp('[   ]');",
+        "var foo = new RegExp(' [  ] ');",
+
+        // don't report invalid regex
+        "var foo = new RegExp('[  ');",
+        "var foo = new RegExp('{  ', 'u');"
     ],
 
     invalid: [
+        {
+            code: "var foo = /bar  baz/;",
+            output: "var foo = /bar {2}baz/;",
+            errors: [
+                {
+                    message: "Spaces are hard to count. Use {2}.",
+                    type: "Literal"
+                }
+            ]
+        },
         {
             code: "var foo = /bar    baz/;",
             output: "var foo = /bar {4}baz/;",
@@ -88,6 +126,110 @@ ruleTester.run("no-regex-spaces", rule, {
                 {
                     message: "Spaces are hard to count. Use {4}.",
                     type: "NewExpression"
+                }
+            ]
+        },
+        {
+            code: "var foo = /bar\\  baz/;",
+            output: "var foo = /bar\\ {2}baz/;",
+            errors: [
+                {
+                    message: "Spaces are hard to count. Use {2}.",
+                    type: "Literal"
+                }
+            ]
+        },
+        {
+            code: "var foo = /[   ]  /;",
+            output: "var foo = /[   ] {2}/;",
+            errors: [
+                {
+                    message: "Spaces are hard to count. Use {2}.",
+                    type: "Literal"
+                }
+            ]
+        },
+        {
+            code: "var foo = new RegExp('[   ]  ');",
+            output: "var foo = new RegExp('[   ] {2}');",
+            errors: [
+                {
+                    message: "Spaces are hard to count. Use {2}.",
+                    type: "NewExpression"
+                }
+            ]
+        },
+        {
+            code: "var foo = /(?:  )/;",
+            output: "var foo = /(?: {2})/;",
+            errors: [
+                {
+                    message: "Spaces are hard to count. Use {2}.",
+                    type: "Literal"
+                }
+            ]
+        },
+        {
+            code: "var foo = RegExp('^foo(?=   )');",
+            output: "var foo = RegExp('^foo(?= {3})');",
+            errors: [
+                {
+                    message: "Spaces are hard to count. Use {3}.",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "var foo = /\\  /",
+            output: "var foo = /\\ {2}/",
+            errors: [
+                {
+                    message: "Spaces are hard to count. Use {2}.",
+                    type: "Literal"
+                }
+            ]
+        },
+        {
+            code: "var foo = / \\  /",
+            output: "var foo = / \\ {2}/",
+            errors: [
+                {
+                    message: "Spaces are hard to count. Use {2}.",
+                    type: "Literal"
+                }
+            ]
+        },
+
+        // report only the first occurence of consecutive spaces
+        {
+            code: "var foo = /  foo   /;",
+            output: "var foo = / {2}foo   /;",
+            errors: [
+                {
+                    message: "Spaces are hard to count. Use {2}.",
+                    type: "Literal"
+                }
+            ]
+        },
+
+        // don't fix strings with escape sequences
+        {
+            code: "var foo = new RegExp('\\\\d  ')",
+            output: null,
+            errors: [
+                {
+                    message: "Spaces are hard to count. Use {2}.",
+                    type: "NewExpression"
+                }
+            ]
+        },
+        {
+            code: "var foo = RegExp('\\u0041   ')",
+            output: null,
+            errors: [
+                {
+                    message: "Spaces are hard to count. Use {3}.",
+                    type: "CallExpression"
                 }
             ]
         }

--- a/tests/lib/rules/no-regex-spaces.js
+++ b/tests/lib/rules/no-regex-spaces.js
@@ -20,6 +20,7 @@ ruleTester.run("no-regex-spaces", rule, {
         "var foo = RegExp('foo')",
         "var foo = / /;",
         "var foo = RegExp(' ')",
+        "var foo = / a b c d /;",
         "var foo = /bar {3}baz/g;",
         "var foo = RegExp('bar {3}baz', 'g')",
         "var foo = new RegExp('bar {3}baz')",
@@ -73,6 +74,26 @@ ruleTester.run("no-regex-spaces", rule, {
                 {
                     message: "Spaces are hard to count. Use {4}.",
                     type: "Literal"
+                }
+            ]
+        },
+        {
+            code: "var foo = / a b  c d /;",
+            output: "var foo = / a b {2}c d /;",
+            errors: [
+                {
+                    message: "Spaces are hard to count. Use {2}.",
+                    type: "Literal"
+                }
+            ]
+        },
+        {
+            code: "var foo = RegExp(' a b c d  ');",
+            output: "var foo = RegExp(' a b c d {2}');",
+            errors: [
+                {
+                    message: "Spaces are hard to count. Use {2}.",
+                    type: "CallExpression"
                 }
             ]
         },

--- a/tests/lib/rules/no-regex-spaces.js
+++ b/tests/lib/rules/no-regex-spaces.js
@@ -30,6 +30,9 @@ ruleTester.run("no-regex-spaces", rule, {
         "var RegExp = function() {}; var foo = new RegExp('bar   baz');",
         "var RegExp = function() {}; var foo = RegExp('bar   baz');",
         "var foo = /  +/;",
+        "var foo = /  ?/;",
+        "var foo = /  */;",
+        "var foo = /  {2}/;",
 
         // don't report if there are no consecutive spaces in the source code
         "var foo = /bar \\ baz/;",
@@ -47,9 +50,13 @@ ruleTester.run("no-regex-spaces", rule, {
         "var foo = /[  ]/;",
         "var foo = /[   ]/;",
         "var foo = / [  ] /;",
+        "var foo = / [  ] [  ] /;",
         "var foo = new RegExp('[  ]');",
         "var foo = new RegExp('[   ]');",
         "var foo = new RegExp(' [  ] ');",
+        "var foo = RegExp(' [  ] [  ] ');",
+        "var foo = new RegExp(' \\[   ');",
+        "var foo = new RegExp(' \\[   \\] ');",
 
         // don't report invalid regex
         "var foo = new RegExp('[  ');",
@@ -131,12 +138,42 @@ ruleTester.run("no-regex-spaces", rule, {
             ]
         },
         {
+            code: "var foo = /bar   {3}baz/;",
+            output: "var foo = /bar {2} {3}baz/;",
+            errors: [
+                {
+                    message: "Spaces are hard to count. Use {2}.",
+                    type: "Literal"
+                }
+            ]
+        },
+        {
             code: "var foo = /bar    ?baz/;",
             output: "var foo = /bar {3} ?baz/;",
             errors: [
                 {
                     message: "Spaces are hard to count. Use {3}.",
                     type: "Literal"
+                }
+            ]
+        },
+        {
+            code: "var foo = new RegExp('bar   *baz')",
+            output: "var foo = new RegExp('bar {2} *baz')",
+            errors: [
+                {
+                    message: "Spaces are hard to count. Use {2}.",
+                    type: "NewExpression"
+                }
+            ]
+        },
+        {
+            code: "var foo = RegExp('bar   +baz')",
+            output: "var foo = RegExp('bar {2} +baz')",
+            errors: [
+                {
+                    message: "Spaces are hard to count. Use {2}.",
+                    type: "CallExpression"
                 }
             ]
         },
@@ -171,12 +208,52 @@ ruleTester.run("no-regex-spaces", rule, {
             ]
         },
         {
+            code: "var foo = /  [   ] /;",
+            output: "var foo = / {2}[   ] /;",
+            errors: [
+                {
+                    message: "Spaces are hard to count. Use {2}.",
+                    type: "Literal"
+                }
+            ]
+        },
+        {
             code: "var foo = new RegExp('[   ]  ');",
             output: "var foo = new RegExp('[   ] {2}');",
             errors: [
                 {
                     message: "Spaces are hard to count. Use {2}.",
                     type: "NewExpression"
+                }
+            ]
+        },
+        {
+            code: "var foo = RegExp('  [ ]');",
+            output: "var foo = RegExp(' {2}[ ]');",
+            errors: [
+                {
+                    message: "Spaces are hard to count. Use {2}.",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "var foo = /\\[  /;",
+            output: "var foo = /\\[ {2}/;",
+            errors: [
+                {
+                    message: "Spaces are hard to count. Use {2}.",
+                    type: "Literal"
+                }
+            ]
+        },
+        {
+            code: "var foo = /\\[  \\]/;",
+            output: "var foo = /\\[ {2}\\]/;",
+            errors: [
+                {
+                    message: "Spaces are hard to count. Use {2}.",
+                    type: "Literal"
                 }
             ]
         },
@@ -251,6 +328,16 @@ ruleTester.run("no-regex-spaces", rule, {
                 {
                     message: "Spaces are hard to count. Use {3}.",
                     type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "var foo = new RegExp('\\\\[  \\\\]');",
+            output: null,
+            errors: [
+                {
+                    message: "Spaces are hard to count. Use {2}.",
+                    type: "NewExpression"
                 }
             ]
         }


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix #12226 + 2 other bugs.

This PR fixes 3 unrelated bugs in `no-regex-spaces`:

1. False positives in character classes (e.g. `/[  ]/` fixed to `/[ {2}]/`)
2. Invalid autofix for strings with escape sequences (e.g. `RegExp('\\d  ')` fixed to `RegExp('\\ {2} ')`)
3. Regex with invalid syntax were reported and fixed (e.g. `RegExp('[  ')` fixed to `RegExp('[ {2}')`). This might not be a bug, but I guess it's better to ignore invalid regex.

**1. Character classes**

The following tests were failing:

```js
// valid[]
"var foo = /[  ]/;",
"var foo = /[   ]/;",
"var foo = / [  ] /;",
"var foo = new RegExp('[  ]');",
"var foo = new RegExp('[   ]');",
"var foo = new RegExp(' [  ] ');",

// invalid[]
"var foo = /[   ]  /;",
"var foo = new RegExp('[   ]  ');"
```

The code is now using `regexpp` parser to target only spaces with `"Alternative"` parent.

Example:

```js
/* eslint no-regex-spaces:error */

var foo = /[  ]/;
var foo = new RegExp('[   ]  ');
```

Previous fix:

```js
/* eslint no-regex-spaces:error */

var foo = /[ {2}]/; // incorrect
var foo = new RegExp('[ {3}] {2}'); // incorrect
```

New behavior:

```js
/* eslint no-regex-spaces:error */

var foo = /[  ]/; // no error
var foo = new RegExp('[   ] {2}'); // error and autofix, but not inside []
```

**2. Strings with escape sequences**

It was assumed that the indexes are same as in the string's source code literal presentation.

The following tests were failing:

```js
// valid[]
"var foo = new RegExp('bar \\ baz')",
"var foo = new RegExp('bar\\ \\ baz')",
"var foo = new RegExp('bar \\u0020 baz')",
"var foo = new RegExp('bar\\u0020\\u0020baz')",

// invalid[]
"var foo = new RegExp('\\\\d  ')"
"var foo = RegExp('\\u0041   ')"
```

The logic is now changed to check for consecutive spaces in the source code (`Node.raw`), and also don't fix if the raw presentation is not same as the internal.

Example:

```js
/* eslint no-regex-spaces:error */

var foo = new RegExp('bar \ baz');
var foo = new RegExp('\\d  ');
```

Previous fix:

```js
/* eslint no-regex-spaces:error */

var foo = new RegExp('bar {2} baz'); // incorrect, requires 3 spaces
var foo = new RegExp('\\ {2} '); // incorrect, missing 'd'
```

New behavior:

```js
/* eslint no-regex-spaces:error */

var foo = new RegExp('bar \ baz'); // no error, there are no consecutive spaces in the source
var foo = new RegExp('\\d  '); // error, but no autofix
```

**3. Invalid syntax**

The following tests were failing:

```js
// valid[]
"var foo = new RegExp('[  ');",
"var foo = new RegExp('{  ', 'u');"
```

Example:

```js
/* eslint no-regex-spaces:error */

var foo = new RegExp('[  ');
```

Previous fix:

```js
/* eslint no-regex-spaces:error */

var foo = new RegExp('[ {2}');
```

New behavior:

```js
/* eslint no-regex-spaces:error */

var foo = new RegExp('[  '); // no error
```


<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Use `regexpp` to parse, don't fix strings that have a different raw representation, don't report regex with invalid syntax.

**Is there anything you'd like reviewers to focus on?**

Everything please, I didn't use `regexpp` before.

The cases in `2.` could be auto-fixed but that would require a utility to map indexes (that could be a future enhancement, I believe at the moment it's good enough to prevent invalid autofix).

There are some edge cases where the rule will report an error, e.g. `RegExp('[  ]\\u0020\\u0020')`, but that would require the same utility.

