### PR TITLE
Update: no-self-assign should detect member expression with this

### DIFF
--- a/lib/rules/no-self-assign.js
+++ b/lib/rules/no-self-assign.js
@@ -61,6 +61,9 @@ function isSameMember(left, right) {
     if (lobj.type === "MemberExpression") {
         return isSameMember(lobj, robj);
     }
+    if (lobj.type === "ThisExpression" && lobj.type === robj.type) {
+        return true;
+    }
     return lobj.type === "Identifier" && lobj.name === robj.name;
 }
 

--- a/lib/rules/no-self-assign.js
+++ b/lib/rules/no-self-assign.js
@@ -61,7 +61,7 @@ function isSameMember(left, right) {
     if (lobj.type === "MemberExpression") {
         return isSameMember(lobj, robj);
     }
-    if (lobj.type === "ThisExpression" && lobj.type === robj.type) {
+    if (lobj.type === "ThisExpression") {
         return true;
     }
     return lobj.type === "Identifier" && lobj.name === robj.name;

--- a/tests/lib/rules/no-self-assign.js
+++ b/tests/lib/rules/no-self-assign.js
@@ -70,6 +70,14 @@ ruleTester.run("no-self-assign", rule, {
         {
             code: "a[\n    'b'\n] = a[\n    'b'\n]",
             options: [{ props: false }]
+        },
+        {
+            code: "this.x = this.y",
+            options: [{ props: true }]
+        },
+        {
+            code: "this.x = this.x",
+            options: [{ props: false }]
         }
     ],
     invalid: [
@@ -120,6 +128,11 @@ ruleTester.run("no-self-assign", rule, {
         { code: "a.b.c = a.b.c", options: [{ props: true }], errors: ["'a.b.c' is assigned to itself."] },
         { code: "a[b] = a[b]", options: [{ props: true }], errors: ["'a[b]' is assigned to itself."] },
         { code: "a['b'] = a['b']", options: [{ props: true }], errors: ["'a['b']' is assigned to itself."] },
-        { code: "a[\n    'b'\n] = a[\n    'b'\n]", options: [{ props: true }], errors: ["'a['b']' is assigned to itself."] }
+        { code: "a[\n    'b'\n] = a[\n    'b'\n]", options: [{ props: true }], errors: ["'a['b']' is assigned to itself."] },
+        {
+            code: "this.x = this.x",
+            options: [{ props: true }],
+            errors: ["'this.x' is assigned to itself."]
+        }
     ]
 });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Changes an existing rule 

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
**What rule do you want to change?**
[`no-self-assign`](https://eslint.org/docs/rules/no-self-assign)

**Does this change cause the rule to produce more or fewer warnings?**
more

**How will the change be implemented? (New option, new default behavior, etc.)?**
updates default behavior

**Please provide some example code that this change will affect:**

```js
this.x = this.x
```

**What does the rule currently do for this code?**
doesn't raise an issue

**What will the rule do after it's changed?**
raise an issue

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
I updated  `no-self-assign` rule to support member expression using `this` identifier.

**Is there anything you'd like reviewers to focus on?**


