### PR TITLE
Fix: CLIEngine#addPlugin reset lastConfigArrays (fixes #12425)

### DIFF
--- a/lib/cli-engine/cli-engine.js
+++ b/lib/cli-engine/cli-engine.js
@@ -667,11 +667,14 @@ class CLIEngine {
     addPlugin(name, pluginObject) {
         const {
             additionalPluginPool,
-            configArrayFactory
+            configArrayFactory,
+            lastConfigArrays
         } = internalSlotsMap.get(this);
 
         additionalPluginPool.set(name, pluginObject);
         configArrayFactory.clearCache();
+        lastConfigArrays.length = 1;
+        lastConfigArrays[0] = configArrayFactory.getConfigArrayForFile();
     }
 
     /**

--- a/tests/lib/cli-engine/cli-engine.js
+++ b/tests/lib/cli-engine/cli-engine.js
@@ -4022,6 +4022,14 @@ describe("CLIEngine", () => {
 
             assert(engine.getRules().has("node/no-deprecated-api"), "node/no-deprecated-api is present");
         });
+
+        it("should expose the rules of the plugin that is added by 'addPlugin'.", () => {
+            const engine = new CLIEngine({ plugins: ["foo"] });
+
+            engine.addPlugin("foo", require("eslint-plugin-node"));
+
+            assert(engine.getRules().has("foo/no-deprecated-api"), "foo/no-deprecated-api is present");
+        });
     });
 
     describe("resolveFileGlobPatterns", () => {


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix: #12425

**What changes did you make? (Give an overview)**

This PR fixes `CLIEngine#addPlugin()` method to reset `lastConfigArrays` internal state as well. Because `CLIEngine#getRules()` gets plugin rules from the `lastConfigArrays` internal state, this reset is needed.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.
