### PR TITLE
Remove misleading example from no-return-await

### DIFF
--- a/docs/rules/no-return-await.md
+++ b/docs/rules/no-return-await.md
@@ -18,10 +18,6 @@ Examples of **correct** code for this rule:
 
 ```js
 async function foo() {
-    return bar();
-}
-
-async function foo() {
     await bar();
     return;
 }

--- a/docs/rules/no-return-await.md
+++ b/docs/rules/no-return-await.md
@@ -32,6 +32,15 @@ async function foo() {
         return await bar();
     } catch (error) {}
 }
+
+async function foo() {
+    /** 
+     * Note: Though this is not a lint rule violation, 
+     * this function simply proxies a value and does not 
+     * need to be async  
+     */
+    return bar();
+}
 ```
 
 In the last example the `await` is necessary to be able to catch errors thrown from `bar()`.

--- a/docs/rules/no-return-await.md
+++ b/docs/rules/no-return-await.md
@@ -34,11 +34,6 @@ async function foo() {
 }
 
 async function foo() {
-    /** 
-     * Note: Though this is not a lint rule violation, 
-     * this function simply proxies a value and does not 
-     * need to be async  
-     */
     return bar();
 }
 ```


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
The example in the Correct Code section that marks a function as `async` without using `await` is a bit misleading.

It incorrectly implies that a function must itself be async if it's simply returning a promise without ever awaiting it. In fact, doing so would slightly hurt performance without any benefit.


**Is there anything you'd like reviewers to focus on?**
Nope, small change :)

