### PR TITLE
Update: deprecate sourceCode#isSpaceBetweenTokens()

### DIFF
--- a/docs/developer-guide/working-with-rules.md
+++ b/docs/developer-guide/working-with-rules.md
@@ -392,7 +392,7 @@ Once you have an instance of `SourceCode`, you can use the methods on it to work
 * `getCommentsAfter(nodeOrToken)` - returns an array of comment tokens that occur directly after the given node or token.
 * `getCommentsInside(node)` - returns an array of all comment tokens inside a given node.
 * `getJSDocComment(node)` - returns the JSDoc comment for a given node or `null` if there is none.
-* `isSpaceBetweenTokens(first, second)` - returns true if there is a whitespace character between the two tokens.
+* `isSpaceBetween(nodeOrToken, nodeOrToken)` - returns true if there is a whitespace character between the two tokens or, if given a node, the last token of the first node and the first token of the second node.
 * `getFirstToken(node, skipOptions)` - returns the first token representing the given node.
 * `getFirstTokens(node, countOptions)` - returns the first `count` tokens representing the given node.
 * `getLastToken(node, skipOptions)` - returns the last token representing the given node.
@@ -447,6 +447,7 @@ Please note that the following methods have been deprecated and will be removed 
 * `getComments()` - replaced by `getCommentsBefore()`, `getCommentsAfter()`, and `getCommentsInside()`
 * `getTokenOrCommentBefore()` - replaced by `getTokenBefore()` with the `{ includeComments: true }` option
 * `getTokenOrCommentAfter()` - replaced by `getTokenAfter()` with the `{ includeComments: true }` option
+* `isSpaceBetweenTokens()` - replaced by `isSpaceBetween()`
 
 ### Options Schemas
 

