### PR TITLE
Docs: add notice about `function` keyword in keyword-spacing

### DIFF
--- a/docs/rules/keyword-spacing.md
+++ b/docs/rules/keyword-spacing.md
@@ -15,7 +15,7 @@ if (foo) {
 
 Of course, you could also have a style guide that disallows spaces around keywords.
 
-However, if you want to enforce the style of spacing between `function` keyword and parenthesis, please refer to [space-before-function-paren](space-before-function-paren.md).
+However, if you want to enforce the style of spacing between the `function` keyword and the following opening parenthesis, please refer to [space-before-function-paren](space-before-function-paren.md).
 
 ## Rule Details
 

--- a/docs/rules/keyword-spacing.md
+++ b/docs/rules/keyword-spacing.md
@@ -1,7 +1,7 @@
 # enforce consistent spacing before and after keywords (keyword-spacing)
 
-Keywords are syntax elements of JavaScript, such as `function` and `if`.
-These identifiers have special meaning to the language and so often appear in a different color in code editors.
+Keywords are syntax elements of JavaScript, such as `try` and `if`.
+These keywords have special meaning to the language and so often appear in a different color in code editors.
 As an important part of the language, style guides often refer to the spacing that should be used around keywords.
 For example, you might have a style guide that says keywords should be always surrounded by spaces, which would mean `if-else` statements must look like this:
 
@@ -14,6 +14,8 @@ if (foo) {
 ```
 
 Of course, you could also have a style guide that disallows spaces around keywords.
+
+However, if you want to enforce the style of spacing between `function` keyword and parenthesis, please refer to [space-before-function-paren](space-before-function-paren.md).
 
 ## Rule Details
 


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

Documentation update

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Added notice about `function` keyword to reduce confusion.
