### PR TITLE
New: baseIndent option for indent rule

### DIFF
--- a/docs/rules/indent.md
+++ b/docs/rules/indent.md
@@ -86,6 +86,7 @@ This rule has an object option:
 * `"flatTernaryExpressions": true` (`false` by default) requires no indentation for ternary expressions which are nested in other ternary expressions.
 * `"ignoredNodes"` accepts an array of [selectors](/docs/developer-guide/selectors.md). If an AST node is matched by any of the selectors, the indentation of tokens which are direct children of that node will be ignored. This can be used as an escape hatch to relax the rule if you disagree with the indentation that it enforces for a particular syntactic pattern.
 * `"ignoreComments"` (default: false) can be used when comments do not need to be aligned with nodes on the previous or next line.
+* `"baseIndent"` (default: 0) enforces extra indentation for top-level statements.
 
 Level of indentation denotes the multiple of the indent specified. Example:
 
@@ -689,6 +690,18 @@ if (foo) {
 // comment intentionally de-indented
     doSomethingElse();
 }
+```
+
+### baseIndent
+
+   Examples of additional **correct** code for this rule with the `4, { "baseIndent": 2 }` option:
+
+```js
+        /*eslint indent: ["error", 4, { "baseIndent": 2 }] */
+
+        if (foo) {
+            doSomething();
+        }
 ```
 
 

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -242,11 +242,13 @@ class OffsetStorage {
      * @param {TokenInfo} tokenInfo a TokenInfo instance
      * @param {number} indentSize The desired size of each indentation level
      * @param {string} indentType The indentation character
+     * @param {number} baseIndent The multiplier of indentation for top-level statements
      */
-    constructor(tokenInfo, indentSize, indentType) {
+    constructor(tokenInfo, indentSize, indentType, baseIndent) {
         this._tokenInfo = tokenInfo;
         this._indentSize = indentSize;
         this._indentType = indentType;
+        this._baseIndent = indentType.repeat(baseIndent * indentSize);
 
         this._tree = new BinarySearchTree();
         this._tree.insert(0, { offset: 0, from: null, force: false });
@@ -452,7 +454,7 @@ class OffsetStorage {
 
                 this._desiredIndentCache.set(
                     token,
-                    (offsetInfo.from ? this.getDesiredIndent(offsetInfo.from) : "") + this._indentType.repeat(offset)
+                    (offsetInfo.from ? this.getDesiredIndent(offsetInfo.from) : this._baseIndent) + this._indentType.repeat(offset)
                 );
             }
         }
@@ -602,6 +604,10 @@ module.exports = {
                     ignoreComments: {
                         type: "boolean",
                         default: false
+                    },
+                    baseIndent: {
+                        type: "integer",
+                        minimum: 0
                     }
                 },
                 additionalProperties: false
@@ -644,7 +650,8 @@ module.exports = {
             ImportDeclaration: 1,
             flatTernaryExpressions: false,
             ignoredNodes: [],
-            ignoreComments: false
+            ignoreComments: false,
+            baseIndent: 0
         };
 
         if (context.options.length) {
@@ -671,7 +678,7 @@ module.exports = {
 
         const sourceCode = context.getSourceCode();
         const tokenInfo = new TokenInfo(sourceCode);
-        const offsets = new OffsetStorage(tokenInfo, indentSize, indentType === "space" ? " " : "\t");
+        const offsets = new OffsetStorage(tokenInfo, indentSize, indentType === "space" ? " " : "\t", options.baseIndent);
         const parameterParens = new WeakSet();
 
         /**

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -5360,6 +5360,13 @@ ruleTester.run("indent", rule, {
                 ;[1, 2, 3].forEach(() => {})
             }
         `,
+        {
+            code: "" +
+                "    if (foo) {\n" +
+                "        doSomething();\n" +
+                "    }",
+            options: [4, { baseIndent: 1 }]
+        },
 
         // import expressions
         {
@@ -10493,6 +10500,18 @@ ruleTester.run("indent", rule, {
                 }
             `,
             errors: expectedErrors([5, 8, 4, "Block"])
+        },
+        {
+            code: "" +
+                "if (foo) {\n" +
+                "            doSomething();\n" +
+                "        }",
+            output: "" +
+                "        if (foo) {\n" +
+                "            doSomething();\n" +
+                "        }",
+            options: [4, { baseIndent: 2 }],
+            errors: expectedErrors([1, 8, 0, "Keyword"])
         },
 
         // import expressions


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**
[X] Documentation update
[X] Changes an existing rule

**What rule do you want to change?**
`indent`

**Does this change cause the rule to produce more or fewer warnings?**
No.

**How will the change be implemented? (New option, new default behavior, etc.)?**
New option.

**Please provide some example code that this change will affect:**
```js
        if (foo) {
            doSomething();
        }
```

**What does the rule currently do for this code?**
```
  1:1  error  Expected indentation of 0 spaces but found 8   indent
  2:1  error  Expected indentation of 0 spaces but found 12  indent
  3:1  error  Expected indentation of 0 spaces but found 8   indent
```

**What will the rule do after it's changed?**
It passes ok with `indent: ["error", 4, { "baseIndent": 2 }]`.

**What changes did you make? (Give an overview)**
Indent rule, docs, test.

It is not the most wanted feature but quite useful in some cases.

