### PR TITLE
Fix: invalid autofix in function-call-argument-newline (fixes #12454)

### DIFF
--- a/lib/rules/function-call-argument-newline.js
+++ b/lib/rules/function-call-argument-newline.js
@@ -70,6 +70,8 @@ module.exports = {
                         { includeComments: true }
                     );
 
+                    const hasLineCommentBefore = tokenBefore.type === "Line";
+
                     context.report({
                         node,
                         loc: {
@@ -77,7 +79,7 @@ module.exports = {
                             end: currentArgToken.loc.start
                         },
                         messageId: checker.messageId,
-                        fix: checker.createFix(currentArgToken, tokenBefore)
+                        fix: hasLineCommentBefore ? null : checker.createFix(currentArgToken, tokenBefore)
                     });
                 }
             }

--- a/tests/lib/rules/function-call-argument-newline.js
+++ b/tests/lib/rules/function-call-argument-newline.js
@@ -505,6 +505,50 @@ ruleTester.run("function-call-argument-newline", rule, {
                     endColumn: 1
                 }
             ]
+        },
+        {
+            code: "fn(a,// comment\n{b, c})",
+            output: null,
+            options: ["never"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "unexpectedLineBreak",
+                    line: 1,
+                    column: 16,
+                    endLine: 2,
+                    endColumn: 1
+                }
+            ]
+        },
+        {
+            code: "fn(a, // comment\nb)",
+            output: null,
+            options: ["never"],
+            errors: [
+                {
+                    messageId: "unexpectedLineBreak",
+                    line: 1,
+                    column: 17,
+                    endLine: 2,
+                    endColumn: 1
+                }
+            ]
+        },
+        {
+            code: "fn(`\n`, b, // comment\nc)",
+            output: null,
+            options: ["consistent"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "unexpectedLineBreak",
+                    line: 2,
+                    column: 17,
+                    endLine: 3,
+                    endColumn: 1
+                }
+            ]
         }
     ]
 });

--- a/tests/lib/rules/function-call-argument-newline.js
+++ b/tests/lib/rules/function-call-argument-newline.js
@@ -391,15 +391,15 @@ ruleTester.run("function-call-argument-newline", rule, {
             ]
         },
         {
-            code: "fn(a,/* commeent */\nb)",
-            output: "fn(a,/* commeent */ b)",
+            code: "fn(a,/* comment */\nb)",
+            output: "fn(a,/* comment */ b)",
             options: ["never"],
             parserOptions: { ecmaVersion: 6 },
             errors: [
                 {
                     messageId: "unexpectedLineBreak",
                     line: 1,
-                    column: 20,
+                    column: 19,
                     endLine: 2,
                     endColumn: 1
                 }

--- a/tests/lib/rules/function-call-argument-newline.js
+++ b/tests/lib/rules/function-call-argument-newline.js
@@ -390,6 +390,21 @@ ruleTester.run("function-call-argument-newline", rule, {
                 }
             ]
         },
+        {
+            code: "fn(a,/* commeent */\nb)",
+            output: "fn(a,/* commeent */ b)",
+            options: ["never"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    messageId: "unexpectedLineBreak",
+                    line: 1,
+                    column: 20,
+                    endLine: 2,
+                    endColumn: 1
+                }
+            ]
+        },
 
         /* "consistent" */
         {


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This is a PR for #12454
- Add checking whether there is a line comment(`// comment`) before currentArgToken

**Is there anything you'd like reviewers to focus on?**


