### PR TITLE
Update: Disable require-await for async generators (fixes #12459)

### DIFF
--- a/lib/rules/require-await.js
+++ b/lib/rules/require-await.js
@@ -64,7 +64,7 @@ module.exports = {
          * @returns {void}
          */
         function exitFunction(node) {
-            if (node.async && !scopeInfo.hasAwait && !astUtils.isEmptyFunction(node)) {
+            if (node.async && !node.generator && !scopeInfo.hasAwait && !astUtils.isEmptyFunction(node)) {
                 context.report({
                     node,
                     loc: astUtils.getFunctionHeadLoc(node, sourceCode),

--- a/tests/lib/rules/require-await.js
+++ b/tests/lib/rules/require-await.js
@@ -41,7 +41,11 @@ ruleTester.run("require-await", rule, {
         "function foo() { doSomething() }",
 
         // for-await-of
-        "async function foo() { for await (x of xs); }"
+        "async function foo() { for await (x of xs); }",
+
+        // async generators do not require await
+        "async function * bar () { yield * foo() }",
+        "async function * bar () { yield * await foo() }"
     ],
     invalid: [
         {
@@ -83,6 +87,10 @@ ruleTester.run("require-await", rule, {
         {
             code: "async function foo() { await async () => { doSomething() } }",
             errors: ["Async arrow function has no 'await' expression."]
+        },
+        {
+            code: "async function foo () { baz() }",
+            errors: ["Async function 'foo' has no 'await' expression."]
         }
     ]
 });


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Changes an existing rule
<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
I disabled `require-await` for async generators. #12459

**Is there anything you'd like reviewers to focus on?**
Should documentation of `require-await` updated somehow?

