### PR TITLE
Docs: fix wrong max-depth example (fixes #11991)

### DIFF
--- a/docs/rules/max-depth.md
+++ b/docs/rules/max-depth.md
@@ -24,14 +24,14 @@ Examples of **incorrect** code for this rule with the default `{ "max": 4 }` opt
 
 function foo() {
     for (;;) { // Nested 1 deep
-        let val = () => (param) => { // Nested 2 deep
+        while (true) { // Nested 2 deep
             if (true) { // Nested 3 deep
                 if (true) { // Nested 4 deep
                     if (true) { // Nested 5 deep
                     }
                 }
             }
-        };
+        }
     }
 }
 ```
@@ -44,12 +44,12 @@ Examples of **correct** code for this rule with the default `{ "max": 4 }` optio
 
 function foo() {
     for (;;) { // Nested 1 deep
-        let val = () => (param) => { // Nested 2 deep
-           if (true) { // Nested 3 deep
+        while (true) { // Nested 2 deep
+            if (true) { // Nested 3 deep
                 if (true) { // Nested 4 deep
                 }
             }
-        };
+        }
     }
 }
 ```


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
As mentioned by @imai0917 on #11991, the example given for `max-depth` in the documentation doesn't trigger the rule, so this updates the example with one that does.

**Is there anything you'd like reviewers to focus on?**


