### PR TITLE
Fix: array-bracket-newline consistent error with comments (fixes #12416)

### DIFF
--- a/lib/rules/array-bracket-newline.js
+++ b/lib/rules/array-bracket-newline.js
@@ -216,7 +216,7 @@ module.exports = {
                 ) ||
                 (
                     options.consistent &&
-                    firstIncComment.loc.start.line !== openBracket.loc.end.line
+                    openBracket.loc.end.line !== first.loc.start.line
                 )
             );
 

--- a/tests/lib/rules/array-bracket-newline.js
+++ b/tests/lib/rules/array-bracket-newline.js
@@ -65,6 +65,10 @@ ruleTester.run("array-bracket-newline", rule, {
         { code: "var a = [\n]", options: ["consistent"] },
         { code: "var a = [1]", options: ["consistent"] },
         { code: "var a = [\n1\n]", options: ["consistent"] },
+        { code: "var a = [//\n1\n]", options: ["consistent"] },
+        { code: "var a = [/**/\n1\n]", options: ["consistent"] },
+        { code: "var a = [/*\n*/1\n]", options: ["consistent"] },
+        { code: "var a = [//\n]", options: ["consistent"] },
 
         // { multiline: true }
         { code: "var foo = [];", options: [{ multiline: true }] },
@@ -156,6 +160,10 @@ ruleTester.run("array-bracket-newline", rule, {
         { code: "var [\n] = foo", options: ["consistent"], parserOptions: { ecmaVersion: 6 } },
         { code: "var [a] = foo", options: ["consistent"], parserOptions: { ecmaVersion: 6 } },
         { code: "var [\na\n] = foo", options: ["consistent"], parserOptions: { ecmaVersion: 6 } },
+        { code: "var [//\na\n] = foo", options: ["consistent"], parserOptions: { ecmaVersion: 6 } },
+        { code: "var [/**/\na\n] = foo", options: ["consistent"], parserOptions: { ecmaVersion: 6 } },
+        { code: "var [/*\n*/a\n] = foo", options: ["consistent"], parserOptions: { ecmaVersion: 6 } },
+        { code: "var [//\n] = foo", options: ["consistent"], parserOptions: { ecmaVersion: 6 } },
 
         // { multiline: true }
         { code: "var [] = foo;", options: [{ multiline: true }], parserOptions: { ecmaVersion: 6 } },
@@ -526,6 +534,21 @@ ruleTester.run("array-bracket-newline", rule, {
                     column: 1,
                     endLine: 2,
                     endColumn: 2
+                }
+            ]
+        },
+        {
+            code: "var foo = [//\n1]",
+            output: "var foo = [//\n1\n]",
+            options: ["consistent"],
+            errors: [
+                {
+                    messageId: "missingClosingLinebreak",
+                    type: "ArrayExpression",
+                    line: 2,
+                    column: 2,
+                    endLine: 2,
+                    endColumn: 3
                 }
             ]
         },
@@ -1456,6 +1479,22 @@ ruleTester.run("array-bracket-newline", rule, {
                     column: 1,
                     endLine: 2,
                     endColumn: 2
+                }
+            ]
+        },
+        {
+            code: "var [//\na] = foo",
+            output: "var [//\na\n] = foo",
+            options: ["consistent"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "missingClosingLinebreak",
+                    type: "ArrayPattern",
+                    line: 2,
+                    column: 2,
+                    endLine: 2,
+                    endColumn: 3
                 }
             ]
         },


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix #12416

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment**

* **ESLint Version:**  6.5.1
* **Node Version:** 10.16.0
* **npm Version:** 6.9.0

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
  parserOptions: {
    ecmaVersion: 2015,
  }
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**

[Online Demo Link](https://eslint.org/demo#eyJ0ZXh0IjoiLyplc2xpbnQgYXJyYXktYnJhY2tldC1uZXdsaW5lOiBbXCJlcnJvclwiLCBcImNvbnNpc3RlbnRcIl0qL1xuXG5jb25zdCBmb28gPSBbIC8vIGNvbW1lbnRcbiAgMSxcbiAgMlxuXTsiLCJvcHRpb25zIjp7InBhcnNlck9wdGlvbnMiOnsiZWNtYVZlcnNpb24iOjYsInNvdXJjZVR5cGUiOiJzY3JpcHQiLCJlY21hRmVhdHVyZXMiOnt9fSwicnVsZXMiOnt9LCJlbnYiOnt9fX0=)

```js
/*eslint array-bracket-newline: ["error", "consistent"]*/

const foo = [ // comment
  1,
  2
];
```

**What did you expect to happen?**

No errors.

**What actually happened? Please include the actual, raw output from ESLint.**

```
  3:13  error  There should be no linebreak after '['   array-bracket-newline
  6:1   error  There should be no linebreak before ']'  array-bracket-newline
```

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Check for the linebreak between `[` and the first non-comment token inside, instead of between `[` and the first token including comments.

**Is there anything you'd like reviewers to focus on?**

This was certainly unexpected behavior of the `consistent` option, given that `always` option doesn't report errors on the same code ([Demo Link](https://eslint.org/demo#eyJ0ZXh0IjoiLyplc2xpbnQgYXJyYXktYnJhY2tldC1uZXdsaW5lOiBbXCJlcnJvclwiLCBcImFsd2F5c1wiXSovXG5cbmNvbnN0IGZvbyA9IFsgLy8gY29tbWVudFxuICAxLFxuICAyXG5dOyIsIm9wdGlvbnMiOnsicGFyc2VyT3B0aW9ucyI6eyJlY21hVmVyc2lvbiI6Niwic291cmNlVHlwZSI6InNjcmlwdCIsImVjbWFGZWF0dXJlcyI6e319LCJydWxlcyI6e30sImVudiI6e319fQ==)).

All tests added in `valid` were invalid before this change.

Two added `invalid` tests were already invalid, but in a different way. The rule was reporting unexpected linebreaks after the opening brackets ([Demo Link](https://eslint.org/demo#eyJ0ZXh0IjoiLyplc2xpbnQgYXJyYXktYnJhY2tldC1uZXdsaW5lOiBbXCJlcnJvclwiLCBcImNvbnNpc3RlbnRcIl0qL1xuXG52YXIgZm9vID0gWy8vXG4gIDFdO1xuXG52YXIgWy8vXG4gIGFdID0gZm9vOyIsIm9wdGlvbnMiOnsicGFyc2VyT3B0aW9ucyI6eyJlY21hVmVyc2lvbiI6Niwic291cmNlVHlwZSI6InNjcmlwdCIsImVjbWFGZWF0dXJlcyI6e319LCJydWxlcyI6e30sImVudiI6e319fQ==)). After the change, the rule will report missing linebreaks before the closing brackets.

I think that this change in general cannot generate more warnings - arrays/patterns that were valid will stay valid. The only difference, apart from fixing the original example, is in what the rule reports in cases such as those two invalid.
