### PR TITLE
Fix: Add check to avoid null reference. (fixes #12430)

### DIFF
--- a/lib/rules/object-curly-spacing.js
+++ b/lib/rules/object-curly-spacing.js
@@ -177,9 +177,8 @@ module.exports = {
                     options.arraysInObjectsException && astUtils.isClosingBracketToken(penultimate) ||
                     options.objectsInObjectsException && astUtils.isClosingBraceToken(penultimate)
                 );
-                
                 const penultimateNode = shouldCheckPenultimate && sourceCode.getNodeByRangeIndex(penultimate.range[0]);
-                
+
                 const penultimateType = penultimateNode && penultimateNode.type;
 
                 const closingCurlyBraceMustBeSpaced = (

--- a/lib/rules/object-curly-spacing.js
+++ b/lib/rules/object-curly-spacing.js
@@ -177,7 +177,10 @@ module.exports = {
                     options.arraysInObjectsException && astUtils.isClosingBracketToken(penultimate) ||
                     options.objectsInObjectsException && astUtils.isClosingBraceToken(penultimate)
                 );
-                const penultimateType = shouldCheckPenultimate && sourceCode.getNodeByRangeIndex(penultimate.range[0]).type;
+                
+                const penultimateNode = shouldCheckPenultimate && sourceCode.getNodeByRangeIndex(penultimate.range[0]);
+                
+                const penultimateType = penultimateNode && penultimateNode.type;
 
                 const closingCurlyBraceMustBeSpaced = (
                     options.arraysInObjectsException && penultimateType === "ArrayExpression" ||


### PR DESCRIPTION
`getNodeByRangeIndex` has a return path that returns null. Assuming that a 'type' property exists can lead to errors.

<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
https://github.com/eslint/eslint/issues/12430

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->
I don't have tests. It's a simple, straightforward change. I'm also not entirely sure how to replicate the problem, as a node shouldn't be getting this far usually without having a `type` property, so a parser may be to blame. As it is, the `getNodeByRangeIndex` method _does_ have a `null` return path, so this change is valid anyway.

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Added a simple check to make sure an object wasn't null before referencing properties inside it.

**Is there anything you'd like reviewers to focus on?**
No

