### PR TITLE
Fix: curly `multi` reports single lexical declarations (fixes #11908)

### DIFF
--- a/lib/rules/curly.js
+++ b/lib/rules/curly.js
@@ -240,7 +240,7 @@ module.exports = {
             if (node.type === "IfStatement" && node.consequent === body && requiresBraceOfConsequent(node)) {
                 expected = true;
             } else if (multiOnly) {
-                if (hasBlock && body.body.length === 1) {
+                if (hasBlock && body.body.length === 1 && !isLexicalDeclaration(body.body[0])) {
                     expected = false;
                 }
             } else if (multiLine) {

--- a/tests/lib/rules/curly.js
+++ b/tests/lib/rules/curly.js
@@ -165,6 +165,35 @@ ruleTester.run("curly", rule, {
             parserOptions: { ecmaVersion: 6 }
         },
         {
+            code: "if (foo) { const bar = 'baz'; }",
+            options: ["multi"],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "while (foo) { let bar = 'baz'; }",
+            options: ["multi"],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "for(;;) { function foo() {} }",
+            options: ["multi"]
+        },
+        {
+            code: "for (foo in bar) { class Baz {} }",
+            options: ["multi"],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "if (foo) { let bar; } else { baz(); }",
+            options: ["multi", "consistent"],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "if (foo) { bar(); } else { const baz = 'quux'; }",
+            options: ["multi", "consistent"],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
             code: "if (foo) { \n const bar = 'baz'; \n }",
             options: ["multi-or-nest"],
             parserOptions: { ecmaVersion: 6 }
@@ -611,6 +640,44 @@ ruleTester.run("curly", rule, {
             errors: [
                 {
                     messageId: "unexpectedCurlyAfterCondition",
+                    data: { name: "if" },
+                    type: "IfStatement"
+                }
+            ]
+        },
+        {
+            code: "if (foo) { var bar = 'baz'; }",
+            output: "if (foo)  var bar = 'baz'; ",
+            options: ["multi"],
+            errors: [
+                {
+                    messageId: "unexpectedCurlyAfterCondition",
+                    data: { name: "if" },
+                    type: "IfStatement"
+                }
+            ]
+        },
+        {
+            code: "if (foo) { let bar; } else baz();",
+            output: "if (foo) { let bar; } else {baz();}",
+            options: ["multi", "consistent"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "missingCurlyAfter",
+                    data: { name: "else" },
+                    type: "IfStatement"
+                }
+            ]
+        },
+        {
+            code: "if (foo) bar(); else { const baz = 'quux' }",
+            output: "if (foo) {bar();} else { const baz = 'quux' }",
+            options: ["multi", "consistent"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "missingCurlyAfterCondition",
                     data: { name: "if" },
                     type: "IfStatement"
                 }


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix #11908

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**Tell us about your environment**

* **ESLint Version:**  6.6.0
* **Node Version:** 10.16.0
* **npm Version:** 6.9.0

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

<details>
<summary>Configuration</summary>

<!-- Paste your configuration below: -->
```js
module.exports = {
    parserOptions: {
		ecmaVersion: 2015,
    }
};
```

</details>

**What did you do? Please include the actual source code causing the issue.**

[Online Demo Link](https://eslint.org/demo#eyJ0ZXh0IjoiLyogZXNsaW50IGN1cmx5OiBbXCJlcnJvclwiLCBcIm11bHRpXCJdICovXG5cbmlmIChmb28pIHtcblx0Y29uc3QgYSA9IDE7XG59Iiwib3B0aW9ucyI6eyJwYXJzZXJPcHRpb25zIjp7ImVjbWFWZXJzaW9uIjo2LCJzb3VyY2VUeXBlIjoic2NyaXB0IiwiZWNtYUZlYXR1cmVzIjp7fX0sInJ1bGVzIjp7fSwiZW52Ijp7fX19)

```js
/* eslint curly: ["error", "multi"] */

if (foo) {
    const a = 1;
}
```

**What did you expect to happen?**

0 errors. A block with only one statement which is a lexical declaration doesn't make much sense, but still these curly braces cannot be removed.

**What actually happened? Please include the actual, raw output from ESLint.**

1 error and syntax error in the fixed code.

```
3:1  error  Unnecessary { after 'if' condition  curly
```

```js
/* eslint curly: ["error", "multi"] */

if (foo) 
    const a = 1;

```

```
4:2  error  Parsing error: Unexpected token const
```

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Changed the `multi` option to not report single-statement blocks if that statement is a `let`, `const`, `function` or `class` declaration.

**Is there anything you'd like reviewers to focus on?**

The following added `valid` test were invalid, and the autofix was producing syntax errors:

```js
if (foo) { const bar = 'baz'; }
while (foo) { let bar = 'baz'; }
for (foo in bar) { class Baz {} }
```

The same applies to these `valid` tests with the `consistent` modifier:

```js
if (foo) { let bar; } else { baz(); }
if (foo) { bar(); } else { const baz = 'quux'; }
```

The following `valid` test was also invalid. This code without braces is not a syntax error in non-strict mode, but it's a legacy syntax, so the original code shouldn't be reported and auto-fixed:

```js
for(;;) { function foo() {} }
```

This `invalid` test was invalid before, it's a regression test:

```js
if (foo) { var bar = 'baz'; }
```

These two `invalid` tests with the  `consistent` modifier were `invalid` before, but in a different way. Autofix was removing braces, which was producing syntax errors. After this PR, autofix will do the opposite, put the braces around the statement that isn't in a block.

```js
if (foo) { let bar; } else baz();
if (foo) bar(); else { const baz = 'quux' }
```

That's the only case where this PR can produce more warnings (e.g. 2 instead of 1), but that can happen only in chains that already have warnings.