--- a/lib/source-code/source-code.js
+++ b/lib/source-code/source-code.js
@@ -432,7 +432,7 @@ class SourceCode extends TokenStore {
      * any of the tokens found between the two given nodes or tokens.
      * @public
      */
-    isSpaceBetweenTokens(first, second) {
+    isSpaceBetween(first, second) {
         if (nodesOrTokensOverlap(first, second)) {
             return false;
         }
@@ -455,6 +455,20 @@ class SourceCode extends TokenStore {
         }
 
         return false;
+    }
+
+    /**
+     * Determines if two nodes or tokens have at least one whitespace character
+     * between them. Order does not matter. Returns false if the given nodes or
+     * tokens overlap.
+     * @param {...ASTNode|Token} args The nodes or tokens to check between.
+     * @returns {boolean} True if there is a whitespace character between
+     * any of the tokens found between the two given nodes or tokens.
+     * @deprecated in favor of isSpaceBetween().
+     * @public
+     */
+    isSpaceBetweenTokens(...args) {
+        return this.isSpaceBetween(...args);
     }
 
     /**

--- a/tests/lib/source-code/source-code.js
+++ b/tests/lib/source-code/source-code.js
@@ -1789,6 +1789,339 @@ describe("SourceCode", () => {
         });
     });
 
+    describe("isSpaceBetween()", () => {
+        describe("should return true when there is at least one whitespace character between two tokens", () => {
+            leche.withData([
+                ["let foo", true],
+                ["let  foo", true],
+                ["let /**/ foo", true],
+                ["let/**/foo", false],
+                ["let/*\n*/foo", false]
+            ], (code, expected) => {
+                describe("when the first given is located before the second", () => {
+                    it(code, () => {
+                        const ast = espree.parse(code, DEFAULT_CONFIG),
+                            sourceCode = new SourceCode(code, ast);
+
+                        assert.strictEqual(
+                            sourceCode.isSpaceBetween(
+                                sourceCode.ast.tokens[0],
+                                sourceCode.ast.tokens[sourceCode.ast.tokens.length - 1]
+                            ),
+                            expected
+                        );
+                    });
+                });
+
+                describe("when the first given is located after the second", () => {
+                    it(code, () => {
+                        const ast = espree.parse(code, DEFAULT_CONFIG),
+                            sourceCode = new SourceCode(code, ast);
+
+                        assert.strictEqual(
+                            sourceCode.isSpaceBetween(
+                                sourceCode.ast.tokens[sourceCode.ast.tokens.length - 1],
+                                sourceCode.ast.tokens[0]
+                            ),
+                            expected
+                        );
+                    });
+                });
+            });
+
+            leche.withData([
+                ["a+b", false],
+                ["a +b", true],
+                ["a/**/+b", false],
+                ["a/* */+b", false],
+                ["a/**/ +b", true],
+                ["a/**/ /**/+b", true],
+                ["a/* */ /* */+b", true],
+                ["a/**/\n/**/+b", true],
+                ["a/* */\n/* */+b", true],
+                ["a/**/+b/**/+c", false],
+                ["a/* */+b/* */+c", false],
+                ["a/**/+b /**/+c", true],
+                ["a/* */+b /* */+c", true],
+                ["a/**/ +b/**/+c", true],
+                ["a/* */ +b/* */+c", true],
+                ["a/**/+b\t/**/+c", true],
+                ["a/* */+b\t/* */+c", true],
+                ["a/**/\t+b/**/+c", true],
+                ["a/* */\t+b/* */+c", true],
+                ["a/**/+b\n/**/+c", true],
+                ["a/* */+b\n/* */+c", true],
+                ["a/**/\n+b/**/+c", true],
+                ["a/* */\n+b/* */+c", true],
+                ["a/* */+' /**/ '/* */+c", false],
+                ["a/* */+ ' /**/ '/* */+c", true],
+                ["a/* */+' /**/ ' /* */+c", true],
+                ["a/* */+ ' /**/ ' /* */+c", true],
+                ["a/* */+` /*\n*/ `/* */+c", false],
+                ["a/* */+ ` /*\n*/ `/* */+c", true],
+                ["a/* */+` /*\n*/ ` /* */+c", true],
+                ["a/* */+ ` /*\n*/ ` /* */+c", true]
+            ], (code, expected) => {
+                describe("when the first given is located before the second", () => {
+                    it(code, () => {
+                        const ast = espree.parse(code, DEFAULT_CONFIG),
+                            sourceCode = new SourceCode(code, ast);
+
+                        assert.strictEqual(
+                            sourceCode.isSpaceBetween(
+                                sourceCode.ast.tokens[0],
+                                sourceCode.ast.tokens[sourceCode.ast.tokens.length - 2]
+                            ),
+                            expected
+                        );
+                    });
+                });
+
+                describe("when the first given is located after the second", () => {
+                    it(code, () => {
+                        const ast = espree.parse(code, DEFAULT_CONFIG),
+                            sourceCode = new SourceCode(code, ast);
+
+                        assert.strictEqual(
+                            sourceCode.isSpaceBetween(
+                                sourceCode.ast.tokens[sourceCode.ast.tokens.length - 2],
+                                sourceCode.ast.tokens[0]
+                            ),
+                            expected
+                        );
+                    });
+                });
+            });
+        });
+
+        describe("should return true when there is at least one whitespace character between a token and a node", () => {
+            leche.withData([
+                [";let foo = bar", false],
+                [";/**/let foo = bar", false],
+                [";/* */let foo = bar", false],
+                ["; let foo = bar", true],
+                ["; let foo = bar", true],
+                ["; /**/let foo = bar", true],
+                ["; /* */let foo = bar", true],
+                [";/**/ let foo = bar", true],
+                [";/* */ let foo = bar", true],
+                ["; /**/ let foo = bar", true],
+                ["; /* */ let foo = bar", true],
+                [";\tlet foo = bar", true],
+                [";\tlet foo = bar", true],
+                [";\t/**/let foo = bar", true],
+                [";\t/* */let foo = bar", true],
+                [";/**/\tlet foo = bar", true],
+                [";/* */\tlet foo = bar", true],
+                [";\t/**/\tlet foo = bar", true],
+                [";\t/* */\tlet foo = bar", true],
+                [";\nlet foo = bar", true],
+                [";\nlet foo = bar", true],
+                [";\n/**/let foo = bar", true],
+                [";\n/* */let foo = bar", true],
+                [";/**/\nlet foo = bar", true],
+                [";/* */\nlet foo = bar", true],
+                [";\n/**/\nlet foo = bar", true],
+                [";\n/* */\nlet foo = bar", true]
+            ], (code, expected) => {
+                describe("when the first given is located before the second", () => {
+                    it(code, () => {
+                        const ast = espree.parse(code, DEFAULT_CONFIG),
+                            sourceCode = new SourceCode(code, ast);
+
+                        assert.strictEqual(
+                            sourceCode.isSpaceBetween(
+                                sourceCode.ast.tokens[0],
+                                sourceCode.ast.body[sourceCode.ast.body.length - 1]
+                            ),
+                            expected
+                        );
+                    });
+                });
+
+                describe("when the first given is located after the second", () => {
+                    it(code, () => {
+                        const ast = espree.parse(code, DEFAULT_CONFIG),
+                            sourceCode = new SourceCode(code, ast);
+
+                        assert.strictEqual(
+                            sourceCode.isSpaceBetween(
+                                sourceCode.ast.body[sourceCode.ast.body.length - 1],
+                                sourceCode.ast.tokens[0]
+                            ),
+                            expected
+                        );
+                    });
+                });
+            });
+        });
+
+        describe("should return true when there is at least one whitespace character between a node and a token", () => {
+            leche.withData([
+                ["let foo = bar;;", false],
+                ["let foo = bar;;;", false],
+                ["let foo = 1; let bar = 2;;", true],
+                ["let foo = bar;/**/;", false],
+                ["let foo = bar;/* */;", false],
+                ["let foo = bar;;;", false],
+                ["let foo = bar; ;", true],
+                ["let foo = bar; /**/;", true],
+                ["let foo = bar; /* */;", true],
+                ["let foo = bar;/**/ ;", true],
+                ["let foo = bar;/* */ ;", true],
+                ["let foo = bar; /**/ ;", true],
+                ["let foo = bar; /* */ ;", true],
+                ["let foo = bar;\t;", true],
+                ["let foo = bar;\t/**/;", true],
+                ["let foo = bar;\t/* */;", true],
+                ["let foo = bar;/**/\t;", true],
+                ["let foo = bar;/* */\t;", true],
+                ["let foo = bar;\t/**/\t;", true],
+                ["let foo = bar;\t/* */\t;", true],
+                ["let foo = bar;\n;", true],
+                ["let foo = bar;\n/**/;", true],
+                ["let foo = bar;\n/* */;", true],
+                ["let foo = bar;/**/\n;", true],
+                ["let foo = bar;/* */\n;", true],
+                ["let foo = bar;\n/**/\n;", true],
+                ["let foo = bar;\n/* */\n;", true]
+            ], (code, expected) => {
+                describe("when the first given is located before the second", () => {
+                    it(code, () => {
+                        const ast = espree.parse(code, DEFAULT_CONFIG),
+                            sourceCode = new SourceCode(code, ast);
+
+                        assert.strictEqual(
+                            sourceCode.isSpaceBetween(
+                                sourceCode.ast.body[0],
+                                sourceCode.ast.tokens[sourceCode.ast.tokens.length - 1]
+                            ),
+                            expected
+                        );
+                    });
+                });
+
+                describe("when the first given is located after the second", () => {
+                    it(code, () => {
+                        const ast = espree.parse(code, DEFAULT_CONFIG),
+                            sourceCode = new SourceCode(code, ast);
+
+                        assert.strictEqual(
+                            sourceCode.isSpaceBetween(
+                                sourceCode.ast.tokens[sourceCode.ast.tokens.length - 1],
+                                sourceCode.ast.body[0]
+                            ),
+                            expected
+                        );
+                    });
+                });
+            });
+        });
+
+        describe("should return true when there is at least one whitespace character between two nodes", () => {
+            leche.withData([
+                ["let foo = bar;let baz = qux;", false],
+                ["let foo = bar;/**/let baz = qux;", false],
+                ["let foo = bar;/* */let baz = qux;", false],
+                ["let foo = bar; let baz = qux;", true],
+                ["let foo = bar; /**/let baz = qux;", true],
+                ["let foo = bar; /* */let baz = qux;", true],
+                ["let foo = bar;/**/ let baz = qux;", true],
+                ["let foo = bar;/* */ let baz = qux;", true],
+                ["let foo = bar; /**/ let baz = qux;", true],
+                ["let foo = bar; /* */ let baz = qux;", true],
+                ["let foo = bar;\tlet baz = qux;", true],
+                ["let foo = bar;\t/**/let baz = qux;", true],
+                ["let foo = bar;\t/* */let baz = qux;", true],
+                ["let foo = bar;/**/\tlet baz = qux;", true],
+                ["let foo = bar;/* */\tlet baz = qux;", true],
+                ["let foo = bar;\t/**/\tlet baz = qux;", true],
+                ["let foo = bar;\t/* */\tlet baz = qux;", true],
+                ["let foo = bar;\nlet baz = qux;", true],
+                ["let foo = bar;\n/**/let baz = qux;", true],
+                ["let foo = bar;\n/* */let baz = qux;", true],
+                ["let foo = bar;/**/\nlet baz = qux;", true],
+                ["let foo = bar;/* */\nlet baz = qux;", true],
+                ["let foo = bar;\n/**/\nlet baz = qux;", true],
+                ["let foo = bar;\n/* */\nlet baz = qux;", true],
+                ["let foo = 1;let foo2 = 2; let foo3 = 3;", true]
+            ], (code, expected) => {
+                describe("when the first given is located before the second", () => {
+                    it(code, () => {
+                        const ast = espree.parse(code, DEFAULT_CONFIG),
+                            sourceCode = new SourceCode(code, ast);
+
+                        assert.strictEqual(
+                            sourceCode.isSpaceBetween(
+                                sourceCode.ast.body[0],
+                                sourceCode.ast.body[sourceCode.ast.body.length - 1]
+                            ),
+                            expected
+                        );
+                    });
+                });
+
+                describe("when the first given is located after the second", () => {
+                    it(code, () => {
+                        const ast = espree.parse(code, DEFAULT_CONFIG),
+                            sourceCode = new SourceCode(code, ast);
+
+                        assert.strictEqual(
+                            sourceCode.isSpaceBetween(
+                                sourceCode.ast.body[sourceCode.ast.body.length - 1],
+                                sourceCode.ast.body[0]
+                            ),
+                            expected
+                        );
+                    });
+                });
+            });
+        });
+
+        describe("should return false either of the arguments' location is inside the other one", () => {
+            leche.withData([
+                ["let foo = bar;", false]
+            ], (code, expected) => {
+                it(code, () => {
+                    const ast = espree.parse(code, DEFAULT_CONFIG),
+                        sourceCode = new SourceCode(code, ast);
+
+                    assert.strictEqual(
+                        sourceCode.isSpaceBetween(
+                            sourceCode.ast.tokens[0],
+                            sourceCode.ast.body[0]
+                        ),
+                        expected
+                    );
+
+                    assert.strictEqual(
+                        sourceCode.isSpaceBetween(
+                            sourceCode.ast.tokens[sourceCode.ast.tokens.length - 1],
+                            sourceCode.ast.body[0]
+                        ),
+                        expected
+                    );
+
+                    assert.strictEqual(
+                        sourceCode.isSpaceBetween(
+                            sourceCode.ast.body[0],
+                            sourceCode.ast.tokens[0]
+                        ),
+                        expected
+                    );
+
+                    assert.strictEqual(
+                        sourceCode.isSpaceBetween(
+                            sourceCode.ast.body[0],
+                            sourceCode.ast.tokens[sourceCode.ast.tokens.length - 1]
+                        ),
+                        expected
+                    );
+                });
+            });
+        });
+    });
+
     describe("isSpaceBetweenTokens()", () => {
         describe("should return true when there is at least one whitespace character between two tokens", () => {
             leche.withData([


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[X] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
Please evaluate just the last commit. We should wait to merge this until after we land https://github.com/eslint/eslint/pull/12491. I'll rebase at that time. Adding the "do not merge" label until then.
<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
While working on https://github.com/eslint/eslint/pull/12491, noticed that `sourceCode#isSpaceBetweenTokens()` currently allows for nodes as well as tokens as arguments. I think that it would make sense to rename this method to isSpaceBetween() and leave the ability for it to check between nodes and tokens, as that's a useful behavior that is most likely being used by custom rules (since we use it in at least one of our core rules). We could deprecate isSpaceBetweenTokens() and leave it as an alias that calls through to isSpaceBetween() for the sake of backwards compatibility.

**Is there anything you'd like reviewers to focus on?**
Does this API make sense?

