### PR TITLE
New: Add resolveRelativeToConfigFile setting (fixes #3458)

### DIFF
--- a/conf/config-schema.js
+++ b/conf/config-schema.js
@@ -22,6 +22,7 @@ const baseConfigProperties = {
     settings: { type: "object" },
     noInlineConfig: { type: "boolean" },
     reportUnusedDisableDirectives: { type: "boolean" },
+    resolveRelativeToConfigFile: { type: "boolean" },
 
     ecmaFeatures: { type: "object" } // deprecated; logs a warning when used
 };

--- a/lib/cli-engine/config-array-factory.js
+++ b/lib/cli-engine/config-array-factory.js
@@ -346,7 +346,12 @@ class ConfigArrayFactory {
         cwd = process.cwd(),
         resolvePluginsRelativeTo = cwd
     } = {}) {
-        internalSlotsMap.set(this, { additionalPluginPool, cwd, resolvePluginsRelativeTo: path.resolve(cwd, resolvePluginsRelativeTo) });
+        internalSlotsMap.set(this, {
+            additionalPluginPool,
+            cwd,
+            resolvePluginsRelativeTo: path.resolve(cwd, resolvePluginsRelativeTo),
+            resolveRelativeToConfigFile: false
+        });
     }
 
     /**
@@ -532,6 +537,7 @@ class ConfigArrayFactory {
             plugins: pluginList,
             processor,
             reportUnusedDisableDirectives,
+            resolveRelativeToConfigFile,
             root,
             rules,
             settings,
@@ -540,6 +546,23 @@ class ConfigArrayFactory {
         filePath,
         name
     ) {
+        if (resolveRelativeToConfigFile) {
+            const internalSlot = internalSlotsMap.get(this);
+
+            /*
+             * If we encounter a config file with resolveRelativeToConfigFile=true, then we enable that behavior
+             * permanently for all subsequent config files.  This approach is needed because ESLint normally waits
+             * to calculate config options until after everything is loaded, wheres plugins get loaded right away.
+             * This design isn't ideal, but it works in practice because "resolveRelativeToConfigFile" has a
+             * relatively simple use case:  It opts-in to the modern module resolution behavior that eventually
+             * should be the default for ESLint.
+             */
+            if (!internalSlot.resolveRelativeToConfigFile) {
+                debug("Plugins will be resolved using the resolveRelativeToConfigFile behavior");
+                internalSlot.resolveRelativeToConfigFile = true;
+            }
+        }
+
         const extendList = Array.isArray(extend) ? extend : [extend];
 
         // Flatten `extends`.
