### PR TITLE
Chore: enable jsdoc/require-description

### DIFF
--- a/lib/cli-engine/cascading-config-array-factory.js
+++ b/lib/cli-engine/cascading-config-array-factory.js
@@ -152,6 +152,7 @@ function createCLIConfigArray({
  */
 class ConfigurationNotFoundError extends Error {
 
+    // eslint-disable-next-line jsdoc/require-description
     /**
      * @param {string} directoryPath The directory path.
      */

--- a/lib/cli-engine/config-array/config-dependency.js
+++ b/lib/cli-engine/config-array/config-dependency.js
@@ -81,6 +81,7 @@ class ConfigDependency {
         this.importerPath = importerPath;
     }
 
+    // eslint-disable-next-line jsdoc/require-description
     /**
      * @returns {Object} a JSON compatible object.
      */
@@ -95,6 +96,7 @@ class ConfigDependency {
         return obj;
     }
 
+    // eslint-disable-next-line jsdoc/require-description
     /**
      * @returns {Object} an object to display by `console.log()`.
      */

--- a/lib/cli-engine/config-array/override-tester.js
+++ b/lib/cli-engine/config-array/override-tester.js
@@ -166,6 +166,7 @@ class OverrideTester {
         ));
     }
 
+    // eslint-disable-next-line jsdoc/require-description
     /**
      * @returns {Object} a JSON compatible object.
      */
@@ -182,6 +183,7 @@ class OverrideTester {
         };
     }
 
+    // eslint-disable-next-line jsdoc/require-description
     /**
      * @returns {Object} an object to display by `console.log()`.
      */

