### PR TITLE
Fix: no-useless-rename handles ExperimentalRestProperty (fixes #12335)

### DIFF
--- a/lib/rules/no-useless-rename.js
+++ b/lib/rules/no-useless-rename.js
@@ -93,6 +93,14 @@ module.exports = {
 
             for (const property of node.properties) {
 
+                /*
+                 * TODO: Remove after babel-eslint removes ExperimentalRestProperty
+                 * https://github.com/eslint/eslint/issues/12335
+                 */
+                if (property.type === "ExperimentalRestProperty") {
+                    continue;
+                }
+
                 /**
                  * Properties using shorthand syntax and rest elements can not be renamed.
                  * If the property is computed, we have no idea if a rename is useless or not.

--- a/tests/fixtures/parsers/babel-eslint10/object-pattern-with-rest-element.js
+++ b/tests/fixtures/parsers/babel-eslint10/object-pattern-with-rest-element.js
@@ -1,0 +1,151 @@
+/**
+ * Parser: babel-eslint@10.0.3
+ * Source code:
+ * const { ...foo } = bar;
+ */
+exports.parse = () => ({
+  type: "Program",
+  start: 0,
+  end: 24,
+  loc: { start: { line: 1, column: 0 }, end: { line: 2, column: 0 } },
+  range: [0, 24],
+  comments: [],
+  tokens: [
+      {
+          type: "Keyword",
+          value: "const",
+          start: 0,
+          end: 5,
+          loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 5 } },
+          range: [0, 5]
+      },
+      {
+          type: "Punctuator",
+          value: "{",
+          start: 6,
+          end: 7,
+          loc: { start: { line: 1, column: 6 }, end: { line: 1, column: 7 } },
+          range: [6, 7]
+      },
+      {
+          type: "Punctuator",
+          value: "...",
+          start: 8,
+          end: 11,
+          loc: { start: { line: 1, column: 8 }, end: { line: 1, column: 11 } },
+          range: [8, 11]
+      },
+      {
+          type: "Identifier",
+          value: "foo",
+          start: 11,
+          end: 14,
+          loc: { start: { line: 1, column: 11 }, end: { line: 1, column: 14 } },
+          range: [11, 14]
+      },
+      {
+          type: "Punctuator",
+          value: "}",
+          start: 15,
+          end: 16,
+          loc: { start: { line: 1, column: 15 }, end: { line: 1, column: 16 } },
+          range: [15, 16]
+      },
+      {
+          type: "Punctuator",
+          value: "=",
+          start: 17,
+          end: 18,
+          loc: { start: { line: 1, column: 17 }, end: { line: 1, column: 18 } },
+          range: [17, 18]
+      },
+      {
+          type: "Identifier",
+          value: "bar",
+          start: 19,
+          end: 22,
+          loc: { start: { line: 1, column: 19 }, end: { line: 1, column: 22 } },
+          range: [19, 22]
+      },
+      {
+          type: "Punctuator",
+          value: ";",
+          start: 22,
+          end: 23,
+          loc: { start: { line: 1, column: 22 }, end: { line: 1, column: 23 } },
+          range: [22, 23]
+      }
+  ],
+  sourceType: "module",
+  body: [
+      {
+          type: "VariableDeclaration",
+          start: 0,
+          end: 23,
+          loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 23 } },
+          range: [0, 23],
+          declarations: [
+              {
+                  type: "VariableDeclarator",
+                  start: 6,
+                  end: 22,
+                  loc: { start: { line: 1, column: 6 }, end: { line: 1, column: 22 } },
+                  range: [6, 22],
+                  id: {
+                      type: "ObjectPattern",
+                      start: 6,
+                      end: 16,
+                      loc: {
+                          start: { line: 1, column: 6 },
+                          end: { line: 1, column: 16 }
+                      },
+                      range: [6, 16],
+                      properties: [
+                          {
+                              type: "ExperimentalRestProperty",
+                              start: 8,
+                              end: 14,
+                              loc: {
+                                  start: { line: 1, column: 8 },
+                                  end: { line: 1, column: 14 }
+                              },
+                              range: [8, 14],
+                              argument: {
+                                  type: "Identifier",
+                                  start: 11,
+                                  end: 14,
+                                  loc: {
+                                      start: { line: 1, column: 11 },
+                                      end: { line: 1, column: 14 },
+                                      identifierName: "foo"
+                                  },
+                                  range: [11, 14],
+                                  name: "foo",
+                                  _babelType: "Identifier"
+                              },
+                              _babelType: "RestElement"
+                          }
+                      ],
+                      _babelType: "ObjectPattern"
+                  },
+                  init: {
+                      type: "Identifier",
+                      start: 19,
+                      end: 22,
+                      loc: {
+                          start: { line: 1, column: 19 },
+                          end: { line: 1, column: 22 },
+                          identifierName: "bar"
+                      },
+                      range: [19, 22],
+                      name: "bar",
+                      _babelType: "Identifier"
+                  },
+                  _babelType: "VariableDeclarator"
+              }
+          ],
+          kind: "const",
+          _babelType: "VariableDeclaration"
+      }
+  ]
+});

--- a/tests/lib/rules/no-useless-rename.js
+++ b/tests/lib/rules/no-useless-rename.js
@@ -113,6 +113,15 @@ ruleTester.run("no-useless-rename", rule, {
         {
             code: "export {foo as foo, bar as bar} from 'foo';",
             options: [{ ignoreExport: true }]
+        },
+
+        /*
+         * TODO: Remove after babel-eslint removes ExperimentalRestProperty
+         * https://github.com/eslint/eslint/issues/12335
+         */
+        {
+            code: "const { ...foo } = bar;",
+            parser: require.resolve("../../fixtures/parsers/babel-eslint10/object-pattern-with-rest-element")
         }
     ],
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

fixes #12335

**What changes did you make? (Give an overview)**

https://github.com/eslint/eslint/pull/12322 removed the check for `ExperimentalRestProperty`, causing the rule to crash with babel-eslint. This will be fixed by https://github.com/babel/babel-eslint/pull/785 on the babel-eslint side.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular!
