### PR TITLE
Docs: Fixes object type for `rules` in "Use a Plugin"

### DIFF
--- a/docs/user-guide/configuring.md
+++ b/docs/user-guide/configuring.md
@@ -376,11 +376,11 @@ For example:
         "plugin:@foo/foo/recommended",
         "plugin:@bar/recommended"
     ],
-    "rules": [
+    "rules": {
         "jquery/a-rule": "error",
         "@foo/foo/some-rule": "error",
         "@bar/another-rule": "error"
-    ],
+    },
     "env": {
         "jquery/jquery": true,
         "@foo/foo/env-foo": true,


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
This patch updates the [Use a Plugin](https://eslint.org/docs/user-guide/configuring#use-a-plugin) example which has `rules` listed as an array instead of a regular object.

**Is there anything you'd like reviewers to focus on?**
This is a very small change because I just happened to notice it while trying to learn how to use `eslint` 😸 

