### PR TITLE
Update: measure plugin loading time and output in debug message

### DIFF
--- a/lib/cli-engine/config-array-factory.js
+++ b/lib/cli-engine/config-array-factory.js
@@ -859,8 +859,14 @@ class ConfigArrayFactory {
         if (filePath) {
             try {
                 writeDebugLogForLoading(request, relativeTo, filePath);
+
+                const startTime = Date.now();
+                const pluginDefinition = require(filePath);
+
+                debug(`Plugin ${filePath} loaded in: ${Date.now() - startTime}ms`);
+
                 return new ConfigDependency({
-                    definition: normalizePlugin(require(filePath)),
+                    definition: normalizePlugin(pluginDefinition),
                     filePath,
                     id,
                     importerName,


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**What changes did you make? (Give an overview)**
I've added measurement of loading time for each plugin. Times are shown in debug output.

The reason is in unexpectedly significant startup time for some plugins, even when there is nothing to check for them. One possible example:
- ESLint configuration has `typescript-eslint` plugin added
- pre-commit hook is configured to run ESLint on modified files
- the commit does not contain `.ts` files (only `.js`, so ESLint is still launched, but there is nothing for `typescript-eslint` to check)

In this example `typescript-eslint` plugin is still loaded and consumes more than half a second to load https://github.com/typescript-eslint/typescript-eslint/issues/1040

More examples:
- https://github.com/lo1tuma/eslint-plugin-mocha/issues/213
- eslint-plugin-react - adds about 250ms to ESLint startup time
- eslint-plugin-import - adds about 350ms

So in case you added these four plugins, ESLint will require 1.5s to start. It's significant for both CLI tools and for pre-commit hooks. I'd like to know exact timings in order to tune ESLint configuration (pre-commit hook may have the fastest one, CI configuration should have the slowest one).

**Is there anything you'd like reviewers to focus on?**
