### PR TITLE
Breaking: Check assignment targets in no-extra-parens

### DIFF
--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -343,6 +343,17 @@ module.exports = {
         }
 
         /**
+         * Determines if the given node can be the assignment target in destructuring or the LHS of an assignment.
+         * This is to avoid an autofix that could change behavior because parsers mistakenly allow invalid syntax,
+         * such as `(a = b) = c` and `[(a = b) = c] = []`. Ideally, this function shouldn't be necessary.
+         * @param {ASTNode} [node] The node to check
+         * @returns {boolean} `true` if the given node can be a valid assignment target
+         */
+        function canBeAssignmentTarget(node) {
+            return node && (node.type === "Identifier" || node.type === "MemberExpression");
+        }
+
+        /**
          * Report the node
          * @param {ASTNode} node node to evaluate
          * @returns {void}
@@ -679,6 +690,12 @@ module.exports = {
                     .forEach(report);
             },
 
+            ArrayPattern(node) {
+                node.elements
+                    .filter(e => canBeAssignmentTarget(e) && hasExcessParens(e))
+                    .forEach(report);
+            },
+
             ArrowFunctionExpression(node) {
                 if (isReturnAssignException(node)) {
                     return;
@@ -705,6 +722,10 @@ module.exports = {
             },
 
             AssignmentExpression(node) {
+                if (canBeAssignmentTarget(node.left) && hasExcessParens(node.left)) {
+                    report(node.left);
+                }
+
                 if (!isReturnAssignException(node) && hasExcessParensWithPrecedence(node.right, precedence(node))) {
                     report(node.right);
                 }
@@ -947,6 +968,15 @@ module.exports = {
                     .forEach(property => report(property.value));
             },
 
+            ObjectPattern(node) {
+                node.properties
+                    .filter(property => {
+                        const value = property.value;
+
+                        return canBeAssignmentTarget(value) && hasExcessParens(value);
+                    }).forEach(property => report(property.value));
+            },
+
             Property(node) {
                 if (node.computed) {
                     const { key } = node;
@@ -954,6 +984,14 @@ module.exports = {
                     if (key && hasExcessParensWithPrecedence(key, PRECEDENCE_OF_ASSIGNMENT_EXPR)) {
                         report(key);
                     }
+                }
+            },
+
+            RestElement(node) {
+                const argument = node.argument;
+
+                if (canBeAssignmentTarget(argument) && hasExcessParens(argument)) {
+                    report(argument);
                 }
             },
 
@@ -1054,7 +1092,11 @@ module.exports = {
             },
 
             AssignmentPattern(node) {
-                const { right } = node;
+                const { left, right } = node;
+
+                if (canBeAssignmentTarget(left) && hasExcessParens(left)) {
+                    report(left);
+                }
 
                 if (right && hasExcessParensWithPrecedence(right, PRECEDENCE_OF_ASSIGNMENT_EXPR)) {
                     report(right);

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -1403,6 +1403,25 @@ ruleTester.run("no-extra-parens", rule, {
         invalid("const [a = (b)] = []", "const [a = b] = []", "Identifier"),
         invalid("const {a = (b)} = {}", "const {a = b} = {}", "Identifier"),
 
+        // LHS of assigments/Assignment targets
+        invalid("(a) = b", "a = b", "Identifier"),
+        invalid("(a.b) = c", "a.b = c", "MemberExpression"),
+        invalid("(a) += b", "a += b", "Identifier"),
+        invalid("(a.b) >>= c", "a.b >>= c", "MemberExpression"),
+        invalid("[(a) = b] = []", "[a = b] = []", "Identifier"),
+        invalid("[(a.b) = c] = []", "[a.b = c] = []", "MemberExpression"),
+        invalid("({ a: (b) = c } = {})", "({ a: b = c } = {})", "Identifier"),
+        invalid("({ a: (b.c) = d } = {})", "({ a: b.c = d } = {})", "MemberExpression"),
+        invalid("[(a)] = []", "[a] = []", "Identifier"),
+        invalid("[(a.b)] = []", "[a.b] = []", "MemberExpression"),
+        invalid("[,(a),,] = []", "[,a,,] = []", "Identifier"),
+        invalid("[...(a)] = []", "[...a] = []", "Identifier"),
+        invalid("[...(a.b)] = []", "[...a.b] = []", "MemberExpression"),
+        invalid("({ a: (b) } = {})", "({ a: b } = {})", "Identifier"),
+        invalid("({ a: (b.c) } = {})", "({ a: b.c } = {})", "MemberExpression"),
+
+        // TODO: add tests for the RestElement in object patterns when it becomes supported in espree
+
         // https://github.com/eslint/eslint/issues/11706 (also in valid[])
         {
             code: "for ((a = (b in c)); ;);",

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -1420,7 +1420,12 @@ ruleTester.run("no-extra-parens", rule, {
         invalid("({ a: (b) } = {})", "({ a: b } = {})", "Identifier"),
         invalid("({ a: (b.c) } = {})", "({ a: b.c } = {})", "MemberExpression"),
 
-        // TODO: add tests for the RestElement in object patterns when it becomes supported in espree
+        /*
+         * TODO: Add these tests for RestElement's parenthesized arguments in object patterns when that becomes supported by Espree.
+         *
+         * invalid("({ ...(a) } = {})", "({ ...a } = {})", "Identifier"),
+         * invalid("({ ...(a.b) } = {})", "({ ...a.b } = {})", "MemberExpression")
+         */
 
         // https://github.com/eslint/eslint/issues/11706 (also in valid[])
         {


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Changes an existing rule

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**What rule do you want to change?**

no-extra-parens

**Does this change cause the rule to produce more or fewer warnings?**

more

**How will the change be implemented? (New option, new default behavior, etc.)?**

new default behavior

**Please provide some example code that this change will affect:**

```js
// left-hand side of assignments
(a) = b;
(a) += b;
(a.b) = c;

// left-hand side of default assignments
[(a) = b] = [];
[(a.b) = c] = [];
({ a: (b) = c } = {});
({ a: (b.c) = d } = {});

// array pattern elements and rest element
[(a)] = [];
[(a.b)] = [];
[...(a)] = [];
[...(a.b)] = [];

// object pattern property values and rest property
({ a: (b) } = {});
({ a: (b.c) } = {});
({ ...(a) } = {});   // these currently aren't allowed in acorn, there is an open issue
({ ...(a.b) } = {});


```

**What does the rule currently do for this code?**

No errors.

**What will the rule do after it's changed?**

All lines will be errors.

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Check missed nodes.

**Is there anything you'd like reviewers to focus on?**

Core rules usually don't assume that the syntax can be invalid, and a function like `canBeAssignmentTarget` shouldn't be necessary. But, default assignments (in particular, parenthesised assignments that look like default assignments) seem to a be a common problem for parsers.

For instance, the following simple examples are actually invalid syntax, but interpreted as a valid code by acorn, espree, babel, typescript-eslint and the majority of parsers that can be found on the ast-explorer site:

```js
(a = b) = c; // invalid syntax

[(a = b) = c] = []; // invalid syntax
```

Removing these parens would change semantics, and that's why all checks added in this PR use the `canBeAssignmentTarget` function. This is unusual, but seems to be a safe solution at this moment. Is it okay?

Also, please verify that the examples in the test cases are valid syntax.

