### PR TITLE
Update: improve report location for no-trailing-spaces (fixes #12315)

### DIFF
--- a/lib/rules/no-trailing-spaces.js
+++ b/lib/rules/no-trailing-spaces.js
@@ -122,7 +122,7 @@ module.exports = {
                     fixRange = [];
 
                 for (let i = 0, ii = lines.length; i < ii; i++) {
-                    const matches = re.exec(lines[i]);
+                    const lineNumber = i + 1;
 
                     /*
                      * Always add linebreak length to line length to accommodate for line break (\n or \r\n)
@@ -132,14 +132,22 @@ module.exports = {
                     const linebreakLength = linebreaks && linebreaks[i] ? linebreaks[i].length : 1;
                     const lineLength = lines[i].length + linebreakLength;
 
+                    const matches = re.exec(lines[i]);
+
                     if (matches) {
                         const location = {
-                            line: i + 1,
-                            column: matches.index
+                            start: {
+                                line: lineNumber,
+                                column: matches.index
+                            },
+                            end: {
+                                line: lineNumber,
+                                column: lineLength - linebreakLength
+                            }
                         };
 
-                        const rangeStart = totalLength + location.column;
-                        const rangeEnd = totalLength + lineLength - linebreakLength;
+                        const rangeStart = totalLength + location.start.column;
+                        const rangeEnd = totalLength + location.end.column;
                         const containingNode = sourceCode.getNodeByRangeIndex(rangeStart);
 
                         if (containingNode && containingNode.type === "TemplateElement" &&
@@ -160,7 +168,7 @@ module.exports = {
 
                         fixRange = [rangeStart, rangeEnd];
 
-                        if (!ignoreComments || !commentLineNumbers.has(location.line)) {
+                        if (!ignoreComments || !commentLineNumbers.has(lineNumber)) {
                             report(node, location, fixRange);
                         }
                     }

--- a/tests/lib/rules/no-trailing-spaces.js
+++ b/tests/lib/rules/no-trailing-spaces.js
@@ -268,12 +268,16 @@ ruleTester.run("no-trailing-spaces", rule, {
                 message: "Trailing spaces not allowed.",
                 type: "Program",
                 line: 1,
-                column: 11
+                column: 11,
+                endLine: 1,
+                endColumn: 12
             }, {
                 message: "Trailing spaces not allowed.",
                 type: "Program",
                 line: 2,
-                column: 8
+                column: 8,
+                endLine: 2,
+                endColumn: 9
             }]
         },
         {
@@ -284,7 +288,9 @@ ruleTester.run("no-trailing-spaces", rule, {
                 message: "Trailing spaces not allowed.",
                 type: "Program",
                 line: 1,
-                column: 11
+                column: 11,
+                endLine: 1,
+                endColumn: 12
             }]
         },
         {
@@ -295,7 +301,9 @@ ruleTester.run("no-trailing-spaces", rule, {
                 message: "Trailing spaces not allowed.",
                 type: "Program",
                 line: 1,
-                column: 1
+                column: 1,
+                endLine: 1,
+                endColumn: 6
             }]
         },
         {
@@ -317,7 +325,9 @@ ruleTester.run("no-trailing-spaces", rule, {
                 message: "Trailing spaces not allowed.",
                 type: "Program",
                 line: 1,
-                column: 15 // there are invalid spaces in columns 15 and 16
+                column: 15, // there are invalid spaces in columns 15 and 16
+                endLine: 1,
+                endColumn: 17
             }]
         },
         {
@@ -331,13 +341,17 @@ ruleTester.run("no-trailing-spaces", rule, {
                     message: "Trailing spaces not allowed.",
                     type: "Program",
                     line: 1,
-                    column: 15
+                    column: 15,
+                    endLine: 1,
+                    endColumn: 18
                 },
                 {
                     message: "Trailing spaces not allowed.",
                     type: "Program",
                     line: 2,
-                    column: 15
+                    column: 15,
+                    endLine: 2,
+                    endColumn: 17
                 }
             ]
         },
@@ -349,7 +363,9 @@ ruleTester.run("no-trailing-spaces", rule, {
                 message: "Trailing spaces not allowed.",
                 type: "Program",
                 line: 3,
-                column: 7
+                column: 7,
+                endLine: 3,
+                endColumn: 9
             }]
         },
         {
@@ -361,13 +377,17 @@ ruleTester.run("no-trailing-spaces", rule, {
                     message: "Trailing spaces not allowed.",
                     type: "Program",
                     line: 4,
-                    column: 7
+                    column: 7,
+                    endLine: 4,
+                    endColumn: 9
                 },
                 {
                     message: "Trailing spaces not allowed.",
                     type: "Program",
                     line: 5,
-                    column: 1
+                    column: 1,
+                    endLine: 5,
+                    endColumn: 2
                 }
             ]
         },
@@ -380,7 +400,9 @@ ruleTester.run("no-trailing-spaces", rule, {
                     message: "Trailing spaces not allowed.",
                     type: "Program",
                     line: 4,
-                    column: 7
+                    column: 7,
+                    endLine: 4,
+                    endColumn: 9
                 }
             ]
         },
@@ -396,7 +418,9 @@ ruleTester.run("no-trailing-spaces", rule, {
                     message: "Trailing spaces not allowed.",
                     type: "Program",
                     line: 3,
-                    column: 7
+                    column: 7,
+                    endLine: 3,
+                    endColumn: 9
                 }
             ]
         },
@@ -411,7 +435,9 @@ ruleTester.run("no-trailing-spaces", rule, {
                     message: "Trailing spaces not allowed.",
                     type: "Program",
                     line: 2,
-                    column: 8
+                    column: 8,
+                    endLine: 2,
+                    endColumn: 9
                 }
             ]
         },
@@ -423,13 +449,17 @@ ruleTester.run("no-trailing-spaces", rule, {
                     message: "Trailing spaces not allowed.",
                     type: "Program",
                     line: 1,
-                    column: 1
+                    column: 1,
+                    endLine: 1,
+                    endColumn: 5
                 },
                 {
                     message: "Trailing spaces not allowed.",
                     type: "Program",
                     line: 2,
-                    column: 8
+                    column: 8,
+                    endLine: 2,
+                    endColumn: 9
                 }
             ]
         },
@@ -444,7 +474,9 @@ ruleTester.run("no-trailing-spaces", rule, {
                     message: "Trailing spaces not allowed.",
                     type: "Program",
                     line: 1,
-                    column: 17
+                    column: 17,
+                    endLine: 1,
+                    endColumn: 18
                 }
             ]
         },
@@ -457,7 +489,9 @@ ruleTester.run("no-trailing-spaces", rule, {
                     message: "Trailing spaces not allowed.",
                     type: "Program",
                     line: 1,
-                    column: 26
+                    column: 26,
+                    endLine: 1,
+                    endColumn: 27
                 }
             ]
         },
@@ -470,13 +504,17 @@ ruleTester.run("no-trailing-spaces", rule, {
                     message: "Trailing spaces not allowed.",
                     type: "Program",
                     line: 1,
-                    column: 3
+                    column: 3,
+                    endLine: 1,
+                    endColumn: 4
                 },
                 {
                     message: "Trailing spaces not allowed.",
                     type: "Program",
                     line: 2,
-                    column: 24
+                    column: 24,
+                    endLine: 2,
+                    endColumn: 25
                 }
             ]
         },
@@ -489,7 +527,9 @@ ruleTester.run("no-trailing-spaces", rule, {
                     message: "Trailing spaces not allowed.",
                     type: "Program",
                     line: 1,
-                    column: 20
+                    column: 20,
+                    endLine: 1,
+                    endColumn: 21
                 }
             ]
         },
@@ -502,7 +542,9 @@ ruleTester.run("no-trailing-spaces", rule, {
                     message: "Trailing spaces not allowed.",
                     type: "Program",
                     line: 1,
-                    column: 34
+                    column: 34,
+                    endLine: 1,
+                    endColumn: 35
                 }
             ]
         }


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Changes an existing rule #12315

Reports the full location (start+end) of trailing spaces.

Before this fix:

![image](https://user-images.githubusercontent.com/44349756/67299602-2d8aac00-f4ed-11e9-9ea7-1593f774f925.png)

After this fix:

![image](https://user-images.githubusercontent.com/44349756/67299625-354a5080-f4ed-11e9-8626-1d011f8ffb08.png)


<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**


Added the `end` to the location.

**Is there anything you'd like reviewers to focus on?**

It looks a bit unusual to read from the `location` to calculate the `range`, but I didn't change that. Tried a version with intermediate variables and it didn't add any clarity (was the opposite, actually).

This is a kind of enhancement, but I think it could be processed as a bug fix (i.e. accepted with 1 confirmation).