### PR TITLE
Chore: enable default-param-last

### DIFF
--- a/lib/rules/capitalized-comments.js
+++ b/lib/rules/capitalized-comments.js
@@ -59,7 +59,7 @@ const DEFAULTS = {
  * @param {string} which Either "line" or "block".
  * @returns {Object} The normalized options.
  */
-function getNormalizedOptions(rawOptions = {}, which) {
+function getNormalizedOptions(rawOptions, which) {
     return Object.assign({}, DEFAULTS, rawOptions[which] || rawOptions);
 }
 
@@ -70,7 +70,7 @@ function getNormalizedOptions(rawOptions = {}, which) {
  * @returns {Object} An object with "Line" and "Block" keys and corresponding
  * normalized options objects.
  */
-function getAllNormalizedOptions(rawOptions) {
+function getAllNormalizedOptions(rawOptions = {}) {
     return {
         Line: getNormalizedOptions(rawOptions, "line"),
         Block: getNormalizedOptions(rawOptions, "block")

--- a/packages/eslint-config-eslint/default.yml
+++ b/packages/eslint-config-eslint/default.yml
@@ -20,6 +20,7 @@ rules:
     consistent-return: "error"
     curly: ["error", "all"]
     default-case: "error"
+    default-param-last: "error"
     dot-location: ["error", "property"]
     dot-notation: ["error", { allowKeywords: true }]
     eol-last: "error"


### PR DESCRIPTION
note: this is a breaking change in eslint-config-eslint.

refs:https://github.com/eslint/eslint/commit/0313441d016c8aa0674c135f9da67a676e766ec5

<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**


[x] Other, please explain: just dog fooding the new rule. :-)

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**


**Is there anything you'd like reviewers to focus on?**
not really.

