### PR TITLE
Fix: no-cond-assign with `always` option reports switch case clauses

### DIFF
--- a/lib/rules/no-cond-assign.js
+++ b/lib/rules/no-cond-assign.js
@@ -2,9 +2,20 @@
  * @fileoverview Rule to flag assignment in a conditional statement's test expression
  * @author Stephen Murray <spmurrayzzz>
  */
+
 "use strict";
 
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
 const astUtils = require("./utils/ast-utils");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+const TEST_CONDITION_PARENT_TYPES = new Set(["IfStatement", "WhileStatement", "DoWhileStatement", "ForStatement", "ConditionalExpression"]);
 
 const NODE_DESCRIPTIONS = {
     DoWhileStatement: "a 'do...while' statement",
@@ -55,7 +66,7 @@ module.exports = {
          */
         function isConditionalTestExpression(node) {
             return node.parent &&
-                node.parent.test &&
+                TEST_CONDITION_PARENT_TYPES.has(node.parent.type) &&
                 node === node.parent.test;
         }
 

--- a/tests/lib/rules/no-cond-assign.js
+++ b/tests/lib/rules/no-cond-assign.js
@@ -41,7 +41,10 @@ ruleTester.run("no-cond-assign", rule, {
         { code: "if (function(node) { return node = parentNode; }) { }", options: ["except-parens"] },
         { code: "if (function(node) { return node = parentNode; }) { }", options: ["always"] },
         { code: "x = 0;", options: ["always"] },
-        "var x; var b = (x === 0) ? 1 : 0;"
+        "var x; var b = (x === 0) ? 1 : 0;",
+        { code: "switch (foo) { case a = b: bar(); }", options: ["except-parens"] },
+        { code: "switch (foo) { case a = b: bar(); }", options: ["always"] },
+        { code: "switch (foo) { case baz + (a = b): bar(); }", options: ["always"] }
     ],
     invalid: [
         { code: "var x; if (x = 0) { var b = 1; }", errors: [{ messageId: "missing", type: "IfStatement", line: 1, column: 12 }] },
@@ -62,6 +65,7 @@ ruleTester.run("no-cond-assign", rule, {
         { code: "do { } while ((x = x + 1));", options: ["always"], errors: [{ messageId: "unexpected", data: { type: "a 'do...while' statement" }, type: "DoWhileStatement" }] },
         { code: "for(; (x = y); ) { }", options: ["always"], errors: [{ messageId: "unexpected", data: { type: "a 'for' statement" }, type: "ForStatement" }] },
         { code: "var x; var b = (x = 0) ? 1 : 0;", errors: [{ messageId: "missing", type: "ConditionalExpression" }] },
+        { code: "var x; var b = x && (y = 0) ? 1 : 0;", options: ["always"], errors: [{ messageId: "unexpected", type: "ConditionalExpression" }] },
         { code: "(((3496.29)).bkufyydt = 2e308) ? foo : bar;", errors: [{ messageId: "missing", type: "ConditionalExpression" }] }
     ]
 });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix

This bug fix can produce only fewer warnings.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment**

* **ESLint Version:**  6.5.1
* **Node Version:** 10.16.0
* **npm Version:** 6.9.0

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
  parserOptions: {
    ecmaVersion: 2015,
  }
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**

[Online Demo Link](https://eslint.org/demo#eyJ0ZXh0IjoiLyogZXNsaW50IG5vLWNvbmQtYXNzaWduOiBbXCJlcnJvclwiLCBcImFsd2F5c1wiXSAqL1xuXG5zd2l0Y2ggKGZvbykge1xuICAgIGNhc2UgYSA9IGI6IFxuICAgICAgICBicmVhaztcbn0iLCJvcHRpb25zIjp7InBhcnNlck9wdGlvbnMiOnsiZWNtYVZlcnNpb24iOjUsInNvdXJjZVR5cGUiOiJzY3JpcHQiLCJlY21hRmVhdHVyZXMiOnt9fSwicnVsZXMiOnt9LCJlbnYiOnt9fX0=)

```js
/* eslint no-cond-assign: ["error", "always"] */

switch (foo) {
    case a = b: 
        break;
}
```

**What did you expect to happen?**

No errors. Per the documentation, this rule doesn't target switch case clauses.

**What actually happened? Please include the actual, raw output from ESLint.**

```
 4:5  error  Unexpected assignment within SwitchCase  no-cond-assign
```

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Check parent statement's type.

**Is there anything you'd like reviewers to focus on?**

This test case was already valid:

```js
{ code: "switch (foo) { case a = b: bar(); }", options: ["except-parens"] }
```

These test cases were invalid, that's the bug fixed by this PR:

```js
{ code: "switch (foo) { case a = b: bar(); }", options: ["always"] },
{ code: "switch (foo) { case baz + (a = b): bar(); }", options: ["always"] }
```

This test case was added for regression, as there were no test cases for `always` with `ConditionalExpression`. It was already invalid:

```js
{ code: "var x; var b = x && (y = 0) ? 1 : 0;", options: ["always"], errors: [{ messageId: "unexpected", type: "ConditionalExpression" }] },
```

I'll open a separate issue for conditional expressions.