### PR TITLE
Update: false positives in function-call-argument-newline (fixes #12123)

### DIFF
--- a/lib/rules/function-call-argument-newline.js
+++ b/lib/rules/function-call-argument-newline.js
@@ -40,13 +40,13 @@ module.exports = {
         const checkers = {
             unexpected: {
                 messageId: "unexpectedLineBreak",
-                check: (prevToken, currentToken) => prevToken.loc.start.line !== currentToken.loc.start.line,
+                check: (prevToken, currentToken) => prevToken.loc.end.line !== currentToken.loc.start.line,
                 createFix: (token, tokenBefore) => fixer =>
                     fixer.replaceTextRange([tokenBefore.range[1], token.range[0]], " ")
             },
             missing: {
                 messageId: "missingLineBreak",
-                check: (prevToken, currentToken) => prevToken.loc.start.line === currentToken.loc.start.line,
+                check: (prevToken, currentToken) => prevToken.loc.end.line === currentToken.loc.start.line,
                 createFix: (token, tokenBefore) => fixer =>
                     fixer.replaceTextRange([tokenBefore.range[1], token.range[0]], "\n")
             }
@@ -61,7 +61,7 @@ module.exports = {
          */
         function checkArguments(node, checker) {
             for (let i = 1; i < node.arguments.length; i++) {
-                const prevArgToken = sourceCode.getFirstToken(node.arguments[i - 1]);
+                const prevArgToken = sourceCode.getLastToken(node.arguments[i - 1]);
                 const currentArgToken = sourceCode.getFirstToken(node.arguments[i]);
 
                 if (checker.check(prevArgToken, currentArgToken)) {
@@ -101,10 +101,10 @@ module.exports = {
             } else if (option === "always") {
                 checkArguments(node, checkers.missing);
             } else if (option === "consistent") {
-                const firstArgToken = sourceCode.getFirstToken(node.arguments[0]);
+                const firstArgToken = sourceCode.getLastToken(node.arguments[0]);
                 const secondArgToken = sourceCode.getFirstToken(node.arguments[1]);
 
-                if (firstArgToken.loc.start.line === secondArgToken.loc.start.line) {
+                if (firstArgToken.loc.end.line === secondArgToken.loc.start.line) {
                     checkArguments(node, checkers.unexpected);
                 } else {
                     checkArguments(node, checkers.missing);

--- a/tests/lib/rules/function-call-argument-newline.js
+++ b/tests/lib/rules/function-call-argument-newline.js
@@ -46,6 +46,7 @@ ruleTester.run("function-call-argument-newline", rule, {
             options: ["always"],
             parserOptions: { ecmaVersion: 6 }
         },
+        { code: "fn({\n\ta: 1\n},\n\tb,\n\tc)", options: ["always"] },
 
         /* "never" */
         { code: "fn(a, b)", options: ["never"] },
@@ -59,10 +60,13 @@ ruleTester.run("function-call-argument-newline", rule, {
             options: ["never"],
             parserOptions: { ecmaVersion: 6 }
         },
+        { code: "fn({\n\ta: 1\n}, b)", options: ["never"] },
 
         /* "consistent" */
         { code: "fn(a, b, c)", options: ["consistent"] },
-        { code: "fn(a,\n\tb,\n\tc)", options: ["consistent"] }
+        { code: "fn(a,\n\tb,\n\tc)", options: ["consistent"] },
+        { code: "fn({\n\ta: 1\n}, b, c)", options: ["consistent"] },
+        { code: "fn({\n\ta: 1\n},\n\tb,\n\tc)", options: ["consistent"] }
     ],
     invalid: [
 
@@ -202,6 +206,20 @@ ruleTester.run("function-call-argument-newline", rule, {
                 }
             ]
         },
+        {
+            code: "fn({\n\ta: 1\n}, b)",
+            output: "fn({\n\ta: 1\n},\nb)",
+            options: ["always"],
+            errors: [
+                {
+                    messageId: "missingLineBreak",
+                    line: 3,
+                    column: 3,
+                    endLine: 3,
+                    endColumn: 4
+                }
+            ]
+        },
 
         /* "never" */
         {
@@ -324,6 +342,20 @@ ruleTester.run("function-call-argument-newline", rule, {
                 }
             ]
         },
+        {
+            code: "fn({\n\ta: 1\n},\nb)",
+            output: "fn({\n\ta: 1\n}, b)",
+            options: ["never"],
+            errors: [
+                {
+                    messageId: "unexpectedLineBreak",
+                    line: 3,
+                    column: 3,
+                    endLine: 4,
+                    endColumn: 1
+                }
+            ]
+        },
 
         /* "consistent" */
         {
@@ -379,6 +411,34 @@ ruleTester.run("function-call-argument-newline", rule, {
                     column: 18,
                     endLine: 2,
                     endColumn: 19
+                }
+            ]
+        },
+        {
+            code: "fn({\n\ta: 1\n},\nb, c)",
+            output: "fn({\n\ta: 1\n},\nb,\nc)",
+            options: ["consistent"],
+            errors: [
+                {
+                    messageId: "missingLineBreak",
+                    line: 4,
+                    column: 3,
+                    endLine: 4,
+                    endColumn: 4
+                }
+            ]
+        },
+        {
+            code: "fn({\n\ta: 1\n}, b,\nc)",
+            output: "fn({\n\ta: 1\n}, b, c)",
+            options: ["consistent"],
+            errors: [
+                {
+                    messageId: "unexpectedLineBreak",
+                    line: 3,
+                    column: 6,
+                    endLine: 4,
+                    endColumn: 1
                 }
             ]
         }

--- a/tests/lib/rules/function-call-argument-newline.js
+++ b/tests/lib/rules/function-call-argument-newline.js
@@ -47,6 +47,7 @@ ruleTester.run("function-call-argument-newline", rule, {
             parserOptions: { ecmaVersion: 6 }
         },
         { code: "fn({\n\ta: 1\n},\n\tb,\n\tc)", options: ["always"] },
+        { code: "fn(`\n`,\n\ta)", options: ["always"], parserOptions: { ecmaVersion: 6 } },
 
         /* "never" */
         { code: "fn(a, b)", options: ["never"] },
@@ -61,12 +62,15 @@ ruleTester.run("function-call-argument-newline", rule, {
             parserOptions: { ecmaVersion: 6 }
         },
         { code: "fn({\n\ta: 1\n}, b)", options: ["never"] },
+        { code: "fn(`\n`, a)", options: ["never"], parserOptions: { ecmaVersion: 6 } },
 
         /* "consistent" */
         { code: "fn(a, b, c)", options: ["consistent"] },
         { code: "fn(a,\n\tb,\n\tc)", options: ["consistent"] },
         { code: "fn({\n\ta: 1\n}, b, c)", options: ["consistent"] },
-        { code: "fn({\n\ta: 1\n},\n\tb,\n\tc)", options: ["consistent"] }
+        { code: "fn({\n\ta: 1\n},\n\tb,\n\tc)", options: ["consistent"] },
+        { code: "fn(`\n`, b, c)", options: ["consistent"], parserOptions: { ecmaVersion: 6 } },
+        { code: "fn(`\n`,\n\tb,\n\tc)", options: ["consistent"], parserOptions: { ecmaVersion: 6 } }
     ],
     invalid: [
 
@@ -220,6 +224,21 @@ ruleTester.run("function-call-argument-newline", rule, {
                 }
             ]
         },
+        {
+            code: "fn(`\n`, b)",
+            output: "fn(`\n`,\nb)",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "missingLineBreak",
+                    line: 2,
+                    column: 3,
+                    endLine: 2,
+                    endColumn: 4
+                }
+            ]
+        },
 
         /* "never" */
         {
@@ -356,6 +375,21 @@ ruleTester.run("function-call-argument-newline", rule, {
                 }
             ]
         },
+        {
+            code: "fn(`\n`,\nb)",
+            output: "fn(`\n`, b)",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "unexpectedLineBreak",
+                    line: 2,
+                    column: 3,
+                    endLine: 3,
+                    endColumn: 1
+                }
+            ]
+        },
 
         /* "consistent" */
         {
@@ -438,6 +472,36 @@ ruleTester.run("function-call-argument-newline", rule, {
                     line: 3,
                     column: 6,
                     endLine: 4,
+                    endColumn: 1
+                }
+            ]
+        },
+        {
+            code: "fn(`\n`,\nb, c)",
+            output: "fn(`\n`,\nb,\nc)",
+            options: ["consistent"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "missingLineBreak",
+                    line: 3,
+                    column: 3,
+                    endLine: 3,
+                    endColumn: 4
+                }
+            ]
+        },
+        {
+            code: "fn(`\n`, b,\nc)",
+            output: "fn(`\n`, b, c)",
+            options: ["consistent"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "unexpectedLineBreak",
+                    line: 2,
+                    column: 6,
+                    endLine: 3,
                     endColumn: 1
                 }
             ]


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Fixes #12123

Given two adjacent arguments (`a` & `b`), the rule logic was previously:
1. let `prevArgToken` be the _first_ token of `a`
2. let `currentArgToken` be the _first_ token of `b`
3. compare the _start_ line number of `prevArgToken` with the _start_ line number of `currentArgToken`

This meant that the following examples were treated as invalid, despite the linebreaks **between** arguments being correct for the specified option:

```js
/*eslint function-call-argument-newline:["error", "never"] */
fn({
 a: 1
}, b);

/*eslint function-call-argument-newline:["error", "consistent"] */
fn({
 a: 1
}, b, c);
```

Changed the rule logic to be:
1. let `prevArgToken` be the _last_ token of `a`
2. let `currentArgToken` be the _first_ token of `b`
3. compare the _end_ line number of `prevArgToken` with the _start_ line number of `currentArgToken`

Valid & invalid tests added for each of the three options (`always`, `never`, `consistent`).

All new & all existing unit tests are passing.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular
