### PR TITLE
Chore: Provide debug log for parser errors

### DIFF
--- a/lib/linter/linter.js
+++ b/lib/linter/linter.js
@@ -666,6 +666,8 @@ function parse(text, parser, providedParserOptions, filePath) {
         // If the message includes a leading line number, strip it:
         const message = `Parsing error: ${ex.message.replace(/^line \d+:/iu, "").trim()}`;
 
+        debug("%s\n%s", message, ex.stack);
+
         return {
             success: false,
             error: {


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Other, please explain:

When there's an exception thrown by the parser, currently ESLint swallows this exception.
This is fine for end users, as it allows ESLint to provide a nicer experience, but can make it hard for parser developers to debug problems when reported by users.

This change simply adds a debug log message which includes the exception stack when a parser exception occurs.

That way we can just instruct users to run `eslint --debug` so we can get the exception stack (amongst other things) from them.