### PR TITLE
Update: Add enforceForIndexOf option to use-isnan (fixes #12207)

### DIFF
--- a/docs/rules/use-isnan.md
+++ b/docs/rules/use-isnan.md
@@ -45,10 +45,8 @@ if (!isNaN(foo)) {
 
 This rule has an object option, with two options:
 
-* `"enforceForSwitchCase"` when set to `true` disallows `case NaN` and `switch(NaN)` in `switch` statements. Default is `false`, meaning
-that this rule by default does not warn about `case NaN` or `switch(NaN)`.
-* `"enforceForIndexOf"` when set to `true` disallows the use of `Array` prototype methods `indexOf` and `lastIndexOf` with `NaN`. Default is `false`, meaning
-that this rule by default does not warn about `indexOf(NaN)` or `lastIndexOf(NaN)` method calls.
+* `"enforceForSwitchCase"` when set to `true` disallows `case NaN` and `switch(NaN)` in `switch` statements. Default is `false`, meaning that this rule by default does not warn about `case NaN` or `switch(NaN)`.
+* `"enforceForIndexOf"` when set to `true` disallows the use of `indexOf` and `lastIndexOf` methods with `NaN`. Default is `false`, meaning that this rule by default does not warn about `indexOf(NaN)` or `lastIndexOf(NaN)` method calls.
 
 ### enforceForSwitchCase
 

--- a/docs/rules/use-isnan.md
+++ b/docs/rules/use-isnan.md
@@ -43,10 +43,12 @@ if (!isNaN(foo)) {
 
 ## Options
 
-This rule has an object option, with one option:
+This rule has an object option, with two options:
 
 * `"enforceForSwitchCase"` when set to `true` disallows `case NaN` and `switch(NaN)` in `switch` statements. Default is `false`, meaning
 that this rule by default does not warn about `case NaN` or `switch(NaN)`.
+* `"enforceForIndexOf"` when set to `true` disallows the use of `Array` prototype methods `indexOf` and `lastIndexOf` with `NaN`. Default is `false`, meaning
+that this rule by default does not warn about `indexOf(NaN)` or `lastIndexOf(NaN)` method calls.
 
 ### enforceForSwitchCase
 
@@ -103,3 +105,75 @@ if (Number.isNaN(a)) {
     baz();
 } // ...
 ```
+
+### enforceForIndexOf
+
+The following methods internally use the `===` comparison to match the given value with an array element:
+
+* [`Array.prototype.indexOf`](https://www.ecma-international.org/ecma-262/6.0/#sec-array.prototype.indexof)
+* [`Array.prototype.lastIndexOf`](https://www.ecma-international.org/ecma-262/6.0/#sec-array.prototype.lastindexof)
+
+Therefore, for any array `foo`, `foo.indexOf(NaN)` and `foo.lastIndexOf(NaN)` will always return `-1`.
+
+Set `"enforceForIndexOf"` to `true` if you want this rule to report `indexOf(NaN)` and `lastIndexOf(NaN)` method calls.
+
+Examples of **incorrect** code for this rule with `"enforceForIndexOf"` option set to `true`:
+
+```js
+/*eslint use-isnan: ["error", {"enforceForIndexOf": true}]*/
+
+var hasNaN = myArray.indexOf(NaN) >= 0;
+
+var firstIndex = myArray.indexOf(NaN);
+
+var lastIndex = myArray.lastIndexOf(NaN);
+```
+
+Examples of **correct** code for this rule with `"enforceForIndexOf"` option set to `true`:
+
+```js
+/*eslint use-isnan: ["error", {"enforceForIndexOf": true}]*/
+
+function myIsNaN(val) {
+    return typeof val === "number" && isNaN(val);
+}
+
+function indexOfNaN(arr) {
+    for (var i = 0; i < arr.length; i++) {
+        if (myIsNaN(arr[i])) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+function lastIndexOfNaN(arr) {
+    for (var i = arr.length - 1; i >= 0; i--) {
+        if (myIsNaN(arr[i])) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+var hasNaN = myArray.some(myIsNaN);
+
+var hasNaN = indexOfNaN(myArray) >= 0;
+
+var firstIndex = indexOfNaN(myArray);
+
+var lastIndex = lastIndexOfNaN(myArray);
+
+// ES2015
+var hasNaN = myArray.some(Number.isNaN);
+
+// ES2015
+var firstIndex = myArray.findIndex(Number.isNaN);
+
+// ES2016
+var hasNaN = myArray.includes(NaN);
+```
+
+#### Known Limitations
+
+This option checks methods with the given names, *even if* the object which has the method is *not* an array.

--- a/tests/lib/rules/use-isnan.js
+++ b/tests/lib/rules/use-isnan.js
@@ -114,6 +114,102 @@ ruleTester.run("use-isnan", rule, {
         {
             code: "switch(foo) { case bar: break; case 1: break; default: break; }",
             options: [{ enforceForSwitchCase: true }]
+        },
+
+        //------------------------------------------------------------------------------
+        // enforceForIndexOf
+        //------------------------------------------------------------------------------
+
+        "foo.indexOf(NaN)",
+        "foo.lastIndexOf(NaN)",
+        {
+            code: "foo.indexOf(NaN)",
+            options: [{}]
+        },
+        {
+            code: "foo.lastIndexOf(NaN)",
+            options: [{}]
+        },
+        {
+            code: "foo.indexOf(NaN)",
+            options: [{ enforceForIndexOf: false }]
+        },
+        {
+            code: "foo.lastIndexOf(NaN)",
+            options: [{ enforceForIndexOf: false }]
+        },
+        {
+            code: "indexOf(NaN)",
+            options: [{ enforceForIndexOf: true }]
+        },
+        {
+            code: "lastIndexOf(NaN)",
+            options: [{ enforceForIndexOf: true }]
+        },
+        {
+            code: "new foo.indexOf(NaN)",
+            options: [{ enforceForIndexOf: true }]
+        },
+        {
+            code: "foo.bar(NaN)",
+            options: [{ enforceForIndexOf: true }]
+        },
+        {
+            code: "foo.IndexOf(NaN)",
+            options: [{ enforceForIndexOf: true }]
+        },
+        {
+            code: "foo[indexOf](NaN)",
+            options: [{ enforceForIndexOf: true }]
+        },
+        {
+            code: "foo[lastIndexOf](NaN)",
+            options: [{ enforceForIndexOf: true }]
+        },
+        {
+            code: "indexOf.foo(NaN)",
+            options: [{ enforceForIndexOf: true }]
+        },
+        {
+            code: "foo.indexOf()",
+            options: [{ enforceForIndexOf: true }]
+        },
+        {
+            code: "foo.lastIndexOf()",
+            options: [{ enforceForIndexOf: true }]
+        },
+        {
+            code: "foo.indexOf(a)",
+            options: [{ enforceForIndexOf: true }]
+        },
+        {
+            code: "foo.lastIndexOf(Nan)",
+            options: [{ enforceForIndexOf: true }]
+        },
+        {
+            code: "foo.indexOf(a, NaN)",
+            options: [{ enforceForIndexOf: true }]
+        },
+        {
+            code: "foo.lastIndexOf(NaN, b)",
+            options: [{ enforceForIndexOf: true }]
+        },
+        {
+            code: "foo.indexOf(a, b)",
+            options: [{ enforceForIndexOf: true }]
+        },
+        {
+            code: "foo.lastIndexOf(NaN, NaN)",
+            options: [{ enforceForIndexOf: true }]
+        },
+        {
+            code: "foo.indexOf(...NaN)",
+            options: [{ enforceForIndexOf: true }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "foo.lastIndexOf(NaN())",
+            options: [{ enforceForIndexOf: true }]
         }
     ],
     invalid: [
@@ -246,6 +342,41 @@ ruleTester.run("use-isnan", rule, {
                 { messageId: "switchNaN", type: "SwitchStatement", column: 1 },
                 { messageId: "caseNaN", type: "SwitchCase", column: 15 }
             ]
+        },
+
+        //------------------------------------------------------------------------------
+        // enforceForIndexOf
+        //------------------------------------------------------------------------------
+
+        {
+            code: "foo.indexOf(NaN)",
+            options: [{ enforceForIndexOf: true }],
+            errors: [{ messageId: "indexOfNaN", type: "CallExpression", data: { methodName: "indexOf" } }]
+        },
+        {
+            code: "foo.lastIndexOf(NaN)",
+            options: [{ enforceForIndexOf: true }],
+            errors: [{ messageId: "indexOfNaN", type: "CallExpression", data: { methodName: "lastIndexOf" } }]
+        },
+        {
+            code: "foo['indexOf'](NaN)",
+            options: [{ enforceForIndexOf: true }],
+            errors: [{ messageId: "indexOfNaN", type: "CallExpression", data: { methodName: "indexOf" } }]
+        },
+        {
+            code: "foo['lastIndexOf'](NaN)",
+            options: [{ enforceForIndexOf: true }],
+            errors: [{ messageId: "indexOfNaN", type: "CallExpression", data: { methodName: "lastIndexOf" } }]
+        },
+        {
+            code: "foo().indexOf(NaN)",
+            options: [{ enforceForIndexOf: true }],
+            errors: [{ messageId: "indexOfNaN", type: "CallExpression", data: { methodName: "indexOf" } }]
+        },
+        {
+            code: "foo.bar.lastIndexOf(NaN)",
+            options: [{ enforceForIndexOf: true }],
+            errors: [{ messageId: "indexOfNaN", type: "CallExpression", data: { methodName: "lastIndexOf" } }]
         }
     ]
 });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Changes an existing rule #12207

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

Examples of **incorrect** code for this rule with `"enforceForIndexOf"` option set to `true`:

```js
/*eslint use-isnan: ["error", {"enforceForIndexOf": true}]*/

var hasNaN = myArray.indexOf(NaN) >= 0;

var firstIndex = myArray.indexOf(NaN);

var lastIndex = myArray.lastIndexOf(NaN);
```

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

New option `enforceForIndexOf` in the `use-isnan` rule.

**Is there anything you'd like reviewers to focus on?**

It seemed too complex to have an advice in the message since it depends on whether the user wants to find index or just check for existence, and also what environments are available. There are examples in the docs for different environments.
