### PR TITLE
Update: rule 'lines-around-comment' - add 'false' options

### DIFF
--- a/docs/rules/lines-around-comment.md
+++ b/docs/rules/lines-around-comment.md
@@ -1,20 +1,21 @@
 # require empty lines around comments (lines-around-comment)
 
-Many style guides require empty lines before or after comments. The primary goal
-of these rules is to make the comments easier to read and improve readability of the code.
+Many style guides require empty lines before or after comments.
+The primary goal of these rules is to make the comments easier to read and improve readability of the code.
 
 ## Rule Details
 
-This rule requires empty lines before and/or after comments. It can be enabled separately for both block (`/*`) and line (`//`) comments. This rule does not apply to comments that appear on the same line as code and does not require empty lines at the beginning or end of a file.
+This rule requires or rejects empty lines before and/or after comments. It can be enabled separately for both block (`/*`) and line (`//`) comments.
+This rule does not apply to comments that appear on the same line as code and does not require empty lines at the beginning or end of a file.
 
 ## Options
 
 This rule has an object option:
 
-* `"beforeBlockComment": true` (default) requires an empty line before block comments
-* `"afterBlockComment": true` requires an empty line after block comments
-* `"beforeLineComment": true` requires an empty line before line comments
-* `"afterLineComment": true` requires an empty line after line comments
+* `"beforeBlockComment": true/false` (default: true) requires/rejects an empty line before block comments
+* `"afterBlockComment": true/false` requires/rejects an empty line after block comments
+* `"beforeLineComment": true/false` requires/rejects an empty line before line comments
+* `"afterLineComment": true/false` requires/rejects an empty line after line comments
 * `"allowBlockStart": true` allows comments to appear at the start of block statements
 * `"allowBlockEnd": true` allows comments to appear at the end of block statements
 * `"allowObjectStart": true` allows comments to appear at the start of object literals
@@ -72,6 +73,29 @@ var night = "long";
 
 /* what a great and wonderful day */
 
