### PR TITLE
New: add option for camelcase (fixes #12527)

### DIFF
--- a/docs/rules/camelcase.md
+++ b/docs/rules/camelcase.md
@@ -15,7 +15,7 @@ This rule has an object option:
 * `"ignoreDestructuring": false` (default) enforces camelcase style for destructured identifiers
 * `"ignoreDestructuring": true` does not check destructured identifiers
 * `"ignoreImports": false` (default) enforces camelcase style for ES2015 imports
-* `"ignoreImports": true` does not check ES2015 imports
+* `"ignoreImports": true` does not check ES2015 imports (but still checks any use of the imports later in the code except function arguments)
 * `allow` (`string[]`) list of properties to accept. Accept regex.
 
 ### properties: "always"

--- a/docs/rules/camelcase.md
+++ b/docs/rules/camelcase.md
@@ -14,6 +14,8 @@ This rule has an object option:
 * `"properties": "never"` does not check property names
 * `"ignoreDestructuring": false` (default) enforces camelcase style for destructured identifiers
 * `"ignoreDestructuring": true` does not check destructured identifiers
+* `"ignoreImports": false` (default) enforces camelcase style for ES2015 imports
+* `"ignoreImports": true` does not check ES2015 imports
 * `allow` (`string[]`) list of properties to accept. Accept regex.
 
 ### properties: "always"
@@ -150,6 +152,36 @@ var { category_id } = query;
 var { category_id = 1 } = query;
 
 var { category_id: category_id } = query;
+```
+
+### ignoreImports: false
+
+Examples of **incorrect** code for this rule with the default `{ "ignoreImports": false }` option:
+
+```js
+/*eslint camelcase: "error"*/
+
+import { snake_cased } from 'mod';
+```
+
+### ignoreImports: true
+
+Examples of **incorrect** code for this rule with the `{ "ignoreImports": true }` option:
+
+```js
+/*eslint camelcase: ["error", {ignoreImports: true}]*/
+
+import default_import from 'mod';
+
+import * as namespaced_import from 'mod';
+```
+
+Examples of **correct** code for this rule with the `{ "ignoreImports": true }` option:
+
+```js
+/*eslint camelcase: ["error", {ignoreImports: true}]*/
+
+import { snake_cased } from 'mod';
 ```
 
 ## allow

--- a/tests/lib/rules/camelcase.js
+++ b/tests/lib/rules/camelcase.js
@@ -157,6 +157,11 @@ ruleTester.run("camelcase", rule, {
             parserOptions: { ecmaVersion: 6, sourceType: "module" }
         },
         {
+            code: "import { camelCased } from 'mod'",
+            options: [{ ignoreImports: false }],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" }
+        },
+        {
             code: "function foo({ no_camelcased: camelCased }) {};",
             parserOptions: { ecmaVersion: 6 }
         },
@@ -552,6 +557,30 @@ ruleTester.run("camelcase", rule, {
         {
             code: "import * as snake_cased from 'mod'",
             options: [{ ignoreImports: true }],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [
+                {
+                    messageId: "notCamelCase",
+                    data: { name: "snake_cased" },
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
+            code: "import snake_cased from 'mod'",
+            options: [{ ignoreImports: false }],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [
+                {
+                    messageId: "notCamelCase",
+                    data: { name: "snake_cased" },
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
+            code: "import * as snake_cased from 'mod'",
+            options: [{ ignoreImports: false }],
             parserOptions: { ecmaVersion: 6, sourceType: "module" },
             errors: [
                 {

--- a/tests/lib/rules/camelcase.js
+++ b/tests/lib/rules/camelcase.js
@@ -152,6 +152,11 @@ ruleTester.run("camelcase", rule, {
             parserOptions: { ecmaVersion: 6, sourceType: "module" }
         },
         {
+            code: "import { snake_cased } from 'mod'",
+            options: [{ ignoreImports: true }],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" }
+        },
+        {
             code: "function foo({ no_camelcased: camelCased }) {};",
             parserOptions: { ecmaVersion: 6 }
         },
@@ -528,6 +533,30 @@ ruleTester.run("camelcase", rule, {
                 {
                     messageId: "notCamelCase",
                     data: { name: "no_camelcased" },
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
+            code: "import snake_cased from 'mod'",
+            options: [{ ignoreImports: true }],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [
+                {
+                    messageId: "notCamelCase",
+                    data: { name: "snake_cased" },
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
+            code: "import * as snake_cased from 'mod'",
+            options: [{ ignoreImports: true }],
+            parserOptions: { ecmaVersion: 6, sourceType: "module" },
+            errors: [
+                {
+                    messageId: "notCamelCase",
+                    data: { name: "snake_cased" },
                     type: "Identifier"
                 }
             ]


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

Changes an existing rule

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Added a new option `ignoreImports` to rule `camelcase`. The option is `false` by default.
Also, this PR is with some refactorings.

Fixes #12527 .


