### PR TITLE
Update: Report global Atomics calls in no-obj-calls (fixes #12234)

### DIFF
--- a/docs/rules/no-obj-calls.md
+++ b/docs/rules/no-obj-calls.md
@@ -6,13 +6,17 @@ The [ECMAScript 5 specification](https://es5.github.io/#x15.8) makes it clear th
 
 > The Math object does not have a `[[Call]]` internal property; it is not possible to invoke the Math object as a function.
 
-And the [ECMAScript 2015 specification](https://www.ecma-international.org/ecma-262/6.0/index.html#sec-reflect-object) makes it clear that `Reflect` cannot be invoked:
+The [ECMAScript 2015 specification](https://www.ecma-international.org/ecma-262/6.0/index.html#sec-reflect-object) makes it clear that `Reflect` cannot be invoked:
 
 > The Reflect object also does not have a `[[Call]]` internal method; it is not possible to invoke the Reflect object as a function.
 
+And the [ECMAScript 2017 specification](https://www.ecma-international.org/ecma-262/8.0/index.html#sec-atomics-object) makes it clear that `Atomics` cannot be invoked:
+
+> The Atomics object does not have a [[Call]] internal method; it is not possible to invoke the Atomics object as a function.
+
 ## Rule Details
 
-This rule disallows calling the `Math`, `JSON` and `Reflect` objects as functions.
+This rule disallows calling the `Math`, `JSON`, `Reflect` and `Atomics` objects as functions.
 
 Examples of **incorrect** code for this rule:
 
@@ -22,6 +26,7 @@ Examples of **incorrect** code for this rule:
 var math = Math();
 var json = JSON();
 var reflect = Reflect();
+var atomics = Atomics();
 ```
 
 Examples of **correct** code for this rule:
@@ -34,6 +39,7 @@ function area(r) {
 }
 var object = JSON.parse("{}");
 var value = Reflect.get({ x: 1, y: 2 }, "x");
+var first = Atomics.load(foo, 0);
 ```
 
 ## Further Reading

--- a/tests/lib/rules/no-obj-calls.js
+++ b/tests/lib/rules/no-obj-calls.js
@@ -20,11 +20,112 @@ const ruleTester = new RuleTester();
 
 ruleTester.run("no-obj-calls", rule, {
     valid: [
-        "var x = Math.random();"
+        "var x = Math;",
+        "var x = Math.random();",
+        "var x = Math.PI;",
+        "var x = foo.Math();",
+        "JSON.parse(foo)",
+        "Reflect.get(foo, 'x')",
+        "Atomics.load(foo, 0)",
+
+        // non-existing variables
+        "/*globals Math: off*/ Math();",
+        {
+            code: "JSON();",
+            globals: { JSON: "off" }
+        },
+        "Reflect();",
+        "Atomics();",
+        {
+            code: "Atomics();",
+            env: { es6: true }
+        },
+
+        // shadowed variables
+        "var Math; Math();",
+        {
+            code: "let JSON; JSON();",
+            parserOptions: { ecmaVersion: 2015 }
+        },
+        {
+            code: "if (foo) { const Reflect = 1; Reflect(); }",
+            parserOptions: { ecmaVersion: 2015 },
+            env: { es6: true }
+        },
+        "function foo(Math) { Math(); }",
+        {
+            code: "function foo(Atomics) { Atomics(); }",
+            env: { es2017: true }
+        },
+        "function foo() { var JSON; JSON(); }",
+        {
+            code: "function foo() { var Atomics = bar(); var baz = Atomics(5); }",
+            globals: { Atomics: false }
+        }
     ],
     invalid: [
-        { code: "var x = Math();", errors: [{ message: "'Math' is not a function.", type: "CallExpression" }] },
-        { code: "var x = JSON();", errors: [{ message: "'JSON' is not a function.", type: "CallExpression" }] },
-        { code: "var x = Reflect();", errors: [{ message: "'Reflect' is not a function.", type: "CallExpression" }] }
+
+        // test full message
+        {
+            code: "Math();",
+            errors: [{ message: "'Math' is not a function.", type: "CallExpression" }]
+        },
+
+        {
+            code: "var x = Math();",
+            errors: [{ messageId: "unexpectedCall", data: { name: "Math" }, type: "CallExpression" }]
+        },
+        {
+            code: "f(Math());",
+            errors: [{ messageId: "unexpectedCall", data: { name: "Math" }, type: "CallExpression", column: 3, endColumn: 9 }]
+        },
+        {
+            code: "Math().foo;",
+            errors: [{ messageId: "unexpectedCall", data: { name: "Math" }, type: "CallExpression", column: 1, endColumn: 7 }]
+        },
+        {
+            code: "var x = JSON();",
+            errors: [{ messageId: "unexpectedCall", data: { name: "JSON" }, type: "CallExpression" }]
+        },
+        {
+            code: "x = JSON(str);",
+            errors: [{ messageId: "unexpectedCall", data: { name: "JSON" }, type: "CallExpression" }]
+        },
+        {
+            code: "Math( JSON() );",
+            errors: [
+                { messageId: "unexpectedCall", data: { name: "Math" }, type: "CallExpression", column: 1, endColumn: 15 },
+                { messageId: "unexpectedCall", data: { name: "JSON" }, type: "CallExpression", column: 7, endColumn: 13 }
+            ]
+        },
+        {
+            code: "var x = Reflect();",
+            env: { es6: true },
+            errors: [{ messageId: "unexpectedCall", data: { name: "Reflect" }, type: "CallExpression" }]
+        },
+        {
+            code: "var x = Reflect();",
+            env: { es2017: true },
+            errors: [{ messageId: "unexpectedCall", data: { name: "Reflect" }, type: "CallExpression" }]
+        },
+        {
+            code: "/*globals Reflect: true*/ Reflect();",
+            errors: [{ messageId: "unexpectedCall", data: { name: "Reflect" }, type: "CallExpression" }]
+        },
+        {
+            code: "var x = Atomics();",
+            env: { es2017: true },
+            errors: [{ messageId: "unexpectedCall", data: { name: "Atomics" }, type: "CallExpression" }]
+        },
+        {
+            code: "var x = Atomics();",
+            env: { es2020: true },
+            errors: [{ messageId: "unexpectedCall", data: { name: "Atomics" }, type: "CallExpression" }]
+        },
+        {
+            code: "var x = Atomics();",
+            globals: { Atomics: false },
+            errors: [{ messageId: "unexpectedCall", data: { name: "Atomics" }, type: "CallExpression" }]
+        }
     ]
 });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix
[X] Changes an existing rule #12234

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

This PR modifies the `no-obj-calls` to:

* Report `Atomics()` as described in #12234, which can produce **more** errors by default.
* Report only globals, which can produce fewer errors.

E.g., the rule will not report `Math()` if the `Math` is shadowed or turned `off`.

Also, the rule will not report `Reflect()` if an ES2015+ environment is not activated (and the variable isn't added manually as a global in the config file or `/*global*/`). The same applies to `Atomics` and ES2017+ environment.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Added `Atomics` to the list of non-callable globals and modified the logic to report only references to defined global variables.

**Is there anything you'd like reviewers to focus on?**