### PR TITLE
Chore: add JSDoc types for RuleTester test cases

### DIFF
--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -65,6 +65,7 @@ const ajv = require("../shared/ajv")({ strictDefaults: true });
  * @property {string} [parser] The absolute path for the parser.
  * @property {{ [name: string]: any }} [parserOptions] Options for the parser.
  * @property {{ [name: string]: "readonly" | "writable" | "off" }} [globals] The additional global variables.
+ * @property {{ [name: string]: boolean] }} [env] Environments for the test case.
  */
 
 /**

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -72,7 +72,7 @@ const ajv = require("../shared/ajv")({ strictDefaults: true });
  * A test case that is expected to fail lint.
  * @typedef {Object} InvalidTestCase
  * @property {string} code Code for the test case.
- * @property {number | Array<TestCaseError | string>} errors Expected errors.
+ * @property {number | Array<TestCaseError | string | RegExp>} errors Expected errors.
  * @property {string | null} [output] The expected code after autofixes are applied. If set to `null`, the test runner will assert that no autofix is suggested.
  * @property {any[]} [options] Options for the test case.
  * @property {{ [name: string]: any }} [settings] Settings for the test case.

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -275,31 +275,31 @@ class RuleTester {
     /**
      * @typedef {{
      *   code: string,
-     *   options?: any,
+     *   options?: any[],
      *   filename?: string,
-     *   parserOptions?: Linter.ParserOptions,
+     *   parserOptions?: { [name: string]: any },
      *   settings?: { [name: string]: any },
      *   parser?: string,
-     *   globals?: { [name: string]: boolean }
+     *   globals?: { [name: string]: "readonly" | "writable" | "off" }
      * }} ValidTestCase
      *
      * @typedef {{
      *   code: string,
      *   errors: number | Array<TestCaseError | string>,
      *   output?: string | null,
-     *   options?: any,
+     *   options?: any[],
      *   filename?: string,
-     *   parserOptions?: Linter.ParserOptions,
+     *   parserOptions?: { [name: string]: any },
      *   settings?: { [name: string]: any },
      *   parser?: string,
-     *   globals?: { [name: string]: boolean }
+     *   globals?: { [name: string]: "readonly" | "writable" | "off" }
      * }} InvalidTestCase
      *
      * @typedef {{
      *   message?: string | RegExp,
      *   messageId?: string,
      *   type?: string,
-     *   data?: any,
+     *   data?: { [name: string]: string },
      *   line?: number,
      *   column?: number,
      *   endLine?: number,

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -50,6 +50,50 @@ const
 
 const ajv = require("../shared/ajv")({ strictDefaults: true });
 
+
+//------------------------------------------------------------------------------
+// Typedefs
+//------------------------------------------------------------------------------
+
+/**
+ * A test case that is expected to pass lint.
+ * @typedef {object} ValidTestCase
+ * @property {string} code Code for the test case.
+ * @property {any[]} [options] Options for the test case.
+ * @property {{ [name: string]: any }} [settings] Settings for the test case.
+ * @property {string} [filename] The fake filename for the test case. Useful for rules that make assertion about filenames.
+ * @property {string} [parser] The absolute path for the parser.
+ * @property {{ [name: string]: any }} [parserOptions] Options for the parser.
+ * @property {{ [name: string]: "readonly" | "writable" | "off" }} [globals] The additional global variables.
+ */
+
+/**
+ * A test case that is expected to fail lint.
+ * @typedef {object} InvalidTestCase
+ * @property {string} code Code for the test case.
+ * @property {number | Array<TestCaseError | string>} errors Expected errors.
+ * @property {string | null} [output] The expected code after autofixes are applied. If set to `null`, the test runner will assert that no autofix is suggested.
+ * @property {any[]} [options] Options for the test case.
+ * @property {{ [name: string]: any }} [settings] Settings for the test case.
+ * @property {string} [filename] The fake filename for the test case. Useful for rules that make assertion about filenames.
+ * @property {string} [parser] The absolute path for the parser.
+ * @property {{ [name: string]: any }} [parserOptions] Options for the parser.
+ * @property {{ [name: string]: "readonly" | "writable" | "off" }} [globals] The additional global variables.
+ */
+
+/**
+ * A description of a reported error used in a rule tester test.
+ * @typedef {object} TestCaseError
+ * @property {string | RegExp} message Message.
+ * @property {string} [messageId] Message ID.
+ * @property {string} [type] The type of the reported AST node.
+ * @property {{ [name: string]: string }} [data] The data used to fill the message template.
+ * @property {number} [line] The 1-based line number of the reported start location.
+ * @property {number} [column] The 1-based column number of the reported start location.
+ * @property {number} [endLine] The 1-based line number of the reported end location.
+ * @property {number} [endColumn] The 1-based column number of the reported end location.
+ */
+
 //------------------------------------------------------------------------------
 // Private Members
 //------------------------------------------------------------------------------
