### PR TITLE
Allow $schema property in configuration

### DIFF
--- a/conf/config-schema.js
+++ b/conf/config-schema.js
@@ -6,6 +6,7 @@
 "use strict";
 
 const baseConfigProperties = {
+    $schema: { type: "string" },
     env: { type: "object" },
     extends: { $ref: "#/definitions/stringOrStrings" },
     globals: { type: "object" },


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
I added $schema as an allowed property in the configuration. If a developer configures ESLint using JSON (`.eslintrc.json`), this change would optionally allow them to define a `$schema`, which some code editors/IDEs will pickup and use to provide intellisense for the file.

Example `.eslintrc.json`:
```json
{
  "$schema": "http://json.schemastore.org/eslintrc",
  "root": true,
  "extends": "@react-native-community"
}
```

**Is there anything you'd like reviewers to focus on?**
None, there are no other changes. This is just to stop ESLint from throwing an error when the field is provided.

