### PR TITLE
Update: no-useless-rename also reports default values (fixes #12301)

### DIFF
--- a/lib/rules/no-useless-rename.js
+++ b/lib/rules/no-useless-rename.js
@@ -42,8 +42,6 @@ module.exports = {
             ignoreImport = options.ignoreImport === true,
             ignoreExport = options.ignoreExport === true;
 
-        const sourceCode = context.getSourceCode();
-
         //--------------------------------------------------------------------------
         // Helpers
         //--------------------------------------------------------------------------
@@ -93,22 +91,13 @@ module.exports = {
                 return;
             }
 
-            const properties = node.properties;
-
-            for (let i = 0; i < properties.length; i++) {
-                const property = properties[i];
-
-                if (property.shorthand) {
-                    continue;
-                }
+            for (const property of node.properties) {
 
                 /**
-                 * If an ObjectPattern property is computed, we have no idea
-                 * if a rename is useless or not. If an ObjectPattern property
-                 * lacks a key, it is likely an ExperimentalRestProperty and
-                 * so there is no "renaming" occurring here.
+                 * Properties using shorthand syntax and rest elements can not be renamed.
+                 * If the property is computed, we have no idea if a rename is useless or not.
                  */
-                if (property.computed || !property.key) {
+                if (property.shorthand || property.type === "RestElement" || property.computed) {
                     continue;
                 }
 

--- a/lib/rules/no-useless-rename.js
+++ b/lib/rules/no-useless-rename.js
@@ -36,7 +36,8 @@ module.exports = {
     },
 
     create(context) {
-        const options = context.options[0] || {},
+        const sourceCode = context.getSourceCode(),
+            options = context.options[0] || {},
             ignoreDestructuring = options.ignoreDestructuring === true,
             ignoreImport = options.ignoreImport === true,
             ignoreExport = options.ignoreExport === true;
@@ -69,10 +70,15 @@ module.exports = {
                     if (sourceCode.commentsExistBetween(initial, result)) {
                         return null;
                     }
+
+                    const replacementText = result.type === "AssignmentPattern"
+                        ? sourceCode.getText(result)
+                        : name;
+
                     return fixer.replaceTextRange([
                         initial.range[0],
                         result.range[1]
-                    ], name);
+                    ], replacementText);
                 }
             });
         }
@@ -90,7 +96,9 @@ module.exports = {
             const properties = node.properties;
 
             for (let i = 0; i < properties.length; i++) {
-                if (properties[i].shorthand) {
+                const property = properties[i];
+
+                if (property.shorthand) {
                     continue;
                 }
 
@@ -100,13 +108,15 @@ module.exports = {
                  * lacks a key, it is likely an ExperimentalRestProperty and
                  * so there is no "renaming" occurring here.
                  */
-                if (properties[i].computed || !properties[i].key) {
+                if (property.computed || !property.key) {
                     continue;
                 }
 
-                if (properties[i].key.type === "Identifier" && properties[i].key.name === properties[i].value.name ||
-                        properties[i].key.type === "Literal" && properties[i].key.value === properties[i].value.name) {
-                    reportError(properties[i], properties[i].key, properties[i].value, "Destructuring assignment");
+                const key = (property.key.type === "Identifier" && property.key.name) || (property.key.type === "Literal" && property.key.value);
+                const renamedKey = property.value.type === "AssignmentPattern" ? property.value.left.name : property.value.name;
+
+                if (key === renamedKey) {
+                    reportError(property, property.key, property.value, "Destructuring assignment");
                 }
             }
         }

--- a/tests/lib/rules/no-useless-rename.js
+++ b/tests/lib/rules/no-useless-rename.js
@@ -183,6 +183,21 @@ ruleTester.run("no-useless-rename", rule, {
             errors: ["Destructuring assignment bar unnecessarily renamed.", "Destructuring assignment baz unnecessarily renamed."]
         },
         {
+            code: "let {foo: foo = 1, 'bar': bar = 1, baz: baz} = obj;",
+            output: "let {foo = 1, bar = 1, baz} = obj;",
+            errors: ["Destructuring assignment foo unnecessarily renamed.", "Destructuring assignment bar unnecessarily renamed.", "Destructuring assignment baz unnecessarily renamed."]
+        },
+        {
+            code: "let {foo: {bar: bar = 1, 'baz': baz = 1}} = obj;",
+            output: "let {foo: {bar = 1, baz = 1}} = obj;",
+            errors: ["Destructuring assignment bar unnecessarily renamed.", "Destructuring assignment baz unnecessarily renamed."]
+        },
+        {
+            code: "let {foo: {bar: bar = {}} = {}} = obj;",
+            output: "let {foo: {bar = {}} = {}} = obj;",
+            errors: ["Destructuring assignment bar unnecessarily renamed."]
+        },
+        {
             code: "function func({foo: foo}) {}",
             output: "function func({foo}) {}",
             errors: ["Destructuring assignment foo unnecessarily renamed."]
@@ -203,6 +218,21 @@ ruleTester.run("no-useless-rename", rule, {
             errors: ["Destructuring assignment foo unnecessarily renamed.", "Destructuring assignment bar unnecessarily renamed."]
         },
         {
+            code: "function func({foo: foo = 1, 'bar': bar = 1, baz: baz}) {}",
+            output: "function func({foo = 1, bar = 1, baz}) {}",
+            errors: ["Destructuring assignment foo unnecessarily renamed.", "Destructuring assignment bar unnecessarily renamed.", "Destructuring assignment baz unnecessarily renamed."]
+        },
+        {
+            code: "function func({foo: {bar: bar = 1, 'baz': baz = 1}}) {}",
+            output: "function func({foo: {bar = 1, baz = 1}}) {}",
+            errors: ["Destructuring assignment bar unnecessarily renamed.", "Destructuring assignment baz unnecessarily renamed."]
+        },
+        {
+            code: "function func({foo: {bar: bar = {}} = {}}) {}",
+            output: "function func({foo: {bar = {}} = {}}) {}",
+            errors: ["Destructuring assignment bar unnecessarily renamed."]
+        },
+        {
             code: "({foo: foo}) => {}",
             output: "({foo}) => {}",
             errors: ["Destructuring assignment foo unnecessarily renamed."]
@@ -221,6 +251,21 @@ ruleTester.run("no-useless-rename", rule, {
             code: "({foo: foo, bar: bar}) => {}",
             output: "({foo, bar}) => {}",
             errors: ["Destructuring assignment foo unnecessarily renamed.", "Destructuring assignment bar unnecessarily renamed."]
+        },
+        {
+            code: "({foo: foo = 1, 'bar': bar = 1, baz: baz}) => {}",
+            output: "({foo = 1, bar = 1, baz}) => {}",
+            errors: ["Destructuring assignment foo unnecessarily renamed.", "Destructuring assignment bar unnecessarily renamed.", "Destructuring assignment baz unnecessarily renamed."]
+        },
+        {
+            code: "({foo: {bar: bar = 1, 'baz': baz = 1}}) => {}",
+            output: "({foo: {bar = 1, baz = 1}}) => {}",
+            errors: ["Destructuring assignment bar unnecessarily renamed.", "Destructuring assignment baz unnecessarily renamed."]
+        },
+        {
+            code: "({foo: {bar: bar = {}} = {}}) => {}",
+            output: "({foo: {bar = {}} = {}}) => {}",
+            errors: ["Destructuring assignment bar unnecessarily renamed."]
         },
         {
             code: "const {foo: foo, ...stuff} = myObject;",


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

fixes #12301 

**What changes did you make? (Give an overview)**

This updates `no-useless-rename` to check destructured assignments with default values. I think this should be considered a semver-minor bug fix, since it feels like an oversight that this rule doesn't already check this case.

**Is there anything you'd like reviewers to focus on?**

Are reviewers in agreement that this should be default behavior and not behind an option?

