### PR TITLE
Fix: no-misleading-character-class crash on invalid regex (fixes #12169)

### DIFF
--- a/lib/rules/no-misleading-character-class.js
+++ b/lib/rules/no-misleading-character-class.js
@@ -131,12 +131,6 @@ module.exports = {
          * @returns {void}
          */
         function verify(node, pattern, flags) {
-            const patternNode = parser.parsePattern(
-                pattern,
-                0,
-                pattern.length,
-                flags.includes("u")
-            );
             const has = {
                 surrogatePairWithoutUFlag: false,
                 combiningClass: false,
@@ -145,6 +139,20 @@ module.exports = {
                 regionalIndicatorSymbol: false,
                 zwj: false
             };
+            let patternNode;
+
+            try {
+                patternNode = parser.parsePattern(
+                    pattern,
+                    0,
+                    pattern.length,
+                    flags.includes("u")
+                );
+            } catch (e) {
+
+                // Ignore regular expressions with syntax errors
+                return;
+            }
 
             visitRegExpAST(patternNode, {
                 onCharacterClassEnter(ccNode) {

--- a/tests/lib/rules/no-misleading-character-class.js
+++ b/tests/lib/rules/no-misleading-character-class.js
@@ -63,7 +63,11 @@ ruleTester.run("no-misleading-character-class", rule, {
 
         // Ignore solo ZWJ.
         "var r = /[\\u200D]/",
-        "var r = /[\\u200D]/u"
+        "var r = /[\\u200D]/u",
+
+        // don't report and don't crash on invalid regex
+        "var r = new RegExp('[Á] [ ');",
+        "var r = RegExp('{ [Á]', 'u');"
     ],
     invalid: [
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix #12169

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment**

* **ESLint Version:**  6.4.0
* **Node Version:** 10.16.0
* **npm Version:** 6.9.0

**What parser (default, Babel-ESLint, etc.) are you using?**

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
  parserOptions: {
    ecmaVersion: 2015,
  }
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**

```js
/* eslint no-misleading-character-class: ["error"] */

var r = new RegExp('[Á] [ ');
```

**What did you expect to happen?**

Not to crash.

**What actually happened? Please include the actual, raw output from ESLint.**

```
SyntaxError: Invalid regular expression: /[Á] [ /: Unterminated character class
    at RegExpValidator.raise ...
```

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

`try/catch` to ignore invalid regular expressions.

**Is there anything you'd like reviewers to focus on?**

The original issue is about regex literals with `@typescript-eslint/parser`, but the same applies to the regex constructor with the default parser.

I think it isn't necessary to add a `@typescript-eslint/parser` test since it's testable with the default?
