### PR TITLE
Fix: no-constant-condition doesn't introspect arrays (fixes #12225)

### DIFF
--- a/lib/rules/no-constant-condition.js
+++ b/lib/rules/no-constant-condition.js
@@ -103,10 +103,10 @@ module.exports = {
                     return true;
 
                 case "ArrayExpression": {
-                    if (!(node.parent.operator === "+")) {
-                        return true;
+                    if (node.parent.operator === "+" && node.parent.type === "BinaryExpression") {
+                        return node.elements.every(element => isConstant(element, false));
                     }
-                    return node.elements.every(element => isConstant(element, false));
+                    return true;
                 }
 
                 case "UnaryExpression":

--- a/lib/rules/no-constant-condition.js
+++ b/lib/rules/no-constant-condition.js
@@ -91,10 +91,7 @@ module.exports = {
          */
         function isConstant(node, inBooleanPosition) {
 
-            /*
-             * Bug in espree (#425) causes [,] to return children of null
-             * so we need to check for existance until that is fixed
-             */
+            // node.elements can return null values in the case of sparse arrays ex. [,]
             if (!node) {
                 return true;
             }
@@ -106,7 +103,7 @@ module.exports = {
                     return true;
 
                 case "ArrayExpression": {
-                    if (inBooleanPosition) {
+                    if (!(node.parent.operator === "+")) {
                         return true;
                     }
                     return node.elements.every(element => isConstant(element, false));

--- a/lib/rules/no-constant-condition.js
+++ b/lib/rules/no-constant-condition.js
@@ -90,13 +90,27 @@ module.exports = {
          * @private
          */
         function isConstant(node, inBooleanPosition) {
+
+            /*
+             * Bug in espree (#425) causes [,] to return children of null
+             * so we need to check for existance until that is fixed
+             */
+            if (!node) {
+                return true;
+            }
             switch (node.type) {
                 case "Literal":
                 case "ArrowFunctionExpression":
                 case "FunctionExpression":
                 case "ObjectExpression":
-                case "ArrayExpression":
                     return true;
+
+                case "ArrayExpression": {
+                    if (inBooleanPosition) {
+                        return true;
+                    }
+                    return node.elements.every(element => isConstant(element, false));
+                }
 
                 case "UnaryExpression":
                     if (node.operator === "void") {

--- a/lib/rules/no-constant-condition.js
+++ b/lib/rules/no-constant-condition.js
@@ -103,7 +103,7 @@ module.exports = {
                     return true;
 
                 case "ArrayExpression": {
-                    if (node.parent.operator === "+" && node.parent.type === "BinaryExpression") {
+                    if (node.parent.type === "BinaryExpression" && node.parent.operator === "+") {
                         return node.elements.every(element => isConstant(element, false));
                     }
                     return true;

--- a/tests/lib/rules/no-constant-condition.js
+++ b/tests/lib/rules/no-constant-condition.js
@@ -80,6 +80,7 @@ ruleTester.run("no-constant-condition", rule, {
         "if ('' + [y, 'm'] === '' + [ty, 'tm']) {}",
         "if ('' + [y, 'm'] === '' + ['ty']) {}",
         "if ([,] in\n\n($2))\n ;\nelse\n ;",
+        "if ([...x]+'' === 'y'){}",
 
         // { checkLoops: false }
         { code: "while(true);", options: [{ checkLoops: false }] },
@@ -212,6 +213,18 @@ ruleTester.run("no-constant-condition", rule, {
         },
         {
             code: "if([a]==[a]) {}",
+            errors: [{ messageId: "unexpected", type: "BinaryExpression" }]
+        },
+        {
+            code: "if([a] - '') {}",
+            errors: [{ messageId: "unexpected", type: "BinaryExpression" }]
+        },
+        {
+            code: "if(+1) {}",
+            errors: [{ messageId: "unexpected", type: "UnaryExpression" }]
+        },
+        {
+            code: "if ([,] + ''){}",
             errors: [{ messageId: "unexpected", type: "BinaryExpression" }]
         }
     ]

--- a/tests/lib/rules/no-constant-condition.js
+++ b/tests/lib/rules/no-constant-condition.js
@@ -209,6 +209,10 @@ ruleTester.run("no-constant-condition", rule, {
         {
             code: "if(''+[]) {}",
             errors: [{ messageId: "unexpected", type: "BinaryExpression" }]
+        },
+        {
+            code: "if([a]==[a]) {}",
+            errors: [{ messageId: "unexpected", type: "BinaryExpression" }]
         }
     ]
 });

--- a/tests/lib/rules/no-constant-condition.js
+++ b/tests/lib/rules/no-constant-condition.js
@@ -73,6 +73,14 @@ ruleTester.run("no-constant-condition", rule, {
         "if ((key || 'k') in obj) {}",
         "if ((foo || {}) instanceof obj) {}",
 
+        // #12225
+        "if ('' + [y] === '' + [ty]) {}",
+        "if ('a' === '' + [ty]) {}",
+        "if ('' + [y, m, d] === 'a') {}",
+        "if ('' + [y, 'm'] === '' + [ty, 'tm']) {}",
+        "if ('' + [y, 'm'] === '' + ['ty']) {}",
+        "if ([,] in\n\n($2))\n ;\nelse\n ;",
+
         // { checkLoops: false }
         { code: "while(true);", options: [{ checkLoops: false }] },
         { code: "for(;true;);", options: [{ checkLoops: false }] },
@@ -183,6 +191,24 @@ ruleTester.run("no-constant-condition", rule, {
         {
             code: "function* foo() { for (let foo = 1 + 2 + 3 + (yield); true; baz) {}}",
             errors: [{ messageId: "unexpected", type: "Literal" }]
+        },
+
+        // #12225
+        {
+            code: "if([a]) {}",
+            errors: [{ messageId: "unexpected", type: "ArrayExpression" }]
+        },
+        {
+            code: "if([]) {}",
+            errors: [{ messageId: "unexpected", type: "ArrayExpression" }]
+        },
+        {
+            code: "if(''+['a']) {}",
+            errors: [{ messageId: "unexpected", type: "BinaryExpression" }]
+        },
+        {
+            code: "if(''+[]) {}",
+            errors: [{ messageId: "unexpected", type: "BinaryExpression" }]
         }
     ]
 });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

https://github.com/eslint/eslint/issues/12225

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

no-constant-condition uses a recursive function `isConstant` to detect if items are constants. 

Previously we were presuming that all arrays were always constant. Since an array can hold variables, if we are inside of a binary evaluation it is possible for the array to change and there for change the conditional.   

Now, if we are in a binary expression, we will calculate isConstant on each element of the array, and only return true if all elements are constant

**Is there anything you'd like reviewers to focus on?**

Per the espree docs, array elements of sparse arrays have values of null. I have added a check at the beginning of the function to handle this, but I could see the argument to handle this situation in other ways such as a filter.

