### PR TITLE
Docs: fix no-sequences `with` examples

### DIFF
--- a/docs/rules/no-sequences.md
+++ b/docs/rules/no-sequences.md
@@ -37,8 +37,6 @@ if (doSomething(), !!test);
 switch (val = foo(), val) {}
 
 while (val = foo(), val < 42);
-
-with (doSomething(), val) {}
 ```
 
 Examples of **correct** code for this rule:
@@ -59,8 +57,6 @@ if ((doSomething(), !!test));
 switch ((val = foo(), val)) {}
 
 while ((val = foo(), val < 42));
-
-// with ((doSomething(), val)) {}
 ```
 
 ## When Not To Use It


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Documentation update
<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

There is an unusual commented `// with` example in [no-sequences](https://eslint.org/docs/rules/no-sequences) documentation.

It could have something with linting documentation examples (#2271) in the past?

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Removed both `with` examples from this document.

The example can be uncommented now and `npm test` will work well. Nevertheless, I think that `with` is not of particular importance for this rule, there are no examples with `with` in other rules (apart from how to disable it in `no-with` and `no-restricted-syntax`) so I guess it's better to avoid it in examples?

**Is there anything you'd like reviewers to focus on?**

If it isn't okay to remove these lines, I'll revert it and just uncomment the example.