+var day = "great"
+```
+
+Examples of **incorrect** code for this rule with the `{ "afterBlockComment": false }` option:
+
+```js
+/*eslint lines-around-comment: ["error", { "afterBlockComment": true }]*/
+
+var night = "long";
+
+/* what a great and wonderful day */
+
+var day = "great"
+```
+
+Examples of **correct** code for this rule with the `{ "afterBlockComment": false }` option:
+
+```js
+/*eslint lines-around-comment: ["error", { "afterBlockComment": true }]*/
+
+var night = "long";
+
+/* what a great and wonderful day */
 var day = "great"
 ```
 

--- a/lib/rules/lines-around-comment.js
+++ b/lib/rules/lines-around-comment.js
@@ -15,6 +15,12 @@ const lodash = require("lodash"),
 // Helpers
 //------------------------------------------------------------------------------
 
+const LT = `[${Array.from(astUtils.LINEBREAKS).join("")}]`;
+const PADDING_LINE_SEQUENCE = new RegExp(
+    String.raw`^(\s*?${LT})\s*${LT}(\s*;?)$`,
+    "u"
+);
+
 /**
  * Return an array with with any line numbers that are empty.
  * @param {Array} lines An array of each line of the file.
@@ -46,6 +52,18 @@ function getCommentLineNums(comments) {
     return lines;
 }
 
+/**
+ * This returns the concatenation of the first 2 captured strings.
+ * @param {string} _ Unused. Whole matched string.
+ * @param {string} trailingSpaces The trailing spaces of the first line.
+ * @param {string} indentSpaces The indentation spaces of the last line.
+ * @returns {string} The concatenation of trailingSpaces and indentSpaces.
+ * @private
+ */
+function replacerToRemovePaddingLines(_, trailingSpaces, indentSpaces) {
+    return trailingSpaces + indentSpaces;
+}
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -68,20 +86,16 @@ module.exports = {
                 type: "object",
                 properties: {
                     beforeBlockComment: {
-                        type: "boolean",
-                        default: true
+                        type: "boolean"
                     },
                     afterBlockComment: {
-                        type: "boolean",
-                        default: false
+                        type: "boolean"
                     },
                     beforeLineComment: {
-                        type: "boolean",
-                        default: false
+                        type: "boolean"
                     },
                     afterLineComment: {
-                        type: "boolean",
-                        default: false
+                        type: "boolean"
                     },
                     allowBlockStart: {
                         type: "boolean",
@@ -120,8 +134,10 @@ module.exports = {
             }
         ],
         messages: {
-            after: "Expected line after comment.",
-            before: "Expected line before comment."
+            "expected-after": "Expected line after comment.",
+            "unexpected-after": "Unexpected line after comment.",
+            "expected-before": "Expected line before comment.",
+            "unexpected-before": "Unexpected line before comment."
         }
     },
 
@@ -133,12 +149,11 @@ module.exports = {
         const customIgnoreRegExp = new RegExp(ignorePattern, "u");
         const applyDefaultIgnorePatterns = options.applyDefaultIgnorePatterns !== false;
 
-        options.beforeBlockComment = typeof options.beforeBlockComment !== "undefined" ? options.beforeBlockComment : true;
+        options.beforeBlockComment = "beforeBlockComment" in options ? options.beforeBlockComment : true;
 
         const sourceCode = context.getSourceCode();
 
         const lines = sourceCode.lines,
-            numLines = lines.length + 1,
             comments = sourceCode.getAllComments(),
             commentLines = getCommentLineNums(comments),
             emptyLines = getEmptyLineNums(lines),
@@ -308,7 +323,7 @@ module.exports = {
                 return;
             }
 
-            let after = opts.after,
+            const after = opts.after,
                 before = opts.before;
 
             const prevLineNum = token.loc.start.line - 1,
@@ -330,14 +345,6 @@ module.exports = {
             const exceptionStartAllowed = blockStartAllowed || classStartAllowed || objectStartAllowed || arrayStartAllowed;
             const exceptionEndAllowed = blockEndAllowed || classEndAllowed || objectEndAllowed || arrayEndAllowed;
 
-            // ignore top of the file and bottom of the file
-            if (prevLineNum < 1) {
-                before = false;
-            }
-            if (nextLineNum >= numLines) {
-                after = false;
-            }
-
             // we ignore all inline comments
             if (commentIsNotAlone) {
                 return;
@@ -347,30 +354,64 @@ module.exports = {
             const nextTokenOrComment = sourceCode.getTokenAfter(token, { includeComments: true });
 
             // check for newline before
-            if (!exceptionStartAllowed && before && !lodash.includes(commentAndEmptyLines, prevLineNum) &&
+            if (typeof before === "boolean" && !exceptionStartAllowed && previousTokenOrComment &&
                     !(astUtils.isCommentToken(previousTokenOrComment) && astUtils.isTokenOnSameLine(previousTokenOrComment, token))) {
-                const lineStart = token.range[0] - token.loc.start.column;
-                const range = [lineStart, lineStart];
+                if (before && !lodash.includes(commentAndEmptyLines, prevLineNum)) {
+                    const lineStart = token.range[0] - token.loc.start.column;
+                    const range = [lineStart, lineStart];
 
-                context.report({
-                    node: token,
-                    messageId: "before",
-                    fix(fixer) {
-                        return fixer.insertTextBeforeRange(range, "\n");
-                    }
-                });
+                    context.report({
+                        node: token,
+                        messageId: "expected-before",
+                        fix(fixer) {
+                            return fixer.insertTextBeforeRange(range, "\n");
+                        }
+                    });
+                }
+                if (!before && lodash.includes(emptyLines, prevLineNum)) {
+                    const start = previousTokenOrComment.range[1];
+                    const end = token.range[0];
+                    const text = context.getSourceCode().text
+                        .slice(start, end)
+                        .replace(PADDING_LINE_SEQUENCE, replacerToRemovePaddingLines);
+
+                    context.report({
+                        node: token,
+                        messageId: "unexpected-before",
+                        fix(fixer) {
+                            return fixer.replaceTextRange([start, end], text);
+                        }
+                    });
+                }
             }
 
             // check for newline after
-            if (!exceptionEndAllowed && after && !lodash.includes(commentAndEmptyLines, nextLineNum) &&
+            if (typeof after === "boolean" && !exceptionEndAllowed && nextTokenOrComment &&
                     !(astUtils.isCommentToken(nextTokenOrComment) && astUtils.isTokenOnSameLine(token, nextTokenOrComment))) {
-                context.report({
-                    node: token,
-                    messageId: "after",
-                    fix(fixer) {
-                        return fixer.insertTextAfter(token, "\n");
-                    }
-                });
+                if (after && !lodash.includes(commentAndEmptyLines, nextLineNum)) {
+                    context.report({
+                        node: token,
+                        messageId: "expected-after",
+                        fix(fixer) {
+                            return fixer.insertTextAfter(token, "\n");
+                        }
+                    });
+                }
+                if (!after && lodash.includes(emptyLines, nextLineNum)) {
+                    const start = token.range[1];
+                    const end = nextTokenOrComment.range[0];
+                    const text = context.getSourceCode().text
+                        .slice(start, end)
+                        .replace(PADDING_LINE_SEQUENCE, replacerToRemovePaddingLines);
+
+                    context.report({
+                        node: token,
+                        messageId: "unexpected-after",
+                        fix(fixer) {
+                            return fixer.replaceTextRange([start, end], text);
+                        }
+                    });
+                }
             }
 
         }
@@ -383,14 +424,14 @@ module.exports = {
             Program() {
                 comments.forEach(token => {
                     if (token.type === "Line") {
-                        if (options.beforeLineComment || options.afterLineComment) {
+                        if (typeof options.beforeLineComment === "boolean" || typeof options.afterLineComment === "boolean") {
                             checkForEmptyLine(token, {
                                 after: options.afterLineComment,
                                 before: options.beforeLineComment
                             });
                         }
                     } else if (token.type === "Block") {
-                        if (options.beforeBlockComment || options.afterBlockComment) {
+                        if (typeof options.beforeBlockComment === "boolean" || typeof options.afterBlockComment === "boolean") {
                             checkForEmptyLine(token, {
                                 after: options.afterBlockComment,
                                 before: options.beforeBlockComment

--- a/packages/eslint-config-eslint/default.yml
+++ b/packages/eslint-config-eslint/default.yml
@@ -59,9 +59,7 @@ rules:
     keyword-spacing: "error"
     lines-around-comment: ["error", {
         beforeBlockComment: true,
-        afterBlockComment: false,
-        beforeLineComment: true,
-        afterLineComment: false
+        beforeLineComment: true
     }]
     max-len: ["error", 160, {
         "ignoreComments": true,

--- a/tests/lib/rules/lines-around-comment.js
+++ b/tests/lib/rules/lines-around-comment.js
@@ -60,6 +60,20 @@ ruleTester.run("lines-around-comment", rule, {
             options: [{ afterBlockComment: false }]
         },
         {
+            code: "bar()\n/** block block block\n * block \n */\nvar a = 1;",
+
+            // check for ignore `beforeBlockComment`
+            /* eslint-disable-next-line no-undefined */
+            options: [{ beforeBlockComment: undefined }]
+        },
+        {
+            code: "bar()\n/** block block block\n * block \n */\n\nvar a = 1;",
+
+            // check for ignore `beforeBlockComment`
+            /* eslint-disable-next-line no-undefined */
+            options: [{ beforeBlockComment: undefined, afterBlockComment: true }]
+        },
+        {
             code: "/** \nblock \nblock block\n */\n/* block \n block \n */",
             options: [{ afterBlockComment: true, beforeBlockComment: true }]
         },
@@ -857,7 +871,7 @@ ruleTester.run("lines-around-comment", rule, {
         {
             code: "bar()\n/** block block block\n * block \n */\nvar a = 1;",
             output: "bar()\n\n/** block block block\n * block \n */\nvar a = 1;",
-            errors: [{ messageId: "before", type: "Block" }]
+            errors: [{ messageId: "expected-before", type: "Block" }]
         },
 
         // line comments
@@ -865,25 +879,28 @@ ruleTester.run("lines-around-comment", rule, {
             code: "baz()\n// A line comment with no empty line after\nvar a = 1;",
             output: "baz()\n// A line comment with no empty line after\n\nvar a = 1;",
             options: [{ afterLineComment: true }],
-            errors: [{ messageId: "after", type: "Line" }]
+            errors: [{ messageId: "expected-after", type: "Line" }]
         },
         {
-            code: "baz()\n// A line comment with no empty line after\nvar a = 1;",
+            code: "baz()\n// A line comment with no empty line after\n\nvar a = 1;",
             output: "baz()\n\n// A line comment with no empty line after\nvar a = 1;",
             options: [{ beforeLineComment: true, afterLineComment: false }],
-            errors: [{ messageId: "before", type: "Line" }]
+            errors: [
+                { messageId: "expected-before", type: "Line" },
+                { messageId: "unexpected-after", type: "Line" }
+            ]
         },
         {
             code: "// A line comment with no empty line after\nvar a = 1;",
             output: "// A line comment with no empty line after\n\nvar a = 1;",
             options: [{ beforeLineComment: true, afterLineComment: true }],
-            errors: [{ messageId: "after", type: "Line", line: 1, column: 1 }]
+            errors: [{ messageId: "expected-after", type: "Line", line: 1, column: 1 }]
         },
         {
             code: "baz()\n// A line comment with no empty line after\nvar a = 1;",
             output: "baz()\n\n// A line comment with no empty line after\n\nvar a = 1;",
             options: [{ beforeLineComment: true, afterLineComment: true }],
-            errors: [{ messageId: "before", type: "Line", line: 2 }, { messageId: "after", type: "Line", line: 2 }]
+            errors: [{ messageId: "expected-before", type: "Line", line: 2 }, { messageId: "expected-after", type: "Line", line: 2 }]
         },
 
         // block comments
@@ -891,15 +908,15 @@ ruleTester.run("lines-around-comment", rule, {
             code: "bar()\n/**\n * block block block\n */\nvar a = 1;",
             output: "bar()\n\n/**\n * block block block\n */\n\nvar a = 1;",
             options: [{ afterBlockComment: true, beforeBlockComment: true }],
-            errors: [{ messageId: "before", type: "Block", line: 2 }, { messageId: "after", type: "Block", line: 2 }]
+            errors: [{ messageId: "expected-before", type: "Block", line: 2 }, { messageId: "expected-after", type: "Block", line: 2 }]
         },
         {
             code: "bar()\n/* first block comment */ /* second block comment */\nvar a = 1;",
             output: "bar()\n\n/* first block comment */ /* second block comment */\n\nvar a = 1;",
             options: [{ afterBlockComment: true, beforeBlockComment: true }],
             errors: [
-                { messageId: "before", type: "Block", line: 2 },
-                { messageId: "after", type: "Block", line: 2 }
+                { messageId: "expected-before", type: "Block", line: 2 },
+                { messageId: "expected-after", type: "Block", line: 2 }
             ]
         },
         {
@@ -907,21 +924,27 @@ ruleTester.run("lines-around-comment", rule, {
             output: "bar()\n\n/* first block comment */ /* second block\n comment */\n\nvar a = 1;",
             options: [{ afterBlockComment: true, beforeBlockComment: true }],
             errors: [
-                { messageId: "before", type: "Block", line: 2 },
-                { messageId: "after", type: "Block", line: 2 }
+                { messageId: "expected-before", type: "Block", line: 2 },
+                { messageId: "expected-after", type: "Block", line: 2 }
             ]
         },
         {
-            code: "bar()\n/**\n * block block block\n */\nvar a = 1;",
+            code: "bar()\n\n/**\n * block block block\n */\nvar a = 1;",
             output: "bar()\n/**\n * block block block\n */\n\nvar a = 1;",
             options: [{ afterBlockComment: true, beforeBlockComment: false }],
-            errors: [{ messageId: "after", type: "Block", line: 2 }]
+            errors: [
+                { messageId: "unexpected-before", type: "Block", line: 3 },
+                { messageId: "expected-after", type: "Block", line: 3 }
+            ]
         },
         {
-            code: "bar()\n/**\n * block block block\n */\nvar a = 1;",
+            code: "bar()\n/**\n * block block block\n */\n\nvar a = 1;",
             output: "bar()\n\n/**\n * block block block\n */\nvar a = 1;",
             options: [{ afterBlockComment: false, beforeBlockComment: true }],
-            errors: [{ messageId: "before", type: "Block", line: 2 }]
+            errors: [
+                { messageId: "expected-before", type: "Block", line: 2 },
+                { messageId: "unexpected-after", type: "Block", line: 2 }
+            ]
         },
         {
             code: "var a,\n// line\nb;",
@@ -930,7 +953,7 @@ ruleTester.run("lines-around-comment", rule, {
                 beforeLineComment: true,
                 allowBlockStart: true
             }],
-            errors: [{ messageId: "before", type: "Line", line: 2 }]
+            errors: [{ messageId: "expected-before", type: "Line", line: 2 }]
         },
         {
             code: "function foo(){\nvar a = 1;\n// line at block start\nvar g = 1;\n}",
@@ -939,7 +962,7 @@ ruleTester.run("lines-around-comment", rule, {
                 beforeLineComment: true,
                 allowBlockStart: true
             }],
-            errors: [{ messageId: "before", type: "Line", line: 3 }]
+            errors: [{ messageId: "expected-before", type: "Line", line: 3 }]
         },
         {
             code: "var a,\n// line\nb;",
@@ -948,7 +971,7 @@ ruleTester.run("lines-around-comment", rule, {
                 afterLineComment: true,
                 allowBlockEnd: true
             }],
-            errors: [{ messageId: "after", type: "Line", line: 2 }]
+            errors: [{ messageId: "expected-after", type: "Line", line: 2 }]
         },
         {
             code: "function foo(){\nvar a = 1;\n\n// line at block start\nvar g = 1;\n}",
@@ -957,7 +980,7 @@ ruleTester.run("lines-around-comment", rule, {
                 afterLineComment: true,
                 allowBlockEnd: true
             }],
-            errors: [{ messageId: "after", type: "Line", line: 4 }]
+            errors: [{ messageId: "expected-after", type: "Line", line: 4 }]
         },
         {
             code: "switch ('foo'){\ncase 'foo':\n// line at switch case start\nbreak;\n}",
@@ -965,7 +988,7 @@ ruleTester.run("lines-around-comment", rule, {
             options: [{
                 beforeLineComment: true
             }],
-            errors: [{ messageId: "before", type: "Line", line: 3 }]
+            errors: [{ messageId: "expected-before", type: "Line", line: 3 }]
         },
         {
             code: "switch ('foo'){\ncase 'foo':\nbreak;\n\ndefault:\n// line at switch case start\nbreak;\n}",
@@ -973,7 +996,7 @@ ruleTester.run("lines-around-comment", rule, {
             options: [{
                 beforeLineComment: true
             }],
-            errors: [{ messageId: "before", type: "Line", line: 6 }]
+            errors: [{ messageId: "expected-before", type: "Line", line: 6 }]
         },
         {
             code: "while(true){\n// line at block start and end\n}",
@@ -982,7 +1005,7 @@ ruleTester.run("lines-around-comment", rule, {
                 afterLineComment: true,
                 allowBlockStart: true
             }],
-            errors: [{ messageId: "after", type: "Line", line: 2 }]
+            errors: [{ messageId: "expected-after", type: "Line", line: 2 }]
         },
         {
             code: "while(true){\n// line at block start and end\n}",
@@ -991,7 +1014,7 @@ ruleTester.run("lines-around-comment", rule, {
                 beforeLineComment: true,
                 allowBlockEnd: true
             }],
-            errors: [{ messageId: "before", type: "Line", line: 2 }]
+            errors: [{ messageId: "expected-before", type: "Line", line: 2 }]
         },
         {
             code: "class A {\n// line at class start\nconstructor() {}\n}",
@@ -1000,7 +1023,7 @@ ruleTester.run("lines-around-comment", rule, {
                 beforeLineComment: true
             }],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ messageId: "before", type: "Line", line: 2 }]
+            errors: [{ messageId: "expected-before", type: "Line", line: 2 }]
         },
         {
             code: "class A {\n// line at class start\nconstructor() {}\n}",
@@ -1011,7 +1034,7 @@ ruleTester.run("lines-around-comment", rule, {
                 beforeLineComment: true
             }],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ messageId: "before", type: "Line", line: 2 }]
+            errors: [{ messageId: "expected-before", type: "Line", line: 2 }]
         },
         {
             code: "class B {\nconstructor() {}\n\n// line at class end\n}",
@@ -1020,7 +1043,7 @@ ruleTester.run("lines-around-comment", rule, {
                 afterLineComment: true
             }],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ messageId: "after", type: "Line", line: 4 }]
+            errors: [{ messageId: "expected-after", type: "Line", line: 4 }]
         },
         {
             code: "class B {\nconstructor() {}\n\n// line at class end\n}",
@@ -1031,7 +1054,7 @@ ruleTester.run("lines-around-comment", rule, {
                 allowClassEnd: false
             }],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ messageId: "after", type: "Line", line: 4 }]
+            errors: [{ messageId: "expected-after", type: "Line", line: 4 }]
         },
         {
             code: "switch ('foo'){\ncase 'foo':\nvar g = 1;\n\n// line at switch case end\n}",
@@ -1039,7 +1062,7 @@ ruleTester.run("lines-around-comment", rule, {
             options: [{
                 afterLineComment: true
             }],
-            errors: [{ messageId: "after", type: "Line", line: 5 }]
+            errors: [{ messageId: "expected-after", type: "Line", line: 5 }]
         },
         {
             code: "switch ('foo'){\ncase 'foo':\nbreak;\n\ndefault:\nvar g = 1;\n\n// line at switch case end\n}",
@@ -1047,7 +1070,7 @@ ruleTester.run("lines-around-comment", rule, {
             options: [{
                 afterLineComment: true
             }],
-            errors: [{ messageId: "after", type: "Line", line: 8 }]
+            errors: [{ messageId: "expected-after", type: "Line", line: 8 }]
         },
 
         // object start comments
@@ -1066,7 +1089,7 @@ ruleTester.run("lines-around-comment", rule, {
             options: [{
                 beforeLineComment: true
             }],
-            errors: [{ messageId: "before", type: "Line", line: 2 }]
+            errors: [{ messageId: "expected-before", type: "Line", line: 2 }]
         },
         {
             code:
@@ -1089,7 +1112,7 @@ ruleTester.run("lines-around-comment", rule, {
             options: [{
                 beforeLineComment: true
             }],
-            errors: [{ messageId: "before", type: "Line", line: 3 }]
+            errors: [{ messageId: "expected-before", type: "Line", line: 3 }]
         },
         {
             code:
@@ -1106,7 +1129,7 @@ ruleTester.run("lines-around-comment", rule, {
             options: [{
                 beforeBlockComment: true
             }],
-            errors: [{ messageId: "before", type: "Block", line: 2 }]
+            errors: [{ messageId: "expected-before", type: "Block", line: 2 }]
         },
         {
             code:
@@ -1133,7 +1156,7 @@ ruleTester.run("lines-around-comment", rule, {
             options: [{
                 beforeLineComment: true
             }],
-            errors: [{ messageId: "before", type: "Block", line: 3 }]
+            errors: [{ messageId: "expected-before", type: "Block", line: 3 }]
         },
         {
             code:
@@ -1151,7 +1174,7 @@ ruleTester.run("lines-around-comment", rule, {
                 beforeLineComment: true
             }],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ messageId: "before", type: "Line", line: 2 }]
+            errors: [{ messageId: "expected-before", type: "Line", line: 2 }]
         },
         {
             code:
@@ -1169,7 +1192,7 @@ ruleTester.run("lines-around-comment", rule, {
                 beforeLineComment: true
             }],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ messageId: "before", type: "Line", line: 2 }]
+            errors: [{ messageId: "expected-before", type: "Line", line: 2 }]
         },
         {
             code:
@@ -1187,7 +1210,7 @@ ruleTester.run("lines-around-comment", rule, {
                 beforeBlockComment: true
             }],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ messageId: "before", type: "Block", line: 2 }]
+            errors: [{ messageId: "expected-before", type: "Block", line: 2 }]
         },
         {
             code:
@@ -1205,7 +1228,7 @@ ruleTester.run("lines-around-comment", rule, {
                 beforeBlockComment: true
             }],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ messageId: "before", type: "Block", line: 2 }]
+            errors: [{ messageId: "expected-before", type: "Block", line: 2 }]
         },
 
         // object end comments
@@ -1224,7 +1247,7 @@ ruleTester.run("lines-around-comment", rule, {
             options: [{
                 afterLineComment: true
             }],
-            errors: [{ messageId: "after", type: "Line", line: 3 }]
+            errors: [{ messageId: "expected-after", type: "Line", line: 3 }]
         },
         {
             code:
@@ -1247,7 +1270,7 @@ ruleTester.run("lines-around-comment", rule, {
             options: [{
                 afterLineComment: true
             }],
-            errors: [{ messageId: "after", type: "Line", line: 5 }]
+            errors: [{ messageId: "expected-after", type: "Line", line: 5 }]
         },
         {
             code:
@@ -1266,7 +1289,7 @@ ruleTester.run("lines-around-comment", rule, {
             options: [{
                 afterBlockComment: true
             }],
-            errors: [{ messageId: "after", type: "Block", line: 4 }]
+            errors: [{ messageId: "expected-after", type: "Block", line: 4 }]
         },
         {
             code:
@@ -1295,7 +1318,7 @@ ruleTester.run("lines-around-comment", rule, {
             options: [{
                 afterBlockComment: true
             }],
-            errors: [{ messageId: "after", type: "Block", line: 6 }]
+            errors: [{ messageId: "expected-after", type: "Block", line: 6 }]
         },
         {
             code:
@@ -1313,7 +1336,7 @@ ruleTester.run("lines-around-comment", rule, {
                 afterLineComment: true
             }],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ messageId: "after", type: "Line", line: 3 }]
+            errors: [{ messageId: "expected-after", type: "Line", line: 3 }]
         },
         {
             code:
@@ -1331,7 +1354,7 @@ ruleTester.run("lines-around-comment", rule, {
                 afterLineComment: true
             }],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ messageId: "after", type: "Line", line: 3 }]
+            errors: [{ messageId: "expected-after", type: "Line", line: 3 }]
         },
         {
             code:
@@ -1351,7 +1374,7 @@ ruleTester.run("lines-around-comment", rule, {
                 afterBlockComment: true
             }],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ messageId: "after", type: "Block", line: 4 }]
+            errors: [{ messageId: "expected-after", type: "Block", line: 4 }]
         },
         {
             code:
@@ -1371,7 +1394,7 @@ ruleTester.run("lines-around-comment", rule, {
                 afterBlockComment: true
             }],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ messageId: "after", type: "Block", line: 4 }]
+            errors: [{ messageId: "expected-after", type: "Block", line: 4 }]
         },
 
         // array start comments
@@ -1390,7 +1413,7 @@ ruleTester.run("lines-around-comment", rule, {
             options: [{
                 beforeLineComment: true
             }],
-            errors: [{ messageId: "before", type: "Line", line: 2 }]
+            errors: [{ messageId: "expected-before", type: "Line", line: 2 }]
         },
         {
             code:
@@ -1407,7 +1430,7 @@ ruleTester.run("lines-around-comment", rule, {
             options: [{
                 beforeBlockComment: true
             }],
-            errors: [{ messageId: "before", type: "Block", line: 2 }]
+            errors: [{ messageId: "expected-before", type: "Block", line: 2 }]
         },
         {
             code:
@@ -1425,7 +1448,7 @@ ruleTester.run("lines-around-comment", rule, {
                 beforeLineComment: true
             }],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ messageId: "before", type: "Line", line: 2 }]
+            errors: [{ messageId: "expected-before", type: "Line", line: 2 }]
         },
         {
             code:
@@ -1443,7 +1466,7 @@ ruleTester.run("lines-around-comment", rule, {
                 beforeBlockComment: true
             }],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ messageId: "before", type: "Block", line: 2 }]
+            errors: [{ messageId: "expected-before", type: "Block", line: 2 }]
         },
 
         // array end comments
@@ -1462,7 +1485,7 @@ ruleTester.run("lines-around-comment", rule, {
             options: [{
                 afterLineComment: true
             }],
-            errors: [{ messageId: "after", type: "Line", line: 3 }]
+            errors: [{ messageId: "expected-after", type: "Line", line: 3 }]
         },
         {
             code:
@@ -1481,7 +1504,7 @@ ruleTester.run("lines-around-comment", rule, {
             options: [{
                 afterBlockComment: true
             }],
-            errors: [{ messageId: "after", type: "Block", line: 4 }]
+            errors: [{ messageId: "expected-after", type: "Block", line: 4 }]
         },
         {
             code:
@@ -1499,7 +1522,7 @@ ruleTester.run("lines-around-comment", rule, {
                 afterLineComment: true
             }],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ messageId: "after", type: "Line", line: 3 }]
+            errors: [{ messageId: "expected-after", type: "Line", line: 3 }]
         },
         {
             code:
@@ -1519,7 +1542,7 @@ ruleTester.run("lines-around-comment", rule, {
                 afterBlockComment: true
             }],
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ messageId: "after", type: "Block", line: 4 }]
+            errors: [{ messageId: "expected-after", type: "Block", line: 4 }]
         },
 
         // ignorePattern
@@ -1546,69 +1569,69 @@ ruleTester.run("lines-around-comment", rule, {
                 applyDefaultIgnorePatterns: false
             }],
             errors: [
-                { messageId: "before", type: "Block", line: 7 },
-                { messageId: "after", type: "Block", line: 7 }
+                { messageId: "expected-before", type: "Block", line: 7 },
+                { messageId: "expected-after", type: "Block", line: 7 }
             ]
         },
         {
             code: "foo;\n/* eslint */",
             output: "foo;\n\n/* eslint */",
             options: [{ applyDefaultIgnorePatterns: false }],
-            errors: [{ messageId: "before", type: "Block" }]
+            errors: [{ messageId: "expected-before", type: "Block" }]
         },
         {
             code: "foo;\n/* jshint */",
             output: "foo;\n\n/* jshint */",
             options: [{ applyDefaultIgnorePatterns: false }],
-            errors: [{ messageId: "before", type: "Block" }]
+            errors: [{ messageId: "expected-before", type: "Block" }]
         },
         {
             code: "foo;\n/* jslint */",
             output: "foo;\n\n/* jslint */",
             options: [{ applyDefaultIgnorePatterns: false }],
-            errors: [{ messageId: "before", type: "Block" }]
+            errors: [{ messageId: "expected-before", type: "Block" }]
         },
         {
             code: "foo;\n/* istanbul */",
             output: "foo;\n\n/* istanbul */",
             options: [{ applyDefaultIgnorePatterns: false }],
-            errors: [{ messageId: "before", type: "Block" }]
+            errors: [{ messageId: "expected-before", type: "Block" }]
         },
         {
             code: "foo;\n/* global */",
             output: "foo;\n\n/* global */",
             options: [{ applyDefaultIgnorePatterns: false }],
-            errors: [{ messageId: "before", type: "Block" }]
+            errors: [{ messageId: "expected-before", type: "Block" }]
         },
         {
             code: "foo;\n/* globals */",
             output: "foo;\n\n/* globals */",
             options: [{ applyDefaultIgnorePatterns: false }],
-            errors: [{ messageId: "before", type: "Block" }]
+            errors: [{ messageId: "expected-before", type: "Block" }]
         },
         {
             code: "foo;\n/* exported */",
             output: "foo;\n\n/* exported */",
             options: [{ applyDefaultIgnorePatterns: false }],
-            errors: [{ messageId: "before", type: "Block" }]
+            errors: [{ messageId: "expected-before", type: "Block" }]
         },
         {
             code: "foo;\n/* jscs */",
             output: "foo;\n\n/* jscs */",
             options: [{ applyDefaultIgnorePatterns: false }],
-            errors: [{ messageId: "before", type: "Block" }]
+            errors: [{ messageId: "expected-before", type: "Block" }]
         },
         {
             code: "foo\n/* something else */",
             output: "foo\n\n/* something else */",
             options: [{ ignorePattern: "pragma" }],
-            errors: [{ messageId: "before", type: "Block" }]
+            errors: [{ messageId: "expected-before", type: "Block" }]
         },
         {
             code: "foo\n/* eslint */",
             output: "foo\n\n/* eslint */",
             options: [{ applyDefaultIgnorePatterns: false }],
-            errors: [{ messageId: "before", type: "Block" }]
+            errors: [{ messageId: "expected-before", type: "Block" }]
         },
 
         // "fallthrough" patterns are not ignored by default
@@ -1616,7 +1639,7 @@ ruleTester.run("lines-around-comment", rule, {
             code: "foo;\n/* fallthrough */",
             output: "foo;\n\n/* fallthrough */",
             options: [],
-            errors: [{ messageId: "before", type: "Block" }]
+            errors: [{ messageId: "expected-before", type: "Block" }]
         }
     ]
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->
This edit is the minimum change to correct the problem: #11129

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[x] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**Tell us about your environment**

* **ESLint Version: 6.5.0**
* **Node Version: 12.10.0**
* **npm Version: 6.11.3**

**What parser (default, Babel-ESLint, etc.) are you using?**
default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
  'parserOptions': {
    ecmaVersion: 2018,
    sourceType: 'script'
  },
  'env': {
    node: true,
    es6: true
  },
  'rules': {
    'padding-line-between-statements': ['warn',
      { blankLine: 'always', prev: ['class', 'function'], next: '*' }
    ],
    'no-multiple-empty-lines': ['warn',
      { max: 2, maxEOF: 0, maxBOF: 0 }
    ],
    'lines-around-comment': ['warn',
      {
        'beforeBlockComment': undefined,
        'beforeLineComment': true,
        'afterBlockComment': false,
        'afterLineComment': false
      }
    ]
  }
}
```

