### PR TITLE
Update: no-trailing-spaces false negatives after comments (fixes #12479)

### DIFF
--- a/lib/rules/no-trailing-spaces.js
+++ b/lib/rules/no-trailing-spaces.js
@@ -90,7 +90,11 @@ module.exports = {
             const lines = new Set();
 
             comments.forEach(comment => {
-                for (let i = comment.loc.start.line; i <= comment.loc.end.line; i++) {
+                const endLine = comment.type === "Block"
+                    ? comment.loc.end.line - 1
+                    : comment.loc.end.line;
+
+                for (let i = comment.loc.start.line; i <= endLine; i++) {
                     lines.add(i);
                 }
             });

--- a/tests/lib/rules/no-trailing-spaces.js
+++ b/tests/lib/rules/no-trailing-spaces.js
@@ -86,6 +86,14 @@ ruleTester.run("no-trailing-spaces", rule, {
         {
             code: "#!/usr/bin/env node ",
             options: [{ ignoreComments: true }]
+        },
+        {
+            code: "/* \n */ // ",
+            options: [{ ignoreComments: true }]
+        },
+        {
+            code: "/* \n */ /* \n */",
+            options: [{ ignoreComments: true }]
         }
     ],
 
@@ -445,6 +453,58 @@ ruleTester.run("no-trailing-spaces", rule, {
                     type: "Program",
                     line: 1,
                     column: 17
+                }
+            ]
+        },
+        {
+            code: "/* */ ",
+            output: "/* */",
+            options: [{ ignoreComments: true }],
+            errors: [
+                {
+                    message: "Trailing spaces not allowed.",
+                    type: "Program",
+                    line: 1,
+                    column: 6
+                }
+            ]
+        },
+        {
+            code: "/* */foo ",
+            output: "/* */foo",
+            options: [{ ignoreComments: true }],
+            errors: [
+                {
+                    message: "Trailing spaces not allowed.",
+                    type: "Program",
+                    line: 1,
+                    column: 9
+                }
+            ]
+        },
+        {
+            code: "/* \n */ ",
+            output: "/* \n */",
+            options: [{ ignoreComments: true }],
+            errors: [
+                {
+                    message: "Trailing spaces not allowed.",
+                    type: "Program",
+                    line: 2,
+                    column: 4
+                }
+            ]
+        },
+        {
+            code: "/* \n */ foo ",
+            output: "/* \n */ foo",
+            options: [{ ignoreComments: true }],
+            errors: [
+                {
+                    message: "Trailing spaces not allowed.",
+                    type: "Program",
+                    line: 2,
+                    column: 8
                 }
             ]
         },


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X ] Bug fix #12479

This change produces **more** errors.

This PR fixes `no-trailing-spaces` to report trailing spaces after block comments when the `ignoreComments` option is set to `true`. 

The option allows trailing spaces * in * comments, not after comments.

In addition to the example from #12479, the following are also false negatives (all lines with comments have trailing spaces):

```js
/* eslint no-trailing-spaces: ["error", { ignoreComments: true }]*/ 

/* */     

/* */foo     

/* 
*/foo     
```

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Don't count the last line of a `Block` comment as a 'comment line' that should be ignored.

**Is there anything you'd like reviewers to focus on?**
