### PR TITLE
Update: improve report location for no-mixed-operators

### DIFF
--- a/lib/rules/no-mixed-operators.js
+++ b/lib/rules/no-mixed-operators.js
@@ -205,13 +205,13 @@ module.exports = {
 
             context.report({
                 node: left,
-                loc: getOperatorToken(left).loc.start,
+                loc: getOperatorToken(left).loc,
                 message,
                 data
             });
             context.report({
                 node: right,
-                loc: getOperatorToken(right).loc.start,
+                loc: getOperatorToken(right).loc,
                 message,
                 data
             });

--- a/tests/lib/rules/no-mixed-operators.js
+++ b/tests/lib/rules/no-mixed-operators.js
@@ -64,8 +64,8 @@ ruleTester.run("no-mixed-operators", rule, {
         {
             code: "a && b || c",
             errors: [
-                { column: 3, message: "Unexpected mix of '&&' and '||'." },
-                { column: 8, message: "Unexpected mix of '&&' and '||'." }
+                { column: 3, endColumn: 5, message: "Unexpected mix of '&&' and '||'." },
+                { column: 8, endColumn: 10, message: "Unexpected mix of '&&' and '||'." }
             ]
         },
         {
@@ -110,48 +110,48 @@ ruleTester.run("no-mixed-operators", rule, {
             code: "a + b - c",
             options: [{ allowSamePrecedence: false }],
             errors: [
-                { column: 3, message: "Unexpected mix of '+' and '-'." },
-                { column: 7, message: "Unexpected mix of '+' and '-'." }
+                { column: 3, endColumn: 4, message: "Unexpected mix of '+' and '-'." },
+                { column: 7, endColumn: 8, message: "Unexpected mix of '+' and '-'." }
             ]
         },
         {
             code: "a * b / c",
             options: [{ allowSamePrecedence: false }],
             errors: [
-                { column: 3, message: "Unexpected mix of '*' and '/'." },
-                { column: 7, message: "Unexpected mix of '*' and '/'." }
+                { column: 3, endColumn: 4, message: "Unexpected mix of '*' and '/'." },
+                { column: 7, endColumn: 8, message: "Unexpected mix of '*' and '/'." }
             ]
         },
         {
             code: "a || b ? c : d",
             options: [{ groups: [["&&", "||", "?:"]] }],
             errors: [
-                { column: 3, message: "Unexpected mix of '||' and '?:'." },
-                { column: 8, message: "Unexpected mix of '||' and '?:'." }
+                { column: 3, endColumn: 5, message: "Unexpected mix of '||' and '?:'." },
+                { column: 8, endColumn: 9, message: "Unexpected mix of '||' and '?:'." }
             ]
         },
         {
             code: "a && b ? 1 : 2",
             options: [{ groups: [["&&", "||", "?:"]] }],
             errors: [
-                { column: 3, message: "Unexpected mix of '&&' and '?:'." },
-                { column: 8, message: "Unexpected mix of '&&' and '?:'." }
+                { column: 3, endColumn: 5, message: "Unexpected mix of '&&' and '?:'." },
+                { column: 8, endColumn: 9, message: "Unexpected mix of '&&' and '?:'." }
             ]
         },
         {
             code: "x ? a && b : 0",
             options: [{ groups: [["&&", "||", "?:"]] }],
             errors: [
-                { column: 3, message: "Unexpected mix of '?:' and '&&'." },
-                { column: 7, message: "Unexpected mix of '?:' and '&&'." }
+                { column: 3, endColumn: 4, message: "Unexpected mix of '?:' and '&&'." },
+                { column: 7, endColumn: 9, message: "Unexpected mix of '?:' and '&&'." }
             ]
         },
         {
             code: "x ? 0 : a && b",
             options: [{ groups: [["&&", "||", "?:"]] }],
             errors: [
-                { column: 3, message: "Unexpected mix of '?:' and '&&'." },
-                { column: 11, message: "Unexpected mix of '?:' and '&&'." }
+                { column: 3, endColumn: 4, message: "Unexpected mix of '?:' and '&&'." },
+                { column: 11, endColumn: 13, message: "Unexpected mix of '?:' and '&&'." }
             ]
         }
     ]


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**
[x] Changes an existing rule

**What changes did you make? (Give an overview)**
Make no-mixed-operators report both start and end location, instead of only start location. 

```js
let p = a && b || c
//        ~    ~    before
//        ~~   ~~   after
 
``` 

**Is there anything you'd like reviewers to focus on?**
No