</details>

**What rule do you want to change?**
* `lines-around-comment`

**Does this change cause the rule to produce more or fewer warnings?**
A new warning is added that there is an extra empty line after the comment.

**How will the change be implemented? (New option, new default behavior, etc.)?**
modify `lines-around-comment` rule so that it works with values for each of its options:
`true` - require a blank line
`false` - prohibits blank lines
`undefined` - validation is ignored

**What does the rule currently do for this code?**
Nothing

**What will the rule do after it's changed?**
Will issue one of the warnings:
`Unexpected line after comment` or `Unexpected line before comment`

**What did you do? Please include the actual source code causing the issue.**

```js
/**
 * Copyright
 */

'use strict';

console.log(1)
```

**What did you expect to happen?**

> 1:1  warning  Unexpected line after comment  lines-around-comment

if run with `--fix`:
```js
/**
 * Copyright
 */
'use strict';

console.log(1)
```

**What actually happened? Please include the actual, raw output from ESLint.**

> no warnings

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Implemented the 1st point of this proposal:
https://github.com/eslint/eslint/issues/11129#issuecomment-535809679

**Is there anything you'd like reviewers to focus on?**

This edit is the minimum change to correct the problem: https://github.com/eslint/eslint/issues/11129
This solution can be applied until consensus is reached on one of the following issues, which make major changes to the operation of rules related to this problem:
* https://github.com/eslint/rfcs/pull/41
* https://github.com/eslint/eslint/issues/11129#issuecomment-536327392

After implementing one of the listed proposals, this rule will be marked as `deprecated`.
Therefore, I would like to make these changes to the current version, until the resolution of all issues with these proposals.