### PR TITLE
Fix: no-useless-return autofix removes comments

### DIFF
--- a/lib/rules/no-useless-return.js
+++ b/lib/rules/no-useless-return.js
@@ -82,6 +82,7 @@ module.exports = {
     create(context) {
         const segmentInfoMap = new WeakMap();
         const usedUnreachableSegments = new WeakSet();
+        const sourceCode = context.getSourceCode();
         let scopeInfo = null;
 
         /**
@@ -216,7 +217,7 @@ module.exports = {
                         loc: node.loc,
                         message: "Unnecessary return statement.",
                         fix(fixer) {
-                            if (isRemovable(node)) {
+                            if (isRemovable(node) && !sourceCode.getCommentsInside(node).length) {
 
                                 /*
                                  * Extend the replacement range to include the
@@ -224,7 +225,7 @@ module.exports = {
                                  * no-else-return.
                                  * https://github.com/eslint/eslint/issues/8026
                                  */
-                                return new FixTracker(fixer, context.getSourceCode())
+                                return new FixTracker(fixer, sourceCode)
                                     .retainEnclosingFunction(node)
                                     .remove(node);
                             }

--- a/tests/lib/rules/no-useless-return.js
+++ b/tests/lib/rules/no-useless-return.js
@@ -197,6 +197,14 @@ ruleTester.run("no-useless-return", rule, {
             output: "function foo() { if (foo) return; }"
         },
         {
+            code: "function foo() { bar(); return/**/; }",
+            output: null
+        },
+        {
+            code: "function foo() { bar(); return//\n; }",
+            output: null
+        },
+        {
             code: "foo(); return;",
             output: "foo(); ",
             parserOptions: { ecmaFeatures: { globalReturn: true } }


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment**

* **ESLint Version:**  6.4.0
* **Node Version:** 10.16.0
* **npm Version:** 6.9.0

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
  parserOptions: {
    ecmaVersion: 2015,
  }
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**

[Demo link](https://eslint.org/demo#eyJ0ZXh0IjoiLyogZXNsaW50IG5vLXVzZWxlc3MtcmV0dXJuOmVycm9yICovXG5cbmZ1bmN0aW9uIGZvbygpIHtcbiAgYmFyKCk7XG4gIHJldHVybiAvKiBjb21tZW50ICovO1xufVxuXG5mdW5jdGlvbiBiYXooKSB7XG4gIGJhcigpO1xuICByZXR1cm4gLy8gY29tbWVudFxuICA7XG59Iiwib3B0aW9ucyI6eyJwYXJzZXJPcHRpb25zIjp7ImVjbWFWZXJzaW9uIjo2LCJzb3VyY2VUeXBlIjoic2NyaXB0IiwiZWNtYUZlYXR1cmVzIjp7fX0sInJ1bGVzIjp7ImNvbnN0cnVjdG9yLXN1cGVyIjoyLCJmb3ItZGlyZWN0aW9uIjoyLCJnZXR0ZXItcmV0dXJuIjoyLCJuby1hc3luYy1wcm9taXNlLWV4ZWN1dG9yIjoyLCJuby1jYXNlLWRlY2xhcmF0aW9ucyI6Miwibm8tY2xhc3MtYXNzaWduIjoyLCJuby1jb21wYXJlLW5lZy16ZXJvIjoyLCJuby1jb25kLWFzc2lnbiI6Miwibm8tY29uc3QtYXNzaWduIjoyLCJuby1jb25zdGFudC1jb25kaXRpb24iOjIsIm5vLWNvbnRyb2wtcmVnZXgiOjIsIm5vLWRlYnVnZ2VyIjoyLCJuby1kZWxldGUtdmFyIjoyLCJuby1kdXBlLWFyZ3MiOjIsIm5vLWR1cGUtY2xhc3MtbWVtYmVycyI6Miwibm8tZHVwZS1rZXlzIjoyLCJuby1kdXBsaWNhdGUtY2FzZSI6Miwibm8tZW1wdHkiOjIsIm5vLWVtcHR5LWNoYXJhY3Rlci1jbGFzcyI6Miwibm8tZW1wdHktcGF0dGVybiI6Miwibm8tZXgtYXNzaWduIjoyLCJuby1leHRyYS1ib29sZWFuLWNhc3QiOjIsIm5vLWV4dHJhLXNlbWkiOjIsIm5vLWZhbGx0aHJvdWdoIjoyLCJuby1mdW5jLWFzc2lnbiI6Miwibm8tZ2xvYmFsLWFzc2lnbiI6Miwibm8taW5uZXItZGVjbGFyYXRpb25zIjoyLCJuby1pbnZhbGlkLXJlZ2V4cCI6Miwibm8taXJyZWd1bGFyLXdoaXRlc3BhY2UiOjIsIm5vLW1pc2xlYWRpbmctY2hhcmFjdGVyLWNsYXNzIjoyLCJuby1taXhlZC1zcGFjZXMtYW5kLXRhYnMiOjIsIm5vLW5ldy1zeW1ib2wiOjIsIm5vLW9iai1jYWxscyI6Miwibm8tb2N0YWwiOjIsIm5vLXByb3RvdHlwZS1idWlsdGlucyI6Miwibm8tcmVkZWNsYXJlIjoyLCJuby1yZWdleC1zcGFjZXMiOjIsIm5vLXNlbGYtYXNzaWduIjoyLCJuby1zaGFkb3ctcmVzdHJpY3RlZC1uYW1lcyI6Miwibm8tc3BhcnNlLWFycmF5cyI6Miwibm8tdGhpcy1iZWZvcmUtc3VwZXIiOjIsIm5vLXVuZXhwZWN0ZWQtbXVsdGlsaW5lIjoyLCJuby11bnJlYWNoYWJsZSI6Miwibm8tdW5zYWZlLWZpbmFsbHkiOjIsIm5vLXVuc2FmZS1uZWdhdGlvbiI6Miwibm8tdW51c2VkLWxhYmVscyI6Miwibm8tdXNlbGVzcy1jYXRjaCI6Miwibm8tdXNlbGVzcy1lc2NhcGUiOjIsIm5vLXdpdGgiOjIsInJlcXVpcmUtYXRvbWljLXVwZGF0ZXMiOjIsInJlcXVpcmUteWllbGQiOjIsInVzZS1pc25hbiI6MiwidmFsaWQtdHlwZW9mIjoyfSwiZW52Ijp7fX19)

```js
/* eslint no-useless-return:error */

function foo() {
  bar();
  return /* comment */;
}

function baz() {
  bar();
  return // comment
  ;
}
```

**What did you expect to happen?**

2 errors, but no autofix as it would remove comments.

**What actually happened? Please include the actual, raw output from ESLint.**

```js
/* eslint no-useless-return:error */

function foo() {
  bar();
  
}

function baz() {
  bar();
  
}
```

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Report errors but don't fix if there are comments inside the `return` statement's node.

**Is there anything you'd like reviewers to focus on?**

I think it's better to manually fix the code in this situation than to auto-remove `return` and preserve comments.
