### PR TITLE
Fix: prefer-named-capture-group incorrect locations (fixes #12233)

### DIFF
--- a/lib/rules/prefer-named-capture-group.js
+++ b/lib/rules/prefer-named-capture-group.js
@@ -50,16 +50,16 @@ module.exports = {
         /**
          * Function to check regular expression.
          *
-         * @param {string} regex The regular expression to be check.
+         * @param {string} pattern The regular expression pattern to be check.
          * @param {ASTNode} node AST node which contains regular expression.
          * @param {boolean} uFlag Flag indicates whether unicode mode is enabled or not.
          * @returns {void}
          */
-        function checkRegex(regex, node, uFlag) {
+        function checkRegex(pattern, node, uFlag) {
             let ast;
 
             try {
-                ast = parser.parsePattern(regex, 0, regex.length, uFlag);
+                ast = parser.parsePattern(pattern, 0, pattern.length, uFlag);
             } catch (_) {
 
                 // ignore regex syntax errors
@@ -69,12 +69,22 @@ module.exports = {
             regexpp.visitRegExpAST(ast, {
                 onCapturingGroupEnter(group) {
                     if (!group.name) {
-                        const locNode = node.type === "Literal" ? node : node.arguments[0];
+                        let locNode, rawPattern, loc;
 
-                        context.report({
-                            node,
-                            messageId: "required",
-                            loc: {
+                        if (node.type === "Literal") {
+                            locNode = node;
+                            rawPattern = locNode.raw.slice(1, locNode.raw.lastIndexOf("/"));
+                        } else {
+                            locNode = node.arguments[0];
+                            if (locNode.type === "Literal" && typeof locNode.value === "string") {
+                                rawPattern = locNode.raw.slice(1, -1);
+                            } else if (locNode.type === "TemplateLiteral" && locNode.expressions.length === 0 && locNode.quasis.length === 1) {
+                                rawPattern = locNode.quasis[0].value.raw;
+                            }
+                        }
+
+                        if (pattern === rawPattern && locNode.loc.start.line === locNode.loc.end.line) {
+                            loc = {
                                 start: {
                                     line: locNode.loc.start.line,
                                     column: locNode.loc.start.column + group.start + 1
@@ -83,7 +93,15 @@ module.exports = {
                                     line: locNode.loc.start.line,
                                     column: locNode.loc.start.column + group.end + 1
                                 }
-                            },
+                            };
+                        } else {
+                            loc = locNode.loc;
+                        }
+
+                        context.report({
+                            node,
+                            messageId: "required",
+                            loc,
                             data: {
                                 group: group.raw
                             }

--- a/lib/rules/prefer-named-capture-group.js
+++ b/lib/rules/prefer-named-capture-group.js
@@ -69,39 +69,9 @@ module.exports = {
             regexpp.visitRegExpAST(ast, {
                 onCapturingGroupEnter(group) {
                     if (!group.name) {
-                        let locNode, rawPattern, loc;
-
-                        if (node.type === "Literal") {
-                            locNode = node;
-                            rawPattern = locNode.raw.slice(1, locNode.raw.lastIndexOf("/"));
-                        } else {
-                            locNode = node.arguments[0];
-                            if (locNode.type === "Literal" && typeof locNode.value === "string") {
-                                rawPattern = locNode.raw.slice(1, -1);
-                            } else if (locNode.type === "TemplateLiteral" && locNode.expressions.length === 0 && locNode.quasis.length === 1) {
-                                rawPattern = locNode.quasis[0].value.raw;
-                            }
-                        }
-
-                        if (pattern === rawPattern && locNode.loc.start.line === locNode.loc.end.line) {
-                            loc = {
-                                start: {
-                                    line: locNode.loc.start.line,
-                                    column: locNode.loc.start.column + group.start + 1
-                                },
-                                end: {
-                                    line: locNode.loc.start.line,
-                                    column: locNode.loc.start.column + group.end + 1
-                                }
-                            };
-                        } else {
-                            loc = locNode.loc;
-                        }
-
                         context.report({
                             node,
                             messageId: "required",
-                            loc,
                             data: {
                                 group: group.raw
                             }

--- a/tests/lib/rules/prefer-named-capture-group.js
+++ b/tests/lib/rules/prefer-named-capture-group.js
@@ -71,6 +71,17 @@ ruleTester.run("prefer-named-capture-group", rule, {
             }]
         },
         {
+            code: "new RegExp(`a(bc)d`)",
+            errors: [{
+                messageId: "required",
+                type: "NewExpression",
+                data: { group: "(bc)" },
+                line: 1,
+                column: 14,
+                endColumn: 18
+            }]
+        },
+        {
             code: "/([0-9]{4})-(\\w{5})/",
             errors: [
                 {
@@ -90,6 +101,120 @@ ruleTester.run("prefer-named-capture-group", rule, {
                     endColumn: 20
                 }
             ]
+        },
+
+        // For computed, multiline and strings with escape sequences, report the whole arguments[0] location.
+        {
+            code: "new RegExp('(' + 'a)')",
+            errors: [{
+                messageId: "required",
+                type: "NewExpression",
+                data: { group: "(a)" },
+                line: 1,
+                column: 12,
+                endColumn: 22
+            }]
+        },
+        {
+            code: "new RegExp('a(bc)d' + 'e')",
+            errors: [{
+                messageId: "required",
+                type: "NewExpression",
+                data: { group: "(bc)" },
+                line: 1,
+                column: 12,
+                endColumn: 26
+            }]
+        },
+        {
+            code: "RegExp('(a)'+'')",
+            errors: [{
+                messageId: "required",
+                type: "CallExpression",
+                data: { group: "(a)" },
+                line: 1,
+                column: 8,
+                endColumn: 16
+            }]
+        },
+        {
+            code: "RegExp( '' + '(ab)')",
+            errors: [{
+                messageId: "required",
+                type: "CallExpression",
+                data: { group: "(ab)" },
+                line: 1,
+                column: 9,
+                endColumn: 20
+            }]
+        },
+        {
+            code: "new RegExp(`(ab)${''}`)",
+            errors: [{
+                messageId: "required",
+                type: "NewExpression",
+                data: { group: "(ab)" },
+                line: 1,
+                column: 12,
+                endColumn: 23
+            }]
+        },
+        {
+            code: "new RegExp(`(a)\n`)",
+            errors: [{
+                messageId: "required",
+                type: "NewExpression",
+                data: { group: "(a)" },
+                line: 1,
+                column: 12,
+                endLine: 2,
+                endColumn: 2
+            }]
+        },
+        {
+            code: "RegExp(`a(b\nc)d`)",
+            errors: [{
+                messageId: "required",
+                type: "CallExpression",
+                data: { group: "(b\nc)" },
+                line: 1,
+                column: 8,
+                endLine: 2,
+                endColumn: 5
+            }]
+        },
+        {
+            code: "new RegExp('a(b)\\'')",
+            errors: [{
+                messageId: "required",
+                type: "NewExpression",
+                data: { group: "(b)" },
+                line: 1,
+                column: 12,
+                endColumn: 20
+            }]
+        },
+        {
+            code: "RegExp('(a)\\\\d')",
+            errors: [{
+                messageId: "required",
+                type: "CallExpression",
+                data: { group: "(a)" },
+                line: 1,
+                column: 8,
+                endColumn: 16
+            }]
+        },
+        {
+            code: "RegExp(`\\a(b)`)",
+            errors: [{
+                messageId: "required",
+                type: "CallExpression",
+                data: { group: "(b)" },
+                line: 1,
+                column: 8,
+                endColumn: 15
+            }]
         }
     ]
 });

--- a/tests/lib/rules/prefer-named-capture-group.js
+++ b/tests/lib/rules/prefer-named-capture-group.js
@@ -44,8 +44,8 @@ ruleTester.run("prefer-named-capture-group", rule, {
                 type: "Literal",
                 data: { group: "([0-9]{4})" },
                 line: 1,
-                column: 2,
-                endColumn: 12
+                column: 1,
+                endColumn: 13
             }]
         },
         {
@@ -55,8 +55,8 @@ ruleTester.run("prefer-named-capture-group", rule, {
                 type: "NewExpression",
                 data: { group: "([0-9]{4})" },
                 line: 1,
-                column: 13,
-                endColumn: 23
+                column: 1,
+                endColumn: 25
             }]
         },
         {
@@ -66,8 +66,8 @@ ruleTester.run("prefer-named-capture-group", rule, {
                 type: "CallExpression",
                 data: { group: "([0-9]{4})" },
                 line: 1,
-                column: 9,
-                endColumn: 19
+                column: 1,
+                endColumn: 21
             }]
         },
         {
@@ -75,10 +75,7 @@ ruleTester.run("prefer-named-capture-group", rule, {
             errors: [{
                 messageId: "required",
                 type: "NewExpression",
-                data: { group: "(bc)" },
-                line: 1,
-                column: 14,
-                endColumn: 18
+                data: { group: "(bc)" }
             }]
         },
         {
@@ -89,30 +86,25 @@ ruleTester.run("prefer-named-capture-group", rule, {
                     type: "Literal",
                     data: { group: "([0-9]{4})" },
                     line: 1,
-                    column: 2,
-                    endColumn: 12
+                    column: 1,
+                    endColumn: 21
                 },
                 {
                     messageId: "required",
                     type: "Literal",
                     data: { group: "(\\w{5})" },
                     line: 1,
-                    column: 13,
-                    endColumn: 20
+                    column: 1,
+                    endColumn: 21
                 }
             ]
         },
-
-        // For computed, multiline and strings with escape sequences, report the whole arguments[0] location.
         {
             code: "new RegExp('(' + 'a)')",
             errors: [{
                 messageId: "required",
                 type: "NewExpression",
-                data: { group: "(a)" },
-                line: 1,
-                column: 12,
-                endColumn: 22
+                data: { group: "(a)" }
             }]
         },
         {
@@ -120,10 +112,7 @@ ruleTester.run("prefer-named-capture-group", rule, {
             errors: [{
                 messageId: "required",
                 type: "NewExpression",
-                data: { group: "(bc)" },
-                line: 1,
-                column: 12,
-                endColumn: 26
+                data: { group: "(bc)" }
             }]
         },
         {
@@ -131,10 +120,7 @@ ruleTester.run("prefer-named-capture-group", rule, {
             errors: [{
                 messageId: "required",
                 type: "CallExpression",
-                data: { group: "(a)" },
-                line: 1,
-                column: 8,
-                endColumn: 16
+                data: { group: "(a)" }
             }]
         },
         {
@@ -142,10 +128,7 @@ ruleTester.run("prefer-named-capture-group", rule, {
             errors: [{
                 messageId: "required",
                 type: "CallExpression",
-                data: { group: "(ab)" },
-                line: 1,
-                column: 9,
-                endColumn: 20
+                data: { group: "(ab)" }
             }]
         },
         {
@@ -153,10 +136,7 @@ ruleTester.run("prefer-named-capture-group", rule, {
             errors: [{
                 messageId: "required",
                 type: "NewExpression",
-                data: { group: "(ab)" },
-                line: 1,
-                column: 12,
-                endColumn: 23
+                data: { group: "(ab)" }
             }]
         },
         {
@@ -166,9 +146,9 @@ ruleTester.run("prefer-named-capture-group", rule, {
                 type: "NewExpression",
                 data: { group: "(a)" },
                 line: 1,
-                column: 12,
+                column: 1,
                 endLine: 2,
-                endColumn: 2
+                endColumn: 3
             }]
         },
         {
@@ -176,11 +156,7 @@ ruleTester.run("prefer-named-capture-group", rule, {
             errors: [{
                 messageId: "required",
                 type: "CallExpression",
-                data: { group: "(b\nc)" },
-                line: 1,
-                column: 8,
-                endLine: 2,
-                endColumn: 5
+                data: { group: "(b\nc)" }
             }]
         },
         {
@@ -188,10 +164,7 @@ ruleTester.run("prefer-named-capture-group", rule, {
             errors: [{
                 messageId: "required",
                 type: "NewExpression",
-                data: { group: "(b)" },
-                line: 1,
-                column: 12,
-                endColumn: 20
+                data: { group: "(b)" }
             }]
         },
         {
@@ -199,10 +172,7 @@ ruleTester.run("prefer-named-capture-group", rule, {
             errors: [{
                 messageId: "required",
                 type: "CallExpression",
-                data: { group: "(a)" },
-                line: 1,
-                column: 8,
-                endColumn: 16
+                data: { group: "(a)" }
             }]
         },
         {
@@ -210,10 +180,7 @@ ruleTester.run("prefer-named-capture-group", rule, {
             errors: [{
                 messageId: "required",
                 type: "CallExpression",
-                data: { group: "(b)" },
-                line: 1,
-                column: 8,
-                endColumn: 15
+                data: { group: "(b)" }
             }]
         }
     ]


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix #12233

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

This PR fixes reporting incorrect location in `prefer-named-capture-group` when the pattern in `RegExp()` or `new RegExp()` is any of the following:

* Computed string
* String with an escape sequence
* Multiline string

**Tell us about your environment**

* **ESLint Version:**  6.3.0
* **Node Version:** 10.16.0
* **npm Version:** 6.9.0

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
  parserOptions: {
    ecmaVersion: 2015,
  }
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**

[Demo link](https://eslint.org/demo#eyJ0ZXh0IjoiLyogZXNsaW50IHByZWZlci1uYW1lZC1jYXB0dXJlLWdyb3VwOmVycm9yICovXG5cblJlZ0V4cCgnJyArICcoYSknKTtcblJlZ0V4cCgnXFxcXGRcXFxcZChhKScpO1xuUmVnRXhwKGBcbihhKWBcbik7Iiwib3B0aW9ucyI6eyJwYXJzZXJPcHRpb25zIjp7ImVjbWFWZXJzaW9uIjo2LCJzb3VyY2VUeXBlIjoic2NyaXB0IiwiZWNtYUZlYXR1cmVzIjp7fX0sInJ1bGVzIjp7ImNvbnN0cnVjdG9yLXN1cGVyIjoyLCJmb3ItZGlyZWN0aW9uIjoyLCJnZXR0ZXItcmV0dXJuIjoyLCJuby1hc3luYy1wcm9taXNlLWV4ZWN1dG9yIjoyLCJuby1jYXNlLWRlY2xhcmF0aW9ucyI6Miwibm8tY2xhc3MtYXNzaWduIjoyLCJuby1jb21wYXJlLW5lZy16ZXJvIjoyLCJuby1jb25kLWFzc2lnbiI6Miwibm8tY29uc3QtYXNzaWduIjoyLCJuby1jb25zdGFudC1jb25kaXRpb24iOjIsIm5vLWNvbnRyb2wtcmVnZXgiOjIsIm5vLWRlYnVnZ2VyIjoyLCJuby1kZWxldGUtdmFyIjoyLCJuby1kdXBlLWFyZ3MiOjIsIm5vLWR1cGUtY2xhc3MtbWVtYmVycyI6Miwibm8tZHVwZS1rZXlzIjoyLCJuby1kdXBsaWNhdGUtY2FzZSI6Miwibm8tZW1wdHkiOjIsIm5vLWVtcHR5LWNoYXJhY3Rlci1jbGFzcyI6Miwibm8tZW1wdHktcGF0dGVybiI6Miwibm8tZXgtYXNzaWduIjoyLCJuby1leHRyYS1ib29sZWFuLWNhc3QiOjIsIm5vLWV4dHJhLXNlbWkiOjIsIm5vLWZhbGx0aHJvdWdoIjoyLCJuby1mdW5jLWFzc2lnbiI6Miwibm8tZ2xvYmFsLWFzc2lnbiI6Miwibm8taW5uZXItZGVjbGFyYXRpb25zIjoyLCJuby1pbnZhbGlkLXJlZ2V4cCI6Miwibm8taXJyZWd1bGFyLXdoaXRlc3BhY2UiOjIsIm5vLW1pc2xlYWRpbmctY2hhcmFjdGVyLWNsYXNzIjoyLCJuby1taXhlZC1zcGFjZXMtYW5kLXRhYnMiOjIsIm5vLW5ldy1zeW1ib2wiOjIsIm5vLW9iai1jYWxscyI6Miwibm8tb2N0YWwiOjIsIm5vLXByb3RvdHlwZS1idWlsdGlucyI6Miwibm8tcmVkZWNsYXJlIjoyLCJuby1yZWdleC1zcGFjZXMiOjIsIm5vLXNlbGYtYXNzaWduIjoyLCJuby1zaGFkb3ctcmVzdHJpY3RlZC1uYW1lcyI6Miwibm8tc3BhcnNlLWFycmF5cyI6Miwibm8tdGhpcy1iZWZvcmUtc3VwZXIiOjIsIm5vLXVuZGVmIjoyLCJuby11bmV4cGVjdGVkLW11bHRpbGluZSI6Miwibm8tdW5yZWFjaGFibGUiOjIsIm5vLXVuc2FmZS1maW5hbGx5IjoyLCJuby11bnNhZmUtbmVnYXRpb24iOjIsIm5vLXVudXNlZC1sYWJlbHMiOjIsIm5vLXVudXNlZC12YXJzIjoyLCJuby11c2VsZXNzLWNhdGNoIjoyLCJuby11c2VsZXNzLWVzY2FwZSI6Miwibm8td2l0aCI6MiwicmVxdWlyZS1hdG9taWMtdXBkYXRlcyI6MiwicmVxdWlyZS15aWVsZCI6MiwidXNlLWlzbmFuIjoyLCJ2YWxpZC10eXBlb2YiOjJ9LCJlbnYiOnt9fX0=)

```js
/* eslint prefer-named-capture-group:error */

RegExp('' + '(a)');
RegExp('\\d\\d(a)');
RegExp(`
(a)`
);
```

**What did you expect to happen?**

3 errors with correct locations.

**What actually happened? Please include the actual, raw output from ESLint.**

```
  3:9   error  Capture group '(a)' should be converted to a named or non-capturing group  prefer-named-capture-group
  4:13  error  Capture group '(a)' should be converted to a named or non-capturing group  prefer-named-capture-group
  5:10  error  Capture group '(a)' should be converted to a named or non-capturing group  prefer-named-capture-group
```

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

In the above cases, report the whole `arguments[0]` location.

**Is there anything you'd like reviewers to focus on?**