### PR TITLE
Update: curly multi-or-nest flagging semis on next line (fixes #12370)

### DIFF
--- a/lib/rules/curly.js
+++ b/lib/rules/curly.js
@@ -97,10 +97,15 @@ module.exports = {
          * @private
          */
         function isOneLiner(node) {
-            const first = sourceCode.getFirstToken(node),
-                last = sourceCode.getLastToken(node);
+            if (node.type === "EmptyStatement") {
+                return true;
+            }
 
-            return first.loc.start.line === last.loc.end.line;
+            const first = sourceCode.getFirstToken(node);
+            const last = sourceCode.getLastToken(node);
+            const lastExcludingSemicolon = astUtils.isSemicolonToken(last) ? sourceCode.getTokenBefore(last) : last;
+
+            return first.loc.start.line === lastExcludingSemicolon.loc.end.line;
         }
 
         /**

--- a/tests/lib/rules/curly.js
+++ b/tests/lib/rules/curly.js
@@ -216,11 +216,48 @@ ruleTester.run("curly", rule, {
             parserOptions: { ecmaVersion: 6 }
         },
         {
-            code: "while (true) doSomething() \n ;",
+            code: "while (foo) doSomething() \n ;",
             options: ["multi-or-nest"]
         },
         {
             code: "do doSomething() \n ;while (foo)",
+            options: ["multi-or-nest"]
+        },
+        {
+            code: "if (foo)\n;",
+            options: ["multi-or-nest"]
+        },
+        {
+            code: "if (foo) doSomething(); \n else if (bar)\n;",
+            options: ["multi-or-nest"]
+        },
+        {
+            code: "if (foo) doSomething(); \n else\n;",
+            options: ["multi-or-nest"]
+        },
+        {
+            code: "if (foo) doSomething(); \n else if (bar) doSomethingElse(); \n else\n;",
+            options: ["multi-or-nest"]
+        },
+        {
+            code: "for (var i = 0; foo; i++)\n;",
+            options: ["multi-or-nest"]
+        },
+        {
+            code: "for (var foo in bar)\n;",
+            options: ["multi-or-nest"]
+        },
+        {
+            code: "for (var foo of bar)\n;",
+            options: ["multi-or-nest"],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "while (foo)\n;",
+            options: ["multi-or-nest"]
+        },
+        {
+            code: "do\n;while (foo)",
             options: ["multi-or-nest"]
         },
 
@@ -936,6 +973,57 @@ ruleTester.run("curly", rule, {
             output: "if (true)\n{foo()\n;}[1, 2, 3].bar()",
             options: ["multi-line"],
             errors: [{ messageId: "missingCurlyAfterCondition", data: { name: "if" }, type: "IfStatement" }]
+        },
+
+        // https://github.com/eslint/eslint/issues/12370
+        {
+            code: "if (foo) {\ndoSomething()\n;\n}",
+            output: "if (foo) \ndoSomething()\n;\n",
+            options: ["multi-or-nest"],
+            errors: [{ messageId: "unexpectedCurlyAfterCondition", data: { name: "if" }, type: "IfStatement" }]
+        },
+        {
+            code: "if (foo) doSomething();\nelse if (bar) {\ndoSomethingElse()\n;\n}",
+            output: "if (foo) doSomething();\nelse if (bar) \ndoSomethingElse()\n;\n",
+            options: ["multi-or-nest"],
+            errors: [{ messageId: "unexpectedCurlyAfterCondition", data: { name: "if" }, type: "IfStatement" }]
+        },
+        {
+            code: "if (foo) doSomething();\nelse {\ndoSomethingElse()\n;\n}",
+            output: "if (foo) doSomething();\nelse \ndoSomethingElse()\n;\n",
+            options: ["multi-or-nest"],
+            errors: [{ messageId: "unexpectedCurlyAfter", data: { name: "else" }, type: "IfStatement" }]
+        },
+        {
+            code: "for (var i = 0; foo; i++) {\ndoSomething()\n;\n}",
+            output: "for (var i = 0; foo; i++) \ndoSomething()\n;\n",
+            options: ["multi-or-nest"],
+            errors: [{ messageId: "unexpectedCurlyAfterCondition", data: { name: "for" }, type: "ForStatement" }]
+        },
+        {
+            code: "for (var foo in bar) {\ndoSomething()\n;\n}",
+            output: "for (var foo in bar) \ndoSomething()\n;\n",
+            options: ["multi-or-nest"],
+            errors: [{ messageId: "unexpectedCurlyAfter", data: { name: "for-in" }, type: "ForInStatement" }]
+        },
+        {
+            code: "for (var foo of bar) {\ndoSomething()\n;\n}",
+            output: "for (var foo of bar) \ndoSomething()\n;\n",
+            options: ["multi-or-nest"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ messageId: "unexpectedCurlyAfter", data: { name: "for-of" }, type: "ForOfStatement" }]
+        },
+        {
+            code: "while (foo) {\ndoSomething()\n;\n}",
+            output: "while (foo) \ndoSomething()\n;\n",
+            options: ["multi-or-nest"],
+            errors: [{ messageId: "unexpectedCurlyAfterCondition", data: { name: "while" }, type: "WhileStatement" }]
+        },
+        {
+            code: "do {\ndoSomething()\n;\n} while (foo)",
+            output: "do \ndoSomething()\n;\n while (foo)",
+            options: ["multi-or-nest"],
+            errors: [{ messageId: "unexpectedCurlyAfter", data: { name: "do" }, type: "DoWhileStatement" }]
         }
     ]
 });

--- a/tests/lib/rules/curly.js
+++ b/tests/lib/rules/curly.js
@@ -185,6 +185,45 @@ ruleTester.run("curly", rule, {
             parserOptions: { ecmaVersion: 6 }
         },
 
+        // https://github.com/eslint/eslint/issues/12370
+        {
+            code: "if (foo) doSomething() \n ;",
+            options: ["multi-or-nest"]
+        },
+        {
+            code: "if (foo) doSomething(); \n else if (bar) doSomethingElse() \n ;",
+            options: ["multi-or-nest"]
+        },
+        {
+            code: "if (foo) doSomething(); \n else doSomethingElse() \n ;",
+            options: ["multi-or-nest"]
+        },
+        {
+            code: "if (foo) doSomething(); \n else if (bar) doSomethingElse(); \n else doAnotherThing() \n ;",
+            options: ["multi-or-nest"]
+        },
+        {
+            code: "for (var i = 0; foo; i++) doSomething() \n ;",
+            options: ["multi-or-nest"]
+        },
+        {
+            code: "for (var foo in bar) console.log(foo) \n ;",
+            options: ["multi-or-nest"]
+        },
+        {
+            code: "for (var foo of bar) console.log(foo) \n ;",
+            options: ["multi-or-nest"],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "while (true) doSomething() \n ;",
+            options: ["multi-or-nest"]
+        },
+        {
+            code: "do doSomething() \n ;while (foo)",
+            options: ["multi-or-nest"]
+        },
+
         // https://github.com/eslint/eslint/issues/3856
         {
             code: "if (true) { if (false) console.log(1) } else console.log(2)",


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix

Fixes #12370.

**What changes did you make? (Give an overview)**

I made the `isOneLiner` function use the last token excluding the semicolon instead of just the last token, like the `isCollapsedOneLiner` function, which stopped multi-or-nest flagging code like the following as one line.
```js
console.log('foo')
;
```


**Is there anything you'd like reviewers to focus on?**

No.