### PR TITLE
Update: Check member expressions with `this` in operator-assignment

### DIFF
--- a/lib/rules/operator-assignment.js
+++ b/lib/rules/operator-assignment.js
@@ -71,6 +71,9 @@ function same(a, b) {
              */
             return same(a.object, b.object) && same(a.property, b.property);
 
+        case "ThisExpression":
+            return true;
+
         default:
             return false;
     }
@@ -83,8 +86,14 @@ function same(a, b) {
  * @returns {boolean} `true` if the node can be fixed
  */
 function canBeFixed(node) {
-    return node.type === "Identifier" ||
-        node.type === "MemberExpression" && node.object.type === "Identifier" && (!node.computed || node.property.type === "Literal");
+    return (
+        node.type === "Identifier" ||
+        (
+            node.type === "MemberExpression" &&
+            (node.object.type === "Identifier" || node.object.type === "ThisExpression") &&
+            (!node.computed || node.property.type === "Literal")
+        )
+    );
 }
 
 module.exports = {

--- a/tests/lib/rules/operator-assignment.js
+++ b/tests/lib/rules/operator-assignment.js
@@ -72,7 +72,19 @@ ruleTester.run("operator-assignment", rule, {
             options: ["never"]
         },
         "x = y ** x",
-        "x = x * y + z"
+        "x = x * y + z",
+        {
+            code: "this.x = this.y + z",
+            options: ["always"]
+        },
+        {
+            code: "this.x = foo.x + y",
+            options: ["always"]
+        },
+        {
+            code: "this.x = foo.this.x + y",
+            options: ["always"]
+        }
     ],
 
     invalid: [{
@@ -170,6 +182,15 @@ ruleTester.run("operator-assignment", rule, {
         options: ["never"],
         errors: UNEXPECTED_OPERATOR_ASSIGNMENT
     }, {
+        code: "this.foo = this.foo + bar",
+        output: "this.foo += bar",
+        errors: EXPECTED_OPERATOR_ASSIGNMENT
+    }, {
+        code: "this.foo += bar",
+        output: "this.foo = this.foo + bar",
+        options: ["never"],
+        errors: UNEXPECTED_OPERATOR_ASSIGNMENT
+    }, {
         code: "foo.bar.baz = foo.bar.baz + qux",
         output: null, // not fixed; fixing would cause a foo.bar getter to activate once rather than twice
         errors: EXPECTED_OPERATOR_ASSIGNMENT
@@ -179,8 +200,21 @@ ruleTester.run("operator-assignment", rule, {
         options: ["never"],
         errors: UNEXPECTED_OPERATOR_ASSIGNMENT
     }, {
+        code: "this.foo.bar = this.foo.bar + baz",
+        output: null, // not fixed; fixing would cause a this.foo getter to activate once rather than twice
+        errors: EXPECTED_OPERATOR_ASSIGNMENT
+    }, {
+        code: "this.foo.bar += baz",
+        output: null, // not fixed; fixing would cause a this.foo getter to activate twice rather than once
+        options: ["never"],
+        errors: UNEXPECTED_OPERATOR_ASSIGNMENT
+    }, {
         code: "foo[bar] = foo[bar] + baz",
         output: null, // not fixed; fixing would cause bar.toString() to get called once instead of twice
+        errors: EXPECTED_OPERATOR_ASSIGNMENT
+    }, {
+        code: "this[foo] = this[foo] + bar",
+        output: null, // not fixed; fixing would cause foo.toString() to get called once instead of twice
         errors: EXPECTED_OPERATOR_ASSIGNMENT
     }, {
         code: "foo[bar] >>>= baz",
@@ -188,8 +222,17 @@ ruleTester.run("operator-assignment", rule, {
         options: ["never"],
         errors: UNEXPECTED_OPERATOR_ASSIGNMENT
     }, {
+        code: "this[foo] >>>= bar",
+        output: null, // not fixed; fixing would cause foo.toString() to get called twice instead of once
+        options: ["never"],
+        errors: UNEXPECTED_OPERATOR_ASSIGNMENT
+    }, {
         code: "foo[5] = foo[5] / baz",
         output: "foo[5] /= baz", // this is ok because 5 is a literal, so toString won't get called
+        errors: EXPECTED_OPERATOR_ASSIGNMENT
+    }, {
+        code: "this[5] = this[5] / foo",
+        output: "this[5] /= foo", // this is ok because 5 is a literal, so toString won't get called
         errors: EXPECTED_OPERATOR_ASSIGNMENT
     }, {
         code: "/*1*/x/*2*/./*3*/y/*4*/= x.y +/*5*/z/*6*/./*7*/w/*8*/;",


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix
[X] Changes an existing rule

I believe this is a bug fix, but it produces **more** warnings.

This PR fixes two things in the `operator-assignment` rule:

* The default `always` option was ignoring `this` member expressions, such as `this.x = this.x + y`.
* The `never` option was reporting `this` member expressions, but didn't auto-fix in some cases where it seems to be safe, such as `this.x += y`.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**What rule do you want to change?**

`operator-assignment`

**Does this change cause the rule to produce more or fewer warnings?**

more

**How will the change be implemented? (New option, new default behavior, etc.)?**

new default behavior

**Please provide some example code that this change will affect:**

```js
/* eslint operator-assignment: ["error", "always"] */

this.foo = this.foo + bar
```

**What does the rule currently do for this code?**

No errors

**What will the rule do after it's changed?**

Error and autofix to:

```js
/* eslint operator-assignment: ["error", "always"] */

this.foo += bar
```


<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Account for `ThisExpression` in the function that compares two expressions. Also in the function that determines whether the autofix is safe.

**Is there anything you'd like reviewers to focus on?**

All added tests in `valid` were valid before, those are just regression tests.

The following tests with the `never` option had the same behavior (which is an error without autofix) before this PR, and that isn't changed.

```js
this.foo.bar += baz
this[foo] >>>= bar
```

The following test with the `never` option was already an error, but wasn't being auto-fixed. That's changed now.

```js
this.foo += bar
```

The following tests with the default `always` options are new warnings:

```js
this.foo = this.foo + bar
this.foo.bar = this.foo.bar + baz
this[foo] = this[foo] + bar
this[5] = this[5] / foo
```

Can this be treated as a semver-minor bug fix that produces more warnings? There was a similar case in #12279.
