### PR TITLE
Update: no-path-concat rule checks template literals (fixes #12323)

### DIFF
--- a/docs/rules/no-path-concat.md
+++ b/docs/rules/no-path-concat.md
@@ -35,6 +35,8 @@ var fullPath = __dirname + "/foo.js";
 
 var fullPath = __filename + "/foo.js";
 
+var fullPath = `${__dirname}/foo.js`;
+
 ```
 
 Examples of **correct** code for this rule:
@@ -43,6 +45,8 @@ Examples of **correct** code for this rule:
 /*eslint no-path-concat: "error"*/
 
 var fullPath = dirname + "/foo.js";
+
+var fullPath = `${dirname}/foo.js`;
 ```
 
 ## When Not To Use It

--- a/lib/rules/no-path-concat.js
+++ b/lib/rules/no-path-concat.js
@@ -42,8 +42,16 @@ module.exports = {
                         (right.type === "Identifier" && MATCHER.test(right.name)))
                 ) {
 
-                    context.report({ node, message: "Use path.join() or path.resolve() instead of + to create paths." });
+                    context.report({ node, message: "Use path.join() or path.resolve() instead of concatenation to create paths." });
                 }
+            },
+
+            TemplateLiteral(node) {
+                node.expressions.forEach(element => {
+                    if (element.type === "Identifier" && MATCHER.test(element.name)) {
+                        context.report({ node, message: "Use path.join() or path.resolve() instead of concatenation to create paths." });
+                    }
+                });
             }
 
         };

--- a/tests/bin/eslint.js
+++ b/tests/bin/eslint.js
@@ -8,7 +8,8 @@
 const childProcess = require("child_process");
 const fs = require("fs");
 const assert = require("chai").assert;
