### PR TITLE
Fix: operator-assignment removes and duplicates comments

### DIFF
--- a/lib/rules/operator-assignment.js
+++ b/lib/rules/operator-assignment.js
@@ -150,6 +150,11 @@ module.exports = {
                                 const leftText = sourceCode.getText().slice(node.range[0], equalsToken.range[0]);
                                 const rightText = sourceCode.getText().slice(operatorToken.range[1], node.right.range[1]);
 
+                                // Check for comments that would be removed.
+                                if (sourceCode.commentsExistBetween(equalsToken, operatorToken)) {
+                                    return null;
+                                }
+
                                 return fixer.replaceText(node, `${leftText}${expr.operator}=${rightText}`);
                             }
                             return null;
@@ -182,10 +187,16 @@ module.exports = {
                     messageId: "unexpected",
                     fix(fixer) {
                         if (canBeFixed(node.left)) {
+                            const firstToken = sourceCode.getFirstToken(node);
                             const operatorToken = getOperatorToken(node);
                             const leftText = sourceCode.getText().slice(node.range[0], operatorToken.range[0]);
                             const newOperator = node.operator.slice(0, -1);
                             let rightText;
+
+                            // Check for comments that would be duplicated.
+                            if (sourceCode.commentsExistBetween(firstToken, operatorToken)) {
+                                return null;
+                            }
 
                             // If this change would modify precedence (e.g. `foo *= bar + 1` => `foo = foo * (bar + 1)`), parenthesize the right side.
                             if (

--- a/tests/lib/rules/operator-assignment.js
+++ b/tests/lib/rules/operator-assignment.js
@@ -192,6 +192,86 @@ ruleTester.run("operator-assignment", rule, {
         output: "foo[5] /= baz", // this is ok because 5 is a literal, so toString won't get called
         errors: EXPECTED_OPERATOR_ASSIGNMENT
     }, {
+        code: "/*1*/x/*2*/./*3*/y/*4*/= x.y +/*5*/z/*6*/./*7*/w/*8*/;",
+        output: "/*1*/x/*2*/./*3*/y/*4*/+=/*5*/z/*6*/./*7*/w/*8*/;", // these comments are preserved
+        options: ["always"],
+        errors: EXPECTED_OPERATOR_ASSIGNMENT
+    }, {
+        code: "x // 1\n . // 2\n y // 3\n = x.y + //4\n z //5\n . //6\n w;",
+        output: "x // 1\n . // 2\n y // 3\n += //4\n z //5\n . //6\n w;", // these comments are preserved
+        options: ["always"],
+        errors: EXPECTED_OPERATOR_ASSIGNMENT
+    }, {
+        code: "x = /*1*/ x + y",
+        output: null, // not fixed; fixing would remove this comment
+        options: ["always"],
+        errors: EXPECTED_OPERATOR_ASSIGNMENT
+    }, {
+        code: "x = //1\n x + y",
+        output: null, // not fixed; fixing would remove this comment
+        options: ["always"],
+        errors: EXPECTED_OPERATOR_ASSIGNMENT
+    }, {
+        code: "x.y = x/*1*/.y + z",
+        output: null, // not fixed; fixing would remove this comment
+        options: ["always"],
+        errors: EXPECTED_OPERATOR_ASSIGNMENT
+    }, {
+        code: "x.y = x. //1\n y + z",
+        output: null, // not fixed; fixing would remove this comment
+        options: ["always"],
+        errors: EXPECTED_OPERATOR_ASSIGNMENT
+    }, {
+        code: "x = x /*1*/ + y",
+        output: null, // not fixed; fixing would remove this comment
+        options: ["always"],
+        errors: EXPECTED_OPERATOR_ASSIGNMENT
+    }, {
+        code: "x = x //1\n + y",
+        output: null, // not fixed; fixing would remove this comment
+        options: ["always"],
+        errors: EXPECTED_OPERATOR_ASSIGNMENT
+    }, {
+        code: "/*1*/x +=/*2*/y/*3*/;",
+        output: "/*1*/x = x +/*2*/y/*3*/;", // these comments are preserved and not duplicated
+        options: ["never"],
+        errors: UNEXPECTED_OPERATOR_ASSIGNMENT
+    }, {
+        code: "x +=//1\n y",
+        output: "x = x +//1\n y", // this comment is preserved and not duplicated
+        options: ["never"],
+        errors: UNEXPECTED_OPERATOR_ASSIGNMENT
+    }, {
+        code: "(/*1*/x += y)",
+        output: "(/*1*/x = x + y)", // this comment is preserved and not duplicated
+        options: ["never"],
+        errors: UNEXPECTED_OPERATOR_ASSIGNMENT
+    }, {
+        code: "x/*1*/+=  y",
+        output: null, // not fixed; fixing would duplicate this comment
+        options: ["never"],
+        errors: UNEXPECTED_OPERATOR_ASSIGNMENT
+    }, {
+        code: "x //1\n +=  y",
+        output: null, // not fixed; fixing would duplicate this comment
+        options: ["never"],
+        errors: UNEXPECTED_OPERATOR_ASSIGNMENT
+    }, {
+        code: "(/*1*/x) +=  y",
+        output: null, // not fixed; fixing would duplicate this comment
+        options: ["never"],
+        errors: UNEXPECTED_OPERATOR_ASSIGNMENT
+    }, {
+        code: "x/*1*/.y +=  z",
+        output: null, // not fixed; fixing would duplicate this comment
+        options: ["never"],
+        errors: UNEXPECTED_OPERATOR_ASSIGNMENT
+    }, {
+        code: "x.//1\n y +=  z",
+        output: null, // not fixed; fixing would duplicate this comment
+        options: ["never"],
+        errors: UNEXPECTED_OPERATOR_ASSIGNMENT
+    }, {
         code: "(foo.bar) ^= ((((((((((((((((baz))))))))))))))))",
         output: "(foo.bar) = (foo.bar) ^ ((((((((((((((((baz))))))))))))))))",
         options: ["never"],


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix

This PR fixes `operator-assignment` to prevent autofix if it would remove or duplicate comments.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment**

* **ESLint Version:**  6.5.1
* **Node Version:** 10.16.0
* **npm Version:** 6.9.0

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
  parserOptions: {
    ecmaVersion: 2015,
  }
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**

[Online Demo Link 1](https://eslint.org/demo#eyJ0ZXh0IjoiLyogZXNsaW50IG9wZXJhdG9yLWFzc2lnbm1lbnQ6IFtcImVycm9yXCIsIFwiYWx3YXlzXCJdKi9cblxueCA9IC8qIGNvbW1lbnQgKi8geCArIHk7XG5cbnggPSB4IC8vIGNvbW1lbnQgXG5cdCsgeTsiLCJvcHRpb25zIjp7InBhcnNlck9wdGlvbnMiOnsiZWNtYVZlcnNpb24iOjYsInNvdXJjZVR5cGUiOiJzY3JpcHQiLCJlY21hRmVhdHVyZXMiOnt9fSwicnVsZXMiOnt9LCJlbnYiOnt9fX0=)

```js
/* eslint operator-assignment: ["error", "always"]*/

x = /* comment */ x + y;

x = x // comment 
	+ y;
```

[Online Demo Link 2](https://eslint.org/demo#eyJ0ZXh0IjoiLyogZXNsaW50IG9wZXJhdG9yLWFzc2lnbm1lbnQ6IFtcImVycm9yXCIsIFwibmV2ZXJcIl0qL1xuXG54IC8qIGNvbW1lbnQgKi8gKz0geTtcblxueCAvLyBjb21tZW50XG5cdCs9IHk7Iiwib3B0aW9ucyI6eyJwYXJzZXJPcHRpb25zIjp7ImVjbWFWZXJzaW9uIjo2LCJzb3VyY2VUeXBlIjoic2NyaXB0IiwiZWNtYUZlYXR1cmVzIjp7fX0sInJ1bGVzIjp7fSwiZW52Ijp7fX19)

```js
/* eslint operator-assignment: ["error", "never"]*/

x /* comment */ += y;

x // comment
	+= y;
```

**What did you expect to happen?**

Not to remove/duplicate comments.

**What actually happened? Please include the actual, raw output from ESLint.**

```js
/* eslint operator-assignment: ["error", "always"]*/

x += y;

x += y;
```

```js
/* eslint operator-assignment: ["error", "never"]*/

x /* comment */ = x /* comment */ + y;

x // comment
	= x // comment
	+ y;
```

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Check for the comments in the ranges there are going to be removed or copied to prevent fixing.

**Is there anything you'd like reviewers to focus on?**
