### PR TITLE
New: add rule no-unexpected-start

### DIFF
--- a/docs/rules/no-unexpected-start.md
+++ b/docs/rules/no-unexpected-start.md
@@ -1,0 +1,45 @@
+# disallow statement continuation characters at the start of statements (no-unexpected-start)
+
+Starting statements with characters like `[`, `(`, `+`, `/`, `-`, `/`, and `` ` `` can sometimes lead to an unexpected multi-line statement. The `no-unexpected-multiline` resolves this by detecting when an unexpected multi-line statement is parsed, but doesn't prevent developers from using these characters at the start of statements.
+
+This is especially common when writing JavaScript without semicolons, which depends on automatic semicolon insertion.
+
+## Rule Details
+
+This rule aims to disallow statements that start with characters that could potentially start an unexpected multi-line statement if a semicolon is missing.
+
+Examples of **incorrect** code for this rule:
+
+```js
+[1, 2, 3].reverse();
+
+`hello`.indexOf("o");
+
+/abc/.source;
+
+(function() { console.log(42) })();
+```
+
+Examples of **correct** code for this rule:
+
+```js
+const numbers = [1, 2, 3];
+numbers.reverse();
+
+const greeting = `hello`;
+greeting.indexOf("o");
+
+const regex = /abc/;
+regex.source;
+
+const f = function() { console.log(42) };
+f();
+
+{
+  console.log(42);
+}
+```
+
+## When Not To Use It
+
+If you want to be able to use short-hand you should disable this rule and use `no-unexpected-multiline`, semicolons, or both.

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -201,6 +201,7 @@ module.exports = new LazyLoadingRuleMap(Object.entries({
     "no-undefined": () => require("./no-undefined"),
     "no-underscore-dangle": () => require("./no-underscore-dangle"),
     "no-unexpected-multiline": () => require("./no-unexpected-multiline"),
+    "no-unexpected-start": () => require("./no-unexpected-start"),
     "no-unmodified-loop-condition": () => require("./no-unmodified-loop-condition"),
     "no-unneeded-ternary": () => require("./no-unneeded-ternary"),
     "no-unreachable": () => require("./no-unreachable"),

--- a/lib/rules/no-unexpected-start.js
+++ b/lib/rules/no-unexpected-start.js
@@ -17,7 +17,7 @@ module.exports = {
             recommended: false,
             url: "https://eslint.org/docs/rules/no-unexpected-start"
         },
-        fixable: null, // or "code" or "whitespace"
+        fixable: null,
         schema: []
     },
 
@@ -36,41 +36,22 @@ module.exports = {
         ];
 
         //----------------------------------------------------------------------
-        // Helpers
-        //----------------------------------------------------------------------
-        /**
-         * Report invalid nodes at the start of a statement
-         * @param {ASTNode} node The node being investigated
-         * @returns {void}
-         * @private
-         */
-        function reportInvalid(node) {
-            const { type, value } = node;
-            const isInvalidType = Object.keys(invalidTypes).includes(type);
-            const isInvalidValue = invalidValues.includes(value);
-
-
-            if (isInvalidType || isInvalidValue) {
-                const char = isInvalidType ? invalidTypes[type] : value;
-
-                const message = `Unexpected continuation character at start of statement: ${char}`;
-
-                context.report({
-                    node,
-                    message
-                });
-            }
-        }
-
-        //----------------------------------------------------------------------
         // Public
         //----------------------------------------------------------------------
 
         return {
             ":statement"(statementNode) {
-                const firstToken = context.getSourceCode().getFirstToken(statementNode);
+                const node = context.getSourceCode().getFirstToken(statementNode);
+                const { type, value } = node;
+                const isInvalidType = Object.keys(invalidTypes).includes(type);
+                const isInvalidValue = invalidValues.includes(value);
 
-                reportInvalid(firstToken);
+                if (isInvalidType || isInvalidValue) {
+                    const char = isInvalidType ? invalidTypes[type] : value;
+                    const message = `Unexpected continuation character at start of statement: ${char}`;
+
+                    context.report({ node, message });
+                }
             }
         };
     }

--- a/lib/rules/no-unexpected-start.js
+++ b/lib/rules/no-unexpected-start.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview disallow statement continuation characters at the start of statements
- * @author Fraction
+ * @author Christian Bundy <christianbundy@fraction.io>
  */
 "use strict";
 

--- a/lib/rules/no-unexpected-start.js
+++ b/lib/rules/no-unexpected-start.js
@@ -22,10 +22,10 @@ module.exports = {
     },
 
     create(context) {
-        const invalidTypes = [
-            "RegularExpression",
-            "Template"
-        ];
+        const invalidTypes = {
+            RegularExpression: "/",
+            Template: "`"
+        };
 
         const invalidValues = [
             "[",
@@ -39,17 +39,27 @@ module.exports = {
         // Helpers
         //----------------------------------------------------------------------
         /**
-         * Check whether the node's type and value are invalid.
-         * @param {string} type The node type.
-         * @param {string} value The node value.
-         * @returns {boolean} Whether type and value are valid.
+         * Report invalid nodes at the start of a statement
+         * @param {ASTNode} node The node being investigated
+         * @returns {void}
          * @private
          */
-        function isInvalid(type, value) {
-            const isInvalidType = invalidTypes.includes(type);
+        function reportInvalid(node) {
+            const { type, value } = node;
+            const isInvalidType = Object.keys(invalidTypes).includes(type);
             const isInvalidValue = invalidValues.includes(value);
 
-            return isInvalidType || isInvalidValue;
+
+            if (isInvalidType || isInvalidValue) {
+                const char = isInvalidType ? invalidTypes[type] : value;
+
+                const message = `Unexpected continuation character at start of statement: ${char}`;
+
+                context.report({
+                    node,
+                    message
+                });
+            }
         }
 
         //----------------------------------------------------------------------
@@ -59,14 +69,8 @@ module.exports = {
         return {
             ":statement"(statementNode) {
                 const firstToken = context.getSourceCode().getFirstToken(statementNode);
-                const { type, value } = firstToken;
 
-                if (isInvalid(type, value)) {
-                    context.report({
-                        node: firstToken,
-                        message: "Unexpected start of statement."
-                    });
-                }
+                reportInvalid(firstToken);
             }
         };
     }

--- a/lib/rules/no-unexpected-start.js
+++ b/lib/rules/no-unexpected-start.js
@@ -1,0 +1,73 @@
+/**
+ * @fileoverview disallow statement continuation characters at the start of statements
+ * @author Fraction
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+    meta: {
+        type: "suggestion",
+        docs: {
+            description: "disallow statement continuation characters at the start of statements",
+            category: "Best Practices",
+            recommended: false,
+            url: "https://eslint.org/docs/rules/no-unexpected-start"
+        },
+        fixable: null, // or "code" or "whitespace"
+        schema: []
+    },
+
+    create(context) {
+        const invalidTypes = [
+            "RegularExpression",
+            "Template"
+        ];
+
+        const invalidValues = [
+            "[",
+            "(",
+            "+",
+            "/",
+            "-"
+        ];
+
+        //----------------------------------------------------------------------
+        // Helpers
+        //----------------------------------------------------------------------
+        /**
+         * Check whether the node's type and value are invalid.
+         * @param {string} type The node type.
+         * @param {string} value The node value.
+         * @returns {boolean} Whether type and value are valid.
+         * @private
+         */
+        function isInvalid(type, value) {
+            const isInvalidType = invalidTypes.includes(type);
+            const isInvalidValue = invalidValues.includes(value);
+
+            return isInvalidType || isInvalidValue;
+        }
+
+        //----------------------------------------------------------------------
+        // Public
+        //----------------------------------------------------------------------
+
+        return {
+            ":statement"(statementNode) {
+                const firstToken = context.getSourceCode().getFirstToken(statementNode);
+                const { type, value } = firstToken;
+
+                if (isInvalid(type, value)) {
+                    context.report({
+                        node: firstToken,
+                        message: "Unexpected start of statement."
+                    });
+                }
+            }
+        };
+    }
+};

--- a/tests/lib/rules/no-unexpected-start.js
+++ b/tests/lib/rules/no-unexpected-start.js
@@ -1,0 +1,77 @@
+/**
+ * @fileoverview disallow statement continuation characters at the start of statements
+ * @author Fraction
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../lib/rules/no-unexpected-start"),
+
+    RuleTester = require("../../../lib/rule-tester/rule-tester");
+
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-unexpected-start", rule, {
+
+    valid: [
+        "var numbers = [1, 2, 3]; numbers.reverse()",
+        "{ console.log(42) }",
+        ";;;;console.log(42)"
+    ],
+
+    invalid: [
+        {
+            code: "[1, 2, 3].reverse()",
+            errors: [{
+                message: "Unexpected start of statement."
+            }]
+        },
+        {
+            code: "(function () { console.log(42) })()",
+            errors: [{
+                message: "Unexpected start of statement."
+            }]
+        },
+        {
+            code: ";(function () {})()",
+            errors: [{
+                message: "Unexpected start of statement."
+            }]
+        },
+        {
+            code: "`hello`.indexOf('o')",
+            parserOptions: {
+                ecmaVersion: 8
+            },
+            errors: [{
+                message: "Unexpected start of statement."
+            }]
+        },
+        {
+            code: "+42",
+            errors: [{
+                message: "Unexpected start of statement."
+            }]
+        },
+        {
+            code: "-42",
+            errors: [{
+                message: "Unexpected start of statement."
+            }]
+        },
+        {
+            code: "/foo/",
+            errors: [{
+                message: "Unexpected start of statement."
+            }]
+        }
+    ]
+});

--- a/tests/lib/rules/no-unexpected-start.js
+++ b/tests/lib/rules/no-unexpected-start.js
@@ -19,6 +19,8 @@ const rule = require("../../../lib/rules/no-unexpected-start"),
 
 const ruleTester = new RuleTester();
 
+const prefix = "Unexpected continuation character at start of statement: ";
+
 ruleTester.run("no-unexpected-start", rule, {
 
     valid: [
@@ -31,19 +33,19 @@ ruleTester.run("no-unexpected-start", rule, {
         {
             code: "[1, 2, 3].reverse()",
             errors: [{
-                message: "Unexpected start of statement."
+                message: `${prefix}[`
             }]
         },
         {
             code: "(function () { console.log(42) })()",
             errors: [{
-                message: "Unexpected start of statement."
+                message: `${prefix}(`
             }]
         },
         {
             code: ";(function () {})()",
             errors: [{
-                message: "Unexpected start of statement."
+                message: `${prefix}(`
             }]
         },
         {
@@ -52,25 +54,25 @@ ruleTester.run("no-unexpected-start", rule, {
                 ecmaVersion: 8
             },
             errors: [{
-                message: "Unexpected start of statement."
+                message: `${prefix}\``
             }]
         },
         {
             code: "+42",
             errors: [{
-                message: "Unexpected start of statement."
+                message: `${prefix}+`
             }]
         },
         {
             code: "-42",
             errors: [{
-                message: "Unexpected start of statement."
+                message: `${prefix}-`
             }]
         },
         {
             code: "/foo/",
             errors: [{
-                message: "Unexpected start of statement."
+                message: `${prefix}/`
             }]
         }
     ]

--- a/tests/lib/rules/no-unexpected-start.js
+++ b/tests/lib/rules/no-unexpected-start.js
@@ -26,7 +26,13 @@ ruleTester.run("no-unexpected-start", rule, {
     valid: [
         "var numbers = [1, 2, 3]; numbers.reverse()",
         "{ console.log(42) }",
-        ";;;;console.log(42)"
+        ";;;;console.log(42)",
+        {
+            code: "myTag`Hello ${myWorld}`",
+            parserOptions: {
+                ecmaVersion: 8
+            }
+        }
     ],
 
     invalid: [

--- a/tools/rule-types.json
+++ b/tools/rule-types.json
@@ -188,6 +188,7 @@
     "no-undefined": "suggestion",
     "no-underscore-dangle": "suggestion",
     "no-unexpected-multiline": "problem",
+    "no-unexpected-start": "suggestion",
     "no-unmodified-loop-condition": "problem",
     "no-unneeded-ternary": "suggestion",
     "no-unreachable": "problem",


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[x] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**Please describe what the rule should do:**

This rule should warn about statement continuation characters at the beginning of statements.


**What category of rule is this? (place an "X" next to just one item)**

[ ] Enforces code style
[x] Warns about a potential error
[ ] Suggests an alternate way of doing something
[ ] Other (please specify:)

**Provide 2-3 code examples that this rule will warn about:**

```js
[1, 2, 3].reverse();
/[abc]/.test("a");
+1 - 2;
```

**Why should this rule be included in ESLint (instead of a plugin)?**

I'm happy to create a plugin instead, but I think this goes above and beyond `no-unexpected-multiline` to ensure that *even if your code is copied and pasted without semicolons* it still won't create an ASI hazard.

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Added a rule, documentation, and tests.

**Is there anything you'd like reviewers to focus on?**

- I went through a list of all of the JS punctuation and I'm fairly confident that I'm detecting all problematic node types and values that would don't throw a syntax error (like `< 42` and such), but it might be worth double-checking that I haven't missed anything.
- I used the `:statement` selector, which seemed way too simple. Usually when something is simple it means I've taken a terrible shortcut, so please guide me toward a better solution if one exists. :sweat_smile: 
- I'm really not crazy about the name `no-unexpected-start`. Maybe `safe-statement-start` or something instead? I'm very open to any and all suggestions.

See also: #12228 #12229 

CC: @mysticatea @platinumazure