### PR TITLE
Fix: sourceCode#isSpaceBetweenTokens() checks non-adjacent tokens

### DIFF
--- a/lib/source-code/source-code.js
+++ b/lib/source-code/source-code.js
@@ -411,19 +411,28 @@ class SourceCode extends TokenStore {
     }
 
     /**
-     * Determines if two tokens have at least one whitespace character
-     * between them. This completely disregards comments in making the
-     * determination, so comments count as zero-length substrings.
-     * @param {Token} first The token to check after.
-     * @param {Token} second The token to check before.
-     * @returns {boolean} True if there is only space between tokens, false
-     *  if there is anything other than whitespace between tokens.
+     * Determines if two nodes or tokens have at least one whitespace character
+     * between them.
+     * @param {ASTNode|Token} first The node or token to check after.
+     * @param {ASTNode|Token} second The node or token to check before.
+     * @returns {boolean} True if there is a whitespace character between
+     * any of the tokens found between the two given nodes or tokens.
      * @public
      */
     isSpaceBetweenTokens(first, second) {
-        const text = this.text.slice(first.range[1], second.range[0]);
+        let currentToken = this.getLastToken(first) || first;
 
-        return /\s/u.test(text.replace(/\/\*.*?\*\//gus, ""));
+        while (currentToken !== (this.getFirstToken(second) || second)) {
+            const nextToken = this.getTokenAfter(currentToken, { includeComments: true });
+
+            if (/\s/u.test(this.text.slice(currentToken.range[1], nextToken.range[0]))) {
+                return true;
+            }
+
+            currentToken = nextToken;
+        }
+
+        return false;
     }
 
     /**

--- a/lib/source-code/source-code.js
+++ b/lib/source-code/source-code.js
@@ -78,6 +78,18 @@ function sortedMerge(tokens, comments) {
     return result;
 }
 
+/**
+ * Determines if two nodes or tokens overlap.
+ * @param {ASTNode|Token} first The first node or token to check.
+ * @param {ASTNode|Token} second The second node or token to check.
+ * @returns {boolean} True if the two nodes or tokens overlap.
+ * @private
+ */
+function nodesOrTokensOverlap(first, second) {
+    return (first.range[0] <= second.range[0] && first.range[1] >= second.range[0]) ||
+        (second.range[0] <= first.range[0] && second.range[1] >= first.range[0]);
+}
+
 //------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
@@ -421,16 +433,13 @@ class SourceCode extends TokenStore {
      * @public
      */
     isSpaceBetweenTokens(first, second) {
-
-        // Arguments are overlapping.
-        if (first.range[0] <= second.range[0] && first.range[1] >= second.range[0] ||
-            second.range[0] <= first.range[0] && second.range[1] >= first.range[0]) {
+        if (nodesOrTokensOverlap(first, second)) {
             return false;
         }
 
-        const nodesAreReversed = second.range[1] <= first.range[0];
-        const startingNodeOrToken = nodesAreReversed ? second : first;
-        const endingNodeOrToken = nodesAreReversed ? first : second;
+        const [startingNodeOrToken, endingNodeOrToken] = first.range[1] <= second.range[0]
+            ? [first, second]
+            : [second, first];
         const firstToken = this.getLastToken(startingNodeOrToken) || startingNodeOrToken;
         const finalToken = this.getFirstToken(endingNodeOrToken) || endingNodeOrToken;
         let currentToken = firstToken;

--- a/lib/source-code/source-code.js
+++ b/lib/source-code/source-code.js
@@ -420,12 +420,13 @@ class SourceCode extends TokenStore {
      * @public
      */
     isSpaceBetweenTokens(first, second) {
+        const finalToken = this.getFirstToken(second) || second;
         let currentToken = this.getLastToken(first) || first;
 
-        while (currentToken !== (this.getFirstToken(second) || second)) {
+        while (currentToken !== finalToken) {
             const nextToken = this.getTokenAfter(currentToken, { includeComments: true });
 
-            if (/\s/u.test(this.text.slice(currentToken.range[1], nextToken.range[0]))) {
+            if (currentToken.range[1] !== nextToken.range[0]) {
                 return true;
             }
 

--- a/lib/source-code/source-code.js
+++ b/lib/source-code/source-code.js
@@ -412,16 +412,28 @@ class SourceCode extends TokenStore {
 
     /**
      * Determines if two nodes or tokens have at least one whitespace character
-     * between them.
-     * @param {ASTNode|Token} first The node or token to check after.
-     * @param {ASTNode|Token} second The node or token to check before.
+     * between them. Order does not matter. Returns false if the given nodes or
+     * tokens overlap.
+     * @param {ASTNode|Token} first The first node or token to check between.
+     * @param {ASTNode|Token} second The second node or token to check between.
      * @returns {boolean} True if there is a whitespace character between
      * any of the tokens found between the two given nodes or tokens.
      * @public
      */
     isSpaceBetweenTokens(first, second) {
-        const finalToken = this.getFirstToken(second) || second;
-        let currentToken = this.getLastToken(first) || first;
+
+        // Arguments are overlapping.
+        if (first.range[0] <= second.range[0] && first.range[1] >= second.range[0] ||
+            second.range[0] <= first.range[0] && second.range[1] >= first.range[0]) {
+            return false;
+        }
+
+        const nodesAreReversed = second.range[1] <= first.range[0];
+        const startingNodeOrToken = nodesAreReversed ? second : first;
+        const endingNodeOrToken = nodesAreReversed ? first : second;
+        const firstToken = this.getLastToken(startingNodeOrToken) || startingNodeOrToken;
+        const finalToken = this.getFirstToken(endingNodeOrToken) || endingNodeOrToken;
+        let currentToken = firstToken;
 
         while (currentToken !== finalToken) {
             const nextToken = this.getTokenAfter(currentToken, { includeComments: true });

--- a/tests/lib/source-code/source-code.js
+++ b/tests/lib/source-code/source-code.js
@@ -1790,193 +1790,201 @@ describe("SourceCode", () => {
     });
 
     describe("isSpaceBetweenTokens()", () => {
-        leche.withData([
-            ["let foo", true],
-            ["let  foo", true],
-            ["let /**/ foo", true],
-            ["let/**/foo", false],
-            ["let/*\n*/foo", false]
-        ], (code, expected) => {
-            it("should return true when there is at least one whitespace character between two tokens", () => {
-                const ast = espree.parse(code, DEFAULT_CONFIG),
-                    sourceCode = new SourceCode(code, ast);
+        describe("should return true when there is at least one whitespace character between two tokens", () => {
+            leche.withData([
+                ["let foo", true],
+                ["let  foo", true],
+                ["let /**/ foo", true],
+                ["let/**/foo", false],
+                ["let/*\n*/foo", false]
+            ], (code, expected) => {
+                it(code, () => {
+                    const ast = espree.parse(code, DEFAULT_CONFIG),
+                        sourceCode = new SourceCode(code, ast);
 
-                assert.strictEqual(
-                    sourceCode.isSpaceBetweenTokens(
-                        sourceCode.ast.tokens[0], sourceCode.ast.tokens[sourceCode.ast.tokens.length - 1]
-                    ),
-                    expected
-                );
+                    assert.strictEqual(
+                        sourceCode.isSpaceBetweenTokens(
+                            sourceCode.ast.tokens[0], sourceCode.ast.tokens[sourceCode.ast.tokens.length - 1]
+                        ),
+                        expected
+                    );
+                });
+            });
+
+            leche.withData([
+                ["a+b", false],
+                ["a +b", true],
+                ["a/**/+b", false],
+                ["a/* */+b", false],
+                ["a/**/ +b", true],
+                ["a/**/ /**/+b", true],
+                ["a/* */ /* */+b", true],
+                ["a/**/\n/**/+b", true],
+                ["a/* */\n/* */+b", true],
+                ["a/**/+b/**/+c", false],
+                ["a/* */+b/* */+c", false],
+                ["a/**/+b /**/+c", true],
+                ["a/* */+b /* */+c", true],
+                ["a/**/ +b/**/+c", true],
+                ["a/* */ +b/* */+c", true],
+                ["a/**/+b\t/**/+c", true],
+                ["a/* */+b\t/* */+c", true],
+                ["a/**/\t+b/**/+c", true],
+                ["a/* */\t+b/* */+c", true],
+                ["a/**/+b\n/**/+c", true],
+                ["a/* */+b\n/* */+c", true],
+                ["a/**/\n+b/**/+c", true],
+                ["a/* */\n+b/* */+c", true],
+                ["a/* */+' /**/ '/* */+c", false],
+                ["a/* */+ ' /**/ '/* */+c", true],
+                ["a/* */+' /**/ ' /* */+c", true],
+                ["a/* */+ ' /**/ ' /* */+c", true],
+                ["a/* */+` /*\n*/ `/* */+c", false],
+                ["a/* */+ ` /*\n*/ `/* */+c", true],
+                ["a/* */+` /*\n*/ ` /* */+c", true],
+                ["a/* */+ ` /*\n*/ ` /* */+c", true]
+            ], (code, expected) => {
+                it(code, () => {
+                    const ast = espree.parse(code, DEFAULT_CONFIG),
+                        sourceCode = new SourceCode(code, ast);
+
+                    assert.strictEqual(
+                        sourceCode.isSpaceBetweenTokens(
+                            sourceCode.ast.tokens[0], sourceCode.ast.tokens[sourceCode.ast.tokens.length - 2]
+                        ),
+                        expected
+                    );
+                });
             });
         });
 
-        leche.withData([
-            ["a+b", false],
-            ["a +b", true],
-            ["a/**/+b", false],
-            ["a/* */+b", false],
-            ["a/**/ +b", true],
-            ["a/**/ /**/+b", true],
-            ["a/* */ /* */+b", true],
-            ["a/**/\n/**/+b", true],
-            ["a/* */\n/* */+b", true],
-            ["a/**/+b/**/+c", false],
-            ["a/* */+b/* */+c", false],
-            ["a/**/+b /**/+c", true],
-            ["a/* */+b /* */+c", true],
-            ["a/**/ +b/**/+c", true],
-            ["a/* */ +b/* */+c", true],
-            ["a/**/+b\t/**/+c", true],
-            ["a/* */+b\t/* */+c", true],
-            ["a/**/\t+b/**/+c", true],
-            ["a/* */\t+b/* */+c", true],
-            ["a/**/+b\n/**/+c", true],
-            ["a/* */+b\n/* */+c", true],
-            ["a/**/\n+b/**/+c", true],
-            ["a/* */\n+b/* */+c", true],
-            ["a/* */+' /**/ '/* */+c", false],
-            ["a/* */+ ' /**/ '/* */+c", true],
-            ["a/* */+' /**/ ' /* */+c", true],
-            ["a/* */+ ' /**/ ' /* */+c", true],
-            ["a/* */+` /*\n*/ `/* */+c", false],
-            ["a/* */+ ` /*\n*/ `/* */+c", true],
-            ["a/* */+` /*\n*/ ` /* */+c", true],
-            ["a/* */+ ` /*\n*/ ` /* */+c", true]
-        ], (code, expected) => {
-            it("should return true when there is at least one whitespace character between two tokens", () => {
-                const ast = espree.parse(code, DEFAULT_CONFIG),
-                    sourceCode = new SourceCode(code, ast);
+        describe("should return true when there is at least one whitespace character between a token and a node", () => {
+            leche.withData([
+                [";let foo = bar", false],
+                [";/**/let foo = bar", false],
+                [";/* */let foo = bar", false],
+                ["; let foo = bar", true],
+                ["; let foo = bar", true],
+                ["; /**/let foo = bar", true],
+                ["; /* */let foo = bar", true],
+                [";/**/ let foo = bar", true],
+                [";/* */ let foo = bar", true],
+                ["; /**/ let foo = bar", true],
+                ["; /* */ let foo = bar", true],
+                [";\tlet foo = bar", true],
+                [";\tlet foo = bar", true],
+                [";\t/**/let foo = bar", true],
+                [";\t/* */let foo = bar", true],
+                [";/**/\tlet foo = bar", true],
+                [";/* */\tlet foo = bar", true],
+                [";\t/**/\tlet foo = bar", true],
+                [";\t/* */\tlet foo = bar", true],
+                [";\nlet foo = bar", true],
+                [";\nlet foo = bar", true],
+                [";\n/**/let foo = bar", true],
+                [";\n/* */let foo = bar", true],
+                [";/**/\nlet foo = bar", true],
+                [";/* */\nlet foo = bar", true],
+                [";\n/**/\nlet foo = bar", true],
+                [";\n/* */\nlet foo = bar", true]
+            ], (code, expected) => {
+                it(code, () => {
+                    const ast = espree.parse(code, DEFAULT_CONFIG),
+                        sourceCode = new SourceCode(code, ast);
 
-                assert.strictEqual(
-                    sourceCode.isSpaceBetweenTokens(
-                        sourceCode.ast.tokens[0], sourceCode.ast.tokens[sourceCode.ast.tokens.length - 2]
-                    ),
-                    expected
-                );
+                    assert.strictEqual(
+                        sourceCode.isSpaceBetweenTokens(
+                            sourceCode.ast.tokens[0], sourceCode.ast.body[sourceCode.ast.body.length - 1]
+                        ),
+                        expected
+                    );
+                });
             });
         });
 
-        leche.withData([
-            [";let foo = bar", false],
-            [";/**/let foo = bar", false],
-            [";/* */let foo = bar", false],
-            ["; let foo = bar", true],
-            ["; let foo = bar", true],
-            ["; /**/let foo = bar", true],
-            ["; /* */let foo = bar", true],
-            [";/**/ let foo = bar", true],
-            [";/* */ let foo = bar", true],
-            ["; /**/ let foo = bar", true],
-            ["; /* */ let foo = bar", true],
-            [";\tlet foo = bar", true],
-            [";\tlet foo = bar", true],
-            [";\t/**/let foo = bar", true],
-            [";\t/* */let foo = bar", true],
-            [";/**/\tlet foo = bar", true],
-            [";/* */\tlet foo = bar", true],
-            [";\t/**/\tlet foo = bar", true],
-            [";\t/* */\tlet foo = bar", true],
-            [";\nlet foo = bar", true],
-            [";\nlet foo = bar", true],
-            [";\n/**/let foo = bar", true],
-            [";\n/* */let foo = bar", true],
-            [";/**/\nlet foo = bar", true],
-            [";/* */\nlet foo = bar", true],
-            [";\n/**/\nlet foo = bar", true],
-            [";\n/* */\nlet foo = bar", true]
-        ], (code, expected) => {
-            it("should return true when there is at least one whitespace character between a token and a node", () => {
-                const ast = espree.parse(code, DEFAULT_CONFIG),
-                    sourceCode = new SourceCode(code, ast);
+        describe("should return true when there is at least one whitespace character between a node and a token", () => {
+            leche.withData([
+                ["let foo = bar;;", false],
+                ["let foo = bar;;;", false],
+                ["let foo = 1; let bar = 2;;", true],
+                ["let foo = bar;/**/;", false],
+                ["let foo = bar;/* */;", false],
+                ["let foo = bar;;;", false],
+                ["let foo = bar; ;", true],
+                ["let foo = bar; /**/;", true],
+                ["let foo = bar; /* */;", true],
+                ["let foo = bar;/**/ ;", true],
+                ["let foo = bar;/* */ ;", true],
+                ["let foo = bar; /**/ ;", true],
+                ["let foo = bar; /* */ ;", true],
+                ["let foo = bar;\t;", true],
+                ["let foo = bar;\t/**/;", true],
+                ["let foo = bar;\t/* */;", true],
+                ["let foo = bar;/**/\t;", true],
+                ["let foo = bar;/* */\t;", true],
+                ["let foo = bar;\t/**/\t;", true],
+                ["let foo = bar;\t/* */\t;", true],
+                ["let foo = bar;\n;", true],
+                ["let foo = bar;\n/**/;", true],
+                ["let foo = bar;\n/* */;", true],
+                ["let foo = bar;/**/\n;", true],
+                ["let foo = bar;/* */\n;", true],
+                ["let foo = bar;\n/**/\n;", true],
+                ["let foo = bar;\n/* */\n;", true]
+            ], (code, expected) => {
+                it(code, () => {
+                    const ast = espree.parse(code, DEFAULT_CONFIG),
+                        sourceCode = new SourceCode(code, ast);
 
-                assert.strictEqual(
-                    sourceCode.isSpaceBetweenTokens(
-                        sourceCode.ast.tokens[0], sourceCode.ast.body[sourceCode.ast.body.length - 1]
-                    ),
-                    expected
-                );
+                    assert.strictEqual(
+                        sourceCode.isSpaceBetweenTokens(
+                            sourceCode.ast.body[0], sourceCode.ast.tokens[sourceCode.ast.tokens.length - 1]
+                        ),
+                        expected
+                    );
+                });
             });
         });
 
-        leche.withData([
-            ["let foo = bar;;", false],
-            ["let foo = bar;;;", false],
-            ["let foo = 1; let bar = 2;;", true],
-            ["let foo = bar;/**/;", false],
-            ["let foo = bar;/* */;", false],
-            ["let foo = bar;;;", false],
-            ["let foo = bar; ;", true],
-            ["let foo = bar; /**/;", true],
-            ["let foo = bar; /* */;", true],
-            ["let foo = bar;/**/ ;", true],
-            ["let foo = bar;/* */ ;", true],
-            ["let foo = bar; /**/ ;", true],
-            ["let foo = bar; /* */ ;", true],
-            ["let foo = bar;\t;", true],
-            ["let foo = bar;\t/**/;", true],
-            ["let foo = bar;\t/* */;", true],
-            ["let foo = bar;/**/\t;", true],
-            ["let foo = bar;/* */\t;", true],
-            ["let foo = bar;\t/**/\t;", true],
-            ["let foo = bar;\t/* */\t;", true],
-            ["let foo = bar;\n;", true],
-            ["let foo = bar;\n/**/;", true],
-            ["let foo = bar;\n/* */;", true],
-            ["let foo = bar;/**/\n;", true],
-            ["let foo = bar;/* */\n;", true],
-            ["let foo = bar;\n/**/\n;", true],
-            ["let foo = bar;\n/* */\n;", true]
-        ], (code, expected) => {
-            it("should return true when there is at least one whitespace character between a node and a token", () => {
-                const ast = espree.parse(code, DEFAULT_CONFIG),
-                    sourceCode = new SourceCode(code, ast);
+        describe("should return true when there is at least one whitespace character between two nodes", () => {
+            leche.withData([
+                ["let foo = bar;let baz = qux;", false],
+                ["let foo = bar;/**/let baz = qux;", false],
+                ["let foo = bar;/* */let baz = qux;", false],
+                ["let foo = bar; let baz = qux;", true],
+                ["let foo = bar; /**/let baz = qux;", true],
+                ["let foo = bar; /* */let baz = qux;", true],
+                ["let foo = bar;/**/ let baz = qux;", true],
+                ["let foo = bar;/* */ let baz = qux;", true],
+                ["let foo = bar; /**/ let baz = qux;", true],
+                ["let foo = bar; /* */ let baz = qux;", true],
+                ["let foo = bar;\tlet baz = qux;", true],
+                ["let foo = bar;\t/**/let baz = qux;", true],
+                ["let foo = bar;\t/* */let baz = qux;", true],
+                ["let foo = bar;/**/\tlet baz = qux;", true],
+                ["let foo = bar;/* */\tlet baz = qux;", true],
+                ["let foo = bar;\t/**/\tlet baz = qux;", true],
+                ["let foo = bar;\t/* */\tlet baz = qux;", true],
+                ["let foo = bar;\nlet baz = qux;", true],
+                ["let foo = bar;\n/**/let baz = qux;", true],
+                ["let foo = bar;\n/* */let baz = qux;", true],
+                ["let foo = bar;/**/\nlet baz = qux;", true],
+                ["let foo = bar;/* */\nlet baz = qux;", true],
+                ["let foo = bar;\n/**/\nlet baz = qux;", true],
+                ["let foo = bar;\n/* */\nlet baz = qux;", true],
+                ["let foo = 1;let foo2 = 2; let foo3 = 3;", true]
+            ], (code, expected) => {
+                it(code, () => {
+                    const ast = espree.parse(code, DEFAULT_CONFIG),
+                        sourceCode = new SourceCode(code, ast);
 
-                assert.strictEqual(
-                    sourceCode.isSpaceBetweenTokens(
-                        sourceCode.ast.body[0], sourceCode.ast.tokens[sourceCode.ast.tokens.length - 1]
-                    ),
-                    expected
-                );
-            });
-        });
-
-        leche.withData([
-            ["let foo = bar;let baz = qux;", false],
-            ["let foo = bar;/**/let baz = qux;", false],
-            ["let foo = bar;/* */let baz = qux;", false],
-            ["let foo = bar; let baz = qux;", true],
-            ["let foo = bar; /**/let baz = qux;", true],
-            ["let foo = bar; /* */let baz = qux;", true],
-            ["let foo = bar;/**/ let baz = qux;", true],
-            ["let foo = bar;/* */ let baz = qux;", true],
-            ["let foo = bar; /**/ let baz = qux;", true],
-            ["let foo = bar; /* */ let baz = qux;", true],
-            ["let foo = bar;\tlet baz = qux;", true],
-            ["let foo = bar;\t/**/let baz = qux;", true],
-            ["let foo = bar;\t/* */let baz = qux;", true],
-            ["let foo = bar;/**/\tlet baz = qux;", true],
-            ["let foo = bar;/* */\tlet baz = qux;", true],
-            ["let foo = bar;\t/**/\tlet baz = qux;", true],
-            ["let foo = bar;\t/* */\tlet baz = qux;", true],
-            ["let foo = bar;\nlet baz = qux;", true],
-            ["let foo = bar;\n/**/let baz = qux;", true],
-            ["let foo = bar;\n/* */let baz = qux;", true],
-            ["let foo = bar;/**/\nlet baz = qux;", true],
-            ["let foo = bar;/* */\nlet baz = qux;", true],
-            ["let foo = bar;\n/**/\nlet baz = qux;", true],
-            ["let foo = bar;\n/* */\nlet baz = qux;", true],
-            ["let foo = 1;let foo2 = 2; let foo3 = 3;", true]
-        ], (code, expected) => {
-            it("should return true when there is at least one whitespace character between two nodes", () => {
-                const ast = espree.parse(code, DEFAULT_CONFIG),
-                    sourceCode = new SourceCode(code, ast);
-
-                assert.strictEqual(
-                    sourceCode.isSpaceBetweenTokens(
-                        sourceCode.ast.body[0], sourceCode.ast.body[sourceCode.ast.body.length - 1]
-                    ),
-                    expected
-                );
+                    assert.strictEqual(
+                        sourceCode.isSpaceBetweenTokens(
+                            sourceCode.ast.body[0], sourceCode.ast.body[sourceCode.ast.body.length - 1]
+                        ),
+                        expected
+                    );
+                });
             });
         });
     });

--- a/tests/lib/source-code/source-code.js
+++ b/tests/lib/source-code/source-code.js
@@ -1790,29 +1790,190 @@ describe("SourceCode", () => {
     });
 
     describe("isSpaceBetweenTokens()", () => {
-
         leche.withData([
-            ["let foo = bar;", true],
-            ["let  foo = bar;", true],
-            ["let /**/ foo = bar;", true],
-            ["let/**/foo = bar;", false],
-            ["let/*\n*/foo = bar", false],
-            ["a+b", false],
-            ["a/**/+b", false],
-            ["a/* */+b", false],
-            ["a/**/ +b", true],
-            ["a/**/ /**/+b", true],
-            ["a/**/\n/**/+b", true],
-            ["a +b", true]
+            ["let foo", true],
+            ["let  foo", true],
+            ["let /**/ foo", true],
+            ["let/**/foo", false],
+            ["let/*\n*/foo", false]
         ], (code, expected) => {
-
-            it("should return true when there is one space between tokens", () => {
+            it("should return true when there is at least one whitespace character between two tokens", () => {
                 const ast = espree.parse(code, DEFAULT_CONFIG),
                     sourceCode = new SourceCode(code, ast);
 
                 assert.strictEqual(
                     sourceCode.isSpaceBetweenTokens(
-                        sourceCode.ast.tokens[0], sourceCode.ast.tokens[1]
+                        sourceCode.ast.tokens[0], sourceCode.ast.tokens[sourceCode.ast.tokens.length - 1]
+                    ),
+                    expected
+                );
+            });
+        });
+
+        leche.withData([
+            ["a+b", false],
+            ["a +b", true],
+            ["a/**/+b", false],
+            ["a/* */+b", false],
+            ["a/**/ +b", true],
+            ["a/**/ /**/+b", true],
+            ["a/* */ /* */+b", true],
+            ["a/**/\n/**/+b", true],
+            ["a/* */\n/* */+b", true],
+            ["a/**/+b/**/+c", false],
+            ["a/* */+b/* */+c", false],
+            ["a/**/+b /**/+c", true],
+            ["a/* */+b /* */+c", true],
+            ["a/**/ +b/**/+c", true],
+            ["a/* */ +b/* */+c", true],
+            ["a/**/+b\t/**/+c", true],
+            ["a/* */+b\t/* */+c", true],
+            ["a/**/\t+b/**/+c", true],
+            ["a/* */\t+b/* */+c", true],
+            ["a/**/+b\n/**/+c", true],
+            ["a/* */+b\n/* */+c", true],
+            ["a/**/\n+b/**/+c", true],
+            ["a/* */\n+b/* */+c", true],
+            ["a/* */+' /**/ '/* */+c", false],
+            ["a/* */+ ' /**/ '/* */+c", true],
+            ["a/* */+' /**/ ' /* */+c", true],
+            ["a/* */+ ' /**/ ' /* */+c", true],
+            ["a/* */+` /*\n*/ `/* */+c", false],
+            ["a/* */+ ` /*\n*/ `/* */+c", true],
+            ["a/* */+` /*\n*/ ` /* */+c", true],
+            ["a/* */+ ` /*\n*/ ` /* */+c", true]
+        ], (code, expected) => {
+            it("should return true when there is at least one whitespace character between two tokens", () => {
+                const ast = espree.parse(code, DEFAULT_CONFIG),
+                    sourceCode = new SourceCode(code, ast);
+
+                assert.strictEqual(
+                    sourceCode.isSpaceBetweenTokens(
+                        sourceCode.ast.tokens[0], sourceCode.ast.tokens[sourceCode.ast.tokens.length - 2]
+                    ),
+                    expected
+                );
+            });
+        });
+
+        leche.withData([
+            [";let foo = bar", false],
+            [";/**/let foo = bar", false],
+            [";/* */let foo = bar", false],
+            ["; let foo = bar", true],
+            ["; let foo = bar", true],
+            ["; /**/let foo = bar", true],
+            ["; /* */let foo = bar", true],
+            [";/**/ let foo = bar", true],
+            [";/* */ let foo = bar", true],
+            ["; /**/ let foo = bar", true],
+            ["; /* */ let foo = bar", true],
+            [";\tlet foo = bar", true],
+            [";\tlet foo = bar", true],
+            [";\t/**/let foo = bar", true],
+            [";\t/* */let foo = bar", true],
+            [";/**/\tlet foo = bar", true],
+            [";/* */\tlet foo = bar", true],
+            [";\t/**/\tlet foo = bar", true],
+            [";\t/* */\tlet foo = bar", true],
+            [";\nlet foo = bar", true],
+            [";\nlet foo = bar", true],
+            [";\n/**/let foo = bar", true],
+            [";\n/* */let foo = bar", true],
+            [";/**/\nlet foo = bar", true],
+            [";/* */\nlet foo = bar", true],
+            [";\n/**/\nlet foo = bar", true],
+            [";\n/* */\nlet foo = bar", true]
+        ], (code, expected) => {
+            it("should return true when there is at least one whitespace character between a token and a node", () => {
+                const ast = espree.parse(code, DEFAULT_CONFIG),
+                    sourceCode = new SourceCode(code, ast);
+
+                assert.strictEqual(
+                    sourceCode.isSpaceBetweenTokens(
+                        sourceCode.ast.tokens[0], sourceCode.ast.body[sourceCode.ast.body.length - 1]
+                    ),
+                    expected
+                );
+            });
+        });
+
+        leche.withData([
+            ["let foo = bar;;", false],
+            ["let foo = bar;;;", false],
+            ["let foo = 1; let bar = 2;;", true],
+            ["let foo = bar;/**/;", false],
+            ["let foo = bar;/* */;", false],
+            ["let foo = bar;;;", false],
+            ["let foo = bar; ;", true],
+            ["let foo = bar; /**/;", true],
+            ["let foo = bar; /* */;", true],
+            ["let foo = bar;/**/ ;", true],
+            ["let foo = bar;/* */ ;", true],
+            ["let foo = bar; /**/ ;", true],
+            ["let foo = bar; /* */ ;", true],
+            ["let foo = bar;\t;", true],
+            ["let foo = bar;\t/**/;", true],
+            ["let foo = bar;\t/* */;", true],
+            ["let foo = bar;/**/\t;", true],
+            ["let foo = bar;/* */\t;", true],
+            ["let foo = bar;\t/**/\t;", true],
+            ["let foo = bar;\t/* */\t;", true],
+            ["let foo = bar;\n;", true],
+            ["let foo = bar;\n/**/;", true],
+            ["let foo = bar;\n/* */;", true],
+            ["let foo = bar;/**/\n;", true],
+            ["let foo = bar;/* */\n;", true],
+            ["let foo = bar;\n/**/\n;", true],
+            ["let foo = bar;\n/* */\n;", true]
+        ], (code, expected) => {
+            it("should return true when there is at least one whitespace character between a node and a token", () => {
+                const ast = espree.parse(code, DEFAULT_CONFIG),
+                    sourceCode = new SourceCode(code, ast);
+
+                assert.strictEqual(
+                    sourceCode.isSpaceBetweenTokens(
+                        sourceCode.ast.body[0], sourceCode.ast.tokens[sourceCode.ast.tokens.length - 1]
+                    ),
+                    expected
+                );
+            });
+        });
+
+        leche.withData([
+            ["let foo = bar;let baz = qux;", false],
+            ["let foo = bar;/**/let baz = qux;", false],
+            ["let foo = bar;/* */let baz = qux;", false],
+            ["let foo = bar; let baz = qux;", true],
+            ["let foo = bar; /**/let baz = qux;", true],
+            ["let foo = bar; /* */let baz = qux;", true],
+            ["let foo = bar;/**/ let baz = qux;", true],
+            ["let foo = bar;/* */ let baz = qux;", true],
+            ["let foo = bar; /**/ let baz = qux;", true],
+            ["let foo = bar; /* */ let baz = qux;", true],
+            ["let foo = bar;\tlet baz = qux;", true],
+            ["let foo = bar;\t/**/let baz = qux;", true],
+            ["let foo = bar;\t/* */let baz = qux;", true],
+            ["let foo = bar;/**/\tlet baz = qux;", true],
+            ["let foo = bar;/* */\tlet baz = qux;", true],
+            ["let foo = bar;\t/**/\tlet baz = qux;", true],
+            ["let foo = bar;\t/* */\tlet baz = qux;", true],
+            ["let foo = bar;\nlet baz = qux;", true],
+            ["let foo = bar;\n/**/let baz = qux;", true],
+            ["let foo = bar;\n/* */let baz = qux;", true],
+            ["let foo = bar;/**/\nlet baz = qux;", true],
+            ["let foo = bar;/* */\nlet baz = qux;", true],
+            ["let foo = bar;\n/**/\nlet baz = qux;", true],
+            ["let foo = bar;\n/* */\nlet baz = qux;", true],
+            ["let foo = 1;let foo2 = 2; let foo3 = 3;", true]
+        ], (code, expected) => {
+            it("should return true when there is at least one whitespace character between two nodes", () => {
+                const ast = espree.parse(code, DEFAULT_CONFIG),
+                    sourceCode = new SourceCode(code, ast);
+
+                assert.strictEqual(
+                    sourceCode.isSpaceBetweenTokens(
+                        sourceCode.ast.body[0], sourceCode.ast.body[sourceCode.ast.body.length - 1]
                     ),
                     expected
                 );

--- a/tests/lib/source-code/source-code.js
+++ b/tests/lib/source-code/source-code.js
@@ -1798,16 +1798,34 @@ describe("SourceCode", () => {
                 ["let/**/foo", false],
                 ["let/*\n*/foo", false]
             ], (code, expected) => {
-                it(code, () => {
-                    const ast = espree.parse(code, DEFAULT_CONFIG),
-                        sourceCode = new SourceCode(code, ast);
+                describe("when the first given is located before the second", () => {
+                    it(code, () => {
+                        const ast = espree.parse(code, DEFAULT_CONFIG),
+                            sourceCode = new SourceCode(code, ast);
 
-                    assert.strictEqual(
-                        sourceCode.isSpaceBetweenTokens(
-                            sourceCode.ast.tokens[0], sourceCode.ast.tokens[sourceCode.ast.tokens.length - 1]
-                        ),
-                        expected
-                    );
+                        assert.strictEqual(
+                            sourceCode.isSpaceBetweenTokens(
+                                sourceCode.ast.tokens[0],
+                                sourceCode.ast.tokens[sourceCode.ast.tokens.length - 1]
+                            ),
+                            expected
+                        );
+                    });
+                });
+
+                describe("when the first given is located after the second", () => {
+                    it(code, () => {
+                        const ast = espree.parse(code, DEFAULT_CONFIG),
+                            sourceCode = new SourceCode(code, ast);
+
+                        assert.strictEqual(
+                            sourceCode.isSpaceBetweenTokens(
+                                sourceCode.ast.tokens[sourceCode.ast.tokens.length - 1],
+                                sourceCode.ast.tokens[0]
+                            ),
+                            expected
+                        );
+                    });
                 });
             });
 
@@ -1844,16 +1862,34 @@ describe("SourceCode", () => {
                 ["a/* */+` /*\n*/ ` /* */+c", true],
                 ["a/* */+ ` /*\n*/ ` /* */+c", true]
             ], (code, expected) => {
-                it(code, () => {
-                    const ast = espree.parse(code, DEFAULT_CONFIG),
-                        sourceCode = new SourceCode(code, ast);
+                describe("when the first given is located before the second", () => {
+                    it(code, () => {
+                        const ast = espree.parse(code, DEFAULT_CONFIG),
+                            sourceCode = new SourceCode(code, ast);
 
-                    assert.strictEqual(
-                        sourceCode.isSpaceBetweenTokens(
-                            sourceCode.ast.tokens[0], sourceCode.ast.tokens[sourceCode.ast.tokens.length - 2]
-                        ),
-                        expected
-                    );
+                        assert.strictEqual(
+                            sourceCode.isSpaceBetweenTokens(
+                                sourceCode.ast.tokens[0],
+                                sourceCode.ast.tokens[sourceCode.ast.tokens.length - 2]
+                            ),
+                            expected
+                        );
+                    });
+                });
+
+                describe("when the first given is located after the second", () => {
+                    it(code, () => {
+                        const ast = espree.parse(code, DEFAULT_CONFIG),
+                            sourceCode = new SourceCode(code, ast);
+
+                        assert.strictEqual(
+                            sourceCode.isSpaceBetweenTokens(
+                                sourceCode.ast.tokens[sourceCode.ast.tokens.length - 2],
+                                sourceCode.ast.tokens[0]
+                            ),
+                            expected
+                        );
+                    });
                 });
             });
         });
@@ -1888,16 +1924,34 @@ describe("SourceCode", () => {
                 [";\n/**/\nlet foo = bar", true],
                 [";\n/* */\nlet foo = bar", true]
             ], (code, expected) => {
-                it(code, () => {
-                    const ast = espree.parse(code, DEFAULT_CONFIG),
-                        sourceCode = new SourceCode(code, ast);
+                describe("when the first given is located before the second", () => {
+                    it(code, () => {
+                        const ast = espree.parse(code, DEFAULT_CONFIG),
+                            sourceCode = new SourceCode(code, ast);
 
-                    assert.strictEqual(
-                        sourceCode.isSpaceBetweenTokens(
-                            sourceCode.ast.tokens[0], sourceCode.ast.body[sourceCode.ast.body.length - 1]
-                        ),
-                        expected
-                    );
+                        assert.strictEqual(
+                            sourceCode.isSpaceBetweenTokens(
+                                sourceCode.ast.tokens[0],
+                                sourceCode.ast.body[sourceCode.ast.body.length - 1]
+                            ),
+                            expected
+                        );
+                    });
+                });
+
+                describe("when the first given is located after the second", () => {
+                    it(code, () => {
+                        const ast = espree.parse(code, DEFAULT_CONFIG),
+                            sourceCode = new SourceCode(code, ast);
+
+                        assert.strictEqual(
+                            sourceCode.isSpaceBetweenTokens(
+                                sourceCode.ast.body[sourceCode.ast.body.length - 1],
+                                sourceCode.ast.tokens[0]
+                            ),
+                            expected
+                        );
+                    });
                 });
             });
         });
@@ -1932,16 +1986,34 @@ describe("SourceCode", () => {
                 ["let foo = bar;\n/**/\n;", true],
                 ["let foo = bar;\n/* */\n;", true]
             ], (code, expected) => {
-                it(code, () => {
-                    const ast = espree.parse(code, DEFAULT_CONFIG),
-                        sourceCode = new SourceCode(code, ast);
+                describe("when the first given is located before the second", () => {
+                    it(code, () => {
+                        const ast = espree.parse(code, DEFAULT_CONFIG),
+                            sourceCode = new SourceCode(code, ast);
 
-                    assert.strictEqual(
-                        sourceCode.isSpaceBetweenTokens(
-                            sourceCode.ast.body[0], sourceCode.ast.tokens[sourceCode.ast.tokens.length - 1]
-                        ),
-                        expected
-                    );
+                        assert.strictEqual(
+                            sourceCode.isSpaceBetweenTokens(
+                                sourceCode.ast.body[0],
+                                sourceCode.ast.tokens[sourceCode.ast.tokens.length - 1]
+                            ),
+                            expected
+                        );
+                    });
+                });
+
+                describe("when the first given is located after the second", () => {
+                    it(code, () => {
+                        const ast = espree.parse(code, DEFAULT_CONFIG),
+                            sourceCode = new SourceCode(code, ast);
+
+                        assert.strictEqual(
+                            sourceCode.isSpaceBetweenTokens(
+                                sourceCode.ast.tokens[sourceCode.ast.tokens.length - 1],
+                                sourceCode.ast.body[0]
+                            ),
+                            expected
+                        );
+                    });
                 });
             });
         });
@@ -1974,13 +2046,74 @@ describe("SourceCode", () => {
                 ["let foo = bar;\n/* */\nlet baz = qux;", true],
                 ["let foo = 1;let foo2 = 2; let foo3 = 3;", true]
             ], (code, expected) => {
+                describe("when the first given is located before the second", () => {
+                    it(code, () => {
+                        const ast = espree.parse(code, DEFAULT_CONFIG),
+                            sourceCode = new SourceCode(code, ast);
+
+                        assert.strictEqual(
+                            sourceCode.isSpaceBetweenTokens(
+                                sourceCode.ast.body[0],
+                                sourceCode.ast.body[sourceCode.ast.body.length - 1]
+                            ),
+                            expected
+                        );
+                    });
+                });
+
+                describe("when the first given is located after the second", () => {
+                    it(code, () => {
+                        const ast = espree.parse(code, DEFAULT_CONFIG),
+                            sourceCode = new SourceCode(code, ast);
+
+                        assert.strictEqual(
+                            sourceCode.isSpaceBetweenTokens(
+                                sourceCode.ast.body[sourceCode.ast.body.length - 1],
+                                sourceCode.ast.body[0]
+                            ),
+                            expected
+                        );
+                    });
+                });
+            });
+        });
+
+        describe("should return false either of the arguments' location is inside the other one", () => {
+            leche.withData([
+                ["let foo = bar;", false]
+            ], (code, expected) => {
                 it(code, () => {
                     const ast = espree.parse(code, DEFAULT_CONFIG),
                         sourceCode = new SourceCode(code, ast);
 
                     assert.strictEqual(
                         sourceCode.isSpaceBetweenTokens(
-                            sourceCode.ast.body[0], sourceCode.ast.body[sourceCode.ast.body.length - 1]
+                            sourceCode.ast.tokens[0],
+                            sourceCode.ast.body[0]
+                        ),
+                        expected
+                    );
+
+                    assert.strictEqual(
+                        sourceCode.isSpaceBetweenTokens(
+                            sourceCode.ast.tokens[sourceCode.ast.tokens.length - 1],
+                            sourceCode.ast.body[0]
+                        ),
+                        expected
+                    );
+
+                    assert.strictEqual(
+                        sourceCode.isSpaceBetweenTokens(
+                            sourceCode.ast.body[0],
+                            sourceCode.ast.tokens[0]
+                        ),
+                        expected
+                    );
+
+                    assert.strictEqual(
+                        sourceCode.isSpaceBetweenTokens(
+                            sourceCode.ast.body[0],
+                            sourceCode.ast.tokens[sourceCode.ast.tokens.length - 1]
                         ),
                         expected
                     );


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

I noticed that `sourceCode#isSpaceBetweenTokens()` assumes that the given arguments are tokens and that they are adjacent, but there is nothing stopping a consumer from using non-adjacent tokens as well as AST nodes (example [here](https://github.com/eslint/eslint/blob/master/lib/rules/space-before-blocks.js#L98)).

I think it would make sense to only allow tokens that are adjacent as arguments, however, that would be a breaking change. This PR updates the logic so that it will check for any whitespace between tokens (including comments) between two given nodes or tokens. The only difference in behavior is the following two tests (two tokens with a string containing spaces between them is currently incorrectly being flagged as containing whitespace):

```
// Both of the following should return false but currently return true.

a/* */+' /**/ '/* */+c

a/* */+` /*
*/ `/* */+c
```

The rest of the tests cover the current behavior that already exists.

**Is there anything you'd like reviewers to focus on?**

Does this seem like the correct solution to the rest of the team?