--- a/lib/cli-engine/file-enumerator.js
+++ b/lib/cli-engine/file-enumerator.js
@@ -149,6 +149,7 @@ function readdirSafeSync(directoryPath) {
  */
 class NoFilesFoundError extends Error {
 
+    // eslint-disable-next-line jsdoc/require-description
     /**
      * @param {string} pattern The glob pattern which was not found.
      * @param {boolean} globDisabled If `true` then the pattern was a glob pattern, but glob was disabled.
@@ -165,6 +166,7 @@ class NoFilesFoundError extends Error {
  */
 class AllFilesIgnoredError extends Error {
 
+    // eslint-disable-next-line jsdoc/require-description
     /**
      * @param {string} pattern The glob pattern which was not found.
      */

--- a/lib/cli-engine/formatters/html.js
+++ b/lib/cli-engine/formatters/html.js
@@ -96,6 +96,7 @@ function renderMessages(messages, parentIndex, rulesMeta) {
     }).join("\n");
 }
 
+// eslint-disable-next-line jsdoc/require-description
 /**
  * @param {Array} results Test results.
  * @param {Object} rulesMeta Dictionary containing metadata for each rule executed by the analysis.

--- a/lib/cli-engine/ignored-paths.js
+++ b/lib/cli-engine/ignored-paths.js
@@ -121,6 +121,7 @@ function relativize(globPattern, relativePathToOldBaseDir) {
  */
 class IgnoredPaths {
 
+    // eslint-disable-next-line jsdoc/require-description
     /**
      * @param {Object} providedOptions object containing 'ignore', 'ignorePath' and 'patterns' properties
      */

--- a/lib/init/autoconfig.js
+++ b/lib/init/autoconfig.js
@@ -69,6 +69,7 @@ function makeRegistryItems(rulesConfig) {
  */
 class Registry {
 
+    // eslint-disable-next-line jsdoc/require-description
     /**
      * @param {rulesConfig} [rulesConfig] Hash of rule names and arrays of possible configurations
      */

--- a/lib/init/config-rule.js
+++ b/lib/init/config-rule.js
@@ -174,6 +174,7 @@ function combinePropertyObjects(objArr1, objArr2) {
  */
 class RuleConfigSet {
 
+    // eslint-disable-next-line jsdoc/require-description
     /**
      * @param {ruleConfig[]} configs Valid rule configurations
      */

--- a/lib/linter/code-path-analysis/code-path-analyzer.js
+++ b/lib/linter/code-path-analysis/code-path-analyzer.js
@@ -597,6 +597,7 @@ function postprocess(analyzer, node) {
  */
 class CodePathAnalyzer {
 
+    // eslint-disable-next-line jsdoc/require-description
     /**
      * @param {EventGenerator} eventGenerator An event generator to wrap.
      */

--- a/lib/linter/code-path-analysis/code-path-segment.js
+++ b/lib/linter/code-path-analysis/code-path-segment.js
@@ -33,6 +33,7 @@ function isReachable(segment) {
  */
 class CodePathSegment {
 
+    // eslint-disable-next-line jsdoc/require-description
     /**
      * @param {string} id An identifier.
      * @param {CodePathSegment[]} allPrevSegments An array of the previous segments.

--- a/lib/linter/code-path-analysis/code-path-state.js
+++ b/lib/linter/code-path-analysis/code-path-state.js
@@ -218,6 +218,7 @@ function finalizeTestSegmentsOfFor(context, choiceContext, head) {
  */
 class CodePathState {
 
+    // eslint-disable-next-line jsdoc/require-description
     /**
      * @param {IdGenerator} idGenerator An id generator to generate id for code
      *   path segments.

--- a/lib/linter/code-path-analysis/code-path.js
+++ b/lib/linter/code-path-analysis/code-path.js
@@ -21,6 +21,7 @@ const IdGenerator = require("./id-generator");
  */
 class CodePath {
 
+    // eslint-disable-next-line jsdoc/require-description
     /**
      * @param {string} id An identifier.
      * @param {CodePath|null} upper The code path of the upper function scope.

--- a/lib/linter/code-path-analysis/fork-context.js
+++ b/lib/linter/code-path-analysis/fork-context.js
@@ -97,6 +97,7 @@ function mergeExtraSegments(context, segments) {
  */
 class ForkContext {
 
+    // eslint-disable-next-line jsdoc/require-description
     /**
      * @param {IdGenerator} idGenerator An identifier generator for segments.
      * @param {ForkContext|null} upper An upper fork context.

--- a/lib/linter/code-path-analysis/id-generator.js
+++ b/lib/linter/code-path-analysis/id-generator.js
@@ -18,6 +18,7 @@
  */
 class IdGenerator {
 
+    // eslint-disable-next-line jsdoc/require-description
     /**
      * @param {string} prefix Optional. A prefix of generated ids.
      */

--- a/lib/linter/node-event-generator.js
+++ b/lib/linter/node-event-generator.js
@@ -202,6 +202,7 @@ const parseSelector = lodash.memoize(rawSelector => {
  */
 class NodeEventGenerator {
 
+    // eslint-disable-next-line jsdoc/require-description
     /**
      * @param {SafeEmitter} emitter
      * An SafeEmitter which is the destination of events. This emitter must already

--- a/lib/rules/default-param-last.js
+++ b/lib/rules/default-param-last.js
@@ -25,6 +25,7 @@ module.exports = {
 
     create(context) {
 
+        // eslint-disable-next-line jsdoc/require-description
         /**
          * @param {ASTNode} node function node
          * @returns {void}

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -187,6 +187,7 @@ class BinarySearchTree {
  */
 class TokenInfo {
 
+    // eslint-disable-next-line jsdoc/require-description
     /**
      * @param {SourceCode} sourceCode A SourceCode object
      */
@@ -236,6 +237,7 @@ class TokenInfo {
  */
 class OffsetStorage {
 
+    // eslint-disable-next-line jsdoc/require-description
     /**
      * @param {TokenInfo} tokenInfo a TokenInfo instance
      * @param {number} indentSize The desired size of each indentation level

--- a/lib/rules/no-dupe-keys.js
+++ b/lib/rules/no-dupe-keys.js
@@ -23,6 +23,7 @@ const SET_KIND = /^(?:init|set)$/u;
  */
 class ObjectInfo {
 
+    // eslint-disable-next-line jsdoc/require-description
     /**
      * @param {ObjectInfo|null} upper The information of the outer object.
      * @param {ASTNode} node The ObjectExpression node of this information.

--- a/lib/rules/no-unused-expressions.js
+++ b/lib/rules/no-unused-expressions.js
@@ -47,6 +47,7 @@ module.exports = {
             allowTernary = config.allowTernary || false,
             allowTaggedTemplates = config.allowTaggedTemplates || false;
 
+        // eslint-disable-next-line jsdoc/require-description
         /**
          * @param {ASTNode} node any node
          * @returns {boolean} whether the given node structurally represents a directive
@@ -56,6 +57,7 @@ module.exports = {
                 node.expression.type === "Literal" && typeof node.expression.value === "string";
         }
 
+        // eslint-disable-next-line jsdoc/require-description
         /**
          * @param {Function} predicate ([a] -> Boolean) the function used to make the determination
          * @param {a[]} list the input list
@@ -70,6 +72,7 @@ module.exports = {
             return list.slice();
         }
 
+        // eslint-disable-next-line jsdoc/require-description
         /**
          * @param {ASTNode} node a Program or BlockStatement node
          * @returns {ASTNode[]} the leading sequence of directive nodes in the given node's body
@@ -78,6 +81,7 @@ module.exports = {
             return takeWhile(looksLikeDirective, node.body);
         }
 
+        // eslint-disable-next-line jsdoc/require-description
         /**
          * @param {ASTNode} node any node
          * @param {ASTNode[]} ancestors the given node's ancestors

--- a/lib/rules/prefer-destructuring.js
+++ b/lib/rules/prefer-destructuring.js
@@ -103,6 +103,7 @@ module.exports = {
         // Helpers
         //--------------------------------------------------------------------------
 
+        // eslint-disable-next-line jsdoc/require-description
         /**
          * @param {string} nodeType "AssignmentExpression" or "VariableDeclarator"
          * @param {string} destructuringType "array" or "object"

--- a/lib/rules/vars-on-top.js
+++ b/lib/rules/vars-on-top.js
@@ -32,6 +32,7 @@ module.exports = {
         // Helpers
         //--------------------------------------------------------------------------
 
+        // eslint-disable-next-line jsdoc/require-description
         /**
          * @param {ASTNode} node any node
          * @returns {boolean} whether the given node structurally represents a directive

--- a/lib/shared/traverser.js
+++ b/lib/shared/traverser.js
@@ -65,6 +65,7 @@ class Traverser {
         this._leave = null;
     }
 
+    // eslint-disable-next-line jsdoc/require-description
     /**
      * @returns {ASTNode} The current node.
      */
@@ -72,6 +73,7 @@ class Traverser {
         return this._current;
     }
 
+    // eslint-disable-next-line jsdoc/require-description
     /**
      * @returns {ASTNode[]} The ancestor nodes.
      */

--- a/packages/eslint-config-eslint/default.yml
+++ b/packages/eslint-config-eslint/default.yml
@@ -48,6 +48,7 @@ rules:
     jsdoc/check-types: "error"
     jsdoc/implements-on-classes: "error"
     jsdoc/newline-after-description: ["error", "never"]
+    jsdoc/require-description: "error"
     jsdoc/require-hyphen-before-param-description: ["error", "never"]
     jsdoc/require-jsdoc: "error"
     jsdoc/require-param: "error"

--- a/tests/lib/rule-tester/rule-tester.js
+++ b/tests/lib/rule-tester/rule-tester.js
@@ -67,7 +67,7 @@ describe("RuleTester", () => {
     let ruleTester;
 
     /**
-     * @description A helper function to verify Node.js core error messages.
+     * A helper function to verify Node.js core error messages.
      * @param {string} actual The actual input
      * @param {string} expected The expected input
      * @returns {Function} Error callback to verify that the message is correct


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Following up on https://github.com/eslint/eslint/pull/12336#pullrequestreview-295990298, this PR enables the `jsdoc/require-description` rule, using `eslint-disable-*` comments for the 30 instances where a description is missing. As @mysticatea suggested, this will ensure we don't add any new JSDoc blocks that are missing descriptions.

**Is there anything you'd like reviewers to focus on?**
Nothing in particular!