@@ -842,7 +865,13 @@ class ConfigArrayFactory {
         let error;
 
         try {
-            filePath = ModuleResolver.resolve(request, relativeTo);
+            const { resolveRelativeToConfigFile } = internalSlotsMap.get(this);
+
+            if (resolveRelativeToConfigFile) {
+                filePath = ModuleResolver.resolve(request, importerPath);
+            } else {
+                filePath = ModuleResolver.resolve(request, relativeTo);
+            }
         } catch (resolveError) {
             error = resolveError;
             /* istanbul ignore else */

--- a/lib/cli-engine/config-array/config-array.js
+++ b/lib/cli-engine/config-array/config-array.js
@@ -60,6 +60,7 @@ const { ExtractedConfig } = require("./extracted-config");
  * @property {Record<string, DependentPlugin>|undefined} plugins The plugin loaders.
  * @property {string|undefined} processor The processor name to refer plugin's processor.
  * @property {boolean|undefined} reportUnusedDisableDirectives The flag to report unused `eslint-disable` comments.
+ * @property {boolean|undefined} resolveRelativeToConfigFile When set to `true`, plugins are resolved relative to the config file that imports them.
  * @property {boolean|undefined} root The flag to express root.
  * @property {Record<string, RuleConf>|undefined} rules The rule settings
  * @property {Object|undefined} settings The shared settings.
@@ -258,6 +259,11 @@ function createConfig(instance, indices) {
         // Adopt the reportUnusedDisableDirectives which was found at first.
         if (config.reportUnusedDisableDirectives === void 0 && element.reportUnusedDisableDirectives !== void 0) {
             config.reportUnusedDisableDirectives = element.reportUnusedDisableDirectives;
+        }
+
+        // Adopt the resolveRelativeToConfigFile which was found at first.
+        if (config.resolveRelativeToConfigFile === void 0 && element.resolveRelativeToConfigFile !== void 0) {
+            config.resolveRelativeToConfigFile = element.resolveRelativeToConfigFile;
         }
 
         // Merge others.

--- a/lib/cli-engine/config-array/extracted-config.js
+++ b/lib/cli-engine/config-array/extracted-config.js
@@ -84,6 +84,12 @@ class ExtractedConfig {
         this.reportUnusedDisableDirectives = void 0;
 
         /**
+         * When set to `true`, plugins are resolved relative to the config file that imports them.
+         * @type {boolean|undefined}
+         */
+        this.resolveRelativeToConfigFile = void 0;
+
+        /**
          * Rule settings.
          * @type {Record<string, [SeverityConf, ...any[]]>}
          */

--- a/lib/shared/types.js
+++ b/lib/shared/types.js
@@ -37,6 +37,7 @@ module.exports = {};
  * @property {string[]} [plugins] The plugin specifiers.
  * @property {string} [processor] The processor specifier.
  * @property {boolean|undefined} reportUnusedDisableDirectives The flag to report unused `eslint-disable` comments.
+ * @property {boolean|undefined} resolveRelativeToConfigFile When set to `true`, plugins are resolved relative to the config file that imports them.
  * @property {boolean} [root] The root flag.
  * @property {Record<string, RuleConf>} [rules] The rule settings.
  * @property {Object} [settings] The shared settings.
@@ -56,6 +57,7 @@ module.exports = {};
  * @property {string[]} [plugins] The plugin specifiers.
  * @property {string} [processor] The processor specifier.
  * @property {boolean|undefined} reportUnusedDisableDirectives The flag to report unused `eslint-disable` comments.
+ * @property {boolean|undefined} resolveRelativeToConfigFile When set to `true`, plugins are resolved relative to the config file that imports them.
  * @property {Record<string, RuleConf>} [rules] The rule settings.
  * @property {Object} [settings] The shared settings.
  */

--- a/tests/lib/cli-engine/config-array-factory.js
+++ b/tests/lib/cli-engine/config-array-factory.js
@@ -60,6 +60,7 @@ function assertConfig(actual, providedExpected) {
         parserOptions: {},
         plugins: [],
         reportUnusedDisableDirectives: void 0,
+        resolveRelativeToConfigFile: void 0,
         rules: {},
         settings: {},
         ...providedExpected

--- a/tests/lib/cli-engine/config-array/config-array.js
+++ b/tests/lib/cli-engine/config-array/config-array.js
@@ -435,6 +435,7 @@ describe("ConfigArray", () => {
                 },
                 plugins: {},
                 processor: null,
+                resolveRelativeToConfigFile: void 0,
                 reportUnusedDisableDirectives: void 0,
                 rules: {},
                 settings: {}
@@ -466,6 +467,7 @@ describe("ConfigArray", () => {
                 },
                 plugins: {},
                 processor: null,
+                resolveRelativeToConfigFile: void 0,
                 reportUnusedDisableDirectives: void 0,
                 rules: {},
                 settings: {}
@@ -609,7 +611,8 @@ describe("ConfigArray", () => {
                 settings: {},
                 processor: null,
                 noInlineConfig: void 0,
-                reportUnusedDisableDirectives: void 0
+                reportUnusedDisableDirectives: void 0,
+                resolveRelativeToConfigFile: void 0
             });
             assert.deepStrictEqual(config[0], {
                 rules: {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain: 

**What changes did you make? (Give an overview)**

This PR fixes https://github.com/eslint/eslint/issues/3458.  It introduces a new setting `resolveRelativeToConfigFile` for **.eslintrc.js**.  The setting is an optional boolean value that defaults to `false`.  By default, ESLint behaves the old way, where plugins always get loaded from one centralized folder.

Whereas if `resolveRelativeToConfigFile` is true, then ESLint uses the modern convention of resolving plugins relative to the config file that imports them.  This enables a shared ESLint config package to supply its own dependencies, rather than imposing that responsibility on every consumer of the package.  See https://github.com/eslint/eslint/issues/3458#issuecomment-516666620 for a complete explanation of this scenario.

**Is there anything you'd like reviewers to focus on?**

I struggled a bit with defining the setting, because ESLint doesn't inherit config settings until [_finalizeConfigArray()](https://github.com/eslint/eslint/blob/e5637badd42f087d115f81575b832097fe6fe554/lib/cli-engine/cascading-config-array-factory.js#L249), which doesn't happen until after all config files and plugins have been loaded.  I worked around this by using `internalSlotsMap` to store the state.  It means that if we encounter a config file with `resolveRelativeToConfigFile=true`, then the new behavior is enabled for all subsequent config files.  Although not ideal, this approach should work just fine for the expected usage of this feature.  I'm open to other approaches, though.