### PR TITLE
Chore: enable additional eslint-plugin-jsdoc rules

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -1017,7 +1017,6 @@ function time(cmd, runs, runNumber, results, cb) {
 
 /**
  * Run a performance test.
- *
  * @param {string} title - A title.
  * @param {string} targets - Test targets.
  * @param {number} multiplier - A multiplier for limitation.

--- a/Makefile.js
+++ b/Makefile.js
@@ -941,7 +941,7 @@ target.checkLicenses = function() {
 /**
  * Downloads a repository which has many js files to test performance with multi files.
  * Here, it's eslint@1.10.3 (450 files)
- * @param {Function} cb - A callback function.
+ * @param {Function} cb A callback function.
  * @returns {void}
  */
 function downloadMultifilesTestTarget(cb) {
@@ -1017,10 +1017,10 @@ function time(cmd, runs, runNumber, results, cb) {
 
 /**
  * Run a performance test.
- * @param {string} title - A title.
- * @param {string} targets - Test targets.
- * @param {number} multiplier - A multiplier for limitation.
- * @param {Function} cb - A callback function.
+ * @param {string} title A title.
+ * @param {string} targets Test targets.
+ * @param {number} multiplier A multiplier for limitation.
+ * @param {Function} cb A callback function.
  * @returns {void}
  */
 function runPerformanceTest(title, targets, multiplier, cb) {

--- a/lib/cli-engine/cascading-config-array-factory.js
+++ b/lib/cli-engine/cascading-config-array-factory.js
@@ -153,7 +153,7 @@ function createCLIConfigArray({
 class ConfigurationNotFoundError extends Error {
 
     /**
-     * @param {string} directoryPath - The directory path.
+     * @param {string} directoryPath The directory path.
      */
     constructor(directoryPath) {
         super(`No ESLint configuration found in ${directoryPath}.`);

--- a/lib/cli-engine/cli-engine.js
+++ b/lib/cli-engine/cli-engine.js
@@ -387,7 +387,6 @@ function isErrorMessage(message) {
  * name will be the `cacheFile/.cache_hashOfCWD`
  *
  * if cacheFile points to a file or looks like a file then in will just use that file
- *
  * @param {string} cacheFile The name of file to be used to store the cache
  * @param {string} cwd Current working directory
  * @returns {string} the resolved path to the cache file

--- a/lib/cli-engine/cli-engine.js
+++ b/lib/cli-engine/cli-engine.js
@@ -145,7 +145,7 @@ function validateFixTypes(fixTypes) {
 
 /**
  * It will calculate the error and warning count for collection of messages per file
- * @param {LintMessage[]} messages - Collection of messages
+ * @param {LintMessage[]} messages Collection of messages
  * @returns {Object} Contains the stats
  * @private
  */
@@ -173,7 +173,7 @@ function calculateStatsPerFile(messages) {
 
 /**
  * It will calculate the error and warning count for collection of results from all files
- * @param {LintResult[]} results - Collection of messages from all the files
+ * @param {LintResult[]} results Collection of messages from all the files
  * @returns {Object} Contains the stats
  * @private
  */
@@ -272,8 +272,8 @@ function verifyText({
 
 /**
  * Returns result with warning by ignore settings
- * @param {string} filePath - File path of checked code
- * @param {string} baseDir  - Absolute path of base directory
+ * @param {string} filePath File path of checked code
+ * @param {string} baseDir  Absolute path of base directory
  * @returns {LintResult} Result with single warning
  * @private
  */

--- a/lib/cli-engine/config-array/config-array.js
+++ b/lib/cli-engine/config-array/config-array.js
@@ -126,7 +126,6 @@ function isNonNullObject(x) {
  *
  * Assign every property values of `y` to `x` if `x` doesn't have the property.
  * If `x`'s property value is an object, it does recursive.
- *
  * @param {Object} target The destination to merge
  * @param {Object|undefined} source The source to merge.
  * @returns {void}
@@ -157,7 +156,6 @@ function mergeWithoutOverwrite(target, source) {
 /**
  * Merge plugins.
  * `target`'s definition is prior to `source`'s.
- *
  * @param {Record<string, DependentPlugin>} target The destination to merge
  * @param {Record<string, DependentPlugin>|undefined} source The source to merge.
  * @returns {void}
@@ -187,7 +185,6 @@ function mergePlugins(target, source) {
 /**
  * Merge rule configs.
  * `target`'s definition is prior to `source`'s.
- *
  * @param {Record<string, Array>} target The destination to merge
  * @param {Record<string, RuleConf>|undefined} source The source to merge.
  * @returns {void}
@@ -382,7 +379,6 @@ function ensurePluginMemberMaps(instance) {
  * You need to call `ConfigArray#extractConfig(filePath)` method in order to
  * extract, merge and get only the config data which is related to an arbitrary
  * file.
- *
  * @extends {Array<ConfigArrayElement>}
  */
 class ConfigArray extends Array {

--- a/lib/cli-engine/file-enumerator.js
+++ b/lib/cli-engine/file-enumerator.js
@@ -150,8 +150,8 @@ function readdirSafeSync(directoryPath) {
 class NoFilesFoundError extends Error {
 
     /**
-     * @param {string} pattern - The glob pattern which was not found.
-     * @param {boolean} globDisabled - If `true` then the pattern was a glob pattern, but glob was disabled.
+     * @param {string} pattern The glob pattern which was not found.
+     * @param {boolean} globDisabled If `true` then the pattern was a glob pattern, but glob was disabled.
      */
     constructor(pattern, globDisabled) {
         super(`No files matching '${pattern}' were found${globDisabled ? " (glob was disabled)" : ""}.`);
@@ -166,7 +166,7 @@ class NoFilesFoundError extends Error {
 class AllFilesIgnoredError extends Error {
 
     /**
-     * @param {string} pattern - The glob pattern which was not found.
+     * @param {string} pattern The glob pattern which was not found.
      */
     constructor(pattern) {
         super(`All files matched by '${pattern}' are ignored.`);

--- a/lib/init/autoconfig.js
+++ b/lib/init/autoconfig.js
@@ -31,7 +31,6 @@ const MAX_CONFIG_COMBINATIONS = 17, // 16 combinations + 1 for severity only
 
 /**
  * Information about a rule configuration, in the context of a Registry.
- *
  * @typedef {Object}     registryItem
  * @param   {ruleConfig} config        A valid configuration for the rule
  * @param   {number}     specificity   The number of elements in the ruleConfig array
@@ -82,7 +81,6 @@ class Registry {
      *
      * It will set the registry's `rule` property to an object having rule names
      * as keys and an array of registryItems as values.
-     *
      * @returns {void}
      */
     populateFromCoreRules() {
@@ -101,7 +99,6 @@ class Registry {
      * configurations.
      *
      * The length of the returned array will be <= MAX_CONFIG_COMBINATIONS.
-     *
      * @returns {Object[]}          "rules" configurations to use for linting
      */
     buildRuleSets() {
@@ -114,7 +111,6 @@ class Registry {
          *
          * This is broken out into its own function so that it doesn't need to be
          * created inside of the while loop.
-         *
          * @param   {string} rule The ruleId to add.
          * @returns {void}
          */
@@ -162,7 +158,6 @@ class Registry {
      *
      * Note: this also removes rule configurations which were not linted
      * (meaning, they have an undefined errorCount).
-     *
      * @returns {void}
      */
     stripFailingConfigs() {
@@ -185,7 +180,6 @@ class Registry {
 
     /**
      * Removes rule configurations which were not included in a ruleSet
-     *
      * @returns {void}
      */
     stripExtraConfigs() {
@@ -204,7 +198,6 @@ class Registry {
      * Creates a registry of rules which had no error-free configs.
      * The new registry is intended to be analyzed to determine whether its rules
      * should be disabled or set to warning.
-     *
      * @returns {Registry}  A registry of failing rules.
      */
     getFailingRulesRegistry() {
@@ -225,7 +218,6 @@ class Registry {
     /**
      * Create an eslint config for any rules which only have one configuration
      * in the registry.
-     *
      * @returns {Object} An eslint config with rules section populated
      */
     createConfig() {
@@ -243,7 +235,6 @@ class Registry {
 
     /**
      * Return a cloned registry containing only configs with a desired specificity
-     *
      * @param   {number} specificity Only keep configs with this specificity
      * @returns {Registry}           A registry of rules
      */
@@ -261,7 +252,6 @@ class Registry {
 
     /**
      * Lint SourceCodes against all configurations in the registry, and record results
-     *
      * @param   {Object[]} sourceCodes  SourceCode objects for each filename
      * @param   {Object}   config       ESLint config object
      * @param   {progressCallback} [cb] Optional callback for reporting execution status
@@ -327,7 +317,6 @@ class Registry {
  *
  * This will return a new config with `"extends": "eslint:recommended"` and
  * only the rules which have configurations different from the recommended config.
- *
  * @param   {Object} config config object
  * @returns {Object}        config object using `"extends": "eslint:recommended"`
  */

--- a/lib/init/config-file.js
+++ b/lib/init/config-file.js
@@ -23,7 +23,6 @@ const debug = require("debug")("eslint:config-file");
  * Determines sort order for object keys for json-stable-stringify
  *
  * see: https://github.com/samn/json-stable-stringify#cmp
- *
  * @param   {Object} a The first comparison object ({key: akey, value: avalue})
  * @param   {Object} b The second comparison object ({key: bkey, value: bvalue})
  * @returns {number}   1 or -1, used in stringify cmp method

--- a/lib/init/config-initializer.js
+++ b/lib/init/config-initializer.js
@@ -147,7 +147,6 @@ function getModulesList(config, installESLint) {
  *
  * Note: This clones the config object and returns a new config to avoid mutating
  * the original config parameter.
- *
  * @param   {Object} answers  answers received from inquirer
  * @param   {Object} config   config object
  * @returns {Object}          config object with configured rules

--- a/lib/init/config-rule.js
+++ b/lib/init/config-rule.js
@@ -33,7 +33,6 @@ function explodeArray(xs) {
  *
  * For example:
  * combineArrays([a, [b, c]], [x, y]); // -> [[a, x], [a, y], [b, c, x], [b, c, y]]
- *
  * @param   {Array} arr1 The first array to combine.
  * @param   {Array} arr2 The second array to combine.
  * @returns {Array}      A mixture of the elements of the first and second arrays.
@@ -71,7 +70,6 @@ function combineArrays(arr1, arr2) {
  *     [{before: true}, {before: false}],
  *     [{after: true}, {after: false}]
  * ]
- *
  * @param   {Object[]} objects Array of objects, each with one property/value pair
  * @returns {Array[]}          Array of arrays of objects grouped by property
  */
@@ -98,7 +96,6 @@ function groupByProperty(objects) {
  * element in the array is the severity, and is the only required element.
  * Configs may also have one or more additional elements to specify rule
  * configuration or options.
- *
  * @typedef {Array|number} ruleConfig
  * @param {number}  0  The rule's severity (0, 1, 2).
  */
@@ -134,7 +131,6 @@ function groupByProperty(objects) {
  *     {before: false, after: true},
  *     {before: false, after: false}
  * ]
- *
  * @param   {Object[]} objArr1 Single key/value objects, all with the same key
  * @param   {Object[]} objArr2 Single key/value objects, all with another key
  * @returns {Object[]}         Combined objects for each combination of input properties and values
@@ -193,7 +189,6 @@ class RuleConfigSet {
     /**
      * Add a severity level to the front of all configs in the instance.
      * This should only be called after all configs have been added to the instance.
-     *
      * @returns {void}
      */
     addErrorSeverity() {

--- a/lib/init/npm-utils.js
+++ b/lib/init/npm-utils.js
@@ -21,7 +21,6 @@ const fs = require("fs"),
 /**
  * Find the closest package.json file, starting at process.cwd (by default),
  * and working up to root.
- *
  * @param   {string} [startDir=process.cwd()] Starting directory
  * @returns {string}                          Absolute path to closest package.json file
  */
@@ -88,7 +87,6 @@ function fetchPeerDependencies(packageName) {
 
 /**
  * Check whether node modules are include in a project's package.json.
- *
  * @param   {string[]} packages           Array of node module names
  * @param   {Object}  opt                 Options Object
  * @param   {boolean} opt.dependencies    Set to true to check for direct dependencies
@@ -136,7 +134,6 @@ function check(packages, opt) {
  * package.json.
  *
  * Convenience wrapper around check().
- *
  * @param   {string[]} packages  Array of node modules to check.
  * @param   {string}   rootDir   The directory contianing a package.json
  * @returns {Object}             An object whose keys are the module names
@@ -151,7 +148,6 @@ function checkDeps(packages, rootDir) {
  * package.json.
  *
  * Convenience wrapper around check().
- *
  * @param   {string[]} packages  Array of node modules to check.
  * @returns {Object}             An object whose keys are the module names
  *                               and values are booleans indicating installation.
@@ -162,7 +158,6 @@ function checkDevDeps(packages) {
 
 /**
  * Check whether package.json is found in current path.
- *
  * @param   {string} [startDir] Starting directory
  * @returns {boolean} Whether a package.json is found in current path.
  */

--- a/lib/linter/code-path-analysis/code-path-analyzer.js
+++ b/lib/linter/code-path-analysis/code-path-analyzer.js
@@ -22,7 +22,7 @@ const assert = require("assert"),
 
 /**
  * Checks whether or not a given node is a `case` node (not `default` node).
- * @param {ASTNode} node - A `SwitchCase` node to check.
+ * @param {ASTNode} node A `SwitchCase` node to check.
  * @returns {boolean} `true` if the node is a `case` node (not `default` node).
  */
 function isCaseNode(node) {
@@ -32,7 +32,7 @@ function isCaseNode(node) {
 /**
  * Checks whether the given logical operator is taken into account for the code
  * path analysis.
- * @param {string} operator - The operator found in the LogicalExpression node
+ * @param {string} operator The operator found in the LogicalExpression node
  * @returns {boolean} `true` if the operator is "&&" or "||"
  */
 function isHandledLogicalOperator(operator) {
@@ -41,7 +41,7 @@ function isHandledLogicalOperator(operator) {
 
 /**
  * Gets the label if the parent node of a given node is a LabeledStatement.
- * @param {ASTNode} node - A node to get.
+ * @param {ASTNode} node A node to get.
  * @returns {string|null} The label or `null`.
  */
 function getLabel(node) {
@@ -54,7 +54,7 @@ function getLabel(node) {
 /**
  * Checks whether or not a given logical expression node goes different path
  * between the `true` case and the `false` case.
- * @param {ASTNode} node - A node to check.
+ * @param {ASTNode} node A node to check.
  * @returns {boolean} `true` if the node is a test of a choice statement.
  */
 function isForkingByTrueOrFalse(node) {
@@ -82,7 +82,7 @@ function isForkingByTrueOrFalse(node) {
  * This is used to detect infinity loops (e.g. `while (true) {}`).
  * Statements preceded by an infinity loop are unreachable if the loop didn't
  * have any `break` statement.
- * @param {ASTNode} node - A node to get.
+ * @param {ASTNode} node A node to get.
  * @returns {boolean|undefined} a boolean value if the node is a Literal node,
  *   otherwise `undefined`.
  */
@@ -97,7 +97,7 @@ function getBooleanValueIfSimpleConstant(node) {
  * Checks that a given identifier node is a reference or not.
  *
  * This is used to detect the first throwable node in a `try` block.
- * @param {ASTNode} node - An Identifier node to check.
+ * @param {ASTNode} node An Identifier node to check.
  * @returns {boolean} `true` if the node is a reference.
  */
 function isIdentifierReference(node) {
@@ -147,8 +147,8 @@ function isIdentifierReference(node) {
  *
  * In this process, both "onCodePathSegmentStart" and "onCodePathSegmentEnd"
  * events are fired.
- * @param {CodePathAnalyzer} analyzer - The instance.
- * @param {ASTNode} node - The current AST node.
+ * @param {CodePathAnalyzer} analyzer The instance.
+ * @param {ASTNode} node The current AST node.
  * @returns {void}
  */
 function forwardCurrentToHead(analyzer, node) {
@@ -204,8 +204,8 @@ function forwardCurrentToHead(analyzer, node) {
 /**
  * Updates the current segment with empty.
  * This is called at the last of functions or the program.
- * @param {CodePathAnalyzer} analyzer - The instance.
- * @param {ASTNode} node - The current AST node.
+ * @param {CodePathAnalyzer} analyzer The instance.
+ * @param {ASTNode} node The current AST node.
  * @returns {void}
  */
 function leaveFromCurrentSegment(analyzer, node) {
@@ -234,8 +234,8 @@ function leaveFromCurrentSegment(analyzer, node) {
  *
  * For example, if the node is `parent.consequent`, this creates a fork from the
  * current path.
- * @param {CodePathAnalyzer} analyzer - The instance.
- * @param {ASTNode} node - The current AST node.
+ * @param {CodePathAnalyzer} analyzer The instance.
+ * @param {ASTNode} node The current AST node.
  * @returns {void}
  */
 function preprocess(analyzer, node) {
@@ -343,8 +343,8 @@ function preprocess(analyzer, node) {
 
 /**
  * Updates the code path due to the type of a given node in entering.
- * @param {CodePathAnalyzer} analyzer - The instance.
- * @param {ASTNode} node - The current AST node.
+ * @param {CodePathAnalyzer} analyzer The instance.
+ * @param {ASTNode} node The current AST node.
  * @returns {void}
  */
 function processCodePathToEnter(analyzer, node) {
@@ -439,8 +439,8 @@ function processCodePathToEnter(analyzer, node) {
 
 /**
  * Updates the code path due to the type of a given node in leaving.
- * @param {CodePathAnalyzer} analyzer - The instance.
- * @param {ASTNode} node - The current AST node.
+ * @param {CodePathAnalyzer} analyzer The instance.
+ * @param {ASTNode} node The current AST node.
  * @returns {void}
  */
 function processCodePathToExit(analyzer, node) {
@@ -552,8 +552,8 @@ function processCodePathToExit(analyzer, node) {
 
 /**
  * Updates the code path to finalize the current code path.
- * @param {CodePathAnalyzer} analyzer - The instance.
- * @param {ASTNode} node - The current AST node.
+ * @param {CodePathAnalyzer} analyzer The instance.
+ * @param {ASTNode} node The current AST node.
  * @returns {void}
  */
 function postprocess(analyzer, node) {
@@ -598,7 +598,7 @@ function postprocess(analyzer, node) {
 class CodePathAnalyzer {
 
     /**
-     * @param {EventGenerator} eventGenerator - An event generator to wrap.
+     * @param {EventGenerator} eventGenerator An event generator to wrap.
      */
     constructor(eventGenerator) {
         this.original = eventGenerator;
@@ -612,7 +612,7 @@ class CodePathAnalyzer {
     /**
      * Does the process to enter a given AST node.
      * This updates state of analysis and calls `enterNode` of the wrapped.
-     * @param {ASTNode} node - A node which is entering.
+     * @param {ASTNode} node A node which is entering.
      * @returns {void}
      */
     enterNode(node) {
@@ -638,7 +638,7 @@ class CodePathAnalyzer {
     /**
      * Does the process to leave a given AST node.
      * This updates state of analysis and calls `leaveNode` of the wrapped.
-     * @param {ASTNode} node - A node which is leaving.
+     * @param {ASTNode} node A node which is leaving.
      * @returns {void}
      */
     leaveNode(node) {
@@ -662,8 +662,8 @@ class CodePathAnalyzer {
     /**
      * This is called on a code path looped.
      * Then this raises a looped event.
-     * @param {CodePathSegment} fromSegment - A segment of prev.
-     * @param {CodePathSegment} toSegment - A segment of next.
+     * @param {CodePathSegment} fromSegment A segment of prev.
+     * @param {CodePathSegment} toSegment A segment of next.
      * @returns {void}
      */
     onLooped(fromSegment, toSegment) {

--- a/lib/linter/code-path-analysis/code-path-analyzer.js
+++ b/lib/linter/code-path-analysis/code-path-analyzer.js
@@ -22,7 +22,6 @@ const assert = require("assert"),
 
 /**
  * Checks whether or not a given node is a `case` node (not `default` node).
- *
  * @param {ASTNode} node - A `SwitchCase` node to check.
  * @returns {boolean} `true` if the node is a `case` node (not `default` node).
  */
@@ -33,7 +32,6 @@ function isCaseNode(node) {
 /**
  * Checks whether the given logical operator is taken into account for the code
  * path analysis.
- *
  * @param {string} operator - The operator found in the LogicalExpression node
  * @returns {boolean} `true` if the operator is "&&" or "||"
  */
@@ -43,7 +41,6 @@ function isHandledLogicalOperator(operator) {
 
 /**
  * Gets the label if the parent node of a given node is a LabeledStatement.
- *
  * @param {ASTNode} node - A node to get.
  * @returns {string|null} The label or `null`.
  */
@@ -57,7 +54,6 @@ function getLabel(node) {
 /**
  * Checks whether or not a given logical expression node goes different path
  * between the `true` case and the `false` case.
- *
  * @param {ASTNode} node - A node to check.
  * @returns {boolean} `true` if the node is a test of a choice statement.
  */
@@ -86,7 +82,6 @@ function isForkingByTrueOrFalse(node) {
  * This is used to detect infinity loops (e.g. `while (true) {}`).
  * Statements preceded by an infinity loop are unreachable if the loop didn't
  * have any `break` statement.
- *
  * @param {ASTNode} node - A node to get.
  * @returns {boolean|undefined} a boolean value if the node is a Literal node,
  *   otherwise `undefined`.
@@ -102,7 +97,6 @@ function getBooleanValueIfSimpleConstant(node) {
  * Checks that a given identifier node is a reference or not.
  *
  * This is used to detect the first throwable node in a `try` block.
- *
  * @param {ASTNode} node - An Identifier node to check.
  * @returns {boolean} `true` if the node is a reference.
  */
@@ -153,7 +147,6 @@ function isIdentifierReference(node) {
  *
  * In this process, both "onCodePathSegmentStart" and "onCodePathSegmentEnd"
  * events are fired.
- *
  * @param {CodePathAnalyzer} analyzer - The instance.
  * @param {ASTNode} node - The current AST node.
  * @returns {void}
@@ -211,7 +204,6 @@ function forwardCurrentToHead(analyzer, node) {
 /**
  * Updates the current segment with empty.
  * This is called at the last of functions or the program.
- *
  * @param {CodePathAnalyzer} analyzer - The instance.
  * @param {ASTNode} node - The current AST node.
  * @returns {void}
@@ -242,7 +234,6 @@ function leaveFromCurrentSegment(analyzer, node) {
  *
  * For example, if the node is `parent.consequent`, this creates a fork from the
  * current path.
- *
  * @param {CodePathAnalyzer} analyzer - The instance.
  * @param {ASTNode} node - The current AST node.
  * @returns {void}
@@ -352,7 +343,6 @@ function preprocess(analyzer, node) {
 
 /**
  * Updates the code path due to the type of a given node in entering.
- *
  * @param {CodePathAnalyzer} analyzer - The instance.
  * @param {ASTNode} node - The current AST node.
  * @returns {void}
@@ -449,7 +439,6 @@ function processCodePathToEnter(analyzer, node) {
 
 /**
  * Updates the code path due to the type of a given node in leaving.
- *
  * @param {CodePathAnalyzer} analyzer - The instance.
  * @param {ASTNode} node - The current AST node.
  * @returns {void}
@@ -563,7 +552,6 @@ function processCodePathToExit(analyzer, node) {
 
 /**
  * Updates the code path to finalize the current code path.
- *
  * @param {CodePathAnalyzer} analyzer - The instance.
  * @param {ASTNode} node - The current AST node.
  * @returns {void}
@@ -624,7 +612,6 @@ class CodePathAnalyzer {
     /**
      * Does the process to enter a given AST node.
      * This updates state of analysis and calls `enterNode` of the wrapped.
-     *
      * @param {ASTNode} node - A node which is entering.
      * @returns {void}
      */
@@ -651,7 +638,6 @@ class CodePathAnalyzer {
     /**
      * Does the process to leave a given AST node.
      * This updates state of analysis and calls `leaveNode` of the wrapped.
-     *
      * @param {ASTNode} node - A node which is leaving.
      * @returns {void}
      */
@@ -676,7 +662,6 @@ class CodePathAnalyzer {
     /**
      * This is called on a code path looped.
      * Then this raises a looped event.
-     *
      * @param {CodePathSegment} fromSegment - A segment of prev.
      * @param {CodePathSegment} toSegment - A segment of next.
      * @returns {void}

--- a/lib/linter/code-path-analysis/code-path-segment.js
+++ b/lib/linter/code-path-analysis/code-path-segment.js
@@ -17,7 +17,7 @@ const debug = require("./debug-helpers");
 
 /**
  * Checks whether or not a given segment is reachable.
- * @param {CodePathSegment} segment - A segment to check.
+ * @param {CodePathSegment} segment A segment to check.
  * @returns {boolean} `true` if the segment is reachable.
  */
 function isReachable(segment) {
@@ -34,10 +34,10 @@ function isReachable(segment) {
 class CodePathSegment {
 
     /**
-     * @param {string} id - An identifier.
-     * @param {CodePathSegment[]} allPrevSegments - An array of the previous segments.
+     * @param {string} id An identifier.
+     * @param {CodePathSegment[]} allPrevSegments An array of the previous segments.
      *   This array includes unreachable segments.
-     * @param {boolean} reachable - A flag which shows this is reachable.
+     * @param {boolean} reachable A flag which shows this is reachable.
      */
     constructor(id, allPrevSegments, reachable) {
 
@@ -97,7 +97,7 @@ class CodePathSegment {
 
     /**
      * Checks a given previous segment is coming from the end of a loop.
-     * @param {CodePathSegment} segment - A previous segment to check.
+     * @param {CodePathSegment} segment A previous segment to check.
      * @returns {boolean} `true` if the segment is coming from the end of a loop.
      */
     isLoopedPrevSegment(segment) {
@@ -106,7 +106,7 @@ class CodePathSegment {
 
     /**
      * Creates the root segment.
-     * @param {string} id - An identifier.
+     * @param {string} id An identifier.
      * @returns {CodePathSegment} The created segment.
      */
     static newRoot(id) {
@@ -115,8 +115,8 @@ class CodePathSegment {
 
     /**
      * Creates a segment that follows given segments.
-     * @param {string} id - An identifier.
-     * @param {CodePathSegment[]} allPrevSegments - An array of the previous segments.
+     * @param {string} id An identifier.
+     * @param {CodePathSegment[]} allPrevSegments An array of the previous segments.
      * @returns {CodePathSegment} The created segment.
      */
     static newNext(id, allPrevSegments) {
@@ -129,8 +129,8 @@ class CodePathSegment {
 
     /**
      * Creates an unreachable segment that follows given segments.
-     * @param {string} id - An identifier.
-     * @param {CodePathSegment[]} allPrevSegments - An array of the previous segments.
+     * @param {string} id An identifier.
+     * @param {CodePathSegment[]} allPrevSegments An array of the previous segments.
      * @returns {CodePathSegment} The created segment.
      */
     static newUnreachable(id, allPrevSegments) {
@@ -149,8 +149,8 @@ class CodePathSegment {
      * Creates a segment that follows given segments.
      * This factory method does not connect with `allPrevSegments`.
      * But this inherits `reachable` flag.
-     * @param {string} id - An identifier.
-     * @param {CodePathSegment[]} allPrevSegments - An array of the previous segments.
+     * @param {string} id An identifier.
+     * @param {CodePathSegment[]} allPrevSegments An array of the previous segments.
      * @returns {CodePathSegment} The created segment.
      */
     static newDisconnected(id, allPrevSegments) {
@@ -161,7 +161,7 @@ class CodePathSegment {
      * Makes a given segment being used.
      *
      * And this function registers the segment into the previous segments as a next.
-     * @param {CodePathSegment} segment - A segment to mark.
+     * @param {CodePathSegment} segment A segment to mark.
      * @returns {void}
      */
     static markUsed(segment) {
@@ -188,8 +188,8 @@ class CodePathSegment {
 
     /**
      * Marks a previous segment as looped.
-     * @param {CodePathSegment} segment - A segment.
-     * @param {CodePathSegment} prevSegment - A previous segment to mark.
+     * @param {CodePathSegment} segment A segment.
+     * @param {CodePathSegment} prevSegment A previous segment to mark.
      * @returns {void}
      */
     static markPrevSegmentAsLooped(segment, prevSegment) {
@@ -198,7 +198,7 @@ class CodePathSegment {
 
     /**
      * Replaces unused segments with the previous segments of each unused segment.
-     * @param {CodePathSegment[]} segments - An array of segments to replace.
+     * @param {CodePathSegment[]} segments An array of segments to replace.
      * @returns {CodePathSegment[]} The replaced array.
      */
     static flattenUnusedSegments(segments) {

--- a/lib/linter/code-path-analysis/code-path-segment.js
+++ b/lib/linter/code-path-analysis/code-path-segment.js
@@ -17,7 +17,6 @@ const debug = require("./debug-helpers");
 
 /**
  * Checks whether or not a given segment is reachable.
- *
  * @param {CodePathSegment} segment - A segment to check.
  * @returns {boolean} `true` if the segment is reachable.
  */
@@ -98,7 +97,6 @@ class CodePathSegment {
 
     /**
      * Checks a given previous segment is coming from the end of a loop.
-     *
      * @param {CodePathSegment} segment - A previous segment to check.
      * @returns {boolean} `true` if the segment is coming from the end of a loop.
      */
@@ -108,7 +106,6 @@ class CodePathSegment {
 
     /**
      * Creates the root segment.
-     *
      * @param {string} id - An identifier.
      * @returns {CodePathSegment} The created segment.
      */
@@ -118,7 +115,6 @@ class CodePathSegment {
 
     /**
      * Creates a segment that follows given segments.
-     *
      * @param {string} id - An identifier.
      * @param {CodePathSegment[]} allPrevSegments - An array of the previous segments.
      * @returns {CodePathSegment} The created segment.
@@ -133,7 +129,6 @@ class CodePathSegment {
 
     /**
      * Creates an unreachable segment that follows given segments.
-     *
      * @param {string} id - An identifier.
      * @param {CodePathSegment[]} allPrevSegments - An array of the previous segments.
      * @returns {CodePathSegment} The created segment.
@@ -154,7 +149,6 @@ class CodePathSegment {
      * Creates a segment that follows given segments.
      * This factory method does not connect with `allPrevSegments`.
      * But this inherits `reachable` flag.
-     *
      * @param {string} id - An identifier.
      * @param {CodePathSegment[]} allPrevSegments - An array of the previous segments.
      * @returns {CodePathSegment} The created segment.
@@ -167,7 +161,6 @@ class CodePathSegment {
      * Makes a given segment being used.
      *
      * And this function registers the segment into the previous segments as a next.
-     *
      * @param {CodePathSegment} segment - A segment to mark.
      * @returns {void}
      */
@@ -195,7 +188,6 @@ class CodePathSegment {
 
     /**
      * Marks a previous segment as looped.
-     *
      * @param {CodePathSegment} segment - A segment.
      * @param {CodePathSegment} prevSegment - A previous segment to mark.
      * @returns {void}
@@ -206,7 +198,6 @@ class CodePathSegment {
 
     /**
      * Replaces unused segments with the previous segments of each unused segment.
-     *
      * @param {CodePathSegment[]} segments - An array of segments to replace.
      * @returns {CodePathSegment[]} The replaced array.
      */

--- a/lib/linter/code-path-analysis/code-path-state.js
+++ b/lib/linter/code-path-analysis/code-path-state.js
@@ -22,10 +22,10 @@ const CodePathSegment = require("./code-path-segment"),
  * array as well.
  *
  * This adds only reachable and used segments.
- * @param {CodePathSegment[]} dest - A destination array (`returnedSegments` or `thrownSegments`).
- * @param {CodePathSegment[]} others - Another destination array (`returnedSegments` or `thrownSegments`).
- * @param {CodePathSegment[]} all - The unified destination array (`finalSegments`).
- * @param {CodePathSegment[]} segments - Segments to add.
+ * @param {CodePathSegment[]} dest A destination array (`returnedSegments` or `thrownSegments`).
+ * @param {CodePathSegment[]} others Another destination array (`returnedSegments` or `thrownSegments`).
+ * @param {CodePathSegment[]} all The unified destination array (`finalSegments`).
+ * @param {CodePathSegment[]} segments Segments to add.
  * @returns {void}
  */
 function addToReturnedOrThrown(dest, others, all, segments) {
@@ -41,8 +41,8 @@ function addToReturnedOrThrown(dest, others, all, segments) {
 
 /**
  * Gets a loop-context for a `continue` statement.
- * @param {CodePathState} state - A state to get.
- * @param {string} label - The label of a `continue` statement.
+ * @param {CodePathState} state A state to get.
+ * @param {string} label The label of a `continue` statement.
  * @returns {LoopContext} A loop-context for a `continue` statement.
  */
 function getContinueContext(state, label) {
@@ -65,8 +65,8 @@ function getContinueContext(state, label) {
 
 /**
  * Gets a context for a `break` statement.
- * @param {CodePathState} state - A state to get.
- * @param {string} label - The label of a `break` statement.
+ * @param {CodePathState} state A state to get.
+ * @param {string} label The label of a `break` statement.
  * @returns {LoopContext|SwitchContext} A context for a `break` statement.
  */
 function getBreakContext(state, label) {
@@ -85,7 +85,7 @@ function getBreakContext(state, label) {
 
 /**
  * Gets a context for a `return` statement.
- * @param {CodePathState} state - A state to get.
+ * @param {CodePathState} state A state to get.
  * @returns {TryContext|CodePathState} A context for a `return` statement.
  */
 function getReturnContext(state) {
@@ -103,7 +103,7 @@ function getReturnContext(state) {
 
 /**
  * Gets a context for a `throw` statement.
- * @param {CodePathState} state - A state to get.
+ * @param {CodePathState} state A state to get.
  * @returns {TryContext|CodePathState} A context for a `throw` statement.
  */
 function getThrowContext(state) {
@@ -123,8 +123,8 @@ function getThrowContext(state) {
 
 /**
  * Removes a given element from a given array.
- * @param {any[]} xs - An array to remove the specific element.
- * @param {any} x - An element to be removed.
+ * @param {any[]} xs An array to remove the specific element.
+ * @param {any} x An element to be removed.
  * @returns {void}
  */
 function remove(xs, x) {
@@ -137,8 +137,8 @@ function remove(xs, x) {
  * This is used in a process for switch statements.
  * If there is the "default" chunk before other cases, the order is different
  * between node's and running's.
- * @param {CodePathSegment[]} prevSegments - Forward segments to disconnect.
- * @param {CodePathSegment[]} nextSegments - Backward segments to disconnect.
+ * @param {CodePathSegment[]} prevSegments Forward segments to disconnect.
+ * @param {CodePathSegment[]} nextSegments Backward segments to disconnect.
  * @returns {void}
  */
 function removeConnection(prevSegments, nextSegments) {
@@ -155,9 +155,9 @@ function removeConnection(prevSegments, nextSegments) {
 
 /**
  * Creates looping path.
- * @param {CodePathState} state - The instance.
- * @param {CodePathSegment[]} unflattenedFromSegments - Segments which are source.
- * @param {CodePathSegment[]} unflattenedToSegments - Segments which are destination.
+ * @param {CodePathState} state The instance.
+ * @param {CodePathSegment[]} unflattenedFromSegments Segments which are source.
+ * @param {CodePathSegment[]} unflattenedToSegments Segments which are destination.
  * @returns {void}
  */
 function makeLooped(state, unflattenedFromSegments, unflattenedToSegments) {
@@ -192,9 +192,9 @@ function makeLooped(state, unflattenedFromSegments, unflattenedToSegments) {
  *
  * - Adds `false` paths to paths which are leaving from the loop.
  * - Sets `true` paths to paths which go to the body.
- * @param {LoopContext} context - A loop context to modify.
- * @param {ChoiceContext} choiceContext - A choice context of this loop.
- * @param {CodePathSegment[]} head - The current head paths.
+ * @param {LoopContext} context A loop context to modify.
+ * @param {ChoiceContext} choiceContext A choice context of this loop.
+ * @param {CodePathSegment[]} head The current head paths.
  * @returns {void}
  */
 function finalizeTestSegmentsOfFor(context, choiceContext, head) {
@@ -219,9 +219,9 @@ function finalizeTestSegmentsOfFor(context, choiceContext, head) {
 class CodePathState {
 
     /**
-     * @param {IdGenerator} idGenerator - An id generator to generate id for code
+     * @param {IdGenerator} idGenerator An id generator to generate id for code
      *   path segments.
-     * @param {Function} onLooped - A callback function to notify looping.
+     * @param {Function} onLooped A callback function to notify looping.
      */
     constructor(idGenerator, onLooped) {
         this.idGenerator = idGenerator;
@@ -266,7 +266,7 @@ class CodePathState {
 
     /**
      * Creates and stacks new forking context.
-     * @param {boolean} forkLeavingPath - A flag which shows being in a
+     * @param {boolean} forkLeavingPath A flag which shows being in a
      *   "finally" block.
      * @returns {ForkContext} The created context.
      */
@@ -335,11 +335,11 @@ class CodePathState {
      *     a -> foo();
      *     a -> b -> foo();
      *     a -> b -> bar();
-     * @param {string} kind - A kind string.
+     * @param {string} kind A kind string.
      *   If the new context is LogicalExpression's, this is `"&&"` or `"||"`.
      *   If it's IfStatement's or ConditionalExpression's, this is `"test"`.
      *   Otherwise, this is `"loop"`.
-     * @param {boolean} isForkingAsResult - A flag that shows that goes different
+     * @param {boolean} isForkingAsResult A flag that shows that goes different
      *   paths between `true` and `false`.
      * @returns {void}
      */
@@ -538,9 +538,9 @@ class CodePathState {
 
     /**
      * Creates a context object of SwitchStatement and stacks it.
-     * @param {boolean} hasCase - `true` if the switch statement has one or more
+     * @param {boolean} hasCase `true` if the switch statement has one or more
      *   case parts.
-     * @param {string|null} label - The label text.
+     * @param {string|null} label The label text.
      * @returns {void}
      */
     pushSwitchContext(hasCase, label) {
@@ -637,8 +637,8 @@ class CodePathState {
 
     /**
      * Makes a code path segment for a `SwitchCase` node.
-     * @param {boolean} isEmpty - `true` if the body is empty.
-     * @param {boolean} isDefault - `true` if the body is the default case.
+     * @param {boolean} isEmpty `true` if the body is empty.
+     * @param {boolean} isDefault `true` if the body is the default case.
      * @returns {void}
      */
     makeSwitchCaseBody(isEmpty, isDefault) {
@@ -687,7 +687,7 @@ class CodePathState {
 
     /**
      * Creates a context object of TryStatement and stacks it.
-     * @param {boolean} hasFinalizer - `true` if the try statement has a
+     * @param {boolean} hasFinalizer `true` if the try statement has a
      *   `finally` block.
      * @returns {void}
      */
@@ -879,10 +879,10 @@ class CodePathState {
 
     /**
      * Creates a context object of a loop statement and stacks it.
-     * @param {string} type - The type of the node which was triggered. One of
+     * @param {string} type The type of the node which was triggered. One of
      *   `WhileStatement`, `DoWhileStatement`, `ForStatement`, `ForInStatement`,
      *   and `ForStatement`.
-     * @param {string|null} label - A label of the node which was triggered.
+     * @param {string|null} label A label of the node which was triggered.
      * @returns {void}
      */
     pushLoopContext(type, label) {
@@ -1025,7 +1025,7 @@ class CodePathState {
 
     /**
      * Makes a code path segment for the test part of a WhileStatement.
-     * @param {boolean|undefined} test - The test value (only when constant).
+     * @param {boolean|undefined} test The test value (only when constant).
      * @returns {void}
      */
     makeWhileTest(test) {
@@ -1076,7 +1076,7 @@ class CodePathState {
 
     /**
      * Makes a code path segment for the test part of a DoWhileStatement.
-     * @param {boolean|undefined} test - The test value (only when constant).
+     * @param {boolean|undefined} test The test value (only when constant).
      * @returns {void}
      */
     makeDoWhileTest(test) {
@@ -1096,7 +1096,7 @@ class CodePathState {
 
     /**
      * Makes a code path segment for the test part of a ForStatement.
-     * @param {boolean|undefined} test - The test value (only when constant).
+     * @param {boolean|undefined} test The test value (only when constant).
      * @returns {void}
      */
     makeForTest(test) {
@@ -1252,9 +1252,9 @@ class CodePathState {
 
     /**
      * Creates new context for BreakStatement.
-     * @param {boolean} breakable - The flag to indicate it can break by
+     * @param {boolean} breakable The flag to indicate it can break by
      *      an unlabeled BreakStatement.
-     * @param {string|null} label - The label of this context.
+     * @param {string|null} label The label of this context.
      * @returns {Object} The new context.
      */
     pushBreakContext(breakable, label) {
@@ -1295,7 +1295,7 @@ class CodePathState {
      *
      * It registers the head segment to a context of `break`.
      * It makes new unreachable segment, then it set the head with the segment.
-     * @param {string} label - A label of the break statement.
+     * @param {string} label A label of the break statement.
      * @returns {void}
      */
     makeBreak(label) {
@@ -1320,7 +1320,7 @@ class CodePathState {
      *
      * It makes a looping path.
      * It makes new unreachable segment, then it set the head with the segment.
-     * @param {string} label - A label of the continue statement.
+     * @param {string} label A label of the continue statement.
      * @returns {void}
      */
     makeContinue(label) {

--- a/lib/linter/code-path-analysis/code-path-state.js
+++ b/lib/linter/code-path-analysis/code-path-state.js
@@ -22,7 +22,6 @@ const CodePathSegment = require("./code-path-segment"),
  * array as well.
  *
  * This adds only reachable and used segments.
- *
  * @param {CodePathSegment[]} dest - A destination array (`returnedSegments` or `thrownSegments`).
  * @param {CodePathSegment[]} others - Another destination array (`returnedSegments` or `thrownSegments`).
  * @param {CodePathSegment[]} all - The unified destination array (`finalSegments`).
@@ -42,7 +41,6 @@ function addToReturnedOrThrown(dest, others, all, segments) {
 
 /**
  * Gets a loop-context for a `continue` statement.
- *
  * @param {CodePathState} state - A state to get.
  * @param {string} label - The label of a `continue` statement.
  * @returns {LoopContext} A loop-context for a `continue` statement.
@@ -67,7 +65,6 @@ function getContinueContext(state, label) {
 
 /**
  * Gets a context for a `break` statement.
- *
  * @param {CodePathState} state - A state to get.
  * @param {string} label - The label of a `break` statement.
  * @returns {LoopContext|SwitchContext} A context for a `break` statement.
@@ -88,7 +85,6 @@ function getBreakContext(state, label) {
 
 /**
  * Gets a context for a `return` statement.
- *
  * @param {CodePathState} state - A state to get.
  * @returns {TryContext|CodePathState} A context for a `return` statement.
  */
@@ -107,7 +103,6 @@ function getReturnContext(state) {
 
 /**
  * Gets a context for a `throw` statement.
- *
  * @param {CodePathState} state - A state to get.
  * @returns {TryContext|CodePathState} A context for a `throw` statement.
  */
@@ -128,7 +123,6 @@ function getThrowContext(state) {
 
 /**
  * Removes a given element from a given array.
- *
  * @param {any[]} xs - An array to remove the specific element.
  * @param {any} x - An element to be removed.
  * @returns {void}
@@ -143,7 +137,6 @@ function remove(xs, x) {
  * This is used in a process for switch statements.
  * If there is the "default" chunk before other cases, the order is different
  * between node's and running's.
- *
  * @param {CodePathSegment[]} prevSegments - Forward segments to disconnect.
  * @param {CodePathSegment[]} nextSegments - Backward segments to disconnect.
  * @returns {void}
@@ -162,7 +155,6 @@ function removeConnection(prevSegments, nextSegments) {
 
 /**
  * Creates looping path.
- *
  * @param {CodePathState} state - The instance.
  * @param {CodePathSegment[]} unflattenedFromSegments - Segments which are source.
  * @param {CodePathSegment[]} unflattenedToSegments - Segments which are destination.
@@ -200,7 +192,6 @@ function makeLooped(state, unflattenedFromSegments, unflattenedToSegments) {
  *
  * - Adds `false` paths to paths which are leaving from the loop.
  * - Sets `true` paths to paths which go to the body.
- *
  * @param {LoopContext} context - A loop context to modify.
  * @param {ChoiceContext} choiceContext - A choice context of this loop.
  * @param {CodePathSegment[]} head - The current head paths.
@@ -275,7 +266,6 @@ class CodePathState {
 
     /**
      * Creates and stacks new forking context.
-     *
      * @param {boolean} forkLeavingPath - A flag which shows being in a
      *   "finally" block.
      * @returns {ForkContext} The created context.
@@ -313,7 +303,6 @@ class CodePathState {
     /**
      * Creates a bypass path.
      * This is used for such as IfStatement which does not have "else" chunk.
-     *
      * @returns {void}
      */
     forkBypassPath() {
@@ -346,7 +335,6 @@ class CodePathState {
      *     a -> foo();
      *     a -> b -> foo();
      *     a -> b -> bar();
-     *
      * @param {string} kind - A kind string.
      *   If the new context is LogicalExpression's, this is `"&&"` or `"||"`.
      *   If it's IfStatement's or ConditionalExpression's, this is `"test"`.
@@ -368,7 +356,6 @@ class CodePathState {
 
     /**
      * Pops the last choice context and finalizes it.
-     *
      * @returns {ChoiceContext} The popped context.
      */
     popChoiceContext() {
@@ -456,7 +443,6 @@ class CodePathState {
     /**
      * Makes a code path segment of the right-hand operand of a logical
      * expression.
-     *
      * @returns {void}
      */
     makeLogicalRight() {
@@ -500,7 +486,6 @@ class CodePathState {
 
     /**
      * Makes a code path segment of the `if` block.
-     *
      * @returns {void}
      */
     makeIfConsequent() {
@@ -527,7 +512,6 @@ class CodePathState {
 
     /**
      * Makes a code path segment of the `else` block.
-     *
      * @returns {void}
      */
     makeIfAlternate() {
@@ -554,7 +538,6 @@ class CodePathState {
 
     /**
      * Creates a context object of SwitchStatement and stacks it.
-     *
      * @param {boolean} hasCase - `true` if the switch statement has one or more
      *   case parts.
      * @param {string|null} label - The label text.
@@ -581,7 +564,6 @@ class CodePathState {
      * - Creates the next code path segment from `context.brokenForkContext`.
      * - If the last `SwitchCase` node is not a `default` part, creates a path
      *   to the `default` body.
-     *
      * @returns {void}
      */
     popSwitchContext() {
@@ -655,7 +637,6 @@ class CodePathState {
 
     /**
      * Makes a code path segment for a `SwitchCase` node.
-     *
      * @param {boolean} isEmpty - `true` if the body is empty.
      * @param {boolean} isDefault - `true` if the body is the default case.
      * @returns {void}
@@ -706,7 +687,6 @@ class CodePathState {
 
     /**
      * Creates a context object of TryStatement and stacks it.
-     *
      * @param {boolean} hasFinalizer - `true` if the try statement has a
      *   `finally` block.
      * @returns {void}
@@ -729,7 +709,6 @@ class CodePathState {
 
     /**
      * Pops the last context of TryStatement and finalizes it.
-     *
      * @returns {void}
      */
     popTryContext() {
@@ -785,7 +764,6 @@ class CodePathState {
 
     /**
      * Makes a code path segment for a `catch` block.
-     *
      * @returns {void}
      */
     makeCatchBlock() {
@@ -814,7 +792,6 @@ class CodePathState {
      * In the `finally` block, parallel paths are created. The parallel paths
      * are used as leaving-paths. The leaving-paths are paths from `return`
      * statements and `throw` statements in a `try` block or a `catch` block.
-     *
      * @returns {void}
      */
     makeFinallyBlock() {
@@ -874,7 +851,6 @@ class CodePathState {
     /**
      * Makes a code path segment from the first throwable node to the `catch`
      * block or the `finally` block.
-     *
      * @returns {void}
      */
     makeFirstThrowablePathInTryBlock() {
@@ -903,7 +879,6 @@ class CodePathState {
 
     /**
      * Creates a context object of a loop statement and stacks it.
-     *
      * @param {string} type - The type of the node which was triggered. One of
      *   `WhileStatement`, `DoWhileStatement`, `ForStatement`, `ForInStatement`,
      *   and `ForStatement`.
@@ -979,7 +954,6 @@ class CodePathState {
 
     /**
      * Pops the last context of a loop statement and finalizes it.
-     *
      * @returns {void}
      */
     popLoopContext() {
@@ -1051,7 +1025,6 @@ class CodePathState {
 
     /**
      * Makes a code path segment for the test part of a WhileStatement.
-     *
      * @param {boolean|undefined} test - The test value (only when constant).
      * @returns {void}
      */
@@ -1068,7 +1041,6 @@ class CodePathState {
 
     /**
      * Makes a code path segment for the body part of a WhileStatement.
-     *
      * @returns {void}
      */
     makeWhileBody() {
@@ -1090,7 +1062,6 @@ class CodePathState {
 
     /**
      * Makes a code path segment for the body part of a DoWhileStatement.
-     *
      * @returns {void}
      */
     makeDoWhileBody() {
@@ -1105,7 +1076,6 @@ class CodePathState {
 
     /**
      * Makes a code path segment for the test part of a DoWhileStatement.
-     *
      * @param {boolean|undefined} test - The test value (only when constant).
      * @returns {void}
      */
@@ -1126,7 +1096,6 @@ class CodePathState {
 
     /**
      * Makes a code path segment for the test part of a ForStatement.
-     *
      * @param {boolean|undefined} test - The test value (only when constant).
      * @returns {void}
      */
@@ -1145,7 +1114,6 @@ class CodePathState {
 
     /**
      * Makes a code path segment for the update part of a ForStatement.
-     *
      * @returns {void}
      */
     makeForUpdate() {
@@ -1173,7 +1141,6 @@ class CodePathState {
 
     /**
      * Makes a code path segment for the body part of a ForStatement.
-     *
      * @returns {void}
      */
     makeForBody() {
@@ -1227,7 +1194,6 @@ class CodePathState {
     /**
      * Makes a code path segment for the left part of a ForInStatement and a
      * ForOfStatement.
-     *
      * @returns {void}
      */
     makeForInOfLeft() {
@@ -1244,7 +1210,6 @@ class CodePathState {
     /**
      * Makes a code path segment for the right part of a ForInStatement and a
      * ForOfStatement.
-     *
      * @returns {void}
      */
     makeForInOfRight() {
@@ -1263,7 +1228,6 @@ class CodePathState {
     /**
      * Makes a code path segment for the body part of a ForInStatement and a
      * ForOfStatement.
-     *
      * @returns {void}
      */
     makeForInOfBody() {
@@ -1288,7 +1252,6 @@ class CodePathState {
 
     /**
      * Creates new context for BreakStatement.
-     *
      * @param {boolean} breakable - The flag to indicate it can break by
      *      an unlabeled BreakStatement.
      * @param {string|null} label - The label of this context.
@@ -1306,7 +1269,6 @@ class CodePathState {
 
     /**
      * Removes the top item of the break context stack.
-     *
      * @returns {Object} The removed context.
      */
     popBreakContext() {
@@ -1333,7 +1295,6 @@ class CodePathState {
      *
      * It registers the head segment to a context of `break`.
      * It makes new unreachable segment, then it set the head with the segment.
-     *
      * @param {string} label - A label of the break statement.
      * @returns {void}
      */
@@ -1359,7 +1320,6 @@ class CodePathState {
      *
      * It makes a looping path.
      * It makes new unreachable segment, then it set the head with the segment.
-     *
      * @param {string} label - A label of the continue statement.
      * @returns {void}
      */
@@ -1395,7 +1355,6 @@ class CodePathState {
      *
      * It registers the head segment to a context of `return`.
      * It makes new unreachable segment, then it set the head with the segment.
-     *
      * @returns {void}
      */
     makeReturn() {
@@ -1412,7 +1371,6 @@ class CodePathState {
      *
      * It registers the head segment to a context of `throw`.
      * It makes new unreachable segment, then it set the head with the segment.
-     *
      * @returns {void}
      */
     makeThrow() {

--- a/lib/linter/code-path-analysis/code-path.js
+++ b/lib/linter/code-path-analysis/code-path.js
@@ -22,9 +22,9 @@ const IdGenerator = require("./id-generator");
 class CodePath {
 
     /**
-     * @param {string} id - An identifier.
-     * @param {CodePath|null} upper - The code path of the upper function scope.
-     * @param {Function} onLooped - A callback function to notify looping.
+     * @param {string} id An identifier.
+     * @param {CodePath|null} upper The code path of the upper function scope.
+     * @param {Function} onLooped A callback function to notify looping.
      */
     constructor(id, upper, onLooped) {
 
@@ -62,7 +62,7 @@ class CodePath {
 
     /**
      * Gets the state of a given code path.
-     * @param {CodePath} codePath - A code path to get.
+     * @param {CodePath} codePath A code path to get.
      * @returns {CodePathState} The state of the code path.
      */
     static getState(codePath) {
@@ -125,10 +125,10 @@ class CodePath {
      *
      * - `controller.skip()` - Skip the following segments in this branch.
      * - `controller.break()` - Skip all following segments.
-     * @param {Object} [options] - Omittable.
-     * @param {CodePathSegment} [options.first] - The first segment to traverse.
-     * @param {CodePathSegment} [options.last] - The last segment to traverse.
-     * @param {Function} callback - A callback function.
+     * @param {Object} [options] Omittable.
+     * @param {CodePathSegment} [options.first] The first segment to traverse.
+     * @param {CodePathSegment} [options.last] The last segment to traverse.
+     * @param {Function} callback A callback function.
      * @returns {void}
      */
     traverseSegments(options, callback) {
@@ -169,7 +169,7 @@ class CodePath {
 
         /**
          * Checks a given previous segment has been visited.
-         * @param {CodePathSegment} prevSegment - A previous segment to check.
+         * @param {CodePathSegment} prevSegment A previous segment to check.
          * @returns {boolean} `true` if the segment has been visited.
          */
         function isVisited(prevSegment) {

--- a/lib/linter/code-path-analysis/code-path.js
+++ b/lib/linter/code-path-analysis/code-path.js
@@ -62,7 +62,6 @@ class CodePath {
 
     /**
      * Gets the state of a given code path.
-     *
      * @param {CodePath} codePath - A code path to get.
      * @returns {CodePathState} The state of the code path.
      */
@@ -126,7 +125,6 @@ class CodePath {
      *
      * - `controller.skip()` - Skip the following segments in this branch.
      * - `controller.break()` - Skip all following segments.
-     *
      * @param {Object} [options] - Omittable.
      * @param {CodePathSegment} [options.first] - The first segment to traverse.
      * @param {CodePathSegment} [options.last] - The last segment to traverse.

--- a/lib/linter/code-path-analysis/debug-helpers.js
+++ b/lib/linter/code-path-analysis/debug-helpers.js
@@ -39,7 +39,6 @@ module.exports = {
 
     /**
      * Dumps given objects.
-     *
      * @param {...any} args - objects to dump.
      * @returns {void}
      */
@@ -47,7 +46,6 @@ module.exports = {
 
     /**
      * Dumps the current analyzing state.
-     *
      * @param {ASTNode} node - A node to dump.
      * @param {CodePathState} state - A state to dump.
      * @param {boolean} leaving - A flag whether or not it's leaving
@@ -73,7 +71,6 @@ module.exports = {
     /**
      * Dumps a DOT code of a given code path.
      * The DOT code can be visialized with Graphvis.
-     *
      * @param {CodePath} codePath - A code path to dump.
      * @returns {void}
      * @see http://www.graphviz.org
@@ -139,7 +136,6 @@ module.exports = {
     /**
      * Makes a DOT code of a given code path.
      * The DOT code can be visialized with Graphvis.
-     *
      * @param {CodePath} codePath - A code path to make DOT.
      * @param {Object} traceMap - Optional. A map to check whether or not segments had been done.
      * @returns {string} A DOT code of the code path.

--- a/lib/linter/code-path-analysis/debug-helpers.js
+++ b/lib/linter/code-path-analysis/debug-helpers.js
@@ -17,7 +17,7 @@ const debug = require("debug")("eslint:code-path");
 
 /**
  * Gets id of a given segment.
- * @param {CodePathSegment} segment - A segment to get.
+ * @param {CodePathSegment} segment A segment to get.
  * @returns {string} Id of the segment.
  */
 /* istanbul ignore next */
@@ -39,16 +39,16 @@ module.exports = {
 
     /**
      * Dumps given objects.
-     * @param {...any} args - objects to dump.
+     * @param {...any} args objects to dump.
      * @returns {void}
      */
     dump: debug,
 
     /**
      * Dumps the current analyzing state.
-     * @param {ASTNode} node - A node to dump.
-     * @param {CodePathState} state - A state to dump.
-     * @param {boolean} leaving - A flag whether or not it's leaving
+     * @param {ASTNode} node A node to dump.
+     * @param {CodePathState} state A state to dump.
+     * @param {boolean} leaving A flag whether or not it's leaving
      * @returns {void}
      */
     dumpState: !debug.enabled ? debug : /* istanbul ignore next */ function(node, state, leaving) {
@@ -71,7 +71,7 @@ module.exports = {
     /**
      * Dumps a DOT code of a given code path.
      * The DOT code can be visialized with Graphvis.
-     * @param {CodePath} codePath - A code path to dump.
+     * @param {CodePath} codePath A code path to dump.
      * @returns {void}
      * @see http://www.graphviz.org
      * @see http://www.webgraphviz.com
@@ -136,8 +136,8 @@ module.exports = {
     /**
      * Makes a DOT code of a given code path.
      * The DOT code can be visialized with Graphvis.
-     * @param {CodePath} codePath - A code path to make DOT.
-     * @param {Object} traceMap - Optional. A map to check whether or not segments had been done.
+     * @param {CodePath} codePath A code path to make DOT.
+     * @param {Object} traceMap Optional. A map to check whether or not segments had been done.
      * @returns {string} A DOT code of the code path.
      */
     makeDotArrows(codePath, traceMap) {

--- a/lib/linter/code-path-analysis/fork-context.js
+++ b/lib/linter/code-path-analysis/fork-context.js
@@ -22,7 +22,6 @@ const assert = require("assert"),
 
 /**
  * Gets whether or not a given segment is reachable.
- *
  * @param {CodePathSegment} segment - A segment to get.
  * @returns {boolean} `true` if the segment is reachable.
  */
@@ -36,7 +35,6 @@ function isReachable(segment) {
  * When `context.segmentsList` is `[[a, b], [c, d], [e, f]]`, `begin` is `0`, and
  * `end` is `-1`, this creates `[g, h]`. This `g` is from `a`, `c`, and `e`.
  * This `h` is from `b`, `d`, and `f`.
- *
  * @param {ForkContext} context - An instance.
  * @param {number} begin - The first index of the previous segments.
  * @param {number} end - The last index of the previous segments.
@@ -69,7 +67,6 @@ function makeSegments(context, begin, end, create) {
  * control statement (such as `break`, `continue`) from the `finally` block, the
  * destination's segments may be half of the source segments. In that case, this
  * merges segments.
- *
  * @param {ForkContext} context - An instance.
  * @param {CodePathSegment[]} segments - Segments to merge.
  * @returns {CodePathSegment[]} The merged segments.
@@ -142,7 +139,6 @@ class ForkContext {
 
     /**
      * Creates new segments from this context.
-     *
      * @param {number} begin - The first index of previous segments.
      * @param {number} end - The last index of previous segments.
      * @returns {CodePathSegment[]} New segments.
@@ -154,7 +150,6 @@ class ForkContext {
     /**
      * Creates new segments from this context.
      * The new segments is always unreachable.
-     *
      * @param {number} begin - The first index of previous segments.
      * @param {number} end - The last index of previous segments.
      * @returns {CodePathSegment[]} New segments.
@@ -167,7 +162,6 @@ class ForkContext {
      * Creates new segments from this context.
      * The new segments don't have connections for previous segments.
      * But these inherit the reachable flag from this context.
-     *
      * @param {number} begin - The first index of previous segments.
      * @param {number} end - The last index of previous segments.
      * @returns {CodePathSegment[]} New segments.
@@ -179,7 +173,6 @@ class ForkContext {
     /**
      * Adds segments into this context.
      * The added segments become the head.
-     *
      * @param {CodePathSegment[]} segments - Segments to add.
      * @returns {void}
      */
@@ -192,7 +185,6 @@ class ForkContext {
     /**
      * Replaces the head segments with given segments.
      * The current head segments are removed.
-     *
      * @param {CodePathSegment[]} segments - Segments to add.
      * @returns {void}
      */
@@ -204,7 +196,6 @@ class ForkContext {
 
     /**
      * Adds all segments of a given fork context into this context.
-     *
      * @param {ForkContext} context - A fork context to add.
      * @returns {void}
      */
@@ -220,7 +211,6 @@ class ForkContext {
 
     /**
      * Clears all secments in this context.
-     *
      * @returns {void}
      */
     clear() {
@@ -229,7 +219,6 @@ class ForkContext {
 
     /**
      * Creates the root fork context.
-     *
      * @param {IdGenerator} idGenerator - An identifier generator for segments.
      * @returns {ForkContext} New fork context.
      */
@@ -243,7 +232,6 @@ class ForkContext {
 
     /**
      * Creates an empty fork context preceded by a given context.
-     *
      * @param {ForkContext} parentContext - The parent fork context.
      * @param {boolean} forkLeavingPath - A flag which shows inside of `finally` block.
      * @returns {ForkContext} New fork context.

--- a/lib/linter/code-path-analysis/fork-context.js
+++ b/lib/linter/code-path-analysis/fork-context.js
@@ -22,7 +22,7 @@ const assert = require("assert"),
 
 /**
  * Gets whether or not a given segment is reachable.
- * @param {CodePathSegment} segment - A segment to get.
+ * @param {CodePathSegment} segment A segment to get.
  * @returns {boolean} `true` if the segment is reachable.
  */
 function isReachable(segment) {
@@ -35,10 +35,10 @@ function isReachable(segment) {
  * When `context.segmentsList` is `[[a, b], [c, d], [e, f]]`, `begin` is `0`, and
  * `end` is `-1`, this creates `[g, h]`. This `g` is from `a`, `c`, and `e`.
  * This `h` is from `b`, `d`, and `f`.
- * @param {ForkContext} context - An instance.
- * @param {number} begin - The first index of the previous segments.
- * @param {number} end - The last index of the previous segments.
- * @param {Function} create - A factory function of new segments.
+ * @param {ForkContext} context An instance.
+ * @param {number} begin The first index of the previous segments.
+ * @param {number} end The last index of the previous segments.
+ * @param {Function} create A factory function of new segments.
  * @returns {CodePathSegment[]} New segments.
  */
 function makeSegments(context, begin, end, create) {
@@ -67,8 +67,8 @@ function makeSegments(context, begin, end, create) {
  * control statement (such as `break`, `continue`) from the `finally` block, the
  * destination's segments may be half of the source segments. In that case, this
  * merges segments.
- * @param {ForkContext} context - An instance.
- * @param {CodePathSegment[]} segments - Segments to merge.
+ * @param {ForkContext} context An instance.
+ * @param {CodePathSegment[]} segments Segments to merge.
  * @returns {CodePathSegment[]} The merged segments.
  */
 function mergeExtraSegments(context, segments) {
@@ -98,9 +98,9 @@ function mergeExtraSegments(context, segments) {
 class ForkContext {
 
     /**
-     * @param {IdGenerator} idGenerator - An identifier generator for segments.
-     * @param {ForkContext|null} upper - An upper fork context.
-     * @param {number} count - A number of parallel segments.
+     * @param {IdGenerator} idGenerator An identifier generator for segments.
+     * @param {ForkContext|null} upper An upper fork context.
+     * @param {number} count A number of parallel segments.
      */
     constructor(idGenerator, upper, count) {
         this.idGenerator = idGenerator;
@@ -139,8 +139,8 @@ class ForkContext {
 
     /**
      * Creates new segments from this context.
-     * @param {number} begin - The first index of previous segments.
-     * @param {number} end - The last index of previous segments.
+     * @param {number} begin The first index of previous segments.
+     * @param {number} end The last index of previous segments.
      * @returns {CodePathSegment[]} New segments.
      */
     makeNext(begin, end) {
@@ -150,8 +150,8 @@ class ForkContext {
     /**
      * Creates new segments from this context.
      * The new segments is always unreachable.
-     * @param {number} begin - The first index of previous segments.
-     * @param {number} end - The last index of previous segments.
+     * @param {number} begin The first index of previous segments.
+     * @param {number} end The last index of previous segments.
      * @returns {CodePathSegment[]} New segments.
      */
     makeUnreachable(begin, end) {
@@ -162,8 +162,8 @@ class ForkContext {
      * Creates new segments from this context.
      * The new segments don't have connections for previous segments.
      * But these inherit the reachable flag from this context.
-     * @param {number} begin - The first index of previous segments.
-     * @param {number} end - The last index of previous segments.
+     * @param {number} begin The first index of previous segments.
+     * @param {number} end The last index of previous segments.
      * @returns {CodePathSegment[]} New segments.
      */
     makeDisconnected(begin, end) {
@@ -173,7 +173,7 @@ class ForkContext {
     /**
      * Adds segments into this context.
      * The added segments become the head.
-     * @param {CodePathSegment[]} segments - Segments to add.
+     * @param {CodePathSegment[]} segments Segments to add.
      * @returns {void}
      */
     add(segments) {
@@ -185,7 +185,7 @@ class ForkContext {
     /**
      * Replaces the head segments with given segments.
      * The current head segments are removed.
-     * @param {CodePathSegment[]} segments - Segments to add.
+     * @param {CodePathSegment[]} segments Segments to add.
      * @returns {void}
      */
     replaceHead(segments) {
@@ -196,7 +196,7 @@ class ForkContext {
 
     /**
      * Adds all segments of a given fork context into this context.
-     * @param {ForkContext} context - A fork context to add.
+     * @param {ForkContext} context A fork context to add.
      * @returns {void}
      */
     addAll(context) {
@@ -219,7 +219,7 @@ class ForkContext {
 
     /**
      * Creates the root fork context.
-     * @param {IdGenerator} idGenerator - An identifier generator for segments.
+     * @param {IdGenerator} idGenerator An identifier generator for segments.
      * @returns {ForkContext} New fork context.
      */
     static newRoot(idGenerator) {
@@ -232,8 +232,8 @@ class ForkContext {
 
     /**
      * Creates an empty fork context preceded by a given context.
-     * @param {ForkContext} parentContext - The parent fork context.
-     * @param {boolean} forkLeavingPath - A flag which shows inside of `finally` block.
+     * @param {ForkContext} parentContext The parent fork context.
+     * @param {boolean} forkLeavingPath A flag which shows inside of `finally` block.
      * @returns {ForkContext} New fork context.
      */
     static newEmpty(parentContext, forkLeavingPath) {

--- a/lib/linter/code-path-analysis/id-generator.js
+++ b/lib/linter/code-path-analysis/id-generator.js
@@ -28,7 +28,6 @@ class IdGenerator {
 
     /**
      * Generates id.
-     *
      * @returns {string} A generated id.
      */
     next() {

--- a/lib/linter/code-path-analysis/id-generator.js
+++ b/lib/linter/code-path-analysis/id-generator.js
@@ -19,7 +19,7 @@
 class IdGenerator {
 
     /**
-     * @param {string} prefix - Optional. A prefix of generated ids.
+     * @param {string} prefix Optional. A prefix of generated ids.
      */
     constructor(prefix) {
         this.prefix = String(prefix);

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -555,7 +555,6 @@ function resolveGlobals(providedGlobals, enabledEnvironments) {
 
 /**
  * Strips Unicode BOM from a given text.
- *
  * @param {string} text - A text to strip.
  * @returns {string} The stripped text.
  */

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -438,7 +438,7 @@ const eslintEnvPattern = /\/\*\s*eslint-env\s(.+?)\*\//gu;
 
 /**
  * Checks whether or not there is a comment which has "eslint-env *" in a given text.
- * @param {string} text - A source code text to check.
+ * @param {string} text A source code text to check.
  * @returns {Object|null} A result of parseListConfig() with "eslint-env *" comment.
  */
 function findEslintEnv(text) {
@@ -555,7 +555,7 @@ function resolveGlobals(providedGlobals, enabledEnvironments) {
 
 /**
  * Strips Unicode BOM from a given text.
- * @param {string} text - A text to strip.
+ * @param {string} text A text to strip.
  * @returns {string} The stripped text.
  */
 function stripUnicodeBOM(text) {

--- a/lib/linter/node-event-generator.js
+++ b/lib/linter/node-event-generator.js
@@ -286,7 +286,7 @@ class NodeEventGenerator {
 
     /**
      * Emits an event of entering AST node.
-     * @param {ASTNode} node - A node which was entered.
+     * @param {ASTNode} node A node which was entered.
      * @returns {void}
      */
     enterNode(node) {
@@ -298,7 +298,7 @@ class NodeEventGenerator {
 
     /**
      * Emits an event of leaving AST node.
-     * @param {ASTNode} node - A node which was left.
+     * @param {ASTNode} node A node which was left.
      * @returns {void}
      */
     leaveNode(node) {

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -78,7 +78,6 @@ const hasOwnProperty = Function.call.bind(Object.hasOwnProperty);
 /**
  * Clones a given value deeply.
  * Note: This ignores `parent` property.
- *
  * @param {any} x - A value to clone.
  * @returns {any} A cloned value.
  */
@@ -104,7 +103,6 @@ function cloneDeeplyExcludesParent(x) {
 
 /**
  * Freezes a given value deeply.
- *
  * @param {any} x - A value to freeze.
  * @returns {void}
  */

--- a/lib/rule-tester/rule-tester.js
+++ b/lib/rule-tester/rule-tester.js
@@ -78,7 +78,7 @@ const hasOwnProperty = Function.call.bind(Object.hasOwnProperty);
 /**
  * Clones a given value deeply.
  * Note: This ignores `parent` property.
- * @param {any} x - A value to clone.
+ * @param {any} x A value to clone.
  * @returns {any} A cloned value.
  */
 function cloneDeeplyExcludesParent(x) {
@@ -103,7 +103,7 @@ function cloneDeeplyExcludesParent(x) {
 
 /**
  * Freezes a given value deeply.
- * @param {any} x - A value to freeze.
+ * @param {any} x A value to freeze.
  * @returns {void}
  */
 function freezeDeeply(x) {
@@ -144,8 +144,8 @@ const IT = Symbol("it");
 /**
  * This is `it` default handler if `it` don't exist.
  * @this {Mocha}
- * @param {string} text - The description of the test case.
- * @param {Function} method - The logic of the test case.
+ * @param {string} text The description of the test case.
+ * @param {Function} method The logic of the test case.
  * @returns {any} Returned value of `method`.
  */
 function itDefaultHandler(text, method) {
@@ -162,8 +162,8 @@ function itDefaultHandler(text, method) {
 /**
  * This is `describe` default handler if `describe` don't exist.
  * @this {Mocha}
- * @param {string} text - The description of the test case.
- * @param {Function} method - The logic of the test case.
+ * @param {string} text The description of the test case.
+ * @param {Function} method The logic of the test case.
  * @returns {any} Returned value of `method`.
  */
 function describeDefaultHandler(text, method) {

--- a/lib/rules/accessor-pairs.js
+++ b/lib/rules/accessor-pairs.js
@@ -79,7 +79,7 @@ function areEqualKeys(left, right) {
 
 /**
  * Checks whether or not a given node is of an accessor kind ('get' or 'set').
- * @param {ASTNode} node - A node to check.
+ * @param {ASTNode} node A node to check.
  * @returns {boolean} `true` if the node is of an accessor kind.
  */
 function isAccessorKind(node) {
@@ -88,8 +88,8 @@ function isAccessorKind(node) {
 
 /**
  * Checks whether or not a given node is an `Identifier` node which was named a given name.
- * @param {ASTNode} node - A node to check.
- * @param {string} name - An expected name of the node.
+ * @param {ASTNode} node A node to check.
+ * @param {string} name An expected name of the node.
  * @returns {boolean} `true` if the node is an `Identifier` node which was named as expected.
  */
 function isIdentifier(node, name) {
@@ -98,10 +98,10 @@ function isIdentifier(node, name) {
 
 /**
  * Checks whether or not a given node is an argument of a specified method call.
- * @param {ASTNode} node - A node to check.
- * @param {number} index - An expected index of the node in arguments.
- * @param {string} object - An expected name of the object of the method.
- * @param {string} property - An expected name of the method.
+ * @param {ASTNode} node A node to check.
+ * @param {number} index An expected index of the node in arguments.
+ * @param {string} object An expected name of the object of the method.
+ * @param {string} property An expected name of the method.
  * @returns {boolean} `true` if the node is an argument of the specified method call.
  */
 function isArgumentOfMethodCall(node, index, object, property) {
@@ -119,7 +119,7 @@ function isArgumentOfMethodCall(node, index, object, property) {
 
 /**
  * Checks whether or not a given node is a property descriptor.
- * @param {ASTNode} node - A node to check.
+ * @param {ASTNode} node A node to check.
  * @returns {boolean} `true` if the node is a property descriptor.
  */
 function isPropertyDescriptor(node) {

--- a/lib/rules/array-bracket-newline.js
+++ b/lib/rules/array-bracket-newline.js
@@ -65,7 +65,7 @@ module.exports = {
 
         /**
          * Normalizes a given option value.
-         * @param {string|Object|undefined} option - An option value to parse.
+         * @param {string|Object|undefined} option An option value to parse.
          * @returns {{multiline: boolean, minItems: number}} Normalized option object.
          */
         function normalizeOptionValue(option) {
@@ -96,7 +96,7 @@ module.exports = {
 
         /**
          * Normalizes a given option value.
-         * @param {string|Object|undefined} options - An option value to parse.
+         * @param {string|Object|undefined} options An option value to parse.
          * @returns {{ArrayExpression: {multiline: boolean, minItems: number}, ArrayPattern: {multiline: boolean, minItems: number}}} Normalized option object.
          */
         function normalizeOptions(options) {
@@ -107,8 +107,8 @@ module.exports = {
 
         /**
          * Reports that there shouldn't be a linebreak after the first token
-         * @param {ASTNode} node - The node to report in the event of an error.
-         * @param {Token} token - The token to use for the report.
+         * @param {ASTNode} node The node to report in the event of an error.
+         * @param {Token} token The token to use for the report.
          * @returns {void}
          */
         function reportNoBeginningLinebreak(node, token) {
@@ -130,8 +130,8 @@ module.exports = {
 
         /**
          * Reports that there shouldn't be a linebreak before the last token
-         * @param {ASTNode} node - The node to report in the event of an error.
-         * @param {Token} token - The token to use for the report.
+         * @param {ASTNode} node The node to report in the event of an error.
+         * @param {Token} token The token to use for the report.
          * @returns {void}
          */
         function reportNoEndingLinebreak(node, token) {
@@ -153,8 +153,8 @@ module.exports = {
 
         /**
          * Reports that there should be a linebreak after the first token
-         * @param {ASTNode} node - The node to report in the event of an error.
-         * @param {Token} token - The token to use for the report.
+         * @param {ASTNode} node The node to report in the event of an error.
+         * @param {Token} token The token to use for the report.
          * @returns {void}
          */
         function reportRequiredBeginningLinebreak(node, token) {
@@ -170,8 +170,8 @@ module.exports = {
 
         /**
          * Reports that there should be a linebreak before the last token
-         * @param {ASTNode} node - The node to report in the event of an error.
-         * @param {Token} token - The token to use for the report.
+         * @param {ASTNode} node The node to report in the event of an error.
+         * @param {Token} token The token to use for the report.
          * @returns {void}
          */
         function reportRequiredEndingLinebreak(node, token) {
@@ -187,7 +187,7 @@ module.exports = {
 
         /**
          * Reports a given node if it violated this rule.
-         * @param {ASTNode} node - A node to check. This is an ArrayExpression node or an ArrayPattern node.
+         * @param {ASTNode} node A node to check. This is an ArrayExpression node or an ArrayPattern node.
          * @returns {void}
          */
         function check(node) {

--- a/lib/rules/array-bracket-newline.js
+++ b/lib/rules/array-bracket-newline.js
@@ -65,7 +65,6 @@ module.exports = {
 
         /**
          * Normalizes a given option value.
-         *
          * @param {string|Object|undefined} option - An option value to parse.
          * @returns {{multiline: boolean, minItems: number}} Normalized option object.
          */
@@ -97,7 +96,6 @@ module.exports = {
 
         /**
          * Normalizes a given option value.
-         *
          * @param {string|Object|undefined} options - An option value to parse.
          * @returns {{ArrayExpression: {multiline: boolean, minItems: number}, ArrayPattern: {multiline: boolean, minItems: number}}} Normalized option object.
          */
@@ -189,7 +187,6 @@ module.exports = {
 
         /**
          * Reports a given node if it violated this rule.
-         *
          * @param {ASTNode} node - A node to check. This is an ArrayExpression node or an ArrayPattern node.
          * @returns {void}
          */

--- a/lib/rules/array-bracket-spacing.js
+++ b/lib/rules/array-bracket-spacing.js
@@ -59,7 +59,7 @@ module.exports = {
          * Determines whether an option is set, relative to the spacing option.
          * If spaced is "always", then check whether option is set to false.
          * If spaced is "never", then check whether option is set to true.
-         * @param {Object} option - The option to exclude.
+         * @param {Object} option The option to exclude.
          * @returns {boolean} Whether or not the property is excluded.
          */
         function isOptionSet(option) {
@@ -79,8 +79,8 @@ module.exports = {
 
         /**
          * Reports that there shouldn't be a space after the first token
-         * @param {ASTNode} node - The node to report in the event of an error.
-         * @param {Token} token - The token to use for the report.
+         * @param {ASTNode} node The node to report in the event of an error.
+         * @param {Token} token The token to use for the report.
          * @returns {void}
          */
         function reportNoBeginningSpace(node, token) {
@@ -101,8 +101,8 @@ module.exports = {
 
         /**
          * Reports that there shouldn't be a space before the last token
-         * @param {ASTNode} node - The node to report in the event of an error.
-         * @param {Token} token - The token to use for the report.
+         * @param {ASTNode} node The node to report in the event of an error.
+         * @param {Token} token The token to use for the report.
          * @returns {void}
          */
         function reportNoEndingSpace(node, token) {
@@ -123,8 +123,8 @@ module.exports = {
 
         /**
          * Reports that there should be a space after the first token
-         * @param {ASTNode} node - The node to report in the event of an error.
-         * @param {Token} token - The token to use for the report.
+         * @param {ASTNode} node The node to report in the event of an error.
+         * @param {Token} token The token to use for the report.
          * @returns {void}
          */
         function reportRequiredBeginningSpace(node, token) {
@@ -143,8 +143,8 @@ module.exports = {
 
         /**
          * Reports that there should be a space before the last token
-         * @param {ASTNode} node - The node to report in the event of an error.
-         * @param {Token} token - The token to use for the report.
+         * @param {ASTNode} node The node to report in the event of an error.
+         * @param {Token} token The token to use for the report.
          * @returns {void}
          */
         function reportRequiredEndingSpace(node, token) {
@@ -163,7 +163,7 @@ module.exports = {
 
         /**
          * Determines if a node is an object type
-         * @param {ASTNode} node - The node to check.
+         * @param {ASTNode} node The node to check.
          * @returns {boolean} Whether or not the node is an object type.
          */
         function isObjectType(node) {
@@ -172,7 +172,7 @@ module.exports = {
 
         /**
          * Determines if a node is an array type
-         * @param {ASTNode} node - The node to check.
+         * @param {ASTNode} node The node to check.
          * @returns {boolean} Whether or not the node is an array type.
          */
         function isArrayType(node) {
@@ -181,7 +181,7 @@ module.exports = {
 
         /**
          * Validates the spacing around array brackets
-         * @param {ASTNode} node - The node we're checking for spacing
+         * @param {ASTNode} node The node we're checking for spacing
          * @returns {void}
          */
         function validateArraySpacing(node) {

--- a/lib/rules/array-callback-return.js
+++ b/lib/rules/array-callback-return.js
@@ -22,7 +22,6 @@ const TARGET_METHODS = /^(?:every|filter|find(?:Index)?|map|reduce(?:Right)?|som
 
 /**
  * Checks a given code path segment is reachable.
- *
  * @param {CodePathSegment} segment - A segment to check.
  * @returns {boolean} `true` if the segment is reachable.
  */
@@ -35,7 +34,6 @@ function isReachable(segment) {
  *
  * - FunctionExpression -> the function name or `function` keyword.
  * - ArrowFunctionExpression -> `=>` token.
- *
  * @param {ASTNode} node - A function node to get.
  * @param {SourceCode} sourceCode - A source code to get tokens.
  * @returns {ASTNode|Token} The node or the token of a location.
@@ -50,7 +48,6 @@ function getLocation(node, sourceCode) {
 /**
  * Checks a given node is a MemberExpression node which has the specified name's
  * property.
- *
  * @param {ASTNode} node - A node to check.
  * @returns {boolean} `true` if the node is a MemberExpression node which has
  *      the specified name's property
@@ -65,7 +62,6 @@ function isTargetMethod(node) {
 /**
  * Checks whether or not a given node is a function expression which is the
  * callback of an array method.
- *
  * @param {ASTNode} node - A node to check. This is one of
  *      FunctionExpression or ArrowFunctionExpression.
  * @returns {boolean} `true` if the node is the callback of an array method.
@@ -188,7 +184,6 @@ module.exports = {
          *
          * If the last code path segment is reachable, there are paths which are not
          * returned or thrown.
-         *
          * @param {ASTNode} node - A node to check.
          * @returns {void}
          */

--- a/lib/rules/array-callback-return.js
+++ b/lib/rules/array-callback-return.js
@@ -22,7 +22,7 @@ const TARGET_METHODS = /^(?:every|filter|find(?:Index)?|map|reduce(?:Right)?|som
 
 /**
  * Checks a given code path segment is reachable.
- * @param {CodePathSegment} segment - A segment to check.
+ * @param {CodePathSegment} segment A segment to check.
  * @returns {boolean} `true` if the segment is reachable.
  */
 function isReachable(segment) {
@@ -34,8 +34,8 @@ function isReachable(segment) {
  *
  * - FunctionExpression -> the function name or `function` keyword.
  * - ArrowFunctionExpression -> `=>` token.
- * @param {ASTNode} node - A function node to get.
- * @param {SourceCode} sourceCode - A source code to get tokens.
+ * @param {ASTNode} node A function node to get.
+ * @param {SourceCode} sourceCode A source code to get tokens.
  * @returns {ASTNode|Token} The node or the token of a location.
  */
 function getLocation(node, sourceCode) {
@@ -48,7 +48,7 @@ function getLocation(node, sourceCode) {
 /**
  * Checks a given node is a MemberExpression node which has the specified name's
  * property.
- * @param {ASTNode} node - A node to check.
+ * @param {ASTNode} node A node to check.
  * @returns {boolean} `true` if the node is a MemberExpression node which has
  *      the specified name's property
  */
@@ -62,7 +62,7 @@ function isTargetMethod(node) {
 /**
  * Checks whether or not a given node is a function expression which is the
  * callback of an array method.
- * @param {ASTNode} node - A node to check. This is one of
+ * @param {ASTNode} node A node to check. This is one of
  *      FunctionExpression or ArrowFunctionExpression.
  * @returns {boolean} `true` if the node is the callback of an array method.
  */
@@ -184,7 +184,7 @@ module.exports = {
          *
          * If the last code path segment is reachable, there are paths which are not
          * returned or thrown.
-         * @param {ASTNode} node - A node to check.
+         * @param {ASTNode} node A node to check.
          * @returns {void}
          */
         function checkLastSegment(node) {

--- a/lib/rules/array-element-newline.js
+++ b/lib/rules/array-element-newline.js
@@ -62,7 +62,7 @@ module.exports = {
 
         /**
          * Normalizes a given option value.
-         * @param {string|Object|undefined} providedOption - An option value to parse.
+         * @param {string|Object|undefined} providedOption An option value to parse.
          * @returns {{multiline: boolean, minItems: number}} Normalized option object.
          */
         function normalizeOptionValue(providedOption) {
@@ -89,7 +89,7 @@ module.exports = {
 
         /**
          * Normalizes a given option value.
-         * @param {string|Object|undefined} options - An option value to parse.
+         * @param {string|Object|undefined} options An option value to parse.
          * @returns {{ArrayExpression: {multiline: boolean, minItems: number}, ArrayPattern: {multiline: boolean, minItems: number}}} Normalized option object.
          */
         function normalizeOptions(options) {
@@ -100,7 +100,7 @@ module.exports = {
 
         /**
          * Reports that there shouldn't be a line break after the first token
-         * @param {Token} token - The token to use for the report.
+         * @param {Token} token The token to use for the report.
          * @returns {void}
          */
         function reportNoLineBreak(token) {
@@ -149,7 +149,7 @@ module.exports = {
 
         /**
          * Reports that there should be a line break after the first token
-         * @param {Token} token - The token to use for the report.
+         * @param {Token} token The token to use for the report.
          * @returns {void}
          */
         function reportRequiredLineBreak(token) {
@@ -169,7 +169,7 @@ module.exports = {
 
         /**
          * Reports a given node if it violated this rule.
-         * @param {ASTNode} node - A node to check. This is an ObjectExpression node or an ObjectPattern node.
+         * @param {ASTNode} node A node to check. This is an ObjectExpression node or an ObjectPattern node.
          * @returns {void}
          */
         function check(node) {

--- a/lib/rules/array-element-newline.js
+++ b/lib/rules/array-element-newline.js
@@ -62,7 +62,6 @@ module.exports = {
 
         /**
          * Normalizes a given option value.
-         *
          * @param {string|Object|undefined} providedOption - An option value to parse.
          * @returns {{multiline: boolean, minItems: number}} Normalized option object.
          */
@@ -90,7 +89,6 @@ module.exports = {
 
         /**
          * Normalizes a given option value.
-         *
          * @param {string|Object|undefined} options - An option value to parse.
          * @returns {{ArrayExpression: {multiline: boolean, minItems: number}, ArrayPattern: {multiline: boolean, minItems: number}}} Normalized option object.
          */
@@ -171,7 +169,6 @@ module.exports = {
 
         /**
          * Reports a given node if it violated this rule.
-         *
          * @param {ASTNode} node - A node to check. This is an ObjectExpression node or an ObjectPattern node.
          * @returns {void}
          */

--- a/lib/rules/arrow-parens.js
+++ b/lib/rules/arrow-parens.js
@@ -16,7 +16,6 @@ const astUtils = require("./utils/ast-utils");
 
 /**
  * Get location should be reported by AST node.
- *
  * @param {ASTNode} node AST Node.
  * @returns {Location} Location information.
  */

--- a/lib/rules/block-scoped-var.js
+++ b/lib/rules/block-scoped-var.js
@@ -31,7 +31,7 @@ module.exports = {
 
         /**
          * Makes a block scope.
-         * @param {ASTNode} node - A node of a scope.
+         * @param {ASTNode} node A node of a scope.
          * @returns {void}
          */
         function enterScope(node) {
@@ -48,7 +48,7 @@ module.exports = {
 
         /**
          * Reports a given reference.
-         * @param {eslint-scope.Reference} reference - A reference to report.
+         * @param {eslint-scope.Reference} reference A reference to report.
          * @returns {void}
          */
         function report(reference) {
@@ -59,7 +59,7 @@ module.exports = {
 
         /**
          * Finds and reports references which are outside of valid scopes.
-         * @param {ASTNode} node - A node to get variables.
+         * @param {ASTNode} node A node to get variables.
          * @returns {void}
          */
         function checkForVariables(node) {

--- a/lib/rules/block-spacing.js
+++ b/lib/rules/block-spacing.js
@@ -41,7 +41,7 @@ module.exports = {
 
         /**
          * Gets the open brace token from a given node.
-         * @param {ASTNode} node - A BlockStatement/SwitchStatement node to get.
+         * @param {ASTNode} node A BlockStatement/SwitchStatement node to get.
          * @returns {Token} The token of the open brace.
          */
         function getOpenBrace(node) {
@@ -58,8 +58,8 @@ module.exports = {
          * Checks whether or not:
          *   - given tokens are on same line.
          *   - there is/isn't a space between given tokens.
-         * @param {Token} left - A token to check.
-         * @param {Token} right - The token which is next to `left`.
+         * @param {Token} left A token to check.
+         * @param {Token} right The token which is next to `left`.
          * @returns {boolean}
          *    When the option is `"always"`, `true` if there are one or more spaces between given tokens.
          *    When the option is `"never"`, `true` if there are not any spaces between given tokens.
@@ -74,7 +74,7 @@ module.exports = {
 
         /**
          * Reports invalid spacing style inside braces.
-         * @param {ASTNode} node - A BlockStatement/SwitchStatement node to get.
+         * @param {ASTNode} node A BlockStatement/SwitchStatement node to get.
          * @returns {void}
          */
         function checkSpacingInsideBraces(node) {

--- a/lib/rules/capitalized-comments.js
+++ b/lib/rules/capitalized-comments.js
@@ -54,7 +54,6 @@ const DEFAULTS = {
  *   set is returned. Options specified in overrides will take priority
  *   over options specified in the main options object, which will in
  *   turn take priority over the rule's defaults.
- *
  * @param {Object|string} rawOptions The user-provided options.
  * @param {string} which Either "line" or "block".
  * @returns {Object} The normalized options.
@@ -65,7 +64,6 @@ function getNormalizedOptions(rawOptions, which) {
 
 /**
  * Get normalized options for block and line comments.
- *
  * @param {Object|string} rawOptions The user-provided options.
  * @returns {Object} An object with "Line" and "Block" keys and corresponding
  * normalized options objects.
@@ -82,7 +80,6 @@ function getAllNormalizedOptions(rawOptions = {}) {
  * options.
  *
  * This is done in order to avoid invoking the RegExp constructor repeatedly.
- *
  * @param {Object} normalizedOptions The normalized rule options.
  * @returns {void}
  */
@@ -162,7 +159,6 @@ module.exports = {
          * Also, it follows from this definition that only block comments can
          * be considered as possibly inline. This is because line comments
          * would consume any following tokens on the same line as the comment.
-         *
          * @param {ASTNode} comment The comment node to check.
          * @returns {boolean} True if the comment is an inline comment, false
          * otherwise.
@@ -181,7 +177,6 @@ module.exports = {
 
         /**
          * Determine if a comment follows another comment.
-         *
          * @param {ASTNode} comment The comment to check.
          * @returns {boolean} True if the comment follows a valid comment.
          */
@@ -196,7 +191,6 @@ module.exports = {
 
         /**
          * Check a comment to determine if it is valid for this rule.
-         *
          * @param {ASTNode} comment The comment node to process.
          * @param {Object} options The options for checking this comment.
          * @returns {boolean} True if the comment is valid, false otherwise.
@@ -261,7 +255,6 @@ module.exports = {
 
         /**
          * Process a comment to determine if it needs to be reported.
-         *
          * @param {ASTNode} comment The comment node to process.
          * @returns {void}
          */

--- a/lib/rules/class-methods-use-this.js
+++ b/lib/rules/class-methods-use-this.js
@@ -61,7 +61,7 @@ module.exports = {
 
         /**
          * Check if the node is an instance method
-         * @param {ASTNode} node - node to check
+         * @param {ASTNode} node node to check
          * @returns {boolean} True if its an instance method
          * @private
          */
@@ -71,7 +71,7 @@ module.exports = {
 
         /**
          * Check if the node is an instance method not excluded by config
-         * @param {ASTNode} node - node to check
+         * @param {ASTNode} node node to check
          * @returns {boolean} True if it is an instance method, and not excluded by config
          * @private
          */
@@ -84,7 +84,7 @@ module.exports = {
          * Checks if we are leaving a function that is a method, and reports if 'this' has not been used.
          * Static methods and the constructor are exempt.
          * Then pops the context off the stack.
-         * @param {ASTNode} node - A function node that was entered.
+         * @param {ASTNode} node A function node that was entered.
          * @returns {void}
          * @private
          */

--- a/lib/rules/comma-dangle.js
+++ b/lib/rules/comma-dangle.js
@@ -27,7 +27,7 @@ const DEFAULT_OPTIONS = Object.freeze({
 /**
  * Checks whether or not a trailing comma is allowed in a given node.
  * If the `lastItem` is `RestElement` or `RestProperty`, it disallows trailing commas.
- * @param {ASTNode} lastItem - The node of the last element in the given node.
+ * @param {ASTNode} lastItem The node of the last element in the given node.
  * @returns {boolean} `true` if a trailing comma is allowed.
  */
 function isTrailingCommaAllowed(lastItem) {
@@ -40,7 +40,7 @@ function isTrailingCommaAllowed(lastItem) {
 
 /**
  * Normalize option value.
- * @param {string|Object|undefined} optionValue - The 1st option value to normalize.
+ * @param {string|Object|undefined} optionValue The 1st option value to normalize.
  * @returns {Object} The normalized option value.
  */
 function normalizeOptions(optionValue) {
@@ -140,7 +140,7 @@ module.exports = {
 
         /**
          * Gets the last item of the given node.
-         * @param {ASTNode} node - The node to get.
+         * @param {ASTNode} node The node to get.
          * @returns {ASTNode|null} The last node or null.
          */
         function getLastItem(node) {
@@ -170,8 +170,8 @@ module.exports = {
          * Gets the trailing comma token of the given node.
          * If the trailing comma does not exist, this returns the token which is
          * the insertion point of the trailing comma token.
-         * @param {ASTNode} node - The node to get.
-         * @param {ASTNode} lastItem - The last item of the node.
+         * @param {ASTNode} node The node to get.
+         * @param {ASTNode} lastItem The last item of the node.
          * @returns {Token} The trailing comma token or the insertion point.
          */
         function getTrailingToken(node, lastItem) {
@@ -196,7 +196,7 @@ module.exports = {
          * Checks whether or not a given node is multiline.
          * This rule handles a given node as multiline when the closing parenthesis
          * and the last element are not on the same line.
-         * @param {ASTNode} node - A node to check.
+         * @param {ASTNode} node A node to check.
          * @returns {boolean} `true` if the node is multiline.
          */
         function isMultiline(node) {
@@ -214,7 +214,7 @@ module.exports = {
 
         /**
          * Reports a trailing comma if it exists.
-         * @param {ASTNode} node - A node to check. Its type is one of
+         * @param {ASTNode} node A node to check. Its type is one of
          *   ObjectExpression, ObjectPattern, ArrayExpression, ArrayPattern,
          *   ImportDeclaration, and ExportNamedDeclaration.
          * @returns {void}
@@ -246,7 +246,7 @@ module.exports = {
          *
          * If a given node is `ArrayPattern` which has `RestElement`, the trailing
          * comma is disallowed, so report if it exists.
-         * @param {ASTNode} node - A node to check. Its type is one of
+         * @param {ASTNode} node A node to check. Its type is one of
          *   ObjectExpression, ObjectPattern, ArrayExpression, ArrayPattern,
          *   ImportDeclaration, and ExportNamedDeclaration.
          * @returns {void}
@@ -280,7 +280,7 @@ module.exports = {
          * If a given node is multiline, reports the last element of a given node
          * when it does not have a trailing comma.
          * Otherwise, reports a trailing comma if it exists.
-         * @param {ASTNode} node - A node to check. Its type is one of
+         * @param {ASTNode} node A node to check. Its type is one of
          *   ObjectExpression, ObjectPattern, ArrayExpression, ArrayPattern,
          *   ImportDeclaration, and ExportNamedDeclaration.
          * @returns {void}
@@ -297,7 +297,7 @@ module.exports = {
          * Only if a given node is not multiline, reports the last element of a given node
          * when it does not have a trailing comma.
          * Otherwise, reports a trailing comma if it exists.
-         * @param {ASTNode} node - A node to check. Its type is one of
+         * @param {ASTNode} node A node to check. Its type is one of
          *   ObjectExpression, ObjectPattern, ArrayExpression, ArrayPattern,
          *   ImportDeclaration, and ExportNamedDeclaration.
          * @returns {void}

--- a/lib/rules/comma-dangle.js
+++ b/lib/rules/comma-dangle.js
@@ -27,7 +27,6 @@ const DEFAULT_OPTIONS = Object.freeze({
 /**
  * Checks whether or not a trailing comma is allowed in a given node.
  * If the `lastItem` is `RestElement` or `RestProperty`, it disallows trailing commas.
- *
  * @param {ASTNode} lastItem - The node of the last element in the given node.
  * @returns {boolean} `true` if a trailing comma is allowed.
  */
@@ -41,7 +40,6 @@ function isTrailingCommaAllowed(lastItem) {
 
 /**
  * Normalize option value.
- *
  * @param {string|Object|undefined} optionValue - The 1st option value to normalize.
  * @returns {Object} The normalized option value.
  */
@@ -172,7 +170,6 @@ module.exports = {
          * Gets the trailing comma token of the given node.
          * If the trailing comma does not exist, this returns the token which is
          * the insertion point of the trailing comma token.
-         *
          * @param {ASTNode} node - The node to get.
          * @param {ASTNode} lastItem - The last item of the node.
          * @returns {Token} The trailing comma token or the insertion point.
@@ -199,7 +196,6 @@ module.exports = {
          * Checks whether or not a given node is multiline.
          * This rule handles a given node as multiline when the closing parenthesis
          * and the last element are not on the same line.
-         *
          * @param {ASTNode} node - A node to check.
          * @returns {boolean} `true` if the node is multiline.
          */
@@ -218,7 +214,6 @@ module.exports = {
 
         /**
          * Reports a trailing comma if it exists.
-         *
          * @param {ASTNode} node - A node to check. Its type is one of
          *   ObjectExpression, ObjectPattern, ArrayExpression, ArrayPattern,
          *   ImportDeclaration, and ExportNamedDeclaration.
@@ -251,7 +246,6 @@ module.exports = {
          *
          * If a given node is `ArrayPattern` which has `RestElement`, the trailing
          * comma is disallowed, so report if it exists.
-         *
          * @param {ASTNode} node - A node to check. Its type is one of
          *   ObjectExpression, ObjectPattern, ArrayExpression, ArrayPattern,
          *   ImportDeclaration, and ExportNamedDeclaration.
@@ -286,7 +280,6 @@ module.exports = {
          * If a given node is multiline, reports the last element of a given node
          * when it does not have a trailing comma.
          * Otherwise, reports a trailing comma if it exists.
-         *
          * @param {ASTNode} node - A node to check. Its type is one of
          *   ObjectExpression, ObjectPattern, ArrayExpression, ArrayPattern,
          *   ImportDeclaration, and ExportNamedDeclaration.
@@ -304,7 +297,6 @@ module.exports = {
          * Only if a given node is not multiline, reports the last element of a given node
          * when it does not have a trailing comma.
          * Otherwise, reports a trailing comma if it exists.
-         *
          * @param {ASTNode} node - A node to check. Its type is one of
          *   ObjectExpression, ObjectPattern, ArrayExpression, ArrayPattern,
          *   ImportDeclaration, and ExportNamedDeclaration.

--- a/lib/rules/comma-spacing.js
+++ b/lib/rules/comma-spacing.js
@@ -105,7 +105,7 @@ module.exports = {
 
         /**
          * Validates the spacing around a comma token.
-         * @param {Object} tokens - The tokens to be validated.
+         * @param {Object} tokens The tokens to be validated.
          * @param {Token} tokens.comma The token representing the comma.
          * @param {Token} [tokens.left] The last token before the comma.
          * @param {Token} [tokens.right] The first token after the comma.

--- a/lib/rules/computed-property-spacing.js
+++ b/lib/rules/computed-property-spacing.js
@@ -59,9 +59,9 @@ module.exports = {
 
         /**
          * Reports that there shouldn't be a space after the first token
-         * @param {ASTNode} node - The node to report in the event of an error.
-         * @param {Token} token - The token to use for the report.
-         * @param {Token} tokenAfter - The token after `token`.
+         * @param {ASTNode} node The node to report in the event of an error.
+         * @param {Token} token The token to use for the report.
+         * @param {Token} tokenAfter The token after `token`.
          * @returns {void}
          */
         function reportNoBeginningSpace(node, token, tokenAfter) {
@@ -80,9 +80,9 @@ module.exports = {
 
         /**
          * Reports that there shouldn't be a space before the last token
-         * @param {ASTNode} node - The node to report in the event of an error.
-         * @param {Token} token - The token to use for the report.
-         * @param {Token} tokenBefore - The token before `token`.
+         * @param {ASTNode} node The node to report in the event of an error.
+         * @param {Token} token The token to use for the report.
+         * @param {Token} tokenBefore The token before `token`.
          * @returns {void}
          */
         function reportNoEndingSpace(node, token, tokenBefore) {
@@ -101,8 +101,8 @@ module.exports = {
 
         /**
          * Reports that there should be a space after the first token
-         * @param {ASTNode} node - The node to report in the event of an error.
-         * @param {Token} token - The token to use for the report.
+         * @param {ASTNode} node The node to report in the event of an error.
+         * @param {Token} token The token to use for the report.
          * @returns {void}
          */
         function reportRequiredBeginningSpace(node, token) {
@@ -121,8 +121,8 @@ module.exports = {
 
         /**
          * Reports that there should be a space before the last token
-         * @param {ASTNode} node - The node to report in the event of an error.
-         * @param {Token} token - The token to use for the report.
+         * @param {ASTNode} node The node to report in the event of an error.
+         * @param {Token} token The token to use for the report.
          * @returns {void}
          */
         function reportRequiredEndingSpace(node, token) {

--- a/lib/rules/consistent-return.js
+++ b/lib/rules/consistent-return.js
@@ -88,7 +88,6 @@ module.exports = {
         /**
          * Checks whether of not the implicit returning is consistent if the last
          * code path segment is reachable.
-         *
          * @param {ASTNode} node - A program/function node to check.
          * @returns {void}
          */

--- a/lib/rules/consistent-return.js
+++ b/lib/rules/consistent-return.js
@@ -18,8 +18,8 @@ const astUtils = require("./utils/ast-utils");
 
 /**
  * Checks whether or not a given node is an `Identifier` node which was named a given name.
- * @param {ASTNode} node - A node to check.
- * @param {string} name - An expected name of the node.
+ * @param {ASTNode} node A node to check.
+ * @param {string} name An expected name of the node.
  * @returns {boolean} `true` if the node is an `Identifier` node which was named as expected.
  */
 function isIdentifier(node, name) {
@@ -28,7 +28,7 @@ function isIdentifier(node, name) {
 
 /**
  * Checks whether or not a given code path segment is unreachable.
- * @param {CodePathSegment} segment - A CodePathSegment to check.
+ * @param {CodePathSegment} segment A CodePathSegment to check.
  * @returns {boolean} `true` if the segment is unreachable.
  */
 function isUnreachable(segment) {
@@ -88,7 +88,7 @@ module.exports = {
         /**
          * Checks whether of not the implicit returning is consistent if the last
          * code path segment is reachable.
-         * @param {ASTNode} node - A program/function node to check.
+         * @param {ASTNode} node A program/function node to check.
          * @returns {void}
          */
         function checkLastSegment(node) {

--- a/lib/rules/consistent-this.js
+++ b/lib/rules/consistent-this.js
@@ -46,8 +46,8 @@ module.exports = {
         /**
          * Reports that a variable declarator or assignment expression is assigning
          * a non-'this' value to the specified alias.
-         * @param {ASTNode} node - The assigning node.
-         * @param {string}  name - the name of the alias that was incorrectly used.
+         * @param {ASTNode} node The assigning node.
+         * @param {string}  name the name of the alias that was incorrectly used.
          * @returns {void}
          */
         function reportBadAssignment(node, name) {
@@ -57,9 +57,9 @@ module.exports = {
         /**
          * Checks that an assignment to an identifier only assigns 'this' to the
          * appropriate alias, and the alias is only assigned to 'this'.
-         * @param {ASTNode} node - The assigning node.
-         * @param {Identifier} name - The name of the variable assigned to.
-         * @param {Expression} value - The value of the assignment.
+         * @param {ASTNode} node The assigning node.
+         * @param {Identifier} name The name of the variable assigned to.
+         * @param {Expression} value The value of the assignment.
          * @returns {void}
          */
         function checkAssignment(node, name, value) {

--- a/lib/rules/constructor-super.js
+++ b/lib/rules/constructor-super.js
@@ -11,7 +11,6 @@
 
 /**
  * Checks whether a given code path segment is reachable or not.
- *
  * @param {CodePathSegment} segment - A code path segment to check.
  * @returns {boolean} `true` if the segment is reachable.
  */
@@ -36,7 +35,6 @@ function isConstructorFunction(node) {
 
 /**
  * Checks whether a given node can be a constructor or not.
- *
  * @param {ASTNode} node - A node to check.
  * @returns {boolean} `true` if the node can be a constructor.
  */

--- a/lib/rules/constructor-super.js
+++ b/lib/rules/constructor-super.js
@@ -11,7 +11,7 @@
 
 /**
  * Checks whether a given code path segment is reachable or not.
- * @param {CodePathSegment} segment - A code path segment to check.
+ * @param {CodePathSegment} segment A code path segment to check.
  * @returns {boolean} `true` if the segment is reachable.
  */
 function isReachable(segment) {
@@ -20,7 +20,7 @@ function isReachable(segment) {
 
 /**
  * Checks whether or not a given node is a constructor.
- * @param {ASTNode} node - A node to check. This node type is one of
+ * @param {ASTNode} node A node to check. This node type is one of
  *   `Program`, `FunctionDeclaration`, `FunctionExpression`, and
  *   `ArrowFunctionExpression`.
  * @returns {boolean} `true` if the node is a constructor.
@@ -35,7 +35,7 @@ function isConstructorFunction(node) {
 
 /**
  * Checks whether a given node can be a constructor or not.
- * @param {ASTNode} node - A node to check.
+ * @param {ASTNode} node A node to check.
  * @returns {boolean} `true` if the node can be a constructor.
  */
 function isPossibleConstructor(node) {
@@ -135,7 +135,7 @@ module.exports = {
 
         /**
          * Gets the flag which shows `super()` is called in some paths.
-         * @param {CodePathSegment} segment - A code path segment to get.
+         * @param {CodePathSegment} segment A code path segment to get.
          * @returns {boolean} The flag which shows `super()` is called in some paths
          */
         function isCalledInSomePath(segment) {
@@ -144,7 +144,7 @@ module.exports = {
 
         /**
          * Gets the flag which shows `super()` is called in all paths.
-         * @param {CodePathSegment} segment - A code path segment to get.
+         * @param {CodePathSegment} segment A code path segment to get.
          * @returns {boolean} The flag which shows `super()` is called in all paths.
          */
         function isCalledInEveryPath(segment) {
@@ -166,8 +166,8 @@ module.exports = {
 
             /**
              * Stacks a constructor information.
-             * @param {CodePath} codePath - A code path which was started.
-             * @param {ASTNode} node - The current node.
+             * @param {CodePath} codePath A code path which was started.
+             * @param {ASTNode} node The current node.
              * @returns {void}
              */
             onCodePathStart(codePath, node) {
@@ -198,8 +198,8 @@ module.exports = {
             /**
              * Pops a constructor information.
              * And reports if `super()` lacked.
-             * @param {CodePath} codePath - A code path which was ended.
-             * @param {ASTNode} node - The current node.
+             * @param {CodePath} codePath A code path which was ended.
+             * @param {ASTNode} node The current node.
              * @returns {void}
              */
             onCodePathEnd(codePath, node) {
@@ -229,7 +229,7 @@ module.exports = {
 
             /**
              * Initialize information of a given code path segment.
-             * @param {CodePathSegment} segment - A code path segment to initialize.
+             * @param {CodePathSegment} segment A code path segment to initialize.
              * @returns {void}
              */
             onCodePathSegmentStart(segment) {
@@ -256,9 +256,9 @@ module.exports = {
             /**
              * Update information of the code path segment when a code path was
              * looped.
-             * @param {CodePathSegment} fromSegment - The code path segment of the
+             * @param {CodePathSegment} fromSegment The code path segment of the
              *      end of a loop.
-             * @param {CodePathSegment} toSegment - A code path segment of the head
+             * @param {CodePathSegment} toSegment A code path segment of the head
              *      of a loop.
              * @returns {void}
              */
@@ -301,7 +301,7 @@ module.exports = {
 
             /**
              * Checks for a call of `super()`.
-             * @param {ASTNode} node - A CallExpression node to check.
+             * @param {ASTNode} node A CallExpression node to check.
              * @returns {void}
              */
             "CallExpression:exit"(node) {
@@ -356,7 +356,7 @@ module.exports = {
 
             /**
              * Set the mark to the returned path as `super()` was called.
-             * @param {ASTNode} node - A ReturnStatement node to check.
+             * @param {ASTNode} node A ReturnStatement node to check.
              * @returns {void}
              */
             ReturnStatement(node) {

--- a/lib/rules/curly.js
+++ b/lib/rules/curly.js
@@ -119,7 +119,7 @@ module.exports = {
 
         /**
          * Checks if the given token is an `else` token or not.
-         * @param {Token} token - The token to check.
+         * @param {Token} token The token to check.
          * @returns {boolean} `true` if the token is an `else` token.
          */
         function isElseKeywordToken(token) {
@@ -128,7 +128,7 @@ module.exports = {
 
         /**
          * Gets the `else` keyword token of a given `IfStatement` node.
-         * @param {ASTNode} node - A `IfStatement` node to get.
+         * @param {ASTNode} node A `IfStatement` node to get.
          * @returns {Token} The `else` keyword token.
          */
         function getElseKeyword(node) {
@@ -142,7 +142,7 @@ module.exports = {
          * 1. The given node has the `alternate` node.
          * 2. There is a `IfStatement` which doesn't have `alternate` node in the
          *    trailing statement chain of the `consequent` node.
-         * @param {ASTNode} node - A IfStatement node to check.
+         * @param {ASTNode} node A IfStatement node to check.
          * @returns {boolean} `true` if the node requires braces of the consequent chunk.
          */
         function requiresBraceOfConsequent(node) {

--- a/lib/rules/curly.js
+++ b/lib/rules/curly.js
@@ -119,7 +119,6 @@ module.exports = {
 
         /**
          * Checks if the given token is an `else` token or not.
-         *
          * @param {Token} token - The token to check.
          * @returns {boolean} `true` if the token is an `else` token.
          */
@@ -143,7 +142,6 @@ module.exports = {
          * 1. The given node has the `alternate` node.
          * 2. There is a `IfStatement` which doesn't have `alternate` node in the
          *    trailing statement chain of the `consequent` node.
-         *
          * @param {ASTNode} node - A IfStatement node to check.
          * @returns {boolean} `true` if the node requires braces of the consequent chunk.
          */

--- a/lib/rules/func-names.js
+++ b/lib/rules/func-names.js
@@ -13,7 +13,7 @@ const astUtils = require("./utils/ast-utils");
 
 /**
  * Checks whether or not a given variable is a function name.
- * @param {eslint-scope.Variable} variable - A variable to check.
+ * @param {eslint-scope.Variable} variable A variable to check.
  * @returns {boolean} `true` if the variable is a function name.
  */
 function isFunctionName(variable) {
@@ -73,7 +73,7 @@ module.exports = {
 
         /**
          * Returns the config option for the given node.
-         * @param {ASTNode} node - A node to get the config for.
+         * @param {ASTNode} node A node to get the config for.
          * @returns {string} The config option.
          */
         function getConfigForNode(node) {
@@ -91,7 +91,7 @@ module.exports = {
         /**
          * Determines whether the current FunctionExpression node is a get, set, or
          * shorthand method in an object literal or a class.
-         * @param {ASTNode} node - A node to check.
+         * @param {ASTNode} node A node to check.
          * @returns {boolean} True if the node is a get, set, or shorthand method.
          */
         function isObjectOrClassMethod(node) {
@@ -109,7 +109,7 @@ module.exports = {
         /**
          * Determines whether the current FunctionExpression node has a name that would be
          * inferred from context in a conforming ES6 environment.
-         * @param {ASTNode} node - A node to check.
+         * @param {ASTNode} node A node to check.
          * @returns {boolean} True if the node would have a name assigned automatically.
          */
         function hasInferredName(node) {
@@ -125,7 +125,7 @@ module.exports = {
 
         /**
          * Reports that an unnamed function should be named
-         * @param {ASTNode} node - The node to report in the event of an error.
+         * @param {ASTNode} node The node to report in the event of an error.
          * @returns {void}
          */
         function reportUnexpectedUnnamedFunction(node) {
@@ -139,7 +139,7 @@ module.exports = {
 
         /**
          * Reports that a named function should be unnamed
-         * @param {ASTNode} node - The node to report in the event of an error.
+         * @param {ASTNode} node The node to report in the event of an error.
          * @returns {void}
          */
         function reportUnexpectedNamedFunction(node) {

--- a/lib/rules/generator-star-spacing.js
+++ b/lib/rules/generator-star-spacing.js
@@ -78,8 +78,8 @@ module.exports = {
 
         /**
          * Returns resolved option definitions based on an option and defaults
-         * @param {any} option - The option object or string value
-         * @param {Object} defaults - The defaults to use if options are not present
+         * @param {any} option The option object or string value
+         * @param {Object} defaults The defaults to use if options are not present
          * @returns {Object} the resolved object definition
          */
         function optionToDefinition(option, defaults) {
@@ -106,7 +106,7 @@ module.exports = {
 
         /**
          * Checks if the given token is a star token or not.
-         * @param {Token} token - The token to check.
+         * @param {Token} token The token to check.
          * @returns {boolean} `true` if the token is a star token.
          */
         function isStarToken(token) {
@@ -115,7 +115,7 @@ module.exports = {
 
         /**
          * Gets the generator star token of the given function node.
-         * @param {ASTNode} node - The function node to get.
+         * @param {ASTNode} node The function node to get.
          * @returns {Token} Found star token.
          */
         function getStarToken(node) {

--- a/lib/rules/generator-star-spacing.js
+++ b/lib/rules/generator-star-spacing.js
@@ -78,7 +78,6 @@ module.exports = {
 
         /**
          * Returns resolved option definitions based on an option and defaults
-         *
          * @param {any} option - The option object or string value
          * @param {Object} defaults - The defaults to use if options are not present
          * @returns {Object} the resolved object definition
@@ -107,7 +106,6 @@ module.exports = {
 
         /**
          * Checks if the given token is a star token or not.
-         *
          * @param {Token} token - The token to check.
          * @returns {boolean} `true` if the token is a star token.
          */
@@ -117,7 +115,6 @@ module.exports = {
 
         /**
          * Gets the generator star token of the given function node.
-         *
          * @param {ASTNode} node - The function node to get.
          * @returns {Token} Found star token.
          */
@@ -139,7 +136,6 @@ module.exports = {
 
         /**
          * Checks the spacing between two tokens before or after the star token.
-         *
          * @param {string} kind Either "named", "anonymous", or "method"
          * @param {string} side Either "before" or "after".
          * @param {Token} leftToken `function` keyword token if side is "before", or
@@ -173,7 +169,6 @@ module.exports = {
 
         /**
          * Enforces the spacing around the star if node is a generator function.
-         *
          * @param {ASTNode} node A function expression or declaration node.
          * @returns {void}
          */

--- a/lib/rules/getter-return.js
+++ b/lib/rules/getter-return.js
@@ -18,7 +18,6 @@ const TARGET_NODE_TYPE = /^(?:Arrow)?FunctionExpression$/u;
 
 /**
  * Checks a given code path segment is reachable.
- *
  * @param {CodePathSegment} segment - A segment to check.
  * @returns {boolean} `true` if the segment is reachable.
  */
@@ -30,7 +29,6 @@ function isReachable(segment) {
  * Gets a readable location.
  *
  * - FunctionExpression -> the function name or `function` keyword.
- *
  * @param {ASTNode} node - A function node to get.
  * @returns {ASTNode|Token} The node or the token of a location.
  */
@@ -92,7 +90,6 @@ module.exports = {
          *
          * If the last code path segment is reachable, there are paths which are not
          * returned or thrown.
-         *
          * @param {ASTNode} node - A node to check.
          * @returns {void}
          */

--- a/lib/rules/getter-return.js
+++ b/lib/rules/getter-return.js
@@ -18,7 +18,7 @@ const TARGET_NODE_TYPE = /^(?:Arrow)?FunctionExpression$/u;
 
 /**
  * Checks a given code path segment is reachable.
- * @param {CodePathSegment} segment - A segment to check.
+ * @param {CodePathSegment} segment A segment to check.
  * @returns {boolean} `true` if the segment is reachable.
  */
 function isReachable(segment) {
@@ -29,7 +29,7 @@ function isReachable(segment) {
  * Gets a readable location.
  *
  * - FunctionExpression -> the function name or `function` keyword.
- * @param {ASTNode} node - A function node to get.
+ * @param {ASTNode} node A function node to get.
  * @returns {ASTNode|Token} The node or the token of a location.
  */
 function getId(node) {
@@ -90,7 +90,7 @@ module.exports = {
          *
          * If the last code path segment is reachable, there are paths which are not
          * returned or thrown.
-         * @param {ASTNode} node - A node to check.
+         * @param {ASTNode} node A node to check.
          * @returns {void}
          */
         function checkLastSegment(node) {
@@ -110,7 +110,7 @@ module.exports = {
 
         /**
          * Checks whether a node means a getter function.
-         * @param {ASTNode} node - a node to check.
+         * @param {ASTNode} node a node to check.
          * @returns {boolean} if node means a getter, return true; else return false.
          */
         function isGetter(node) {

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -329,7 +329,6 @@ class OffsetStorage {
      * Instead, the correct way would be to offset `baz` by 1 level from `bar`, offset `bar` by 1 level from the `)`, and
      * offset the `)` by 0 levels from `foo`. This ensures that the offset between `bar` and the `)` are correctly collapsed
      * in the second case.
-     *
      * @param {Token} token The token
      * @param {Token} fromToken The token that `token` should be offset from
      * @param {number} offset The desired indent level
@@ -358,7 +357,6 @@ class OffsetStorage {
      *
      * The `setDesiredOffsets` methods inserts ranges like the ones above. The third line above would be inserted by using:
      * `setDesiredOffsets([30, 43], fooToken, 1);`
-     *
      * @param {[number, number]} range A [start, end] pair. All tokens with range[0] <= token.start < range[1] will have the offset applied.
      * @param {Token} fromToken The token that this is offset from
      * @param {number} offset The desired indent level

--- a/lib/rules/init-declarations.js
+++ b/lib/rules/init-declarations.js
@@ -11,7 +11,7 @@
 
 /**
  * Checks whether or not a given node is a for loop.
- * @param {ASTNode} block - A node to check.
+ * @param {ASTNode} block A node to check.
  * @returns {boolean} `true` when the node is a for loop.
  */
 function isForLoop(block) {
@@ -22,7 +22,7 @@ function isForLoop(block) {
 
 /**
  * Checks whether or not a given declarator node has its initializer.
- * @param {ASTNode} node - A declarator node to check.
+ * @param {ASTNode} node A declarator node to check.
  * @returns {boolean} `true` when the node has its initializer.
  */
 function isInitialized(node) {

--- a/lib/rules/jsx-quotes.js
+++ b/lib/rules/jsx-quotes.js
@@ -65,7 +65,7 @@ module.exports = {
 
         /**
          * Checks if the given string literal node uses the expected quotes
-         * @param {ASTNode} node - A string literal node.
+         * @param {ASTNode} node A string literal node.
          * @returns {boolean} Whether or not the string literal used the expected quotes.
          * @public
          */

--- a/lib/rules/keyword-spacing.js
+++ b/lib/rules/keyword-spacing.js
@@ -41,7 +41,7 @@ const KEYS = keywords.concat(["as", "async", "await", "from", "get", "let", "of"
 
 /**
  * Checks whether or not a given token is a "Template" token ends with "${".
- * @param {Token} token - A token to check.
+ * @param {Token} token A token to check.
  * @returns {boolean} `true` if the token is a "Template" token ends with "${".
  */
 function isOpenParenOfTemplate(token) {
@@ -50,7 +50,7 @@ function isOpenParenOfTemplate(token) {
 
 /**
  * Checks whether or not a given token is a "Template" token starts with "}".
- * @param {Token} token - A token to check.
+ * @param {Token} token A token to check.
  * @returns {boolean} `true` if the token is a "Template" token starts with "}".
  */
 function isCloseParenOfTemplate(token) {
@@ -112,8 +112,8 @@ module.exports = {
 
         /**
          * Reports a given token if there are not space(s) before the token.
-         * @param {Token} token - A token to report.
-         * @param {RegExp} pattern - A pattern of the previous token to check.
+         * @param {Token} token A token to report.
+         * @param {RegExp} pattern A pattern of the previous token to check.
          * @returns {void}
          */
         function expectSpaceBefore(token, pattern) {
@@ -138,8 +138,8 @@ module.exports = {
 
         /**
          * Reports a given token if there are space(s) before the token.
-         * @param {Token} token - A token to report.
-         * @param {RegExp} pattern - A pattern of the previous token to check.
+         * @param {Token} token A token to report.
+         * @param {RegExp} pattern A pattern of the previous token to check.
          * @returns {void}
          */
         function unexpectSpaceBefore(token, pattern) {
@@ -164,8 +164,8 @@ module.exports = {
 
         /**
          * Reports a given token if there are not space(s) after the token.
-         * @param {Token} token - A token to report.
-         * @param {RegExp} pattern - A pattern of the next token to check.
+         * @param {Token} token A token to report.
+         * @param {RegExp} pattern A pattern of the next token to check.
          * @returns {void}
          */
         function expectSpaceAfter(token, pattern) {
@@ -190,8 +190,8 @@ module.exports = {
 
         /**
          * Reports a given token if there are space(s) after the token.
-         * @param {Token} token - A token to report.
-         * @param {RegExp} pattern - A pattern of the next token to check.
+         * @param {Token} token A token to report.
+         * @param {RegExp} pattern A pattern of the next token to check.
          * @returns {void}
          */
         function unexpectSpaceAfter(token, pattern) {
@@ -216,7 +216,7 @@ module.exports = {
 
         /**
          * Parses the option object and determines check methods for each keyword.
-         * @param {Object|undefined} options - The option object to parse.
+         * @param {Object|undefined} options The option object to parse.
          * @returns {Object} - Normalized option object.
          *      Keys are keywords (there are for every keyword).
          *      Values are instances of `{"before": function, "after": function}`.
@@ -256,8 +256,8 @@ module.exports = {
         /**
          * Reports a given token if usage of spacing followed by the token is
          * invalid.
-         * @param {Token} token - A token to report.
-         * @param {RegExp|undefined} pattern - Optional. A pattern of the previous
+         * @param {Token} token A token to report.
+         * @param {RegExp} [pattern] Optional. A pattern of the previous
          *      token to check.
          * @returns {void}
          */
@@ -268,8 +268,8 @@ module.exports = {
         /**
          * Reports a given token if usage of spacing preceded by the token is
          * invalid.
-         * @param {Token} token - A token to report.
-         * @param {RegExp|undefined} pattern - Optional. A pattern of the next
+         * @param {Token} token A token to report.
+         * @param {RegExp} [pattern] Optional. A pattern of the next
          *      token to check.
          * @returns {void}
          */
@@ -279,7 +279,7 @@ module.exports = {
 
         /**
          * Reports a given token if usage of spacing around the token is invalid.
-         * @param {Token} token - A token to report.
+         * @param {Token} token A token to report.
          * @returns {void}
          */
         function checkSpacingAround(token) {
@@ -290,7 +290,7 @@ module.exports = {
         /**
          * Reports the first token of a given node if the first token is a keyword
          * and usage of spacing around the token is invalid.
-         * @param {ASTNode|null} node - A node to report.
+         * @param {ASTNode|null} node A node to report.
          * @returns {void}
          */
         function checkSpacingAroundFirstToken(node) {
@@ -307,7 +307,7 @@ module.exports = {
          *
          * This is used for unary operators (e.g. `typeof`), `function`, and `super`.
          * Other rules are handling usage of spacing preceded by those keywords.
-         * @param {ASTNode|null} node - A node to report.
+         * @param {ASTNode|null} node A node to report.
          * @returns {void}
          */
         function checkSpacingBeforeFirstToken(node) {
@@ -321,7 +321,7 @@ module.exports = {
         /**
          * Reports the previous token of a given node if the token is a keyword and
          * usage of spacing around the token is invalid.
-         * @param {ASTNode|null} node - A node to report.
+         * @param {ASTNode|null} node A node to report.
          * @returns {void}
          */
         function checkSpacingAroundTokenBefore(node) {
@@ -335,7 +335,7 @@ module.exports = {
         /**
          * Reports `async` or `function` keywords of a given node if usage of
          * spacing around those keywords is invalid.
-         * @param {ASTNode} node - A node to report.
+         * @param {ASTNode} node A node to report.
          * @returns {void}
          */
         function checkSpacingForFunction(node) {
@@ -352,7 +352,7 @@ module.exports = {
         /**
          * Reports `class` and `extends` keywords of a given node if usage of
          * spacing around those keywords is invalid.
-         * @param {ASTNode} node - A node to report.
+         * @param {ASTNode} node A node to report.
          * @returns {void}
          */
         function checkSpacingForClass(node) {
@@ -363,7 +363,7 @@ module.exports = {
         /**
          * Reports `if` and `else` keywords of a given node if usage of spacing
          * around those keywords is invalid.
-         * @param {ASTNode} node - A node to report.
+         * @param {ASTNode} node A node to report.
          * @returns {void}
          */
         function checkSpacingForIfStatement(node) {
@@ -374,7 +374,7 @@ module.exports = {
         /**
          * Reports `try`, `catch`, and `finally` keywords of a given node if usage
          * of spacing around those keywords is invalid.
-         * @param {ASTNode} node - A node to report.
+         * @param {ASTNode} node A node to report.
          * @returns {void}
          */
         function checkSpacingForTryStatement(node) {
@@ -386,7 +386,7 @@ module.exports = {
         /**
          * Reports `do` and `while` keywords of a given node if usage of spacing
          * around those keywords is invalid.
-         * @param {ASTNode} node - A node to report.
+         * @param {ASTNode} node A node to report.
          * @returns {void}
          */
         function checkSpacingForDoWhileStatement(node) {
@@ -397,7 +397,7 @@ module.exports = {
         /**
          * Reports `for` and `in` keywords of a given node if usage of spacing
          * around those keywords is invalid.
-         * @param {ASTNode} node - A node to report.
+         * @param {ASTNode} node A node to report.
          * @returns {void}
          */
         function checkSpacingForForInStatement(node) {
@@ -408,7 +408,7 @@ module.exports = {
         /**
          * Reports `for` and `of` keywords of a given node if usage of spacing
          * around those keywords is invalid.
-         * @param {ASTNode} node - A node to report.
+         * @param {ASTNode} node A node to report.
          * @returns {void}
          */
         function checkSpacingForForOfStatement(node) {
@@ -429,7 +429,7 @@ module.exports = {
          *
          *     import*as A from "./a"; /*error Expected space(s) after "import".
          *                               error Expected space(s) before "as".
-         * @param {ASTNode} node - A node to report.
+         * @param {ASTNode} node A node to report.
          * @returns {void}
          */
         function checkSpacingForModuleDeclaration(node) {
@@ -453,7 +453,7 @@ module.exports = {
         /**
          * Reports `as` keyword of a given node if usage of spacing around this
          * keyword is invalid.
-         * @param {ASTNode} node - A node to report.
+         * @param {ASTNode} node A node to report.
          * @returns {void}
          */
         function checkSpacingForImportNamespaceSpecifier(node) {
@@ -465,7 +465,7 @@ module.exports = {
         /**
          * Reports `static`, `get`, and `set` keywords of a given node if usage of
          * spacing around those keywords is invalid.
-         * @param {ASTNode} node - A node to report.
+         * @param {ASTNode} node A node to report.
          * @returns {void}
          */
         function checkSpacingForProperty(node) {
@@ -505,7 +505,7 @@ module.exports = {
         /**
          * Reports `await` keyword of a given node if usage of spacing before
          * this keyword is invalid.
-         * @param {ASTNode} node - A node to report.
+         * @param {ASTNode} node A node to report.
          * @returns {void}
          */
         function checkSpacingForAwaitExpression(node) {

--- a/lib/rules/keyword-spacing.js
+++ b/lib/rules/keyword-spacing.js
@@ -41,7 +41,6 @@ const KEYS = keywords.concat(["as", "async", "await", "from", "get", "let", "of"
 
 /**
  * Checks whether or not a given token is a "Template" token ends with "${".
- *
  * @param {Token} token - A token to check.
  * @returns {boolean} `true` if the token is a "Template" token ends with "${".
  */
@@ -51,7 +50,6 @@ function isOpenParenOfTemplate(token) {
 
 /**
  * Checks whether or not a given token is a "Template" token starts with "}".
- *
  * @param {Token} token - A token to check.
  * @returns {boolean} `true` if the token is a "Template" token starts with "}".
  */
@@ -114,7 +112,6 @@ module.exports = {
 
         /**
          * Reports a given token if there are not space(s) before the token.
-         *
          * @param {Token} token - A token to report.
          * @param {RegExp} pattern - A pattern of the previous token to check.
          * @returns {void}
@@ -141,7 +138,6 @@ module.exports = {
 
         /**
          * Reports a given token if there are space(s) before the token.
-         *
          * @param {Token} token - A token to report.
          * @param {RegExp} pattern - A pattern of the previous token to check.
          * @returns {void}
@@ -168,7 +164,6 @@ module.exports = {
 
         /**
          * Reports a given token if there are not space(s) after the token.
-         *
          * @param {Token} token - A token to report.
          * @param {RegExp} pattern - A pattern of the next token to check.
          * @returns {void}
@@ -195,7 +190,6 @@ module.exports = {
 
         /**
          * Reports a given token if there are space(s) after the token.
-         *
          * @param {Token} token - A token to report.
          * @param {RegExp} pattern - A pattern of the next token to check.
          * @returns {void}
@@ -222,7 +216,6 @@ module.exports = {
 
         /**
          * Parses the option object and determines check methods for each keyword.
-         *
          * @param {Object|undefined} options - The option object to parse.
          * @returns {Object} - Normalized option object.
          *      Keys are keywords (there are for every keyword).
@@ -263,7 +256,6 @@ module.exports = {
         /**
          * Reports a given token if usage of spacing followed by the token is
          * invalid.
-         *
          * @param {Token} token - A token to report.
          * @param {RegExp|undefined} pattern - Optional. A pattern of the previous
          *      token to check.
@@ -276,7 +268,6 @@ module.exports = {
         /**
          * Reports a given token if usage of spacing preceded by the token is
          * invalid.
-         *
          * @param {Token} token - A token to report.
          * @param {RegExp|undefined} pattern - Optional. A pattern of the next
          *      token to check.
@@ -288,7 +279,6 @@ module.exports = {
 
         /**
          * Reports a given token if usage of spacing around the token is invalid.
-         *
          * @param {Token} token - A token to report.
          * @returns {void}
          */
@@ -300,7 +290,6 @@ module.exports = {
         /**
          * Reports the first token of a given node if the first token is a keyword
          * and usage of spacing around the token is invalid.
-         *
          * @param {ASTNode|null} node - A node to report.
          * @returns {void}
          */
@@ -318,7 +307,6 @@ module.exports = {
          *
          * This is used for unary operators (e.g. `typeof`), `function`, and `super`.
          * Other rules are handling usage of spacing preceded by those keywords.
-         *
          * @param {ASTNode|null} node - A node to report.
          * @returns {void}
          */
@@ -333,7 +321,6 @@ module.exports = {
         /**
          * Reports the previous token of a given node if the token is a keyword and
          * usage of spacing around the token is invalid.
-         *
          * @param {ASTNode|null} node - A node to report.
          * @returns {void}
          */
@@ -348,7 +335,6 @@ module.exports = {
         /**
          * Reports `async` or `function` keywords of a given node if usage of
          * spacing around those keywords is invalid.
-         *
          * @param {ASTNode} node - A node to report.
          * @returns {void}
          */
@@ -366,7 +352,6 @@ module.exports = {
         /**
          * Reports `class` and `extends` keywords of a given node if usage of
          * spacing around those keywords is invalid.
-         *
          * @param {ASTNode} node - A node to report.
          * @returns {void}
          */
@@ -378,7 +363,6 @@ module.exports = {
         /**
          * Reports `if` and `else` keywords of a given node if usage of spacing
          * around those keywords is invalid.
-         *
          * @param {ASTNode} node - A node to report.
          * @returns {void}
          */
@@ -390,7 +374,6 @@ module.exports = {
         /**
          * Reports `try`, `catch`, and `finally` keywords of a given node if usage
          * of spacing around those keywords is invalid.
-         *
          * @param {ASTNode} node - A node to report.
          * @returns {void}
          */
@@ -403,7 +386,6 @@ module.exports = {
         /**
          * Reports `do` and `while` keywords of a given node if usage of spacing
          * around those keywords is invalid.
-         *
          * @param {ASTNode} node - A node to report.
          * @returns {void}
          */
@@ -415,7 +397,6 @@ module.exports = {
         /**
          * Reports `for` and `in` keywords of a given node if usage of spacing
          * around those keywords is invalid.
-         *
          * @param {ASTNode} node - A node to report.
          * @returns {void}
          */
@@ -427,7 +408,6 @@ module.exports = {
         /**
          * Reports `for` and `of` keywords of a given node if usage of spacing
          * around those keywords is invalid.
-         *
          * @param {ASTNode} node - A node to report.
          * @returns {void}
          */
@@ -449,7 +429,6 @@ module.exports = {
          *
          *     import*as A from "./a"; /*error Expected space(s) after "import".
          *                               error Expected space(s) before "as".
-         *
          * @param {ASTNode} node - A node to report.
          * @returns {void}
          */
@@ -474,7 +453,6 @@ module.exports = {
         /**
          * Reports `as` keyword of a given node if usage of spacing around this
          * keyword is invalid.
-         *
          * @param {ASTNode} node - A node to report.
          * @returns {void}
          */
@@ -487,7 +465,6 @@ module.exports = {
         /**
          * Reports `static`, `get`, and `set` keywords of a given node if usage of
          * spacing around those keywords is invalid.
-         *
          * @param {ASTNode} node - A node to report.
          * @returns {void}
          */
@@ -528,7 +505,6 @@ module.exports = {
         /**
          * Reports `await` keyword of a given node if usage of spacing before
          * this keyword is invalid.
-         *
          * @param {ASTNode} node - A node to report.
          * @returns {void}
          */

--- a/lib/rules/lines-around-directive.js
+++ b/lib/rules/lines-around-directive.js
@@ -131,7 +131,7 @@ module.exports = {
 
         /**
          * Check lines around directives in node
-         * @param {ASTNode} node - node to check
+         * @param {ASTNode} node node to check
          * @returns {void}
          */
         function checkDirectives(node) {

--- a/lib/rules/max-len.js
+++ b/lib/rules/max-len.js
@@ -198,7 +198,6 @@ module.exports = {
 
         /**
          * Ensure that an array exists at [key] on `object`, and add `value` to it.
-         *
          * @param {Object} object the object to mutate
          * @param {string} key the object's key
          * @param {*} value the value to add
@@ -214,7 +213,6 @@ module.exports = {
 
         /**
          * Retrieves an array containing all strings (" or ') in the source code.
-         *
          * @returns {ASTNode[]} An array of string nodes.
          */
         function getAllStrings() {
@@ -224,7 +222,6 @@ module.exports = {
 
         /**
          * Retrieves an array containing all template literals in the source code.
-         *
          * @returns {ASTNode[]} An array of template literal nodes.
          */
         function getAllTemplateLiterals() {
@@ -234,7 +231,6 @@ module.exports = {
 
         /**
          * Retrieves an array containing all RegExp literals in the source code.
-         *
          * @returns {ASTNode[]} An array of RegExp literal nodes.
          */
         function getAllRegExpLiterals() {
@@ -244,7 +240,6 @@ module.exports = {
 
         /**
          * A reducer to group an AST node by line number, both start and end.
-         *
          * @param {Object} acc the accumulator
          * @param {ASTNode} node the AST node in question
          * @returns {Object} the modified accumulator

--- a/lib/rules/max-statements-per-line.js
+++ b/lib/rules/max-statements-per-line.js
@@ -80,7 +80,7 @@ module.exports = {
 
         /**
          * Gets the actual last token of a given node.
-         * @param {ASTNode} node - A node to get. This is a node except EmptyStatement.
+         * @param {ASTNode} node A node to get. This is a node except EmptyStatement.
          * @returns {Token} The actual last token.
          */
         function getActualLastToken(node) {
@@ -90,7 +90,7 @@ module.exports = {
         /**
          * Addresses a given node.
          * It updates the state of this rule, then reports the node if the node violated this rule.
-         * @param {ASTNode} node - A node to check.
+         * @param {ASTNode} node A node to check.
          * @returns {void}
          */
         function enterStatement(node) {
@@ -124,7 +124,7 @@ module.exports = {
 
         /**
          * Updates the state of this rule with the end line of leaving node to check with the next statement.
-         * @param {ASTNode} node - A node to check.
+         * @param {ASTNode} node A node to check.
          * @returns {void}
          */
         function leaveStatement(node) {

--- a/lib/rules/max-statements-per-line.js
+++ b/lib/rules/max-statements-per-line.js
@@ -61,7 +61,6 @@ module.exports = {
 
         /**
          * Reports with the first extra statement, and clears it.
-         *
          * @returns {void}
          */
         function reportFirstExtraStatementAndClear() {
@@ -81,7 +80,6 @@ module.exports = {
 
         /**
          * Gets the actual last token of a given node.
-         *
          * @param {ASTNode} node - A node to get. This is a node except EmptyStatement.
          * @returns {Token} The actual last token.
          */
@@ -92,7 +90,6 @@ module.exports = {
         /**
          * Addresses a given node.
          * It updates the state of this rule, then reports the node if the node violated this rule.
-         *
          * @param {ASTNode} node - A node to check.
          * @returns {void}
          */
@@ -127,7 +124,6 @@ module.exports = {
 
         /**
          * Updates the state of this rule with the end line of leaving node to check with the next statement.
-         *
          * @param {ASTNode} node - A node to check.
          * @returns {void}
          */

--- a/lib/rules/multiline-ternary.js
+++ b/lib/rules/multiline-ternary.js
@@ -46,9 +46,9 @@ module.exports = {
 
         /**
          * Tests whether node is preceded by supplied tokens
-         * @param {ASTNode} node - node to check
-         * @param {ASTNode} parentNode - parent of node to report
-         * @param {boolean} expected - whether newline was expected or not
+         * @param {ASTNode} node node to check
+         * @param {ASTNode} parentNode parent of node to report
+         * @param {boolean} expected whether newline was expected or not
          * @returns {void}
          * @private
          */

--- a/lib/rules/newline-after-var.js
+++ b/lib/rules/newline-after-var.js
@@ -72,7 +72,7 @@ module.exports = {
          *     var foo = 1
          *
          *     ;(a || b).doSomething()
-         * @param {ASTNode} node - The node to get.
+         * @param {ASTNode} node The node to get.
          * @returns {Token} The token to compare line to the next statement.
          */
         function getLastToken(node) {
@@ -92,7 +92,7 @@ module.exports = {
         /**
          * Determine if provided keyword is a variable declaration
          * @private
-         * @param {string} keyword - keyword to test
+         * @param {string} keyword keyword to test
          * @returns {boolean} True if `keyword` is a type of var
          */
         function isVar(keyword) {
@@ -102,7 +102,7 @@ module.exports = {
         /**
          * Determine if provided keyword is a variant of for specifiers
          * @private
-         * @param {string} keyword - keyword to test
+         * @param {string} keyword keyword to test
          * @returns {boolean} True if `keyword` is a variant of for specifier
          */
         function isForTypeSpecifier(keyword) {
@@ -112,7 +112,7 @@ module.exports = {
         /**
          * Determine if provided keyword is an export specifiers
          * @private
-         * @param {string} nodeType - nodeType to test
+         * @param {string} nodeType nodeType to test
          * @returns {boolean} True if `nodeType` is an export specifier
          */
         function isExportSpecifier(nodeType) {
@@ -123,7 +123,7 @@ module.exports = {
         /**
          * Determine if provided node is the last of their parent block.
          * @private
-         * @param {ASTNode} node - node to test
+         * @param {ASTNode} node node to test
          * @returns {boolean} True if `node` is last of their parent block.
          */
         function isLastNode(node) {
@@ -158,7 +158,7 @@ module.exports = {
          * set to "always", or checks that there is no blank line when mode is set
          * to "never"
          * @private
-         * @param {ASTNode} node - `VariableDeclaration` node to test
+         * @param {ASTNode} node `VariableDeclaration` node to test
          * @returns {void}
          */
         function checkForBlankLine(node) {

--- a/lib/rules/newline-after-var.js
+++ b/lib/rules/newline-after-var.js
@@ -72,7 +72,6 @@ module.exports = {
          *     var foo = 1
          *
          *     ;(a || b).doSomething()
-         *
          * @param {ASTNode} node - The node to get.
          * @returns {Token} The token to compare line to the next statement.
          */

--- a/lib/rules/newline-before-return.js
+++ b/lib/rules/newline-before-return.js
@@ -160,7 +160,6 @@ module.exports = {
          * The fix is not considered safe if the given return statement has leading comments,
          * as we cannot safely determine if the newline should be added before or after the comments.
          * For more information, see: https://github.com/eslint/eslint/issues/5958#issuecomment-222767211
-         *
          * @param {ASTNode} node - The return statement node to check.
          * @returns {boolean} `true` if it can fix the node.
          * @private

--- a/lib/rules/newline-before-return.js
+++ b/lib/rules/newline-before-return.js
@@ -39,8 +39,8 @@ module.exports = {
 
         /**
          * Tests whether node is preceded by supplied tokens
-         * @param {ASTNode} node - node to check
-         * @param {Array} testTokens - array of tokens to test against
+         * @param {ASTNode} node node to check
+         * @param {Array} testTokens array of tokens to test against
          * @returns {boolean} Whether or not the node is preceded by one of the supplied tokens
          * @private
          */
@@ -52,7 +52,7 @@ module.exports = {
 
         /**
          * Checks whether node is the first node after statement or in block
-         * @param {ASTNode} node - node to check
+         * @param {ASTNode} node node to check
          * @returns {boolean} Whether or not the node is the first node after statement or in block
          * @private
          */
@@ -80,8 +80,8 @@ module.exports = {
 
         /**
          * Returns the number of lines of comments that precede the node
-         * @param {ASTNode} node - node to check for overlapping comments
-         * @param {number} lineNumTokenBefore - line number of previous token, to check for overlapping comments
+         * @param {ASTNode} node node to check for overlapping comments
+         * @param {number} lineNumTokenBefore line number of previous token, to check for overlapping comments
          * @returns {number} Number of lines of comments that precede the node
          * @private
          */
@@ -115,7 +115,7 @@ module.exports = {
 
         /**
          * Returns the line number of the token before the node that is passed in as an argument
-         * @param {ASTNode} node - The node to use as the start of the calculation
+         * @param {ASTNode} node The node to use as the start of the calculation
          * @returns {number} Line number of the token before `node`
          * @private
          */
@@ -142,7 +142,7 @@ module.exports = {
 
         /**
          * Checks whether node is preceded by a newline
-         * @param {ASTNode} node - node to check
+         * @param {ASTNode} node node to check
          * @returns {boolean} Whether or not the node is preceded by a newline
          * @private
          */
@@ -160,7 +160,7 @@ module.exports = {
          * The fix is not considered safe if the given return statement has leading comments,
          * as we cannot safely determine if the newline should be added before or after the comments.
          * For more information, see: https://github.com/eslint/eslint/issues/5958#issuecomment-222767211
-         * @param {ASTNode} node - The return statement node to check.
+         * @param {ASTNode} node The return statement node to check.
          * @returns {boolean} `true` if it can fix the node.
          * @private
          */

--- a/lib/rules/newline-per-chained-call.js
+++ b/lib/rules/newline-per-chained-call.js
@@ -53,7 +53,7 @@ module.exports = {
          * Get the prefix of a given MemberExpression node.
          * If the MemberExpression node is a computed value it returns a
          * left bracket. If not it returns a period.
-         * @param  {ASTNode} node - A MemberExpression node to get
+         * @param  {ASTNode} node A MemberExpression node to get
          * @returns {string} The prefix of the node.
          */
         function getPrefix(node) {
@@ -63,7 +63,7 @@ module.exports = {
         /**
          * Gets the property text of a given MemberExpression node.
          * If the text is multiline, this returns only the first line.
-         * @param {ASTNode} node - A MemberExpression node to get.
+         * @param {ASTNode} node A MemberExpression node to get.
          * @returns {string} The property text of the node.
          */
         function getPropertyText(node) {

--- a/lib/rules/newline-per-chained-call.js
+++ b/lib/rules/newline-per-chained-call.js
@@ -53,7 +53,6 @@ module.exports = {
          * Get the prefix of a given MemberExpression node.
          * If the MemberExpression node is a computed value it returns a
          * left bracket. If not it returns a period.
-         *
          * @param  {ASTNode} node - A MemberExpression node to get
          * @returns {string} The prefix of the node.
          */
@@ -64,7 +63,6 @@ module.exports = {
         /**
          * Gets the property text of a given MemberExpression node.
          * If the text is multiline, this returns only the first line.
-         *
          * @param {ASTNode} node - A MemberExpression node to get.
          * @returns {string} The property text of the node.
          */

--- a/lib/rules/no-class-assign.js
+++ b/lib/rules/no-class-assign.js
@@ -33,7 +33,7 @@ module.exports = {
 
         /**
          * Finds and reports references that are non initializer and writable.
-         * @param {Variable} variable - A variable to check.
+         * @param {Variable} variable A variable to check.
          * @returns {void}
          */
         function checkVariable(variable) {
@@ -45,7 +45,7 @@ module.exports = {
 
         /**
          * Finds and reports references that are non initializer and writable.
-         * @param {ASTNode} node - A ClassDeclaration/ClassExpression node to check.
+         * @param {ASTNode} node A ClassDeclaration/ClassExpression node to check.
          * @returns {void}
          */
         function checkForClass(node) {

--- a/lib/rules/no-compare-neg-zero.js
+++ b/lib/rules/no-compare-neg-zero.js
@@ -35,7 +35,6 @@ module.exports = {
 
         /**
          * Checks a given node is -0
-         *
          * @param {ASTNode} node - A node to check.
          * @returns {boolean} `true` if the node is -0.
          */

--- a/lib/rules/no-compare-neg-zero.js
+++ b/lib/rules/no-compare-neg-zero.js
@@ -35,7 +35,7 @@ module.exports = {
 
         /**
          * Checks a given node is -0
-         * @param {ASTNode} node - A node to check.
+         * @param {ASTNode} node A node to check.
          * @returns {boolean} `true` if the node is -0.
          */
         function isNegZero(node) {

--- a/lib/rules/no-confusing-arrow.js
+++ b/lib/rules/no-confusing-arrow.js
@@ -14,7 +14,7 @@ const astUtils = require("./utils/ast-utils.js");
 
 /**
  * Checks whether or not a node is a conditional expression.
- * @param {ASTNode} node - node to test
+ * @param {ASTNode} node node to test
  * @returns {boolean} `true` if the node is a conditional expression.
  */
 function isConditional(node) {
@@ -59,7 +59,7 @@ module.exports = {
 
         /**
          * Reports if an arrow function contains an ambiguous conditional.
-         * @param {ASTNode} node - A node to check and report.
+         * @param {ASTNode} node A node to check and report.
          * @returns {void}
          */
         function checkArrowFunc(node) {

--- a/lib/rules/no-console.js
+++ b/lib/rules/no-console.js
@@ -54,7 +54,6 @@ module.exports = {
 
         /**
          * Checks whether the given reference is 'console' or not.
-         *
          * @param {eslint-scope.Reference} reference - The reference to check.
          * @returns {boolean} `true` if the reference is 'console'.
          */
@@ -67,7 +66,6 @@ module.exports = {
         /**
          * Checks whether the property name of the given MemberExpression node
          * is allowed by options or not.
-         *
          * @param {ASTNode} node - The MemberExpression node to check.
          * @returns {boolean} `true` if the property name of the node is allowed.
          */
@@ -80,7 +78,6 @@ module.exports = {
         /**
          * Checks whether the given reference is a member access which is not
          * allowed by options or not.
-         *
          * @param {eslint-scope.Reference} reference - The reference to check.
          * @returns {boolean} `true` if the reference is a member access which
          *      is not allowed by options.
@@ -98,7 +95,6 @@ module.exports = {
 
         /**
          * Reports the given reference as a violation.
-         *
          * @param {eslint-scope.Reference} reference - The reference to report.
          * @returns {void}
          */

--- a/lib/rules/no-console.js
+++ b/lib/rules/no-console.js
@@ -54,7 +54,7 @@ module.exports = {
 
         /**
          * Checks whether the given reference is 'console' or not.
-         * @param {eslint-scope.Reference} reference - The reference to check.
+         * @param {eslint-scope.Reference} reference The reference to check.
          * @returns {boolean} `true` if the reference is 'console'.
          */
         function isConsole(reference) {
@@ -66,7 +66,7 @@ module.exports = {
         /**
          * Checks whether the property name of the given MemberExpression node
          * is allowed by options or not.
-         * @param {ASTNode} node - The MemberExpression node to check.
+         * @param {ASTNode} node The MemberExpression node to check.
          * @returns {boolean} `true` if the property name of the node is allowed.
          */
         function isAllowed(node) {
@@ -78,7 +78,7 @@ module.exports = {
         /**
          * Checks whether the given reference is a member access which is not
          * allowed by options or not.
-         * @param {eslint-scope.Reference} reference - The reference to check.
+         * @param {eslint-scope.Reference} reference The reference to check.
          * @returns {boolean} `true` if the reference is a member access which
          *      is not allowed by options.
          */
@@ -95,7 +95,7 @@ module.exports = {
 
         /**
          * Reports the given reference as a violation.
-         * @param {eslint-scope.Reference} reference - The reference to report.
+         * @param {eslint-scope.Reference} reference The reference to report.
          * @returns {void}
          */
         function report(reference) {

--- a/lib/rules/no-const-assign.js
+++ b/lib/rules/no-const-assign.js
@@ -33,7 +33,7 @@ module.exports = {
 
         /**
          * Finds and reports references that are non initializer and writable.
-         * @param {Variable} variable - A variable to check.
+         * @param {Variable} variable A variable to check.
          * @returns {void}
          */
         function checkVariable(variable) {

--- a/lib/rules/no-dupe-args.js
+++ b/lib/rules/no-dupe-args.js
@@ -35,7 +35,7 @@ module.exports = {
 
         /**
          * Checks whether or not a given definition is a parameter's.
-         * @param {eslint-scope.DefEntry} def - A definition to check.
+         * @param {eslint-scope.DefEntry} def A definition to check.
          * @returns {boolean} `true` if the definition is a parameter's.
          */
         function isParameter(def) {

--- a/lib/rules/no-dupe-class-members.js
+++ b/lib/rules/no-dupe-class-members.js
@@ -55,7 +55,6 @@ module.exports = {
 
         /**
          * Gets the name text of a given node.
-         *
          * @param {ASTNode} node - A node to get the name.
          * @returns {string} The name text of the node.
          */

--- a/lib/rules/no-dupe-class-members.js
+++ b/lib/rules/no-dupe-class-members.js
@@ -32,8 +32,8 @@ module.exports = {
 
         /**
          * Gets state of a given member name.
-         * @param {string} name - A name of a member.
-         * @param {boolean} isStatic - A flag which specifies that is a static member.
+         * @param {string} name A name of a member.
+         * @param {boolean} isStatic A flag which specifies that is a static member.
          * @returns {Object} A state of a given member name.
          *   - retv.init {boolean} A flag which shows the name is declared as normal member.
          *   - retv.get {boolean} A flag which shows the name is declared as getter.
@@ -55,7 +55,7 @@ module.exports = {
 
         /**
          * Gets the name text of a given node.
-         * @param {ASTNode} node - A node to get the name.
+         * @param {ASTNode} node A node to get the name.
          * @returns {string} The name text of the node.
          */
         function getName(node) {

--- a/lib/rules/no-dupe-keys.js
+++ b/lib/rules/no-dupe-keys.js
@@ -24,8 +24,8 @@ const SET_KIND = /^(?:init|set)$/u;
 class ObjectInfo {
 
     /**
-     * @param {ObjectInfo|null} upper - The information of the outer object.
-     * @param {ASTNode} node - The ObjectExpression node of this information.
+     * @param {ObjectInfo|null} upper The information of the outer object.
+     * @param {ASTNode} node The ObjectExpression node of this information.
      */
     constructor(upper, node) {
         this.upper = upper;
@@ -35,7 +35,7 @@ class ObjectInfo {
 
     /**
      * Gets the information of the given Property node.
-     * @param {ASTNode} node - The Property node to get.
+     * @param {ASTNode} node The Property node to get.
      * @returns {{get: boolean, set: boolean}} The information of the property.
      */
     getPropertyInfo(node) {
@@ -49,7 +49,7 @@ class ObjectInfo {
 
     /**
      * Checks whether the given property has been defined already or not.
-     * @param {ASTNode} node - The Property node to check.
+     * @param {ASTNode} node The Property node to check.
      * @returns {boolean} `true` if the property has been defined.
      */
     isPropertyDefined(node) {
@@ -63,7 +63,7 @@ class ObjectInfo {
 
     /**
      * Defines the given property.
-     * @param {ASTNode} node - The Property node to define.
+     * @param {ASTNode} node The Property node to define.
      * @returns {void}
      */
     defineProperty(node) {

--- a/lib/rules/no-duplicate-imports.js
+++ b/lib/rules/no-duplicate-imports.js
@@ -10,7 +10,6 @@
 
 /**
  * Returns the name of the module imported or re-exported.
- *
  * @param {ASTNode} node - A node to get.
  * @returns {string} the name of the module, or empty string if no name.
  */
@@ -24,7 +23,6 @@ function getValue(node) {
 
 /**
  * Checks if the name of the import or export exists in the given array, and reports if so.
- *
  * @param {RuleContext} context - The ESLint rule context object.
  * @param {ASTNode} node - A node to get.
  * @param {string} value - The name of the imported or exported module.
@@ -52,7 +50,6 @@ function checkAndReport(context, node, value, array, messageId) {
 
 /**
  * Returns a function handling the imports of a given file
- *
  * @param {RuleContext} context - The ESLint rule context object.
  * @param {boolean} includeExports - Whether or not to check for exports in addition to imports.
  * @param {string[]} importsInFile - The array containing other imports in the file.
@@ -78,7 +75,6 @@ function handleImports(context, includeExports, importsInFile, exportsInFile) {
 
 /**
  * Returns a function handling the exports of a given file
- *
  * @param {RuleContext} context - The ESLint rule context object.
  * @param {string[]} importsInFile - The array containing other imports in the file.
  * @param {string[]} exportsInFile - The array containing other exports in the file.

--- a/lib/rules/no-duplicate-imports.js
+++ b/lib/rules/no-duplicate-imports.js
@@ -10,7 +10,7 @@
 
 /**
  * Returns the name of the module imported or re-exported.
- * @param {ASTNode} node - A node to get.
+ * @param {ASTNode} node A node to get.
  * @returns {string} the name of the module, or empty string if no name.
  */
 function getValue(node) {
@@ -23,11 +23,11 @@ function getValue(node) {
 
 /**
  * Checks if the name of the import or export exists in the given array, and reports if so.
- * @param {RuleContext} context - The ESLint rule context object.
- * @param {ASTNode} node - A node to get.
- * @param {string} value - The name of the imported or exported module.
- * @param {string[]} array - The array containing other imports or exports in the file.
- * @param {string} messageId - A messageId to be reported after the name of the module
+ * @param {RuleContext} context The ESLint rule context object.
+ * @param {ASTNode} node A node to get.
+ * @param {string} value The name of the imported or exported module.
+ * @param {string[]} array The array containing other imports or exports in the file.
+ * @param {string} messageId A messageId to be reported after the name of the module
  *
  * @returns {void} No return value
  */
@@ -45,15 +45,15 @@ function checkAndReport(context, node, value, array, messageId) {
 
 /**
  * @callback nodeCallback
- * @param {ASTNode} node - A node to handle.
+ * @param {ASTNode} node A node to handle.
  */
 
 /**
  * Returns a function handling the imports of a given file
- * @param {RuleContext} context - The ESLint rule context object.
- * @param {boolean} includeExports - Whether or not to check for exports in addition to imports.
- * @param {string[]} importsInFile - The array containing other imports in the file.
- * @param {string[]} exportsInFile - The array containing other exports in the file.
+ * @param {RuleContext} context The ESLint rule context object.
+ * @param {boolean} includeExports Whether or not to check for exports in addition to imports.
+ * @param {string[]} importsInFile The array containing other imports in the file.
+ * @param {string[]} exportsInFile The array containing other exports in the file.
  *
  * @returns {nodeCallback} A function passed to ESLint to handle the statement.
  */
@@ -75,9 +75,9 @@ function handleImports(context, includeExports, importsInFile, exportsInFile) {
 
 /**
  * Returns a function handling the exports of a given file
- * @param {RuleContext} context - The ESLint rule context object.
- * @param {string[]} importsInFile - The array containing other imports in the file.
- * @param {string[]} exportsInFile - The array containing other exports in the file.
+ * @param {RuleContext} context The ESLint rule context object.
+ * @param {string[]} importsInFile The array containing other imports in the file.
+ * @param {string[]} exportsInFile The array containing other exports in the file.
  *
  * @returns {nodeCallback} A function passed to ESLint to handle the statement.
  */

--- a/lib/rules/no-else-return.js
+++ b/lib/rules/no-else-return.js
@@ -58,7 +58,6 @@ module.exports = {
          *
          * This is not a generic function. In particular, it is assumed that the scope is a function scope or
          * a function's inner scope, and that the names can be valid identifiers in the given scope.
-         *
          * @param {string[]} names Array of variable names.
          * @param {eslint-scope.Scope} scope Function scope or a function's inner scope.
          * @returns {boolean} True if all names can be safely declared, false otherwise.
@@ -134,7 +133,6 @@ module.exports = {
 
         /**
          * Checks whether the removal of `else` and its braces is safe from variable name collisions.
-         *
          * @param {Node} node The 'else' node.
          * @param {eslint-scope.Scope} scope The scope in which the node and the whole 'if' statement is.
          * @returns {boolean} True if it is safe, false otherwise.
@@ -171,7 +169,6 @@ module.exports = {
 
         /**
          * Display the context report if rule is violated
-         *
          * @param {Node} node The 'else' node
          * @returns {void}
          */
@@ -255,7 +252,6 @@ module.exports = {
 
         /**
          * Check to see if the node is a ReturnStatement
-         *
          * @param {Node} node The node being evaluated
          * @returns {boolean} True if node is a return
          */
@@ -267,7 +263,6 @@ module.exports = {
          * Naive return checking, does not iterate through the whole
          * BlockStatement because we make the assumption that the ReturnStatement
          * will be the last node in the body of the BlockStatement.
-         *
          * @param {Node} node The consequent/alternate node
          * @returns {boolean} True if it has a return
          */
@@ -284,7 +279,6 @@ module.exports = {
         /**
          * Check to see if the node is valid for evaluation,
          * meaning it has an else.
-         *
          * @param {Node} node The node being evaluated
          * @returns {boolean} True if the node is valid
          */
@@ -296,7 +290,6 @@ module.exports = {
          * If the consequent is an IfStatement, check to see if it has an else
          * and both its consequent and alternate path return, meaning this is
          * a nested case of rule violation.  If-Else not considered currently.
-         *
          * @param {Node} node The consequent node
          * @returns {boolean} True if this is a nested rule violation
          */
@@ -309,7 +302,6 @@ module.exports = {
          * Check the consequent/body node to make sure it is not
          * a ReturnStatement or an IfStatement that returns on both
          * code paths.
-         *
          * @param {Node} node The consequent or body node
          * @returns {boolean} `true` if it is a Return/If node that always returns.
          */

--- a/lib/rules/no-empty-function.js
+++ b/lib/rules/no-empty-function.js
@@ -28,7 +28,7 @@ const ALLOW_OPTIONS = Object.freeze([
 
 /**
  * Gets the kind of a given function node.
- * @param {ASTNode} node - A function node to get. This is one of
+ * @param {ASTNode} node A function node to get. This is one of
  *      an ArrowFunctionExpression, a FunctionDeclaration, or a
  *      FunctionExpression.
  * @returns {string} The kind of the function. This is one of "functions",
@@ -129,7 +129,7 @@ module.exports = {
          * - Not allowed by options.
          * - The body is empty.
          * - The body doesn't have any comments.
-         * @param {ASTNode} node - A function node to report. This is one of
+         * @param {ASTNode} node A function node to report. This is one of
          *      an ArrowFunctionExpression, a FunctionDeclaration, or a
          *      FunctionExpression.
          * @returns {void}

--- a/lib/rules/no-empty-function.js
+++ b/lib/rules/no-empty-function.js
@@ -28,7 +28,6 @@ const ALLOW_OPTIONS = Object.freeze([
 
 /**
  * Gets the kind of a given function node.
- *
  * @param {ASTNode} node - A function node to get. This is one of
  *      an ArrowFunctionExpression, a FunctionDeclaration, or a
  *      FunctionExpression.
@@ -130,7 +129,6 @@ module.exports = {
          * - Not allowed by options.
          * - The body is empty.
          * - The body doesn't have any comments.
-         *
          * @param {ASTNode} node - A function node to report. This is one of
          *      an ArrowFunctionExpression, a FunctionDeclaration, or a
          *      FunctionExpression.

--- a/lib/rules/no-eval.js
+++ b/lib/rules/no-eval.js
@@ -22,7 +22,6 @@ const candidatesOfGlobalObject = Object.freeze([
 
 /**
  * Checks a given node is a Identifier node of the specified name.
- *
  * @param {ASTNode} node - A node to check.
  * @param {string} name - A name to check.
  * @returns {boolean} `true` if the node is a Identifier node of the name.
@@ -33,7 +32,6 @@ function isIdentifier(node, name) {
 
 /**
  * Checks a given node is a Literal node of the specified string value.
- *
  * @param {ASTNode} node - A node to check.
  * @param {string} name - A name to check.
  * @returns {boolean} `true` if the node is a Literal node of the name.
@@ -57,7 +55,6 @@ function isConstant(node, name) {
 /**
  * Checks a given node is a MemberExpression node which has the specified name's
  * property.
- *
  * @param {ASTNode} node - A node to check.
  * @param {string} name - A name to check.
  * @returns {boolean} `true` if the node is a MemberExpression node which has
@@ -113,7 +110,6 @@ module.exports = {
          *
          * This is used in order to check whether or not `this` binding is a
          * reference to the global object.
-         *
          * @param {ASTNode} node - A node of the scope. This is one of Program,
          *      FunctionDeclaration, FunctionExpression, and ArrowFunctionExpression.
          * @returns {void}
@@ -132,7 +128,6 @@ module.exports = {
 
         /**
          * Pops a variable scope from the stack.
-         *
          * @returns {void}
          */
         function exitVarScope() {
@@ -148,7 +143,6 @@ module.exports = {
          * The location of the report is always `eval` `Identifier` (or possibly
          * `Literal`). The type of the report is `CallExpression` if the parent is
          * `CallExpression`. Otherwise, it's the given node type.
-         *
          * @param {ASTNode} node - A node to report.
          * @returns {void}
          */
@@ -171,7 +165,6 @@ module.exports = {
 
         /**
          * Reports accesses of `eval` via the global object.
-         *
          * @param {eslint-scope.Scope} globalScope - The global scope.
          * @returns {void}
          */
@@ -205,7 +198,6 @@ module.exports = {
 
         /**
          * Reports all accesses of `eval` (excludes direct calls to eval).
-         *
          * @param {eslint-scope.Scope} globalScope - The global scope.
          * @returns {void}
          */

--- a/lib/rules/no-eval.js
+++ b/lib/rules/no-eval.js
@@ -22,8 +22,8 @@ const candidatesOfGlobalObject = Object.freeze([
 
 /**
  * Checks a given node is a Identifier node of the specified name.
- * @param {ASTNode} node - A node to check.
- * @param {string} name - A name to check.
+ * @param {ASTNode} node A node to check.
+ * @param {string} name A name to check.
  * @returns {boolean} `true` if the node is a Identifier node of the name.
  */
 function isIdentifier(node, name) {
@@ -32,8 +32,8 @@ function isIdentifier(node, name) {
 
 /**
  * Checks a given node is a Literal node of the specified string value.
- * @param {ASTNode} node - A node to check.
- * @param {string} name - A name to check.
+ * @param {ASTNode} node A node to check.
+ * @param {string} name A name to check.
  * @returns {boolean} `true` if the node is a Literal node of the name.
  */
 function isConstant(node, name) {
@@ -55,8 +55,8 @@ function isConstant(node, name) {
 /**
  * Checks a given node is a MemberExpression node which has the specified name's
  * property.
- * @param {ASTNode} node - A node to check.
- * @param {string} name - A name to check.
+ * @param {ASTNode} node A node to check.
+ * @param {string} name A name to check.
  * @returns {boolean} `true` if the node is a MemberExpression node which has
  *      the specified name's property
  */
@@ -110,7 +110,7 @@ module.exports = {
          *
          * This is used in order to check whether or not `this` binding is a
          * reference to the global object.
-         * @param {ASTNode} node - A node of the scope. This is one of Program,
+         * @param {ASTNode} node A node of the scope. This is one of Program,
          *      FunctionDeclaration, FunctionExpression, and ArrowFunctionExpression.
          * @returns {void}
          */
@@ -143,7 +143,7 @@ module.exports = {
          * The location of the report is always `eval` `Identifier` (or possibly
          * `Literal`). The type of the report is `CallExpression` if the parent is
          * `CallExpression`. Otherwise, it's the given node type.
-         * @param {ASTNode} node - A node to report.
+         * @param {ASTNode} node A node to report.
          * @returns {void}
          */
         function report(node) {
@@ -165,7 +165,7 @@ module.exports = {
 
         /**
          * Reports accesses of `eval` via the global object.
-         * @param {eslint-scope.Scope} globalScope - The global scope.
+         * @param {eslint-scope.Scope} globalScope The global scope.
          * @returns {void}
          */
         function reportAccessingEvalViaGlobalObject(globalScope) {
@@ -198,7 +198,7 @@ module.exports = {
 
         /**
          * Reports all accesses of `eval` (excludes direct calls to eval).
-         * @param {eslint-scope.Scope} globalScope - The global scope.
+         * @param {eslint-scope.Scope} globalScope The global scope.
          * @returns {void}
          */
         function reportAccessingEval(globalScope) {

--- a/lib/rules/no-ex-assign.js
+++ b/lib/rules/no-ex-assign.js
@@ -33,7 +33,7 @@ module.exports = {
 
         /**
          * Finds and reports references that are non initializer and writable.
-         * @param {Variable} variable - A variable to check.
+         * @param {Variable} variable A variable to check.
          * @returns {void}
          */
         function checkVariable(variable) {

--- a/lib/rules/no-extra-bind.js
+++ b/lib/rules/no-extra-bind.js
@@ -56,7 +56,7 @@ module.exports = {
 
         /**
          * Reports a given function node.
-         * @param {ASTNode} node - A node to report. This is a FunctionExpression or
+         * @param {ASTNode} node A node to report. This is a FunctionExpression or
          *      an ArrowFunctionExpression.
          * @returns {void}
          */
@@ -88,7 +88,7 @@ module.exports = {
          * method.
          *
          * e.g. `(function() {}.bind(foo))`
-         * @param {ASTNode} node - A node to report. This is a FunctionExpression or
+         * @param {ASTNode} node A node to report. This is a FunctionExpression or
          *      an ArrowFunctionExpression.
          * @returns {boolean} `true` if the node is the callee of `.bind()` method.
          */
@@ -110,7 +110,7 @@ module.exports = {
 
         /**
          * Adds a scope information object to the stack.
-         * @param {ASTNode} node - A node to add. This node is a FunctionExpression
+         * @param {ASTNode} node A node to add. This node is a FunctionExpression
          *      or a FunctionDeclaration node.
          * @returns {void}
          */
@@ -126,7 +126,7 @@ module.exports = {
          * Removes the scope information object from the top of the stack.
          * At the same time, this reports the function node if the function has
          * `.bind()` and the `this` keywords found.
-         * @param {ASTNode} node - A node to remove. This node is a
+         * @param {ASTNode} node A node to remove. This node is a
          *      FunctionExpression or a FunctionDeclaration node.
          * @returns {void}
          */
@@ -141,7 +141,7 @@ module.exports = {
         /**
          * Reports a given arrow function if the function is callee of `.bind()`
          * method.
-         * @param {ASTNode} node - A node to report. This node is an
+         * @param {ASTNode} node A node to report. This node is an
          *      ArrowFunctionExpression.
          * @returns {void}
          */

--- a/lib/rules/no-extra-bind.js
+++ b/lib/rules/no-extra-bind.js
@@ -47,7 +47,6 @@ module.exports = {
          * Checks if a node is free of side effects.
          *
          * This check is stricter than it needs to be, in order to keep the implementation simple.
-         *
          * @param {ASTNode} node A node to check.
          * @returns {boolean} True if the node is known to be side-effect free, false otherwise.
          */
@@ -57,7 +56,6 @@ module.exports = {
 
         /**
          * Reports a given function node.
-         *
          * @param {ASTNode} node - A node to report. This is a FunctionExpression or
          *      an ArrowFunctionExpression.
          * @returns {void}
@@ -90,7 +88,6 @@ module.exports = {
          * method.
          *
          * e.g. `(function() {}.bind(foo))`
-         *
          * @param {ASTNode} node - A node to report. This is a FunctionExpression or
          *      an ArrowFunctionExpression.
          * @returns {boolean} `true` if the node is the callee of `.bind()` method.
@@ -113,7 +110,6 @@ module.exports = {
 
         /**
          * Adds a scope information object to the stack.
-         *
          * @param {ASTNode} node - A node to add. This node is a FunctionExpression
          *      or a FunctionDeclaration node.
          * @returns {void}
@@ -130,7 +126,6 @@ module.exports = {
          * Removes the scope information object from the top of the stack.
          * At the same time, this reports the function node if the function has
          * `.bind()` and the `this` keywords found.
-         *
          * @param {ASTNode} node - A node to remove. This node is a
          *      FunctionExpression or a FunctionDeclaration node.
          * @returns {void}
@@ -146,7 +141,6 @@ module.exports = {
         /**
          * Reports a given arrow function if the function is callee of `.bind()`
          * method.
-         *
          * @param {ASTNode} node - A node to report. This node is an
          *      ArrowFunctionExpression.
          * @returns {void}
@@ -159,7 +153,6 @@ module.exports = {
 
         /**
          * Set the mark as the `this` keyword was found in this scope.
-         *
          * @returns {void}
          */
         function markAsThisFound() {

--- a/lib/rules/no-extra-boolean-cast.js
+++ b/lib/rules/no-extra-boolean-cast.js
@@ -49,7 +49,6 @@ module.exports = {
 
         /**
          * Check if a node is in a context where its value would be coerced to a boolean at runtime.
-         *
          * @param {ASTNode} node The node
          * @param {ASTNode} parent Its parent
          * @returns {boolean} If it is in a boolean context
@@ -67,7 +66,6 @@ module.exports = {
 
         /**
          * Check if a node has comments inside.
-         *
          * @param {ASTNode} node The node to check.
          * @returns {boolean} `true` if it has comments inside.
          */

--- a/lib/rules/no-extra-label.js
+++ b/lib/rules/no-extra-label.js
@@ -40,7 +40,7 @@ module.exports = {
 
         /**
          * Creates a new scope with a breakable statement.
-         * @param {ASTNode} node - A node to create. This is a BreakableStatement.
+         * @param {ASTNode} node A node to create. This is a BreakableStatement.
          * @returns {void}
          */
         function enterBreakableStatement(node) {
@@ -64,7 +64,7 @@ module.exports = {
          *
          * This ignores it if the body is a breakable statement.
          * In this case it's handled in the `enterBreakableStatement` function.
-         * @param {ASTNode} node - A node to create. This is a LabeledStatement.
+         * @param {ASTNode} node A node to create. This is a LabeledStatement.
          * @returns {void}
          */
         function enterLabeledStatement(node) {
@@ -82,7 +82,7 @@ module.exports = {
          *
          * This ignores it if the body is a breakable statement.
          * In this case it's handled in the `exitBreakableStatement` function.
-         * @param {ASTNode} node - A node. This is a LabeledStatement.
+         * @param {ASTNode} node A node. This is a LabeledStatement.
          * @returns {void}
          */
         function exitLabeledStatement(node) {
@@ -93,7 +93,7 @@ module.exports = {
 
         /**
          * Reports a given control node if it's unnecessary.
-         * @param {ASTNode} node - A node. This is a BreakStatement or a
+         * @param {ASTNode} node A node. This is a BreakStatement or a
          *      ContinueStatement.
          * @returns {void}
          */

--- a/lib/rules/no-extra-label.js
+++ b/lib/rules/no-extra-label.js
@@ -40,7 +40,6 @@ module.exports = {
 
         /**
          * Creates a new scope with a breakable statement.
-         *
          * @param {ASTNode} node - A node to create. This is a BreakableStatement.
          * @returns {void}
          */
@@ -54,7 +53,6 @@ module.exports = {
 
         /**
          * Removes the top scope of the stack.
-         *
          * @returns {void}
          */
         function exitBreakableStatement() {
@@ -66,7 +64,6 @@ module.exports = {
          *
          * This ignores it if the body is a breakable statement.
          * In this case it's handled in the `enterBreakableStatement` function.
-         *
          * @param {ASTNode} node - A node to create. This is a LabeledStatement.
          * @returns {void}
          */
@@ -85,7 +82,6 @@ module.exports = {
          *
          * This ignores it if the body is a breakable statement.
          * In this case it's handled in the `exitBreakableStatement` function.
-         *
          * @param {ASTNode} node - A node. This is a LabeledStatement.
          * @returns {void}
          */
@@ -97,7 +93,6 @@ module.exports = {
 
         /**
          * Reports a given control node if it's unnecessary.
-         *
          * @param {ASTNode} node - A node. This is a BreakStatement or a
          *      ContinueStatement.
          * @returns {void}

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -88,7 +88,7 @@ module.exports = {
 
         /**
          * Determines if this rule should be enforced for a node given the current configuration.
-         * @param {ASTNode} node - The node to be checked.
+         * @param {ASTNode} node The node to be checked.
          * @returns {boolean} True if the rule should be enforced for this node.
          * @private
          */
@@ -127,7 +127,7 @@ module.exports = {
 
         /**
          * Determines if a node is surrounded by parentheses.
-         * @param {ASTNode} node - The node to be checked.
+         * @param {ASTNode} node The node to be checked.
          * @returns {boolean} True if the node is parenthesised.
          * @private
          */
@@ -137,7 +137,7 @@ module.exports = {
 
         /**
          * Determines if a node is surrounded by parentheses twice.
-         * @param {ASTNode} node - The node to be checked.
+         * @param {ASTNode} node The node to be checked.
          * @returns {boolean} True if the node is doubly parenthesised.
          * @private
          */
@@ -147,7 +147,7 @@ module.exports = {
 
         /**
          * Determines if a node is surrounded by (potentially) invalid parentheses.
-         * @param {ASTNode} node - The node to be checked.
+         * @param {ASTNode} node The node to be checked.
          * @returns {boolean} True if the node is incorrectly parenthesised.
          * @private
          */
@@ -158,7 +158,7 @@ module.exports = {
         /**
          * Determines if a node that is expected to be parenthesised is surrounded by
          * (potentially) invalid extra parentheses.
-         * @param {ASTNode} node - The node to be checked.
+         * @param {ASTNode} node The node to be checked.
          * @returns {boolean} True if the node is has an unexpected extra pair of parentheses.
          * @private
          */
@@ -168,7 +168,7 @@ module.exports = {
 
         /**
          * Determines if a node test expression is allowed to have a parenthesised assignment
-         * @param {ASTNode} node - The node to be checked.
+         * @param {ASTNode} node The node to be checked.
          * @returns {boolean} True if the assignment can be parenthesised.
          * @private
          */
@@ -178,7 +178,7 @@ module.exports = {
 
         /**
          * Determines if a node is in a return statement
-         * @param {ASTNode} node - The node to be checked.
+         * @param {ASTNode} node The node to be checked.
          * @returns {boolean} True if the node is in a return statement.
          * @private
          */
@@ -197,7 +197,7 @@ module.exports = {
 
         /**
          * Determines if a constructor function is newed-up with parens
-         * @param {ASTNode} newExpression - The NewExpression node to be checked.
+         * @param {ASTNode} newExpression The NewExpression node to be checked.
          * @returns {boolean} True if the constructor is called with parens.
          * @private
          */
@@ -217,7 +217,7 @@ module.exports = {
 
         /**
          * Determines if a node is or contains an assignment expression
-         * @param {ASTNode} node - The node to be checked.
+         * @param {ASTNode} node The node to be checked.
          * @returns {boolean} True if the node is or contains an assignment expression.
          * @private
          */
@@ -239,7 +239,7 @@ module.exports = {
 
         /**
          * Determines if a node is contained by or is itself a return statement and is allowed to have a parenthesised assignment
-         * @param {ASTNode} node - The node to be checked.
+         * @param {ASTNode} node The node to be checked.
          * @returns {boolean} True if the assignment can be parenthesised.
          * @private
          */
@@ -261,8 +261,8 @@ module.exports = {
         /**
          * Determines if a node following a [no LineTerminator here] restriction is
          * surrounded by (potentially) invalid extra parentheses.
-         * @param {Token} token - The token preceding the [no LineTerminator here] restriction.
-         * @param {ASTNode} node - The node to be checked.
+         * @param {Token} token The token preceding the [no LineTerminator here] restriction.
+         * @param {ASTNode} node The node to be checked.
          * @returns {boolean} True if the node is incorrectly parenthesised.
          * @private
          */

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -567,7 +567,6 @@ module.exports = {
         /**
          * Checks whether the syntax of the given ancestor of an 'in' expression inside a for-loop initializer
          * is preventing the 'in' keyword from being interpreted as a part of an ill-formed for-in loop.
-         *
          * @param {ASTNode} node Ancestor of an 'in' expression.
          * @param {ASTNode} child Child of the node, ancestor of the same 'in' expression or the 'in' expression itself.
          * @returns {boolean} True if the keyword 'in' would be interpreted as the 'in' operator, without any parenthesis.
@@ -599,7 +598,6 @@ module.exports = {
         /**
          * Starts a new reports buffering. Warnings will be stored in a buffer instead of being reported immediately.
          * An additional logic that requires multiple nodes (e.g. a whole subtree) may dismiss some of the stored warnings.
-         *
          * @returns {void}
          */
         function startNewReportsBuffering() {

--- a/lib/rules/no-extra-semi.js
+++ b/lib/rules/no-extra-semi.js
@@ -64,7 +64,6 @@ module.exports = {
         /**
          * Checks for a part of a class body.
          * This checks tokens from a specified token to a next MethodDefinition or the end of class body.
-         *
          * @param {Token} firstToken - The first token to check.
          * @returns {void}
          */

--- a/lib/rules/no-extra-semi.js
+++ b/lib/rules/no-extra-semi.js
@@ -40,7 +40,7 @@ module.exports = {
 
         /**
          * Reports an unnecessary semicolon error.
-         * @param {Node|Token} nodeOrToken - A node or a token to be reported.
+         * @param {Node|Token} nodeOrToken A node or a token to be reported.
          * @returns {void}
          */
         function report(nodeOrToken) {
@@ -64,7 +64,7 @@ module.exports = {
         /**
          * Checks for a part of a class body.
          * This checks tokens from a specified token to a next MethodDefinition or the end of class body.
-         * @param {Token} firstToken - The first token to check.
+         * @param {Token} firstToken The first token to check.
          * @returns {void}
          */
         function checkForPartOfClassBody(firstToken) {
@@ -82,7 +82,7 @@ module.exports = {
 
             /**
              * Reports this empty statement, except if the parent node is a loop.
-             * @param {Node} node - A EmptyStatement node to be reported.
+             * @param {Node} node A EmptyStatement node to be reported.
              * @returns {void}
              */
             EmptyStatement(node) {
@@ -105,7 +105,7 @@ module.exports = {
 
             /**
              * Checks tokens from the head of this class body to the first MethodDefinition or the end of this class body.
-             * @param {Node} node - A ClassBody node to check.
+             * @param {Node} node A ClassBody node to check.
              * @returns {void}
              */
             ClassBody(node) {
@@ -114,7 +114,7 @@ module.exports = {
 
             /**
              * Checks tokens from this MethodDefinition to the next MethodDefinition or the end of this class body.
-             * @param {Node} node - A MethodDefinition node of the start point.
+             * @param {Node} node A MethodDefinition node of the start point.
              * @returns {void}
              */
             MethodDefinition(node) {

--- a/lib/rules/no-fallthrough.js
+++ b/lib/rules/no-fallthrough.js
@@ -18,9 +18,9 @@ const DEFAULT_FALLTHROUGH_COMMENT = /falls?\s?through/iu;
 
 /**
  * Checks whether or not a given node has a fallthrough comment.
- * @param {ASTNode} node - A SwitchCase node to get comments.
- * @param {RuleContext} context - A rule context which stores comments.
- * @param {RegExp} fallthroughCommentPattern - A pattern to match comment to.
+ * @param {ASTNode} node A SwitchCase node to get comments.
+ * @param {RuleContext} context A rule context which stores comments.
+ * @param {RegExp} fallthroughCommentPattern A pattern to match comment to.
  * @returns {boolean} `true` if the node has a valid fallthrough comment.
  */
 function hasFallthroughComment(node, context, fallthroughCommentPattern) {
@@ -32,7 +32,7 @@ function hasFallthroughComment(node, context, fallthroughCommentPattern) {
 
 /**
  * Checks whether or not a given code path segment is reachable.
- * @param {CodePathSegment} segment - A CodePathSegment to check.
+ * @param {CodePathSegment} segment A CodePathSegment to check.
  * @returns {boolean} `true` if the segment is reachable.
  */
 function isReachable(segment) {
@@ -41,8 +41,8 @@ function isReachable(segment) {
 
 /**
  * Checks whether a node and a token are separated by blank lines
- * @param {ASTNode} node - The node to check
- * @param {Token} token - The token to compare against
+ * @param {ASTNode} node The node to check
+ * @param {Token} token The token to compare against
  * @returns {boolean} `true` if there are blank lines between node and token
  */
 function hasBlankLinesBetween(node, token) {

--- a/lib/rules/no-func-assign.js
+++ b/lib/rules/no-func-assign.js
@@ -29,7 +29,7 @@ module.exports = {
 
         /**
          * Reports a reference if is non initializer and writable.
-         * @param {References} references - Collection of reference to check.
+         * @param {References} references Collection of reference to check.
          * @returns {void}
          */
         function checkReference(references) {
@@ -40,7 +40,7 @@ module.exports = {
 
         /**
          * Finds and reports references that are non initializer and writable.
-         * @param {Variable} variable - A variable to check.
+         * @param {Variable} variable A variable to check.
          * @returns {void}
          */
         function checkVariable(variable) {
@@ -51,7 +51,7 @@ module.exports = {
 
         /**
          * Checks parameters of a given function node.
-         * @param {ASTNode} node - A function node to check.
+         * @param {ASTNode} node A function node to check.
          * @returns {void}
          */
         function checkForFunction(node) {

--- a/lib/rules/no-global-assign.js
+++ b/lib/rules/no-global-assign.js
@@ -41,9 +41,9 @@ module.exports = {
 
         /**
          * Reports write references.
-         * @param {Reference} reference - A reference to check.
-         * @param {int} index - The index of the reference in the references.
-         * @param {Reference[]} references - The array that the reference belongs to.
+         * @param {Reference} reference A reference to check.
+         * @param {int} index The index of the reference in the references.
+         * @param {Reference[]} references The array that the reference belongs to.
          * @returns {void}
          */
         function checkReference(reference, index, references) {
@@ -68,7 +68,7 @@ module.exports = {
 
         /**
          * Reports write references if a given variable is read-only builtin.
-         * @param {Variable} variable - A variable to check.
+         * @param {Variable} variable A variable to check.
          * @returns {void}
          */
         function checkVariable(variable) {

--- a/lib/rules/no-implicit-coercion.js
+++ b/lib/rules/no-implicit-coercion.js
@@ -16,7 +16,7 @@ const ALLOWABLE_OPERATORS = ["~", "!!", "+", "*"];
 
 /**
  * Parses and normalizes an option object.
- * @param {Object} options - An option object to parse.
+ * @param {Object} options An option object to parse.
  * @returns {Object} The parsed and normalized option object.
  */
 function parseOptions(options) {
@@ -30,7 +30,7 @@ function parseOptions(options) {
 
 /**
  * Checks whether or not a node is a double logical nigating.
- * @param {ASTNode} node - An UnaryExpression node to check.
+ * @param {ASTNode} node An UnaryExpression node to check.
  * @returns {boolean} Whether or not the node is a double logical nigating.
  */
 function isDoubleLogicalNegating(node) {
@@ -43,7 +43,7 @@ function isDoubleLogicalNegating(node) {
 
 /**
  * Checks whether or not a node is a binary negating of `.indexOf()` method calling.
- * @param {ASTNode} node - An UnaryExpression node to check.
+ * @param {ASTNode} node An UnaryExpression node to check.
  * @returns {boolean} Whether or not the node is a binary negating of `.indexOf()` method calling.
  */
 function isBinaryNegatingOfIndexOf(node) {
@@ -58,7 +58,7 @@ function isBinaryNegatingOfIndexOf(node) {
 
 /**
  * Checks whether or not a node is a multiplying by one.
- * @param {BinaryExpression} node - A BinaryExpression node to check.
+ * @param {BinaryExpression} node A BinaryExpression node to check.
  * @returns {boolean} Whether or not the node is a multiplying by one.
  */
 function isMultiplyByOne(node) {
@@ -118,7 +118,7 @@ function isEmptyString(node) {
 
 /**
  * Checks whether or not a node is a concatenating with an empty string.
- * @param {ASTNode} node - A BinaryExpression node to check.
+ * @param {ASTNode} node A BinaryExpression node to check.
  * @returns {boolean} Whether or not the node is a concatenating with an empty string.
  */
 function isConcatWithEmptyString(node) {
@@ -130,7 +130,7 @@ function isConcatWithEmptyString(node) {
 
 /**
  * Checks whether or not a node is appended with an empty string.
- * @param {ASTNode} node - An AssignmentExpression node to check.
+ * @param {ASTNode} node An AssignmentExpression node to check.
  * @returns {boolean} Whether or not the node is appended with an empty string.
  */
 function isAppendEmptyString(node) {
@@ -139,7 +139,7 @@ function isAppendEmptyString(node) {
 
 /**
  * Returns the operand that is not an empty string from a flagged BinaryExpression.
- * @param {ASTNode} node - The flagged BinaryExpression node to check.
+ * @param {ASTNode} node The flagged BinaryExpression node to check.
  * @returns {ASTNode} The operand that is not an empty string from a flagged BinaryExpression.
  */
 function getNonEmptyOperand(node) {
@@ -196,9 +196,9 @@ module.exports = {
 
         /**
          * Reports an error and autofixes the node
-         * @param {ASTNode} node - An ast node to report the error on.
-         * @param {string} recommendation - The recommended code for the issue
-         * @param {bool} shouldFix - Whether this report should fix the node
+         * @param {ASTNode} node An ast node to report the error on.
+         * @param {string} recommendation The recommended code for the issue
+         * @param {bool} shouldFix Whether this report should fix the node
          * @returns {void}
          */
         function report(node, recommendation, shouldFix) {

--- a/lib/rules/no-implied-eval.js
+++ b/lib/rules/no-implied-eval.js
@@ -64,7 +64,6 @@ module.exports = {
          * Determines if a node represents a call to a potentially implied eval.
          *
          * This checks the callee name and that there's an argument, but not the type of the argument.
-         *
          * @param {ASTNode} node The CallExpression to check.
          * @returns {boolean} True if the node matches, false if not.
          * @private

--- a/lib/rules/no-invalid-this.js
+++ b/lib/rules/no-invalid-this.js
@@ -60,7 +60,7 @@ module.exports = {
          * The checking context is not initialized yet.
          * Because most functions don't have `this` keyword.
          * When `this` keyword was found, the checking context is initialized.
-         * @param {ASTNode} node - A function node that was entered.
+         * @param {ASTNode} node A function node that was entered.
          * @returns {void}
          */
         function enterFunction(node) {

--- a/lib/rules/no-invalid-this.js
+++ b/lib/rules/no-invalid-this.js
@@ -38,7 +38,6 @@ module.exports = {
          *
          * The return value has a flag that whether or not `this` keyword is valid.
          * The flag is initialized when got at the first time.
-         *
          * @returns {{valid: boolean}}
          *   an object which has a flag that whether or not `this` keyword is valid.
          */
@@ -61,7 +60,6 @@ module.exports = {
          * The checking context is not initialized yet.
          * Because most functions don't have `this` keyword.
          * When `this` keyword was found, the checking context is initialized.
-         *
          * @param {ASTNode} node - A function node that was entered.
          * @returns {void}
          */

--- a/lib/rules/no-labels.js
+++ b/lib/rules/no-labels.js
@@ -51,7 +51,6 @@ module.exports = {
 
         /**
          * Gets the kind of a given node.
-         *
          * @param {ASTNode} node - A node to get.
          * @returns {string} The kind of the node.
          */
@@ -67,7 +66,6 @@ module.exports = {
 
         /**
          * Checks whether the label of a given kind is allowed or not.
-         *
          * @param {string} kind - A kind to check.
          * @returns {boolean} `true` if the kind is allowed.
          */
@@ -81,7 +79,6 @@ module.exports = {
 
         /**
          * Checks whether a given name is a label of a loop or not.
-         *
          * @param {string} label - A name of a label to check.
          * @returns {boolean} `true` if the name is a label of a loop.
          */

--- a/lib/rules/no-labels.js
+++ b/lib/rules/no-labels.js
@@ -51,7 +51,7 @@ module.exports = {
 
         /**
          * Gets the kind of a given node.
-         * @param {ASTNode} node - A node to get.
+         * @param {ASTNode} node A node to get.
          * @returns {string} The kind of the node.
          */
         function getBodyKind(node) {
@@ -66,7 +66,7 @@ module.exports = {
 
         /**
          * Checks whether the label of a given kind is allowed or not.
-         * @param {string} kind - A kind to check.
+         * @param {string} kind A kind to check.
          * @returns {boolean} `true` if the kind is allowed.
          */
         function isAllowed(kind) {
@@ -79,7 +79,7 @@ module.exports = {
 
         /**
          * Checks whether a given name is a label of a loop or not.
-         * @param {string} label - A name of a label to check.
+         * @param {string} label A name of a label to check.
          * @returns {boolean} `true` if the name is a label of a loop.
          */
         function getKind(label) {

--- a/lib/rules/no-lone-blocks.js
+++ b/lib/rules/no-lone-blocks.js
@@ -31,7 +31,7 @@ module.exports = {
 
         /**
          * Reports a node as invalid.
-         * @param {ASTNode} node - The node to be reported.
+         * @param {ASTNode} node The node to be reported.
          * @returns {void}
          */
         function report(node) {

--- a/lib/rules/no-loop-func.js
+++ b/lib/rules/no-loop-func.js
@@ -14,7 +14,7 @@
  *
  * We don't need to check nested functions, so this ignores those.
  * `Scope.through` contains references of nested functions.
- * @param {ASTNode} node - An AST node to get.
+ * @param {ASTNode} node An AST node to get.
  * @returns {ASTNode|null} The containing loop node of the specified node, or
  *      `null`.
  */
@@ -62,8 +62,8 @@ function getContainingLoopNode(node) {
 /**
  * Gets the containing loop node of a given node.
  * If the loop was nested, this returns the most outer loop.
- * @param {ASTNode} node - A node to get. This is a loop node.
- * @param {ASTNode|null} excludedNode - A node that the result node should not
+ * @param {ASTNode} node A node to get. This is a loop node.
+ * @param {ASTNode|null} excludedNode A node that the result node should not
  *      include.
  * @returns {ASTNode} The most outer loop node.
  */
@@ -83,8 +83,8 @@ function getTopLoopNode(node, excludedNode) {
 /**
  * Checks whether a given reference which refers to an upper scope's variable is
  * safe or not.
- * @param {ASTNode} loopNode - A containing loop node.
- * @param {eslint-scope.Reference} reference - A reference to check.
+ * @param {ASTNode} loopNode A containing loop node.
+ * @param {eslint-scope.Reference} reference A reference to check.
  * @returns {boolean} `true` if the reference is safe or not.
  */
 function isSafe(loopNode, reference) {
@@ -128,7 +128,7 @@ function isSafe(loopNode, reference) {
      * It's safeafe if the reference matches one of the following condition.
      * - is readonly.
      * - doesn't exist inside a local function and after the border.
-     * @param {eslint-scope.Reference} upperRef - A reference to check.
+     * @param {eslint-scope.Reference} upperRef A reference to check.
      * @returns {boolean} `true` if the reference is safe.
      */
     function isSafeReference(upperRef) {

--- a/lib/rules/no-loop-func.js
+++ b/lib/rules/no-loop-func.js
@@ -14,7 +14,6 @@
  *
  * We don't need to check nested functions, so this ignores those.
  * `Scope.through` contains references of nested functions.
- *
  * @param {ASTNode} node - An AST node to get.
  * @returns {ASTNode|null} The containing loop node of the specified node, or
  *      `null`.
@@ -63,7 +62,6 @@ function getContainingLoopNode(node) {
 /**
  * Gets the containing loop node of a given node.
  * If the loop was nested, this returns the most outer loop.
- *
  * @param {ASTNode} node - A node to get. This is a loop node.
  * @param {ASTNode|null} excludedNode - A node that the result node should not
  *      include.
@@ -85,7 +83,6 @@ function getTopLoopNode(node, excludedNode) {
 /**
  * Checks whether a given reference which refers to an upper scope's variable is
  * safe or not.
- *
  * @param {ASTNode} loopNode - A containing loop node.
  * @param {eslint-scope.Reference} reference - A reference to check.
  * @returns {boolean} `true` if the reference is safe or not.
@@ -131,7 +128,6 @@ function isSafe(loopNode, reference) {
      * It's safeafe if the reference matches one of the following condition.
      * - is readonly.
      * - doesn't exist inside a local function and after the border.
-     *
      * @param {eslint-scope.Reference} upperRef - A reference to check.
      * @returns {boolean} `true` if the reference is safe.
      */
@@ -177,7 +173,6 @@ module.exports = {
          *
          * - has a loop node in ancestors.
          * - has any references which refers to an unsafe variable.
-         *
          * @param {ASTNode} node The AST node to check.
          * @returns {boolean} Whether or not the node is within a loop.
          */

--- a/lib/rules/no-magic-numbers.js
+++ b/lib/rules/no-magic-numbers.js
@@ -61,7 +61,7 @@ module.exports = {
 
         /**
          * Returns whether the node is number literal
-         * @param {Node} node - the node literal being evaluated
+         * @param {Node} node the node literal being evaluated
          * @returns {boolean} true if the node is a number literal
          */
         function isNumber(node) {
@@ -70,7 +70,7 @@ module.exports = {
 
         /**
          * Returns whether the number should be ignored
-         * @param {number} num - the number
+         * @param {number} num the number
          * @returns {boolean} true if the number should be ignored
          */
         function shouldIgnoreNumber(num) {
@@ -79,8 +79,8 @@ module.exports = {
 
         /**
          * Returns whether the number should be ignored when used as a radix within parseInt() or Number.parseInt()
-         * @param {ASTNode} parent - the non-"UnaryExpression" parent
-         * @param {ASTNode} node - the node literal being evaluated
+         * @param {ASTNode} parent the non-"UnaryExpression" parent
+         * @param {ASTNode} node the node literal being evaluated
          * @returns {boolean} true if the number should be ignored
          */
         function shouldIgnoreParseInt(parent, node) {
@@ -93,7 +93,7 @@ module.exports = {
 
         /**
          * Returns whether the number should be ignored when used to define a JSX prop
-         * @param {ASTNode} parent - the non-"UnaryExpression" parent
+         * @param {ASTNode} parent the non-"UnaryExpression" parent
          * @returns {boolean} true if the number should be ignored
          */
         function shouldIgnoreJSXNumbers(parent) {
@@ -102,7 +102,7 @@ module.exports = {
 
         /**
          * Returns whether the number should be ignored when used as an array index with enabled 'ignoreArrayIndexes' option.
-         * @param {ASTNode} parent - the non-"UnaryExpression" parent.
+         * @param {ASTNode} parent the non-"UnaryExpression" parent.
          * @returns {boolean} true if the number should be ignored
          */
         function shouldIgnoreArrayIndexes(parent) {

--- a/lib/rules/no-misleading-character-class.js
+++ b/lib/rules/no-misleading-character-class.js
@@ -16,7 +16,6 @@ const { isCombiningCharacter, isEmojiModifier, isRegionalIndicatorSymbol, isSurr
  *
  * CharacterClassRange syntax can steal a part of character sequence,
  * so this function reverts CharacterClassRange syntax and restore the sequence.
- *
  * @param {regexpp.AST.CharacterClassElement[]} nodes The node list to iterate character sequences.
  * @returns {IterableIterator<number[]>} The list of character sequences.
  */

--- a/lib/rules/no-mixed-operators.js
+++ b/lib/rules/no-mixed-operators.js
@@ -40,7 +40,6 @@ const TARGET_NODE_TYPE = /^(?:Binary|Logical|Conditional)Expression$/u;
 
 /**
  * Normalizes options.
- *
  * @param {Object|undefined} options - A options object to normalize.
  * @returns {Object} Normalized option object.
  */
@@ -57,7 +56,6 @@ function normalizeOptions(options = {}) {
 
 /**
  * Checks whether any group which includes both given operator exists or not.
- *
  * @param {Array.<string[]>} groups - A list of groups to check.
  * @param {string} left - An operator.
  * @param {string} right - Another operator.
@@ -69,7 +67,6 @@ function includesBothInAGroup(groups, left, right) {
 
 /**
  * Checks whether the given node is a conditional expression and returns the test node else the left node.
- *
  * @param {ASTNode} node - A node which can be a BinaryExpression or a LogicalExpression node.
  * This parent node can be BinaryExpression, LogicalExpression
  *      , or a ConditionalExpression node
@@ -124,7 +121,6 @@ module.exports = {
 
         /**
          * Checks whether a given node should be ignored by options or not.
-         *
          * @param {ASTNode} node - A node to check. This is a BinaryExpression
          *      node or a LogicalExpression node. This parent node is one of
          *      them, too.
@@ -146,7 +142,6 @@ module.exports = {
         /**
          * Checks whether the operator of a given node is mixed with parent
          * node's operator or not.
-         *
          * @param {ASTNode} node - A node to check. This is a BinaryExpression
          *      node or a LogicalExpression node. This parent node is one of
          *      them, too.
@@ -163,7 +158,6 @@ module.exports = {
         /**
          * Checks whether the operator of a given node is mixed with a
          * conditional expression.
-         *
          * @param {ASTNode} node - A node to check. This is a conditional
          *      expression node
          * @returns {boolean} `true` if the node was mixed.
@@ -174,7 +168,6 @@ module.exports = {
 
         /**
          * Gets the operator token of a given node.
-         *
          * @param {ASTNode} node - A node to check. This is a BinaryExpression
          *      node or a LogicalExpression node.
          * @returns {Token} The operator token of the node.
@@ -186,7 +179,6 @@ module.exports = {
         /**
          * Reports both the operator of a given node and the operator of the
          * parent node.
-         *
          * @param {ASTNode} node - A node to check. This is a BinaryExpression
          *      node or a LogicalExpression node. This parent node is one of
          *      them, too.
@@ -220,7 +212,6 @@ module.exports = {
         /**
          * Checks between the operator of this node and the operator of the
          * parent node.
-         *
          * @param {ASTNode} node - A node to check.
          * @returns {void}
          */

--- a/lib/rules/no-mixed-operators.js
+++ b/lib/rules/no-mixed-operators.js
@@ -40,7 +40,7 @@ const TARGET_NODE_TYPE = /^(?:Binary|Logical|Conditional)Expression$/u;
 
 /**
  * Normalizes options.
- * @param {Object|undefined} options - A options object to normalize.
+ * @param {Object|undefined} options A options object to normalize.
  * @returns {Object} Normalized option object.
  */
 function normalizeOptions(options = {}) {
@@ -56,9 +56,9 @@ function normalizeOptions(options = {}) {
 
 /**
  * Checks whether any group which includes both given operator exists or not.
- * @param {Array.<string[]>} groups - A list of groups to check.
- * @param {string} left - An operator.
- * @param {string} right - Another operator.
+ * @param {Array.<string[]>} groups A list of groups to check.
+ * @param {string} left An operator.
+ * @param {string} right Another operator.
  * @returns {boolean} `true` if such group existed.
  */
 function includesBothInAGroup(groups, left, right) {
@@ -67,7 +67,7 @@ function includesBothInAGroup(groups, left, right) {
 
 /**
  * Checks whether the given node is a conditional expression and returns the test node else the left node.
- * @param {ASTNode} node - A node which can be a BinaryExpression or a LogicalExpression node.
+ * @param {ASTNode} node A node which can be a BinaryExpression or a LogicalExpression node.
  * This parent node can be BinaryExpression, LogicalExpression
  *      , or a ConditionalExpression node
  * @returns {ASTNode} node the appropriate node(left or test).
@@ -121,7 +121,7 @@ module.exports = {
 
         /**
          * Checks whether a given node should be ignored by options or not.
-         * @param {ASTNode} node - A node to check. This is a BinaryExpression
+         * @param {ASTNode} node A node to check. This is a BinaryExpression
          *      node or a LogicalExpression node. This parent node is one of
          *      them, too.
          * @returns {boolean} `true` if the node should be ignored.
@@ -142,7 +142,7 @@ module.exports = {
         /**
          * Checks whether the operator of a given node is mixed with parent
          * node's operator or not.
-         * @param {ASTNode} node - A node to check. This is a BinaryExpression
+         * @param {ASTNode} node A node to check. This is a BinaryExpression
          *      node or a LogicalExpression node. This parent node is one of
          *      them, too.
          * @returns {boolean} `true` if the node was mixed.
@@ -158,7 +158,7 @@ module.exports = {
         /**
          * Checks whether the operator of a given node is mixed with a
          * conditional expression.
-         * @param {ASTNode} node - A node to check. This is a conditional
+         * @param {ASTNode} node A node to check. This is a conditional
          *      expression node
          * @returns {boolean} `true` if the node was mixed.
          */
@@ -168,7 +168,7 @@ module.exports = {
 
         /**
          * Gets the operator token of a given node.
-         * @param {ASTNode} node - A node to check. This is a BinaryExpression
+         * @param {ASTNode} node A node to check. This is a BinaryExpression
          *      node or a LogicalExpression node.
          * @returns {Token} The operator token of the node.
          */
@@ -179,7 +179,7 @@ module.exports = {
         /**
          * Reports both the operator of a given node and the operator of the
          * parent node.
-         * @param {ASTNode} node - A node to check. This is a BinaryExpression
+         * @param {ASTNode} node A node to check. This is a BinaryExpression
          *      node or a LogicalExpression node. This parent node is one of
          *      them, too.
          * @returns {void}
@@ -212,7 +212,7 @@ module.exports = {
         /**
          * Checks between the operator of this node and the operator of the
          * parent node.
-         * @param {ASTNode} node - A node to check.
+         * @param {ASTNode} node A node to check.
          * @returns {void}
          */
         function check(node) {

--- a/lib/rules/no-mixed-requires.js
+++ b/lib/rules/no-mixed-requires.js
@@ -58,7 +58,6 @@ module.exports = {
 
         /**
          * Returns the list of built-in modules.
-         *
          * @returns {string[]} An array of built-in Node.js modules.
          */
         function getBuiltinModules() {

--- a/lib/rules/no-native-reassign.js
+++ b/lib/rules/no-native-reassign.js
@@ -46,9 +46,9 @@ module.exports = {
 
         /**
          * Reports write references.
-         * @param {Reference} reference - A reference to check.
-         * @param {int} index - The index of the reference in the references.
-         * @param {Reference[]} references - The array that the reference belongs to.
+         * @param {Reference} reference A reference to check.
+         * @param {int} index The index of the reference in the references.
+         * @param {Reference[]} references The array that the reference belongs to.
          * @returns {void}
          */
         function checkReference(reference, index, references) {
@@ -73,7 +73,7 @@ module.exports = {
 
         /**
          * Reports write references if a given variable is read-only builtin.
-         * @param {Variable} variable - A variable to check.
+         * @param {Variable} variable A variable to check.
          * @returns {void}
          */
         function checkVariable(variable) {

--- a/lib/rules/no-param-reassign.js
+++ b/lib/rules/no-param-reassign.js
@@ -60,7 +60,7 @@ module.exports = {
 
         /**
          * Checks whether or not the reference modifies properties of its variable.
-         * @param {Reference} reference - A reference to check.
+         * @param {Reference} reference A reference to check.
          * @returns {boolean} Whether or not the reference modifies properties of its variable.
          */
         function isModifyingProp(reference) {
@@ -138,9 +138,9 @@ module.exports = {
 
         /**
          * Reports a reference if is non initializer and writable.
-         * @param {Reference} reference - A reference to check.
-         * @param {int} index - The index of the reference in the references.
-         * @param {Reference[]} references - The array that the reference belongs to.
+         * @param {Reference} reference A reference to check.
+         * @param {int} index The index of the reference in the references.
+         * @param {Reference[]} references The array that the reference belongs to.
          * @returns {void}
          */
         function checkReference(reference, index, references) {
@@ -165,7 +165,7 @@ module.exports = {
 
         /**
          * Finds and reports references that are non initializer and writable.
-         * @param {Variable} variable - A variable to check.
+         * @param {Variable} variable A variable to check.
          * @returns {void}
          */
         function checkVariable(variable) {
@@ -176,7 +176,7 @@ module.exports = {
 
         /**
          * Checks parameters of a given function node.
-         * @param {ASTNode} node - A function node to check.
+         * @param {ASTNode} node A function node to check.
          * @returns {void}
          */
         function checkForFunction(node) {

--- a/lib/rules/no-redeclare.js
+++ b/lib/rules/no-redeclare.js
@@ -86,7 +86,7 @@ module.exports = {
 
         /**
          * Find variables in a given scope and flag redeclared ones.
-         * @param {Scope} scope - An eslint-scope scope object.
+         * @param {Scope} scope An eslint-scope scope object.
          * @returns {void}
          * @private
          */

--- a/lib/rules/no-regex-spaces.js
+++ b/lib/rules/no-regex-spaces.js
@@ -52,7 +52,6 @@ module.exports = {
 
         /**
          * Validate regular expression
-         *
          * @param {ASTNode} nodeToReport Node to report.
          * @param {string} pattern Regular expression pattern to validate.
          * @param {string} rawPattern Raw representation of the pattern in the source code.

--- a/lib/rules/no-restricted-imports.js
+++ b/lib/rules/no-restricted-imports.js
@@ -116,7 +116,7 @@ module.exports = {
 
         /**
          * Checks to see if "*" is being used to import everything.
-         * @param {Set.<string>} importNames - Set of import names that are being imported
+         * @param {Set.<string>} importNames Set of import names that are being imported
          * @returns {boolean} whether everything is imported or not
          */
         function isEverythingImported(importNames) {
@@ -145,7 +145,7 @@ module.exports = {
 
         /**
          * Report a restricted path specifically for patterns.
-         * @param {node} node - representing the restricted path reference
+         * @param {node} node representing the restricted path reference
          * @returns {void}
          * @private
          */
@@ -163,8 +163,8 @@ module.exports = {
 
         /**
          * Report a restricted path specifically when using the '*' import.
-         * @param {string} importSource - path of the import
-         * @param {node} node - representing the restricted path reference
+         * @param {string} importSource path of the import
+         * @param {node} node representing the restricted path reference
          * @returns {void}
          * @private
          */
@@ -185,8 +185,8 @@ module.exports = {
 
         /**
          * Check if the given importSource is restricted because '*' is being imported.
-         * @param {string} importSource - path of the import
-         * @param {Set.<string>} importNames - Set of import names that are being imported
+         * @param {string} importSource path of the import
+         * @param {Set.<string>} importNames Set of import names that are being imported
          * @returns {boolean} whether the path is restricted
          * @private
          */
@@ -198,8 +198,8 @@ module.exports = {
 
         /**
          * Check if the given importNames are restricted given a list of restrictedImportNames.
-         * @param {Set.<string>} importNames - Set of import names that are being imported
-         * @param {string[]} restrictedImportNames - array of import names that are restricted for this import
+         * @param {Set.<string>} importNames Set of import names that are being imported
+         * @param {string[]} restrictedImportNames array of import names that are restricted for this import
          * @returns {boolean} whether the objectName is restricted
          * @private
          */
@@ -211,8 +211,8 @@ module.exports = {
 
         /**
          * Check if the given importSource is a restricted path.
-         * @param {string} importSource - path of the import
-         * @param {Set.<string>} importNames - Set of import names that are being imported
+         * @param {string} importSource path of the import
+         * @param {Set.<string>} importNames Set of import names that are being imported
          * @returns {boolean} whether the variable is a restricted path or not
          * @private
          */
@@ -232,7 +232,7 @@ module.exports = {
 
         /**
          * Check if the given importSource is restricted by a pattern.
-         * @param {string} importSource - path of the import
+         * @param {string} importSource path of the import
          * @returns {boolean} whether the variable is a restricted pattern or not
          * @private
          */

--- a/lib/rules/no-self-assign.js
+++ b/lib/rules/no-self-assign.js
@@ -20,8 +20,8 @@ const SPACES = /\s+/gu;
 /**
  * Checks whether the property of 2 given member expression nodes are the same
  * property or not.
- * @param {ASTNode} left - A member expression node to check.
- * @param {ASTNode} right - Another member expression node to check.
+ * @param {ASTNode} left A member expression node to check.
+ * @param {ASTNode} right Another member expression node to check.
  * @returns {boolean} `true` if the member expressions have the same property.
  */
 function isSameProperty(left, right) {
@@ -42,8 +42,8 @@ function isSameProperty(left, right) {
 /**
  * Checks whether 2 given member expression nodes are the reference to the same
  * property or not.
- * @param {ASTNode} left - A member expression node to check.
- * @param {ASTNode} right - Another member expression node to check.
+ * @param {ASTNode} left A member expression node to check.
+ * @param {ASTNode} right Another member expression node to check.
  * @returns {boolean} `true` if the member expressions are the reference to the
  *  same property or not.
  */
@@ -66,12 +66,12 @@ function isSameMember(left, right) {
 
 /**
  * Traverses 2 Pattern nodes in parallel, then reports self-assignments.
- * @param {ASTNode|null} left - A left node to traverse. This is a Pattern or
+ * @param {ASTNode|null} left A left node to traverse. This is a Pattern or
  *      a Property.
- * @param {ASTNode|null} right - A right node to traverse. This is a Pattern or
+ * @param {ASTNode|null} right A right node to traverse. This is a Pattern or
  *      a Property.
- * @param {boolean} props - The flag to check member expressions as well.
- * @param {Function} report - A callback function to report.
+ * @param {boolean} props The flag to check member expressions as well.
+ * @param {Function} report A callback function to report.
  * @returns {void}
  */
 function eachSelfAssignment(left, right, props, report) {
@@ -202,7 +202,7 @@ module.exports = {
 
         /**
          * Reports a given node as self assignments.
-         * @param {ASTNode} node - A node to report. This is an Identifier node.
+         * @param {ASTNode} node A node to report. This is an Identifier node.
          * @returns {void}
          */
         function report(node) {

--- a/lib/rules/no-self-assign.js
+++ b/lib/rules/no-self-assign.js
@@ -20,7 +20,6 @@ const SPACES = /\s+/gu;
 /**
  * Checks whether the property of 2 given member expression nodes are the same
  * property or not.
- *
  * @param {ASTNode} left - A member expression node to check.
  * @param {ASTNode} right - Another member expression node to check.
  * @returns {boolean} `true` if the member expressions have the same property.
@@ -43,7 +42,6 @@ function isSameProperty(left, right) {
 /**
  * Checks whether 2 given member expression nodes are the reference to the same
  * property or not.
- *
  * @param {ASTNode} left - A member expression node to check.
  * @param {ASTNode} right - Another member expression node to check.
  * @returns {boolean} `true` if the member expressions are the reference to the
@@ -68,7 +66,6 @@ function isSameMember(left, right) {
 
 /**
  * Traverses 2 Pattern nodes in parallel, then reports self-assignments.
- *
  * @param {ASTNode|null} left - A left node to traverse. This is a Pattern or
  *      a Property.
  * @param {ASTNode|null} right - A right node to traverse. This is a Pattern or
@@ -205,7 +202,6 @@ module.exports = {
 
         /**
          * Reports a given node as self assignments.
-         *
          * @param {ASTNode} node - A node to report. This is an Identifier node.
          * @returns {void}
          */

--- a/lib/rules/no-sequences.js
+++ b/lib/rules/no-sequences.js
@@ -54,7 +54,7 @@ module.exports = {
         /**
          * Determines whether a node is required by the grammar to be wrapped in
          * parens, e.g. the test of an if statement.
-         * @param {ASTNode} node - The AST node
+         * @param {ASTNode} node The AST node
          * @returns {boolean} True if parens around node belong to parent node.
          */
         function requiresExtraParens(node) {
@@ -64,7 +64,7 @@ module.exports = {
 
         /**
          * Check if a node is wrapped in parens.
-         * @param {ASTNode} node - The AST node
+         * @param {ASTNode} node The AST node
          * @returns {boolean} True if the node has a paren on each side.
          */
         function isParenthesised(node) {
@@ -73,7 +73,7 @@ module.exports = {
 
         /**
          * Check if a node is wrapped in two levels of parens.
-         * @param {ASTNode} node - The AST node
+         * @param {ASTNode} node The AST node
          * @returns {boolean} True if two parens surround the node on each side.
          */
         function isParenthesisedTwice(node) {

--- a/lib/rules/no-shadow.js
+++ b/lib/rules/no-shadow.js
@@ -54,7 +54,6 @@ module.exports = {
 
         /**
          * Check if variable name is allowed.
-         *
          * @param  {ASTNode} variable The variable to check.
          * @returns {boolean} Whether or not the variable name is allowed.
          */
@@ -67,7 +66,6 @@ module.exports = {
          *
          * ClassDeclaration creates two variables of its name into its outer scope and its class scope.
          * So we should ignore the variable in the class scope.
-         *
          * @param {Object} variable The variable to check.
          * @returns {boolean} Whether or not the variable of the class name in the class scope of ClassDeclaration.
          */
@@ -82,7 +80,6 @@ module.exports = {
          *
          * To avoid reporting at declarations such as `var a = function a() {};`.
          * But it should report `var a = function(a) {};` or `var a = function() { function a() {} };`.
-         *
          * @param {Object} variable The variable to check.
          * @param {Object} scopeVar The scope variable to look for.
          * @returns {boolean} Whether or not the variable is inside initializer of scopeVar.

--- a/lib/rules/no-shadow.js
+++ b/lib/rules/no-shadow.js
@@ -136,7 +136,7 @@ module.exports = {
 
         /**
          * Checks the current context for shadowed variables.
-         * @param {Scope} scope - Fixme
+         * @param {Scope} scope Fixme
          * @returns {void}
          */
         function checkForShadows(scope) {

--- a/lib/rules/no-this-before-super.js
+++ b/lib/rules/no-this-before-super.js
@@ -169,7 +169,6 @@ module.exports = {
              *
              * And this treverses all segments of this code path then reports every
              * invalid node.
-             *
              * @param {CodePath} codePath - A code path which was ended.
              * @returns {void}
              */

--- a/lib/rules/no-this-before-super.js
+++ b/lib/rules/no-this-before-super.js
@@ -17,7 +17,7 @@ const astUtils = require("./utils/ast-utils");
 
 /**
  * Checks whether or not a given node is a constructor.
- * @param {ASTNode} node - A node to check. This node type is one of
+ * @param {ASTNode} node A node to check. This node type is one of
  *   `Program`, `FunctionDeclaration`, `FunctionExpression`, and
  *   `ArrowFunctionExpression`.
  * @returns {boolean} `true` if the node is a constructor.
@@ -71,7 +71,7 @@ module.exports = {
 
         /**
          * Gets whether or not `super()` is called in a given code path segment.
-         * @param {CodePathSegment} segment - A code path segment to get.
+         * @param {CodePathSegment} segment A code path segment to get.
          * @returns {boolean} `true` if `super()` is called.
          */
         function isCalled(segment) {
@@ -99,7 +99,7 @@ module.exports = {
 
         /**
          * Sets a given node as invalid.
-         * @param {ASTNode} node - A node to set as invalid. This is one of
+         * @param {ASTNode} node A node to set as invalid. This is one of
          *      a ThisExpression and a Super.
          * @returns {void}
          */
@@ -135,8 +135,8 @@ module.exports = {
 
             /**
              * Adds information of a constructor into the stack.
-             * @param {CodePath} codePath - A code path which was started.
-             * @param {ASTNode} node - The current node.
+             * @param {CodePath} codePath A code path which was started.
+             * @param {ASTNode} node The current node.
              * @returns {void}
              */
             onCodePathStart(codePath, node) {
@@ -169,7 +169,7 @@ module.exports = {
              *
              * And this treverses all segments of this code path then reports every
              * invalid node.
-             * @param {CodePath} codePath - A code path which was ended.
+             * @param {CodePath} codePath A code path which was ended.
              * @returns {void}
              */
             onCodePathEnd(codePath) {
@@ -203,7 +203,7 @@ module.exports = {
 
             /**
              * Initialize information of a given code path segment.
-             * @param {CodePathSegment} segment - A code path segment to initialize.
+             * @param {CodePathSegment} segment A code path segment to initialize.
              * @returns {void}
              */
             onCodePathSegmentStart(segment) {
@@ -224,9 +224,9 @@ module.exports = {
             /**
              * Update information of the code path segment when a code path was
              * looped.
-             * @param {CodePathSegment} fromSegment - The code path segment of the
+             * @param {CodePathSegment} fromSegment The code path segment of the
              *      end of a loop.
-             * @param {CodePathSegment} toSegment - A code path segment of the head
+             * @param {CodePathSegment} toSegment A code path segment of the head
              *      of a loop.
              * @returns {void}
              */
@@ -257,7 +257,7 @@ module.exports = {
 
             /**
              * Reports if this is before `super()`.
-             * @param {ASTNode} node - A target node.
+             * @param {ASTNode} node A target node.
              * @returns {void}
              */
             ThisExpression(node) {
@@ -268,7 +268,7 @@ module.exports = {
 
             /**
              * Reports if this is before `super()`.
-             * @param {ASTNode} node - A target node.
+             * @param {ASTNode} node A target node.
              * @returns {void}
              */
             Super(node) {
@@ -279,7 +279,7 @@ module.exports = {
 
             /**
              * Marks `super()` called.
-             * @param {ASTNode} node - A target node.
+             * @param {ASTNode} node A target node.
              * @returns {void}
              */
             "CallExpression:exit"(node) {

--- a/lib/rules/no-unmodified-loop-condition.js
+++ b/lib/rules/no-unmodified-loop-condition.js
@@ -35,7 +35,6 @@ const DYNAMIC_PATTERN = /^(?:Call|Member|New|TaggedTemplate|Yield)Expression$/u;
 
 /**
  * Checks whether or not a given reference is a write reference.
- *
  * @param {eslint-scope.Reference} reference - A reference to check.
  * @returns {boolean} `true` if the reference is a write reference.
  */
@@ -53,7 +52,6 @@ function isWriteReference(reference) {
 /**
  * Checks whether or not a given loop condition info does not have the modified
  * flag.
- *
  * @param {LoopConditionInfo} condition - A loop condition info to check.
  * @returns {boolean} `true` if the loop condition info is "unmodified".
  */
@@ -64,7 +62,6 @@ function isUnmodified(condition) {
 /**
  * Checks whether or not a given loop condition info does not have the modified
  * flag and does not have the group this condition belongs to.
- *
  * @param {LoopConditionInfo} condition - A loop condition info to check.
  * @returns {boolean} `true` if the loop condition info is "unmodified".
  */
@@ -74,7 +71,6 @@ function isUnmodifiedAndNotBelongToGroup(condition) {
 
 /**
  * Checks whether or not a given reference is inside of a given node.
- *
  * @param {ASTNode} node - A node to check.
  * @param {eslint-scope.Reference} reference - A reference to check.
  * @returns {boolean} `true` if the reference is inside of the node.
@@ -88,7 +84,6 @@ function isInRange(node, reference) {
 
 /**
  * Checks whether or not a given reference is inside of a loop node's condition.
- *
  * @param {ASTNode} node - A node to check.
  * @param {eslint-scope.Reference} reference - A reference to check.
  * @returns {boolean} `true` if the reference is inside of the loop node's
@@ -108,7 +103,6 @@ const isInLoop = {
 /**
  * Gets the function which encloses a given reference.
  * This supports only FunctionDeclaration.
- *
  * @param {eslint-scope.Reference} reference - A reference to get.
  * @returns {ASTNode|null} The function node or null.
  */
@@ -128,7 +122,6 @@ function getEncloseFunctionDeclaration(reference) {
 
 /**
  * Updates the "modified" flags of given loop conditions with given modifiers.
- *
  * @param {LoopConditionInfo[]} conditions - The loop conditions to be updated.
  * @param {eslint-scope.Reference[]} modifiers - The references to update.
  * @returns {void}
@@ -183,7 +176,6 @@ module.exports = {
 
         /**
          * Reports a given condition info.
-         *
          * @param {LoopConditionInfo} condition - A loop condition info to report.
          * @returns {void}
          */
@@ -199,7 +191,6 @@ module.exports = {
 
         /**
          * Registers given conditions to the group the condition belongs to.
-         *
          * @param {LoopConditionInfo[]} conditions - A loop condition info to
          *      register.
          * @returns {void}
@@ -222,7 +213,6 @@ module.exports = {
 
         /**
          * Reports references which are inside of unmodified groups.
-         *
          * @param {LoopConditionInfo[]} conditions - A loop condition info to report.
          * @returns {void}
          */
@@ -234,7 +224,6 @@ module.exports = {
 
         /**
          * Checks whether or not a given group node has any dynamic elements.
-         *
          * @param {ASTNode} root - A node to check.
          *      This node is one of BinaryExpression or ConditionalExpression.
          * @returns {boolean} `true` if the node is dynamic.
@@ -259,7 +248,6 @@ module.exports = {
 
         /**
          * Creates the loop condition information from a given reference.
-         *
          * @param {eslint-scope.Reference} reference - A reference to create.
          * @returns {LoopConditionInfo|null} Created loop condition info, or null.
          */
@@ -313,7 +301,6 @@ module.exports = {
         /**
          * Finds unmodified references which are inside of a loop condition.
          * Then reports the references which are outside of groups.
-         *
          * @param {eslint-scope.Variable} variable - A variable to report.
          * @returns {void}
          */

--- a/lib/rules/no-unmodified-loop-condition.js
+++ b/lib/rules/no-unmodified-loop-condition.js
@@ -35,7 +35,7 @@ const DYNAMIC_PATTERN = /^(?:Call|Member|New|TaggedTemplate|Yield)Expression$/u;
 
 /**
  * Checks whether or not a given reference is a write reference.
- * @param {eslint-scope.Reference} reference - A reference to check.
+ * @param {eslint-scope.Reference} reference A reference to check.
  * @returns {boolean} `true` if the reference is a write reference.
  */
 function isWriteReference(reference) {
@@ -52,7 +52,7 @@ function isWriteReference(reference) {
 /**
  * Checks whether or not a given loop condition info does not have the modified
  * flag.
- * @param {LoopConditionInfo} condition - A loop condition info to check.
+ * @param {LoopConditionInfo} condition A loop condition info to check.
  * @returns {boolean} `true` if the loop condition info is "unmodified".
  */
 function isUnmodified(condition) {
@@ -62,7 +62,7 @@ function isUnmodified(condition) {
 /**
  * Checks whether or not a given loop condition info does not have the modified
  * flag and does not have the group this condition belongs to.
- * @param {LoopConditionInfo} condition - A loop condition info to check.
+ * @param {LoopConditionInfo} condition A loop condition info to check.
  * @returns {boolean} `true` if the loop condition info is "unmodified".
  */
 function isUnmodifiedAndNotBelongToGroup(condition) {
@@ -71,8 +71,8 @@ function isUnmodifiedAndNotBelongToGroup(condition) {
 
 /**
  * Checks whether or not a given reference is inside of a given node.
- * @param {ASTNode} node - A node to check.
- * @param {eslint-scope.Reference} reference - A reference to check.
+ * @param {ASTNode} node A node to check.
+ * @param {eslint-scope.Reference} reference A reference to check.
  * @returns {boolean} `true` if the reference is inside of the node.
  */
 function isInRange(node, reference) {
@@ -84,8 +84,8 @@ function isInRange(node, reference) {
 
 /**
  * Checks whether or not a given reference is inside of a loop node's condition.
- * @param {ASTNode} node - A node to check.
- * @param {eslint-scope.Reference} reference - A reference to check.
+ * @param {ASTNode} node A node to check.
+ * @param {eslint-scope.Reference} reference A reference to check.
  * @returns {boolean} `true` if the reference is inside of the loop node's
  *      condition.
  */
@@ -103,7 +103,7 @@ const isInLoop = {
 /**
  * Gets the function which encloses a given reference.
  * This supports only FunctionDeclaration.
- * @param {eslint-scope.Reference} reference - A reference to get.
+ * @param {eslint-scope.Reference} reference A reference to get.
  * @returns {ASTNode|null} The function node or null.
  */
 function getEncloseFunctionDeclaration(reference) {
@@ -122,8 +122,8 @@ function getEncloseFunctionDeclaration(reference) {
 
 /**
  * Updates the "modified" flags of given loop conditions with given modifiers.
- * @param {LoopConditionInfo[]} conditions - The loop conditions to be updated.
- * @param {eslint-scope.Reference[]} modifiers - The references to update.
+ * @param {LoopConditionInfo[]} conditions The loop conditions to be updated.
+ * @param {eslint-scope.Reference[]} modifiers The references to update.
  * @returns {void}
  */
 function updateModifiedFlag(conditions, modifiers) {
@@ -176,7 +176,7 @@ module.exports = {
 
         /**
          * Reports a given condition info.
-         * @param {LoopConditionInfo} condition - A loop condition info to report.
+         * @param {LoopConditionInfo} condition A loop condition info to report.
          * @returns {void}
          */
         function report(condition) {
@@ -191,7 +191,7 @@ module.exports = {
 
         /**
          * Registers given conditions to the group the condition belongs to.
-         * @param {LoopConditionInfo[]} conditions - A loop condition info to
+         * @param {LoopConditionInfo[]} conditions A loop condition info to
          *      register.
          * @returns {void}
          */
@@ -213,7 +213,7 @@ module.exports = {
 
         /**
          * Reports references which are inside of unmodified groups.
-         * @param {LoopConditionInfo[]} conditions - A loop condition info to report.
+         * @param {LoopConditionInfo[]} conditions A loop condition info to report.
          * @returns {void}
          */
         function checkConditionsInGroup(conditions) {
@@ -224,7 +224,7 @@ module.exports = {
 
         /**
          * Checks whether or not a given group node has any dynamic elements.
-         * @param {ASTNode} root - A node to check.
+         * @param {ASTNode} root A node to check.
          *      This node is one of BinaryExpression or ConditionalExpression.
          * @returns {boolean} `true` if the node is dynamic.
          */
@@ -248,7 +248,7 @@ module.exports = {
 
         /**
          * Creates the loop condition information from a given reference.
-         * @param {eslint-scope.Reference} reference - A reference to create.
+         * @param {eslint-scope.Reference} reference A reference to create.
          * @returns {LoopConditionInfo|null} Created loop condition info, or null.
          */
         function toLoopCondition(reference) {
@@ -301,7 +301,7 @@ module.exports = {
         /**
          * Finds unmodified references which are inside of a loop condition.
          * Then reports the references which are outside of groups.
-         * @param {eslint-scope.Variable} variable - A variable to report.
+         * @param {eslint-scope.Variable} variable A variable to report.
          * @returns {void}
          */
         function checkReferences(variable) {

--- a/lib/rules/no-unneeded-ternary.js
+++ b/lib/rules/no-unneeded-ternary.js
@@ -57,7 +57,7 @@ module.exports = {
 
         /**
          * Test if the node is a boolean literal
-         * @param {ASTNode} node - The node to report.
+         * @param {ASTNode} node The node to report.
          * @returns {boolean} True if the its a boolean literal
          * @private
          */
@@ -91,7 +91,7 @@ module.exports = {
 
         /**
          * Tests if a given node always evaluates to a boolean value
-         * @param {ASTNode} node - An expression node
+         * @param {ASTNode} node An expression node
          * @returns {boolean} True if it is determined that the node will always evaluate to a boolean value
          */
         function isBooleanExpression(node) {
@@ -101,7 +101,7 @@ module.exports = {
 
         /**
          * Test if the node matches the pattern id ? id : expression
-         * @param {ASTNode} node - The ConditionalExpression to check.
+         * @param {ASTNode} node The ConditionalExpression to check.
          * @returns {boolean} True if the pattern is matched, and false otherwise
          * @private
          */

--- a/lib/rules/no-unreachable.js
+++ b/lib/rules/no-unreachable.js
@@ -10,7 +10,7 @@
 
 /**
  * Checks whether or not a given variable declarator has the initializer.
- * @param {ASTNode} node - A VariableDeclarator node to check.
+ * @param {ASTNode} node A VariableDeclarator node to check.
  * @returns {boolean} `true` if the node has the initializer.
  */
 function isInitialized(node) {
@@ -19,7 +19,7 @@ function isInitialized(node) {
 
 /**
  * Checks whether or not a given code path segment is unreachable.
- * @param {CodePathSegment} segment - A CodePathSegment to check.
+ * @param {CodePathSegment} segment A CodePathSegment to check.
  * @returns {boolean} `true` if the segment is unreachable.
  */
 function isUnreachable(segment) {
@@ -57,7 +57,7 @@ class ConsecutiveRange {
 
     /**
      * Checks whether the given node is inside of this range.
-     * @param {ASTNode|Token} node - The node to check.
+     * @param {ASTNode|Token} node The node to check.
      * @returns {boolean} `true` if the node is inside of this range.
      */
     contains(node) {
@@ -69,7 +69,7 @@ class ConsecutiveRange {
 
     /**
      * Checks whether the given node is consecutive to this range.
-     * @param {ASTNode} node - The node to check.
+     * @param {ASTNode} node The node to check.
      * @returns {boolean} `true` if the node is consecutive to this range.
      */
     isConsecutive(node) {
@@ -78,7 +78,7 @@ class ConsecutiveRange {
 
     /**
      * Merges the given node to this range.
-     * @param {ASTNode} node - The node to merge.
+     * @param {ASTNode} node The node to merge.
      * @returns {void}
      */
     merge(node) {
@@ -87,7 +87,7 @@ class ConsecutiveRange {
 
     /**
      * Resets this range by the given node or null.
-     * @param {ASTNode|null} node - The node to reset, or null.
+     * @param {ASTNode|null} node The node to reset, or null.
      * @returns {void}
      */
     reset(node) {
@@ -120,7 +120,7 @@ module.exports = {
 
         /**
          * Reports a given node if it's unreachable.
-         * @param {ASTNode} node - A statement node to report.
+         * @param {ASTNode} node A statement node to report.
          * @returns {void}
          */
         function reportIfUnreachable(node) {

--- a/lib/rules/no-unsafe-finally.js
+++ b/lib/rules/no-unsafe-finally.js
@@ -35,7 +35,6 @@ module.exports = {
 
         /**
          * Checks if the node is the finalizer of a TryStatement
-         *
          * @param {ASTNode} node - node to check.
          * @returns {boolean} - true if the node is the finalizer of a TryStatement
          */
@@ -45,7 +44,6 @@ module.exports = {
 
         /**
          * Climbs up the tree if the node is not a sentinel node
-         *
          * @param {ASTNode} node - node to check.
          * @param {string} label - label of the break or continue statement
          * @returns {boolean} - return whether the node is a finally block or a sentinel node
@@ -82,7 +80,6 @@ module.exports = {
 
         /**
          * Checks whether the possibly-unsafe statement is inside a finally block.
-         *
          * @param {ASTNode} node - node to check.
          * @returns {void}
          */

--- a/lib/rules/no-unsafe-finally.js
+++ b/lib/rules/no-unsafe-finally.js
@@ -35,7 +35,7 @@ module.exports = {
 
         /**
          * Checks if the node is the finalizer of a TryStatement
-         * @param {ASTNode} node - node to check.
+         * @param {ASTNode} node node to check.
          * @returns {boolean} - true if the node is the finalizer of a TryStatement
          */
         function isFinallyBlock(node) {
@@ -44,8 +44,8 @@ module.exports = {
 
         /**
          * Climbs up the tree if the node is not a sentinel node
-         * @param {ASTNode} node - node to check.
-         * @param {string} label - label of the break or continue statement
+         * @param {ASTNode} node node to check.
+         * @param {string} label label of the break or continue statement
          * @returns {boolean} - return whether the node is a finally block or a sentinel node
          */
         function isInFinallyBlock(node, label) {
@@ -80,7 +80,7 @@ module.exports = {
 
         /**
          * Checks whether the possibly-unsafe statement is inside a finally block.
-         * @param {ASTNode} node - node to check.
+         * @param {ASTNode} node node to check.
          * @returns {void}
          */
         function check(node) {

--- a/lib/rules/no-unsafe-negation.js
+++ b/lib/rules/no-unsafe-negation.js
@@ -17,7 +17,6 @@ const astUtils = require("./utils/ast-utils");
 
 /**
  * Checks whether the given operator is a relational operator or not.
- *
  * @param {string} op - The operator type to check.
  * @returns {boolean} `true` if the operator is a relational operator.
  */
@@ -27,7 +26,6 @@ function isRelationalOperator(op) {
 
 /**
  * Checks whether the given node is a logical negation expression or not.
- *
  * @param {ASTNode} node - The node to check.
  * @returns {boolean} `true` if the node is a logical negation expression.
  */

--- a/lib/rules/no-unsafe-negation.js
+++ b/lib/rules/no-unsafe-negation.js
@@ -17,7 +17,7 @@ const astUtils = require("./utils/ast-utils");
 
 /**
  * Checks whether the given operator is a relational operator or not.
- * @param {string} op - The operator type to check.
+ * @param {string} op The operator type to check.
  * @returns {boolean} `true` if the operator is a relational operator.
  */
 function isRelationalOperator(op) {
@@ -26,7 +26,7 @@ function isRelationalOperator(op) {
 
 /**
  * Checks whether the given node is a logical negation expression or not.
- * @param {ASTNode} node - The node to check.
+ * @param {ASTNode} node The node to check.
  * @returns {boolean} `true` if the node is a logical negation expression.
  */
 function isNegation(node) {

--- a/lib/rules/no-unused-expressions.js
+++ b/lib/rules/no-unused-expressions.js
@@ -48,7 +48,7 @@ module.exports = {
             allowTaggedTemplates = config.allowTaggedTemplates || false;
 
         /**
-         * @param {ASTNode} node - any node
+         * @param {ASTNode} node any node
          * @returns {boolean} whether the given node structurally represents a directive
          */
         function looksLikeDirective(node) {
@@ -57,8 +57,8 @@ module.exports = {
         }
 
         /**
-         * @param {Function} predicate - ([a] -> Boolean) the function used to make the determination
-         * @param {a[]} list - the input list
+         * @param {Function} predicate ([a] -> Boolean) the function used to make the determination
+         * @param {a[]} list the input list
          * @returns {a[]} the leading sequence of members in the given list that pass the given predicate
          */
         function takeWhile(predicate, list) {
@@ -71,7 +71,7 @@ module.exports = {
         }
 
         /**
-         * @param {ASTNode} node - a Program or BlockStatement node
+         * @param {ASTNode} node a Program or BlockStatement node
          * @returns {ASTNode[]} the leading sequence of directive nodes in the given node's body
          */
         function directives(node) {
@@ -79,8 +79,8 @@ module.exports = {
         }
 
         /**
-         * @param {ASTNode} node - any node
-         * @param {ASTNode[]} ancestors - the given node's ancestors
+         * @param {ASTNode} node any node
+         * @param {ASTNode[]} ancestors the given node's ancestors
          * @returns {boolean} whether the given node is considered a directive in its current position
          */
         function isDirective(node, ancestors) {
@@ -94,7 +94,7 @@ module.exports = {
 
         /**
          * Determines whether or not a given node is a valid expression. Recurses on short circuit eval and ternary nodes if enabled by flags.
-         * @param {ASTNode} node - any node
+         * @param {ASTNode} node any node
          * @returns {boolean} whether the given node is a valid expression
          */
         function isValidExpression(node) {

--- a/lib/rules/no-unused-labels.js
+++ b/lib/rules/no-unused-labels.js
@@ -35,7 +35,7 @@ module.exports = {
 
         /**
          * Adds a scope info to the stack.
-         * @param {ASTNode} node - A node to add. This is a LabeledStatement.
+         * @param {ASTNode} node A node to add. This is a LabeledStatement.
          * @returns {void}
          */
         function enterLabeledScope(node) {
@@ -49,7 +49,7 @@ module.exports = {
         /**
          * Removes the top of the stack.
          * At the same time, this reports the label if it's never used.
-         * @param {ASTNode} node - A node to report. This is a LabeledStatement.
+         * @param {ASTNode} node A node to report. This is a LabeledStatement.
          * @returns {void}
          */
         function exitLabeledScope(node) {
@@ -79,7 +79,7 @@ module.exports = {
 
         /**
          * Marks the label of a given node as used.
-         * @param {ASTNode} node - A node to mark. This is a BreakStatement or
+         * @param {ASTNode} node A node to mark. This is a BreakStatement or
          *      ContinueStatement.
          * @returns {void}
          */

--- a/lib/rules/no-unused-labels.js
+++ b/lib/rules/no-unused-labels.js
@@ -35,7 +35,6 @@ module.exports = {
 
         /**
          * Adds a scope info to the stack.
-         *
          * @param {ASTNode} node - A node to add. This is a LabeledStatement.
          * @returns {void}
          */
@@ -50,7 +49,6 @@ module.exports = {
         /**
          * Removes the top of the stack.
          * At the same time, this reports the label if it's never used.
-         *
          * @param {ASTNode} node - A node to report. This is a LabeledStatement.
          * @returns {void}
          */
@@ -81,7 +79,6 @@ module.exports = {
 
         /**
          * Marks the label of a given node as used.
-         *
          * @param {ASTNode} node - A node to mark. This is a BreakStatement or
          *      ContinueStatement.
          * @returns {void}

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -103,7 +103,7 @@ module.exports = {
         /**
          * Generate the warning message about the variable being
          * defined and unused, including the ignore pattern if configured.
-         * @param {Variable} unusedVar - eslint-scope variable object.
+         * @param {Variable} unusedVar eslint-scope variable object.
          * @returns {string} The warning message to be used with this unused variable.
          */
         function getDefinedMessage(unusedVar) {
@@ -146,7 +146,7 @@ module.exports = {
 
         /**
          * Determines if a given variable is being exported from a module.
-         * @param {Variable} variable - eslint-scope variable object.
+         * @param {Variable} variable eslint-scope variable object.
          * @returns {boolean} True if the variable is exported, false if not.
          * @private
          */
@@ -172,7 +172,7 @@ module.exports = {
 
         /**
          * Determines if a variable has a sibling rest property
-         * @param {Variable} variable - eslint-scope variable object.
+         * @param {Variable} variable eslint-scope variable object.
          * @returns {boolean} True if the variable is exported, false if not.
          * @private
          */
@@ -195,7 +195,7 @@ module.exports = {
 
         /**
          * Determines if a reference is a read operation.
-         * @param {Reference} ref - An eslint-scope Reference
+         * @param {Reference} ref An eslint-scope Reference
          * @returns {boolean} whether the given reference represents a read operation
          * @private
          */
@@ -205,8 +205,8 @@ module.exports = {
 
         /**
          * Determine if an identifier is referencing an enclosing function name.
-         * @param {Reference} ref - The reference to check.
-         * @param {ASTNode[]} nodes - The candidate function nodes.
+         * @param {Reference} ref The reference to check.
+         * @param {ASTNode[]} nodes The candidate function nodes.
          * @returns {boolean} True if it's a self-reference, false if not.
          * @private
          */
@@ -226,7 +226,7 @@ module.exports = {
 
         /**
          * Gets a list of function definitions for a specified variable.
-         * @param {Variable} variable - eslint-scope variable object.
+         * @param {Variable} variable eslint-scope variable object.
          * @returns {ASTNode[]} Function nodes.
          * @private
          */
@@ -252,8 +252,8 @@ module.exports = {
 
         /**
          * Checks the position of given nodes.
-         * @param {ASTNode} inner - A node which is expected as inside.
-         * @param {ASTNode} outer - A node which is expected as outside.
+         * @param {ASTNode} inner A node which is expected as inside.
+         * @param {ASTNode} outer A node which is expected as outside.
          * @returns {boolean} `true` if the `inner` node exists in the `outer` node.
          * @private
          */
@@ -274,8 +274,8 @@ module.exports = {
          * - The reference is inside of a loop.
          * - The reference is inside of a function scope which is different from
          *   the declaration.
-         * @param {eslint-scope.Reference} ref - A reference to check.
-         * @param {ASTNode} prevRhsNode - The previous RHS node.
+         * @param {eslint-scope.Reference} ref A reference to check.
+         * @param {ASTNode} prevRhsNode The previous RHS node.
          * @returns {ASTNode|null} The RHS node or null.
          * @private
          */
@@ -308,8 +308,8 @@ module.exports = {
         /**
          * Checks whether a given function node is stored to somewhere or not.
          * If the function node is stored, the function can be used later.
-         * @param {ASTNode} funcNode - A function node to check.
-         * @param {ASTNode} rhsNode - The RHS node of the previous assignment.
+         * @param {ASTNode} funcNode A function node to check.
+         * @param {ASTNode} rhsNode The RHS node of the previous assignment.
          * @returns {boolean} `true` if under the following conditions:
          *      - the funcNode is assigned to a variable.
          *      - the funcNode is bound as an argument of a function call.
@@ -364,8 +364,8 @@ module.exports = {
          * - the function is bound as an argument of a function call.
          *
          * If a reference exists in a function which can be used later, the reference is read when the function is called.
-         * @param {ASTNode} id - An Identifier node to check.
-         * @param {ASTNode} rhsNode - The RHS node of the previous assignment.
+         * @param {ASTNode} id An Identifier node to check.
+         * @param {ASTNode} rhsNode The RHS node of the previous assignment.
          * @returns {boolean} `true` if the `id` node exists inside of a function node which can be used later.
          * @private
          */
@@ -381,8 +381,8 @@ module.exports = {
 
         /**
          * Checks whether a given reference is a read to update itself or not.
-         * @param {eslint-scope.Reference} ref - A reference to check.
-         * @param {ASTNode} rhsNode - The RHS node of the previous assignment.
+         * @param {eslint-scope.Reference} ref A reference to check.
+         * @param {ASTNode} rhsNode The RHS node of the previous assignment.
          * @returns {boolean} The reference is a read to update itself.
          * @private
          */
@@ -411,7 +411,7 @@ module.exports = {
 
         /**
          * Determine if an identifier is used either in for-in loops.
-         * @param {Reference} ref - The reference to check.
+         * @param {Reference} ref The reference to check.
          * @returns {boolean} whether reference is used in the for-in loops
          * @private
          */
@@ -447,7 +447,7 @@ module.exports = {
 
         /**
          * Determines if the variable is used.
-         * @param {Variable} variable - The variable to check.
+         * @param {Variable} variable The variable to check.
          * @returns {boolean} True if the variable is used
          * @private
          */
@@ -475,7 +475,7 @@ module.exports = {
 
         /**
          * Checks whether the given variable is after the last used parameter.
-         * @param {eslint-scope.Variable} variable - The variable to check.
+         * @param {eslint-scope.Variable} variable The variable to check.
          * @returns {boolean} `true` if the variable is defined after the last
          * used parameter.
          */
@@ -490,8 +490,8 @@ module.exports = {
 
         /**
          * Gets an array of variables without read references.
-         * @param {Scope} scope - an eslint-scope Scope object.
-         * @param {Variable[]} unusedVars - an array that saving result.
+         * @param {Scope} scope an eslint-scope Scope object.
+         * @param {Variable[]} unusedVars an array that saving result.
          * @returns {Variable[]} unused variables of the scope and descendant scopes.
          * @private
          */

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -252,7 +252,6 @@ module.exports = {
 
         /**
          * Checks the position of given nodes.
-         *
          * @param {ASTNode} inner - A node which is expected as inside.
          * @param {ASTNode} outer - A node which is expected as outside.
          * @returns {boolean} `true` if the `inner` node exists in the `outer` node.
@@ -275,7 +274,6 @@ module.exports = {
          * - The reference is inside of a loop.
          * - The reference is inside of a function scope which is different from
          *   the declaration.
-         *
          * @param {eslint-scope.Reference} ref - A reference to check.
          * @param {ASTNode} prevRhsNode - The previous RHS node.
          * @returns {ASTNode|null} The RHS node or null.
@@ -310,7 +308,6 @@ module.exports = {
         /**
          * Checks whether a given function node is stored to somewhere or not.
          * If the function node is stored, the function can be used later.
-         *
          * @param {ASTNode} funcNode - A function node to check.
          * @param {ASTNode} rhsNode - The RHS node of the previous assignment.
          * @returns {boolean} `true` if under the following conditions:
@@ -367,7 +364,6 @@ module.exports = {
          * - the function is bound as an argument of a function call.
          *
          * If a reference exists in a function which can be used later, the reference is read when the function is called.
-         *
          * @param {ASTNode} id - An Identifier node to check.
          * @param {ASTNode} rhsNode - The RHS node of the previous assignment.
          * @returns {boolean} `true` if the `id` node exists inside of a function node which can be used later.
@@ -385,7 +381,6 @@ module.exports = {
 
         /**
          * Checks whether a given reference is a read to update itself or not.
-         *
          * @param {eslint-scope.Reference} ref - A reference to check.
          * @param {ASTNode} rhsNode - The RHS node of the previous assignment.
          * @returns {boolean} The reference is a read to update itself.
@@ -416,7 +411,6 @@ module.exports = {
 
         /**
          * Determine if an identifier is used either in for-in loops.
-         *
          * @param {Reference} ref - The reference to check.
          * @returns {boolean} whether reference is used in the for-in loops
          * @private
@@ -481,7 +475,6 @@ module.exports = {
 
         /**
          * Checks whether the given variable is after the last used parameter.
-         *
          * @param {eslint-scope.Variable} variable - The variable to check.
          * @returns {boolean} `true` if the variable is defined after the last
          * used parameter.

--- a/lib/rules/no-use-before-define.js
+++ b/lib/rules/no-use-before-define.js
@@ -14,7 +14,6 @@ const FOR_IN_OF_TYPE = /^For(?:In|Of)Statement$/u;
 
 /**
  * Parses a given value as options.
- *
  * @param {any} options - A value to parse.
  * @returns {Object} The parsed options.
  */
@@ -36,7 +35,6 @@ function parseOptions(options) {
 
 /**
  * Checks whether or not a given variable is a function declaration.
- *
  * @param {eslint-scope.Variable} variable - A variable to check.
  * @returns {boolean} `true` if the variable is a function declaration.
  */
@@ -46,7 +44,6 @@ function isFunction(variable) {
 
 /**
  * Checks whether or not a given variable is a class declaration in an upper function scope.
- *
  * @param {eslint-scope.Variable} variable - A variable to check.
  * @param {eslint-scope.Reference} reference - A reference to check.
  * @returns {boolean} `true` if the variable is a class declaration.
@@ -73,7 +70,6 @@ function isOuterVariable(variable, reference) {
 
 /**
  * Checks whether or not a given location is inside of the range of a given node.
- *
  * @param {ASTNode} node - An node to check.
  * @param {number} location - A location to check.
  * @returns {boolean} `true` if the location is inside of the range of the node.
@@ -92,7 +88,6 @@ function isInRange(node, location) {
  *     var {a = a} = obj
  *     for (var a in a) {}
  *     for (var a of a) {}
- *
  * @param {Variable} variable - A variable to check.
  * @param {Reference} reference - A reference to check.
  * @returns {boolean} `true` if the reference is inside of the initializers.

--- a/lib/rules/no-use-before-define.js
+++ b/lib/rules/no-use-before-define.js
@@ -14,7 +14,7 @@ const FOR_IN_OF_TYPE = /^For(?:In|Of)Statement$/u;
 
 /**
  * Parses a given value as options.
- * @param {any} options - A value to parse.
+ * @param {any} options A value to parse.
  * @returns {Object} The parsed options.
  */
 function parseOptions(options) {
@@ -35,7 +35,7 @@ function parseOptions(options) {
 
 /**
  * Checks whether or not a given variable is a function declaration.
- * @param {eslint-scope.Variable} variable - A variable to check.
+ * @param {eslint-scope.Variable} variable A variable to check.
  * @returns {boolean} `true` if the variable is a function declaration.
  */
 function isFunction(variable) {
@@ -44,8 +44,8 @@ function isFunction(variable) {
 
 /**
  * Checks whether or not a given variable is a class declaration in an upper function scope.
- * @param {eslint-scope.Variable} variable - A variable to check.
- * @param {eslint-scope.Reference} reference - A reference to check.
+ * @param {eslint-scope.Variable} variable A variable to check.
+ * @param {eslint-scope.Reference} reference A reference to check.
  * @returns {boolean} `true` if the variable is a class declaration.
  */
 function isOuterClass(variable, reference) {
@@ -57,8 +57,8 @@ function isOuterClass(variable, reference) {
 
 /**
  * Checks whether or not a given variable is a variable declaration in an upper function scope.
- * @param {eslint-scope.Variable} variable - A variable to check.
- * @param {eslint-scope.Reference} reference - A reference to check.
+ * @param {eslint-scope.Variable} variable A variable to check.
+ * @param {eslint-scope.Reference} reference A reference to check.
  * @returns {boolean} `true` if the variable is a variable declaration.
  */
 function isOuterVariable(variable, reference) {
@@ -70,8 +70,8 @@ function isOuterVariable(variable, reference) {
 
 /**
  * Checks whether or not a given location is inside of the range of a given node.
- * @param {ASTNode} node - An node to check.
- * @param {number} location - A location to check.
+ * @param {ASTNode} node An node to check.
+ * @param {number} location A location to check.
  * @returns {boolean} `true` if the location is inside of the range of the node.
  */
 function isInRange(node, location) {
@@ -88,8 +88,8 @@ function isInRange(node, location) {
  *     var {a = a} = obj
  *     for (var a in a) {}
  *     for (var a of a) {}
- * @param {Variable} variable - A variable to check.
- * @param {Reference} reference - A reference to check.
+ * @param {Variable} variable A variable to check.
+ * @param {Reference} reference A reference to check.
  * @returns {boolean} `true` if the reference is inside of the initializers.
  */
 function isInInitializer(variable, reference) {

--- a/lib/rules/no-useless-call.js
+++ b/lib/rules/no-useless-call.js
@@ -13,7 +13,7 @@ const astUtils = require("./utils/ast-utils");
 
 /**
  * Checks whether or not a node is a `.call()`/`.apply()`.
- * @param {ASTNode} node - A CallExpression node to check.
+ * @param {ASTNode} node A CallExpression node to check.
  * @returns {boolean} Whether or not the node is a `.call()`/`.apply()`.
  */
 function isCallOrNonVariadicApply(node) {
@@ -31,9 +31,9 @@ function isCallOrNonVariadicApply(node) {
 
 /**
  * Checks whether or not `thisArg` is not changed by `.call()`/`.apply()`.
- * @param {ASTNode|null} expectedThis - The node that is the owner of the applied function.
- * @param {ASTNode} thisArg - The node that is given to the first argument of the `.call()`/`.apply()`.
- * @param {SourceCode} sourceCode - The ESLint source code object.
+ * @param {ASTNode|null} expectedThis The node that is the owner of the applied function.
+ * @param {ASTNode} thisArg The node that is given to the first argument of the `.call()`/`.apply()`.
+ * @param {SourceCode} sourceCode The ESLint source code object.
  * @returns {boolean} Whether or not `thisArg` is not changed by `.call()`/`.apply()`.
  */
 function isValidThisArg(expectedThis, thisArg, sourceCode) {

--- a/lib/rules/no-useless-concat.js
+++ b/lib/rules/no-useless-concat.js
@@ -16,7 +16,7 @@ const astUtils = require("./utils/ast-utils");
 
 /**
  * Checks whether or not a given node is a concatenation.
- * @param {ASTNode} node - A node to check.
+ * @param {ASTNode} node A node to check.
  * @returns {boolean} `true` if the node is a concatenation.
  */
 function isConcatenation(node) {
@@ -25,7 +25,7 @@ function isConcatenation(node) {
 
 /**
  * Checks if the given token is a `+` token or not.
- * @param {Token} token - The token to check.
+ * @param {Token} token The token to check.
  * @returns {boolean} `true` if the token is a `+` token.
  */
 function isConcatOperatorToken(token) {
@@ -34,7 +34,7 @@ function isConcatOperatorToken(token) {
 
 /**
  * Get's the right most node on the left side of a BinaryExpression with + operator.
- * @param {ASTNode} node - A BinaryExpression node to check.
+ * @param {ASTNode} node A BinaryExpression node to check.
  * @returns {ASTNode} node
  */
 function getLeft(node) {
@@ -48,7 +48,7 @@ function getLeft(node) {
 
 /**
  * Get's the left most node on the right side of a BinaryExpression with + operator.
- * @param {ASTNode} node - A BinaryExpression node to check.
+ * @param {ASTNode} node A BinaryExpression node to check.
  * @returns {ASTNode} node
  */
 function getRight(node) {

--- a/lib/rules/no-useless-constructor.js
+++ b/lib/rules/no-useless-constructor.js
@@ -10,7 +10,6 @@
 
 /**
  * Checks whether a given array of statements is a single call of `super`.
- *
  * @param {ASTNode[]} body - An array of statements to check.
  * @returns {boolean} `true` if the body is a single call of `super`.
  */
@@ -26,7 +25,6 @@ function isSingleSuperCall(body) {
 /**
  * Checks whether a given node is a pattern which doesn't have any side effects.
  * Default parameters and Destructuring parameters can have side effects.
- *
  * @param {ASTNode} node - A pattern node.
  * @returns {boolean} `true` if the node doesn't have any side effects.
  */
@@ -37,7 +35,6 @@ function isSimple(node) {
 /**
  * Checks whether a given array of expressions is `...arguments` or not.
  * `super(...arguments)` passes all arguments through.
- *
  * @param {ASTNode[]} superArgs - An array of expressions to check.
  * @returns {boolean} `true` if the superArgs is `...arguments`.
  */
@@ -52,7 +49,6 @@ function isSpreadArguments(superArgs) {
 
 /**
  * Checks whether given 2 nodes are identifiers which have the same name or not.
- *
  * @param {ASTNode} ctorParam - A node to check.
  * @param {ASTNode} superArg - A node to check.
  * @returns {boolean} `true` if the nodes are identifiers which have the same
@@ -68,7 +64,6 @@ function isValidIdentifierPair(ctorParam, superArg) {
 
 /**
  * Checks whether given 2 nodes are a rest/spread pair which has the same values.
- *
  * @param {ASTNode} ctorParam - A node to check.
  * @param {ASTNode} superArg - A node to check.
  * @returns {boolean} `true` if the nodes are a rest/spread pair which has the
@@ -84,7 +79,6 @@ function isValidRestSpreadPair(ctorParam, superArg) {
 
 /**
  * Checks whether given 2 nodes have the same value or not.
- *
  * @param {ASTNode} ctorParam - A node to check.
  * @param {ASTNode} superArg - A node to check.
  * @returns {boolean} `true` if the nodes have the same value or not.
@@ -99,7 +93,6 @@ function isValidPair(ctorParam, superArg) {
 /**
  * Checks whether the parameters of a constructor and the arguments of `super()`
  * have the same values or not.
- *
  * @param {ASTNode} ctorParams - The parameters of a constructor to check.
  * @param {ASTNode} superArgs - The arguments of `super()` to check.
  * @returns {boolean} `true` if those have the same values.
@@ -120,7 +113,6 @@ function isPassingThrough(ctorParams, superArgs) {
 
 /**
  * Checks whether the constructor body is a redundant super call.
- *
  * @param {Array} body - constructor body content.
  * @param {Array} ctorParams - The params to check against super call.
  * @returns {boolean} true if the construtor body is redundant

--- a/lib/rules/no-useless-constructor.js
+++ b/lib/rules/no-useless-constructor.js
@@ -10,7 +10,7 @@
 
 /**
  * Checks whether a given array of statements is a single call of `super`.
- * @param {ASTNode[]} body - An array of statements to check.
+ * @param {ASTNode[]} body An array of statements to check.
  * @returns {boolean} `true` if the body is a single call of `super`.
  */
 function isSingleSuperCall(body) {
@@ -25,7 +25,7 @@ function isSingleSuperCall(body) {
 /**
  * Checks whether a given node is a pattern which doesn't have any side effects.
  * Default parameters and Destructuring parameters can have side effects.
- * @param {ASTNode} node - A pattern node.
+ * @param {ASTNode} node A pattern node.
  * @returns {boolean} `true` if the node doesn't have any side effects.
  */
 function isSimple(node) {
@@ -35,7 +35,7 @@ function isSimple(node) {
 /**
  * Checks whether a given array of expressions is `...arguments` or not.
  * `super(...arguments)` passes all arguments through.
- * @param {ASTNode[]} superArgs - An array of expressions to check.
+ * @param {ASTNode[]} superArgs An array of expressions to check.
  * @returns {boolean} `true` if the superArgs is `...arguments`.
  */
 function isSpreadArguments(superArgs) {
@@ -49,8 +49,8 @@ function isSpreadArguments(superArgs) {
 
 /**
  * Checks whether given 2 nodes are identifiers which have the same name or not.
- * @param {ASTNode} ctorParam - A node to check.
- * @param {ASTNode} superArg - A node to check.
+ * @param {ASTNode} ctorParam A node to check.
+ * @param {ASTNode} superArg A node to check.
  * @returns {boolean} `true` if the nodes are identifiers which have the same
  *      name.
  */
@@ -64,8 +64,8 @@ function isValidIdentifierPair(ctorParam, superArg) {
 
 /**
  * Checks whether given 2 nodes are a rest/spread pair which has the same values.
- * @param {ASTNode} ctorParam - A node to check.
- * @param {ASTNode} superArg - A node to check.
+ * @param {ASTNode} ctorParam A node to check.
+ * @param {ASTNode} superArg A node to check.
  * @returns {boolean} `true` if the nodes are a rest/spread pair which has the
  *      same values.
  */
@@ -79,8 +79,8 @@ function isValidRestSpreadPair(ctorParam, superArg) {
 
 /**
  * Checks whether given 2 nodes have the same value or not.
- * @param {ASTNode} ctorParam - A node to check.
- * @param {ASTNode} superArg - A node to check.
+ * @param {ASTNode} ctorParam A node to check.
+ * @param {ASTNode} superArg A node to check.
  * @returns {boolean} `true` if the nodes have the same value or not.
  */
 function isValidPair(ctorParam, superArg) {
@@ -93,8 +93,8 @@ function isValidPair(ctorParam, superArg) {
 /**
  * Checks whether the parameters of a constructor and the arguments of `super()`
  * have the same values or not.
- * @param {ASTNode} ctorParams - The parameters of a constructor to check.
- * @param {ASTNode} superArgs - The arguments of `super()` to check.
+ * @param {ASTNode} ctorParams The parameters of a constructor to check.
+ * @param {ASTNode} superArgs The arguments of `super()` to check.
  * @returns {boolean} `true` if those have the same values.
  */
 function isPassingThrough(ctorParams, superArgs) {
@@ -113,8 +113,8 @@ function isPassingThrough(ctorParams, superArgs) {
 
 /**
  * Checks whether the constructor body is a redundant super call.
- * @param {Array} body - constructor body content.
- * @param {Array} ctorParams - The params to check against super call.
+ * @param {Array} body constructor body content.
+ * @param {Array} ctorParams The params to check against super call.
  * @returns {boolean} true if the construtor body is redundant
  */
 function isRedundantSuperCall(body, ctorParams) {
@@ -150,7 +150,7 @@ module.exports = {
 
         /**
          * Checks whether a node is a redundant constructor
-         * @param {ASTNode} node - node to check
+         * @param {ASTNode} node node to check
          * @returns {void}
          */
         function checkForConstructor(node) {

--- a/lib/rules/no-useless-escape.js
+++ b/lib/rules/no-useless-escape.js
@@ -118,8 +118,8 @@ module.exports = {
         /**
          * Checks if the escape character in given string slice is unnecessary.
          * @private
-         * @param {ASTNode} node - node to validate.
-         * @param {string} match - string slice to validate.
+         * @param {ASTNode} node node to validate.
+         * @param {string} match string slice to validate.
          * @returns {void}
          */
         function validateString(node, match) {
@@ -155,7 +155,7 @@ module.exports = {
 
         /**
          * Checks if a node has an escape.
-         * @param {ASTNode} node - node to check.
+         * @param {ASTNode} node node to check.
          * @returns {void}
          */
         function check(node) {

--- a/lib/rules/no-useless-escape.js
+++ b/lib/rules/no-useless-escape.js
@@ -117,7 +117,6 @@ module.exports = {
 
         /**
          * Checks if the escape character in given string slice is unnecessary.
-         *
          * @private
          * @param {ASTNode} node - node to validate.
          * @param {string} match - string slice to validate.
@@ -156,7 +155,6 @@ module.exports = {
 
         /**
          * Checks if a node has an escape.
-         *
          * @param {ASTNode} node - node to check.
          * @returns {void}
          */

--- a/lib/rules/no-useless-rename.js
+++ b/lib/rules/no-useless-rename.js
@@ -48,10 +48,10 @@ module.exports = {
 
         /**
          * Reports error for unnecessarily renamed assignments
-         * @param {ASTNode} node - node to report
-         * @param {ASTNode} initial - node with initial name value
-         * @param {ASTNode} result - node with new name value
-         * @param {string} type - the type of the offending node
+         * @param {ASTNode} node node to report
+         * @param {ASTNode} initial node with initial name value
+         * @param {ASTNode} result node with new name value
+         * @param {string} type the type of the offending node
          * @returns {void}
          */
         function reportError(node, initial, result, type) {
@@ -83,7 +83,7 @@ module.exports = {
 
         /**
          * Checks whether a destructured assignment is unnecessarily renamed
-         * @param {ASTNode} node - node to check
+         * @param {ASTNode} node node to check
          * @returns {void}
          */
         function checkDestructured(node) {
@@ -112,7 +112,7 @@ module.exports = {
 
         /**
          * Checks whether an import is unnecessarily renamed
-         * @param {ASTNode} node - node to check
+         * @param {ASTNode} node node to check
          * @returns {void}
          */
         function checkImport(node) {
@@ -128,7 +128,7 @@ module.exports = {
 
         /**
          * Checks whether an export is unnecessarily renamed
-         * @param {ASTNode} node - node to check
+         * @param {ASTNode} node node to check
          * @returns {void}
          */
         function checkExport(node) {

--- a/lib/rules/no-useless-return.js
+++ b/lib/rules/no-useless-return.js
@@ -17,8 +17,8 @@ const astUtils = require("./utils/ast-utils"),
 
 /**
  * Removes the given element from the array.
- * @param {Array} array - The source array to remove.
- * @param {any} element - The target item to remove.
+ * @param {Array} array The source array to remove.
+ * @param {any} element The target item to remove.
  * @returns {void}
  */
 function remove(array, element) {
@@ -31,7 +31,7 @@ function remove(array, element) {
 
 /**
  * Checks whether it can remove the given return statement or not.
- * @param {ASTNode} node - The return statement node to check.
+ * @param {ASTNode} node The return statement node to check.
  * @returns {boolean} `true` if the node is removeable.
  */
 function isRemovable(node) {
@@ -40,7 +40,7 @@ function isRemovable(node) {
 
 /**
  * Checks whether the given return statement is in a `finally` block or not.
- * @param {ASTNode} node - The return statement node to check.
+ * @param {ASTNode} node The return statement node to check.
  * @returns {boolean} `true` if the node is in a `finally` block.
  */
 function isInFinally(node) {
@@ -84,7 +84,7 @@ module.exports = {
 
         /**
          * Checks whether the given segment is terminated by a return statement or not.
-         * @param {CodePathSegment} segment - The segment to check.
+         * @param {CodePathSegment} segment The segment to check.
          * @returns {boolean} `true` if the segment is terminated by a return statement, or if it's still a part of unreachable.
          */
         function isReturned(segment) {
@@ -106,8 +106,8 @@ module.exports = {
          *
          * This behavior would simulate code paths for the case that the return
          * statement does not exist.
-         * @param {ASTNode[]} uselessReturns - The collected return statements.
-         * @param {CodePathSegment[]} prevSegments - The previous segments to traverse.
+         * @param {ASTNode[]} uselessReturns The collected return statements.
+         * @param {CodePathSegment[]} prevSegments The previous segments to traverse.
          * @param {WeakSet<CodePathSegment>} [providedTraversedSegments] A set of segments that have already been traversed in this call
          * @returns {ASTNode[]} `uselessReturns`.
          */
@@ -147,7 +147,7 @@ module.exports = {
          *
          * This behavior would simulate code paths for the case that the return
          * statement does not exist.
-         * @param {CodePathSegment} segment - The segment to get return statements.
+         * @param {CodePathSegment} segment The segment to get return statements.
          * @returns {void}
          */
         function markReturnStatementsOnSegmentAsUsed(segment) {

--- a/lib/rules/no-useless-return.js
+++ b/lib/rules/no-useless-return.js
@@ -17,7 +17,6 @@ const astUtils = require("./utils/ast-utils"),
 
 /**
  * Removes the given element from the array.
- *
  * @param {Array} array - The source array to remove.
  * @param {any} element - The target item to remove.
  * @returns {void}
@@ -32,7 +31,6 @@ function remove(array, element) {
 
 /**
  * Checks whether it can remove the given return statement or not.
- *
  * @param {ASTNode} node - The return statement node to check.
  * @returns {boolean} `true` if the node is removeable.
  */
@@ -42,7 +40,6 @@ function isRemovable(node) {
 
 /**
  * Checks whether the given return statement is in a `finally` block or not.
- *
  * @param {ASTNode} node - The return statement node to check.
  * @returns {boolean} `true` if the node is in a `finally` block.
  */
@@ -87,7 +84,6 @@ module.exports = {
 
         /**
          * Checks whether the given segment is terminated by a return statement or not.
-         *
          * @param {CodePathSegment} segment - The segment to check.
          * @returns {boolean} `true` if the segment is terminated by a return statement, or if it's still a part of unreachable.
          */
@@ -110,7 +106,6 @@ module.exports = {
          *
          * This behavior would simulate code paths for the case that the return
          * statement does not exist.
-         *
          * @param {ASTNode[]} uselessReturns - The collected return statements.
          * @param {CodePathSegment[]} prevSegments - The previous segments to traverse.
          * @param {WeakSet<CodePathSegment>} [providedTraversedSegments] A set of segments that have already been traversed in this call
@@ -152,7 +147,6 @@ module.exports = {
          *
          * This behavior would simulate code paths for the case that the return
          * statement does not exist.
-         *
          * @param {CodePathSegment} segment - The segment to get return statements.
          * @returns {void}
          */
@@ -184,7 +178,6 @@ module.exports = {
          * - FunctionDeclarations are always executed whether it's returned or not.
          * - BlockStatements do nothing.
          * - BreakStatements go the next merely.
-         *
          * @returns {void}
          */
         function markReturnStatementsOnCurrentSegmentsAsUsed() {

--- a/lib/rules/no-var.js
+++ b/lib/rules/no-var.js
@@ -27,7 +27,6 @@ function isGlobal(variable) {
 /**
  * Finds the nearest function scope or global scope walking up the scope
  * hierarchy.
- *
  * @param {eslint-scope.Scope} scope - The scope to traverse.
  * @returns {eslint-scope.Scope} a function scope or global scope containing the given
  *      scope.
@@ -44,7 +43,6 @@ function getEnclosingFunctionScope(scope) {
 /**
  * Checks whether the given variable has any references from a more specific
  * function expression (i.e. a closure).
- *
  * @param {eslint-scope.Variable} variable - A variable to check.
  * @returns {boolean} `true` if the variable is used from a closure.
  */
@@ -57,7 +55,6 @@ function isReferencedInClosure(variable) {
 
 /**
  * Checks whether the given node is the assignee of a loop.
- *
  * @param {ASTNode} node - A VariableDeclaration node to check.
  * @returns {boolean} `true` if the declaration is assigned as part of loop
  *      iteration.
@@ -69,7 +66,6 @@ function isLoopAssignee(node) {
 
 /**
  * Checks whether the given variable declaration is immediately initialized.
- *
  * @param {ASTNode} node - A VariableDeclaration node to check.
  * @returns {boolean} `true` if the declaration has an initializer.
  */
@@ -81,7 +77,6 @@ const SCOPE_NODE_TYPE = /^(?:Program|BlockStatement|SwitchStatement|ForStatement
 
 /**
  * Gets the scope node which directly contains a given node.
- *
  * @param {ASTNode} node - A node to get. This is a `VariableDeclaration` or
  *      an `Identifier`.
  * @returns {ASTNode} A scope node. This is one of `Program`, `BlockStatement`,
@@ -101,7 +96,6 @@ function getScopeNode(node) {
 
 /**
  * Checks whether a given variable is redeclared or not.
- *
  * @param {eslint-scope.Variable} variable - A variable to check.
  * @returns {boolean} `true` if the variable is redeclared.
  */
@@ -111,7 +105,6 @@ function isRedeclared(variable) {
 
 /**
  * Checks whether a given variable is used from outside of the specified scope.
- *
  * @param {ASTNode} scopeNode - A scope node to check.
  * @returns {Function} The predicate function which checks whether a given
  *      variable is used from outside of the specified scope.
@@ -120,7 +113,6 @@ function isUsedFromOutsideOf(scopeNode) {
 
     /**
      * Checks whether a given reference is inside of the specified scope or not.
-     *
      * @param {eslint-scope.Reference} reference - A reference to check.
      * @returns {boolean} `true` if the reference is inside of the specified
      *      scope.
@@ -145,7 +137,6 @@ function isUsedFromOutsideOf(scopeNode) {
  * - if a reference is before the declarator. E.g. (var a = b, b = 1;)(var {a = b, b} = {};)
  * - if a reference is in the expression of their default value.  E.g. (var {a = a} = {};)
  * - if a reference is in the expression of their initializer.  E.g. (var a = a;)
- *
  * @param {ASTNode} node - The initializer node of VariableDeclarator.
  * @returns {Function} The predicate function.
  * @private
@@ -177,7 +168,6 @@ function hasReferenceInTDZ(node) {
 /**
  * Checks whether a given variable has name that is allowed for 'var' declarations,
  * but disallowed for `let` declarations.
- *
  * @param {eslint-scope.Variable} variable The variable to check.
  * @returns {boolean} `true` if the variable has a disallowed name.
  */
@@ -209,7 +199,6 @@ module.exports = {
 
         /**
          * Checks whether the variables which are defined by the given declarator node have their references in TDZ.
-         *
          * @param {ASTNode} declarator - The VariableDeclarator node to check.
          * @returns {boolean} `true` if one of the variables which are defined by the given declarator node have their references in TDZ.
          */
@@ -271,7 +260,6 @@ module.exports = {
          * the implementation simple, we only convert `var` to `let` within
          * loops when the variable is a loop assignee or the declaration has an
          * initializer.
-         *
          * @param {ASTNode} node - A variable declaration node to check.
          * @returns {boolean} `true` if it can fix the node.
          */
@@ -313,7 +301,6 @@ module.exports = {
 
         /**
          * Reports a given variable declaration node.
-         *
          * @param {ASTNode} node - A variable declaration node to report.
          * @returns {void}
          */

--- a/lib/rules/no-var.js
+++ b/lib/rules/no-var.js
@@ -27,7 +27,7 @@ function isGlobal(variable) {
 /**
  * Finds the nearest function scope or global scope walking up the scope
  * hierarchy.
- * @param {eslint-scope.Scope} scope - The scope to traverse.
+ * @param {eslint-scope.Scope} scope The scope to traverse.
  * @returns {eslint-scope.Scope} a function scope or global scope containing the given
  *      scope.
  */
@@ -43,7 +43,7 @@ function getEnclosingFunctionScope(scope) {
 /**
  * Checks whether the given variable has any references from a more specific
  * function expression (i.e. a closure).
- * @param {eslint-scope.Variable} variable - A variable to check.
+ * @param {eslint-scope.Variable} variable A variable to check.
  * @returns {boolean} `true` if the variable is used from a closure.
  */
 function isReferencedInClosure(variable) {
@@ -55,7 +55,7 @@ function isReferencedInClosure(variable) {
 
 /**
  * Checks whether the given node is the assignee of a loop.
- * @param {ASTNode} node - A VariableDeclaration node to check.
+ * @param {ASTNode} node A VariableDeclaration node to check.
  * @returns {boolean} `true` if the declaration is assigned as part of loop
  *      iteration.
  */
@@ -66,7 +66,7 @@ function isLoopAssignee(node) {
 
 /**
  * Checks whether the given variable declaration is immediately initialized.
- * @param {ASTNode} node - A VariableDeclaration node to check.
+ * @param {ASTNode} node A VariableDeclaration node to check.
  * @returns {boolean} `true` if the declaration has an initializer.
  */
 function isDeclarationInitialized(node) {
@@ -77,7 +77,7 @@ const SCOPE_NODE_TYPE = /^(?:Program|BlockStatement|SwitchStatement|ForStatement
 
 /**
  * Gets the scope node which directly contains a given node.
- * @param {ASTNode} node - A node to get. This is a `VariableDeclaration` or
+ * @param {ASTNode} node A node to get. This is a `VariableDeclaration` or
  *      an `Identifier`.
  * @returns {ASTNode} A scope node. This is one of `Program`, `BlockStatement`,
  *      `SwitchStatement`, `ForStatement`, `ForInStatement`, and
@@ -96,7 +96,7 @@ function getScopeNode(node) {
 
 /**
  * Checks whether a given variable is redeclared or not.
- * @param {eslint-scope.Variable} variable - A variable to check.
+ * @param {eslint-scope.Variable} variable A variable to check.
  * @returns {boolean} `true` if the variable is redeclared.
  */
 function isRedeclared(variable) {
@@ -105,7 +105,7 @@ function isRedeclared(variable) {
 
 /**
  * Checks whether a given variable is used from outside of the specified scope.
- * @param {ASTNode} scopeNode - A scope node to check.
+ * @param {ASTNode} scopeNode A scope node to check.
  * @returns {Function} The predicate function which checks whether a given
  *      variable is used from outside of the specified scope.
  */
@@ -113,7 +113,7 @@ function isUsedFromOutsideOf(scopeNode) {
 
     /**
      * Checks whether a given reference is inside of the specified scope or not.
-     * @param {eslint-scope.Reference} reference - A reference to check.
+     * @param {eslint-scope.Reference} reference A reference to check.
      * @returns {boolean} `true` if the reference is inside of the specified
      *      scope.
      */
@@ -137,7 +137,7 @@ function isUsedFromOutsideOf(scopeNode) {
  * - if a reference is before the declarator. E.g. (var a = b, b = 1;)(var {a = b, b} = {};)
  * - if a reference is in the expression of their default value.  E.g. (var {a = a} = {};)
  * - if a reference is in the expression of their initializer.  E.g. (var a = a;)
- * @param {ASTNode} node - The initializer node of VariableDeclarator.
+ * @param {ASTNode} node The initializer node of VariableDeclarator.
  * @returns {Function} The predicate function.
  * @private
  */
@@ -199,7 +199,7 @@ module.exports = {
 
         /**
          * Checks whether the variables which are defined by the given declarator node have their references in TDZ.
-         * @param {ASTNode} declarator - The VariableDeclarator node to check.
+         * @param {ASTNode} declarator The VariableDeclarator node to check.
          * @returns {boolean} `true` if one of the variables which are defined by the given declarator node have their references in TDZ.
          */
         function hasSelfReferenceInTDZ(declarator) {
@@ -260,7 +260,7 @@ module.exports = {
          * the implementation simple, we only convert `var` to `let` within
          * loops when the variable is a loop assignee or the declaration has an
          * initializer.
-         * @param {ASTNode} node - A variable declaration node to check.
+         * @param {ASTNode} node A variable declaration node to check.
          * @returns {boolean} `true` if it can fix the node.
          */
         function canFix(node) {
@@ -301,7 +301,7 @@ module.exports = {
 
         /**
          * Reports a given variable declaration node.
-         * @param {ASTNode} node - A variable declaration node to report.
+         * @param {ASTNode} node A variable declaration node to report.
          * @returns {void}
          */
         function report(node) {

--- a/lib/rules/no-warning-comments.js
+++ b/lib/rules/no-warning-comments.js
@@ -54,7 +54,6 @@ module.exports = {
          * Convert a warning term into a RegExp which will match a comment containing that whole word in the specified
          * location ("start" or "anywhere"). If the term starts or ends with non word characters, then the match will not
          * require word boundaries on that side.
-         *
          * @param {string} term A term to convert to a RegExp
          * @returns {RegExp} The term converted to a RegExp
          */

--- a/lib/rules/no-whitespace-before-property.js
+++ b/lib/rules/no-whitespace-before-property.js
@@ -38,9 +38,9 @@ module.exports = {
 
         /**
          * Reports whitespace before property token
-         * @param {ASTNode} node - the node to report in the event of an error
-         * @param {Token} leftToken - the left token
-         * @param {Token} rightToken - the right token
+         * @param {ASTNode} node the node to report in the event of an error
+         * @param {Token} leftToken the left token
+         * @param {Token} rightToken the right token
          * @returns {void}
          * @private
          */

--- a/lib/rules/object-curly-newline.js
+++ b/lib/rules/object-curly-newline.js
@@ -44,7 +44,6 @@ const OPTION_VALUE = {
 
 /**
  * Normalizes a given option value.
- *
  * @param {string|Object|undefined} value - An option value to parse.
  * @returns {{multiline: boolean, minProperties: number, consistent: boolean}} Normalized option object.
  */
@@ -72,7 +71,6 @@ function normalizeOptionValue(value) {
 
 /**
  * Normalizes a given option value.
- *
  * @param {string|Object|undefined} options - An option value to parse.
  * @returns {{
  *   ObjectExpression: {multiline: boolean, minProperties: number, consistent: boolean},
@@ -101,7 +99,6 @@ function normalizeOptions(options) {
 /**
  * Determines if ObjectExpression, ObjectPattern, ImportDeclaration or ExportNamedDeclaration
  * node needs to be checked for missing line breaks
- *
  * @param {ASTNode} node - Node under inspection
  * @param {Object} options - option specific to node type
  * @param {Token} first - First object property

--- a/lib/rules/object-curly-newline.js
+++ b/lib/rules/object-curly-newline.js
@@ -44,7 +44,7 @@ const OPTION_VALUE = {
 
 /**
  * Normalizes a given option value.
- * @param {string|Object|undefined} value - An option value to parse.
+ * @param {string|Object|undefined} value An option value to parse.
  * @returns {{multiline: boolean, minProperties: number, consistent: boolean}} Normalized option object.
  */
 function normalizeOptionValue(value) {
@@ -71,7 +71,7 @@ function normalizeOptionValue(value) {
 
 /**
  * Normalizes a given option value.
- * @param {string|Object|undefined} options - An option value to parse.
+ * @param {string|Object|undefined} options An option value to parse.
  * @returns {{
  *   ObjectExpression: {multiline: boolean, minProperties: number, consistent: boolean},
  *   ObjectPattern: {multiline: boolean, minProperties: number, consistent: boolean},
@@ -99,10 +99,10 @@ function normalizeOptions(options) {
 /**
  * Determines if ObjectExpression, ObjectPattern, ImportDeclaration or ExportNamedDeclaration
  * node needs to be checked for missing line breaks
- * @param {ASTNode} node - Node under inspection
- * @param {Object} options - option specific to node type
- * @param {Token} first - First object property
- * @param {Token} last - Last object property
+ * @param {ASTNode} node Node under inspection
+ * @param {Object} options option specific to node type
+ * @param {Token} first First object property
+ * @param {Token} last Last object property
  * @returns {boolean} `true` if node needs to be checked for missing line breaks
  */
 function areLineBreaksRequired(node, options, first, last) {
@@ -168,7 +168,7 @@ module.exports = {
 
         /**
          * Reports a given node if it violated this rule.
-         * @param {ASTNode} node - A node to check. This is an ObjectExpression, ObjectPattern, ImportDeclaration or ExportNamedDeclaration node.
+         * @param {ASTNode} node A node to check. This is an ObjectExpression, ObjectPattern, ImportDeclaration or ExportNamedDeclaration node.
          * @returns {void}
          */
         function check(node) {

--- a/lib/rules/object-curly-spacing.js
+++ b/lib/rules/object-curly-spacing.js
@@ -201,7 +201,6 @@ module.exports = {
          * Because the last token of object patterns might be a type annotation,
          * this traverses tokens preceded by the last property, then returns the
          * first '}' token.
-         *
          * @param {ASTNode} node - The node to get. This node is an
          *      ObjectExpression or an ObjectPattern. And this node has one or
          *      more properties.

--- a/lib/rules/object-curly-spacing.js
+++ b/lib/rules/object-curly-spacing.js
@@ -50,7 +50,7 @@ module.exports = {
          * Determines whether an option is set, relative to the spacing option.
          * If spaced is "always", then check whether option is set to false.
          * If spaced is "never", then check whether option is set to true.
-         * @param {Object} option - The option to exclude.
+         * @param {Object} option The option to exclude.
          * @returns {boolean} Whether or not the property is excluded.
          */
         function isOptionSet(option) {
@@ -69,8 +69,8 @@ module.exports = {
 
         /**
          * Reports that there shouldn't be a space after the first token
-         * @param {ASTNode} node - The node to report in the event of an error.
-         * @param {Token} token - The token to use for the report.
+         * @param {ASTNode} node The node to report in the event of an error.
+         * @param {Token} token The token to use for the report.
          * @returns {void}
          */
         function reportNoBeginningSpace(node, token) {
@@ -91,8 +91,8 @@ module.exports = {
 
         /**
          * Reports that there shouldn't be a space before the last token
-         * @param {ASTNode} node - The node to report in the event of an error.
-         * @param {Token} token - The token to use for the report.
+         * @param {ASTNode} node The node to report in the event of an error.
+         * @param {Token} token The token to use for the report.
          * @returns {void}
          */
         function reportNoEndingSpace(node, token) {
@@ -113,8 +113,8 @@ module.exports = {
 
         /**
          * Reports that there should be a space after the first token
-         * @param {ASTNode} node - The node to report in the event of an error.
-         * @param {Token} token - The token to use for the report.
+         * @param {ASTNode} node The node to report in the event of an error.
+         * @param {Token} token The token to use for the report.
          * @returns {void}
          */
         function reportRequiredBeginningSpace(node, token) {
@@ -133,8 +133,8 @@ module.exports = {
 
         /**
          * Reports that there should be a space before the last token
-         * @param {ASTNode} node - The node to report in the event of an error.
-         * @param {Token} token - The token to use for the report.
+         * @param {ASTNode} node The node to report in the event of an error.
+         * @param {Token} token The token to use for the report.
          * @returns {void}
          */
         function reportRequiredEndingSpace(node, token) {
@@ -201,7 +201,7 @@ module.exports = {
          * Because the last token of object patterns might be a type annotation,
          * this traverses tokens preceded by the last property, then returns the
          * first '}' token.
-         * @param {ASTNode} node - The node to get. This node is an
+         * @param {ASTNode} node The node to get. This node is an
          *      ObjectExpression or an ObjectPattern. And this node has one or
          *      more properties.
          * @returns {Token} '}' token.
@@ -214,7 +214,7 @@ module.exports = {
 
         /**
          * Reports a given object node if spacing in curly braces is invalid.
-         * @param {ASTNode} node - An ObjectExpression or ObjectPattern node to check.
+         * @param {ASTNode} node An ObjectExpression or ObjectPattern node to check.
          * @returns {void}
          */
         function checkForObject(node) {
@@ -232,7 +232,7 @@ module.exports = {
 
         /**
          * Reports a given import node if spacing in curly braces is invalid.
-         * @param {ASTNode} node - An ImportDeclaration node to check.
+         * @param {ASTNode} node An ImportDeclaration node to check.
          * @returns {void}
          */
         function checkForImport(node) {
@@ -260,7 +260,7 @@ module.exports = {
 
         /**
          * Reports a given export node if spacing in curly braces is invalid.
-         * @param {ASTNode} node - An ExportNamedDeclaration node to check.
+         * @param {ASTNode} node An ExportNamedDeclaration node to check.
          * @returns {void}
          */
         function checkForExport(node) {

--- a/lib/rules/object-shorthand.js
+++ b/lib/rules/object-shorthand.js
@@ -147,7 +147,7 @@ module.exports = {
 
         /**
          * Checks whether a node is a string literal.
-         * @param   {ASTNode} node - Any AST node.
+         * @param   {ASTNode} node Any AST node.
          * @returns {boolean} `true` if it is a string literal.
          */
         function isStringLiteral(node) {

--- a/lib/rules/one-var-declaration-per-line.js
+++ b/lib/rules/one-var-declaration-per-line.js
@@ -41,7 +41,7 @@ module.exports = {
         /**
          * Determine if provided keyword is a variant of for specifiers
          * @private
-         * @param {string} keyword - keyword to test
+         * @param {string} keyword keyword to test
          * @returns {boolean} True if `keyword` is a variant of for specifier
          */
         function isForTypeSpecifier(keyword) {
@@ -51,7 +51,7 @@ module.exports = {
         /**
          * Checks newlines around variable declarations.
          * @private
-         * @param {ASTNode} node - `VariableDeclaration` node to test
+         * @param {ASTNode} node `VariableDeclaration` node to test
          * @returns {void}
          */
         function checkForNewLine(node) {

--- a/lib/rules/padded-blocks.js
+++ b/lib/rules/padded-blocks.js
@@ -97,7 +97,7 @@ module.exports = {
 
         /**
          * Gets the open brace token from a given node.
-         * @param {ASTNode} node - A BlockStatement or SwitchStatement node from which to get the open brace.
+         * @param {ASTNode} node A BlockStatement or SwitchStatement node from which to get the open brace.
          * @returns {Token} The token of the open brace.
          */
         function getOpenBrace(node) {

--- a/lib/rules/padding-line-between-statements.js
+++ b/lib/rules/padding-line-between-statements.js
@@ -25,7 +25,6 @@ const CJS_IMPORT = /^require\(/u;
 
 /**
  * Creates tester which check if a node starts with specific keyword.
- *
  * @param {string} keyword The keyword to test.
  * @returns {Object} the created tester.
  * @private
@@ -39,7 +38,6 @@ function newKeywordTester(keyword) {
 
 /**
  * Creates tester which check if a node starts with specific keyword and spans a single line.
- *
  * @param {string} keyword The keyword to test.
  * @returns {Object} the created tester.
  * @private
@@ -54,7 +52,6 @@ function newSinglelineKeywordTester(keyword) {
 
 /**
  * Creates tester which check if a node starts with specific keyword and spans multiple lines.
- *
  * @param {string} keyword The keyword to test.
  * @returns {Object} the created tester.
  * @private
@@ -69,7 +66,6 @@ function newMultilineKeywordTester(keyword) {
 
 /**
  * Creates tester which check if a node is specific type.
- *
  * @param {string} type The node type to test.
  * @returns {Object} the created tester.
  * @private
@@ -83,7 +79,6 @@ function newNodeTypeTester(type) {
 
 /**
  * Checks the given node is an expression statement of IIFE.
- *
  * @param {ASTNode} node The node to check.
  * @returns {boolean} `true` if the node is an expression statement of IIFE.
  * @private
@@ -103,7 +98,6 @@ function isIIFEStatement(node) {
 /**
  * Checks whether the given node is a block-like statement.
  * This checks the last token of the node is the closing brace of a block.
- *
  * @param {SourceCode} sourceCode The source code to get tokens.
  * @param {ASTNode} node The node to check.
  * @returns {boolean} `true` if the node is a block-like statement.
@@ -187,7 +181,6 @@ function isDirectivePrologue(node, sourceCode) {
  *
  *     foo()
  *     ;[1, 2, 3].forEach(bar)
- *
  * @param {SourceCode} sourceCode The source code to get tokens.
  * @param {ASTNode} node The node to get.
  * @returns {Token} The actual last token.
@@ -224,7 +217,6 @@ function replacerToRemovePaddingLines(_, trailingSpaces, indentSpaces) {
 /**
  * Check and report statements for `any` configuration.
  * It does nothing.
- *
  * @returns {void}
  * @private
  */
@@ -236,7 +228,6 @@ function verifyForAny() {
  * This autofix removes blank lines between the given 2 statements.
  * However, if comments exist between 2 blank lines, it does not remove those
  * blank lines automatically.
- *
  * @param {RuleContext} context The rule context to report.
  * @param {ASTNode} _ Unused. The previous node to check.
  * @param {ASTNode} nextNode The next node to check.
@@ -276,7 +267,6 @@ function verifyForNever(context, _, nextNode, paddingLines) {
  * This autofix inserts a blank line between the given 2 statements.
  * If the `prevNode` has trailing comments, it inserts a blank line after the
  * trailing comments.
- *
  * @param {RuleContext} context The rule context to report.
  * @param {ASTNode} prevNode The previous node to check.
  * @param {ASTNode} nextNode The next node to check.
@@ -318,7 +308,6 @@ function verifyForAlways(context, prevNode, nextNode, paddingLines) {
                      *
                      *     // comment.
                      *     bar();
-                     *
                      * @param {Token} token The token to check.
                      * @returns {boolean} `true` if the token is not a trailing comment.
                      * @private
@@ -511,7 +500,6 @@ module.exports = {
 
         /**
          * Checks whether the given node matches the given type.
-         *
          * @param {ASTNode} node The statement node to check.
          * @param {string|string[]} type The statement type to check.
          * @returns {boolean} `true` if the statement node matched the type.
@@ -531,7 +519,6 @@ module.exports = {
 
         /**
          * Finds the last matched configure from configureList.
-         *
          * @param {ASTNode} prevNode The previous statement to match.
          * @param {ASTNode} nextNode The current statement to match.
          * @returns {Object} The tester of the last matched configure.
@@ -554,7 +541,6 @@ module.exports = {
         /**
          * Gets padding line sequences between the given 2 statements.
          * Comments are separators of the padding line sequences.
-         *
          * @param {ASTNode} prevNode The previous statement to count.
          * @param {ASTNode} nextNode The current statement to count.
          * @returns {Array<Token[]>} The array of token pairs.
@@ -584,7 +570,6 @@ module.exports = {
 
         /**
          * Verify padding lines between the given node and the previous node.
-         *
          * @param {ASTNode} node The node to verify.
          * @returns {void}
          * @private
@@ -616,7 +601,6 @@ module.exports = {
         /**
          * Verify padding lines between the given node and the previous node.
          * Then process to enter to new scope.
-         *
          * @param {ASTNode} node The node to verify.
          * @returns {void}
          * @private

--- a/lib/rules/prefer-arrow-callback.js
+++ b/lib/rules/prefer-arrow-callback.js
@@ -11,7 +11,7 @@
 
 /**
  * Checks whether or not a given variable is a function name.
- * @param {eslint-scope.Variable} variable - A variable to check.
+ * @param {eslint-scope.Variable} variable A variable to check.
  * @returns {boolean} `true` if the variable is a function name.
  */
 function isFunctionName(variable) {
@@ -20,9 +20,9 @@ function isFunctionName(variable) {
 
 /**
  * Checks whether or not a given MetaProperty node equals to a given value.
- * @param {ASTNode} node - A MetaProperty node to check.
- * @param {string} metaName - The name of `MetaProperty.meta`.
- * @param {string} propertyName - The name of `MetaProperty.property`.
+ * @param {ASTNode} node A MetaProperty node to check.
+ * @param {string} metaName The name of `MetaProperty.meta`.
+ * @param {string} propertyName The name of `MetaProperty.property`.
  * @returns {boolean} `true` if the node is the specific value.
  */
 function checkMetaProperty(node, metaName, propertyName) {
@@ -31,7 +31,7 @@ function checkMetaProperty(node, metaName, propertyName) {
 
 /**
  * Gets the variable object of `arguments` which is defined implicitly.
- * @param {eslint-scope.Scope} scope - A scope to get.
+ * @param {eslint-scope.Scope} scope A scope to get.
  * @returns {eslint-scope.Variable} The found variable object.
  */
 function getVariableOfArguments(scope) {
@@ -57,7 +57,7 @@ function getVariableOfArguments(scope) {
 
 /**
  * Checkes whether or not a given node is a callback.
- * @param {ASTNode} node - A node to check.
+ * @param {ASTNode} node A node to check.
  * @returns {Object}
  *   {boolean} retv.isCallback - `true` if the node is a callback.
  *   {boolean} retv.isLexicalThis - `true` if the node is with `.bind(this)`.

--- a/lib/rules/prefer-const.js
+++ b/lib/rules/prefer-const.js
@@ -17,7 +17,6 @@ const DESTRUCTURING_HOST_TYPE = /^(?:VariableDeclarator|AssignmentExpression)$/u
 
 /**
  * Checks whether a given node is located at `ForStatement.init` or not.
- *
  * @param {ASTNode} node - A node to check.
  * @returns {boolean} `true` if the node is located at `ForStatement.init`.
  */
@@ -27,7 +26,6 @@ function isInitOfForStatement(node) {
 
 /**
  * Checks whether a given Identifier node becomes a VariableDeclaration or not.
- *
  * @param {ASTNode} identifier - An Identifier node to check.
  * @returns {boolean} `true` if the node can become a VariableDeclaration.
  */
@@ -51,7 +49,6 @@ function canBecomeVariableDeclaration(identifier) {
 /**
  * Checks if an property or element is from outer scope or function parameters
  * in destructing pattern.
- *
  * @param {string} name - A variable name to be checked.
  * @param {eslint-scope.Scope} initScope - A scope to start find.
  * @returns {boolean} Indicates if the variable is from outer scope or function parameters.
@@ -76,7 +73,6 @@ function isOuterVariableInDestructing(name, initScope) {
  * belongs to.
  * This is used to detect a mix of reassigned and never reassigned in a
  * destructuring.
- *
  * @param {eslint-scope.Reference} reference - A reference to get.
  * @returns {ASTNode|null} A VariableDeclarator/AssignmentExpression node or
  *      null.
@@ -162,7 +158,6 @@ function hasMemberExpressionAssignment(node) {
  *   `/*exported foo` directive comment makes such variables. This rule does not
  *   warn such variables because this rule cannot distinguish whether the
  *   exported variables are reassigned or not.
- *
  * @param {eslint-scope.Variable} variable - A variable to get.
  * @param {boolean} ignoreReadBeforeAssign -
  *      The value of `ignoreReadBeforeAssign` option.
@@ -262,7 +257,6 @@ function getIdentifierIfShouldBeConst(variable, ignoreReadBeforeAssign) {
  * reference of given variables belongs to.
  * This is used to detect a mix of reassigned and never reassigned in a
  * destructuring.
- *
  * @param {eslint-scope.Variable[]} variables - Variables to group by destructuring.
  * @param {boolean} ignoreReadBeforeAssign -
  *      The value of `ignoreReadBeforeAssign` option.
@@ -308,7 +302,6 @@ function groupByDestructuring(variables, ignoreReadBeforeAssign) {
 
 /**
  * Finds the nearest parent of node with a given type.
- *
  * @param {ASTNode} node – The node to search from.
  * @param {string} type – The type field of the parent node.
  * @param {Function} shouldStop – a predicate that returns true if the traversal should stop, and false otherwise.
@@ -374,7 +367,6 @@ module.exports = {
          * nullable. In simple declaration or assignment cases, the length of
          * the array is 1. In destructuring cases, the length of the array can
          * be 2 or more.
-         *
          * @param {(eslint-scope.Reference|null)[]} nodes -
          *      References which are grouped by destructuring to report.
          * @returns {void}

--- a/lib/rules/prefer-const.js
+++ b/lib/rules/prefer-const.js
@@ -17,7 +17,7 @@ const DESTRUCTURING_HOST_TYPE = /^(?:VariableDeclarator|AssignmentExpression)$/u
 
 /**
  * Checks whether a given node is located at `ForStatement.init` or not.
- * @param {ASTNode} node - A node to check.
+ * @param {ASTNode} node A node to check.
  * @returns {boolean} `true` if the node is located at `ForStatement.init`.
  */
 function isInitOfForStatement(node) {
@@ -26,7 +26,7 @@ function isInitOfForStatement(node) {
 
 /**
  * Checks whether a given Identifier node becomes a VariableDeclaration or not.
- * @param {ASTNode} identifier - An Identifier node to check.
+ * @param {ASTNode} identifier An Identifier node to check.
  * @returns {boolean} `true` if the node can become a VariableDeclaration.
  */
 function canBecomeVariableDeclaration(identifier) {
@@ -49,8 +49,8 @@ function canBecomeVariableDeclaration(identifier) {
 /**
  * Checks if an property or element is from outer scope or function parameters
  * in destructing pattern.
- * @param {string} name - A variable name to be checked.
- * @param {eslint-scope.Scope} initScope - A scope to start find.
+ * @param {string} name A variable name to be checked.
+ * @param {eslint-scope.Scope} initScope A scope to start find.
  * @returns {boolean} Indicates if the variable is from outer scope or function parameters.
  */
 function isOuterVariableInDestructing(name, initScope) {
@@ -73,7 +73,7 @@ function isOuterVariableInDestructing(name, initScope) {
  * belongs to.
  * This is used to detect a mix of reassigned and never reassigned in a
  * destructuring.
- * @param {eslint-scope.Reference} reference - A reference to get.
+ * @param {eslint-scope.Reference} reference A reference to get.
  * @returns {ASTNode|null} A VariableDeclarator/AssignmentExpression node or
  *      null.
  */
@@ -158,8 +158,8 @@ function hasMemberExpressionAssignment(node) {
  *   `/*exported foo` directive comment makes such variables. This rule does not
  *   warn such variables because this rule cannot distinguish whether the
  *   exported variables are reassigned or not.
- * @param {eslint-scope.Variable} variable - A variable to get.
- * @param {boolean} ignoreReadBeforeAssign -
+ * @param {eslint-scope.Variable} variable A variable to get.
+ * @param {boolean} ignoreReadBeforeAssign
  *      The value of `ignoreReadBeforeAssign` option.
  * @returns {ASTNode|null}
  *      An Identifier node if the variable should change to const.
@@ -257,8 +257,8 @@ function getIdentifierIfShouldBeConst(variable, ignoreReadBeforeAssign) {
  * reference of given variables belongs to.
  * This is used to detect a mix of reassigned and never reassigned in a
  * destructuring.
- * @param {eslint-scope.Variable[]} variables - Variables to group by destructuring.
- * @param {boolean} ignoreReadBeforeAssign -
+ * @param {eslint-scope.Variable[]} variables Variables to group by destructuring.
+ * @param {boolean} ignoreReadBeforeAssign
  *      The value of `ignoreReadBeforeAssign` option.
  * @returns {Map<ASTNode, ASTNode[]>} Grouped identifier nodes.
  */
@@ -302,9 +302,9 @@ function groupByDestructuring(variables, ignoreReadBeforeAssign) {
 
 /**
  * Finds the nearest parent of node with a given type.
- * @param {ASTNode} node – The node to search from.
- * @param {string} type – The type field of the parent node.
- * @param {Function} shouldStop – a predicate that returns true if the traversal should stop, and false otherwise.
+ * @param {ASTNode} node The node to search from.
+ * @param {string} type The type field of the parent node.
+ * @param {Function} shouldStop A predicate that returns true if the traversal should stop, and false otherwise.
  * @returns {ASTNode} The closest ancestor with the specified type; null if no such ancestor exists.
  */
 function findUp(node, type, shouldStop) {
@@ -367,7 +367,7 @@ module.exports = {
          * nullable. In simple declaration or assignment cases, the length of
          * the array is 1. In destructuring cases, the length of the array can
          * be 2 or more.
-         * @param {(eslint-scope.Reference|null)[]} nodes -
+         * @param {(eslint-scope.Reference|null)[]} nodes
          *      References which are grouped by destructuring to report.
          * @returns {void}
          */

--- a/lib/rules/prefer-destructuring.js
+++ b/lib/rules/prefer-destructuring.js
@@ -119,7 +119,6 @@ module.exports = {
          *
          * This is used to differentiate array index access from object property
          * access.
-         *
          * @param {ASTNode} node the node to evaluate
          * @returns {boolean} whether or not the node is an integer
          */
@@ -129,7 +128,6 @@ module.exports = {
 
         /**
          * Report that the given node should use destructuring
-         *
          * @param {ASTNode} reportNode the node to report
          * @param {string} type the type of destructuring that should have been done
          * @param {Function|null} fix the fix function or null to pass to context.report
@@ -153,7 +151,6 @@ module.exports = {
          * Assignment expression is not fixed.
          * Array destructuring is not fixed.
          * Renamed property is not fixed.
-         *
          * @param {ASTNode} node the the node to evaluate
          * @returns {boolean} whether or not the node should be fixed
          */
@@ -168,7 +165,6 @@ module.exports = {
          * Fix a node into object destructuring.
          * This function only handles the simplest case of object destructuring,
          * see {@link shouldFix}.
-         *
          * @param {SourceCodeFixer} fixer the fixer object
          * @param {ASTNode} node the node to be fixed.
          * @returns {Object} a fix for the node
@@ -189,7 +185,6 @@ module.exports = {
          *
          * Pulled out into a separate method so that VariableDeclarators and
          * AssignmentExpressions can share the same verification logic.
-         *
          * @param {ASTNode} leftNode the left-hand side of the assignment
          * @param {ASTNode} rightNode the right-hand side of the assignment
          * @param {ASTNode} reportNode the node to report the error on
@@ -231,7 +226,6 @@ module.exports = {
         /**
          * Check if a given variable declarator is coming from an property access
          * that should be using destructuring instead
-         *
          * @param {ASTNode} node the variable declarator to check
          * @returns {void}
          */
@@ -252,7 +246,6 @@ module.exports = {
 
         /**
          * Run the `prefer-destructuring` check on an AssignmentExpression
-         *
          * @param {ASTNode} node the AssignmentExpression node
          * @returns {void}
          */

--- a/lib/rules/prefer-named-capture-group.js
+++ b/lib/rules/prefer-named-capture-group.js
@@ -49,7 +49,6 @@ module.exports = {
 
         /**
          * Function to check regular expression.
-         *
          * @param {string} pattern The regular expression pattern to be check.
          * @param {ASTNode} node AST node which contains regular expression.
          * @param {boolean} uFlag Flag indicates whether unicode mode is enabled or not.

--- a/lib/rules/prefer-object-spread.js
+++ b/lib/rules/prefer-object-spread.js
@@ -18,7 +18,7 @@ const ANY_SPACE = /\s/u;
 
 /**
  * Helper that checks if the Object.assign call has array spread
- * @param {ASTNode} node - The node that the rule warns on
+ * @param {ASTNode} node The node that the rule warns on
  * @returns {boolean} - Returns true if the Object.assign call has array spread
  */
 function hasArraySpread(node) {
@@ -28,8 +28,8 @@ function hasArraySpread(node) {
 /**
  * Helper that checks if the node needs parentheses to be valid JS.
  * The default is to wrap the node in parentheses to avoid parsing errors.
- * @param {ASTNode} node - The node that the rule warns on
- * @param {Object} sourceCode - in context sourcecode object
+ * @param {ASTNode} node The node that the rule warns on
+ * @param {Object} sourceCode in context sourcecode object
  * @returns {boolean} - Returns true if the node needs parentheses
  */
 function needsParens(node, sourceCode) {
@@ -51,8 +51,8 @@ function needsParens(node, sourceCode) {
 
 /**
  * Determines if an argument needs parentheses. The default is to not add parens.
- * @param {ASTNode} node - The node to be checked.
- * @param {Object} sourceCode - in context sourcecode object
+ * @param {ASTNode} node The node to be checked.
+ * @param {Object} sourceCode in context sourcecode object
  * @returns {boolean} True if the node needs parentheses
  */
 function argNeedsParens(node, sourceCode) {
@@ -142,8 +142,8 @@ function getEndWithSpaces(token, sourceCode) {
 
 /**
  * Autofixes the Object.assign call to use an object spread instead.
- * @param {ASTNode|null} node - The node that the rule warns on, i.e. the Object.assign call
- * @param {string} sourceCode - sourceCode of the Object.assign call
+ * @param {ASTNode|null} node The node that the rule warns on, i.e. the Object.assign call
+ * @param {string} sourceCode sourceCode of the Object.assign call
  * @returns {Function} autofixer - replaces the Object.assign with a spread object.
  */
 function defineFixer(node, sourceCode) {

--- a/lib/rules/prefer-rest-params.js
+++ b/lib/rules/prefer-rest-params.js
@@ -11,7 +11,7 @@
 
 /**
  * Gets the variable object of `arguments` which is defined implicitly.
- * @param {eslint-scope.Scope} scope - A scope to get.
+ * @param {eslint-scope.Scope} scope A scope to get.
  * @returns {eslint-scope.Variable} The found variable object.
  */
 function getVariableOfArguments(scope) {
@@ -41,7 +41,7 @@ function getVariableOfArguments(scope) {
  * - arguments[i]      .... true    // computed member access
  * - arguments[0]      .... true    // computed member access
  * - arguments.length  .... false   // normal member access
- * @param {eslint-scope.Reference} reference - The reference to check.
+ * @param {eslint-scope.Reference} reference The reference to check.
  * @returns {boolean} `true` if the reference is not normal member access.
  */
 function isNotNormalMemberAccess(reference) {
@@ -77,7 +77,7 @@ module.exports = {
 
         /**
          * Reports a given reference.
-         * @param {eslint-scope.Reference} reference - A reference to report.
+         * @param {eslint-scope.Reference} reference A reference to report.
          * @returns {void}
          */
         function report(reference) {

--- a/lib/rules/prefer-rest-params.js
+++ b/lib/rules/prefer-rest-params.js
@@ -41,7 +41,6 @@ function getVariableOfArguments(scope) {
  * - arguments[i]      .... true    // computed member access
  * - arguments[0]      .... true    // computed member access
  * - arguments.length  .... false   // normal member access
- *
  * @param {eslint-scope.Reference} reference - The reference to check.
  * @returns {boolean} `true` if the reference is not normal member access.
  */
@@ -78,7 +77,6 @@ module.exports = {
 
         /**
          * Reports a given reference.
-         *
          * @param {eslint-scope.Reference} reference - A reference to report.
          * @returns {void}
          */
@@ -92,7 +90,6 @@ module.exports = {
 
         /**
          * Reports references of the implicit `arguments` variable if exist.
-         *
          * @returns {void}
          */
         function checkForArguments() {

--- a/lib/rules/prefer-spread.js
+++ b/lib/rules/prefer-spread.js
@@ -13,7 +13,7 @@ const astUtils = require("./utils/ast-utils");
 
 /**
  * Checks whether or not a node is a `.apply()` for variadic.
- * @param {ASTNode} node - A CallExpression node to check.
+ * @param {ASTNode} node A CallExpression node to check.
  * @returns {boolean} Whether or not the node is a `.apply()` for variadic.
  */
 function isVariadicApplyCalling(node) {
@@ -31,9 +31,9 @@ function isVariadicApplyCalling(node) {
 
 /**
  * Checks whether or not `thisArg` is not changed by `.apply()`.
- * @param {ASTNode|null} expectedThis - The node that is the owner of the applied function.
- * @param {ASTNode} thisArg - The node that is given to the first argument of the `.apply()`.
- * @param {RuleContext} context - The ESLint rule context object.
+ * @param {ASTNode|null} expectedThis The node that is the owner of the applied function.
+ * @param {ASTNode} thisArg The node that is given to the first argument of the `.apply()`.
+ * @param {RuleContext} context The ESLint rule context object.
  * @returns {boolean} Whether or not `thisArg` is not changed by `.apply()`.
  */
 function isValidThisArg(expectedThis, thisArg, context) {

--- a/lib/rules/prefer-template.js
+++ b/lib/rules/prefer-template.js
@@ -242,7 +242,6 @@ module.exports = {
 
         /**
          * Reports if a given node is string concatenation with non string literals.
-         *
          * @param {ASTNode} node - A node to check.
          * @returns {void}
          */

--- a/lib/rules/prefer-template.js
+++ b/lib/rules/prefer-template.js
@@ -17,7 +17,7 @@ const astUtils = require("./utils/ast-utils");
 
 /**
  * Checks whether or not a given node is a concatenation.
- * @param {ASTNode} node - A node to check.
+ * @param {ASTNode} node A node to check.
  * @returns {boolean} `true` if the node is a concatenation.
  */
 function isConcatenation(node) {
@@ -26,7 +26,7 @@ function isConcatenation(node) {
 
 /**
  * Gets the top binary expression node for concatenation in parents of a given node.
- * @param {ASTNode} node - A node to get.
+ * @param {ASTNode} node A node to get.
  * @returns {ASTNode} the top binary expression node in parents of a given node.
  */
 function getTopConcatBinaryExpression(node) {
@@ -70,7 +70,7 @@ function hasOctalEscapeSequence(node) {
 
 /**
  * Checks whether or not a given binary expression has string literals.
- * @param {ASTNode} node - A node to check.
+ * @param {ASTNode} node A node to check.
  * @returns {boolean} `true` if the node has string literals.
  */
 function hasStringLiteral(node) {
@@ -84,7 +84,7 @@ function hasStringLiteral(node) {
 
 /**
  * Checks whether or not a given binary expression has non string literals.
- * @param {ASTNode} node - A node to check.
+ * @param {ASTNode} node A node to check.
  * @returns {boolean} `true` if the node has non string literals.
  */
 function hasNonStringLiteral(node) {
@@ -242,7 +242,7 @@ module.exports = {
 
         /**
          * Reports if a given node is string concatenation with non string literals.
-         * @param {ASTNode} node - A node to check.
+         * @param {ASTNode} node A node to check.
          * @returns {void}
          */
         function checkForStringConcat(node) {

--- a/lib/rules/quote-props.js
+++ b/lib/rules/quote-props.js
@@ -85,7 +85,7 @@ module.exports = {
 
         /**
          * Checks whether a certain string constitutes an ES3 token
-         * @param   {string} tokenStr - The string to be checked.
+         * @param   {string} tokenStr The string to be checked.
          * @returns {boolean} `true` if it is an ES3 token.
          */
         function isKeyword(tokenStr) {

--- a/lib/rules/quotes.js
+++ b/lib/rules/quotes.js
@@ -143,7 +143,6 @@ module.exports = {
          *
          * In both cases, inside of the braces is handled as normal JavaScript.
          * The braces are `JSXExpressionContainer` nodes.
-         *
          * @param {ASTNode} node The Literal node to check.
          * @returns {boolean} True if the node is a part of JSX, false if not.
          * @private

--- a/lib/rules/quotes.js
+++ b/lib/rules/quotes.js
@@ -41,7 +41,7 @@ const UNESCAPED_LINEBREAK_PATTERN = new RegExp(String.raw`(^|[^\\])(\\\\)*[${Arr
  * escaping and unescaping as necessary.
  * Only escaping of the minimal set of characters is changed.
  * Note: escaping of newlines when switching from backtick to other quotes is not handled.
- * @param {string} str - A string to convert.
+ * @param {string} str A string to convert.
  * @returns {string} The string with changed quotes.
  * @private
  */
@@ -154,7 +154,7 @@ module.exports = {
         /**
          * Checks whether or not a given node is a directive.
          * The directive is a `ExpressionStatement` which has only a string literal.
-         * @param {ASTNode} node - A node to check.
+         * @param {ASTNode} node A node to check.
          * @returns {boolean} Whether or not the node is a directive.
          * @private
          */
@@ -169,7 +169,7 @@ module.exports = {
         /**
          * Checks whether or not a given node is a part of directive prologues.
          * See also: http://www.ecma-international.org/ecma-262/6.0/#sec-directive-prologues-and-the-use-strict-directive
-         * @param {ASTNode} node - A node to check.
+         * @param {ASTNode} node A node to check.
          * @returns {boolean} Whether or not the node is a part of directive prologues.
          * @private
          */
@@ -197,7 +197,7 @@ module.exports = {
 
         /**
          * Checks whether or not a given node is allowed as non backtick.
-         * @param {ASTNode} node - A node to check.
+         * @param {ASTNode} node A node to check.
          * @returns {boolean} Whether or not the node is allowed as non backtick.
          * @private
          */
@@ -229,7 +229,7 @@ module.exports = {
 
         /**
          * Checks whether or not a given TemplateLiteral node is actually using any of the special features provided by template literal strings.
-         * @param {ASTNode} node - A TemplateLiteral node to check.
+         * @param {ASTNode} node A TemplateLiteral node to check.
          * @returns {boolean} Whether or not the TemplateLiteral node is using any of the special features provided by template literal strings.
          * @private
          */

--- a/lib/rules/radix.js
+++ b/lib/rules/radix.js
@@ -20,7 +20,6 @@ const MODE_ALWAYS = "always",
 
 /**
  * Checks whether a given variable is shadowed or not.
- *
  * @param {eslint-scope.Variable} variable - A variable to check.
  * @returns {boolean} `true` if the variable is shadowed.
  */
@@ -30,7 +29,6 @@ function isShadowed(variable) {
 
 /**
  * Checks whether a given node is a MemberExpression of `parseInt` method or not.
- *
  * @param {ASTNode} node - A node to check.
  * @returns {boolean} `true` if the node is a MemberExpression of `parseInt`
  *      method.
@@ -51,7 +49,6 @@ function isParseIntMethod(node) {
  *
  * - A literal except numbers.
  * - undefined.
- *
  * @param {ASTNode} radix - A node of radix to check.
  * @returns {boolean} `true` if the node is valid.
  */
@@ -64,7 +61,6 @@ function isValidRadix(radix) {
 
 /**
  * Checks whether a given node is a default value of radix or not.
- *
  * @param {ASTNode} radix - A node of radix to check.
  * @returns {boolean} `true` if the node is the literal node of `10`.
  */
@@ -100,7 +96,6 @@ module.exports = {
         /**
          * Checks the arguments of a given CallExpression node and reports it if it
          * offends this rule.
-         *
          * @param {ASTNode} node - A CallExpression node to check.
          * @returns {void}
          */

--- a/lib/rules/radix.js
+++ b/lib/rules/radix.js
@@ -20,7 +20,7 @@ const MODE_ALWAYS = "always",
 
 /**
  * Checks whether a given variable is shadowed or not.
- * @param {eslint-scope.Variable} variable - A variable to check.
+ * @param {eslint-scope.Variable} variable A variable to check.
  * @returns {boolean} `true` if the variable is shadowed.
  */
 function isShadowed(variable) {
@@ -29,7 +29,7 @@ function isShadowed(variable) {
 
 /**
  * Checks whether a given node is a MemberExpression of `parseInt` method or not.
- * @param {ASTNode} node - A node to check.
+ * @param {ASTNode} node A node to check.
  * @returns {boolean} `true` if the node is a MemberExpression of `parseInt`
  *      method.
  */
@@ -49,7 +49,7 @@ function isParseIntMethod(node) {
  *
  * - A literal except numbers.
  * - undefined.
- * @param {ASTNode} radix - A node of radix to check.
+ * @param {ASTNode} radix A node of radix to check.
  * @returns {boolean} `true` if the node is valid.
  */
 function isValidRadix(radix) {
@@ -61,7 +61,7 @@ function isValidRadix(radix) {
 
 /**
  * Checks whether a given node is a default value of radix or not.
- * @param {ASTNode} radix - A node of radix to check.
+ * @param {ASTNode} radix A node of radix to check.
  * @returns {boolean} `true` if the node is the literal node of `10`.
  */
 function isDefaultRadix(radix) {
@@ -96,7 +96,7 @@ module.exports = {
         /**
          * Checks the arguments of a given CallExpression node and reports it if it
          * offends this rule.
-         * @param {ASTNode} node - A CallExpression node to check.
+         * @param {ASTNode} node A CallExpression node to check.
          * @returns {void}
          */
         function checkArguments(node) {

--- a/lib/rules/require-await.js
+++ b/lib/rules/require-await.js
@@ -17,7 +17,7 @@ const astUtils = require("./utils/ast-utils");
 
 /**
  * Capitalize the 1st letter of the given text.
- * @param {string} text - The text to capitalize.
+ * @param {string} text The text to capitalize.
  * @returns {string} The text that the 1st letter was capitalized.
  */
 function capitalizeFirstLetter(text) {
@@ -60,7 +60,7 @@ module.exports = {
         /**
          * Pop the top scope info object from the stack.
          * Also, it reports the function if needed.
-         * @param {ASTNode} node - The node to report.
+         * @param {ASTNode} node The node to report.
          * @returns {void}
          */
         function exitFunction(node) {

--- a/lib/rules/require-await.js
+++ b/lib/rules/require-await.js
@@ -17,7 +17,6 @@ const astUtils = require("./utils/ast-utils");
 
 /**
  * Capitalize the 1st letter of the given text.
- *
  * @param {string} text - The text to capitalize.
  * @returns {string} The text that the 1st letter was capitalized.
  */
@@ -49,7 +48,6 @@ module.exports = {
 
         /**
          * Push the scope info object to the stack.
-         *
          * @returns {void}
          */
         function enterFunction() {
@@ -62,7 +60,6 @@ module.exports = {
         /**
          * Pop the top scope info object from the stack.
          * Also, it reports the function if needed.
-         *
          * @param {ASTNode} node - The node to report.
          * @returns {void}
          */

--- a/lib/rules/require-yield.js
+++ b/lib/rules/require-yield.js
@@ -28,7 +28,7 @@ module.exports = {
 
         /**
          * If the node is a generator function, start counting `yield` keywords.
-         * @param {Node} node - A function node to check.
+         * @param {Node} node A function node to check.
          * @returns {void}
          */
         function beginChecking(node) {
@@ -40,7 +40,7 @@ module.exports = {
         /**
          * If the node is a generator function, end counting `yield` keywords, then
          * reports result.
-         * @param {Node} node - A function node to check.
+         * @param {Node} node A function node to check.
          * @returns {void}
          */
         function endChecking(node) {

--- a/lib/rules/rest-spread-spacing.js
+++ b/lib/rules/rest-spread-spacing.js
@@ -39,7 +39,7 @@ module.exports = {
 
         /**
          * Checks whitespace between rest/spread operators and their expressions
-         * @param {ASTNode} node - The node to check
+         * @param {ASTNode} node The node to check
          * @returns {void}
          */
         function checkWhiteSpace(node) {

--- a/lib/rules/sort-imports.js
+++ b/lib/rules/sort-imports.js
@@ -70,7 +70,7 @@ module.exports = {
          * import * as myModule from "my-module.js" --> all
          * import {myMember} from "my-module.js" --> single
          * import {foo, bar} from  "my-module.js" --> multiple
-         * @param {ASTNode} node - the ImportDeclaration node.
+         * @param {ASTNode} node the ImportDeclaration node.
          * @returns {string} used member parameter style, ["all", "multiple", "single"]
          */
         function usedMemberSyntax(node) {
@@ -89,7 +89,7 @@ module.exports = {
 
         /**
          * Gets the group by member parameter index for given declaration.
-         * @param {ASTNode} node - the ImportDeclaration node.
+         * @param {ASTNode} node the ImportDeclaration node.
          * @returns {number} the declaration group by member index.
          */
         function getMemberParameterGroupIndex(node) {
@@ -98,7 +98,7 @@ module.exports = {
 
         /**
          * Gets the local name of the first imported module.
-         * @param {ASTNode} node - the ImportDeclaration node.
+         * @param {ASTNode} node the ImportDeclaration node.
          * @returns {?string} the local name of the first imported module.
          */
         function getFirstLocalMemberName(node) {

--- a/lib/rules/sort-imports.js
+++ b/lib/rules/sort-imports.js
@@ -70,7 +70,6 @@ module.exports = {
          * import * as myModule from "my-module.js" --> all
          * import {myMember} from "my-module.js" --> single
          * import {foo, bar} from  "my-module.js" --> multiple
-         *
          * @param {ASTNode} node - the ImportDeclaration node.
          * @returns {string} used member parameter style, ["all", "multiple", "single"]
          */

--- a/lib/rules/sort-keys.js
+++ b/lib/rules/sort-keys.js
@@ -23,7 +23,7 @@ const astUtils = require("./utils/ast-utils"),
  *   whether it's a computed property or not.
  * - If the property has a static name, this returns the static name.
  * - Otherwise, this returns null.
- * @param {ASTNode} node - The `Property` node to get.
+ * @param {ASTNode} node The `Property` node to get.
  * @returns {string|null} The property name or null.
  * @private
  */

--- a/lib/rules/sort-keys.js
+++ b/lib/rules/sort-keys.js
@@ -23,7 +23,6 @@ const astUtils = require("./utils/ast-utils"),
  *   whether it's a computed property or not.
  * - If the property has a static name, this returns the static name.
  * - Otherwise, this returns null.
- *
  * @param {ASTNode} node - The `Property` node to get.
  * @returns {string|null} The property name or null.
  * @private
@@ -43,7 +42,6 @@ function getPropertyName(node) {
  *
  * Postfix `I` is meant insensitive.
  * Postfix `N` is meant natual.
- *
  * @private
  */
 const isValidOrders = {

--- a/lib/rules/space-before-blocks.js
+++ b/lib/rules/space-before-blocks.js
@@ -79,7 +79,6 @@ module.exports = {
         /**
          * Checks whether or not a given token is an arrow operator (=>) or a keyword
          * in order to avoid to conflict with `arrow-spacing` and `keyword-spacing`.
-         *
          * @param {Token} token - A token to check.
          * @returns {boolean} `true` if the token is an arrow operator.
          */

--- a/lib/rules/space-before-blocks.js
+++ b/lib/rules/space-before-blocks.js
@@ -79,7 +79,7 @@ module.exports = {
         /**
          * Checks whether or not a given token is an arrow operator (=>) or a keyword
          * in order to avoid to conflict with `arrow-spacing` and `keyword-spacing`.
-         * @param {Token} token - A token to check.
+         * @param {Token} token A token to check.
          * @returns {boolean} `true` if the token is an arrow operator.
          */
         function isConflicted(token) {

--- a/lib/rules/space-infix-ops.js
+++ b/lib/rules/space-infix-ops.js
@@ -41,9 +41,9 @@ module.exports = {
 
         /**
          * Returns the first token which violates the rule
-         * @param {ASTNode} left - The left node of the main node
-         * @param {ASTNode} right - The right node of the main node
-         * @param {string} op - The operator of the main node
+         * @param {ASTNode} left The left node of the main node
+         * @param {ASTNode} right The right node of the main node
+         * @param {string} op The operator of the main node
          * @returns {Object} The violator token or null
          * @private
          */
@@ -61,8 +61,8 @@ module.exports = {
 
         /**
          * Reports an AST node as a rule violation
-         * @param {ASTNode} mainNode - The node to report
-         * @param {Object} culpritToken - The token which has a problem
+         * @param {ASTNode} mainNode The node to report
+         * @param {Object} culpritToken The token which has a problem
          * @returns {void}
          * @private
          */

--- a/lib/rules/spaced-comment.js
+++ b/lib/rules/spaced-comment.js
@@ -51,7 +51,6 @@ function parseMarkersOption(markers) {
  * Generated pattern:
  *
  * 1. A space or an exception pattern sequence.
- *
  * @param {string[]} exceptions - An exception pattern list.
  * @returns {string} A regular expression string for exceptions.
  */
@@ -97,7 +96,6 @@ function createExceptionsPattern(exceptions) {
  *
  * 1. First, a marker or nothing.
  * 2. Next, a space or an exception pattern sequence.
- *
  * @param {string[]} markers - A marker list.
  * @param {string[]} exceptions - An exception pattern list.
  * @returns {RegExp} A RegExp object for the beginning of a comment in `always` mode.
@@ -135,7 +133,6 @@ function createAlwaysStylePattern(markers, exceptions) {
  *
  * 1. First, a marker or nothing (captured).
  * 2. Next, a space or a tab.
- *
  * @param {string[]} markers - A marker list.
  * @returns {RegExp} A RegExp object for `never` mode.
  */

--- a/lib/rules/spaced-comment.js
+++ b/lib/rules/spaced-comment.js
@@ -13,7 +13,7 @@ const astUtils = require("./utils/ast-utils");
 
 /**
  * Escapes the control characters of a given string.
- * @param {string} s - A string to escape.
+ * @param {string} s A string to escape.
  * @returns {string} An escaped string.
  */
 function escape(s) {
@@ -23,7 +23,7 @@ function escape(s) {
 /**
  * Escapes the control characters of a given string.
  * And adds a repeat flag.
- * @param {string} s - A string to escape.
+ * @param {string} s A string to escape.
  * @returns {string} An escaped string.
  */
 function escapeAndRepeat(s) {
@@ -33,7 +33,7 @@ function escapeAndRepeat(s) {
 /**
  * Parses `markers` option.
  * If markers don't include `"*"`, this adds `"*"` to allow JSDoc comments.
- * @param {string[]} [markers] - A marker list.
+ * @param {string[]} [markers] A marker list.
  * @returns {string[]} A marker list.
  */
 function parseMarkersOption(markers) {
@@ -51,7 +51,7 @@ function parseMarkersOption(markers) {
  * Generated pattern:
  *
  * 1. A space or an exception pattern sequence.
- * @param {string[]} exceptions - An exception pattern list.
+ * @param {string[]} exceptions An exception pattern list.
  * @returns {string} A regular expression string for exceptions.
  */
 function createExceptionsPattern(exceptions) {
@@ -96,8 +96,8 @@ function createExceptionsPattern(exceptions) {
  *
  * 1. First, a marker or nothing.
  * 2. Next, a space or an exception pattern sequence.
- * @param {string[]} markers - A marker list.
- * @param {string[]} exceptions - An exception pattern list.
+ * @param {string[]} markers A marker list.
+ * @param {string[]} exceptions An exception pattern list.
  * @returns {RegExp} A RegExp object for the beginning of a comment in `always` mode.
  */
 function createAlwaysStylePattern(markers, exceptions) {
@@ -133,7 +133,7 @@ function createAlwaysStylePattern(markers, exceptions) {
  *
  * 1. First, a marker or nothing (captured).
  * 2. Next, a space or a tab.
- * @param {string[]} markers - A marker list.
+ * @param {string[]} markers A marker list.
  * @returns {RegExp} A RegExp object for `never` mode.
  */
 function createNeverStylePattern(markers) {
@@ -257,10 +257,10 @@ module.exports = {
 
         /**
          * Reports a beginning spacing error with an appropriate message.
-         * @param {ASTNode} node - A comment node to check.
-         * @param {string} message - An error message to report.
-         * @param {Array} match - An array of match results for markers.
-         * @param {string} refChar - Character used for reference in the error message.
+         * @param {ASTNode} node A comment node to check.
+         * @param {string} message An error message to report.
+         * @param {Array} match An array of match results for markers.
+         * @param {string} refChar Character used for reference in the error message.
          * @returns {void}
          */
         function reportBegin(node, message, match, refChar) {
@@ -290,9 +290,9 @@ module.exports = {
 
         /**
          * Reports an ending spacing error with an appropriate message.
-         * @param {ASTNode} node - A comment node to check.
-         * @param {string} message - An error message to report.
-         * @param {string} match - An array of the matched whitespace characters.
+         * @param {ASTNode} node A comment node to check.
+         * @param {string} message An error message to report.
+         * @param {string} match An array of the matched whitespace characters.
          * @returns {void}
          */
         function reportEnd(node, message, match) {
@@ -314,7 +314,7 @@ module.exports = {
 
         /**
          * Reports a given comment if it's invalid.
-         * @param {ASTNode} node - a comment node to check.
+         * @param {ASTNode} node a comment node to check.
          * @returns {void}
          */
         function checkCommentForSpace(node) {

--- a/lib/rules/strict.js
+++ b/lib/rules/strict.js
@@ -43,7 +43,6 @@ function getUseStrictDirectives(statements) {
 
 /**
  * Checks whether a given parameter is a simple parameter.
- *
  * @param {ASTNode} node - A pattern node to check.
  * @returns {boolean} `true` if the node is an Identifier node.
  */
@@ -53,7 +52,6 @@ function isSimpleParameter(node) {
 
 /**
  * Checks whether a given parameter list is a simple parameter list.
- *
  * @param {ASTNode[]} params - A parameter list to check.
  * @returns {boolean} `true` if the every parameter is an Identifier node.
  */

--- a/lib/rules/strict.js
+++ b/lib/rules/strict.js
@@ -43,7 +43,7 @@ function getUseStrictDirectives(statements) {
 
 /**
  * Checks whether a given parameter is a simple parameter.
- * @param {ASTNode} node - A pattern node to check.
+ * @param {ASTNode} node A pattern node to check.
  * @returns {boolean} `true` if the node is an Identifier node.
  */
 function isSimpleParameter(node) {
@@ -52,7 +52,7 @@ function isSimpleParameter(node) {
 
 /**
  * Checks whether a given parameter list is a simple parameter list.
- * @param {ASTNode[]} params - A parameter list to check.
+ * @param {ASTNode[]} params A parameter list to check.
  * @returns {boolean} `true` if the every parameter is an Identifier node.
  */
 function isSimpleParameterList(params) {

--- a/lib/rules/symbol-description.js
+++ b/lib/rules/symbol-description.js
@@ -38,7 +38,7 @@ module.exports = {
         /**
          * Reports if node does not conform the rule in case rule is set to
          * report missing description
-         * @param {ASTNode} node - A CallExpression node to check.
+         * @param {ASTNode} node A CallExpression node to check.
          * @returns {void}
          */
         function checkArgument(node) {

--- a/lib/rules/symbol-description.js
+++ b/lib/rules/symbol-description.js
@@ -38,7 +38,6 @@ module.exports = {
         /**
          * Reports if node does not conform the rule in case rule is set to
          * report missing description
-         *
          * @param {ASTNode} node - A CallExpression node to check.
          * @returns {void}
          */

--- a/lib/rules/template-curly-spacing.js
+++ b/lib/rules/template-curly-spacing.js
@@ -53,7 +53,7 @@ module.exports = {
 
         /**
          * Checks spacing before `}` of a given token.
-         * @param {Token} token - A token to check. This is a Template token.
+         * @param {Token} token A token to check. This is a Template token.
          * @returns {void}
          */
         function checkSpacingBefore(token) {
@@ -82,7 +82,7 @@ module.exports = {
 
         /**
          * Checks spacing after `${` of a given token.
-         * @param {Token} token - A token to check. This is a Template token.
+         * @param {Token} token A token to check. This is a Template token.
          * @returns {void}
          */
         function checkSpacingAfter(token) {

--- a/lib/rules/utils/ast-utils.js
+++ b/lib/rules/utils/ast-utils.js
@@ -68,7 +68,6 @@ function isModifyingReference(reference, index, references) {
 
 /**
  * Checks whether the given string starts with uppercase or not.
- *
  * @param {string} s - The string to check.
  * @returns {boolean} `true` if the string starts with uppercase.
  */
@@ -106,7 +105,6 @@ function getUpperFunction(node) {
  * - ArrowFunctionExpression
  * - FunctionDeclaration
  * - FunctionExpression
- *
  * @param {ASTNode|null} node - A node to check.
  * @returns {boolean} `true` if the node is a function node.
  */
@@ -123,7 +121,6 @@ function isFunction(node) {
  * - ForOfStatement
  * - ForStatement
  * - WhileStatement
- *
  * @param {ASTNode|null} node - A node to check.
  * @returns {boolean} `true` if the node is a loop node.
  */
@@ -133,7 +130,6 @@ function isLoop(node) {
 
 /**
  * Checks whether the given node is in a loop or not.
- *
  * @param {ASTNode} node - The node to check.
  * @returns {boolean} `true` if the node is in a loop.
  */
@@ -268,7 +264,6 @@ function isParenthesised(sourceCode, node) {
 
 /**
  * Checks if the given token is an arrow token or not.
- *
  * @param {Token} token - The token to check.
  * @returns {boolean} `true` if the token is an arrow token.
  */
@@ -278,7 +273,6 @@ function isArrowToken(token) {
 
 /**
  * Checks if the given token is a comma token or not.
- *
  * @param {Token} token - The token to check.
  * @returns {boolean} `true` if the token is a comma token.
  */
@@ -288,7 +282,6 @@ function isCommaToken(token) {
 
 /**
  * Checks if the given token is a dot token or not.
- *
  * @param {Token} token - The token to check.
  * @returns {boolean} `true` if the token is a dot token.
  */
@@ -298,7 +291,6 @@ function isDotToken(token) {
 
 /**
  * Checks if the given token is a semicolon token or not.
- *
  * @param {Token} token - The token to check.
  * @returns {boolean} `true` if the token is a semicolon token.
  */
@@ -308,7 +300,6 @@ function isSemicolonToken(token) {
 
 /**
  * Checks if the given token is a colon token or not.
- *
  * @param {Token} token - The token to check.
  * @returns {boolean} `true` if the token is a colon token.
  */
@@ -318,7 +309,6 @@ function isColonToken(token) {
 
 /**
  * Checks if the given token is an opening parenthesis token or not.
- *
  * @param {Token} token - The token to check.
  * @returns {boolean} `true` if the token is an opening parenthesis token.
  */
@@ -328,7 +318,6 @@ function isOpeningParenToken(token) {
 
 /**
  * Checks if the given token is a closing parenthesis token or not.
- *
  * @param {Token} token - The token to check.
  * @returns {boolean} `true` if the token is a closing parenthesis token.
  */
@@ -338,7 +327,6 @@ function isClosingParenToken(token) {
 
 /**
  * Checks if the given token is an opening square bracket token or not.
- *
  * @param {Token} token - The token to check.
  * @returns {boolean} `true` if the token is an opening square bracket token.
  */
@@ -348,7 +336,6 @@ function isOpeningBracketToken(token) {
 
 /**
  * Checks if the given token is a closing square bracket token or not.
- *
  * @param {Token} token - The token to check.
  * @returns {boolean} `true` if the token is a closing square bracket token.
  */
@@ -358,7 +345,6 @@ function isClosingBracketToken(token) {
 
 /**
  * Checks if the given token is an opening brace token or not.
- *
  * @param {Token} token - The token to check.
  * @returns {boolean} `true` if the token is an opening brace token.
  */
@@ -368,7 +354,6 @@ function isOpeningBraceToken(token) {
 
 /**
  * Checks if the given token is a closing brace token or not.
- *
  * @param {Token} token - The token to check.
  * @returns {boolean} `true` if the token is a closing brace token.
  */
@@ -378,7 +363,6 @@ function isClosingBraceToken(token) {
 
 /**
  * Checks if the given token is a comment token or not.
- *
  * @param {Token} token - The token to check.
  * @returns {boolean} `true` if the token is a comment token.
  */
@@ -388,7 +372,6 @@ function isCommentToken(token) {
 
 /**
  * Checks if the given token is a keyword token or not.
- *
  * @param {Token} token - The token to check.
  * @returns {boolean} `true` if the token is a keyword token.
  */
@@ -398,7 +381,6 @@ function isKeywordToken(token) {
 
 /**
  * Gets the `(` token of the given function node.
- *
  * @param {ASTNode} node - The function node to get.
  * @param {SourceCode} sourceCode - The source code object to get tokens.
  * @returns {Token} `(` token.
@@ -514,7 +496,6 @@ module.exports = {
      * - ForStatement
      * - SwitchStatement
      * - WhileStatement
-     *
      * @param {ASTNode} node - A node to check.
      * @returns {boolean} `true` if the node is breakable.
      */
@@ -568,7 +549,6 @@ module.exports = {
      *         consequent;
      *
      * When taking this `IfStatement`, returns `consequent;` statement.
-     *
      * @param {ASTNode} A node to get.
      * @returns {ASTNode|null} The trailing statement's node.
      */
@@ -576,7 +556,6 @@ module.exports = {
 
     /**
      * Finds the variable by a given name in a given scope and its upper scopes.
-     *
      * @param {eslint-scope.Scope} initScope - A scope to start find.
      * @param {string} name - A variable name to find.
      * @returns {eslint-scope.Variable|null} A found variable or `null`.
@@ -613,7 +592,6 @@ module.exports = {
      * - The location is not on an ES2015 class.
      * - Its `bind`/`call`/`apply` method is not called directly.
      * - The function is not a callback of array methods (such as `.forEach()`) if `thisArg` is given.
-     *
      * @param {ASTNode} node - A function node to check.
      * @param {SourceCode} sourceCode - A SourceCode instance to get comments.
      * @returns {boolean} The function node is the default `this` binding.
@@ -861,7 +839,6 @@ module.exports = {
 
     /**
      * Checks whether the given node is an empty block node or not.
-     *
      * @param {ASTNode|null} node - The node to check.
      * @returns {boolean} `true` if the node is an empty block.
      */
@@ -871,7 +848,6 @@ module.exports = {
 
     /**
      * Checks whether the given node is an empty function node or not.
-     *
      * @param {ASTNode|null} node - The node to check.
      * @returns {boolean} `true` if the node is an empty function.
      */
@@ -906,7 +882,6 @@ module.exports = {
      *     let a = {["a" + "b"]: 1}  // => null
      *     let a = {[tag`b`]: 1}     // => null
      *     let a = {[`${b}`]: 1}     // => null
-     *
      * @param {ASTNode} node - The node to get.
      * @returns {string|null} The property name if static. Otherwise, null.
      */
@@ -1063,7 +1038,6 @@ module.exports = {
      * - `class A { static async foo() {} }`  .... `static async method 'foo'`
      * - `class A { static get foo() {} }`  ...... `static getter 'foo'`
      * - `class A { static set foo(a) {} }`  ..... `static setter 'foo'`
-     *
      * @param {ASTNode} node - The function node to get.
      * @returns {string} The name and kind of the function node.
      */
@@ -1198,7 +1172,6 @@ module.exports = {
      *              ^^^^^^^^^^^^^^
      * - `class A { static set foo(a) {} }`
      *              ^^^^^^^^^^^^^^
-     *
      * @param {ASTNode} node - The function node to get.
      * @param {SourceCode} sourceCode - The source code object to get tokens.
      * @returns {string} The location of the function node for reporting.
@@ -1384,7 +1357,6 @@ module.exports = {
      * "\00", "\01" ... "\09"
      *
      * "\0", when not followed by a digit, is not an octal escape sequence.
-     *
      * @param {string} rawString A string in its raw representation.
      * @returns {boolean} `true` if the string contains at least one octal escape sequence.
      */

--- a/lib/rules/utils/ast-utils.js
+++ b/lib/rules/utils/ast-utils.js
@@ -42,9 +42,9 @@ const OCTAL_ESCAPE_PATTERN = /^(?:[^\\]|\\[^0-7]|\\0(?![0-9]))*\\(?:[1-7]|0[0-9]
 
 /**
  * Checks reference if is non initializer and writable.
- * @param {Reference} reference - A reference to check.
- * @param {int} index - The index of the reference in the references.
- * @param {Reference[]} references - The array that the reference belongs to.
+ * @param {Reference} reference A reference to check.
+ * @param {int} index The index of the reference in the references.
+ * @param {Reference[]} references The array that the reference belongs to.
  * @returns {boolean} Success/Failure
  * @private
  */
@@ -68,7 +68,7 @@ function isModifyingReference(reference, index, references) {
 
 /**
  * Checks whether the given string starts with uppercase or not.
- * @param {string} s - The string to check.
+ * @param {string} s The string to check.
  * @returns {boolean} `true` if the string starts with uppercase.
  */
 function startsWithUpperCase(s) {
@@ -77,7 +77,7 @@ function startsWithUpperCase(s) {
 
 /**
  * Checks whether or not a node is a constructor.
- * @param {ASTNode} node - A function node to check.
+ * @param {ASTNode} node A function node to check.
  * @returns {boolean} Wehether or not a node is a constructor.
  */
 function isES5Constructor(node) {
@@ -86,7 +86,7 @@ function isES5Constructor(node) {
 
 /**
  * Finds a function node from ancestors of a node.
- * @param {ASTNode} node - A start node to find.
+ * @param {ASTNode} node A start node to find.
  * @returns {Node|null} A found function node.
  */
 function getUpperFunction(node) {
@@ -105,7 +105,7 @@ function getUpperFunction(node) {
  * - ArrowFunctionExpression
  * - FunctionDeclaration
  * - FunctionExpression
- * @param {ASTNode|null} node - A node to check.
+ * @param {ASTNode|null} node A node to check.
  * @returns {boolean} `true` if the node is a function node.
  */
 function isFunction(node) {
@@ -121,7 +121,7 @@ function isFunction(node) {
  * - ForOfStatement
  * - ForStatement
  * - WhileStatement
- * @param {ASTNode|null} node - A node to check.
+ * @param {ASTNode|null} node A node to check.
  * @returns {boolean} `true` if the node is a loop node.
  */
 function isLoop(node) {
@@ -130,7 +130,7 @@ function isLoop(node) {
 
 /**
  * Checks whether the given node is in a loop or not.
- * @param {ASTNode} node - The node to check.
+ * @param {ASTNode} node The node to check.
  * @returns {boolean} `true` if the node is in a loop.
  */
 function isInLoop(node) {
@@ -145,7 +145,7 @@ function isInLoop(node) {
 
 /**
  * Checks whether or not a node is `null` or `undefined`.
- * @param {ASTNode} node - A node to check.
+ * @param {ASTNode} node A node to check.
  * @returns {boolean} Whether or not the node is a `null` or `undefined`.
  * @public
  */
@@ -159,7 +159,7 @@ function isNullOrUndefined(node) {
 
 /**
  * Checks whether or not a node is callee.
- * @param {ASTNode} node - A node to check.
+ * @param {ASTNode} node A node to check.
  * @returns {boolean} Whether or not the node is callee.
  */
 function isCallee(node) {
@@ -168,7 +168,7 @@ function isCallee(node) {
 
 /**
  * Checks whether or not a node is `Reflect.apply`.
- * @param {ASTNode} node - A node to check.
+ * @param {ASTNode} node A node to check.
  * @returns {boolean} Whether or not the node is a `Reflect.apply`.
  */
 function isReflectApply(node) {
@@ -184,7 +184,7 @@ function isReflectApply(node) {
 
 /**
  * Checks whether or not a node is `Array.from`.
- * @param {ASTNode} node - A node to check.
+ * @param {ASTNode} node A node to check.
  * @returns {boolean} Whether or not the node is a `Array.from`.
  */
 function isArrayFromMethod(node) {
@@ -200,7 +200,7 @@ function isArrayFromMethod(node) {
 
 /**
  * Checks whether or not a node is a method which has `thisArg`.
- * @param {ASTNode} node - A node to check.
+ * @param {ASTNode} node A node to check.
  * @returns {boolean} Whether or not the node is a method which has `thisArg`.
  */
 function isMethodWhichHasThisArg(node) {
@@ -219,7 +219,7 @@ function isMethodWhichHasThisArg(node) {
 
 /**
  * Creates the negate function of the given function.
- * @param {Function} f - The function to negate.
+ * @param {Function} f The function to negate.
  * @returns {Function} Negated function.
  */
 function negate(f) {
@@ -228,8 +228,8 @@ function negate(f) {
 
 /**
  * Checks whether or not a node has a `@this` tag in its comments.
- * @param {ASTNode} node - A node to check.
- * @param {SourceCode} sourceCode - A SourceCode instance to get comments.
+ * @param {ASTNode} node A node to check.
+ * @param {SourceCode} sourceCode A SourceCode instance to get comments.
  * @returns {boolean} Whether or not the node has a `@this` tag in its comments.
  */
 function hasJSDocThisTag(node, sourceCode) {
@@ -264,7 +264,7 @@ function isParenthesised(sourceCode, node) {
 
 /**
  * Checks if the given token is an arrow token or not.
- * @param {Token} token - The token to check.
+ * @param {Token} token The token to check.
  * @returns {boolean} `true` if the token is an arrow token.
  */
 function isArrowToken(token) {
@@ -273,7 +273,7 @@ function isArrowToken(token) {
 
 /**
  * Checks if the given token is a comma token or not.
- * @param {Token} token - The token to check.
+ * @param {Token} token The token to check.
  * @returns {boolean} `true` if the token is a comma token.
  */
 function isCommaToken(token) {
@@ -282,7 +282,7 @@ function isCommaToken(token) {
 
 /**
  * Checks if the given token is a dot token or not.
- * @param {Token} token - The token to check.
+ * @param {Token} token The token to check.
  * @returns {boolean} `true` if the token is a dot token.
  */
 function isDotToken(token) {
@@ -291,7 +291,7 @@ function isDotToken(token) {
 
 /**
  * Checks if the given token is a semicolon token or not.
- * @param {Token} token - The token to check.
+ * @param {Token} token The token to check.
  * @returns {boolean} `true` if the token is a semicolon token.
  */
 function isSemicolonToken(token) {
@@ -300,7 +300,7 @@ function isSemicolonToken(token) {
 
 /**
  * Checks if the given token is a colon token or not.
- * @param {Token} token - The token to check.
+ * @param {Token} token The token to check.
  * @returns {boolean} `true` if the token is a colon token.
  */
 function isColonToken(token) {
@@ -309,7 +309,7 @@ function isColonToken(token) {
 
 /**
  * Checks if the given token is an opening parenthesis token or not.
- * @param {Token} token - The token to check.
+ * @param {Token} token The token to check.
  * @returns {boolean} `true` if the token is an opening parenthesis token.
  */
 function isOpeningParenToken(token) {
@@ -318,7 +318,7 @@ function isOpeningParenToken(token) {
 
 /**
  * Checks if the given token is a closing parenthesis token or not.
- * @param {Token} token - The token to check.
+ * @param {Token} token The token to check.
  * @returns {boolean} `true` if the token is a closing parenthesis token.
  */
 function isClosingParenToken(token) {
@@ -327,7 +327,7 @@ function isClosingParenToken(token) {
 
 /**
  * Checks if the given token is an opening square bracket token or not.
- * @param {Token} token - The token to check.
+ * @param {Token} token The token to check.
  * @returns {boolean} `true` if the token is an opening square bracket token.
  */
 function isOpeningBracketToken(token) {
@@ -336,7 +336,7 @@ function isOpeningBracketToken(token) {
 
 /**
  * Checks if the given token is a closing square bracket token or not.
- * @param {Token} token - The token to check.
+ * @param {Token} token The token to check.
  * @returns {boolean} `true` if the token is a closing square bracket token.
  */
 function isClosingBracketToken(token) {
@@ -345,7 +345,7 @@ function isClosingBracketToken(token) {
 
 /**
  * Checks if the given token is an opening brace token or not.
- * @param {Token} token - The token to check.
+ * @param {Token} token The token to check.
  * @returns {boolean} `true` if the token is an opening brace token.
  */
 function isOpeningBraceToken(token) {
@@ -354,7 +354,7 @@ function isOpeningBraceToken(token) {
 
 /**
  * Checks if the given token is a closing brace token or not.
- * @param {Token} token - The token to check.
+ * @param {Token} token The token to check.
  * @returns {boolean} `true` if the token is a closing brace token.
  */
 function isClosingBraceToken(token) {
@@ -363,7 +363,7 @@ function isClosingBraceToken(token) {
 
 /**
  * Checks if the given token is a comment token or not.
- * @param {Token} token - The token to check.
+ * @param {Token} token The token to check.
  * @returns {boolean} `true` if the token is a comment token.
  */
 function isCommentToken(token) {
@@ -372,7 +372,7 @@ function isCommentToken(token) {
 
 /**
  * Checks if the given token is a keyword token or not.
- * @param {Token} token - The token to check.
+ * @param {Token} token The token to check.
  * @returns {boolean} `true` if the token is a keyword token.
  */
 function isKeywordToken(token) {
@@ -381,8 +381,8 @@ function isKeywordToken(token) {
 
 /**
  * Gets the `(` token of the given function node.
- * @param {ASTNode} node - The function node to get.
- * @param {SourceCode} sourceCode - The source code object to get tokens.
+ * @param {ASTNode} node The function node to get.
+ * @param {SourceCode} sourceCode The source code object to get tokens.
  * @returns {Token} `(` token.
  */
 function getOpeningParenOfParams(node, sourceCode) {
@@ -393,9 +393,9 @@ function getOpeningParenOfParams(node, sourceCode) {
 
 /**
  * Checks whether or not the tokens of two given nodes are same.
- * @param {ASTNode} left - A node 1 to compare.
- * @param {ASTNode} right - A node 2 to compare.
- * @param {SourceCode} sourceCode - The ESLint source code object.
+ * @param {ASTNode} left A node 1 to compare.
+ * @param {ASTNode} right A node 2 to compare.
+ * @param {SourceCode} sourceCode The ESLint source code object.
  * @returns {boolean} the source code for the given node.
  */
 function equalTokens(left, right, sourceCode) {
@@ -429,8 +429,8 @@ module.exports = {
 
     /**
      * Determines whether two adjacent tokens are on the same line.
-     * @param {Object} left - The left token object.
-     * @param {Object} right - The right token object.
+     * @param {Object} left The left token object.
+     * @param {Object} right The right token object.
      * @returns {boolean} Whether or not the tokens are on the same line.
      * @public
      */
@@ -476,7 +476,7 @@ module.exports = {
 
     /**
      * Checks whether or not a given node is a string literal.
-     * @param {ASTNode} node - A node to check.
+     * @param {ASTNode} node A node to check.
      * @returns {boolean} `true` if the node is a string literal.
      */
     isStringLiteral(node) {
@@ -496,7 +496,7 @@ module.exports = {
      * - ForStatement
      * - SwitchStatement
      * - WhileStatement
-     * @param {ASTNode} node - A node to check.
+     * @param {ASTNode} node A node to check.
      * @returns {boolean} `true` if the node is breakable.
      */
     isBreakableStatement(node) {
@@ -505,7 +505,7 @@ module.exports = {
 
     /**
      * Gets references which are non initializer and writable.
-     * @param {Reference[]} references - An array of references.
+     * @param {Reference[]} references An array of references.
      * @returns {Reference[]} An array of only references which are non initializer and writable.
      * @public
      */
@@ -556,8 +556,8 @@ module.exports = {
 
     /**
      * Finds the variable by a given name in a given scope and its upper scopes.
-     * @param {eslint-scope.Scope} initScope - A scope to start find.
-     * @param {string} name - A variable name to find.
+     * @param {eslint-scope.Scope} initScope A scope to start find.
+     * @param {string} name A variable name to find.
      * @returns {eslint-scope.Variable|null} A found variable or `null`.
      */
     getVariableByName(initScope, name) {
@@ -592,8 +592,8 @@ module.exports = {
      * - The location is not on an ES2015 class.
      * - Its `bind`/`call`/`apply` method is not called directly.
      * - The function is not a callback of array methods (such as `.forEach()`) if `thisArg` is given.
-     * @param {ASTNode} node - A function node to check.
-     * @param {SourceCode} sourceCode - A SourceCode instance to get comments.
+     * @param {ASTNode} node A function node to check.
+     * @param {SourceCode} sourceCode A SourceCode instance to get comments.
      * @returns {boolean} The function node is the default `this` binding.
      */
     isDefaultThisBinding(node, sourceCode) {
@@ -839,7 +839,7 @@ module.exports = {
 
     /**
      * Checks whether the given node is an empty block node or not.
-     * @param {ASTNode|null} node - The node to check.
+     * @param {ASTNode|null} node The node to check.
      * @returns {boolean} `true` if the node is an empty block.
      */
     isEmptyBlock(node) {
@@ -848,7 +848,7 @@ module.exports = {
 
     /**
      * Checks whether the given node is an empty function node or not.
-     * @param {ASTNode|null} node - The node to check.
+     * @param {ASTNode|null} node The node to check.
      * @returns {boolean} `true` if the node is an empty function.
      */
     isEmptyFunction(node) {
@@ -882,7 +882,7 @@ module.exports = {
      *     let a = {["a" + "b"]: 1}  // => null
      *     let a = {[tag`b`]: 1}     // => null
      *     let a = {[`${b}`]: 1}     // => null
-     * @param {ASTNode} node - The node to get.
+     * @param {ASTNode} node The node to get.
      * @returns {string|null} The property name if static. Otherwise, null.
      */
     getStaticPropertyName(node) {
@@ -925,7 +925,7 @@ module.exports = {
 
     /**
      * Get directives from directive prologue of a Program or Function node.
-     * @param {ASTNode} node - The node to check.
+     * @param {ASTNode} node The node to check.
      * @returns {ASTNode[]} The directives found in the directive prologue.
      */
     getDirectivePrologue(node) {
@@ -964,7 +964,7 @@ module.exports = {
     /**
      * Determines whether this node is a decimal integer literal. If a node is a decimal integer literal, a dot added
      * after the node will be parsed as a decimal point, rather than a property-access dot.
-     * @param {ASTNode} node - The node to check.
+     * @param {ASTNode} node The node to check.
      * @returns {boolean} `true` if this node is a decimal integer.
      * @example
      *
@@ -986,7 +986,7 @@ module.exports = {
     /**
      * Determines whether this token is a decimal integer numeric token.
      * This is similar to isDecimalInteger(), but for tokens.
-     * @param {Token} token - The token to check.
+     * @param {Token} token The token to check.
      * @returns {boolean} `true` if this token is a decimal integer.
      */
     isDecimalIntegerNumericToken(token) {
@@ -1038,7 +1038,7 @@ module.exports = {
      * - `class A { static async foo() {} }`  .... `static async method 'foo'`
      * - `class A { static get foo() {} }`  ...... `static getter 'foo'`
      * - `class A { static set foo(a) {} }`  ..... `static setter 'foo'`
-     * @param {ASTNode} node - The function node to get.
+     * @param {ASTNode} node The function node to get.
      * @returns {string} The name and kind of the function node.
      */
     getFunctionNameWithKind(node) {
@@ -1172,8 +1172,8 @@ module.exports = {
      *              ^^^^^^^^^^^^^^
      * - `class A { static set foo(a) {} }`
      *              ^^^^^^^^^^^^^^
-     * @param {ASTNode} node - The function node to get.
-     * @param {SourceCode} sourceCode - The source code object to get tokens.
+     * @param {ASTNode} node The function node to get.
+     * @param {SourceCode} sourceCode The source code object to get tokens.
      * @returns {string} The location of the function node for reporting.
      */
     getFunctionHeadLoc(node, sourceCode) {

--- a/lib/rules/utils/fix-tracker.js
+++ b/lib/rules/utils/fix-tracker.js
@@ -23,7 +23,6 @@ class FixTracker {
 
     /**
      * Create a new FixTracker.
-     *
      * @param {ruleFixer} fixer A ruleFixer instance.
      * @param {SourceCode} sourceCode A SourceCode object for the current code.
      */
@@ -36,7 +35,6 @@ class FixTracker {
     /**
      * Mark the given range as "retained", meaning that other fixes may not
      * may not modify this region in the same pass.
-     *
      * @param {int[]} range The range to retain.
      * @returns {FixTracker} The same RuleFixer, for chained calls.
      */
@@ -50,7 +48,6 @@ class FixTracker {
      * mark it as retained, meaning that other fixes may not modify it in this
      * pass. This is useful for avoiding conflicts in fixes that modify control
      * flow.
-     *
      * @param {ASTNode} node The node to use as a starting point.
      * @returns {FixTracker} The same RuleFixer, for chained calls.
      */
@@ -65,7 +62,6 @@ class FixTracker {
      * range as retained, meaning that other fixes may not modify it in this
      * pass. This is useful for avoiding conflicts in fixes that make a small
      * change to the code where the AST should not be changed.
-     *
      * @param {ASTNode|Token} nodeOrToken The node or token to use as a starting
      *      point. The token to the left and right are use in the range.
      * @returns {FixTracker} The same RuleFixer, for chained calls.
@@ -80,7 +76,6 @@ class FixTracker {
     /**
      * Create a fix command that replaces the given range with the given text,
      * accounting for any retained ranges.
-     *
      * @param {int[]} range The range to remove in the fix.
      * @param {string} text The text to insert in place of the range.
      * @returns {Object} The fix command.
@@ -108,7 +103,6 @@ class FixTracker {
     /**
      * Create a fix command that removes the given node or token, accounting for
      * any retained ranges.
-     *
      * @param {ASTNode|Token} nodeOrToken The node or token to remove.
      * @returns {Object} The fix command.
      */

--- a/lib/rules/utils/lazy-loading-rule-map.js
+++ b/lib/rules/utils/lazy-loading-rule-map.js
@@ -10,7 +10,6 @@ const debug = require("debug")("eslint:rules");
 
 /**
  * The `Map` object that loads each rule when it's accessed.
- *
  * @example
  * const rules = new LazyLoadingRuleMap([
  *     ["eqeqeq", () => require("eqeqeq")],

--- a/lib/rules/vars-on-top.js
+++ b/lib/rules/vars-on-top.js
@@ -33,7 +33,7 @@ module.exports = {
         //--------------------------------------------------------------------------
 
         /**
-         * @param {ASTNode} node - any node
+         * @param {ASTNode} node any node
          * @returns {boolean} whether the given node structurally represents a directive
          */
         function looksLikeDirective(node) {
@@ -43,7 +43,7 @@ module.exports = {
 
         /**
          * Check to see if its a ES6 import declaration
-         * @param {ASTNode} node - any node
+         * @param {ASTNode} node any node
          * @returns {boolean} whether the given node represents a import declaration
          */
         function looksLikeImport(node) {
@@ -53,7 +53,7 @@ module.exports = {
 
         /**
          * Checks whether a given node is a variable declaration or not.
-         * @param {ASTNode} node - any node
+         * @param {ASTNode} node any node
          * @returns {boolean} `true` if the node is a variable declaration.
          */
         function isVariableDeclaration(node) {
@@ -69,8 +69,8 @@ module.exports = {
 
         /**
          * Checks whether this variable is on top of the block body
-         * @param {ASTNode} node - The node to check
-         * @param {ASTNode[]} statements - collection of ASTNodes for the parent node block
+         * @param {ASTNode} node The node to check
+         * @param {ASTNode[]} statements collection of ASTNodes for the parent node block
          * @returns {boolean} True if var is on top otherwise false
          */
         function isVarOnTop(node, statements) {
@@ -98,8 +98,8 @@ module.exports = {
 
         /**
          * Checks whether variable is on top at the global level
-         * @param {ASTNode} node - The node to check
-         * @param {ASTNode} parent - Parent of the node
+         * @param {ASTNode} node The node to check
+         * @param {ASTNode} parent Parent of the node
          * @returns {void}
          */
         function globalVarCheck(node, parent) {
@@ -110,9 +110,9 @@ module.exports = {
 
         /**
          * Checks whether variable is on top at functional block scope level
-         * @param {ASTNode} node - The node to check
-         * @param {ASTNode} parent - Parent of the node
-         * @param {ASTNode} grandParent - Parent of the node's parent
+         * @param {ASTNode} node The node to check
+         * @param {ASTNode} parent Parent of the node
+         * @param {ASTNode} grandParent Parent of the node's parent
          * @returns {void}
          */
         function blockScopeVarCheck(node, parent, grandParent) {

--- a/lib/rules/vars-on-top.js
+++ b/lib/rules/vars-on-top.js
@@ -53,7 +53,6 @@ module.exports = {
 
         /**
          * Checks whether a given node is a variable declaration or not.
-         *
          * @param {ASTNode} node - any node
          * @returns {boolean} `true` if the node is a variable declaration.
          */

--- a/lib/shared/config-ops.js
+++ b/lib/shared/config-ops.js
@@ -77,7 +77,7 @@ module.exports = {
 
     /**
      * Checks whether a given config has valid severity or not.
-     * @param {number|string|Array} ruleConfig - The configuration for an individual rule.
+     * @param {number|string|Array} ruleConfig The configuration for an individual rule.
      * @returns {boolean} `true` if the configuration has valid severity.
      */
     isValidSeverity(ruleConfig) {
@@ -91,7 +91,7 @@ module.exports = {
 
     /**
      * Checks whether every rule of a given config has valid severity or not.
-     * @param {Object} config - The configuration for rules.
+     * @param {Object} config The configuration for rules.
      * @returns {boolean} `true` if the configuration has valid severity.
      */
     isEverySeverityValid(config) {

--- a/lib/shared/runtime-info.js
+++ b/lib/shared/runtime-info.js
@@ -28,8 +28,8 @@ function environment() {
 
     /**
      * Checks if a path is a child of a directory.
-     * @param {string} parentPath - The parent path to check.
-     * @param {string} childPath - The path to check.
+     * @param {string} parentPath The parent path to check.
+     * @param {string} childPath The path to check.
      * @returns {boolean} Whether or not the given path is a child of a directory.
      */
     function isChildOfDirectory(parentPath, childPath) {
@@ -38,8 +38,8 @@ function environment() {
 
     /**
      * Synchronously executes a shell command and formats the result.
-     * @param {string} cmd - The command to execute.
-     * @param {Array} args - The arguments to be executed with the command.
+     * @param {string} cmd The command to execute.
+     * @param {Array} args The arguments to be executed with the command.
      * @returns {string} The version returned by the command.
      */
     function execCommand(cmd, args) {
@@ -63,7 +63,7 @@ function environment() {
 
     /**
      * Normalizes a version number.
-     * @param {string} versionStr - The string to normalize.
+     * @param {string} versionStr The string to normalize.
      * @returns {string} The normalized version number.
      */
     function normalizeVersionStr(versionStr) {
@@ -72,7 +72,7 @@ function environment() {
 
     /**
      * Gets bin version.
-     * @param {string} bin - The bin to check.
+     * @param {string} bin The bin to check.
      * @returns {string} The normalized version returned by the command.
      */
     function getBinVersion(bin) {
@@ -88,8 +88,8 @@ function environment() {
 
     /**
      * Gets installed npm package version.
-     * @param {string} pkg - The package to check.
-     * @param {boolean} global - Whether to check globally or not.
+     * @param {string} pkg The package to check.
+     * @param {boolean} global Whether to check globally or not.
      * @returns {string} The normalized version returned by the command.
      */
     function getNpmPackageVersion(pkg, { global = false } = {}) {

--- a/lib/source-code/source-code.js
+++ b/lib/source-code/source-code.js
@@ -86,13 +86,13 @@ class SourceCode extends TokenStore {
 
     /**
      * Represents parsed source code.
-     * @param {string|Object} textOrConfig - The source code text or config object.
-     * @param {string} textOrConfig.text - The source code text.
-     * @param {ASTNode} textOrConfig.ast - The Program node of the AST representing the code. This AST should be created from the text that BOM was stripped.
-     * @param {Object|null} textOrConfig.parserServices - The parser services.
-     * @param {ScopeManager|null} textOrConfig.scopeManager - The scope of this source code.
-     * @param {Object|null} textOrConfig.visitorKeys - The visitor keys to traverse AST.
-     * @param {ASTNode} [astIfNoConfig] - The Program node of the AST representing the code. This AST should be created from the text that BOM was stripped.
+     * @param {string|Object} textOrConfig The source code text or config object.
+     * @param {string} textOrConfig.text The source code text.
+     * @param {ASTNode} textOrConfig.ast The Program node of the AST representing the code. This AST should be created from the text that BOM was stripped.
+     * @param {Object|null} textOrConfig.parserServices The parser services.
+     * @param {ScopeManager|null} textOrConfig.scopeManager The scope of this source code.
+     * @param {Object|null} textOrConfig.visitorKeys The visitor keys to traverse AST.
+     * @param {ASTNode} [astIfNoConfig] The Program node of the AST representing the code. This AST should be created from the text that BOM was stripped.
      */
     constructor(textOrConfig, astIfNoConfig) {
         let text, ast, parserServices, scopeManager, visitorKeys;

--- a/lib/source-code/token-store/backward-token-comment-cursor.js
+++ b/lib/source-code/token-store/backward-token-comment-cursor.js
@@ -22,11 +22,11 @@ module.exports = class BackwardTokenCommentCursor extends Cursor {
 
     /**
      * Initializes this cursor.
-     * @param {Token[]} tokens - The array of tokens.
-     * @param {Comment[]} comments - The array of comments.
-     * @param {Object} indexMap - The map from locations to indices in `tokens`.
-     * @param {number} startLoc - The start location of the iteration range.
-     * @param {number} endLoc - The end location of the iteration range.
+     * @param {Token[]} tokens The array of tokens.
+     * @param {Comment[]} comments The array of comments.
+     * @param {Object} indexMap The map from locations to indices in `tokens`.
+     * @param {number} startLoc The start location of the iteration range.
+     * @param {number} endLoc The end location of the iteration range.
      */
     constructor(tokens, comments, indexMap, startLoc, endLoc) {
         super();

--- a/lib/source-code/token-store/backward-token-cursor.js
+++ b/lib/source-code/token-store/backward-token-cursor.js
@@ -22,11 +22,11 @@ module.exports = class BackwardTokenCursor extends Cursor {
 
     /**
      * Initializes this cursor.
-     * @param {Token[]} tokens - The array of tokens.
-     * @param {Comment[]} comments - The array of comments.
-     * @param {Object} indexMap - The map from locations to indices in `tokens`.
-     * @param {number} startLoc - The start location of the iteration range.
-     * @param {number} endLoc - The end location of the iteration range.
+     * @param {Token[]} tokens The array of tokens.
+     * @param {Comment[]} comments The array of comments.
+     * @param {Object} indexMap The map from locations to indices in `tokens`.
+     * @param {number} startLoc The start location of the iteration range.
+     * @param {number} endLoc The end location of the iteration range.
      */
     constructor(tokens, comments, indexMap, startLoc, endLoc) {
         super();

--- a/lib/source-code/token-store/cursors.js
+++ b/lib/source-code/token-store/cursors.js
@@ -28,8 +28,8 @@ class CursorFactory {
 
     /**
      * Initializes this cursor.
-     * @param {Function} TokenCursor - The class of the cursor which iterates tokens only.
-     * @param {Function} TokenCommentCursor - The class of the cursor which iterates the mix of tokens and comments.
+     * @param {Function} TokenCursor The class of the cursor which iterates tokens only.
+     * @param {Function} TokenCommentCursor The class of the cursor which iterates the mix of tokens and comments.
      */
     constructor(TokenCursor, TokenCommentCursor) {
         this.TokenCursor = TokenCursor;
@@ -38,12 +38,12 @@ class CursorFactory {
 
     /**
      * Creates a base cursor instance that can be decorated by createCursor.
-     * @param {Token[]} tokens - The array of tokens.
-     * @param {Comment[]} comments - The array of comments.
-     * @param {Object} indexMap - The map from locations to indices in `tokens`.
-     * @param {number} startLoc - The start location of the iteration range.
-     * @param {number} endLoc - The end location of the iteration range.
-     * @param {boolean} includeComments - The flag to iterate comments as well.
+     * @param {Token[]} tokens The array of tokens.
+     * @param {Comment[]} comments The array of comments.
+     * @param {Object} indexMap The map from locations to indices in `tokens`.
+     * @param {number} startLoc The start location of the iteration range.
+     * @param {number} endLoc The end location of the iteration range.
+     * @param {boolean} includeComments The flag to iterate comments as well.
      * @returns {Cursor} The created base cursor.
      */
     createBaseCursor(tokens, comments, indexMap, startLoc, endLoc, includeComments) {
@@ -54,15 +54,15 @@ class CursorFactory {
 
     /**
      * Creates a cursor that iterates tokens with normalized options.
-     * @param {Token[]} tokens - The array of tokens.
-     * @param {Comment[]} comments - The array of comments.
-     * @param {Object} indexMap - The map from locations to indices in `tokens`.
-     * @param {number} startLoc - The start location of the iteration range.
-     * @param {number} endLoc - The end location of the iteration range.
-     * @param {boolean} includeComments - The flag to iterate comments as well.
-     * @param {Function|null} filter - The predicate function to choose tokens.
-     * @param {number} skip - The count of tokens the cursor skips.
-     * @param {number} count - The maximum count of tokens the cursor iterates. Zero is no iteration for backward compatibility.
+     * @param {Token[]} tokens The array of tokens.
+     * @param {Comment[]} comments The array of comments.
+     * @param {Object} indexMap The map from locations to indices in `tokens`.
+     * @param {number} startLoc The start location of the iteration range.
+     * @param {number} endLoc The end location of the iteration range.
+     * @param {boolean} includeComments The flag to iterate comments as well.
+     * @param {Function|null} filter The predicate function to choose tokens.
+     * @param {number} skip The count of tokens the cursor skips.
+     * @param {number} count The maximum count of tokens the cursor iterates. Zero is no iteration for backward compatibility.
      * @returns {Cursor} The created cursor.
      */
     createCursor(tokens, comments, indexMap, startLoc, endLoc, includeComments, filter, skip, count) {

--- a/lib/source-code/token-store/cursors.js
+++ b/lib/source-code/token-store/cursors.js
@@ -38,7 +38,6 @@ class CursorFactory {
 
     /**
      * Creates a base cursor instance that can be decorated by createCursor.
-     *
      * @param {Token[]} tokens - The array of tokens.
      * @param {Comment[]} comments - The array of comments.
      * @param {Object} indexMap - The map from locations to indices in `tokens`.
@@ -55,7 +54,6 @@ class CursorFactory {
 
     /**
      * Creates a cursor that iterates tokens with normalized options.
-     *
      * @param {Token[]} tokens - The array of tokens.
      * @param {Comment[]} comments - The array of comments.
      * @param {Object} indexMap - The map from locations to indices in `tokens`.

--- a/lib/source-code/token-store/decorative-cursor.js
+++ b/lib/source-code/token-store/decorative-cursor.js
@@ -21,7 +21,7 @@ module.exports = class DecorativeCursor extends Cursor {
 
     /**
      * Initializes this cursor.
-     * @param {Cursor} cursor - The cursor to be decorated.
+     * @param {Cursor} cursor The cursor to be decorated.
      */
     constructor(cursor) {
         super();

--- a/lib/source-code/token-store/filter-cursor.js
+++ b/lib/source-code/token-store/filter-cursor.js
@@ -21,8 +21,8 @@ module.exports = class FilterCursor extends DecorativeCursor {
 
     /**
      * Initializes this cursor.
-     * @param {Cursor} cursor - The cursor to be decorated.
-     * @param {Function} predicate - The predicate function to decide tokens this cursor iterates.
+     * @param {Cursor} cursor The cursor to be decorated.
+     * @param {Function} predicate The predicate function to decide tokens this cursor iterates.
      */
     constructor(cursor, predicate) {
         super(cursor);

--- a/lib/source-code/token-store/forward-token-comment-cursor.js
+++ b/lib/source-code/token-store/forward-token-comment-cursor.js
@@ -22,11 +22,11 @@ module.exports = class ForwardTokenCommentCursor extends Cursor {
 
     /**
      * Initializes this cursor.
-     * @param {Token[]} tokens - The array of tokens.
-     * @param {Comment[]} comments - The array of comments.
-     * @param {Object} indexMap - The map from locations to indices in `tokens`.
-     * @param {number} startLoc - The start location of the iteration range.
-     * @param {number} endLoc - The end location of the iteration range.
+     * @param {Token[]} tokens The array of tokens.
+     * @param {Comment[]} comments The array of comments.
+     * @param {Object} indexMap The map from locations to indices in `tokens`.
+     * @param {number} startLoc The start location of the iteration range.
+     * @param {number} endLoc The end location of the iteration range.
      */
     constructor(tokens, comments, indexMap, startLoc, endLoc) {
         super();

--- a/lib/source-code/token-store/forward-token-cursor.js
+++ b/lib/source-code/token-store/forward-token-cursor.js
@@ -22,11 +22,11 @@ module.exports = class ForwardTokenCursor extends Cursor {
 
     /**
      * Initializes this cursor.
-     * @param {Token[]} tokens - The array of tokens.
-     * @param {Comment[]} comments - The array of comments.
-     * @param {Object} indexMap - The map from locations to indices in `tokens`.
-     * @param {number} startLoc - The start location of the iteration range.
-     * @param {number} endLoc - The end location of the iteration range.
+     * @param {Token[]} tokens The array of tokens.
+     * @param {Comment[]} comments The array of comments.
+     * @param {Object} indexMap The map from locations to indices in `tokens`.
+     * @param {number} startLoc The start location of the iteration range.
+     * @param {number} endLoc The end location of the iteration range.
      */
     constructor(tokens, comments, indexMap, startLoc, endLoc) {
         super();

--- a/lib/source-code/token-store/index.js
+++ b/lib/source-code/token-store/index.js
@@ -28,7 +28,6 @@ const INDEX_MAP = Symbol("indexMap");
  *
  * The first/last location of tokens is mapped to the index of the token.
  * The first/last location of comments is mapped to the index of the next token of each comment.
- *
  * @param {Token[]} tokens - The array of tokens.
  * @param {Comment[]} comments - The array of comments.
  * @returns {Object} The map from locations to indices in `tokens`.
@@ -62,7 +61,6 @@ function createIndexMap(tokens, comments) {
 
 /**
  * Creates the cursor iterates tokens with options.
- *
  * @param {CursorFactory} factory - The cursor factory to initialize cursor.
  * @param {Token[]} tokens - The array of tokens.
  * @param {Comment[]} comments - The array of comments.
@@ -98,7 +96,6 @@ function createCursorWithSkip(factory, tokens, comments, indexMap, startLoc, end
 
 /**
  * Creates the cursor iterates tokens with options.
- *
  * @param {CursorFactory} factory - The cursor factory to initialize cursor.
  * @param {Token[]} tokens - The array of tokens.
  * @param {Comment[]} comments - The array of comments.
@@ -138,7 +135,6 @@ function createCursorWithCount(factory, tokens, comments, indexMap, startLoc, en
 /**
  * Creates the cursor iterates tokens with options.
  * This is overload function of the below.
- *
  * @param {Token[]} tokens - The array of tokens.
  * @param {Comment[]} comments - The array of comments.
  * @param {Object} indexMap - The map from locations to indices in `tokens`.
@@ -153,7 +149,6 @@ function createCursorWithCount(factory, tokens, comments, indexMap, startLoc, en
  */
 /**
  * Creates the cursor iterates tokens with options.
- *
  * @param {Token[]} tokens - The array of tokens.
  * @param {Comment[]} comments - The array of comments.
  * @param {Object} indexMap - The map from locations to indices in `tokens`.
@@ -567,7 +562,6 @@ module.exports = class TokenStore {
 
     /**
      * Checks whether any comments exist or not between the given 2 nodes.
-     *
      * @param {ASTNode} left - The node to check.
      * @param {ASTNode} right - The node to check.
      * @returns {boolean} `true` if one or more comments exist.

--- a/lib/source-code/token-store/index.js
+++ b/lib/source-code/token-store/index.js
@@ -28,8 +28,8 @@ const INDEX_MAP = Symbol("indexMap");
  *
  * The first/last location of tokens is mapped to the index of the token.
  * The first/last location of comments is mapped to the index of the next token of each comment.
- * @param {Token[]} tokens - The array of tokens.
- * @param {Comment[]} comments - The array of comments.
+ * @param {Token[]} tokens The array of tokens.
+ * @param {Comment[]} comments The array of comments.
  * @returns {Object} The map from locations to indices in `tokens`.
  * @private
  */
@@ -61,16 +61,16 @@ function createIndexMap(tokens, comments) {
 
 /**
  * Creates the cursor iterates tokens with options.
- * @param {CursorFactory} factory - The cursor factory to initialize cursor.
- * @param {Token[]} tokens - The array of tokens.
- * @param {Comment[]} comments - The array of comments.
- * @param {Object} indexMap - The map from locations to indices in `tokens`.
- * @param {number} startLoc - The start location of the iteration range.
- * @param {number} endLoc - The end location of the iteration range.
- * @param {number|Function|Object} [opts=0] - The option object. If this is a number then it's `opts.skip`. If this is a function then it's `opts.filter`.
- * @param {boolean} [opts.includeComments=false] - The flag to iterate comments as well.
- * @param {Function|null} [opts.filter=null] - The predicate function to choose tokens.
- * @param {number} [opts.skip=0] - The count of tokens the cursor skips.
+ * @param {CursorFactory} factory The cursor factory to initialize cursor.
+ * @param {Token[]} tokens The array of tokens.
+ * @param {Comment[]} comments The array of comments.
+ * @param {Object} indexMap The map from locations to indices in `tokens`.
+ * @param {number} startLoc The start location of the iteration range.
+ * @param {number} endLoc The end location of the iteration range.
+ * @param {number|Function|Object} [opts=0] The option object. If this is a number then it's `opts.skip`. If this is a function then it's `opts.filter`.
+ * @param {boolean} [opts.includeComments=false] The flag to iterate comments as well.
+ * @param {Function|null} [opts.filter=null] The predicate function to choose tokens.
+ * @param {number} [opts.skip=0] The count of tokens the cursor skips.
  * @returns {Cursor} The created cursor.
  * @private
  */
@@ -96,16 +96,16 @@ function createCursorWithSkip(factory, tokens, comments, indexMap, startLoc, end
 
 /**
  * Creates the cursor iterates tokens with options.
- * @param {CursorFactory} factory - The cursor factory to initialize cursor.
- * @param {Token[]} tokens - The array of tokens.
- * @param {Comment[]} comments - The array of comments.
- * @param {Object} indexMap - The map from locations to indices in `tokens`.
- * @param {number} startLoc - The start location of the iteration range.
- * @param {number} endLoc - The end location of the iteration range.
- * @param {number|Function|Object} [opts=0] - The option object. If this is a number then it's `opts.count`. If this is a function then it's `opts.filter`.
- * @param {boolean} [opts.includeComments] - The flag to iterate comments as well.
- * @param {Function|null} [opts.filter=null] - The predicate function to choose tokens.
- * @param {number} [opts.count=0] - The maximum count of tokens the cursor iterates. Zero is no iteration for backward compatibility.
+ * @param {CursorFactory} factory The cursor factory to initialize cursor.
+ * @param {Token[]} tokens The array of tokens.
+ * @param {Comment[]} comments The array of comments.
+ * @param {Object} indexMap The map from locations to indices in `tokens`.
+ * @param {number} startLoc The start location of the iteration range.
+ * @param {number} endLoc The end location of the iteration range.
+ * @param {number|Function|Object} [opts=0] The option object. If this is a number then it's `opts.count`. If this is a function then it's `opts.filter`.
+ * @param {boolean} [opts.includeComments] The flag to iterate comments as well.
+ * @param {Function|null} [opts.filter=null] The predicate function to choose tokens.
+ * @param {number} [opts.count=0] The maximum count of tokens the cursor iterates. Zero is no iteration for backward compatibility.
  * @returns {Cursor} The created cursor.
  * @private
  */
@@ -135,27 +135,27 @@ function createCursorWithCount(factory, tokens, comments, indexMap, startLoc, en
 /**
  * Creates the cursor iterates tokens with options.
  * This is overload function of the below.
- * @param {Token[]} tokens - The array of tokens.
- * @param {Comment[]} comments - The array of comments.
- * @param {Object} indexMap - The map from locations to indices in `tokens`.
- * @param {number} startLoc - The start location of the iteration range.
- * @param {number} endLoc - The end location of the iteration range.
- * @param {Function|Object} opts - The option object. If this is a function then it's `opts.filter`.
- * @param {boolean} [opts.includeComments] - The flag to iterate comments as well.
- * @param {Function|null} [opts.filter=null] - The predicate function to choose tokens.
- * @param {number} [opts.count=0] - The maximum count of tokens the cursor iterates. Zero is no iteration for backward compatibility.
+ * @param {Token[]} tokens The array of tokens.
+ * @param {Comment[]} comments The array of comments.
+ * @param {Object} indexMap The map from locations to indices in `tokens`.
+ * @param {number} startLoc The start location of the iteration range.
+ * @param {number} endLoc The end location of the iteration range.
+ * @param {Function|Object} opts The option object. If this is a function then it's `opts.filter`.
+ * @param {boolean} [opts.includeComments] The flag to iterate comments as well.
+ * @param {Function|null} [opts.filter=null] The predicate function to choose tokens.
+ * @param {number} [opts.count=0] The maximum count of tokens the cursor iterates. Zero is no iteration for backward compatibility.
  * @returns {Cursor} The created cursor.
  * @private
  */
 /**
  * Creates the cursor iterates tokens with options.
- * @param {Token[]} tokens - The array of tokens.
- * @param {Comment[]} comments - The array of comments.
- * @param {Object} indexMap - The map from locations to indices in `tokens`.
- * @param {number} startLoc - The start location of the iteration range.
- * @param {number} endLoc - The end location of the iteration range.
- * @param {number} [beforeCount=0] - The number of tokens before the node to retrieve.
- * @param {boolean} [afterCount=0] - The number of tokens after the node to retrieve.
+ * @param {Token[]} tokens The array of tokens.
+ * @param {Comment[]} comments The array of comments.
+ * @param {Object} indexMap The map from locations to indices in `tokens`.
+ * @param {number} startLoc The start location of the iteration range.
+ * @param {number} endLoc The end location of the iteration range.
+ * @param {number} [beforeCount=0] The number of tokens before the node to retrieve.
+ * @param {boolean} [afterCount=0] The number of tokens after the node to retrieve.
  * @returns {Cursor} The created cursor.
  * @private
  */
@@ -171,7 +171,7 @@ function createCursorWithPadding(tokens, comments, indexMap, startLoc, endLoc, b
 
 /**
  * Gets comment tokens that are adjacent to the current cursor position.
- * @param {Cursor} cursor - A cursor instance.
+ * @param {Cursor} cursor A cursor instance.
  * @returns {Array} An array of comment tokens adjacent to the current cursor position.
  * @private
  */
@@ -206,8 +206,8 @@ module.exports = class TokenStore {
 
     /**
      * Initializes this token store.
-     * @param {Token[]} tokens - The array of tokens.
-     * @param {Comment[]} comments - The array of comments.
+     * @param {Token[]} tokens The array of tokens.
+     * @param {Comment[]} comments The array of comments.
      */
     constructor(tokens, comments) {
         this[TOKENS] = tokens;
@@ -221,9 +221,9 @@ module.exports = class TokenStore {
 
     /**
      * Gets the token starting at the specified index.
-     * @param {number} offset - Index of the start of the token's range.
-     * @param {Object} [options=0] - The option object.
-     * @param {boolean} [options.includeComments=false] - The flag to iterate comments as well.
+     * @param {number} offset Index of the start of the token's range.
+     * @param {Object} [options=0] The option object.
+     * @param {boolean} [options.includeComments=false] The flag to iterate comments as well.
      * @returns {Token|null} The token starting at index, or null if no such token.
      */
     getTokenByRangeStart(offset, options) {
@@ -245,11 +245,11 @@ module.exports = class TokenStore {
 
     /**
      * Gets the first token of the given node.
-     * @param {ASTNode} node - The AST node.
-     * @param {number|Function|Object} [options=0] - The option object. If this is a number then it's `options.skip`. If this is a function then it's `options.filter`.
-     * @param {boolean} [options.includeComments=false] - The flag to iterate comments as well.
-     * @param {Function|null} [options.filter=null] - The predicate function to choose tokens.
-     * @param {number} [options.skip=0] - The count of tokens the cursor skips.
+     * @param {ASTNode} node The AST node.
+     * @param {number|Function|Object} [options=0] The option object. If this is a number then it's `options.skip`. If this is a function then it's `options.filter`.
+     * @param {boolean} [options.includeComments=false] The flag to iterate comments as well.
+     * @param {Function|null} [options.filter=null] The predicate function to choose tokens.
+     * @param {number} [options.skip=0] The count of tokens the cursor skips.
      * @returns {Token|null} An object representing the token.
      */
     getFirstToken(node, options) {
@@ -266,8 +266,8 @@ module.exports = class TokenStore {
 
     /**
      * Gets the last token of the given node.
-     * @param {ASTNode} node - The AST node.
-     * @param {number|Function|Object} [options=0] - The option object. Same options as getFirstToken()
+     * @param {ASTNode} node The AST node.
+     * @param {number|Function|Object} [options=0] The option object. Same options as getFirstToken()
      * @returns {Token|null} An object representing the token.
      */
     getLastToken(node, options) {
@@ -284,8 +284,8 @@ module.exports = class TokenStore {
 
     /**
      * Gets the token that precedes a given node or token.
-     * @param {ASTNode|Token|Comment} node - The AST node or token.
-     * @param {number|Function|Object} [options=0] - The option object. Same options as getFirstToken()
+     * @param {ASTNode|Token|Comment} node The AST node or token.
+     * @param {number|Function|Object} [options=0] The option object. Same options as getFirstToken()
      * @returns {Token|null} An object representing the token.
      */
     getTokenBefore(node, options) {
@@ -302,8 +302,8 @@ module.exports = class TokenStore {
 
     /**
      * Gets the token that follows a given node or token.
-     * @param {ASTNode|Token|Comment} node - The AST node or token.
-     * @param {number|Function|Object} [options=0] - The option object. Same options as getFirstToken()
+     * @param {ASTNode|Token|Comment} node The AST node or token.
+     * @param {number|Function|Object} [options=0] The option object. Same options as getFirstToken()
      * @returns {Token|null} An object representing the token.
      */
     getTokenAfter(node, options) {
@@ -320,9 +320,9 @@ module.exports = class TokenStore {
 
     /**
      * Gets the first token between two non-overlapping nodes.
-     * @param {ASTNode|Token|Comment} left - Node before the desired token range.
-     * @param {ASTNode|Token|Comment} right - Node after the desired token range.
-     * @param {number|Function|Object} [options=0] - The option object. Same options as getFirstToken()
+     * @param {ASTNode|Token|Comment} left Node before the desired token range.
+     * @param {ASTNode|Token|Comment} right Node after the desired token range.
+     * @param {number|Function|Object} [options=0] The option object. Same options as getFirstToken()
      * @returns {Token|null} An object representing the token.
      */
     getFirstTokenBetween(left, right, options) {
@@ -341,7 +341,7 @@ module.exports = class TokenStore {
      * Gets the last token between two non-overlapping nodes.
      * @param {ASTNode|Token|Comment} left Node before the desired token range.
      * @param {ASTNode|Token|Comment} right Node after the desired token range.
-     * @param {number|Function|Object} [options=0] - The option object. Same options as getFirstToken()
+     * @param {number|Function|Object} [options=0] The option object. Same options as getFirstToken()
      * @returns {Token|null} An object representing the token.
      */
     getLastTokenBetween(left, right, options) {
@@ -388,11 +388,11 @@ module.exports = class TokenStore {
 
     /**
      * Gets the first `count` tokens of the given node.
-     * @param {ASTNode} node - The AST node.
-     * @param {number|Function|Object} [options=0] - The option object. If this is a number then it's `options.count`. If this is a function then it's `options.filter`.
-     * @param {boolean} [options.includeComments=false] - The flag to iterate comments as well.
-     * @param {Function|null} [options.filter=null] - The predicate function to choose tokens.
-     * @param {number} [options.count=0] - The maximum count of tokens the cursor iterates.
+     * @param {ASTNode} node The AST node.
+     * @param {number|Function|Object} [options=0] The option object. If this is a number then it's `options.count`. If this is a function then it's `options.filter`.
+     * @param {boolean} [options.includeComments=false] The flag to iterate comments as well.
+     * @param {Function|null} [options.filter=null] The predicate function to choose tokens.
+     * @param {number} [options.count=0] The maximum count of tokens the cursor iterates.
      * @returns {Token[]} Tokens.
      */
     getFirstTokens(node, options) {
@@ -409,8 +409,8 @@ module.exports = class TokenStore {
 
     /**
      * Gets the last `count` tokens of the given node.
-     * @param {ASTNode} node - The AST node.
-     * @param {number|Function|Object} [options=0] - The option object. Same options as getFirstTokens()
+     * @param {ASTNode} node The AST node.
+     * @param {number|Function|Object} [options=0] The option object. Same options as getFirstTokens()
      * @returns {Token[]} Tokens.
      */
     getLastTokens(node, options) {
@@ -427,8 +427,8 @@ module.exports = class TokenStore {
 
     /**
      * Gets the `count` tokens that precedes a given node or token.
-     * @param {ASTNode|Token|Comment} node - The AST node or token.
-     * @param {number|Function|Object} [options=0] - The option object. Same options as getFirstTokens()
+     * @param {ASTNode|Token|Comment} node The AST node or token.
+     * @param {number|Function|Object} [options=0] The option object. Same options as getFirstTokens()
      * @returns {Token[]} Tokens.
      */
     getTokensBefore(node, options) {
@@ -445,8 +445,8 @@ module.exports = class TokenStore {
 
     /**
      * Gets the `count` tokens that follows a given node or token.
-     * @param {ASTNode|Token|Comment} node - The AST node or token.
-     * @param {number|Function|Object} [options=0] - The option object. Same options as getFirstTokens()
+     * @param {ASTNode|Token|Comment} node The AST node or token.
+     * @param {number|Function|Object} [options=0] The option object. Same options as getFirstTokens()
      * @returns {Token[]} Tokens.
      */
     getTokensAfter(node, options) {
@@ -463,9 +463,9 @@ module.exports = class TokenStore {
 
     /**
      * Gets the first `count` tokens between two non-overlapping nodes.
-     * @param {ASTNode|Token|Comment} left - Node before the desired token range.
-     * @param {ASTNode|Token|Comment} right - Node after the desired token range.
-     * @param {number|Function|Object} [options=0] - The option object. Same options as getFirstTokens()
+     * @param {ASTNode|Token|Comment} left Node before the desired token range.
+     * @param {ASTNode|Token|Comment} right Node after the desired token range.
+     * @param {number|Function|Object} [options=0] The option object. Same options as getFirstTokens()
      * @returns {Token[]} Tokens between left and right.
      */
     getFirstTokensBetween(left, right, options) {
@@ -484,7 +484,7 @@ module.exports = class TokenStore {
      * Gets the last `count` tokens between two non-overlapping nodes.
      * @param {ASTNode|Token|Comment} left Node before the desired token range.
      * @param {ASTNode|Token|Comment} right Node after the desired token range.
-     * @param {number|Function|Object} [options=0] - The option object. Same options as getFirstTokens()
+     * @param {number|Function|Object} [options=0] The option object. Same options as getFirstTokens()
      * @returns {Token[]} Tokens between left and right.
      */
     getLastTokensBetween(left, right, options) {
@@ -501,18 +501,18 @@ module.exports = class TokenStore {
 
     /**
      * Gets all tokens that are related to the given node.
-     * @param {ASTNode} node - The AST node.
+     * @param {ASTNode} node The AST node.
      * @param {Function|Object} options The option object. If this is a function then it's `options.filter`.
-     * @param {boolean} [options.includeComments=false] - The flag to iterate comments as well.
-     * @param {Function|null} [options.filter=null] - The predicate function to choose tokens.
-     * @param {number} [options.count=0] - The maximum count of tokens the cursor iterates.
+     * @param {boolean} [options.includeComments=false] The flag to iterate comments as well.
+     * @param {Function|null} [options.filter=null] The predicate function to choose tokens.
+     * @param {number} [options.count=0] The maximum count of tokens the cursor iterates.
      * @returns {Token[]} Array of objects representing tokens.
      */
     /**
      * Gets all tokens that are related to the given node.
-     * @param {ASTNode} node - The AST node.
-     * @param {int} [beforeCount=0] - The number of tokens before the node to retrieve.
-     * @param {int} [afterCount=0] - The number of tokens after the node to retrieve.
+     * @param {ASTNode} node The AST node.
+     * @param {int} [beforeCount=0] The number of tokens before the node to retrieve.
+     * @param {int} [afterCount=0] The number of tokens after the node to retrieve.
      * @returns {Token[]} Array of objects representing tokens.
      */
     getTokens(node, beforeCount, afterCount) {
@@ -532,9 +532,9 @@ module.exports = class TokenStore {
      * @param {ASTNode|Token|Comment} left Node before the desired token range.
      * @param {ASTNode|Token|Comment} right Node after the desired token range.
      * @param {Function|Object} options The option object. If this is a function then it's `options.filter`.
-     * @param {boolean} [options.includeComments=false] - The flag to iterate comments as well.
-     * @param {Function|null} [options.filter=null] - The predicate function to choose tokens.
-     * @param {number} [options.count=0] - The maximum count of tokens the cursor iterates.
+     * @param {boolean} [options.includeComments=false] The flag to iterate comments as well.
+     * @param {Function|null} [options.filter=null] The predicate function to choose tokens.
+     * @param {number} [options.count=0] The maximum count of tokens the cursor iterates.
      * @returns {Token[]} Tokens between left and right.
      */
     /**
@@ -562,8 +562,8 @@ module.exports = class TokenStore {
 
     /**
      * Checks whether any comments exist or not between the given 2 nodes.
-     * @param {ASTNode} left - The node to check.
-     * @param {ASTNode} right - The node to check.
+     * @param {ASTNode} left The node to check.
+     * @param {ASTNode} right The node to check.
      * @returns {boolean} `true` if one or more comments exist.
      */
     commentsExistBetween(left, right) {

--- a/lib/source-code/token-store/limit-cursor.js
+++ b/lib/source-code/token-store/limit-cursor.js
@@ -21,8 +21,8 @@ module.exports = class LimitCursor extends DecorativeCursor {
 
     /**
      * Initializes this cursor.
-     * @param {Cursor} cursor - The cursor to be decorated.
-     * @param {number} count - The count of tokens this cursor iterates.
+     * @param {Cursor} cursor The cursor to be decorated.
+     * @param {number} count The count of tokens this cursor iterates.
      */
     constructor(cursor, count) {
         super(cursor);

--- a/lib/source-code/token-store/padded-token-cursor.js
+++ b/lib/source-code/token-store/padded-token-cursor.js
@@ -22,13 +22,13 @@ module.exports = class PaddedTokenCursor extends ForwardTokenCursor {
 
     /**
      * Initializes this cursor.
-     * @param {Token[]} tokens - The array of tokens.
-     * @param {Comment[]} comments - The array of comments.
-     * @param {Object} indexMap - The map from locations to indices in `tokens`.
-     * @param {number} startLoc - The start location of the iteration range.
-     * @param {number} endLoc - The end location of the iteration range.
-     * @param {number} beforeCount - The number of tokens this cursor iterates before start.
-     * @param {number} afterCount - The number of tokens this cursor iterates after end.
+     * @param {Token[]} tokens The array of tokens.
+     * @param {Comment[]} comments The array of comments.
+     * @param {Object} indexMap The map from locations to indices in `tokens`.
+     * @param {number} startLoc The start location of the iteration range.
+     * @param {number} endLoc The end location of the iteration range.
+     * @param {number} beforeCount The number of tokens this cursor iterates before start.
+     * @param {number} afterCount The number of tokens this cursor iterates after end.
      */
     constructor(tokens, comments, indexMap, startLoc, endLoc, beforeCount, afterCount) {
         super(tokens, comments, indexMap, startLoc, endLoc);

--- a/lib/source-code/token-store/skip-cursor.js
+++ b/lib/source-code/token-store/skip-cursor.js
@@ -21,8 +21,8 @@ module.exports = class SkipCursor extends DecorativeCursor {
 
     /**
      * Initializes this cursor.
-     * @param {Cursor} cursor - The cursor to be decorated.
-     * @param {number} count - The count of tokens this cursor skips.
+     * @param {Cursor} cursor The cursor to be decorated.
+     * @param {number} count The count of tokens this cursor skips.
      */
     constructor(cursor, count) {
         super(cursor);

--- a/lib/source-code/token-store/utils.js
+++ b/lib/source-code/token-store/utils.js
@@ -16,7 +16,6 @@ const lodash = require("lodash");
 
 /**
  * Gets `token.range[0]` from the given token.
- *
  * @param {Node|Token|Comment} token - The token to get.
  * @returns {number} The start location.
  * @private
@@ -32,7 +31,6 @@ function getStartLocation(token) {
 /**
  * Binary-searches the index of the first token which is after the given location.
  * If it was not found, this returns `tokens.length`.
- *
  * @param {(Token|Comment)[]} tokens - It searches the token in this list.
  * @param {number} location - The location to search.
  * @returns {number} The found index or `tokens.length`.
@@ -48,7 +46,6 @@ exports.search = function search(tokens, location) {
 /**
  * Gets the index of the `startLoc` in `tokens`.
  * `startLoc` can be the value of `node.range[1]`, so this checks about `startLoc - 1` as well.
- *
  * @param {(Token|Comment)[]} tokens - The tokens to find an index.
  * @param {Object} indexMap - The map from locations to indices.
  * @param {number} startLoc - The location to get an index.
@@ -77,7 +74,6 @@ exports.getFirstIndex = function getFirstIndex(tokens, indexMap, startLoc) {
 /**
  * Gets the index of the `endLoc` in `tokens`.
  * The information of end locations are recorded at `endLoc - 1` in `indexMap`, so this checks about `endLoc - 1` as well.
- *
  * @param {(Token|Comment)[]} tokens - The tokens to find an index.
  * @param {Object} indexMap - The map from locations to indices.
  * @param {number} endLoc - The location to get an index.

--- a/lib/source-code/token-store/utils.js
+++ b/lib/source-code/token-store/utils.js
@@ -16,7 +16,7 @@ const lodash = require("lodash");
 
 /**
  * Gets `token.range[0]` from the given token.
- * @param {Node|Token|Comment} token - The token to get.
+ * @param {Node|Token|Comment} token The token to get.
  * @returns {number} The start location.
  * @private
  */
@@ -31,8 +31,8 @@ function getStartLocation(token) {
 /**
  * Binary-searches the index of the first token which is after the given location.
  * If it was not found, this returns `tokens.length`.
- * @param {(Token|Comment)[]} tokens - It searches the token in this list.
- * @param {number} location - The location to search.
+ * @param {(Token|Comment)[]} tokens It searches the token in this list.
+ * @param {number} location The location to search.
  * @returns {number} The found index or `tokens.length`.
  */
 exports.search = function search(tokens, location) {
@@ -46,9 +46,9 @@ exports.search = function search(tokens, location) {
 /**
  * Gets the index of the `startLoc` in `tokens`.
  * `startLoc` can be the value of `node.range[1]`, so this checks about `startLoc - 1` as well.
- * @param {(Token|Comment)[]} tokens - The tokens to find an index.
- * @param {Object} indexMap - The map from locations to indices.
- * @param {number} startLoc - The location to get an index.
+ * @param {(Token|Comment)[]} tokens The tokens to find an index.
+ * @param {Object} indexMap The map from locations to indices.
+ * @param {number} startLoc The location to get an index.
  * @returns {number} The index.
  */
 exports.getFirstIndex = function getFirstIndex(tokens, indexMap, startLoc) {
@@ -74,9 +74,9 @@ exports.getFirstIndex = function getFirstIndex(tokens, indexMap, startLoc) {
 /**
  * Gets the index of the `endLoc` in `tokens`.
  * The information of end locations are recorded at `endLoc - 1` in `indexMap`, so this checks about `endLoc - 1` as well.
- * @param {(Token|Comment)[]} tokens - The tokens to find an index.
- * @param {Object} indexMap - The map from locations to indices.
- * @param {number} endLoc - The location to get an index.
+ * @param {(Token|Comment)[]} tokens The tokens to find an index.
+ * @param {Object} indexMap The map from locations to indices.
+ * @param {number} endLoc The location to get an index.
  * @returns {number} The index.
  */
 exports.getLastIndex = function getLastIndex(tokens, indexMap, endLoc) {

--- a/packages/eslint-config-eslint/default.yml
+++ b/packages/eslint-config-eslint/default.yml
@@ -47,6 +47,7 @@ rules:
     jsdoc/check-tag-names: "error"
     jsdoc/check-types: "error"
     jsdoc/implements-on-classes: "error"
+    jsdoc/newline-after-description: ["error", "never"]
     jsdoc/require-jsdoc: "error"
     jsdoc/require-param: "error"
     jsdoc/require-param-description: "error"

--- a/packages/eslint-config-eslint/default.yml
+++ b/packages/eslint-config-eslint/default.yml
@@ -48,6 +48,7 @@ rules:
     jsdoc/check-types: "error"
     jsdoc/implements-on-classes: "error"
     jsdoc/newline-after-description: ["error", "never"]
+    jsdoc/require-hyphen-before-param-description: ["error", "never"]
     jsdoc/require-jsdoc: "error"
     jsdoc/require-param: "error"
     jsdoc/require-param-description: "error"

--- a/tests/lib/cli-engine/cascading-config-array-factory.js
+++ b/tests/lib/cli-engine/cascading-config-array-factory.js
@@ -111,7 +111,6 @@ describe("CascadingConfigArrayFactory", () => {
              * The `expected` object is merged with the default values of config
              * data before comparing, so you can specify only the properties you
              * focus on.
-             *
              * @param {Object} actual The config object to check.
              * @param {Object} expected What the config object should look like.
              * @returns {void}

--- a/tests/lib/cli-engine/cascading-config-array-factory.js
+++ b/tests/lib/cli-engine/cascading-config-array-factory.js
@@ -95,7 +95,7 @@ describe("CascadingConfigArrayFactory", () => {
 
             /**
              * Mocks the current user's home path
-             * @param {string} fakeUserHomePath - fake user's home path
+             * @param {string} fakeUserHomePath fake user's home path
              * @returns {void}
              * @private
              */

--- a/tests/lib/cli-engine/cli-engine.js
+++ b/tests/lib/cli-engine/cli-engine.js
@@ -2110,7 +2110,6 @@ describe("CLIEngine", () => {
 
             /**
              * helper method to delete a file without caring about exceptions
-             *
              * @param {string} filePath The file path
              * @returns {void}
              */

--- a/tests/lib/cli-engine/cli-engine.js
+++ b/tests/lib/cli-engine/cli-engine.js
@@ -66,7 +66,7 @@ describe("CLIEngine", () => {
 
     /**
      * Create the CLIEngine object by mocking some of the plugins
-     * @param {Object} options - options for CLIEngine
+     * @param {Object} options options for CLIEngine
      * @returns {CLIEngine} engine object
      * @private
      */
@@ -1597,7 +1597,7 @@ describe("CLIEngine", () => {
                 /**
                  * Converts CRLF to LF in output.
                  * This is a workaround for git's autocrlf option on Windows.
-                 * @param {Object} result - A result object to convert.
+                 * @param {Object} result A result object to convert.
                  * @returns {void}
                  */
                 function convertCRLF(result) {

--- a/tests/lib/cli-engine/config-array/config-array.js
+++ b/tests/lib/cli-engine/config-array/config-array.js
@@ -357,7 +357,6 @@ describe("ConfigArray", () => {
          * Previously, the merging logic of multiple config data had been
          * implemented in `ConfigOps.merge()` function. But currently, it's
          * implemented in `ConfigArray#extractConfig()` method.
-         *
          * @param {Object} target A config data.
          * @param {Object} source Another config data.
          * @returns {Object} The merged config data.

--- a/tests/lib/cli-engine/config-array/override-tester.js
+++ b/tests/lib/cli-engine/config-array/override-tester.js
@@ -127,7 +127,6 @@ describe("OverrideTester", () => {
          * Previously, the testing logic of `overrides` properties had been
          * implemented in `ConfigOps.pathMatchesGlobs()` function. But
          * currently, it's implemented in `OverrideTester` class.
-         *
          * @param {string} filePath The file path to test patterns against
          * @param {string|string[]} files One or more glob patterns
          * @param {string|string[]} [excludedFiles] One or more glob patterns

--- a/tests/lib/linter/code-path-analysis/code-path-analyzer.js
+++ b/tests/lib/linter/code-path-analysis/code-path-analyzer.js
@@ -32,7 +32,6 @@ const linter = new Linter();
 /**
  * Extracts the content of `/*expected` comments from a given source code.
  * It's expected DOT arrows.
- *
  * @param {string} source - A source code text.
  * @returns {string[]} DOT arrows.
  */

--- a/tests/lib/linter/code-path-analysis/code-path-analyzer.js
+++ b/tests/lib/linter/code-path-analysis/code-path-analyzer.js
@@ -32,7 +32,7 @@ const linter = new Linter();
 /**
  * Extracts the content of `/*expected` comments from a given source code.
  * It's expected DOT arrows.
- * @param {string} source - A source code text.
+ * @param {string} source A source code text.
  * @returns {string[]} DOT arrows.
  */
 function getExpectedDotArrows(source) {

--- a/tests/lib/linter/code-path-analysis/code-path.js
+++ b/tests/lib/linter/code-path-analysis/code-path.js
@@ -19,7 +19,7 @@ const linter = new Linter();
 
 /**
  * Gets the code path of a given source code.
- * @param {string} code - A source code.
+ * @param {string} code A source code.
  * @returns {CodePath[]} A list of created code paths.
  */
 function parseCodePaths(code) {
@@ -37,10 +37,10 @@ function parseCodePaths(code) {
 
 /**
  * Traverses a given code path then returns the order of traversing.
- * @param {CodePath} codePath - A code path to traverse.
- * @param {Object|undefined} [options] - The option object of
+ * @param {CodePath} codePath A code path to traverse.
+ * @param {Object|undefined} [options] The option object of
  *      `codePath.traverseSegments()` method.
- * @param {Function|undefined} [callback] - The callback function of
+ * @param {Function|undefined} [callback] The callback function of
  *      `codePath.traverseSegments()` method.
  * @returns {string[]} The list of segment's ids in the order traversed.
  */

--- a/tests/lib/linter/code-path-analysis/code-path.js
+++ b/tests/lib/linter/code-path-analysis/code-path.js
@@ -19,7 +19,6 @@ const linter = new Linter();
 
 /**
  * Gets the code path of a given source code.
- *
  * @param {string} code - A source code.
  * @returns {CodePath[]} A list of created code paths.
  */
@@ -38,7 +37,6 @@ function parseCodePaths(code) {
 
 /**
  * Traverses a given code path then returns the order of traversing.
- *
  * @param {CodePath} codePath - A code path to traverse.
  * @param {Object|undefined} [options] - The option object of
  *      `codePath.traverseSegments()` method.

--- a/tests/lib/linter/linter.js
+++ b/tests/lib/linter/linter.js
@@ -4064,9 +4064,9 @@ describe("Linter", () => {
 
         /**
          * Assert `context.getDeclaredVariables(node)` is valid.
-         * @param {string} code - A code to check.
-         * @param {string} type - A type string of ASTNode. This method checks variables on the node of the type.
-         * @param {Array<Array<string>>} expectedNamesList - An array of expected variable names. The expected variable names is an array of string.
+         * @param {string} code A code to check.
+         * @param {string} type A type string of ASTNode. This method checks variables on the node of the type.
+         * @param {Array<Array<string>>} expectedNamesList An array of expected variable names. The expected variable names is an array of string.
          * @returns {void}
          */
         function verify(code, type, expectedNamesList) {
@@ -4075,7 +4075,7 @@ describe("Linter", () => {
 
                     /**
                      * Assert `context.getDeclaredVariables(node)` is empty.
-                     * @param {ASTNode} node - A node to check.
+                     * @param {ASTNode} node A node to check.
                      * @returns {void}
                      */
                     function checkEmpty(node) {

--- a/tests/lib/rules/array-bracket-spacing.js
+++ b/tests/lib/rules/array-bracket-spacing.js
@@ -18,7 +18,6 @@ const path = require("path"),
 
 /**
  * Gets the path to the specified parser.
- *
  * @param {string} name - The parser name to get.
  * @returns {string} The path to the specified parser.
  */

--- a/tests/lib/rules/array-bracket-spacing.js
+++ b/tests/lib/rules/array-bracket-spacing.js
@@ -18,7 +18,7 @@ const path = require("path"),
 
 /**
  * Gets the path to the specified parser.
- * @param {string} name - The parser name to get.
+ * @param {string} name The parser name to get.
  * @returns {string} The path to the specified parser.
  */
 function parser(name) {

--- a/tests/lib/rules/comma-dangle.js
+++ b/tests/lib/rules/comma-dangle.js
@@ -19,7 +19,7 @@ const path = require("path"),
 
 /**
  * Gets the path to the parser of the given name.
- * @param {string} name - The name of a parser to get.
+ * @param {string} name The name of a parser to get.
  * @returns {string} The path to the specified parser.
  */
 function parser(name) {

--- a/tests/lib/rules/comma-dangle.js
+++ b/tests/lib/rules/comma-dangle.js
@@ -19,7 +19,6 @@ const path = require("path"),
 
 /**
  * Gets the path to the parser of the given name.
- *
  * @param {string} name - The name of a parser to get.
  * @returns {string} The path to the specified parser.
  */

--- a/tests/lib/rules/keyword-spacing.js
+++ b/tests/lib/rules/keyword-spacing.js
@@ -34,8 +34,8 @@ const NEITHER = { before: false, after: false };
  *         after: false,
  *         overrides: {as: {before: true, after: true}}
  *     }
- * @param {string} keyword - A keyword to be overriden.
- * @param {Object} value - A value to override.
+ * @param {string} keyword A keyword to be overriden.
+ * @param {Object} value A value to override.
  * @returns {Object} An option object to test an "overrides" option.
  */
 function override(keyword, value) {
@@ -52,7 +52,7 @@ function override(keyword, value) {
 
 /**
  * Gets an error message that expected space(s) before a specified keyword.
- * @param {string} keyword - A keyword.
+ * @param {string} keyword A keyword.
  * @returns {string[]} An error message.
  */
 function expectedBefore(keyword) {
@@ -61,7 +61,7 @@ function expectedBefore(keyword) {
 
 /**
  * Gets an error message that expected space(s) after a specified keyword.
- * @param {string} keyword - A keyword.
+ * @param {string} keyword A keyword.
  * @returns {string[]} An error message.
  */
 function expectedAfter(keyword) {
@@ -71,7 +71,7 @@ function expectedAfter(keyword) {
 /**
  * Gets error messages that expected space(s) before and after a specified
  * keyword.
- * @param {string} keyword - A keyword.
+ * @param {string} keyword A keyword.
  * @returns {string[]} Error messages.
  */
 function expectedBeforeAndAfter(keyword) {
@@ -83,7 +83,7 @@ function expectedBeforeAndAfter(keyword) {
 
 /**
  * Gets an error message that unexpected space(s) before a specified keyword.
- * @param {string} keyword - A keyword.
+ * @param {string} keyword A keyword.
  * @returns {string[]} An error message.
  */
 function unexpectedBefore(keyword) {
@@ -92,7 +92,7 @@ function unexpectedBefore(keyword) {
 
 /**
  * Gets an error message that unexpected space(s) after a specified keyword.
- * @param {string} keyword - A keyword.
+ * @param {string} keyword A keyword.
  * @returns {string[]} An error message.
  */
 function unexpectedAfter(keyword) {
@@ -102,7 +102,7 @@ function unexpectedAfter(keyword) {
 /**
  * Gets error messages that unexpected space(s) before and after a specified
  * keyword.
- * @param {string} keyword - A keyword.
+ * @param {string} keyword A keyword.
  * @returns {string[]} Error messages.
  */
 function unexpectedBeforeAndAfter(keyword) {

--- a/tests/lib/rules/keyword-spacing.js
+++ b/tests/lib/rules/keyword-spacing.js
@@ -34,7 +34,6 @@ const NEITHER = { before: false, after: false };
  *         after: false,
  *         overrides: {as: {before: true, after: true}}
  *     }
- *
  * @param {string} keyword - A keyword to be overriden.
  * @param {Object} value - A value to override.
  * @returns {Object} An option object to test an "overrides" option.
@@ -53,7 +52,6 @@ function override(keyword, value) {
 
 /**
  * Gets an error message that expected space(s) before a specified keyword.
- *
  * @param {string} keyword - A keyword.
  * @returns {string[]} An error message.
  */
@@ -63,7 +61,6 @@ function expectedBefore(keyword) {
 
 /**
  * Gets an error message that expected space(s) after a specified keyword.
- *
  * @param {string} keyword - A keyword.
  * @returns {string[]} An error message.
  */
@@ -74,7 +71,6 @@ function expectedAfter(keyword) {
 /**
  * Gets error messages that expected space(s) before and after a specified
  * keyword.
- *
  * @param {string} keyword - A keyword.
  * @returns {string[]} Error messages.
  */
@@ -87,7 +83,6 @@ function expectedBeforeAndAfter(keyword) {
 
 /**
  * Gets an error message that unexpected space(s) before a specified keyword.
- *
  * @param {string} keyword - A keyword.
  * @returns {string[]} An error message.
  */
@@ -97,7 +92,6 @@ function unexpectedBefore(keyword) {
 
 /**
  * Gets an error message that unexpected space(s) after a specified keyword.
- *
  * @param {string} keyword - A keyword.
  * @returns {string[]} An error message.
  */
@@ -108,7 +102,6 @@ function unexpectedAfter(keyword) {
 /**
  * Gets error messages that unexpected space(s) before and after a specified
  * keyword.
- *
  * @param {string} keyword - A keyword.
  * @returns {string[]} Error messages.
  */

--- a/tests/lib/rules/no-empty-function.js
+++ b/tests/lib/rules/no-empty-function.js
@@ -30,7 +30,6 @@ const ALLOW_OPTIONS = Object.freeze([
 /**
  * Folds test items to `{valid: [], invalid: []}`.
  * One item would be converted to 4 valid patterns and 8 invalid patterns.
- *
  * @param {{valid: Object[], invalid: Object[]}} patterns - The result.
  * @param {{code: string, message: string, allow: string}} item - A test item.
  * @returns {{valid: Object[], invalid: Object[]}} The result.

--- a/tests/lib/rules/no-empty-function.js
+++ b/tests/lib/rules/no-empty-function.js
@@ -30,8 +30,8 @@ const ALLOW_OPTIONS = Object.freeze([
 /**
  * Folds test items to `{valid: [], invalid: []}`.
  * One item would be converted to 4 valid patterns and 8 invalid patterns.
- * @param {{valid: Object[], invalid: Object[]}} patterns - The result.
- * @param {{code: string, message: string, allow: string}} item - A test item.
+ * @param {{valid: Object[], invalid: Object[]}} patterns The result.
+ * @param {{code: string, message: string, allow: string}} item A test item.
  * @returns {{valid: Object[], invalid: Object[]}} The result.
  */
 function toValidInvalid(patterns, item) {

--- a/tests/lib/rules/no-invalid-this.js
+++ b/tests/lib/rules/no-invalid-this.js
@@ -29,7 +29,7 @@ function NORMAL() {
 /**
  * A constant value for strict mode environment.
  * This modifies pattern object to make strict mode.
- * @param {Object} pattern - A pattern object to modify.
+ * @param {Object} pattern A pattern object to modify.
  * @returns {void}
  */
 function USE_STRICT(pattern) {
@@ -39,7 +39,7 @@ function USE_STRICT(pattern) {
 /**
  * A constant value for implied strict mode.
  * This modifies pattern object to impose strict mode.
- * @param {Object} pattern - A pattern object to modify.
+ * @param {Object} pattern A pattern object to modify.
  * @returns {void}
  */
 function IMPLIED_STRICT(pattern) {
@@ -51,7 +51,7 @@ function IMPLIED_STRICT(pattern) {
 /**
  * A constant value for modules environment.
  * This modifies pattern object to make modules.
- * @param {Object} pattern - A pattern object to modify.
+ * @param {Object} pattern A pattern object to modify.
  * @returns {void}
  */
 function MODULES(pattern) {
@@ -61,8 +61,8 @@ function MODULES(pattern) {
 
 /**
  * Extracts patterns each condition for a specified type. The type is `valid` or `invalid`.
- * @param {Object[]} patterns - Original patterns.
- * @param {string} type - One of `"valid"` or `"invalid"`.
+ * @param {Object[]} patterns Original patterns.
+ * @param {string} type One of `"valid"` or `"invalid"`.
  * @returns {Object[]} Test patterns.
  */
 function extractPatterns(patterns, type) {

--- a/tests/lib/rules/no-multi-assign.js
+++ b/tests/lib/rules/no-multi-assign.js
@@ -19,9 +19,9 @@ const rule = require("../../../lib/rules/no-multi-assign"),
 /**
  * Returns an error object at the specified line and column
  * @private
- * @param {int} line - line number
- * @param {int} column - column number
- * @param {string} type - Type of node
+ * @param {int} line line number
+ * @param {int} column column number
+ * @param {string} type Type of node
  * @returns {Oject} Error object
  */
 function errorAt(line, column, type) {

--- a/tests/lib/rules/no-multiple-empty-lines.js
+++ b/tests/lib/rules/no-multiple-empty-lines.js
@@ -19,7 +19,7 @@ const ruleTester = new RuleTester();
 
 /**
  * Creates the expected error message object for the specified number of lines
- * @param {lines} lines - The number of lines expected.
+ * @param {lines} lines The number of lines expected.
  * @returns {Object} the expected error message object
  * @private
  */
@@ -37,7 +37,7 @@ function getExpectedError(lines) {
 
 /**
  * Creates the expected error message object for the specified number of lines
- * @param {lines} lines - The number of lines expected.
+ * @param {lines} lines The number of lines expected.
  * @returns {Object} the expected error message object
  * @private
  */
@@ -51,7 +51,7 @@ function getExpectedErrorEOF(lines) {
 
 /**
  * Creates the expected error message object for the specified number of lines
- * @param {lines} lines - The number of lines expected.
+ * @param {lines} lines The number of lines expected.
  * @returns {Object} the expected error message object
  * @private
  */

--- a/tests/lib/rules/one-var-declaration-per-line.js
+++ b/tests/lib/rules/one-var-declaration-per-line.js
@@ -19,8 +19,8 @@ const rule = require("../../../lib/rules/one-var-declaration-per-line"),
 /**
  * Returns an error object at the specified line and column
  * @private
- * @param {int} line - line number
- * @param {int} column - column number
+ * @param {int} line line number
+ * @param {int} column column number
  * @returns {Oject} Error object
  */
 function errorAt(line, column) {

--- a/tests/lib/rules/utils/ast-utils.js
+++ b/tests/lib/rules/utils/ast-utils.js
@@ -357,7 +357,6 @@ describe("ast-utils", () => {
         /**
          * Asserts that the unique node of the given type in the code is either
          * in a loop or not in a loop.
-         *
          * @param {string} code the code to check.
          * @param {string} nodeType the type of the node to consider. The code
          *      must have exactly one node of ths type.

--- a/tests/lib/rules/utils/fix-tracker.js
+++ b/tests/lib/rules/utils/fix-tracker.js
@@ -30,7 +30,6 @@ const DEFAULT_CONFIG = {
 /**
  * Create a SourceCode instance from the given code. Also add parent pointers in
  * the AST so that parent traversals will work.
- *
  * @param {string} text The text of the code.
  * @returns {SourceCode} The SourceCode.
  */

--- a/tests/lib/shared/runtime-info.js
+++ b/tests/lib/shared/runtime-info.js
@@ -23,8 +23,8 @@ const packageJson = require("../../../package.json");
 
 /**
  * Sets up spawn.sync() stub calls to return values and throw errors in the order in which they are given.
- * @param {Function} stub - The stub to set up.
- * @param {Array} returnVals - Values to be returned by subsequent stub calls.
+ * @param {Function} stub The stub to set up.
+ * @param {Array} returnVals Values to be returned by subsequent stub calls.
  * @returns {Function} The set up stub.
  */
 function setupSpawnSyncStubReturnVals(stub, returnVals) {

--- a/tools/internal-rules/consistent-docs-description.js
+++ b/tools/internal-rules/consistent-docs-description.js
@@ -17,7 +17,6 @@ const ALLOWED_FIRST_WORDS = [
 
 /**
  * Gets the property of the Object node passed in that has the name specified.
- *
  * @param {string} property Name of the property to return.
  * @param {ASTNode} node The ObjectExpression node.
  * @returns {ASTNode} The Property node or null if not found.
@@ -42,7 +41,6 @@ function getPropertyFromObject(property, node) {
 
 /**
  * Verifies that the meta.docs.description property follows our internal conventions.
- *
  * @param {RuleContext} context The ESLint rule context.
  * @param {ASTNode} exportsNode ObjectExpression node that the rule exports.
  * @returns {void}

--- a/tools/internal-rules/consistent-docs-url.js
+++ b/tools/internal-rules/consistent-docs-url.js
@@ -13,7 +13,6 @@ const path = require("path");
 
 /**
  * Gets the property of the Object node passed in that has the name specified.
- *
  * @param {string} property Name of the property to return.
  * @param {ASTNode} node The ObjectExpression node.
  * @returns {ASTNode} The Property node or null if not found.
@@ -38,7 +37,6 @@ function getPropertyFromObject(property, node) {
 
 /**
  * Verifies that the meta.docs.url property is present and has the correct value.
- *
  * @param {RuleContext} context The ESLint rule context.
  * @param {ASTNode} exportsNode ObjectExpression node that the rule exports.
  * @returns {void}

--- a/tools/internal-rules/consistent-meta-messages.js
+++ b/tools/internal-rules/consistent-meta-messages.js
@@ -11,7 +11,6 @@
 
 /**
  * Gets the property of the Object node passed in that has the name specified.
- *
  * @param {string} property Name of the property to return.
  * @param {ASTNode} node The ObjectExpression node.
  * @returns {ASTNode} The Property node or null if not found.

--- a/tools/internal-rules/no-invalid-meta.js
+++ b/tools/internal-rules/no-invalid-meta.js
@@ -11,7 +11,6 @@
 
 /**
  * Gets the property of the Object node passed in that has the name specified.
- *
  * @param {string} property Name of the property to return.
  * @param {ASTNode} node The ObjectExpression node.
  * @returns {ASTNode} The Property node or null if not found.
@@ -35,7 +34,6 @@ function getPropertyFromObject(property, node) {
 
 /**
  * Extracts the `meta` property from the ObjectExpression that all rules export.
- *
  * @param {ASTNode} exportsNode ObjectExpression node that the rule exports.
  * @returns {ASTNode} The `meta` Property node or null if not found.
  */
@@ -45,7 +43,6 @@ function getMetaPropertyFromExportsNode(exportsNode) {
 
 /**
  * Whether this `meta` ObjectExpression has a `docs` property defined or not.
- *
  * @param {ASTNode} metaPropertyNode The `meta` ObjectExpression for this rule.
  * @returns {boolean} `true` if a `docs` property exists.
  */
@@ -55,7 +52,6 @@ function hasMetaDocs(metaPropertyNode) {
 
 /**
  * Whether this `meta` ObjectExpression has a `docs.description` property defined or not.
- *
  * @param {ASTNode} metaPropertyNode The `meta` ObjectExpression for this rule.
  * @returns {boolean} `true` if a `docs.description` property exists.
  */
@@ -67,7 +63,6 @@ function hasMetaDocsDescription(metaPropertyNode) {
 
 /**
  * Whether this `meta` ObjectExpression has a `docs.category` property defined or not.
- *
  * @param {ASTNode} metaPropertyNode The `meta` ObjectExpression for this rule.
  * @returns {boolean} `true` if a `docs.category` property exists.
  */
@@ -79,7 +74,6 @@ function hasMetaDocsCategory(metaPropertyNode) {
 
 /**
  * Whether this `meta` ObjectExpression has a `docs.recommended` property defined or not.
- *
  * @param {ASTNode} metaPropertyNode The `meta` ObjectExpression for this rule.
  * @returns {boolean} `true` if a `docs.recommended` property exists.
  */
@@ -91,7 +85,6 @@ function hasMetaDocsRecommended(metaPropertyNode) {
 
 /**
  * Whether this `meta` ObjectExpression has a `schema` property defined or not.
- *
  * @param {ASTNode} metaPropertyNode The `meta` ObjectExpression for this rule.
  * @returns {boolean} `true` if a `schema` property exists.
  */
@@ -101,7 +94,6 @@ function hasMetaSchema(metaPropertyNode) {
 
 /**
  * Checks the validity of the meta definition of this rule and reports any errors found.
- *
  * @param {RuleContext} context The ESLint rule context.
  * @param {ASTNode} exportsNode ObjectExpression node that the rule exports.
  * @returns {void}
@@ -141,7 +133,6 @@ function checkMetaValidity(context, exportsNode) {
 
 /**
  * Whether this node is the correct format for a rule definition or not.
- *
  * @param {ASTNode} node node that the rule exports.
  * @returns {boolean} `true` if the exported node is the correct format for a rule definition
  */

--- a/tools/internal-testers/event-generator-tester.js
+++ b/tools/internal-testers/event-generator-tester.js
@@ -20,8 +20,8 @@ module.exports = {
 
     /**
      * Overrideable `describe` function to test.
-     * @param {string} text - A description.
-     * @param {Function} method - A test logic.
+     * @param {string} text A description.
+     * @param {Function} method A test logic.
      * @returns {any} The returned value with the test logic.
      */
     describe: (typeof describe === "function") ? describe : /* istanbul ignore next */ function(text, method) {
@@ -30,8 +30,8 @@ module.exports = {
 
     /**
      * Overrideable `it` function to test.
-     * @param {string} text - A description.
-     * @param {Function} method - A test logic.
+     * @param {string} text A description.
+     * @param {Function} method A test logic.
      * @returns {any} The returned value with the test logic.
      */
     it: (typeof it === "function") ? it : /* istanbul ignore next */ function(text, method) {
@@ -40,7 +40,7 @@ module.exports = {
 
     /**
      * Does some tests to check a given object implements the EventGenerator interface.
-     * @param {Object} instance - An object to check.
+     * @param {Object} instance An object to check.
      * @returns {void}
      */
     testEventGeneratorInterface(instance) {

--- a/tools/update-rule-types.js
+++ b/tools/update-rule-types.js
@@ -3,7 +3,6 @@
  * Run over the rules directory only. Use this command:
  *
  *   jscodeshift -t tools/update-rule-types.js lib/rules/
- *
  * @author Nicholas C. Zakas
  */
 "use strict";


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Following up on https://github.com/eslint/eslint/pull/12332, this enables two more rules for consistency:
 - [newline-after-description](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-newline-after-description)
 - [require-hyphen-before-param-description](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-hyphen-before-param-description)

I set both to enforce "never" because that seemed like the more common style within the codebase, but I don't have any personal preferences as to which we pick. I do think it would be good if it was consistent, though, since I believe that would reduce overhead for contributors who don't have much experience with JSDoc.

I think it would also be nice to enable [require-description](https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-require-description), but there are 31 instances of missing descriptions and I wanted to move onto some more important things. Could it be worth making a detailed issue with links to the doc blocks missing description and put the `help wanted` label on it?

**Is there anything you'd like reviewers to focus on?**
Do others agree that this is something we should do?