-const EXECUTABLE_PATH = require("path").resolve(`${__dirname}/../../bin/eslint.js`);
+const path = require("path");
+const EXECUTABLE_PATH = path.resolve(path.join(__dirname, "/../../bin/eslint.js"));
 
 /**
  * Returns a Promise for when a child process exits
@@ -166,7 +167,7 @@ describe("bin/eslint.js", () => {
 
         it("successfully handles more than 4k data via stdin", () => {
             const child = runESLint(["--stdin", "--no-eslintrc"]);
-            const large = fs.createReadStream(`${__dirname}/../bench/large.js`, "utf8");
+            const large = fs.createReadStream(path.join(__dirname, "/../bench/large.js"), "utf8");
 
             large.pipe(child.stdin);
 
@@ -182,7 +183,7 @@ describe("bin/eslint.js", () => {
     });
 
     describe("automatically fixing files", () => {
-        const fixturesPath = `${__dirname}/../fixtures/autofix-integration`;
+        const fixturesPath = path.join(__dirname, "/../fixtures/autofix-integration");
         const tempFilePath = `${fixturesPath}/temp.js`;
         const startingText = fs.readFileSync(`${fixturesPath}/left-pad.js`).toString();
         const expectedFixedText = fs.readFileSync(`${fixturesPath}/left-pad-expected.js`).toString();
@@ -359,7 +360,7 @@ describe("bin/eslint.js", () => {
         });
 
         it("prints the error message pointing to line of code", () => {
-            const invalidConfig = `${__dirname}/../fixtures/bin/.eslintrc.yml`;
+            const invalidConfig = path.join(__dirname, "/../fixtures/bin/.eslintrc.yml");
             const child = runESLint(["--no-ignore", invalidConfig]);
             const exitCodeAssertion = assertExitCode(child, 2);
             const outputAssertion = getOutput(child).then(output => {

--- a/tests/lib/cli-engine/config-array/config-array.js
+++ b/tests/lib/cli-engine/config-array/config-array.js
@@ -693,8 +693,8 @@ describe("ConfigArray", () => {
 
         for (const { filePaths } of [
             { filePaths: [__filename] },
-            { filePaths: [__filename, `${__filename}.ts`] },
-            { filePaths: [__filename, `${__filename}.ts`, path.join(__dirname, "foo.js")] }
+            { filePaths: [__filename, `${path.resolve(__filename)}.ts`] },
+            { filePaths: [__filename, `${path.resolve(__filename)}.ts`, path.join(__dirname, "foo.js")] }
         ]) {
             describe(`after it called 'extractConfig(filePath)' ${filePaths.length} time(s) with ${JSON.stringify(filePaths, null, 4)}, the returned array`, () => { // eslint-disable-line no-loop-func
                 let configs;
@@ -721,7 +721,7 @@ describe("ConfigArray", () => {
 
             // Call some times, including with the same arguments.
             configArray.extractConfig(__filename);
-            configArray.extractConfig(`${__filename}.ts`);
+            configArray.extractConfig(`${path.resolve(__filename)}.ts`);
             configArray.extractConfig(path.join(__dirname, "foo.js"));
             configArray.extractConfig(__filename);
             configArray.extractConfig(path.join(__dirname, "foo.js"));

--- a/tests/lib/rules/no-path-concat.js
+++ b/tests/lib/rules/no-path-concat.js
@@ -15,7 +15,7 @@ const rule = require("../../../lib/rules/no-path-concat"),
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 6 } });
 
 ruleTester.run("no-path-concat", rule, {
 
@@ -23,36 +23,68 @@ ruleTester.run("no-path-concat", rule, {
         "var fullPath = dirname + \"foo.js\";",
         "var fullPath = __dirname == \"foo.js\";",
         "if (fullPath === __dirname) {}",
-        "if (__dirname === fullPath) {}"
+        "if (__dirname === fullPath) {}",
+        "var fullPath = `${dirname}/foo.js`;",
+        "var fullPath = `${filename}/foo.js`;",
+        "var fullPath = __dirname == `${dirname}/foo.js`;",
+        "if(__filename === `${filename}/foo.js`){}"
     ],
 
     invalid: [
         {
             code: "var fullPath = __dirname + \"/foo.js\";",
             errors: [{
-                message: "Use path.join() or path.resolve() instead of + to create paths.",
+                message: "Use path.join() or path.resolve() instead of concatenation to create paths.",
                 type: "BinaryExpression"
             }]
         },
         {
             code: "var fullPath = __filename + \"/foo.js\";",
             errors: [{
-                message: "Use path.join() or path.resolve() instead of + to create paths.",
+                message: "Use path.join() or path.resolve() instead of concatenation to create paths.",
                 type: "BinaryExpression"
             }]
         },
         {
             code: "var fullPath = \"/foo.js\" + __filename;",
             errors: [{
-                message: "Use path.join() or path.resolve() instead of + to create paths.",
+                message: "Use path.join() or path.resolve() instead of concatenation to create paths.",
                 type: "BinaryExpression"
             }]
         },
         {
             code: "var fullPath = \"/foo.js\" + __dirname;",
             errors: [{
-                message: "Use path.join() or path.resolve() instead of + to create paths.",
+                message: "Use path.join() or path.resolve() instead of concatenation to create paths.",
                 type: "BinaryExpression"
+            }]
+        },
+        {
+            code: "var fullPath = `${__dirname}/foo.js`",
+            errors: [{
+                message: "Use path.join() or path.resolve() instead of concatenation to create paths.",
+                type: "TemplateLiteral"
+            }]
+        },
+        {
+            code: "var fullPath = `/foo.js${__dirname}`",
+            errors: [{
+                message: "Use path.join() or path.resolve() instead of concatenation to create paths.",
+                type: "TemplateLiteral"
+            }]
+        },
+        {
+            code: "var fullPath = `${__filename}/foo.js`",
+            errors: [{
+                message: "Use path.join() or path.resolve() instead of concatenation to create paths.",
+                type: "TemplateLiteral"
+            }]
+        },
+        {
+            code: "var fullPath = `/foo.js${__filename}`",
+            errors: [{
+                message: "Use path.join() or path.resolve() instead of concatenation to create paths.",
+                type: "TemplateLiteral"
             }]
         }
     ]


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment**

* **ESLint Version:** 6.4.0
* **Node Version:** -
* **npm Version:** -

**What parser (default, Babel-ESLint, etc.) are you using?**

Default.  

**Please show your full configuration:**
**What did you do? Please include the actual source code causing the issue, as well as the command that you used to run ESLint.**

[Online Demo](https://eslint.org/demo#eyJ0ZXh0IjoiLyplc2xpbnQgbm8tcGF0aC1jb25jYXQ6IGVycm9yICovXG5cbmNvbnN0IGEgPSBfX2Rpcm5hbWUgKyBcIi9mb28uanNcIlxuY29uc3QgYiA9IGAke19fZGlybmFtZX0vZm9vLmpzYFxuIiwib3B0aW9ucyI6eyJwYXJzZXJPcHRpb25zIjp7ImVjbWFWZXJzaW9uIjoxMSwic291cmNlVHlwZSI6Im1vZHVsZSIsImVjbWFGZWF0dXJlcyI6e319LCJydWxlcyI6e30sImVudiI6e319fQ==)

```js

/*eslint no-path-concat: error */

const a = __dirname + "/foo.js"
const b = `${__dirname}/foo.js`

```

**What did you expect to happen?**

There are two errors:

- `__dirname + "/foo.js"`
- `` `${__dirname}/foo.js` ``

**What actually happened? Please include the actual, raw output from ESLint.**

There is only one error:

- `__dirname + "/foo.js"`

The rule doesn't seem to consider the interpolation of template literals as concatenation.

**What changes did you make? (Give an overview)**

 - Added a new TemplateLiteral definition for the no-path-concat rule
 - Added tests for the new definition
 - Added new examples to the [no-path-concat] documentation

**Is there anything you'd like reviewers to focus on?**

I haven't changed the error message, but I think we should change it so it mentions template literals interpolation.
