### PR TITLE
Fix: Windows path parsing for JUnit (fixes #12507)

### DIFF
--- a/lib/cli-engine/formatters/junit.js
+++ b/lib/cli-engine/formatters/junit.js
@@ -32,7 +32,7 @@ function getMessageType(message) {
  * @private
  */
 function pathWithoutExt(filePath) {
-    return path.posix.join(path.posix.dirname(filePath), path.basename(filePath, path.extname(filePath)));
+    return path.join(path.dirname(filePath), path.basename(filePath, path.extname(filePath)));
 }
 
 //------------------------------------------------------------------------------

--- a/tests/lib/cli-engine/formatters/junit.js
+++ b/tests/lib/cli-engine/formatters/junit.js
@@ -12,11 +12,36 @@
 //------------------------------------------------------------------------------
 
 const assert = require("chai").assert,
-    formatter = require("../../../../lib/cli-engine/formatters/junit");
+    formatter = require("../../../../lib/cli-engine/formatters/junit"),
+    process = require("process");
 
 //------------------------------------------------------------------------------
 // Tests
 //------------------------------------------------------------------------------
+
+/**
+ * Returns the suppliedFilePath for each test
+ * @returns {string} the filepath in a format that would be expected on either a win32 system or POSIX system
+ * @private
+ */
+function suppliedFilePath() {
+    if (process.platform === "win32") {
+        return "C:\\path\\to\\foo.js";
+    }
+    return "/path/to/foo.js";
+}
+
+/**
+ * Returns the expectedClassName for each test
+ * @returns {string} the expected classname in a win32 system or POSIX system path format
+ * @private
+ */
+function expectedClassName() {
+    if (process.platform === "win32") {
+        return "C:\\path\\to\\foo";
+    }
+    return "/path/to/foo";
+}
 
 describe("formatter:junit", () => {
     describe("when there are no problems", () => {
@@ -31,7 +56,7 @@ describe("formatter:junit", () => {
 
     describe("when passed a single message", () => {
         const code = [{
-            filePath: "/path/to/foo.js",
+            filePath: suppliedFilePath(),
             messages: [{
                 message: "Unexpected foo.",
                 severity: 2,
@@ -44,20 +69,20 @@ describe("formatter:junit", () => {
         it("should return a single <testcase> with a message and the line and col number in the body (error)", () => {
             const result = formatter(code);
 
-            assert.strictEqual(result.replace(/\n/gu, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"/path/to/foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\" classname=\"/path/to/foo\"><failure message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Error - Unexpected foo. (foo)]]></failure></testcase></testsuite></testsuites>");
+            assert.strictEqual(result.replace(/\n/gu, ""), `<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite package="org.eslint" time="0" tests="1" errors="1" name="${suppliedFilePath()}"><testcase time="0" name="org.eslint.foo" classname="${expectedClassName()}"><failure message="Unexpected foo."><![CDATA[line 5, col 10, Error - Unexpected foo. (foo)]]></failure></testcase></testsuite></testsuites>`);
         });
 
         it("should return a single <testcase> with a message and the line and col number in the body (warning)", () => {
             code[0].messages[0].severity = 1;
             const result = formatter(code);
 
-            assert.strictEqual(result.replace(/\n/gu, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"/path/to/foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\" classname=\"/path/to/foo\"><failure message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Warning - Unexpected foo. (foo)]]></failure></testcase></testsuite></testsuites>");
+            assert.strictEqual(result.replace(/\n/gu, ""), `<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite package="org.eslint" time="0" tests="1" errors="1" name="${suppliedFilePath()}"><testcase time="0" name="org.eslint.foo" classname="${expectedClassName()}"><failure message="Unexpected foo."><![CDATA[line 5, col 10, Warning - Unexpected foo. (foo)]]></failure></testcase></testsuite></testsuites>`);
         });
     });
 
     describe("when passed a fatal error message", () => {
         const code = [{
-            filePath: "foo.js",
+            filePath: suppliedFilePath(),
             messages: [{
                 fatal: true,
                 message: "Unexpected foo.",
@@ -70,13 +95,13 @@ describe("formatter:junit", () => {
         it("should return a single <testcase> and an <error>", () => {
             const result = formatter(code);
 
-            assert.strictEqual(result.replace(/\n/gu, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\" classname=\"foo\"><error message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Error - Unexpected foo. (foo)]]></error></testcase></testsuite></testsuites>");
+            assert.strictEqual(result.replace(/\n/gu, ""), `<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite package="org.eslint" time="0" tests="1" errors="1" name="${suppliedFilePath()}"><testcase time="0" name="org.eslint.foo" classname="${expectedClassName()}"><error message="Unexpected foo."><![CDATA[line 5, col 10, Error - Unexpected foo. (foo)]]></error></testcase></testsuite></testsuites>`);
         });
     });
 
     describe("when passed a fatal error message with no line or column", () => {
         const code = [{
-            filePath: "foo.js",
+            filePath: suppliedFilePath(),
             messages: [{
                 fatal: true,
                 message: "Unexpected foo."
@@ -86,13 +111,13 @@ describe("formatter:junit", () => {
         it("should return a single <testcase> and an <error>", () => {
             const result = formatter(code);
 
-            assert.strictEqual(result.replace(/\n/gu, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.unknown\" classname=\"foo\"><error message=\"Unexpected foo.\"><![CDATA[line 0, col 0, Error - Unexpected foo.]]></error></testcase></testsuite></testsuites>");
+            assert.strictEqual(result.replace(/\n/gu, ""), `<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite package="org.eslint" time="0" tests="1" errors="1" name="${suppliedFilePath()}"><testcase time="0" name="org.eslint.unknown" classname="${expectedClassName()}"><error message="Unexpected foo."><![CDATA[line 0, col 0, Error - Unexpected foo.]]></error></testcase></testsuite></testsuites>`);
         });
     });
 
     describe("when passed a fatal error message with no line, column, or message text", () => {
         const code = [{
-            filePath: "foo.js",
+            filePath: suppliedFilePath(),
             messages: [{
                 fatal: true
             }]
@@ -101,13 +126,13 @@ describe("formatter:junit", () => {
         it("should return a single <testcase> and an <error>", () => {
             const result = formatter(code);
 
-            assert.strictEqual(result.replace(/\n/gu, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.unknown\" classname=\"foo\"><error message=\"\"><![CDATA[line 0, col 0, Error - ]]></error></testcase></testsuite></testsuites>");
+            assert.strictEqual(result.replace(/\n/gu, ""), `<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite package="org.eslint" time="0" tests="1" errors="1" name="${suppliedFilePath()}"><testcase time="0" name="org.eslint.unknown" classname="${expectedClassName()}"><error message=""><![CDATA[line 0, col 0, Error - ]]></error></testcase></testsuite></testsuites>`);
         });
     });
 
     describe("when passed multiple messages", () => {
         const code = [{
-            filePath: "foo.js",
+            filePath: suppliedFilePath(),
             messages: [{
                 message: "Unexpected foo.",
                 severity: 2,
@@ -126,13 +151,13 @@ describe("formatter:junit", () => {
         it("should return a multiple <testcase>'s", () => {
             const result = formatter(code);
 
-            assert.strictEqual(result.replace(/\n/gu, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"2\" errors=\"2\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\" classname=\"foo\"><failure message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Error - Unexpected foo. (foo)]]></failure></testcase><testcase time=\"0\" name=\"org.eslint.bar\" classname=\"foo\"><failure message=\"Unexpected bar.\"><![CDATA[line 6, col 11, Warning - Unexpected bar. (bar)]]></failure></testcase></testsuite></testsuites>");
+            assert.strictEqual(result.replace(/\n/gu, ""), `<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite package="org.eslint" time="0" tests="2" errors="2" name="${suppliedFilePath()}"><testcase time="0" name="org.eslint.foo" classname="${expectedClassName()}"><failure message="Unexpected foo."><![CDATA[line 5, col 10, Error - Unexpected foo. (foo)]]></failure></testcase><testcase time="0" name="org.eslint.bar" classname="${expectedClassName()}"><failure message="Unexpected bar."><![CDATA[line 6, col 11, Warning - Unexpected bar. (bar)]]></failure></testcase></testsuite></testsuites>`);
         });
     });
 
     describe("when passed special characters", () => {
         const code = [{
-            filePath: "foo.js",
+            filePath: suppliedFilePath(),
             messages: [{
                 message: "Unexpected <foo></foo>\b\t\n\f\r牛逼.",
                 severity: 1,
@@ -145,13 +170,13 @@ describe("formatter:junit", () => {
         it("should make them go away", () => {
             const result = formatter(code);
 
-            assert.strictEqual(result.replace(/\n/gu, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\" classname=\"foo\"><failure message=\"Unexpected &lt;foo&gt;&lt;/foo&gt;&#8;&#9;&#10;&#12;&#13;&#29275;&#36924;.\"><![CDATA[line 5, col 10, Warning - Unexpected &lt;foo&gt;&lt;/foo&gt;&#8;&#9;&#10;&#12;&#13;&#29275;&#36924;. (foo)]]></failure></testcase></testsuite></testsuites>");
+            assert.strictEqual(result.replace(/\n/gu, ""), `<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite package="org.eslint" time="0" tests="1" errors="1" name="${suppliedFilePath()}"><testcase time="0" name="org.eslint.foo" classname="${expectedClassName()}"><failure message="Unexpected &lt;foo&gt;&lt;/foo&gt;&#8;&#9;&#10;&#12;&#13;&#29275;&#36924;."><![CDATA[line 5, col 10, Warning - Unexpected &lt;foo&gt;&lt;/foo&gt;&#8;&#9;&#10;&#12;&#13;&#29275;&#36924;. (foo)]]></failure></testcase></testsuite></testsuites>`);
         });
     });
 
     describe("when passed multiple files with 1 message each", () => {
         const code = [{
-            filePath: "foo.js",
+            filePath: suppliedFilePath(),
             messages: [{
                 message: "Unexpected foo.",
                 severity: 1,
@@ -173,13 +198,13 @@ describe("formatter:junit", () => {
         it("should return 2 <testsuite>'s", () => {
             const result = formatter(code);
 
-            assert.strictEqual(result.replace(/\n/gu, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\" classname=\"foo\"><failure message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Warning - Unexpected foo. (foo)]]></failure></testcase></testsuite><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"bar.js\"><testcase time=\"0\" name=\"org.eslint.bar\" classname=\"bar\"><failure message=\"Unexpected bar.\"><![CDATA[line 6, col 11, Error - Unexpected bar. (bar)]]></failure></testcase></testsuite></testsuites>");
+            assert.strictEqual(result.replace(/\n/gu, ""), `<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite package="org.eslint" time="0" tests="1" errors="1" name="${suppliedFilePath()}"><testcase time="0" name="org.eslint.foo" classname="${expectedClassName()}"><failure message="Unexpected foo."><![CDATA[line 5, col 10, Warning - Unexpected foo. (foo)]]></failure></testcase></testsuite><testsuite package="org.eslint" time="0" tests="1" errors="1" name="bar.js"><testcase time="0" name="org.eslint.bar" classname="bar"><failure message="Unexpected bar."><![CDATA[line 6, col 11, Error - Unexpected bar. (bar)]]></failure></testcase></testsuite></testsuites>`);
         });
     });
 
     describe("when passed multiple files should print even if no errors", () => {
         const code = [{
-            filePath: "foo.js",
+            filePath: suppliedFilePath(),
             messages: [{
                 message: "Unexpected foo.",
                 severity: 1,
@@ -195,20 +220,20 @@ describe("formatter:junit", () => {
         it("should return 2 <testsuite>", () => {
             const result = formatter(code);
 
-            assert.strictEqual(result.replace(/\n/gu, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\" classname=\"foo\"><failure message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Warning - Unexpected foo. (foo)]]></failure></testcase></testsuite><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"0\" name=\"bar.js\"><testcase time=\"0\" name=\"bar.js\" classname=\"bar\" /></testsuite></testsuites>");
+            assert.strictEqual(result.replace(/\n/gu, ""), `<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite package="org.eslint" time="0" tests="1" errors="1" name="${suppliedFilePath()}"><testcase time="0" name="org.eslint.foo" classname="${expectedClassName()}"><failure message="Unexpected foo."><![CDATA[line 5, col 10, Warning - Unexpected foo. (foo)]]></failure></testcase></testsuite><testsuite package="org.eslint" time="0" tests="1" errors="0" name="bar.js"><testcase time="0" name="bar.js" classname="bar" /></testsuite></testsuites>`);
         });
     });
 
     describe("when passed a file with no errors", () => {
         const code = [{
-            filePath: "foo.js",
+            filePath: suppliedFilePath(),
             messages: []
         }];
 
         it("should print a passing <testcase>", () => {
             const result = formatter(code);
 
-            assert.strictEqual(result.replace(/\n/gu, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"0\" name=\"foo.js\"><testcase time=\"0\" name=\"foo.js\" classname=\"foo\" /></testsuite></testsuites>");
+            assert.strictEqual(result.replace(/\n/gu, ""), `<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite package="org.eslint" time="0" tests="1" errors="0" name="${suppliedFilePath()}"><testcase time="0" name="${suppliedFilePath()}" classname="${expectedClassName()}" /></testsuite></testsuites>`);
         });
     });
 });

--- a/tests/lib/cli-engine/formatters/junit.js
+++ b/tests/lib/cli-engine/formatters/junit.js
@@ -19,29 +19,8 @@ const assert = require("chai").assert,
 // Tests
 //------------------------------------------------------------------------------
 
-/**
- * Returns the suppliedFilePath for each test
- * @returns {string} the filepath in a format that would be expected on either a win32 system or POSIX system
- * @private
- */
-function suppliedFilePath() {
-    if (process.platform === "win32") {
-        return "C:\\path\\to\\foo.js";
-    }
-    return "/path/to/foo.js";
-}
-
-/**
- * Returns the expectedClassName for each test
- * @returns {string} the expected classname in a win32 system or POSIX system path format
- * @private
- */
-function expectedClassName() {
-    if (process.platform === "win32") {
-        return "C:\\path\\to\\foo";
-    }
-    return "/path/to/foo";
-}
+const suppliedFilePath = (process.platform === "win32") ? "C:\\path\\to\\foo.js" : "/path/to/foo.js";
+const expectedClassName = (process.platform === "win32") ? "C:\\path\\to\\foo" : "/path/to/foo";
 
 describe("formatter:junit", () => {
     describe("when there are no problems", () => {
@@ -56,7 +35,7 @@ describe("formatter:junit", () => {
 
     describe("when passed a single message", () => {
         const code = [{
-            filePath: suppliedFilePath(),
+            filePath: suppliedFilePath,
             messages: [{
                 message: "Unexpected foo.",
                 severity: 2,
@@ -69,20 +48,20 @@ describe("formatter:junit", () => {
         it("should return a single <testcase> with a message and the line and col number in the body (error)", () => {
             const result = formatter(code);
 
-            assert.strictEqual(result.replace(/\n/gu, ""), `<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite package="org.eslint" time="0" tests="1" errors="1" name="${suppliedFilePath()}"><testcase time="0" name="org.eslint.foo" classname="${expectedClassName()}"><failure message="Unexpected foo."><![CDATA[line 5, col 10, Error - Unexpected foo. (foo)]]></failure></testcase></testsuite></testsuites>`);
+            assert.strictEqual(result.replace(/\n/gu, ""), `<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite package="org.eslint" time="0" tests="1" errors="1" name="${suppliedFilePath}"><testcase time="0" name="org.eslint.foo" classname="${expectedClassName}"><failure message="Unexpected foo."><![CDATA[line 5, col 10, Error - Unexpected foo. (foo)]]></failure></testcase></testsuite></testsuites>`);
         });
 
         it("should return a single <testcase> with a message and the line and col number in the body (warning)", () => {
             code[0].messages[0].severity = 1;
             const result = formatter(code);
 
-            assert.strictEqual(result.replace(/\n/gu, ""), `<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite package="org.eslint" time="0" tests="1" errors="1" name="${suppliedFilePath()}"><testcase time="0" name="org.eslint.foo" classname="${expectedClassName()}"><failure message="Unexpected foo."><![CDATA[line 5, col 10, Warning - Unexpected foo. (foo)]]></failure></testcase></testsuite></testsuites>`);
+            assert.strictEqual(result.replace(/\n/gu, ""), `<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite package="org.eslint" time="0" tests="1" errors="1" name="${suppliedFilePath}"><testcase time="0" name="org.eslint.foo" classname="${expectedClassName}"><failure message="Unexpected foo."><![CDATA[line 5, col 10, Warning - Unexpected foo. (foo)]]></failure></testcase></testsuite></testsuites>`);
         });
     });
 
     describe("when passed a fatal error message", () => {
         const code = [{
-            filePath: suppliedFilePath(),
+            filePath: suppliedFilePath,
             messages: [{
                 fatal: true,
                 message: "Unexpected foo.",
@@ -95,13 +74,13 @@ describe("formatter:junit", () => {
         it("should return a single <testcase> and an <error>", () => {
             const result = formatter(code);
 
-            assert.strictEqual(result.replace(/\n/gu, ""), `<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite package="org.eslint" time="0" tests="1" errors="1" name="${suppliedFilePath()}"><testcase time="0" name="org.eslint.foo" classname="${expectedClassName()}"><error message="Unexpected foo."><![CDATA[line 5, col 10, Error - Unexpected foo. (foo)]]></error></testcase></testsuite></testsuites>`);
+            assert.strictEqual(result.replace(/\n/gu, ""), `<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite package="org.eslint" time="0" tests="1" errors="1" name="${suppliedFilePath}"><testcase time="0" name="org.eslint.foo" classname="${expectedClassName}"><error message="Unexpected foo."><![CDATA[line 5, col 10, Error - Unexpected foo. (foo)]]></error></testcase></testsuite></testsuites>`);
         });
     });
 
     describe("when passed a fatal error message with no line or column", () => {
         const code = [{
-            filePath: suppliedFilePath(),
+            filePath: suppliedFilePath,
             messages: [{
                 fatal: true,
                 message: "Unexpected foo."
@@ -111,13 +90,13 @@ describe("formatter:junit", () => {
         it("should return a single <testcase> and an <error>", () => {
             const result = formatter(code);
 
-            assert.strictEqual(result.replace(/\n/gu, ""), `<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite package="org.eslint" time="0" tests="1" errors="1" name="${suppliedFilePath()}"><testcase time="0" name="org.eslint.unknown" classname="${expectedClassName()}"><error message="Unexpected foo."><![CDATA[line 0, col 0, Error - Unexpected foo.]]></error></testcase></testsuite></testsuites>`);
+            assert.strictEqual(result.replace(/\n/gu, ""), `<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite package="org.eslint" time="0" tests="1" errors="1" name="${suppliedFilePath}"><testcase time="0" name="org.eslint.unknown" classname="${expectedClassName}"><error message="Unexpected foo."><![CDATA[line 0, col 0, Error - Unexpected foo.]]></error></testcase></testsuite></testsuites>`);
         });
     });
 
     describe("when passed a fatal error message with no line, column, or message text", () => {
         const code = [{
-            filePath: suppliedFilePath(),
+            filePath: suppliedFilePath,
             messages: [{
                 fatal: true
             }]
@@ -126,13 +105,13 @@ describe("formatter:junit", () => {
         it("should return a single <testcase> and an <error>", () => {
             const result = formatter(code);
 
-            assert.strictEqual(result.replace(/\n/gu, ""), `<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite package="org.eslint" time="0" tests="1" errors="1" name="${suppliedFilePath()}"><testcase time="0" name="org.eslint.unknown" classname="${expectedClassName()}"><error message=""><![CDATA[line 0, col 0, Error - ]]></error></testcase></testsuite></testsuites>`);
+            assert.strictEqual(result.replace(/\n/gu, ""), `<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite package="org.eslint" time="0" tests="1" errors="1" name="${suppliedFilePath}"><testcase time="0" name="org.eslint.unknown" classname="${expectedClassName}"><error message=""><![CDATA[line 0, col 0, Error - ]]></error></testcase></testsuite></testsuites>`);
         });
     });
 
     describe("when passed multiple messages", () => {
         const code = [{
-            filePath: suppliedFilePath(),
+            filePath: suppliedFilePath,
             messages: [{
                 message: "Unexpected foo.",
                 severity: 2,
@@ -151,13 +130,13 @@ describe("formatter:junit", () => {
         it("should return a multiple <testcase>'s", () => {
             const result = formatter(code);
 
-            assert.strictEqual(result.replace(/\n/gu, ""), `<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite package="org.eslint" time="0" tests="2" errors="2" name="${suppliedFilePath()}"><testcase time="0" name="org.eslint.foo" classname="${expectedClassName()}"><failure message="Unexpected foo."><![CDATA[line 5, col 10, Error - Unexpected foo. (foo)]]></failure></testcase><testcase time="0" name="org.eslint.bar" classname="${expectedClassName()}"><failure message="Unexpected bar."><![CDATA[line 6, col 11, Warning - Unexpected bar. (bar)]]></failure></testcase></testsuite></testsuites>`);
+            assert.strictEqual(result.replace(/\n/gu, ""), `<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite package="org.eslint" time="0" tests="2" errors="2" name="${suppliedFilePath}"><testcase time="0" name="org.eslint.foo" classname="${expectedClassName}"><failure message="Unexpected foo."><![CDATA[line 5, col 10, Error - Unexpected foo. (foo)]]></failure></testcase><testcase time="0" name="org.eslint.bar" classname="${expectedClassName}"><failure message="Unexpected bar."><![CDATA[line 6, col 11, Warning - Unexpected bar. (bar)]]></failure></testcase></testsuite></testsuites>`);
         });
     });
 
     describe("when passed special characters", () => {
         const code = [{
-            filePath: suppliedFilePath(),
+            filePath: suppliedFilePath,
             messages: [{
                 message: "Unexpected <foo></foo>\b\t\n\f\r牛逼.",
                 severity: 1,
@@ -170,13 +149,13 @@ describe("formatter:junit", () => {
         it("should make them go away", () => {
             const result = formatter(code);
 
-            assert.strictEqual(result.replace(/\n/gu, ""), `<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite package="org.eslint" time="0" tests="1" errors="1" name="${suppliedFilePath()}"><testcase time="0" name="org.eslint.foo" classname="${expectedClassName()}"><failure message="Unexpected &lt;foo&gt;&lt;/foo&gt;&#8;&#9;&#10;&#12;&#13;&#29275;&#36924;."><![CDATA[line 5, col 10, Warning - Unexpected &lt;foo&gt;&lt;/foo&gt;&#8;&#9;&#10;&#12;&#13;&#29275;&#36924;. (foo)]]></failure></testcase></testsuite></testsuites>`);
+            assert.strictEqual(result.replace(/\n/gu, ""), `<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite package="org.eslint" time="0" tests="1" errors="1" name="${suppliedFilePath}"><testcase time="0" name="org.eslint.foo" classname="${expectedClassName}"><failure message="Unexpected &lt;foo&gt;&lt;/foo&gt;&#8;&#9;&#10;&#12;&#13;&#29275;&#36924;."><![CDATA[line 5, col 10, Warning - Unexpected &lt;foo&gt;&lt;/foo&gt;&#8;&#9;&#10;&#12;&#13;&#29275;&#36924;. (foo)]]></failure></testcase></testsuite></testsuites>`);
         });
     });
 
     describe("when passed multiple files with 1 message each", () => {
         const code = [{
-            filePath: suppliedFilePath(),
+            filePath: suppliedFilePath,
             messages: [{
                 message: "Unexpected foo.",
                 severity: 1,
@@ -198,13 +177,13 @@ describe("formatter:junit", () => {
         it("should return 2 <testsuite>'s", () => {
             const result = formatter(code);
 
-            assert.strictEqual(result.replace(/\n/gu, ""), `<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite package="org.eslint" time="0" tests="1" errors="1" name="${suppliedFilePath()}"><testcase time="0" name="org.eslint.foo" classname="${expectedClassName()}"><failure message="Unexpected foo."><![CDATA[line 5, col 10, Warning - Unexpected foo. (foo)]]></failure></testcase></testsuite><testsuite package="org.eslint" time="0" tests="1" errors="1" name="bar.js"><testcase time="0" name="org.eslint.bar" classname="bar"><failure message="Unexpected bar."><![CDATA[line 6, col 11, Error - Unexpected bar. (bar)]]></failure></testcase></testsuite></testsuites>`);
+            assert.strictEqual(result.replace(/\n/gu, ""), `<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite package="org.eslint" time="0" tests="1" errors="1" name="${suppliedFilePath}"><testcase time="0" name="org.eslint.foo" classname="${expectedClassName}"><failure message="Unexpected foo."><![CDATA[line 5, col 10, Warning - Unexpected foo. (foo)]]></failure></testcase></testsuite><testsuite package="org.eslint" time="0" tests="1" errors="1" name="bar.js"><testcase time="0" name="org.eslint.bar" classname="bar"><failure message="Unexpected bar."><![CDATA[line 6, col 11, Error - Unexpected bar. (bar)]]></failure></testcase></testsuite></testsuites>`);
         });
     });
 
     describe("when passed multiple files should print even if no errors", () => {
         const code = [{
-            filePath: suppliedFilePath(),
+            filePath: suppliedFilePath,
             messages: [{
                 message: "Unexpected foo.",
                 severity: 1,
@@ -220,20 +199,20 @@ describe("formatter:junit", () => {
         it("should return 2 <testsuite>", () => {
             const result = formatter(code);
 
-            assert.strictEqual(result.replace(/\n/gu, ""), `<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite package="org.eslint" time="0" tests="1" errors="1" name="${suppliedFilePath()}"><testcase time="0" name="org.eslint.foo" classname="${expectedClassName()}"><failure message="Unexpected foo."><![CDATA[line 5, col 10, Warning - Unexpected foo. (foo)]]></failure></testcase></testsuite><testsuite package="org.eslint" time="0" tests="1" errors="0" name="bar.js"><testcase time="0" name="bar.js" classname="bar" /></testsuite></testsuites>`);
+            assert.strictEqual(result.replace(/\n/gu, ""), `<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite package="org.eslint" time="0" tests="1" errors="1" name="${suppliedFilePath}"><testcase time="0" name="org.eslint.foo" classname="${expectedClassName}"><failure message="Unexpected foo."><![CDATA[line 5, col 10, Warning - Unexpected foo. (foo)]]></failure></testcase></testsuite><testsuite package="org.eslint" time="0" tests="1" errors="0" name="bar.js"><testcase time="0" name="bar.js" classname="bar" /></testsuite></testsuites>`);
         });
     });
 
     describe("when passed a file with no errors", () => {
         const code = [{
-            filePath: suppliedFilePath(),
+            filePath: suppliedFilePath,
             messages: []
         }];
 
         it("should print a passing <testcase>", () => {
             const result = formatter(code);
 
-            assert.strictEqual(result.replace(/\n/gu, ""), `<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite package="org.eslint" time="0" tests="1" errors="0" name="${suppliedFilePath()}"><testcase time="0" name="${suppliedFilePath()}" classname="${expectedClassName()}" /></testsuite></testsuites>`);
+            assert.strictEqual(result.replace(/\n/gu, ""), `<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite package="org.eslint" time="0" tests="1" errors="0" name="${suppliedFilePath}"><testcase time="0" name="${suppliedFilePath}" classname="${expectedClassName}" /></testsuite></testsuites>`);
         });
     });
 });


### PR DESCRIPTION
This commit aims to fix the issues described in #12507 by removing the
assumption that POSIX style filePaths are supplied by messages.

The tests for this are also updated to run on both Windows and POSIX
based systems. The results can be seen by running ESLint with the JUnit
formatter on a Windows system.

Full details can be seen in the issue mentioned above.

<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**
This PR is a followup to fix a missed bug introduced in #11683 where Windows paths are not supported properly.
[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
I changed the function `pathWithoutExt(filePath)` so that it does not assume POSIX style paths. Instead it will allow Node to determine which style of path to expect (POSIX or Windows) based on the OS.

From looking at the original PR it seems that this change to assume POSIX was done after the changes were approved, and might have been to force tests to pass (but I did not verify this).

Hence, I also updated the tests for the JUnit formatter so that they should run correctly on both Windows and *Nix machines by passing in an OS relevant `suppliedFilePath` to the test, and verifying with an OS relevant `expectedClassName`.

**Is there anything you'd like reviewers to focus on?**
Test sanity.