### PR TITLE
Update: add react plugin config for eslint init

### DIFF
--- a/lib/init/config-initializer.js
+++ b/lib/init/config-initializer.js
@@ -291,6 +291,7 @@ function processAnswers(answers) {
             jsx: true
         };
         config.plugins = ["react"];
+        config.extends.push("plugin:react/recommended");
     } else if (answers.framework === "vue") {
         config.plugins = ["vue"];
         config.extends.push("plugin:vue/essential");


### PR DESCRIPTION
This add the recommended config for eslint-plugin-react when using `eslint --init`
doc: https://github.com/yannickcr/eslint-plugin-react#configuration

Without it, eslint detects React components and other stuff as unused vars, while they are used in jsx tags


