### PR TITLE
Chore: Remove unused parameter in dot-location

### DIFF
--- a/lib/rules/dot-location.js
+++ b/lib/rules/dot-location.js
@@ -47,19 +47,18 @@ module.exports = {
 
         /**
          * Reports if the dot between object and property is on the correct loccation.
-         * @param {ASTNode} obj The object owning the property.
-         * @param {ASTNode} prop The property of the object.
-         * @param {ASTNode} node The corresponding node of the token.
+         * @param {ASTNode} node The `MemberExpression` node.
          * @returns {void}
          */
-        function checkDotLocation(obj, prop, node) {
-            const dot = sourceCode.getTokenBefore(prop);
+        function checkDotLocation(node) {
+            const property = node.property;
+            const dot = sourceCode.getTokenBefore(property);
 
             // `obj` expression can be parenthesized, but those paren tokens are not a part of the `obj` node.
             const tokenBeforeDot = sourceCode.getTokenBefore(dot);
 
             const textBeforeDot = sourceCode.getText().slice(tokenBeforeDot.range[1], dot.range[0]);
-            const textAfterDot = sourceCode.getText().slice(dot.range[1], prop.range[0]);
+            const textAfterDot = sourceCode.getText().slice(dot.range[1], property.range[0]);
 
             if (onObject) {
                 if (!astUtils.isTokenOnSameLine(tokenBeforeDot, dot)) {
@@ -69,15 +68,15 @@ module.exports = {
                         node,
                         loc: dot.loc.start,
                         messageId: "expectedDotAfterObject",
-                        fix: fixer => fixer.replaceTextRange([tokenBeforeDot.range[1], prop.range[0]], `${neededTextAfterToken}.${textBeforeDot}${textAfterDot}`)
+                        fix: fixer => fixer.replaceTextRange([tokenBeforeDot.range[1], property.range[0]], `${neededTextAfterToken}.${textBeforeDot}${textAfterDot}`)
                     });
                 }
-            } else if (!astUtils.isTokenOnSameLine(dot, prop)) {
+            } else if (!astUtils.isTokenOnSameLine(dot, property)) {
                 context.report({
                     node,
                     loc: dot.loc.start,
                     messageId: "expectedDotBeforeProperty",
-                    fix: fixer => fixer.replaceTextRange([tokenBeforeDot.range[1], prop.range[0]], `${textBeforeDot}${textAfterDot}.`)
+                    fix: fixer => fixer.replaceTextRange([tokenBeforeDot.range[1], property.range[0]], `${textBeforeDot}${textAfterDot}.`)
                 });
             }
         }
@@ -89,7 +88,7 @@ module.exports = {
          */
         function checkNode(node) {
             if (!node.computed) {
-                checkDotLocation(node.object, node.property, node);
+                checkDotLocation(node);
             }
         }
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Other, please explain:

The `obj` param in `dot-location` check function became unused after some changes. Both `obj` and `prop` are redundant since the third param is their `MemberExpression` node.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Removed the unused `obj` param and the unnecessary `prop` param in `dot-location`.

**Is there anything you'd like reviewers to focus on?**


