### PR TITLE
Update: Allow JSX exception in no-inline-comments (fixes #11270)

### DIFF
--- a/docs/rules/no-inline-comments.md
+++ b/docs/rules/no-inline-comments.md
@@ -35,3 +35,55 @@ var foo = 5;
 var bar = 5;
 //This is a comment below a line of code
 ```
+
+### JSX exception
+
+Comments inside the curly braces in JSX are allowed to be on the same line as the braces, but only if they are not on the same line with other code, and the braces do not enclose an actual expression.
+
+Examples of **incorrect** code for this rule:
+
+```js
+/*eslint no-inline-comments: "error"*/
+
+var foo = <div>{ /* On the same line with other code */ }<h1>Some heading</h1></div>;
+
+var bar = (
+    <div>
+    {   // These braces are not just for the comment, so it can't be on the same line
+        baz
+    }
+    </div>
+);
+```
+
+Examples of **correct** code for this rule:
+
+```js
+/*eslint no-inline-comments: "error"*/
+
+var foo = (
+    <div>
+      {/* These braces are just for this comment and there is nothing else on this line */}
+      <h1>Some heading</h1>
+    </div>
+)
+
+var bar = (
+    <div>
+    {
+        // There is nothing else on this line
+        baz
+    }
+    </div>
+);
+
+var quux = (
+    <div>
+      {/*
+        Multiline
+        comment
+      */}
+      <h1>Some heading</h1>
+    </div>
+)
+```

--- a/tests/lib/rules/no-inline-comments.js
+++ b/tests/lib/rules/no-inline-comments.js
@@ -15,7 +15,13 @@ const rule = require("../../../lib/rules/no-inline-comments"),
 // Tests
 //------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester(),
+const ruleTester = new RuleTester({
+        parserOptions: {
+            ecmaFeatures: {
+                jsx: true
+            }
+        }
+    }),
     lineError = {
         message: "Unexpected comment inline with code.",
         type: "Line"
@@ -32,7 +38,57 @@ ruleTester.run("no-inline-comments", rule, {
         "var a = 2;\n// A valid comment after code",
         "// A solitary comment",
         "var a = 1; // eslint-disable-line no-debugger",
-        "var a = 1; /* eslint-disable-line no-debugger */"
+        "var a = 1; /* eslint-disable-line no-debugger */",
+
+        // JSX exception
+        `var a = (
+            <div>
+            {/*comment*/}
+            </div>
+        )`,
+        `var a = (
+            <div>
+            { /* comment */ }
+            <h1>Some heading</h1>
+            </div>
+        )`,
+        `var a = (
+            <div>
+            {// comment
+            }
+            </div>
+        )`,
+        `var a = (
+            <div>
+            { // comment
+            }
+            </div>
+        )`,
+        `var a = (
+            <div>
+            {/* comment 1 */
+            /* comment 2 */}
+            </div>
+        )`,
+        `var a = (
+            <div>
+            {/*
+              * comment 1
+              */
+             /*
+              * comment 2
+              */}
+            </div>
+        )`,
+        `var a = (
+            <div>
+            {/*
+               multi
+               line
+               comment
+            */}
+            </div>
+        )`
     ],
 
     invalid: [
@@ -55,7 +111,240 @@ ruleTester.run("no-inline-comments", rule, {
         {
             code: "var a = 4;\n/**A\n * block\n * comment\n * inline\n * between\n * code*/ var foo = a;",
             errors: [blockError]
+        },
+        {
+            code: "var a = \n{/**/}",
+            errors: [blockError]
+        },
+
+        // JSX
+        {
+            code: `var a = (
+                <div>{/* comment */}</div>
+            )`,
+            errors: [blockError]
+        },
+        {
+            code: `var a = (
+                <div>{// comment
+                }
+                </div>
+            )`,
+            errors: [lineError]
+        },
+        {
+            code: `var a = (
+                <div>{/* comment */
+                }
+                </div>
+            )`,
+            errors: [blockError]
+        },
+        {
+            code: `var a = (
+                <div>{/*
+                       * comment
+                       */
+                }
+                </div>
+            )`,
+            errors: [blockError]
+        },
+        {
+            code: `var a = (
+                <div>{/*
+                       * comment
+                       */}
+                </div>
+            )`,
+            errors: [blockError]
+        },
+        {
+            code: `var a = (
+                <div>{/*
+                       * comment
+                       */}</div>
+            )`,
+            errors: [blockError]
+        },
+        {
+            code: `var a = (
+                <div>
+                {/*
+                  * comment
+                  */}</div>
+            )`,
+            errors: [blockError]
+        },
+        {
+            code: `var a = (
+                <div>
+                {
+                 /*
+                  * comment
+                  */}</div>
+            )`,
+            errors: [blockError]
+        },
+        {
+            code: `var a = (
+                <div>
+                {
+                /* comment */}</div>
+            )`,
+            errors: [blockError]
+        },
+        {
+            code: `var a = (
+                <div>
+                {b/* comment */}
+                </div>
+            )`,
+            errors: [blockError]
+        },
+        {
+            code: `var a = (
+                <div>
+                {/* comment */b}
+                </div>
+            )`,
+            errors: [blockError]
+        },
+        {
+            code: `var a = (
+                <div>
+                {// comment
+                    b
+                }
+                </div>
+            )`,
+            errors: [lineError]
+        },
+        {
+            code: `var a = (
+                <div>
+                {/* comment */
+                    b
+                }
+                </div>
+            )`,
+            errors: [blockError]
+        },
+        {
+            code: `var a = (
+                <div>
+                {/*
+                  * comment
+                  */
+                    b
+                }
+                </div>
+            )`,
+            errors: [blockError]
+        },
+        {
+            code: `var a = (
+                <div>
+                {
+                    b// comment
+                }
+                </div>
+            )`,
+            errors: [lineError]
+        },
+        {
+            code: `var a = (
+                <div>
+                {
+                    /* comment */b
+                }
+                </div>
+            )`,
+            errors: [blockError]
+        },
+        {
+            code: `var a = (
+                <div>
+                {
+                    b/* comment */
+                }
+                </div>
+            )`,
+            errors: [blockError]
+        },
+        {
+            code: `var a = (
+                <div>
+                {
+                    b
+                /*
+                 * comment
+                 */}
+                </div>
+            )`,
+            errors: [blockError]
+        },
+        {
+            code: `var a = (
+                <div>
+                {
+                    b
+                /* comment */}
+                </div>
+            )`,
+            errors: [blockError]
+        },
+        {
+            code: `var a = (
+                <div>
+                {
+                    { /* this is an empty object literal, not braces for js code! */ }
+                }
+                </div>
+            )`,
+            errors: [blockError]
+        },
+        {
+            code: `var a = (
+                <div>
+                {
+                    {// comment
+                    }
+                }
+                </div>
+            )`,
+            errors: [lineError]
+        },
+        {
+            code: `var a = (
+                <div>
+                {
+                    {
+                    /* comment */}
+                }
+                </div>
+            )`,
+            errors: [blockError]
+        },
+        {
+            code: `var a = (
+                <div>
+                { /* two comments on the same line... */ /* ...are not allowed, same as with a non-JSX code */}
+                </div>
+            )`,
+            errors: [blockError, blockError]
+        },
+        {
+            code: `var a = (
+                <div>
+                {
+                    /* overlapping
+                    */ /*
+                       lines */
+                }
+                </div>
+            )`,
+            errors: [blockError, blockError]
         }
     ]
-
 });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Changes an existing rule #11270

Marked as 'Update' although this change produces fewer warnings by default, because it wasn't a bug.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**What rule do you want to change?**

no-inline-comments

**Does this change cause the rule to produce more or fewer warnings?**

fewer

**How will the change be implemented? (New option, new default behavior, etc.)?**

new default behavior

**Please provide some example code that this change will affect:**

```js
/*eslint no-inline-comments: "error"*/

var foo = (
    <div>
      {/* These braces are just for this comment and there is nothing else on this line */}
      <h1>Some heading</h1>
    </div>
)

var quux = (
    <div>
      {/*
        Multiline
        comment
      */}
      <h1>Some heading</h1>
    </div>
)
```

**What does the rule currently do for this code?**

2 errors.

**What will the rule do after it's changed?**

No errors.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Allow a comment in JSX to be on the same line as the braces (or one brace), only if it there is nothing else on the same line and the braces are for comment only (this generates `JSXEmptyExpression` node).

**Is there anything you'd like reviewers to focus on?**

These are currently errors, and will stay errors:

```js
/*eslint no-inline-comments: "error"*/

var foo = <div>{ /* On the same line with other code */ }<h1>Some heading</h1></div>;

var bar = (
    <div>
    {   // These braces are not just for the comment, so it can't be on the same line
        baz
    }
    </div>
);
```

This was already allowed, and will stay allowed:

```js
var bar = (
    <div>
    {
        // There is nothing else on this line
        baz
    }
    </div>
);
```

Also, two comments on the same line are currently an error everywhere (not just in JSX). This behavior is unchanged.

Labeling as evaluating, as I think it isn't decided yet is this a new default behavior or an option. 

I :+1: for new default behavior. 