@@ -271,41 +315,6 @@ class RuleTester {
     defineRule(name, rule) {
         this.rules[name] = rule;
     }
-
-    /**
-     * @typedef {{
-     *   code: string,
-     *   options?: any[],
-     *   filename?: string,
-     *   parserOptions?: { [name: string]: any },
-     *   settings?: { [name: string]: any },
-     *   parser?: string,
-     *   globals?: { [name: string]: "readonly" | "writable" | "off" }
-     * }} ValidTestCase
-     *
-     * @typedef {{
-     *   code: string,
-     *   errors: number | Array<TestCaseError | string>,
-     *   output?: string | null,
-     *   options?: any[],
-     *   filename?: string,
-     *   parserOptions?: { [name: string]: any },
-     *   settings?: { [name: string]: any },
-     *   parser?: string,
-     *   globals?: { [name: string]: "readonly" | "writable" | "off" }
-     * }} InvalidTestCase
-     *
-     * @typedef {{
-     *   message?: string | RegExp,
-     *   messageId?: string,
-     *   type?: string,
-     *   data?: { [name: string]: string },
-     *   line?: number,
-     *   column?: number,
-     *   endLine?: number,
-     *   endColumn?: number,
-     * }} TestCaseError
-     */
 
     /**
      * Adds a new rule test to execute.

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -65,7 +65,7 @@ const ajv = require("../shared/ajv")({ strictDefaults: true });
  * @property {string} [parser] The absolute path for the parser.
  * @property {{ [name: string]: any }} [parserOptions] Options for the parser.
  * @property {{ [name: string]: "readonly" | "writable" | "off" }} [globals] The additional global variables.
- * @property {{ [name: string]: boolean] }} [env] Environments for the test case.
+ * @property {{ [name: string]: boolean }} [env] Environments for the test case.
  */
 
 /**
@@ -80,7 +80,7 @@ const ajv = require("../shared/ajv")({ strictDefaults: true });
  * @property {string} [parser] The absolute path for the parser.
  * @property {{ [name: string]: any }} [parserOptions] Options for the parser.
  * @property {{ [name: string]: "readonly" | "writable" | "off" }} [globals] The additional global variables.
- * @property {{ [name: string]: boolean] }} [env] Environments for the test case.
+ * @property {{ [name: string]: boolean }} [env] Environments for the test case.
  */
 
 /**

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -57,7 +57,7 @@ const ajv = require("../shared/ajv")({ strictDefaults: true });
 
 /**
  * A test case that is expected to pass lint.
- * @typedef {object} ValidTestCase
+ * @typedef {Object} ValidTestCase
  * @property {string} code Code for the test case.
  * @property {any[]} [options] Options for the test case.
  * @property {{ [name: string]: any }} [settings] Settings for the test case.
@@ -69,7 +69,7 @@ const ajv = require("../shared/ajv")({ strictDefaults: true });
 
 /**
  * A test case that is expected to fail lint.
- * @typedef {object} InvalidTestCase
+ * @typedef {Object} InvalidTestCase
  * @property {string} code Code for the test case.
  * @property {number | Array<TestCaseError | string>} errors Expected errors.
  * @property {string | null} [output] The expected code after autofixes are applied. If set to `null`, the test runner will assert that no autofix is suggested.
@@ -83,7 +83,7 @@ const ajv = require("../shared/ajv")({ strictDefaults: true });
 
 /**
  * A description of a reported error used in a rule tester test.
- * @typedef {object} TestCaseError
+ * @typedef {Object} TestCaseError
  * @property {string | RegExp} message Message.
  * @property {string} [messageId] Message ID.
  * @property {string} [type] The type of the reported AST node.

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -80,6 +80,7 @@ const ajv = require("../shared/ajv")({ strictDefaults: true });
  * @property {string} [parser] The absolute path for the parser.
  * @property {{ [name: string]: any }} [parserOptions] Options for the parser.
  * @property {{ [name: string]: "readonly" | "writable" | "off" }} [globals] The additional global variables.
+ * @property {{ [name: string]: boolean] }} [env] Environments for the test case.
  */
 
 /**

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -84,7 +84,7 @@ const ajv = require("../shared/ajv")({ strictDefaults: true });
 /**
  * A description of a reported error used in a rule tester test.
  * @typedef {Object} TestCaseError
- * @property {string | RegExp} message Message.
+ * @property {string | RegExp} [message] Message.
  * @property {string} [messageId] Message ID.
  * @property {string} [type] The type of the reported AST node.
  * @property {{ [name: string]: string }} [data] The data used to fill the message template.

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -273,10 +273,48 @@ class RuleTester {
     }
 
     /**
+     * @typedef {{
+     *   code: string,
+     *   options?: any,
+     *   filename?: string,
+     *   parserOptions?: Linter.ParserOptions,
+     *   settings?: { [name: string]: any },
+     *   parser?: string,
+     *   globals?: { [name: string]: boolean }
+     * }} ValidTestCase
+     *
+     * @typedef {{
+     *   code: string,
+     *   errors: number | Array<TestCaseError | string>,
+     *   output?: string | null,
+     *   options?: any,
+     *   filename?: string,
+     *   parserOptions?: Linter.ParserOptions,
+     *   settings?: { [name: string]: any },
+     *   parser?: string,
+     *   globals?: { [name: string]: boolean }
+     * }} InvalidTestCase
+     *
+     * @typedef {{
+     *   message?: string | RegExp,
+     *   messageId?: string,
+     *   type?: string,
+     *   data?: any,
+     *   line?: number,
+     *   column?: number,
+     *   endLine?: number,
+     *   endColumn?: number,
+     * }} TestCaseError
+     */
+
+    /**
      * Adds a new rule test to execute.
      * @param {string} ruleName The name of the rule to run.
      * @param {Function} rule The rule to test.
-     * @param {Object} test The collection of tests to run.
+     * @param {{
+     *   valid: (ValidTestCase | string)[],
+     *   invalid: InvalidTestCase[]
+     * }} test The collection of tests to run.
      * @returns {void}
      */
     run(ruleName, rule, test) {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

Improve JSDoc typings.

**What changes did you make? (Give an overview)**
Add type for valid and invalid RuleTester test cases. This addition enables editor autocomplete/suggestions.

The typings are copied from `@types/eslint`.

**Is there anything you'd like reviewers to focus on?**
No

