### PR TITLE
Chore: Clean up inline directive parsing

### DIFF
--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -323,16 +323,20 @@ function getDirectiveComments(filename, ast, ruleMapper, warnInlineConfig) {
         }
 
         const directiveValue = trimmedCommentText.slice(match.index + directiveText.length);
-        let directiveType = "";
 
         switch (directiveText) {
+            case "eslint-disable":
+            case "eslint-enable":
             case "eslint-disable-next-line":
-                directiveType = "disable-next-line";
-                break;
+            case "eslint-disable-line": {
+                const directiveType = directiveText.slice("eslint-".length);
+                const options = { type: directiveType, loc: comment.loc, value: directiveValue, ruleMapper };
+                const { directives, directiveProblems } = createDisableDirectives(options);
 
-            case "eslint-disable-line":
-                directiveType = "disable-line";
+                disableDirectives.push(...directives);
+                problems.push(...directiveProblems);
                 break;
+            }
 
             case "exported":
                 Object.assign(exportedVariables, commentParser.parseStringConfig(directiveValue, comment));
@@ -364,14 +368,6 @@ function getDirectiveComments(filename, ast, ruleMapper, warnInlineConfig) {
                         };
                     }
                 }
-                break;
-
-            case "eslint-disable":
-                directiveType = "disable";
-                break;
-
-            case "eslint-enable":
-                directiveType = "enable";
                 break;
 
             case "eslint": {
@@ -410,14 +406,6 @@ function getDirectiveComments(filename, ast, ruleMapper, warnInlineConfig) {
             }
 
             // no default
-        }
-
-        if (directiveType !== "") {
-            const options = { type: directiveType, loc: comment.loc, value: directiveValue, ruleMapper };
-            const { directives, directiveProblems } = createDisableDirectives(options);
-
-            disableDirectives.push(...directives);
-            problems.push(...directiveProblems);
         }
     });
 

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -292,10 +292,11 @@ function getDirectiveComments(filename, ast, ruleMapper, warnInlineConfig) {
         if (!match) {
             return;
         }
-        const lineCommentSupported = /^eslint-disable-(next-)?line$/u.test(match[1]);
+        const directiveText = match[1];
+        const lineCommentSupported = /^eslint-disable-(next-)?line$/u.test(directiveText);
 
         if (warnInlineConfig && (lineCommentSupported || comment.type === "Block")) {
-            const kind = comment.type === "Block" ? `/*${match[1]}*/` : `//${match[1]}`;
+            const kind = comment.type === "Block" ? `/*${directiveText}*/` : `//${directiveText}`;
 
             problems.push(createLintingProblem({
                 ruleId: null,
@@ -306,14 +307,14 @@ function getDirectiveComments(filename, ast, ruleMapper, warnInlineConfig) {
             return;
         }
 
-        const directiveValue = trimmedCommentText.slice(match.index + match[1].length);
+        const directiveValue = trimmedCommentText.slice(match.index + directiveText.length);
         let directiveType = "";
 
         if (lineCommentSupported) {
             if (comment.loc.start.line === comment.loc.end.line) {
-                directiveType = match[1].slice("eslint-".length);
+                directiveType = directiveText.slice("eslint-".length);
             } else {
-                const message = `${match[1]} comment should not span multiple lines.`;
+                const message = `${directiveText} comment should not span multiple lines.`;
 
                 problems.push(createLintingProblem({
                     ruleId: null,
@@ -322,7 +323,7 @@ function getDirectiveComments(filename, ast, ruleMapper, warnInlineConfig) {
                 }));
             }
         } else if (comment.type === "Block") {
-            switch (match[1]) {
+            switch (directiveText) {
                 case "exported":
                     Object.assign(exportedVariables, commentParser.parseStringConfig(directiveValue, comment));
                     break;

--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -295,7 +295,11 @@ function getDirectiveComments(filename, ast, ruleMapper, warnInlineConfig) {
         const directiveText = match[1];
         const lineCommentSupported = /^eslint-disable-(next-)?line$/u.test(directiveText);
 
-        if (warnInlineConfig && (lineCommentSupported || comment.type === "Block")) {
+        if (comment.type === "Line" && !lineCommentSupported) {
+            return;
+        }
+
+        if (warnInlineConfig) {
             const kind = comment.type === "Block" ? `/*${directiveText}*/` : `//${directiveText}`;
 
             problems.push(createLintingProblem({
@@ -307,100 +311,105 @@ function getDirectiveComments(filename, ast, ruleMapper, warnInlineConfig) {
             return;
         }
 
+        if (lineCommentSupported && comment.loc.start.line !== comment.loc.end.line) {
+            const message = `${directiveText} comment should not span multiple lines.`;
+
+            problems.push(createLintingProblem({
+                ruleId: null,
+                message,
+                loc: comment.loc
+            }));
+            return;
+        }
+
         const directiveValue = trimmedCommentText.slice(match.index + directiveText.length);
         let directiveType = "";
 
-        if (lineCommentSupported) {
-            if (comment.loc.start.line === comment.loc.end.line) {
-                directiveType = directiveText.slice("eslint-".length);
-            } else {
-                const message = `${directiveText} comment should not span multiple lines.`;
+        switch (directiveText) {
+            case "eslint-disable-next-line":
+                directiveType = "disable-next-line";
+                break;
 
-                problems.push(createLintingProblem({
-                    ruleId: null,
-                    message,
-                    loc: comment.loc
-                }));
-            }
-        } else if (comment.type === "Block") {
-            switch (directiveText) {
-                case "exported":
-                    Object.assign(exportedVariables, commentParser.parseStringConfig(directiveValue, comment));
-                    break;
+            case "eslint-disable-line":
+                directiveType = "disable-line";
+                break;
 
-                case "globals":
-                case "global":
-                    for (const [id, { value }] of Object.entries(commentParser.parseStringConfig(directiveValue, comment))) {
-                        let normalizedValue;
+            case "exported":
+                Object.assign(exportedVariables, commentParser.parseStringConfig(directiveValue, comment));
+                break;
+
+            case "globals":
+            case "global":
+                for (const [id, { value }] of Object.entries(commentParser.parseStringConfig(directiveValue, comment))) {
+                    let normalizedValue;
+
+                    try {
+                        normalizedValue = ConfigOps.normalizeConfigGlobal(value);
+                    } catch (err) {
+                        problems.push(createLintingProblem({
+                            ruleId: null,
+                            loc: comment.loc,
+                            message: err.message
+                        }));
+                        continue;
+                    }
+
+                    if (enabledGlobals[id]) {
+                        enabledGlobals[id].comments.push(comment);
+                        enabledGlobals[id].value = normalizedValue;
+                    } else {
+                        enabledGlobals[id] = {
+                            comments: [comment],
+                            value: normalizedValue
+                        };
+                    }
+                }
+                break;
+
+            case "eslint-disable":
+                directiveType = "disable";
+                break;
+
+            case "eslint-enable":
+                directiveType = "enable";
+                break;
+
+            case "eslint": {
+                const parseResult = commentParser.parseJsonConfig(directiveValue, comment.loc);
+
+                if (parseResult.success) {
+                    Object.keys(parseResult.config).forEach(name => {
+                        const rule = ruleMapper(name);
+                        const ruleValue = parseResult.config[name];
+
+                        if (rule === null) {
+                            problems.push(createLintingProblem({ ruleId: name, loc: comment.loc }));
+                            return;
+                        }
 
                         try {
-                            normalizedValue = ConfigOps.normalizeConfigGlobal(value);
+                            validator.validateRuleOptions(rule, name, ruleValue);
                         } catch (err) {
                             problems.push(createLintingProblem({
-                                ruleId: null,
-                                loc: comment.loc,
-                                message: err.message
+                                ruleId: name,
+                                message: err.message,
+                                loc: comment.loc
                             }));
-                            continue;
+
+                            // do not apply the config, if found invalid options.
+                            return;
                         }
 
-                        if (enabledGlobals[id]) {
-                            enabledGlobals[id].comments.push(comment);
-                            enabledGlobals[id].value = normalizedValue;
-                        } else {
-                            enabledGlobals[id] = {
-                                comments: [comment],
-                                value: normalizedValue
-                            };
-                        }
-                    }
-                    break;
-
-                case "eslint-disable":
-                    directiveType = "disable";
-                    break;
-
-                case "eslint-enable":
-                    directiveType = "enable";
-                    break;
-
-                case "eslint": {
-                    const parseResult = commentParser.parseJsonConfig(directiveValue, comment.loc);
-
-                    if (parseResult.success) {
-                        Object.keys(parseResult.config).forEach(name => {
-                            const rule = ruleMapper(name);
-                            const ruleValue = parseResult.config[name];
-
-                            if (rule === null) {
-                                problems.push(createLintingProblem({ ruleId: name, loc: comment.loc }));
-                                return;
-                            }
-
-                            try {
-                                validator.validateRuleOptions(rule, name, ruleValue);
-                            } catch (err) {
-                                problems.push(createLintingProblem({
-                                    ruleId: name,
-                                    message: err.message,
-                                    loc: comment.loc
-                                }));
-
-                                // do not apply the config, if found invalid options.
-                                return;
-                            }
-
-                            configuredRules[name] = ruleValue;
-                        });
-                    } else {
-                        problems.push(parseResult.error);
-                    }
-
-                    break;
+                        configuredRules[name] = ruleValue;
+                    });
+                } else {
+                    problems.push(parseResult.error);
                 }
 
-                // no default
+                break;
             }
+
+            // no default
         }
 
         if (directiveType !== "") {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] Other, please explain:

Clean up somewhat confusing code.

**What changes did you make? (Give an overview)**

While exploring what would be required to implement [RFC #34](https://github.com/eslint/rfcs/pull/34) I looked into this code and found it more confusing than it needs to be.

This refactor untagles some logic having to do with parsing inline directives

There are a few thing going on in this function which were getting conflated:

1. Parsing a `directiveType` out of the comment.
2. Ignoring directives that are in line comments but only support block comments.
3. Warning on and ignoring line comments that span multiple lines.

Previously these three pieces of functionality were tightly coupled which made the code harder to read. After this change each task is handled independently of the other.


**Is there anything you'd like reviewers to focus on?**

GitHub makes this diff look more significant than it really is. The change actually consists of a few small changes:

1. Explicitly ignore line comments for directives that don't support line comments. Previously this was done implicitly because these instances would pass neither the `if(lineCommentSupported)` nor the `else if (comment.type === "Block")` case and thus fall through without ever getting a 
`directiveType` assigned.
2. Derive a `directiveType` for `eslint-disable-next-line` and `eslint-disable-line` the same way we handle all other directives.

The content of all pre-existing case statements have not actually changed.

