### PR TITLE
Update: Add capIsConstructor option to no-invalid-this (fixes #12271)

### DIFF
--- a/docs/rules/no-invalid-this.md
+++ b/docs/rules/no-invalid-this.md
@@ -205,8 +205,7 @@ This rule has an object option, with one option:
 
 ### capIsConstructor
 
-By default, this rule always allows the use of `this` in functions which name starts with an uppercase and anonymous functions
-that are assigned to a variable which name starts with an uppercase, assuming that those functions are used as constructor functions.
+By default, this rule always allows the use of `this` in functions which name starts with an uppercase and anonymous functions that are assigned to a variable which name starts with an uppercase, assuming that those functions are used as constructor functions.
 
 Set `"capIsConstructor"` to `false` if you want those functions to be treated as 'regular' functions.
 

--- a/docs/rules/no-invalid-this.md
+++ b/docs/rules/no-invalid-this.md
@@ -197,6 +197,56 @@ function foo() {
 }
 ```
 
+## Options
+
+This rule has an object option, with one option:
+
+* `"capIsConstructor": false` (default `true`) disables the assumption that a function which name starts with an uppercase is a constructor.
+
+### capIsConstructor
+
+By default, this rule always allows the use of `this` in functions which name starts with an uppercase and anonymous functions
+that are assigned to a variable which name starts with an uppercase, assuming that those functions are used as constructor functions.
+
+Set `"capIsConstructor"` to `false` if you want those functions to be treated as 'regular' functions.
+
+Examples of **incorrect** code for this rule with `"capIsConstructor"` option set to `false`:
+
+```js
+/*eslint no-invalid-this: ["error", { "capIsConstructor": false }]*/
+
+"use strict";
+
+function Foo() {
+    this.a = 0;
+}
+
+var bar = function Foo() {
+    this.a = 0;
+}
+
+var Bar = function() {
+    this.a = 0;
+};
+
+Baz = function() {
+    this.a = 0;
+};
+```
+
+Examples of **correct** code for this rule with `"capIsConstructor"` option set to `false`:
+
+```js
+/*eslint no-invalid-this: ["error", { "capIsConstructor": false }]*/
+
+"use strict";
+
+obj.Foo = function Foo() {
+    // OK, this is in a method.
+    this.a = 0;
+};
+```
+
 ## When Not To Use It
 
 If you don't want to be notified about usage of `this` keyword outside of classes or class-like objects, you can safely disable this rule.

--- a/lib/rules/no-invalid-this.js
+++ b/lib/rules/no-invalid-this.js
@@ -26,10 +26,23 @@ module.exports = {
             url: "https://eslint.org/docs/rules/no-invalid-this"
         },
 
-        schema: []
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    capIsConstructor: {
+                        type: "boolean",
+                        default: true
+                    }
+                },
+                additionalProperties: false
+            }
+        ]
     },
 
     create(context) {
+        const options = context.options[0] || {};
+        const capIsConstructor = options.capIsConstructor !== false;
         const stack = [],
             sourceCode = context.getSourceCode();
 
@@ -48,7 +61,8 @@ module.exports = {
                 current.init = true;
                 current.valid = !astUtils.isDefaultThisBinding(
                     current.node,
-                    sourceCode
+                    sourceCode,
+                    { capIsConstructor }
                 );
             }
             return current;

--- a/lib/rules/utils/ast-utils.js
+++ b/lib/rules/utils/ast-utils.js
@@ -594,10 +594,15 @@ module.exports = {
      * - The function is not a callback of array methods (such as `.forEach()`) if `thisArg` is given.
      * @param {ASTNode} node A function node to check.
      * @param {SourceCode} sourceCode A SourceCode instance to get comments.
+     * @param {boolean} [capIsConstructor = true] `false` disables the assumption that functions which name starts
+     * with an uppercase or are assigned to a variable which name starts with an uppercase are constructors.
      * @returns {boolean} The function node is the default `this` binding.
      */
-    isDefaultThisBinding(node, sourceCode) {
-        if (isES5Constructor(node) || hasJSDocThisTag(node, sourceCode)) {
+    isDefaultThisBinding(node, sourceCode, { capIsConstructor = true } = {}) {
+        if (
+            (capIsConstructor && isES5Constructor(node)) ||
+            hasJSDocThisTag(node, sourceCode)
+        ) {
             return false;
         }
         const isAnonymous = node.id === null;
@@ -671,6 +676,7 @@ module.exports = {
                         return false;
                     }
                     if (
+                        capIsConstructor &&
                         isAnonymous &&
                         parent.left.type === "Identifier" &&
                         startsWithUpperCase(parent.left.name)
@@ -685,6 +691,7 @@ module.exports = {
                  */
                 case "VariableDeclarator":
                     return !(
+                        capIsConstructor &&
                         isAnonymous &&
                         parent.init === currentNode &&
                         parent.id.type === "Identifier" &&

--- a/lib/rules/utils/ast-utils.js
+++ b/lib/rules/utils/ast-utils.js
@@ -581,14 +581,17 @@ module.exports = {
      *
      * First, this checks the node:
      *
-     * - The function name does not start with uppercase (it's a constructor).
+     * - The function name does not start with uppercase. It's a convention to capitalize the names
+     *   of constructor functions. This check is not performed if `capIsConstructor` is set to `false`.
      * - The function does not have a JSDoc comment that has a @this tag.
      *
      * Next, this checks the location of the node.
      * If the location is below, this judges `this` is valid.
      *
      * - The location is not on an object literal.
-     * - The location is not assigned to a variable which starts with an uppercase letter.
+     * - The location is not assigned to a variable which starts with an uppercase letter. Applies to anonymous
+     *   functions only, as the name of the variable is considered to be the name of the function in this case.
+     *   This check is not performed if `capIsConstructor` is set to `false`.
      * - The location is not on an ES2015 class.
      * - Its `bind`/`call`/`apply` method is not called directly.
      * - The function is not a callback of array methods (such as `.forEach()`) if `thisArg` is given.

--- a/tests/lib/rules/no-invalid-this.js
+++ b/tests/lib/rules/no-invalid-this.js
@@ -135,8 +135,32 @@ const patterns = [
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
     {
+        code: "function foo() { console.log(this); z(x => console.log(x, this)); }",
+        parserOptions: { ecmaVersion: 6 },
+        options: [{ capIsConstructor: false }], // test that the option doesn't reverse the logic and mistakenly allows lowercase functions
+        errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
+    },
+    {
+        code: "function Foo() { console.log(this); z(x => console.log(x, this)); }",
+        parserOptions: { ecmaVersion: 6 },
+        options: [{ capIsConstructor: false }],
+        errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
+    },
+    {
         code: "function foo() { \"use strict\"; console.log(this); z(x => console.log(x, this)); }",
         parserOptions: { ecmaVersion: 6 },
+        errors,
+        valid: [],
+        invalid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES]
+    },
+    {
+        code: "function Foo() { \"use strict\"; console.log(this); z(x => console.log(x, this)); }",
+        parserOptions: { ecmaVersion: 6 },
+        options: [{ capIsConstructor: false }],
         errors,
         valid: [],
         invalid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES]
@@ -223,6 +247,20 @@ const patterns = [
     {
         code: "function Foo() { console.log(this); z(x => console.log(x, this)); }",
         parserOptions: { ecmaVersion: 6 },
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "function Foo() { console.log(this); z(x => console.log(x, this)); }",
+        parserOptions: { ecmaVersion: 6 },
+        options: [{}], // test the default value in schema
+        valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "function Foo() { console.log(this); z(x => console.log(x, this)); }",
+        parserOptions: { ecmaVersion: 6 },
+        options: [{ capIsConstructor: true }], // test explicitly set option to the default value
         valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
         invalid: []
     },
@@ -557,8 +595,24 @@ const patterns = [
         invalid: []
     },
     {
+        code: "var Ctor = function() { console.log(this); z(x => console.log(x, this)); }",
+        parserOptions: { ecmaVersion: 6 },
+        options: [{ capIsConstructor: false }],
+        errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
+    },
+    {
         code: "var func = function() { console.log(this); z(x => console.log(x, this)); }",
         parserOptions: { ecmaVersion: 6 },
+        errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
+    },
+    {
+        code: "var func = function() { console.log(this); z(x => console.log(x, this)); }",
+        parserOptions: { ecmaVersion: 6 },
+        options: [{ capIsConstructor: false }],
         errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
@@ -570,8 +624,24 @@ const patterns = [
         invalid: []
     },
     {
+        code: "Ctor = function() { console.log(this); z(x => console.log(x, this)); }",
+        parserOptions: { ecmaVersion: 6 },
+        options: [{ capIsConstructor: false }],
+        errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
+    },
+    {
         code: "func = function() { console.log(this); z(x => console.log(x, this)); }",
         parserOptions: { ecmaVersion: 6 },
+        errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
+    },
+    {
+        code: "func = function() { console.log(this); z(x => console.log(x, this)); }",
+        parserOptions: { ecmaVersion: 6 },
+        options: [{ capIsConstructor: false }],
         errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Changes an existing rule #12271

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**What rule do you want to change?**

`no-invalid-this`

**Does this change cause the rule to produce more or fewer warnings?**

More if the option is set to `false` (default is `true`).

**How will the change be implemented? (New option, new default behavior, etc.)?**

New option.

**Please provide some example code that this change will affect:**

```js
/*eslint no-invalid-this: ["error", { "capIsConstructor": false }]*/

"use strict";

function Foo() {
    this.a = 0;
}

var bar = function Foo() {
    this.a = 0;
}

var Bar = function() {
    this.a = 0;
};

Baz = function() {
    this.a = 0;
};
```

**What does the rule currently do for this code?**

No errors.

**What will the rule do after it's changed?**

4 errors.

Setting the option to `false` means that functions which name starts with an uppercase (or are assigned to such variables) are just regular functions, not constructor functions.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Implemented the new option.

**Is there anything you'd like reviewers to focus on?**

`astUtils.isDefaultThisBinding` signature. This looked to me like a good case for an options object and default value, but both are not used much in the codebase so I'm not sure is it okay? 

Also I couldn't find existing tests for the function, I guess it would be too complex to do that directly and that the rules' tests are good enough.
