### PR TITLE
Fix: added react configuration in eslint init

### DIFF
--- a/lib/init/config-initializer.js
+++ b/lib/init/config-initializer.js
@@ -291,6 +291,7 @@ function processAnswers(answers) {
             jsx: true
         };
         config.plugins = ["react"];
+        config.extends.push("plugin:react/recommended");
     } else if (answers.framework === "vue") {
         config.plugins = ["vue"];
         config.extends.push("plugin:vue/essential");


### PR DESCRIPTION
this fixes the issue when eslint detect react components as unused var when they are added in brackets. also fixes other false warnings

https://github.com/yannickcr/eslint-plugin-react#configuration