### PR TITLE
Fix: Load CommonJS .eslintrc.js files within a "type": "module" package scope (fixes #12319)

### DIFF
--- a/lib/cli-engine/config-array-factory.js
+++ b/lib/cli-engine/config-array-factory.js
@@ -36,6 +36,7 @@
 const fs = require("fs");
 const path = require("path");
 const importFresh = require("import-fresh");
+const requireFromString = require("require-from-string");
 const stripComments = require("strip-json-comments");
 const { validateConfigSchema } = require("../shared/config-validator");
 const naming = require("../shared/naming");
@@ -188,6 +189,19 @@ function loadJSConfigFile(filePath) {
     try {
         return importFresh(filePath);
     } catch (e) {
+        if (e.code === "ERR_REQUIRE_ESM") {
+
+            /*
+             * The JS config file is a CommonJS .js file within a `"type": "module"``
+             * package scope. Node errors when trying to require such a file,
+             * so bypass Node’s check. There’s no need for `importFresh`, because
+             * this method never adds the loaded .js file into `require.cache`.
+             */
+            const content = readFile(filePath);
+
+            return requireFromString(content, filePath, { appendPaths: path.dirname(filePath) });
+        }
+
         debug(`Error reading JavaScript file: ${filePath}`);
         e.message = `Cannot read config file: ${filePath}\nError: ${e.message}`;
         throw e;

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "optionator": "^0.8.2",
     "progress": "^2.0.0",
     "regexpp": "^2.0.1",
+    "require-from-string": "^2.0.2",
     "semver": "^6.1.2",
     "strip-ansi": "^5.2.0",
     "strip-json-comments": "^3.0.1",


### PR DESCRIPTION
Fixes #12319, where CommonJS `.eslintrc.js` files inside a project where the user has added `"type": "module"` to their `package.json` were throwing an error.

Sorry for the lack of tests, but please feel free to complete this PR if you like this approach to solving the problem. It may become moot if the error is removed in Node (see https://github.com/nodejs/modules/issues/389 and https://github.com/nodejs/node/pull/29732).