### PR TITLE
Fix: consistent-return incorrectly reports for generators (fixes #11371)

### DIFF
--- a/lib/rules/consistent-return.js
+++ b/lib/rules/consistent-return.js
@@ -102,7 +102,8 @@ module.exports = {
             if (!funcInfo.hasReturnValue ||
                 funcInfo.codePath.currentSegments.every(isUnreachable) ||
                 astUtils.isES5Constructor(node) ||
-                isClassConstructor(node)
+                isClassConstructor(node) ||
+                node.generator
             ) {
                 return;
             }

--- a/tests/lib/rules/consistent-return.js
+++ b/tests/lib/rules/consistent-return.js
@@ -42,7 +42,11 @@ ruleTester.run("consistent-return", rule, {
 
         // https://github.com/eslint/eslint/issues/7790
         { code: "class Foo { constructor() { if (true) return foo; } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "var Foo = class { constructor() { if (true) return foo; } }", parserOptions: { ecmaVersion: 6 } }
+        { code: "var Foo = class { constructor() { if (true) return foo; } }", parserOptions: { ecmaVersion: 6 } },
+
+        // https://github.com/eslint/eslint/issues/11371
+        { code: "function* foo() { if (false) { return []; } yield* [1, 2, 3];}", parserOptions: { ecmaVersion: 6 } },
+        { code: "function* foo() { yield* [1, 2, 3];}", parserOptions: { ecmaVersion: 6 } }
     ],
 
     invalid: [


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).

    This template is for requesting a rule change. If you are here for another reason, please see below:

    1. To report a bug: https://eslint.org/docs/developer-guide/contributing/reporting-bugs
    2. To propose a new rule: https://eslint.org/docs/developer-guide/contributing/new-rules
    3. To request a change that is not a bug fix, rule change, or new rule: https://eslint.org/docs/developer-guide/contributing/changes
    4. If you have any questions, please stop by our chatroom: https://gitter.im/eslint/eslint

    Note that leaving sections blank will make it difficult for us to troubleshoot and we may have to close the issue.
-->

**What rule do you want to change?**

consistent-return

**Does this change cause the rule to produce more or fewer warnings?**

fewer

**How will the change be implemented? (New option, new default behavior, etc.)?**

New default behaviour

**Please provide some example code that this change will affect:**

<!-- Put your code examples here -->
```js
function* exampleGenerator(option) {
    if (option === false) {
        return [];
    }

    yield* [1, 2, 3];
}
```

**What does the rule currently do for this code?**

Currently, this will produce an error, as there isn't a return for all branches of code. However, returning in a generator is a valid way to exhaust a generator early.

**What will the rule do after it's changed?**

Generator functions will not be reported by this rule.
