### PR TITLE
Chore: cache results in runtime-info

### DIFF
--- a/lib/shared/runtime-info.js
+++ b/lib/shared/runtime-info.js
@@ -20,110 +20,121 @@ const packageJson = require("../../package.json");
 //------------------------------------------------------------------------------
 
 /**
- * Checks if a path is a child of a directory.
- * @param {string} parentPath - The parent path to check.
- * @param {string} childPath - The path to check.
- * @returns {boolean} Whether or not the given path is a child of a directory.
- */
-function isChildOfDirectory(parentPath, childPath) {
-    return !path.relative(parentPath, childPath).startsWith("..");
-}
-
-/**
- * Synchronously executes a shell command and formats the result.
- * @param {string} cmd - The command to execute.
- * @param {Array} args - The arguments to be executed with the command.
- * @returns {string} The version returned by the command.
- */
-function execCommand(cmd, args) {
-    const process = spawn.sync(cmd, args, { encoding: "utf8" });
-
-    if (process.error) {
-        throw process.error;
-    }
-
-    return process.stdout.trim();
-}
-
-/**
- * Normalizes a version number.
- * @param {string} versionStr - The string to normalize.
- * @returns {string} The normalized version number.
- */
-function normalizeVersionStr(versionStr) {
-    return versionStr.startsWith("v") ? versionStr : `v${versionStr}`;
-}
-
-/**
- * Gets bin version.
- * @param {string} bin - The bin to check.
- * @returns {string} The normalized version returned by the command.
- */
-function getBinVersion(bin) {
-    const binArgs = ["--version"];
-
-    try {
-        return normalizeVersionStr(execCommand(bin, binArgs));
-    } catch (e) {
-        log.error(`Error finding ${bin} version running the command \`${bin} ${binArgs.join(" ")}\``);
-        throw e;
-    }
-}
-
-/**
- * Gets installed npm package version.
- * @param {string} pkg - The package to check.
- * @param {boolean} global - Whether to check globally or not.
- * @returns {string} The normalized version returned by the command.
- */
-function getNpmPackageVersion(pkg, { global = false } = {}) {
-    const npmBinArgs = ["bin", "-g"];
-    const npmLsArgs = ["ls", "--depth=0", "--json", "eslint"];
-
-    if (global) {
-        npmLsArgs.push("-g");
-    }
-
-    try {
-        const parsedStdout = JSON.parse(execCommand("npm", npmLsArgs));
-
-        /*
-         * Checking globally returns an empty JSON object, while local checks
-         * include the name and version of the local project.
-         */
-        if (isEmpty(parsedStdout) || !(parsedStdout.dependencies && parsedStdout.dependencies.eslint)) {
-            return "Not found";
-        }
-
-        const [, processBinPath] = process.argv;
-        let npmBinPath;
-
-        try {
-            npmBinPath = execCommand("npm", npmBinArgs);
-        } catch (e) {
-            log.error(`Error finding npm binary path when running command \`npm ${npmBinArgs.join(" ")}\``);
-            throw e;
-        }
-
-        const isGlobal = isChildOfDirectory(npmBinPath, processBinPath);
-        let pkgVersion = parsedStdout.dependencies.eslint.version;
-
-        if ((global && isGlobal) || (!global && !isGlobal)) {
-            pkgVersion += " (Currently used)";
-        }
-
-        return normalizeVersionStr(pkgVersion);
-    } catch (e) {
-        log.error(`Error finding ${pkg} version running the command \`npm ${npmLsArgs.join(" ")}\``);
-        throw e;
-    }
-}
-
-/**
  * Generates and returns execution environment information.
  * @returns {string} A string that contains execution environment information.
  */
 function environment() {
+    const cache = new Map();
+
+    /**
+     * Checks if a path is a child of a directory.
+     * @param {string} parentPath - The parent path to check.
+     * @param {string} childPath - The path to check.
+     * @returns {boolean} Whether or not the given path is a child of a directory.
+     */
+    function isChildOfDirectory(parentPath, childPath) {
+        return !path.relative(parentPath, childPath).startsWith("..");
+    }
+
+    /**
+     * Synchronously executes a shell command and formats the result.
+     * @param {string} cmd - The command to execute.
+     * @param {Array} args - The arguments to be executed with the command.
+     * @returns {string} The version returned by the command.
+     */
+    function execCommand(cmd, args) {
+        const key = [cmd, ...args].join(" ");
+
+        if (cache.has(key)) {
+            return cache.get(key);
+        }
+
+        const process = spawn.sync(cmd, args, { encoding: "utf8" });
+
+        if (process.error) {
+            throw process.error;
+        }
+
+        const result = process.stdout.trim();
+
+        cache.set(key, result);
+        return result;
+    }
+
+    /**
+     * Normalizes a version number.
+     * @param {string} versionStr - The string to normalize.
+     * @returns {string} The normalized version number.
+     */
+    function normalizeVersionStr(versionStr) {
+        return versionStr.startsWith("v") ? versionStr : `v${versionStr}`;
+    }
+
+    /**
+     * Gets bin version.
+     * @param {string} bin - The bin to check.
+     * @returns {string} The normalized version returned by the command.
+     */
+    function getBinVersion(bin) {
+        const binArgs = ["--version"];
+
+        try {
+            return normalizeVersionStr(execCommand(bin, binArgs));
+        } catch (e) {
+            log.error(`Error finding ${bin} version running the command \`${bin} ${binArgs.join(" ")}\``);
+            throw e;
+        }
+    }
+
+    /**
+     * Gets installed npm package version.
+     * @param {string} pkg - The package to check.
+     * @param {boolean} global - Whether to check globally or not.
+     * @returns {string} The normalized version returned by the command.
+     */
+    function getNpmPackageVersion(pkg, { global = false } = {}) {
+        const npmBinArgs = ["bin", "-g"];
+        const npmLsArgs = ["ls", "--depth=0", "--json", "eslint"];
+
+        if (global) {
+            npmLsArgs.push("-g");
+        }
+
+        try {
+            const parsedStdout = JSON.parse(execCommand("npm", npmLsArgs));
+
+            /*
+             * Checking globally returns an empty JSON object, while local checks
+             * include the name and version of the local project.
+             */
+            if (isEmpty(parsedStdout) || !(parsedStdout.dependencies && parsedStdout.dependencies.eslint)) {
+                return "Not found";
+            }
+
+            const [, processBinPath] = process.argv;
+            let npmBinPath;
+
+            try {
+                npmBinPath = execCommand("npm", npmBinArgs);
+            } catch (e) {
+                log.error(`Error finding npm binary path when running command \`npm ${npmBinArgs.join(" ")}\``);
+                throw e;
+            }
+
+            const isGlobal = isChildOfDirectory(npmBinPath, processBinPath);
+            let pkgVersion = parsedStdout.dependencies.eslint.version;
+
+            if ((global && isGlobal) || (!global && !isGlobal)) {
+                pkgVersion += " (Currently used)";
+            }
+
+            return normalizeVersionStr(pkgVersion);
+        } catch (e) {
+            log.error(`Error finding ${pkg} version running the command \`npm ${npmLsArgs.join(" ")}\``);
+            throw e;
+        }
+    }
+
     return [
         "Environment Info:",
         "",

--- a/tests/lib/shared/runtime-info.js
+++ b/tests/lib/shared/runtime-info.js
@@ -86,8 +86,7 @@ describe("RuntimeInfo", () => {
                             }
                         }
                     }
-                `,
-                NPM_BIN_PATH
+                `
             ];
         });
 
@@ -138,6 +137,7 @@ describe("RuntimeInfo", () => {
                     "version": "1.0.0"
                 }
             `);
+            spawnSyncStubArgs.push(NPM_BIN_PATH);
             setupSpawnSyncStubReturnVals(spawnSyncStub, spawnSyncStubArgs);
             process.argv[1] = GLOBAL_ESLINT_BIN_PATH;
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This change improves performance by caching the results of the shell commands the `RuntimeInfo` module executes. In practice, this only improves performance when ESLint is installed locally and globally (which we're actively discouraging these days), but it's something!

In the code path described above, I'm seeing these results on my local machine (average over 5 runs with each branch):

`master`: ~3.072s
`runtime-info-cache-results`: ~2.826s

**Is there anything you'd like reviewers to focus on?**

Nothing in particular. This PR is a lot easier to review by hiding whitespace changes.

