### PR TITLE
Update: indentation of comment followed by semicolon (fixes #12232) 

### DIFF
--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -4950,6 +4950,212 @@ ruleTester.run("indent", rule, {
                 bar
             }];
         `,
+        unIndent`
+            let foo
+
+            // comment
+
+            ;(async () => {})()
+        `,
+        unIndent`
+            let foo
+            // comment
+
+            ;(async () => {})()
+        `,
+        unIndent`
+            let foo
+
+            // comment
+            ;(async () => {})()
+        `,
+        unIndent`
+            let foo
+            // comment
+            ;(async () => {})()
+        `,
+        unIndent`
+            let foo
+
+                /* comment */;
+
+            (async () => {})()
+        `,
+        unIndent`
+            let foo
+                /* comment */;
+
+            (async () => {})()
+        `,
+        unIndent`
+            let foo
+
+                /* comment */;
+            (async () => {})()
+        `,
+        unIndent`
+            let foo
+                /* comment */;
+            (async () => {})()
+        `,
+        unIndent`
+            let foo
+            /* comment */;
+
+            (async () => {})()
+        `,
+        unIndent`
+            let foo
+            /* comment */;
+            (async () => {})()
+        `,
+        unIndent`
+            // comment
+
+            ;(async () => {})()
+        `,
+        unIndent`
+            // comment
+            ;(async () => {})()
+        `,
+        unIndent`
+            {
+                let foo
+
+                // comment
+
+                ;(async () => {})()
+            }
+        `,
+        unIndent`
+            {
+                let foo
+                // comment
+                ;(async () => {})()
+            }
+        `,
+        unIndent`
+            {
+                // comment
+
+                ;(async () => {})()
+            }
+        `,
+        unIndent`
+            {
+                // comment
+                ;(async () => {})()
+            }
+        `,
+        unIndent`
+            const foo = 1
+            const bar = foo
+
+            /* comment */
+
+            ;[1, 2, 3].forEach(() => {})
+        `,
+        unIndent`
+            const foo = 1
+            const bar = foo
+            /* comment */
+
+            ;[1, 2, 3].forEach(() => {})
+        `,
+        unIndent`
+            const foo = 1
+            const bar = foo
+
+            /* comment */
+            ;[1, 2, 3].forEach(() => {})
+        `,
+        unIndent`
+            const foo = 1
+            const bar = foo
+            /* comment */
+            ;[1, 2, 3].forEach(() => {})
+        `,
+        unIndent`
+            const foo = 1
+            const bar = foo
+
+                /* comment */;
+
+            [1, 2, 3].forEach(() => {})
+        `,
+        unIndent`
+            const foo = 1
+            const bar = foo
+                /* comment */;
+
+            [1, 2, 3].forEach(() => {})
+        `,
+        unIndent`
+            const foo = 1
+            const bar = foo
+
+                /* comment */;
+            [1, 2, 3].forEach(() => {})
+        `,
+        unIndent`
+            const foo = 1
+            const bar = foo
+                /* comment */;
+            [1, 2, 3].forEach(() => {})
+        `,
+        unIndent`
+            const foo = 1
+            const bar = foo
+            /* comment */;
+
+            [1, 2, 3].forEach(() => {})
+        `,
+        unIndent`
+            const foo = 1
+            const bar = foo
+            /* comment */;
+            [1, 2, 3].forEach(() => {})
+        `,
+        unIndent`
+            /* comment */
+
+            ;[1, 2, 3].forEach(() => {})
+        `,
+        unIndent`
+            /* comment */
+            ;[1, 2, 3].forEach(() => {})
+        `,
+        unIndent`
+            {
+                const foo = 1
+                const bar = foo
+
+                /* comment */
+
+                ;[1, 2, 3].forEach(() => {})
+            }
+        `,
+        unIndent`
+            {
+                const foo = 1
+                const bar = foo
+                /* comment */
+                ;[1, 2, 3].forEach(() => {})
+            }
+        `,
+        unIndent`
+            {
+                /* comment */
+
+                ;[1, 2, 3].forEach(() => {})
+            }
+        `,
+        unIndent`
+            {
+                /* comment */
+                ;[1, 2, 3].forEach(() => {})
+            }
+        `,
 
         // import expressions
         {
@@ -9605,6 +9811,290 @@ ruleTester.run("indent", rule, {
                 }];
             `,
             errors: expectedErrors([5, 0, 4, "Line"])
+        },
+        {
+            code: unIndent`
+                let foo
+
+                    // comment
+
+                ;(async () => {})()
+            `,
+            output: unIndent`
+                let foo
+
+                // comment
+
+                ;(async () => {})()
+            `,
+            errors: expectedErrors([3, 0, 4, "Line"])
+        },
+        {
+            code: unIndent`
+                let foo
+                    // comment
+                ;(async () => {})()
+            `,
+            output: unIndent`
+                let foo
+                // comment
+                ;(async () => {})()
+            `,
+            errors: expectedErrors([2, 0, 4, "Line"])
+        },
+        {
+            code: unIndent`
+                let foo
+
+                /* comment */;
+
+                (async () => {})()
+            `,
+            output: unIndent`
+                let foo
+
+                    /* comment */;
+
+                (async () => {})()
+            `,
+            errors: expectedErrors([3, 4, 0, "Block"])
+        },
+        {
+            code: unIndent`
+                    // comment
+
+                ;(async () => {})()
+            `,
+            output: unIndent`
+                // comment
+
+                ;(async () => {})()
+            `,
+            errors: expectedErrors([1, 0, 4, "Line"])
+        },
+        {
+            code: unIndent`
+                    // comment
+                ;(async () => {})()
+            `,
+            output: unIndent`
+                // comment
+                ;(async () => {})()
+            `,
+            errors: expectedErrors([1, 0, 4, "Line"])
+        },
+        {
+            code: unIndent`
+                {
+                    let foo
+
+                        // comment
+
+                    ;(async () => {})()
+
+                }
+            `,
+            output: unIndent`
+                {
+                    let foo
+
+                    // comment
+
+                    ;(async () => {})()
+
+                }
+            `,
+            errors: expectedErrors([4, 4, 8, "Line"])
+        },
+        {
+            code: unIndent`
+                {
+                    let foo
+                        // comment
+                    ;(async () => {})()
+
+                }
+            `,
+            output: unIndent`
+                {
+                    let foo
+                    // comment
+                    ;(async () => {})()
+
+                }
+            `,
+            errors: expectedErrors([3, 4, 8, "Line"])
+        },
+        {
+            code: unIndent`
+                {
+                    let foo
+
+                    /* comment */;
+
+                    (async () => {})()
+
+                }
+            `,
+            output: unIndent`
+                {
+                    let foo
+
+                        /* comment */;
+
+                    (async () => {})()
+
+                }
+            `,
+            errors: expectedErrors([4, 8, 4, "Block"])
+        },
+        {
+            code: unIndent`
+                const foo = 1
+                const bar = foo
+
+                    /* comment */
+
+                ;[1, 2, 3].forEach(() => {})
+            `,
+            output: unIndent`
+                const foo = 1
+                const bar = foo
+
+                /* comment */
+
+                ;[1, 2, 3].forEach(() => {})
+            `,
+            errors: expectedErrors([4, 0, 4, "Block"])
+        },
+        {
+            code: unIndent`
+                const foo = 1
+                const bar = foo
+                    /* comment */
+                ;[1, 2, 3].forEach(() => {})
+            `,
+            output: unIndent`
+                const foo = 1
+                const bar = foo
+                /* comment */
+                ;[1, 2, 3].forEach(() => {})
+            `,
+            errors: expectedErrors([3, 0, 4, "Block"])
+        },
+        {
+            code: unIndent`
+                const foo = 1
+                const bar = foo
+
+                /* comment */;
+
+                [1, 2, 3].forEach(() => {})
+            `,
+            output: unIndent`
+                const foo = 1
+                const bar = foo
+
+                    /* comment */;
+
+                [1, 2, 3].forEach(() => {})
+            `,
+            errors: expectedErrors([4, 4, 0, "Block"])
+        },
+        {
+            code: unIndent`
+                    /* comment */
+
+                ;[1, 2, 3].forEach(() => {})
+            `,
+            output: unIndent`
+                /* comment */
+
+                ;[1, 2, 3].forEach(() => {})
+            `,
+            errors: expectedErrors([1, 0, 4, "Block"])
+        },
+        {
+            code: unIndent`
+                    /* comment */
+                ;[1, 2, 3].forEach(() => {})
+            `,
+            output: unIndent`
+                /* comment */
+                ;[1, 2, 3].forEach(() => {})
+            `,
+            errors: expectedErrors([1, 0, 4, "Block"])
+        },
+        {
+            code: unIndent`
+                {
+                    const foo = 1
+                    const bar = foo
+
+                        /* comment */
+
+                    ;[1, 2, 3].forEach(() => {})
+
+                }
+            `,
+            output: unIndent`
+                {
+                    const foo = 1
+                    const bar = foo
+
+                    /* comment */
+
+                    ;[1, 2, 3].forEach(() => {})
+
+                }
+            `,
+            errors: expectedErrors([5, 4, 8, "Block"])
+        },
+        {
+            code: unIndent`
+                {
+                    const foo = 1
+                    const bar = foo
+                        /* comment */
+                    ;[1, 2, 3].forEach(() => {})
+
+                }
+            `,
+            output: unIndent`
+                {
+                    const foo = 1
+                    const bar = foo
+                    /* comment */
+                    ;[1, 2, 3].forEach(() => {})
+
+                }
+            `,
+            errors: expectedErrors([4, 4, 8, "Block"])
+        },
+        {
+            code: unIndent`
+                {
+                    const foo = 1
+                    const bar = foo
+
+                    /* comment */;
+
+                    [1, 2, 3].forEach(() => {})
+
+                }
+            `,
+            output: unIndent`
+                {
+                    const foo = 1
+                    const bar = foo
+
+                        /* comment */;
+
+                    [1, 2, 3].forEach(() => {})
+
+                }
+            `,
+            errors: expectedErrors([5, 8, 4, "Block"])
         },
 
         // import expressions


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

fixes #12232

**What changes did you make? (Give an overview)**
This PR adds additional logic for comments that precede a line that begins with a semicolon. The current behavior (indenting 1 level) exists because the comment is treated as a child of the node on the previous line.

**Is there anything you'd like reviewers to focus on?**
Nothing in particular!

